### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,8 @@
 name: Update changelog
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/kmnhan/erlabpy/security/code-scanning/2](https://github.com/kmnhan/erlabpy/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves reading repository contents and pushing changes, we will set `contents: read` and `contents: write` permissions. The `permissions` block can be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
