### PR TITLE
fix(io): suppress xarray warnings due to new defaults introduced in pydata/xarray#10062

### DIFF
--- a/src/erlab/io/dataloader.py
+++ b/src/erlab/io/dataloader.py
@@ -1648,9 +1648,11 @@ class LoaderBase(metaclass=_Loader):
                         typing.cast(
                             "Sequence[xr.DataArray] | Sequence[xr.Dataset]", data_list
                         ),
-                        combine_attrs=self.combine_attrs,
-                        data_vars="all",
+                        compat="no_conflicts",
+                        data_vars=None,
+                        coords="all",
                         join="exact",
+                        combine_attrs=self.combine_attrs,
                     )
                 except Exception as e:
                     raise RuntimeError(
@@ -1715,7 +1717,9 @@ class LoaderBase(metaclass=_Loader):
             # Magically combine the data
             combined = xr.combine_by_coords(
                 processed,
-                data_vars="all",
+                compat="no_conflicts",
+                data_vars=None,
+                coords="different",
                 join="outer",
                 combine_attrs=self.combine_attrs,
             )


### PR DESCRIPTION
xarray 2025.8.0 deprecates some default arguments to concat, etc.
We switch data_vars to the new default `None` (`all` when concatenating along a new dimension, `minimal` when concatenating along an existing dimension).

However, we have to keep `compat="no_conflicts"` although it is slow to ensure coords are  concatenated correctly; other options will lead to NaN coordinates being ignored during concatenation. The same goes for `coords="different"`.