### PR TITLE
zero DA offset for non-DA lens modes

### DIFF
--- a/src/erlab/io/plugins/da30.py
+++ b/src/erlab/io/plugins/da30.py
@@ -109,8 +109,8 @@ class DA30Loader(LoaderBase):
     def post_process(self, data: xr.DataArray) -> xr.DataArray:
         data = super().post_process(data)
 
-        if "beta" not in data.coords or (
-            len(data.beta) == 1 and not data.attrs.get("Lens Mode", "").startswith("DA")
+        if ("beta" not in data.coords) or not (
+            data.attrs.get("Lens Mode", "").startswith("DA")
         ):
             # Zero DA offset if not using DA lens mode
             data = data.assign_coords(beta=0.0)

--- a/src/erlab/io/plugins/da30.py
+++ b/src/erlab/io/plugins/da30.py
@@ -109,7 +109,10 @@ class DA30Loader(LoaderBase):
     def post_process(self, data: xr.DataArray) -> xr.DataArray:
         data = super().post_process(data)
 
-        if "beta" not in data.coords:
+        if "beta" not in data.coords or (
+            len(data.beta) == 1 and not data.attrs.get("Lens Mode", "").startswith("DA")
+        ):
+            # Zero DA offset if not using DA lens mode
             data = data.assign_coords(beta=0.0)
 
         return data

--- a/tests/accessors/test_kspace.py
+++ b/tests/accessors/test_kspace.py
@@ -9,7 +9,9 @@ from erlab.io.exampledata import generate_data_angles, generate_hvdep_cuts
 
 @pytest.fixture
 def hvdep():
-    return generate_hvdep_cuts((50, 250, 300), seed=1)
+    data = generate_hvdep_cuts((50, 250, 300), seed=1)
+    data.kspace.inner_potential = 10.0
+    return data
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,10 @@ from qtpy import QtCore, QtWidgets
 from erlab.interactive.utils import _WaitDialog
 from erlab.io.exampledata import generate_data_angles, generate_gold_edge
 
-DATA_COMMIT_HASH = "9408f73f3562a5c1e5f6e01dec25bcd16832264e"
+DATA_COMMIT_HASH = "a237e9a1265b89193da4426890616c0c3c055855"
 """The commit hash of the commit to retrieve from `kmnhan/erlabpy-data`."""
 
-DATA_KNOWN_HASH = "75b31cd538ea4847c6eb34017f5d69bed324081329fcc0eece5089677e37df4f"
+DATA_KNOWN_HASH = "163699b2068b2224eaf1edc7b8fa7e5b1eedccaba7d7b655bd8f6593297e6c52"
 """The SHA-256 checksum of the `.tar.gz` file."""
 
 log = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,10 @@ from qtpy import QtCore, QtWidgets
 from erlab.interactive.utils import _WaitDialog
 from erlab.io.exampledata import generate_data_angles, generate_gold_edge
 
-DATA_COMMIT_HASH = "a237e9a1265b89193da4426890616c0c3c055855"
+DATA_COMMIT_HASH = "26535e727236f220a4424538ba00b4b7a2b9666a"
 """The commit hash of the commit to retrieve from `kmnhan/erlabpy-data`."""
 
-DATA_KNOWN_HASH = "163699b2068b2224eaf1edc7b8fa7e5b1eedccaba7d7b655bd8f6593297e6c52"
+DATA_KNOWN_HASH = "f8d0a245747f6f899dc417db86f6ab64cf2c2dc7784aade8416c1c5d5c6c8ca4"
 """The SHA-256 checksum of the `.tar.gz` file."""
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Data taken without clicking zero DA offsets in SES contains a nonzero deflection angle. 

This PR adds a postprocessing step to the loader that sets the beta angle to zero if the lens mode does not start with `"DA"`.