### PR TITLE
Use `libarchive` for unzipping DA30 files if installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "findiff>=0.12.0",
     "h5netcdf>=1.2.0",
-    "igor2>=0.5.9",
+    "igor2>=0.5.12",
     "joblib>=1.3.2",
     "lazy-loader>=0.4",
     "lmfit>=1.3.2",
@@ -38,13 +38,13 @@ dependencies = [
     "tqdm>=4.66.2",
     "varname>=0.13.0",
     "xarray>=2024.10.0",
-    "xarray-lmfit>=0.1.2",
+    "xarray-lmfit>=0.2.1",
 ]
 
 [project.optional-dependencies]
 complete = ["erlab[viz,io,perf,misc]"]
 viz = ["hvplot", "ipywidgets"]
-io = ["astropy>=5.1.1", "nexusformat>=1.0.6"]
+io = ["astropy>=5.1.1", "libarchive-c>=5.2", "nexusformat>=1.0.6"]
 perf = ["numbagg>=0.8.1"]
 misc = ["iminuit>=2.25.2", "csaps>=1.1.0", "dask>=2024.4.1"]
 

--- a/src/erlab/io/dataloader.py
+++ b/src/erlab/io/dataloader.py
@@ -327,6 +327,16 @@ class LoaderBase(metaclass=_Loader):
     is `False`.
     """
 
+    parallel_kwargs: typing.ClassVar[dict[str, typing.Any]] = {"n_jobs": -1}
+    """
+    Additional keyword arguments to be passed to :class:`joblib.Parallel` when loading
+    files in parallel. The default is to use all available CPU cores.
+
+    Set this attribute to configure the default behavior per loader.
+
+    .. versionadded:: 3.9.0
+    """
+
     skip_validate: bool = False
     """
     If `True`, validation checks will be skipped. If `False`, data will be checked with
@@ -1948,7 +1958,7 @@ class LoaderBase(metaclass=_Loader):
 
         if parallel:
             with erlab.utils.parallel.joblib_progress(**tqdm_kw) as _:
-                return joblib.Parallel(n_jobs=-1, max_nbytes=None)(
+                return joblib.Parallel(**self.parallel_kwargs)(
                     joblib.delayed(_load_func)(f) for f in file_paths
                 )
 

--- a/src/erlab/io/plugins/da30.py
+++ b/src/erlab/io/plugins/da30.py
@@ -7,6 +7,7 @@ Omicron's DA30 analyzer using ``SES.exe``. Subclass to implement the actual load
 __all__ = ["CasePreservingConfigParser", "DA30Loader", "load_zip", "parse_ini"]
 
 import configparser
+import importlib
 import os
 import pathlib
 import re
@@ -165,11 +166,10 @@ def load_zip(
 
     if zipped:
         if use_libarchive:
+            use_libarchive = importlib.util.find_spec("libarchive") is not None
             # Check if libarchive is available
-            try:
+            if use_libarchive:
                 import libarchive
-            except ImportError:
-                use_libarchive = False
 
         zf = zipfile.ZipFile(filename, mode="r", allowZip64=False)
         f_names = zf.namelist()

--- a/src/erlab/io/plugins/erpes.py
+++ b/src/erlab/io/plugins/erpes.py
@@ -142,6 +142,8 @@ class ERPESLoader(DA30Loader):
 
     always_single = False
 
+    parallel_kwargs: typing.ClassVar[dict] = {"n_jobs": -1, "prefer": "threads"}
+
     _PATTERN_MULTIFILE = re.compile(r".*\d{4}_S\d{5}.(pxt|zip)")
     _PATTERN_PREFIX = re.compile(r"(.*?)\d{4}(?:_S\d{5})?.(pxt|zip)")
     _PATTERN_FILENO = re.compile(r".*?(\d{4})(?:_S\d{5})?")

--- a/tests/io/plugins/test_da30.py
+++ b/tests/io/plugins/test_da30.py
@@ -33,3 +33,14 @@ def test_load(expected_dir, args, expected) -> None:
     xr.testing.assert_identical(
         loaded, xr.load_dataarray(expected_dir / expected, engine="h5netcdf")
     )
+
+
+def test_zip_libarchive(data_dir):
+    darr_with_libarchive = erlab.io.plugins.da30.load_zip(
+        data_dir / "f0002.zip", use_libarchive=True, without_values=False
+    )
+    darr_without_libarchive = erlab.io.plugins.da30.load_zip(
+        data_dir / "f0002.zip", use_libarchive=False, without_values=False
+    )
+
+    xr.testing.assert_identical(darr_with_libarchive, darr_without_libarchive)

--- a/uv.lock
+++ b/uv.lock
@@ -604,11 +604,13 @@ complete = [
     { name = "hvplot" },
     { name = "iminuit" },
     { name = "ipywidgets" },
+    { name = "libarchive-c" },
     { name = "nexusformat" },
     { name = "numbagg" },
 ]
 io = [
     { name = "astropy" },
+    { name = "libarchive-c" },
     { name = "nexusformat" },
 ]
 misc = [
@@ -672,11 +674,12 @@ requires-dist = [
     { name = "findiff", specifier = ">=0.12.0" },
     { name = "h5netcdf", specifier = ">=1.2.0" },
     { name = "hvplot", marker = "extra == 'viz'" },
-    { name = "igor2", specifier = ">=0.5.9" },
+    { name = "igor2", specifier = ">=0.5.12" },
     { name = "iminuit", marker = "extra == 'misc'", specifier = ">=2.25.2" },
     { name = "ipywidgets", marker = "extra == 'viz'" },
     { name = "joblib", specifier = ">=1.3.2" },
     { name = "lazy-loader", specifier = ">=0.4" },
+    { name = "libarchive-c", marker = "extra == 'io'", specifier = ">=5.2" },
     { name = "lmfit", specifier = ">=1.3.2" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "nexusformat", marker = "extra == 'io'", specifier = ">=1.0.6" },
@@ -985,14 +988,14 @@ wheels = [
 
 [[package]]
 name = "igor2"
-version = "0.5.11"
+version = "0.5.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/0a/e2ef308e4faae786a60d0b7a15e30c602b3339316b89bd9615541af2b154/igor2-0.5.11.tar.gz", hash = "sha256:32311a429b7dec027609e2d5f2c9bdca632b0cb233760522e6fc995f734bb558", size = 59735 }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/aa/2aadb0fca3dd2361ca6ce613fe4a0827114d63a42956c2b68b3f59f2c784/igor2-0.5.12.tar.gz", hash = "sha256:5a284ac3b7aa6a8a59f28509d06359ea29e08d6f9f563566d2a0f15ea9681893", size = 60174 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/55/7025c4bba012ec42760aba6b94ca4c64a53654257914190d56194c267210/igor2-0.5.11-py3-none-any.whl", hash = "sha256:eaa26d7be61ef5bf7ba8c4e6401c11a5513a50aa62289324b94ad716ccfd25ab", size = 32341 },
+    { url = "https://files.pythonhosted.org/packages/83/99/54e15e833757cb329da14e38e53f94bcf06395904e292e3c8c239c819d56/igor2-0.5.12-py3-none-any.whl", hash = "sha256:1d99b30a3b82710578aafb21fbe02572c59f77ad4daba6d13a952115d200bac6", size = 32427 },
 ]
 
 [[package]]
@@ -1356,6 +1359,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6b/c875b30a1ba490860c93da4cabf479e03f584eba06fe5963f6f6644653d8/lazy_loader-0.4.tar.gz", hash = "sha256:47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1", size = 15431 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/60/d497a310bde3f01cb805196ac61b7ad6dc5dcf8dce66634dc34364b20b4f/lazy_loader-0.4-py3-none-any.whl", hash = "sha256:342aa8e14d543a154047afb4ba8ef17f5563baad3fc610d7b15b213b0f119efc", size = 12097 },
+]
+
+[[package]]
+name = "libarchive-c"
+version = "5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/0d/c45fe1307564cf550a407fca69cab3969a093d1d41bcd633b278440b4c30/libarchive_c-5.2.tar.gz", hash = "sha256:fd44a8e28509af6e78262c98d1a54f306eabd2963dfee57bf298977de5057417", size = 52474 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/ef/b21525339880eda2ee8e9018b7c5f74e1856e5bde257dde54b9e2274b323/libarchive_c-5.2-py3-none-any.whl", hash = "sha256:9e6dfae09c9c47cd9348410967af547efe80dc619e2066f20941b57296f0435a", size = 15690 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.2" },
     { name = "varname", specifier = ">=0.13.0" },
     { name = "xarray", specifier = ">=2024.10.0" },
-    { name = "xarray-lmfit", specifier = ">=0.1.2" },
+    { name = "xarray-lmfit", specifier = ">=0.2.1" },
 ]
 provides-extras = ["complete", "viz", "io", "perf", "misc"]
 
@@ -3374,18 +3374,19 @@ wheels = [
 
 [[package]]
 name = "xarray-lmfit"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
+    { name = "lazy-loader" },
     { name = "lmfit" },
     { name = "numpy" },
     { name = "tqdm" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/ad/2345b25ad5c594d4adb23bf48055b98d2c9cd05d2a05edfa7535674fa504/xarray_lmfit-0.2.0.tar.gz", hash = "sha256:8b9a63471ece9d35b62cfe4a69e58c4bb3f66d74dfedfb89f1cd97a09dfad9ce", size = 157741 }
+sdist = { url = "https://files.pythonhosted.org/packages/50/71/2828734f76a71d1992a35872fe8daf88d2bf17300c0961d44a1d726a57b4/xarray_lmfit-0.2.1.tar.gz", hash = "sha256:eeedb533d9487823ad6c95d36d21b8ba23712be04462a398ad80ab07d6536b21", size = 159334 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/b4/46e85c12757c28206a9e0aff871f2ad4e9b447827260ef6749764f7b51e7/xarray_lmfit-0.2.0-py3-none-any.whl", hash = "sha256:372ea5e1b89da763be0810bf5149865fb493d475f33b9f3cfb23daef08b32068", size = 37004 },
+    { url = "https://files.pythonhosted.org/packages/73/46/85735ab3304926811bca3a869e19edf767c225bd281c4bce858ecaf63797/xarray_lmfit-0.2.1-py3-none-any.whl", hash = "sha256:684b5fe8dc43d935cd062014dfd7acfe93fd045ebf25ff3eaa3c08a4d6912a03", size = 37169 },
 ]
 
 [[package]]


### PR DESCRIPTION
This does not give a large performance boost for loading a single file since most overhead comes from i/o operations. However, when loading a large number of relatively small zip files (compared to memory) at once from multiple threads, it is a few seconds faster, probably because the underlying C library of libarchive releases the GIL.

To try out, install [libarchive](https://github.com/Changaco/python-libarchive-c) with

```bash
pip install libarchive-c
```

or

```bash
conda install -c conda-forge python-libarchive-c
```
