### PR TITLE
feat(imagetool.manager): add reusable watch API and deprecate low-level watch transports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ When changing docs content or URLs, verify that `skills/arpes-analysis/SKILL.md`
 
 Use 4-space indentation, Ruff’s 88-character limit, and double quotes. Modules/functions stay snake_case, classes use CapWords. Some Qt widgets keep co-located `.ui` files, import bindings through `qtpy`, and rely on explicit enums such as `QtCore.Qt.CheckState.Checked`. In case of Qt imports, prefer `from qtpy import QtWidgets, QtCore, QtGui`. Install `prek` so Ruff, mypy, and commitizen hooks run automatically. Docstrings use NumPy style. It is recommended to follow PEP 484 type hinting for all public APIs.
 Prefer importing top-level `erlab` in modules that already use `lazy_loader`, even if a narrower import is possible.
+Follow package import conventions by preferring absolute imports over relative imports.
 
 ## Testing Guidelines
 
@@ -43,6 +44,8 @@ Pytest enforces strict markers and `xfail_strict`; name files `test_<feature>.py
 - Do not make runtime code behave differently under pytest (e.g., `PYTEST_VERSION`, `sys.modules["pytest"]`, or test-only env checks in `src/`). Keep production behavior explicit via function arguments/state, and implement test-specific behavior in tests/fixtures/monkeypatching instead.
 - If a code path already shows an explicit UI dialog (`MessageDialog`/`QMessageBox`), avoid duplicate manager alert popups by logging with `extra={"suppress_ui_alert": True}`.
 - `# pragma: no cover` / `# pragma: no branch` is allowed for edge cases that are hard or impractical to exercise in CI; prefer tests when feasible and add a brief comment explaining why the pragma is needed.
+- Do not export private compatibility shims only for monkeypatched tests; update tests to patch the real module/function location instead.
+- Keep watcher semantics stable for IPython users when adding non-IPython support; validate both post-run-cell (IPython) and polling fallback (e.g., marimo/plain namespace) paths in tests.
 
 ## Commit & Pull Request Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ When changing docs content or URLs, verify that `skills/arpes-analysis/SKILL.md`
 Use 4-space indentation, Ruff’s 88-character limit, and double quotes. Modules/functions stay snake_case, classes use CapWords. Some Qt widgets keep co-located `.ui` files, import bindings through `qtpy`, and rely on explicit enums such as `QtCore.Qt.CheckState.Checked`. In case of Qt imports, prefer `from qtpy import QtWidgets, QtCore, QtGui`. Install `prek` so Ruff, mypy, and commitizen hooks run automatically. Docstrings use NumPy style. It is recommended to follow PEP 484 type hinting for all public APIs.
 Prefer importing top-level `erlab` in modules that already use `lazy_loader`, even if a narrower import is possible.
 Follow package import conventions by preferring absolute imports over relative imports.
+Use modern typing syntax as a default rule: use built-in generics (`list[str]`, `dict[str, int]`) and `collections.abc` types (for example `Callable`), and avoid deprecated `typing` aliases (deprecated since Python 3.9).
 
 ## Testing Guidelines
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -200,7 +200,7 @@ If a variable is deleted or replaced with a non-`DataArray`, the manager automat
 When a notebook kernel shuts down, watched windows remain open in  but no longer synchronize. Use {guilabel}`Stop Watching` or run `%watch -z` before closing the kernel to avoid confusion. Variables watched from different notebooks are color-coded for clarity.
 :::
 
-#### Watching outside IPython (for example, marimo)
+#### Outside IPython (e.g., marimo notebooks)
 
 If `%watch` is not available, use the Python API directly:
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -200,6 +200,36 @@ If a variable is deleted or replaced with a non-`DataArray`, the manager automat
 When a notebook kernel shuts down, watched windows remain open in  but no longer synchronize. Use {guilabel}`Stop Watching` or run `%watch -z` before closing the kernel to avoid confusion. Variables watched from different notebooks are color-coded for clarity.
 :::
 
+#### Watching outside IPython (for example, marimo)
+
+If `%watch` is not available, use the Python API directly:
+
+```python
+from erlab.interactive.imagetool.manager import watch
+
+# Start watching a DataArray
+watch("my_data")
+
+# Stop watching one variable
+watch("my_data", stop=True)
+
+# Stop watching everything
+watch(stop_all=True)
+```
+
+In non-IPython environments, watcher updates use a polling fallback. You can adjust the
+frequency with `poll_interval_s` if needed:
+
+```python
+watch("my_data", poll_interval_s=0.5)
+```
+
+:::{note}
+
+{func}`watch <erlab.interactive.imagetool.manager.watch>` can infer a namespace automatically, but providing an explicit `namespace=` argument is safer when you call it indirectly (for example, from helper functions, callbacks, or wrappers) where the caller scope may not be obvious. In those cases, pass the exact mapping you want to watch, like `namespace=globals()`.
+
+:::
+
 (imagetool-manager-fetch)=
 
 ### Accessing manager data programmatically

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -217,12 +217,15 @@ watch("my_data", stop=True)
 watch(stop_all=True)
 ```
 
-In non-IPython environments, watcher updates use a polling fallback. You can adjust the
-frequency with `poll_interval_s` if needed:
+In non-IPython environments, watcher updates falls back to polling, which periodically checks for changes in the watched variables. You can adjust the frequency with `poll_interval_s` if needed:
 
 ```python
 watch("my_data", poll_interval_s=0.5)
 ```
+
+Alternately, you can force an immediate check for changes with {func}`maybe_push <erlab.interactive.imagetool.manager.maybe_push>` instead of waiting for the next poll.
+
+Use {func}`shutdown <erlab.interactive.imagetool.manager.shutdown>` to stop threads cleanly.
 
 :::{note}
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -248,7 +248,7 @@ show_in_manager([data_a, data_b], link=True)
 show_in_manager(new_data, replace=3)
 ```
 
-Additional functions such as {func}`replace_data <erlab.interactive.imagetool.manager.replace_data>`, {func}`watch_data <erlab.interactive.imagetool.manager.watch_data>`, and {func}`unwatch_data <erlab.interactive.imagetool.manager.unwatch_data>` give you finer control when building custom acquisition pipelines.
+Additional functions such as {func}`replace_data <erlab.interactive.imagetool.manager.replace_data>` and {func}`watch <erlab.interactive.imagetool.manager.watch>` give you finer control when building custom acquisition pipelines.
 
 Under the hood these helpers communicate with the GUI via ZeroMQ, so they can be called from any Python process that can reach the manager (even on a different machine). See the API docs for details.
 

--- a/src/erlab/interactive/__init__.py
+++ b/src/erlab/interactive/__init__.py
@@ -60,7 +60,7 @@ def load_ipython_extension(ipython) -> None:
     ipython.register_magics(ImageToolMagics)
 
     # %watch magic
-    from erlab.interactive.imagetool.manager._watcher import (
+    from erlab.interactive.imagetool.manager._watcher._ipython import (
         WatcherMagics,
         enable_ipython_auto_push,
     )

--- a/src/erlab/interactive/__init__.py
+++ b/src/erlab/interactive/__init__.py
@@ -60,11 +60,14 @@ def load_ipython_extension(ipython) -> None:
     ipython.register_magics(ImageToolMagics)
 
     # %watch magic
-    from erlab.interactive.imagetool.manager._watcher import WatcherMagics
+    from erlab.interactive.imagetool.manager._watcher import (
+        WatcherMagics,
+        enable_ipython_auto_push,
+    )
 
     watcher_magics = WatcherMagics(ipython)
     ipython.register_magics(watcher_magics)
-    ipython.events.register("post_run_cell", watcher_magics._watcher._maybe_push)
+    enable_ipython_auto_push(ipython)
 
     # Other tools
     from erlab.interactive._magic import InteractiveToolMagics
@@ -73,7 +76,8 @@ def load_ipython_extension(ipython) -> None:
 
 
 def unload_ipython_extension(ipython) -> None:
-    watcher_magics = ipython.magics_manager.registry.get("WatcherMagics")
-    watcher_magics._watcher.stop_watching_all()
-    watcher_magics._watcher.shutdown()
-    ipython.events.unregister("post_run_cell", watcher_magics._watcher._maybe_push)
+    from erlab.interactive.imagetool.manager._watcher import (
+        shutdown as shutdown_watcher,
+    )
+
+    shutdown_watcher(shell=ipython)

--- a/src/erlab/interactive/imagetool/manager/__init__.py
+++ b/src/erlab/interactive/imagetool/manager/__init__.py
@@ -36,9 +36,12 @@ __all__ = [
     "is_running",
     "load_in_manager",
     "main",
+    "maybe_push",
     "replace_data",
     "show_in_manager",
+    "shutdown",
     "watch",
+    "watched_variables",
 ]
 
 
@@ -70,7 +73,12 @@ from erlab.interactive.imagetool.manager._server import (
     replace_data,
     show_in_manager,
 )
-from erlab.interactive.imagetool.manager._watcher import watch
+from erlab.interactive.imagetool.manager._watcher import (
+    maybe_push,
+    shutdown,
+    watch,
+    watched_variables,
+)
 from erlab.interactive.utils import MessageDialog
 
 logger = logging.getLogger(__name__)

--- a/src/erlab/interactive/imagetool/manager/__init__.py
+++ b/src/erlab/interactive/imagetool/manager/__init__.py
@@ -38,8 +38,7 @@ __all__ = [
     "main",
     "replace_data",
     "show_in_manager",
-    "unwatch_data",
-    "watch_data",
+    "watch",
 ]
 
 
@@ -49,6 +48,7 @@ import pathlib
 import shutil
 import sys
 import typing
+import warnings
 
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -62,14 +62,15 @@ from erlab.interactive.imagetool.manager._server import (
     HOST_IP,
     PORT,
     PORT_WATCH,
+    _unwatch_data,
+    _watch_data,
     fetch,
     is_running,
     load_in_manager,
     replace_data,
     show_in_manager,
-    unwatch_data,
-    watch_data,
 )
+from erlab.interactive.imagetool.manager._watcher import watch
 from erlab.interactive.utils import MessageDialog
 
 logger = logging.getLogger(__name__)
@@ -80,6 +81,36 @@ _manager_instance: ImageToolManager | None = None
 
 _always_use_socket: bool = False
 """Internal flag to use sockets within same process for test coverage."""
+
+
+def watch_data(varname: str, uid: str, data, show: bool = False) -> None:
+    """Compatibility wrapper for the internal watch transport API.
+
+    .. deprecated:: 3.20.0
+       Use :func:`watch` instead.
+    """
+    warnings.warn(
+        "`watch_data` is deprecated and will become private. "
+        "Use `erlab.interactive.imagetool.manager.watch` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _watch_data(varname, uid, data, show=show)
+
+
+def unwatch_data(uid: str, remove: bool = False):
+    """Compatibility wrapper for the internal unwatch transport API.
+
+    .. deprecated:: 3.20.0
+       Use :func:`watch` with ``stop`` options instead.
+    """
+    warnings.warn(
+        "`unwatch_data` is deprecated and will become private. "
+        "Use `erlab.interactive.imagetool.manager.watch(..., stop=True)` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _unwatch_data(uid, remove=remove)
 
 
 class _ManagerApp(QtWidgets.QApplication):

--- a/src/erlab/interactive/imagetool/manager/_server.py
+++ b/src/erlab/interactive/imagetool/manager/_server.py
@@ -12,8 +12,6 @@ __all__ = [
     "load_in_manager",
     "replace_data",
     "show_in_manager",
-    "unwatch_data",
-    "watch_data",
 ]
 
 
@@ -27,6 +25,7 @@ import pickle
 import socket
 import threading
 import typing
+import warnings
 
 import numpy as np
 import pydantic
@@ -782,7 +781,7 @@ def replace_data(
 
 
 @_manager_running
-def watch_data(varname: str, uid: str, data: xr.DataArray, show: bool = False) -> None:
+def _watch_data(varname: str, uid: str, data: xr.DataArray, show: bool = False) -> None:
     """Add or update a watched variable in the ImageToolManager.
 
     Parameters
@@ -808,7 +807,7 @@ def watch_data(varname: str, uid: str, data: xr.DataArray, show: bool = False) -
 
 
 @_manager_running
-def unwatch_data(uid: str, remove: bool = False) -> Response:
+def _unwatch_data(uid: str, remove: bool = False) -> Response:
     """Cancel watching a variable in the ImageToolManager.
 
     Parameters
@@ -826,6 +825,37 @@ def unwatch_data(uid: str, remove: bool = False) -> Response:
     return _query_zmq(
         CommandPacket(packet_type="command", command="unwatch-uid", command_arg=uid)
     )
+
+
+def watch_data(varname: str, uid: str, data: xr.DataArray, show: bool = False) -> None:
+    """Compatibility wrapper for :func:`_watch_data`.
+
+    .. deprecated:: 3.20.0
+       Use :func:`erlab.interactive.imagetool.manager.watch` instead.
+    """
+    warnings.warn(
+        "`watch_data` is deprecated and will become private. "
+        "Use `erlab.interactive.imagetool.manager.watch` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _watch_data(varname, uid, data, show=show)
+
+
+def unwatch_data(uid: str, remove: bool = False) -> Response:
+    """Compatibility wrapper for :func:`_unwatch_data`.
+
+    .. deprecated:: 3.20.0
+       Use :func:`erlab.interactive.imagetool.manager.watch` with ``stop`` options
+       instead.
+    """
+    warnings.warn(
+        "`unwatch_data` is deprecated and will become private. "
+        "Use `erlab.interactive.imagetool.manager.watch(..., stop=True)` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _unwatch_data(uid, remove=remove)
 
 
 def _remove_idx(index: int) -> Response:

--- a/src/erlab/interactive/imagetool/manager/_watcher/__init__.py
+++ b/src/erlab/interactive/imagetool/manager/_watcher/__init__.py
@@ -1,0 +1,24 @@
+"""Watch DataArray changes and synchronize them with ImageTool manager."""
+
+__all__ = [
+    "WatcherMagics",
+    "_core",
+    "_ipython",
+    "enable_ipython_auto_push",
+    "maybe_push",
+    "shutdown",
+    "watch",
+    "watched_variables",
+]
+
+from erlab.interactive.imagetool.manager._watcher import _core, _ipython
+from erlab.interactive.imagetool.manager._watcher._core import (
+    maybe_push,
+    shutdown,
+    watch,
+    watched_variables,
+)
+from erlab.interactive.imagetool.manager._watcher._ipython import (
+    WatcherMagics,
+    enable_ipython_auto_push,
+)

--- a/src/erlab/interactive/imagetool/manager/_watcher/__init__.py
+++ b/src/erlab/interactive/imagetool/manager/_watcher/__init__.py
@@ -1,24 +1,15 @@
 """Watch DataArray changes and synchronize them with ImageTool manager."""
 
 __all__ = [
-    "WatcherMagics",
-    "_core",
-    "_ipython",
-    "enable_ipython_auto_push",
     "maybe_push",
     "shutdown",
     "watch",
     "watched_variables",
 ]
 
-from erlab.interactive.imagetool.manager._watcher import _core, _ipython
 from erlab.interactive.imagetool.manager._watcher._core import (
     maybe_push,
     shutdown,
     watch,
     watched_variables,
-)
-from erlab.interactive.imagetool.manager._watcher._ipython import (
-    WatcherMagics,
-    enable_ipython_auto_push,
 )

--- a/src/erlab/interactive/imagetool/manager/_watcher/_core.py
+++ b/src/erlab/interactive/imagetool/manager/_watcher/_core.py
@@ -618,5 +618,9 @@ def shutdown(
     if watcher is None:
         return
 
-    watcher.stop_watching_all(remove=remove)
-    watcher.shutdown()
+    try:
+        watcher.stop_watching_all(remove=remove)
+    except Exception:
+        logger.exception("Failed to unwatch one or more variables during shutdown")
+    finally:
+        watcher.shutdown()

--- a/src/erlab/interactive/imagetool/manager/_watcher/_ipython.py
+++ b/src/erlab/interactive/imagetool/manager/_watcher/_ipython.py
@@ -1,0 +1,135 @@
+"""IPython-specific watcher integration (magics and shell hooks)."""
+
+from __future__ import annotations
+
+import contextlib
+import typing
+
+from erlab.interactive.imagetool.manager._watcher._core import (
+    _display_message,
+    _get_or_create_watcher,
+    _register_post_run_cell_callback,
+    _ShellProtocol,
+    _Watcher,
+    watch,
+    watched_variables,
+)
+
+if typing.TYPE_CHECKING:
+    from IPython.core.interactiveshell import InteractiveShell
+
+try:
+    import IPython
+    from IPython.core.magic import Magics, line_magic, magics_class
+    from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+except ImportError as e:
+    raise ImportError(
+        "The `IPython` package is required for IPython integration"
+    ) from e
+
+
+def _safe_get_ipython_shell() -> _ShellProtocol | None:
+    with contextlib.suppress(Exception):
+        shell = IPython.get_ipython()
+        if shell is not None and hasattr(shell, "user_ns"):
+            return shell
+    return None
+
+
+def enable_ipython_auto_push(shell: _ShellProtocol | None = None) -> _Watcher:
+    """Enable post-cell synchronization for an IPython shell."""
+    shell_obj = shell or _safe_get_ipython_shell()
+    if shell_obj is None:
+        raise RuntimeError("No active IPython shell found")
+
+    watcher, key = _get_or_create_watcher(shell=shell_obj)
+    _register_post_run_cell_callback(shell_obj, watcher, key)
+    return watcher
+
+
+@magics_class
+class WatcherMagics(Magics):
+    def __init__(self, shell) -> None:
+        # You must call the parent constructor
+        super().__init__(shell)
+        self._watcher, _ = _get_or_create_watcher(shell=self._typed_shell)
+
+    @property
+    def _typed_shell(self) -> InteractiveShell:
+        shell = self.shell
+        if shell is None:
+            raise RuntimeError("IPython shell is not available")
+        return shell
+
+    @magic_arguments()
+    @argument(
+        "-d", action="store_true", help="Stop watching the specified variable(s)."
+    )
+    @argument("-x", action="store_true", help="Remove from manager.")
+    @argument("-z", action="store_true", help="Stop watching all variables.")
+    @argument("darr", nargs="*", help="DataArray variable(s) to be watched.")
+    @line_magic
+    def watch(self, line) -> None:
+        """Watch DataArray variable(s) and show in ImageTool manager.
+
+        This magic command allows you to watch one or more xarray DataArray variables in
+        your IPython environment. When a watched variable is modified, the changes are
+        applied automatically to the data shown in the ImageTool manager.
+
+        Usage:
+
+        * ``%watch``          - Show list of all watched variables
+
+        * ``%watch spam bar`` - Open the DataArray variables spam and bar and keep
+                                watching for changes
+
+        * ``%watch -d spam``  - Stop watching the variable spam
+
+        * ``%watch -x spam``  - Completely remove the variable spam from the manager
+
+        * ``%watch -z``       - Stop watching all variables
+
+        """
+        args = parse_argstring(self.watch, line)
+        shell = self._typed_shell
+
+        if not args.darr and not args.z:
+            watched = watched_variables(shell=shell)
+            if len(watched) == 0:
+                _display_message("No variables are being watched.")
+                return
+            _display_message(
+                "Currently watched variables:\n"
+                + "\n".join([f" - {v}" for v in watched]),
+                "Currently watched variables:\n"
+                + " ".join([f"<code>{varname}</code>" for varname in watched]),
+            )
+
+            return
+
+        if args.z:
+            watch(shell=shell, stop_all=True, remove=args.x)
+            _display_message("Stopped watching all variables.")
+            return
+
+        watch(
+            *args.darr,
+            shell=shell,
+            stop=args.d or args.x,
+            remove=args.x,
+        )
+
+        if args.d or args.x:
+            _display_message(
+                f"Stopped watching {', '.join(args.darr)}",
+                "⏹️ Stopped watching "
+                + " ".join([f"<code>{varname}</code>" for varname in args.darr]),
+            )
+        else:
+            _display_message(
+                f"Watching {', '.join(args.darr)}",
+                "🔄 Watching "
+                + " ".join([f"<code>{varname}</code>" for varname in args.darr]),
+            )
+
+        return

--- a/tests/interactive/imagetool/test_watcher.py
+++ b/tests/interactive/imagetool/test_watcher.py
@@ -58,6 +58,8 @@ def patch_manager(monkeypatch):
 
     # Patch manager attributes on the already-imported module namespace
     manager = watcher_mod.erlab.interactive.imagetool.manager
+    monkeypatch.setattr(manager, "_watch_data", watch_data, raising=False)
+    monkeypatch.setattr(manager, "_unwatch_data", unwatch_data, raising=False)
     monkeypatch.setattr(manager, "watch_data", watch_data, raising=False)
     monkeypatch.setattr(manager, "unwatch_data", unwatch_data, raising=False)
     monkeypatch.setattr(manager, "fetch", fetch, raising=False)
@@ -272,6 +274,252 @@ def test_stop_watching_all_with_remove(fake_shell, patch_manager, monkeypatch):
     watcher._apply_update_now("asdf", "nonexistent")  # should not raise
 
     watcher.shutdown()
+
+
+def test_watch_api_works_without_ipython_extension(patch_manager, monkeypatch):
+    namespace = {
+        "a": xr.DataArray(np.array([1, 2, 3]), dims=("x",)),
+    }
+
+    monkeypatch.setattr(_Watcher, "start_thread", lambda self: None)
+    monkeypatch.setattr(_Watcher, "start_polling", lambda self, interval_s=0.25: None)
+
+    try:
+        watched = watcher_mod.watch("a", namespace=namespace)
+        assert watched == ("a",)
+        assert watcher_mod.watched_variables(namespace=namespace) == ("a",)
+
+        namespace["a"] = xr.DataArray(np.array([9, 8, 7]), dims=("x",))
+        watcher, _ = watcher_mod._get_or_create_watcher(namespace=namespace)
+        watcher._last_send = 0.0
+        watcher_mod.maybe_push(namespace=namespace)
+
+        assert len(patch_manager["last_watch_calls"]) == 2
+        assert np.array_equal(
+            patch_manager["last_watch_calls"][-1][2].values, namespace["a"].values
+        )
+
+        watcher_mod.watch("a", namespace=namespace, stop=True, remove=True)
+        assert watcher_mod.watched_variables(namespace=namespace) == ()
+        assert patch_manager["last_unwatch_calls"][-1][1] is True
+    finally:
+        watcher_mod.shutdown(namespace=namespace)
+
+
+def test_watch_magic_delegates_to_watch_api(
+    ip_shell: IPython.InteractiveShell, monkeypatch
+):
+    calls = []
+
+    def fake_watch(*varnames, **kwargs):
+        calls.append((varnames, kwargs))
+        return ()
+
+    monkeypatch.setattr(watcher_mod, "watch", fake_watch)
+
+    ip_shell.run_line_magic("watch", "darr")
+    assert calls[-1][0] == ("darr",)
+    assert calls[-1][1]["shell"] is ip_shell
+    assert calls[-1][1]["stop"] is False
+    assert calls[-1][1]["remove"] is False
+
+    ip_shell.run_line_magic("watch", "-d darr")
+    assert calls[-1][0] == ("darr",)
+    assert calls[-1][1]["stop"] is True
+    assert calls[-1][1]["remove"] is False
+
+    ip_shell.run_line_magic("watch", "-x darr")
+    assert calls[-1][0] == ("darr",)
+    assert calls[-1][1]["stop"] is True
+    assert calls[-1][1]["remove"] is True
+
+    ip_shell.run_line_magic("watch", "-z")
+    assert calls[-1][0] == ()
+    assert calls[-1][1]["stop_all"] is True
+    assert calls[-1][1]["remove"] is False
+
+    ip_shell.run_line_magic("watch", "-xz")
+    assert calls[-1][0] == ()
+    assert calls[-1][1]["stop_all"] is True
+    assert calls[-1][1]["remove"] is True
+
+
+def test_watch_magic_lists_currently_watched_variables(
+    ip_shell: IPython.InteractiveShell, monkeypatch
+):
+    messages = []
+
+    monkeypatch.setattr(
+        watcher_mod, "watched_variables", lambda **kwargs: ("alpha", "beta")
+    )
+    monkeypatch.setattr(
+        watcher_mod,
+        "_display_message",
+        lambda message, html=None: messages.append((message, html)),
+    )
+
+    ip_shell.run_line_magic("watch", "")
+
+    assert len(messages) == 1
+    assert "Currently watched variables" in messages[0][0]
+    assert "alpha" in messages[0][0]
+    assert "beta" in messages[0][0]
+
+
+def test_watch_api_fallback_namespace_without_ipython(patch_manager, monkeypatch):
+    monkeypatch.setattr(watcher_mod, "_safe_get_ipython_shell", lambda: None)
+    monkeypatch.setattr(_Watcher, "start_thread", lambda self: None)
+    monkeypatch.setattr(_Watcher, "start_polling", lambda self, interval_s=0.25: None)
+
+    globals()["fallback_darr"] = xr.DataArray(np.array([1, 2, 3]), dims=("x",))
+
+    try:
+        watched = watcher_mod.watch("fallback_darr")
+        assert watched == ("fallback_darr",)
+        assert watcher_mod.watch() == ("fallback_darr",)
+
+        # Trigger fallback path in maybe_push/shutdown when no shell/namespace is given.
+        watcher_mod.maybe_push()
+        watcher_mod.shutdown()
+        assert watcher_mod.watched_variables() == ()
+
+        # No watcher left: should be a no-op.
+        watcher_mod.maybe_push()
+        watcher_mod.shutdown()
+    finally:
+        globals().pop("fallback_darr", None)
+        watcher_mod.shutdown(namespace=globals())
+
+
+def test_watcher_type_error_and_push_failure_cleanup(fake_shell, monkeypatch):
+    fake_shell.user_ns["not_da"] = object()
+    watcher = _Watcher(fake_shell)
+
+    with pytest.raises(TypeError, match=r"is not an xarray\.DataArray"):
+        watcher.watch("not_da")
+
+    fake_shell.user_ns["a"] = xr.DataArray(np.array([1, 2, 3]), dims=("x",))
+    monkeypatch.setattr(watcher, "start_thread", lambda: None)
+    monkeypatch.setattr(
+        watcher_mod.erlab.interactive.imagetool.manager,
+        "_watch_data",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        watcher.watch("a")
+
+    assert "a" not in watcher.watched_vars
+    watcher.shutdown()
+
+
+def test_start_polling_and_poll_loop_branches(fake_shell, monkeypatch):
+    watcher = _Watcher(fake_shell)
+
+    with pytest.raises(ValueError, match="interval_s must be > 0"):
+        watcher.start_polling(0)
+
+    started = {"count": 0}
+
+    class FakeThread:
+        def __init__(self, target, daemon):
+            self.target = target
+            self.daemon = daemon
+
+        def start(self):
+            started["count"] += 1
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(watcher_mod.threading, "Thread", FakeThread)
+    watcher.start_polling(0.1)
+    assert started["count"] == 1
+
+    # Already-running poll thread path.
+    watcher._poll_thread = type(
+        "AliveThread",
+        (),
+        {"is_alive": lambda self: True, "join": lambda self, timeout=None: None},
+    )()
+    watcher.start_polling(0.2)
+    assert started["count"] == 1
+
+    calls = {"count": 0}
+
+    class FakeStop:
+        def __init__(self):
+            self._flags = [False, True]
+
+        def wait(self, _):
+            return self._flags.pop(0)
+
+        def set(self):
+            return None
+
+    watcher._poll_stop = FakeStop()
+
+    def _count_call() -> None:
+        calls["count"] += 1
+
+    monkeypatch.setattr(watcher, "_maybe_push", _count_call)
+    watcher._poll_loop()
+    assert calls["count"] == 1
+
+
+def test_callback_registration_failure_and_enable_auto_push_error(
+    fake_shell, monkeypatch
+):
+    watcher = _Watcher(fake_shell)
+    key = 101
+
+    class FailingEvents:
+        def register(self, *_):
+            raise RuntimeError("register failed")
+
+    fake_shell.events = FailingEvents()
+    assert (
+        watcher_mod._register_post_run_cell_callback(fake_shell, watcher, key) is False
+    )
+    assert key not in watcher_mod._POST_RUN_CELL_CALLBACKS
+
+    # events without unregister should still be handled gracefully.
+    shell_without_unregister = type("ShellNoUnregister", (), {"events": object()})()
+    watcher_mod._POST_RUN_CELL_CALLBACKS[key] = (
+        shell_without_unregister,
+        lambda: None,
+    )
+    watcher_mod._unregister_post_run_cell_callback(key)
+    assert key not in watcher_mod._POST_RUN_CELL_CALLBACKS
+
+    monkeypatch.setattr(watcher_mod, "_safe_get_ipython_shell", lambda: None)
+    with pytest.raises(RuntimeError, match="No active IPython shell found"):
+        watcher_mod.enable_ipython_auto_push()
+
+
+def test_manager_watch_transport_wrappers_are_deprecated(monkeypatch):
+    manager = watcher_mod.erlab.interactive.imagetool.manager
+    calls = {"watch": None, "unwatch": None}
+
+    def _fake_watch(varname, uid, data, show=False):
+        calls["watch"] = (varname, uid, data, show)
+
+    def _fake_unwatch(uid, remove=False):
+        calls["unwatch"] = (uid, remove)
+        return "ok"
+
+    monkeypatch.setattr(manager, "_watch_data", _fake_watch, raising=False)
+    monkeypatch.setattr(manager, "_unwatch_data", _fake_unwatch, raising=False)
+
+    darr = xr.DataArray(np.array([1, 2]), dims=("x",))
+    with pytest.deprecated_call(match="watch_data"):
+        manager.watch_data("darr", "uid-1", darr, show=True)
+    assert calls["watch"] == ("darr", "uid-1", darr, True)
+
+    with pytest.deprecated_call(match="unwatch_data"):
+        response = manager.unwatch_data("uid-1", remove=True)
+    assert response == "ok"
+    assert calls["unwatch"] == ("uid-1", True)
 
 
 def test_watcher_real(


### PR DESCRIPTION
Introduces a thread-safe, module-level watcher API (`watch`, `watched_variables`, `maybe_push`, `shutdown`) that works both with and without the IPython extension (including non-IPython notebook environments like marimo). Refactors `%watch` and extension load/unload to delegate to this shared API, keeping IPython behavior consistent while adding a polling fallback when post-cell hooks are unavailable.

This does not affect behavior for existing users of `%watch` in IPython notebooks, but enables new use cases for programmatic data watching in other contexts.

Also internalize manager transport helpers by moving watcher internals to private `_watch_data` / `_unwatch_data`, keeping public `watch_data` / `unwatch_data` only as deprecated compatibility wrappers.