### PR TITLE
feat(imagetool.manager): enhance data replacement logic

### DIFF
--- a/src/erlab/interactive/imagetool/_itool.py
+++ b/src/erlab/interactive/imagetool/_itool.py
@@ -76,14 +76,36 @@ def itool(
     replace
         When using the manager, this argument specifies which existing ImageTool windows
         should be replaced with the new data. If the manager is not used, this argument
-        is ignored. The argument can be a single integer or a list of integers
-        specifying the indices of the windows to be replaced. The length of the list
-        must match the number of windows ``data`` is expected to create. All indices
-        must be valid indices of existing ImageTool windows.
+        is ignored. ``replace`` can be set to:
+
+        - `None` (default):
+            No existing windows are replaced. New windows are created for the new data.
+
+        - A single integer:
+            - A valid index of an existing ImageTool window:
+
+                The data in the window with the specified index is replaced with the new
+                data.
+            - A number that is greater by 1 than the largest existing index:
+
+                A new ImageTool window is created with the new data. This is useful when
+                you want to add a new window on initial execution, but want to replace
+                the window with the same index on subsequent calls.
+
+            - A negative integer:
+                The index is interpreted as an index from the end of the list of
+                existing ImageTool windows, sorted by their indices. For example, ``-1``
+                refers to the window with the largest index, ``-2`` to the second
+                largest, and so on.
+
+        - A list of integers:
+
+            A list of integers specifying the indices of the windows to be replaced,
+            each of which is interpreted as described above. The length of the list must
+            match the number of windows ``data`` is expected to create.
 
         If this argument is used, the ``link``, ``link_colors``, and ``kwargs``
-        arguments are ignored, since no new windows are created. The existing windows
-        are updated with the new data.
+        arguments are ignored, since no new windows are created.
     execute
         Whether to execute the Qt event loop and display the window, by default `None`.
         For more information, see :func:`erlab.interactive.utils.setup_qapp`.

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1006,6 +1006,13 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _data_replace(self, data_list: list[xr.DataArray], indices: list[int]) -> None:
         """Replace data in the ImageTool windows with the given data."""
         for darr, idx in zip(data_list, indices, strict=True):
+            if idx < 0:
+                # Replace newest index
+                idx = sorted(self._tool_wrappers.keys())[idx]
+            elif idx == self.next_idx:
+                # If not yet created, add new tool
+                self._data_recv([darr], {})
+                continue
             self.get_tool(idx).slicer_area.set_data(darr)
         self._sigDataReplaced.emit()
 

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -236,10 +236,8 @@ def test_manager_replace(qtbot, test_data) -> None:
     assert manager.get_tool(0).array_slicer.point_value(0) == 144.0
 
     # Replacing 1 should create a new tool
-    with qtbot.wait_signal(manager._sigDataReplaced):
-        itool(test_data**2, manager=True, replace=1)
-
-    assert manager.ntools == 2
+    itool(test_data**2, manager=True, replace=1)
+    qtbot.wait_until(lambda: manager.ntools == 2)
     assert manager.get_tool(1).array_slicer.point_value(0) == 144.0
 
     # Negative indexing

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -235,6 +235,19 @@ def test_manager_replace(qtbot, test_data) -> None:
 
     assert manager.get_tool(0).array_slicer.point_value(0) == 144.0
 
+    # Replacing 1 should create a new tool
+    with qtbot.wait_signal(manager._sigDataReplaced):
+        itool(test_data**2, manager=True, replace=1)
+
+    assert manager.ntools == 2
+    assert manager.get_tool(1).array_slicer.point_value(0) == 144.0
+
+    # Negative indexing
+    with qtbot.wait_signal(manager._sigDataReplaced):
+        itool(test_data, manager=True, replace=-1)
+
+    assert manager.get_tool(1).array_slicer.point_value(0) == 12.0
+
     manager.remove_all_tools()
     qtbot.wait_until(lambda: manager.ntools == 0)
     manager.close()


### PR DESCRIPTION
The `replace` argument for `itool` now supports negative indices to replace the newest ImageTool window, and allows for replacing the next index if it has not yet been created. For example, if you have 2 windows open (indices 0 and 1), you can use `replace=-1` to replace the newest window (index 1) or `replace=2` to create a new window if it does not exist yet.