### PR TITLE
Io-chunks

### DIFF
--- a/src/erlab/io/plugins/da30.py
+++ b/src/erlab/io/plugins/da30.py
@@ -59,6 +59,7 @@ class DA30Loader(LoaderBase):
     def load_single(
         self,
         file_path: str | os.PathLike,
+        *,
         without_values: bool = False,
         use_libarchive: bool = True,
     ) -> xr.DataArray | xr.DataTree:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,10 @@ from erlab.interactive.utils import _WaitDialog
 from erlab.io.dataloader import LoaderBase
 from erlab.io.exampledata import generate_data_angles, generate_gold_edge
 
-DATA_COMMIT_HASH = "065632d4c5865ce6012c4b7cdc568af3db506104"
+DATA_COMMIT_HASH = "e16f40ad67345a07435afbbc1928568db0f4c71c"
 """The commit hash of the commit to retrieve from `kmnhan/erlabpy-data`."""
 
-DATA_KNOWN_HASH = "892783c7c5030aea81d437d9344947632d17bbd28794c67f09d6a9746e79dce1"
+DATA_KNOWN_HASH = "1236511ac3b6b6f85a07246f6df52db2580404a56679ac63cabe4dc246b2b405"
 """The SHA-256 checksum of the `.tar.gz` file."""
 
 log = logging.getLogger(__name__)

--- a/tests/io/plugins/test_ssrl52.py
+++ b/tests/io/plugins/test_ssrl52.py
@@ -16,6 +16,7 @@ def expected_dir(data_dir):
     return data_dir / "expected"
 
 
+@pytest.mark.parametrize("chunks", [None, "auto"], ids=["no_chunks", "auto_chunks"])
 @pytest.mark.parametrize(
     ("args", "expected"),
     [
@@ -25,8 +26,15 @@ def expected_dir(data_dir):
         ({"identifier": 2, "zap": True}, "f_zap_0002.h5"),
     ],
 )
-def test_load(expected_dir, args, expected) -> None:
-    loaded = erlab.io.load(**args) if isinstance(args, dict) else erlab.io.load(args)
+def test_load(expected_dir, args, expected, chunks) -> None:
+    loaded = (
+        erlab.io.load(**args, chunks=chunks)
+        if isinstance(args, dict)
+        else erlab.io.load(args, chunks=chunks)
+    )
+
+    if chunks is not None:
+        assert loaded.chunks is not None
 
     xr.testing.assert_identical(
         loaded, xr.load_dataarray(expected_dir / expected, engine="h5netcdf")

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from erlab.utils.misc import accepts_kwarg
+
+
+def test_accepts_kwarg_explicit_positional_or_keyword() -> None:
+    def func(a, b=1) -> None:
+        return None
+
+    assert accepts_kwarg(func, "b")
+
+
+def test_accepts_kwarg_explicit_keyword_only() -> None:
+    def func(a, *, c=1) -> None:
+        return None
+
+    assert accepts_kwarg(func, "c")
+
+
+def test_accepts_kwarg_positional_only() -> None:
+    def func(a, /, b) -> None:
+        return None
+
+    assert not accepts_kwarg(func, "a")
+    assert accepts_kwarg(func, "b")
+
+
+def test_accepts_kwarg_requires_explicit_when_strict() -> None:
+    def func(**kwargs) -> None:
+        return None
+
+    assert not accepts_kwarg(func, "missing")
+
+
+def test_accepts_kwarg_allows_kwargs_when_not_strict() -> None:
+    def func(**kwargs) -> None:
+        return None
+
+    assert accepts_kwarg(func, "missing", strict=False)
+
+
+def test_accepts_kwarg_missing_parameter() -> None:
+    def func(a, b) -> None:
+        return None
+
+    assert not accepts_kwarg(func, "c")


### PR DESCRIPTION
Some supported loaders (`erpes`, `maestro`, `ssrl52`) now accept a `chunks` argument in `erlab.io.load`. Users can control the chunk size when loading large datasets to optimize memory usage and performance. The default chunking is `None`.