### PR TITLE
feat(imagetool): add polygon ROI support

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -26,7 +26,7 @@ Inspired by *Image Tool* for Igor Pro, developed by the Advanced Light Source at
 - Easy size adjustment
 - Advanced colormap controls
 - Support for dask-backed data
-- Interactive editing: rotation, normalization, cropping, momentum conversion, and more
+- Interactive editing: rotation, normalization, cropping, momentum conversion, ROIs, and more
 
 ## Getting started
 
@@ -90,7 +90,7 @@ There are several ways to display data in ImageTool:
 
 - Most actions have associated keyboard shortcuts. Explore the menu bar to learn them.
 
-- Right-click on plots for context menus with options like copying slicing code, locking aspect ratio, exporting to a file, opening various tools, and more.
+- Right-click on plots for context menus with options like copying slicing code, locking aspect ratio, exporting to a file, opening various tools, creating ROIs, and more.
 
   :::{hint}
   Holding {kbd}`Alt` inside the context menu will transform some menu items to work with the data cropped to the currently visible area.

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -535,6 +535,14 @@ def _parse_single_arg(arg):
             + ", ".join([f'"{k}": {_parse_single_arg(v)}' for k, v in arg.items()])
             + "}"
         )
+    elif isinstance(arg, np.ndarray):
+        arg = np.array2string(
+            arg,
+            separator=", ",
+            threshold=sys.maxsize,
+            formatter={"float_kind": lambda v: np.format_float_positional(v, trim="-")},
+        ).replace("\n", "")
+        arg = f"np.array({arg})"
 
     return arg
 


### PR DESCRIPTION
This commit introduces support for polygonal Regions of Interest (ROIs) in ImageTool. For each image plot, users can now create a polygon or line ROI from the right-click context menu. The created ROI can be manipulated by dragging its vertices. New vertices can be added by clicking on the edges of the polygon, and existing vertices can be removed by right-clicking on them. The right-click context menu of a ROI also includes options such as editing the ROI's coordinates directly, deleting the ROI, and multidimensional slicing of the data along the edges of the ROI or masking within the polygonal area.