### PR TITLE
fix(qsel): handle decreasing coordinates in width-based selection

### DIFF
--- a/docs/source/user-guide/indexing.ipynb
+++ b/docs/source/user-guide/indexing.ipynb
@@ -80,34 +80,10 @@
    "id": "c61ee48d",
    "metadata": {},
    "source": [
-    "We have a three-dimensional array of intensity given in terms of $k_x$, $k_y$, and\n",
-    "binding energy. \n"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "id": "16477885",
-   "metadata": {
-    "editable": true,
-    "raw_mimetype": "text/restructuredtext",
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": [],
-    "vscode": {
-     "languageId": "raw"
-    }
-   },
-   "source": [
-    "For extracting 2D data (cuts and constant energy surfaces) or 1D data (MDCs and EDCs)\n",
-    "given the coordinate values, xarray provides {meth}`sel <xarray.DataArray.sel>`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8b3790ed",
-   "metadata": {},
-   "source": [
+    "We have a three-dimensional array of intensity given in terms of $k_x$, $k_y$, and binding energy.\n",
+    "\n",
+    "For extracting 2D data (cuts and constant energy surfaces) or 1D data (MDCs and EDCs) given the coordinate values, xarray provides {meth}`xarray.DataArray.sel`.\n",
+    "\n",
     "Let's extract a cut along $k_y = 0.3$."
    ]
   },
@@ -443,7 +419,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "erlab",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -457,7 +433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When performing width-based selection with `qsel` on a coordinate that is not increasing, the selection would result in an empty array. This fix ensures that the slice direction matches the coordinate order, allowing for correct selection regardless of whether the coordinate is increasing or decreasing. Also resolves issues with `qsel.average` with non-uniform coordinates.