### PR TITLE
Automatic xarray broadcasting for numba-accelerated functions

### DIFF
--- a/src/erlab/analysis/fit/functions/general.py
+++ b/src/erlab/analysis/fit/functions/general.py
@@ -34,6 +34,7 @@ import numpy.typing as npt
 import scipy.special
 
 from erlab.constants import kb_eV
+from erlab.utils.array import broadcast_args
 
 #: From :mod:`lmfit.lineshapes`, equal to `numpy.finfo(numpy.float64).resolution`
 TINY: float = 1.0e-15
@@ -171,6 +172,7 @@ def do_convolve_2d(
     return convolved.ravel()
 
 
+@broadcast_args
 @numba.njit(cache=True)
 def gaussian_wh(
     x: npt.NDArray[np.float64], center: float, width: float, height: float
@@ -187,6 +189,7 @@ def gaussian_wh(
     )
 
 
+@broadcast_args
 @numba.njit(cache=True)
 def gaussian(
     x: npt.NDArray[np.float64], center: float, sigma: float, amplitude: float
@@ -204,6 +207,7 @@ def gaussian(
     )
 
 
+@broadcast_args
 @numba.njit(cache=True)
 def lorentzian_wh(
     x: npt.NDArray[np.float64], center: float, width: float, height: float
@@ -218,6 +222,7 @@ def lorentzian_wh(
     return height / (1 + 4 * ((1.0 * x - center) / max(TINY, width)) ** 2)
 
 
+@broadcast_args
 @numba.njit(cache=True)
 def lorentzian(
     x: npt.NDArray[np.float64], center: float, sigma: float, amplitude: float
@@ -235,6 +240,7 @@ def lorentzian(
     )
 
 
+@broadcast_args
 @numba.njit(cache=True)
 def fermi_dirac(
     x: npt.NDArray[np.float64], center: float, temp: float
@@ -259,6 +265,7 @@ def fermi_dirac(
 
 
 # adapted and improved from KWAN Igor procedures
+@broadcast_args
 @numba.njit(cache=True)
 def fermi_dirac_linbkg(
     x: npt.NDArray[np.float64],
@@ -300,6 +307,7 @@ def fermi_dirac_linbkg(
     )
 
 
+@broadcast_args
 def fermi_dirac_linbkg_broad(
     x: npt.NDArray[np.float64],
     center: float,
@@ -324,6 +332,7 @@ def fermi_dirac_linbkg_broad(
     )
 
 
+@broadcast_args
 def step_broad(
     x: npt.NDArray[np.float64],
     center: float = 0.0,
@@ -359,6 +368,7 @@ def step_broad(
     )
 
 
+@broadcast_args
 def step_linbkg_broad(
     x: npt.NDArray[np.float64],
     center: float,
@@ -374,6 +384,7 @@ def step_linbkg_broad(
     )
 
 
+@broadcast_args
 @numba.njit()
 def bcs_gap(
     x, a: float = 1.76, b: float = 1.74, tc: float = 100.0

--- a/src/erlab/utils/array.py
+++ b/src/erlab/utils/array.py
@@ -107,57 +107,40 @@ def is_dims_uniform(
     return all(is_uniform_spaced(darr[dim].values, **kwargs) for dim in dims)
 
 
-def check_arg_2d_darr(func: Callable | None = None):
+def check_arg_2d_darr(func: Callable) -> Callable:
     """Decorate a function to check if the first argument is a 2D DataArray."""
 
-    def _decorator(func):
-        @functools.wraps(func)
-        def _wrapper(*args, **kwargs):
-            if not isinstance(args[0], xr.DataArray) or args[0].ndim != 2:
-                raise ValueError("Input must be a 2-dimensional xarray.DataArray")
-            return func(*args, **kwargs)
+    @functools.wraps(func)
+    def _wrapper(*args, **kwargs):
+        if not isinstance(args[0], xr.DataArray) or args[0].ndim != 2:
+            raise ValueError("Input must be a 2-dimensional xarray.DataArray")
+        return func(*args, **kwargs)
 
-        return _wrapper
-
-    if func is not None:
-        return _decorator(func)
-    return _decorator
+    return _wrapper
 
 
-def check_arg_uniform_dims(func: Callable | None = None):
+def check_arg_uniform_dims(func: Callable) -> Callable:
     """Decorate a function to check if all dims in the first argument are uniform."""
 
-    def _decorator(func):
-        @functools.wraps(func)
-        def _wrapper(*args, **kwargs):
-            if not isinstance(args[0], xr.DataArray) or not is_dims_uniform(args[0]):
-                raise ValueError(
-                    "Coordinates for all dimensions must be uniformly spaced"
-                )
-            return func(*args, **kwargs)
+    @functools.wraps(func)
+    def _wrapper(*args, **kwargs):
+        if not isinstance(args[0], xr.DataArray) or not is_dims_uniform(args[0]):
+            raise ValueError("Coordinates for all dimensions must be uniformly spaced")
+        return func(*args, **kwargs)
 
-        return _wrapper
-
-    if func is not None:
-        return _decorator(func)
-    return _decorator
+    return _wrapper
 
 
-def check_arg_has_no_nans(func: Callable | None = None):
+def check_arg_has_no_nans(func: Callable) -> Callable:
     """Decorate a function to check if the first argument has no NaNs."""
 
-    def _decorator(func):
-        @functools.wraps(func)
-        def _wrapper(*args, **kwargs):
-            if np.isnan(args[0]).any():
-                raise ValueError("Input must not contain any NaN values")
-            return func(*args, **kwargs)
+    @functools.wraps(func)
+    def _wrapper(*args, **kwargs):
+        if np.isnan(args[0]).any():
+            raise ValueError("Input must not contain any NaN values")
+        return func(*args, **kwargs)
 
-        return _wrapper
-
-    if func is not None:
-        return _decorator(func)
-    return _decorator
+    return _wrapper
 
 
 def trim_na(darr: xr.DataArray, dims: Iterable[Hashable] | None = None) -> xr.DataArray:

--- a/tests/plotting/test_general.py
+++ b/tests/plotting/test_general.py
@@ -213,3 +213,59 @@ def test_plot_array(data, colorbar, xlim, ylim, crop, kwargs) -> None:
         else:
             assert ax.get_ylim() == ylim
     plt.close()
+
+
+def test_qsel_average_single_dim() -> None:
+    # Create a simple 2D DataArray with dims 'x' and 'y'
+
+    x = np.array([10, 20])
+    y = np.array([30, 40, 50])
+    data = np.array([[1, 2, 3], [4, 5, 6]])
+    da = xr.DataArray(data, dims=("x", "y"), coords={"x": x, "y": y})
+
+    # Average over the 'x' dimension using qsel.average.
+    # The expected result is the mean along 'x' and retaining the averaged coordinate.
+    # Expected mean data: [[(1+4)/2, (2+5)/2, (3+6)/2]] = [[2.5, 3.5, 4.5]]
+    expected = data.mean(axis=0)
+    result = da.qsel.average("x")
+
+    # After averaging, 'x' should not be a dimension; it is stored as a coordinate.
+    assert "x" not in result.dims
+    # Compare the resulting data with the expected average.
+    np.testing.assert_allclose(result.data, expected)
+    # Check that the coordinate 'x' is the mean of the original x-values.
+    np.testing.assert_allclose(result.coords["x"].data, x.mean())
+
+
+def test_qsel_average_multiple_dim() -> None:
+    # Create a simple 2D DataArray with dims 'x' and 'y'
+
+    x = np.array([0, 10, 20])
+    y = np.array([100, 200])
+    data = np.array([[1, 2], [4, 5], [7, 8]])
+    da = xr.DataArray(data, dims=("x", "y"), coords={"x": x, "y": y})
+
+    # Average over both 'x' and 'y'
+    # Expected result is a scalar value: mean of all data.
+    expected = data.mean()
+    result = da.qsel.average(["x", "y"])
+
+    # The resulting DataArray should have no dimensions.
+    assert not result.dims
+    # Data should be equal to the overall mean.
+    np.testing.assert_allclose(result.data, expected)
+    # Coordinates are retained as scalars equal to the mean of the original coords.
+    np.testing.assert_allclose(result.coords["x"].data, x.mean())
+    np.testing.assert_allclose(result.coords["y"].data, y.mean())
+
+
+def test_qsel_average_invalid_dim() -> None:
+    # Create a simple 1D DataArray
+
+    x = np.array([0, 1, 2])
+    data = np.array([10, 20, 30])
+    da = xr.DataArray(data, dims=("x",), coords={"x": x})
+
+    # Averaging over an invalid dimension should raise a ValueError
+    with pytest.raises(ValueError, match="Dimension `z` not found in data"):
+        _ = da.qsel.average("z")

--- a/tests/utils/test_array.py
+++ b/tests/utils/test_array.py
@@ -4,6 +4,7 @@ import xarray as xr
 import xarray.testing
 
 from erlab.utils.array import (
+    broadcast_args,
     check_arg_has_no_nans,
     is_dims_uniform,
     is_monotonic,
@@ -11,6 +12,32 @@ from erlab.utils.array import (
     trim_na,
     uniform_dims,
 )
+
+
+def test_broadcast_args() -> None:
+    def testfunc(x, y):
+        return x * y
+
+    testfunc_ = broadcast_args(testfunc)
+
+    x_val = np.linspace(0, 1, 5)
+    y_val = np.linspace(2, 3, 10)
+
+    expected_vals = testfunc(x_val[:, np.newaxis], y_val[np.newaxis, :])
+
+    np.testing.assert_array_equal(
+        testfunc_(x_val[:, np.newaxis], y_val[np.newaxis, :]), expected_vals
+    )
+
+    expected = xr.DataArray(expected_vals, coords={"x": x_val, "y": y_val})
+
+    xr.testing.assert_identical(
+        testfunc(
+            xr.DataArray(x_val, coords={"x": x_val}),
+            xr.DataArray(y_val, coords={"y": y_val}),
+        ),
+        expected,
+    )
 
 
 def test_is_uniform_spaced() -> None:

--- a/tests/utils/test_array.py
+++ b/tests/utils/test_array.py
@@ -32,7 +32,7 @@ def test_broadcast_args() -> None:
     expected = xr.DataArray(expected_vals, coords={"x": x_val, "y": y_val})
 
     xr.testing.assert_identical(
-        testfunc(
+        testfunc_(
             xr.DataArray(x_val, coords={"x": x_val}),
             xr.DataArray(y_val, coords={"y": y_val}),
         ),

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "erlab"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "findiff" },


### PR DESCRIPTION
Numba functions only take pure numpy arrays as input. This PR adds a decorator for jitted functions that broadcasts input DataArrays and passes numpy arrays to the decorated function. If the returned array matches the broadcast shape, the output is converted to a DataArray with the broadcasted coordinates and attributes.