### PR TITLE
perf(imagetool): greatly improve performance for dask-based data

### DIFF
--- a/tests/interactive/imagetool/test_watcher.py
+++ b/tests/interactive/imagetool/test_watcher.py
@@ -346,8 +346,8 @@ def test_watcher_real(
         assert text == "Variable synced with IPython"
 
         # Update data
-        ip_session.user_ns["darr"] = darr**2
         with qtbot.wait_signal(manager.server.sigWatchedVarChanged):
+            ip_session.user_ns["darr"] = darr**2
             watcher._maybe_push()
 
         xr.testing.assert_equal(


### PR DESCRIPTION
Previously, indexing/slicing/averaging was done for all plots individually. This commit changes the behavior for dask-based data so that `dask.compute` is now called only once for a given update, which greatly improves performance when working with dask. Regular data retains the original behavior, but should benefit from additional optimizations such as improved signal handling when moving multiple cursors simultaneously and ignored image updates for plots that are hidden.