### PR TITLE
feat(io.igor): add support for saving DataArrays to Igor Pro binary files

### DIFF
--- a/docs/source/user-guide/io.ipynb
+++ b/docs/source/user-guide/io.ipynb
@@ -105,9 +105,21 @@
    "source": [
     "### To Igor Pro\n",
     "\n",
-    "As an experimental feature, {func}`save_as_hdf5 <erlab.io.save_as_hdf5>` can save certain DataArrays in a format that is compatible with the Igor Pro HDF5 loader. An [accompanying Igor procedure ](https://github.com/kmnhan/erlabpy/blob/main/PythonInterface.ipf) is available in the repository. If loading in Igor Pro fails, try saving again with all attributes removed.\n",
+    "ERLabPy provides {func}`erlab.io.igor.save_wave` to save simple {class}`xarray.DataArray` objects to Igor Pro binary files (`.ibw`). The DataArray can have up to 4 dimensions, and the coordinates of the dimensions must be uniformly spaced. Also, any non-dimensional coordinates will not be saved.\n",
     "\n",
-    "Alternatively, [igorwriter](https://github.com/t-onoz/igorwriter) can be used to write numpy arrays to ``.ibw`` and ``.itx`` files directly."
+    "\n",
+    "```python\n",
+    "import erlab\n",
+    "\n",
+    "erlab.io.igor.save_wave(data, \"path/to/wave.ibw\")\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, as an experimental feature, {func}`save_as_hdf5 <erlab.io.save_as_hdf5>` can save certain DataArrays in a format that is compatible with the Igor Pro HDF5 loader. An [accompanying Igor procedure ](https://github.com/kmnhan/erlabpy/blob/main/PythonInterface.ipf) is available in the repository. If loading in Igor Pro fails, try saving again with all attributes removed."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "findiff>=0.12.0",
     "h5netcdf>=1.2.0",
     "igor2>=0.5.12",
+    "igorwriter>=0.6.1",
     "joblib>=1.3.2",
     "lazy-loader>=0.4",
     "lmfit>=1.3.2",
@@ -238,12 +239,15 @@ testpaths = "tests"
 minversion = "8.3"
 log_cli_level = "INFO"
 xfail_strict = true
-filterwarnings = ["always"]
+filterwarnings = [
+    "always",
+    'ignore:.*unclosed file.*igorwriter/builtins/.*:ResourceWarning',
+]
 qt_log_level_fail = "CRITICAL"
 qt_log_ignore = [
     "This plugin does not support raise()",
     "This plugin does not support propagateSizeHints()",
-    "Populating font family aliases.*"
+    "Populating font family aliases.*",
 ]
 
 [tool.pytest_env]

--- a/tests/io/test_igor.py
+++ b/tests/io/test_igor.py
@@ -3,7 +3,7 @@ import pytest
 import xarray as xr
 import xarray.testing
 
-from erlab.io.igor import _parse_wave_shape, load_text, load_wave, set_scale
+from erlab.io.igor import _parse_wave_shape, load_text, load_wave, save_wave, set_scale
 
 WAVE0 = xr.DataArray(
     np.linspace(-0.3, 0.7, 6, dtype=np.float32),
@@ -95,4 +95,54 @@ def test_load_text_multiple_waves(datadir) -> None:
         wave = load_text(datadir / "multiple_waves.itx", dtype=np.float32).rename(
             dim_0="W"
         )
+
     xarray.testing.assert_equal(wave, WAVE0)
+
+
+@pytest.mark.parametrize(
+    ("data", "dims", "coords", "name"),
+    [
+        (np.arange(5, dtype=np.float32), ["x"], {"x": np.linspace(0, 4, 5)}, "wave0"),
+        (
+            np.arange(6, dtype=np.float64).reshape(2, 3),
+            ["x", "y"],
+            {"x": np.linspace(0, 1, 2), "y": np.linspace(0, 2, 3)},
+            "mywave",
+        ),
+    ],
+)
+def test_save_wave_roundtrip(tmp_path, data, dims, coords, name):
+    arr = xr.DataArray(data, dims=dims, coords=coords, name=name)
+    path = tmp_path / "test.ibw"
+    save_wave(arr, path)
+    loaded = load_wave(path)
+    xr.testing.assert_allclose(loaded, arr, atol=1e-6)
+
+
+def test_save_wave_non_uniform_coord(tmp_path):
+    arr = xr.DataArray(np.arange(5), dims=["x"], coords={"x": [0, 1, 3, 6, 10]})
+    path = tmp_path / "fail.ibw"
+    with pytest.raises(ValueError, match="not evenly spaced"):
+        save_wave(arr, path)
+
+
+def test_save_wave_extra_coord_warns(tmp_path):
+    arr = xr.DataArray(np.arange(5), dims=["x"], coords={"x": np.arange(5), "foo": 3})
+    path = tmp_path / "warn.ibw"
+    with pytest.warns(UserWarning, match="not a DataArray dimension"):
+        save_wave(arr, path)
+
+
+def test_save_wave_attrs_roundtrip(tmp_path):
+    arr = xr.DataArray(
+        np.arange(3),
+        dims=["x"],
+        coords={"x": np.arange(3)},
+        name="attrwave",
+        attrs={"foo": 42, "bar": "baz"},
+    )
+    path = tmp_path / "attr.ibw"
+    save_wave(arr, path)
+    loaded = load_wave(path)
+    assert loaded.attrs["foo"] == 42
+    assert loaded.attrs["bar"] == "baz"

--- a/uv.lock
+++ b/uv.lock
@@ -585,6 +585,7 @@ dependencies = [
     { name = "findiff" },
     { name = "h5netcdf" },
     { name = "igor2" },
+    { name = "igorwriter" },
     { name = "joblib" },
     { name = "lazy-loader" },
     { name = "lmfit" },
@@ -683,6 +684,7 @@ requires-dist = [
     { name = "h5netcdf", specifier = ">=1.2.0" },
     { name = "hvplot", marker = "extra == 'viz'" },
     { name = "igor2", specifier = ">=0.5.12" },
+    { name = "igorwriter", specifier = ">=0.6.1" },
     { name = "iminuit", marker = "extra == 'misc'", specifier = ">=2.25.2" },
     { name = "ipywidgets", marker = "extra == 'viz'" },
     { name = "joblib", specifier = ">=1.3.2" },
@@ -1004,6 +1006,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/aa/2aadb0fca3dd2361ca6ce613fe4a0827114d63a42956c2b68b3f59f2c784/igor2-0.5.12.tar.gz", hash = "sha256:5a284ac3b7aa6a8a59f28509d06359ea29e08d6f9f563566d2a0f15ea9681893", size = 60174 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/99/54e15e833757cb329da14e38e53f94bcf06395904e292e3c8c239c819d56/igor2-0.5.12-py3-none-any.whl", hash = "sha256:1d99b30a3b82710578aafb21fbe02572c59f77ad4daba6d13a952115d200bac6", size = 32427 },
+]
+
+[[package]]
+name = "igorwriter"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/3c/bcf2f0690d922fb944fcf58206963134f755052c21ef2904fae67928a787/igorwriter-0.6.1.tar.gz", hash = "sha256:8df17b7e880a4129d4958423402d65ef39f3102c1af8a43ba42602b83dfb7e22", size = 24545 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/81/b43b2df94c7e2abd85bd63dfdf7229d33cad65f4395152d5de3d2858b0ee/igorwriter-0.6.1-py2.py3-none-any.whl", hash = "sha256:3e1f915a45dd35ac922ec0e277211fc5bf6feec5d52cb4b745b3dd1da43e282f", size = 18582 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Implemented `save_wave` function in `erlab.io.igor` to save xarray DataArray objects as Igor Pro binary files (.ibw).
- Adds a new dependency: `igorwriter`