### PR TITLE
Fix miscellaneous bugs

### DIFF
--- a/src/erlab/analysis/fit/functions/general.py
+++ b/src/erlab/analysis/fit/functions/general.py
@@ -26,7 +26,9 @@ __all__ = [
     "voigt",
 ]
 
+import functools
 from collections.abc import Callable, Sequence
+from typing import cast
 
 import numba
 import numpy as np
@@ -34,6 +36,7 @@ import numpy.typing as npt
 import scipy.integrate
 import scipy.signal
 import scipy.special
+import xarray as xr
 
 from erlab.constants import TINY, kb_eV
 from erlab.utils._array_jit import _clip_tiny
@@ -119,6 +122,86 @@ def _convolve(in1, in2, mode: str = "full"):
     return scipy.signal.convolve(
         in1, in2, mode=mode, method=_choose_conv_method_na(in1, in2, mode)
     )
+
+
+def _apply_ufunc_1d(
+    x: npt.NDArray[np.float64] | xr.DataArray,
+    func: Callable[..., npt.NDArray[np.float64]],
+    **kwargs: float | xr.DataArray,
+) -> npt.NDArray[np.float64] | xr.DataArray:
+    """Apply a 1D function over `x` while broadcasting DataArray parameters."""
+    dataarray_kwargs = {
+        name: value for name, value in kwargs.items() if isinstance(value, xr.DataArray)
+    }
+
+    if isinstance(x, xr.DataArray):
+        x_darr = x
+    elif dataarray_kwargs:
+        used_dims = {dim for value in dataarray_kwargs.values() for dim in value.dims}
+        core_dim = "x"
+        while core_dim in used_dims:
+            core_dim = f"_{core_dim}"
+        x_darr = xr.DataArray(
+            np.asarray(x),
+            dims=(core_dim,),
+            coords={core_dim: x},
+            attrs=next(iter(dataarray_kwargs.values())).attrs,
+        )
+    else:
+        return func(x, **kwargs)
+
+    if x_darr.ndim != 1:
+        raise ValueError("`x` must be a 1-dimensional DataArray.")
+
+    if not dataarray_kwargs:
+        if x_darr.chunks is None:
+            result = func(x_darr.data, **kwargs)
+            return xr.DataArray(
+                result,
+                coords=x_darr.coords,
+                dims=x_darr.dims,
+                attrs=x_darr.attrs,
+            )
+
+        result = xr.apply_ufunc(
+            lambda x_1d: func(x_1d, **kwargs),
+            x_darr,
+            input_core_dims=[[x_darr.dims[0]]],
+            output_core_dims=[[x_darr.dims[0]]],
+            keep_attrs=True,
+            dask="parallelized",
+            output_dtypes=[np.float64],
+        )
+        return result.rename(None)
+
+    core_dim = cast("str", x_darr.dims[0])
+    for name, value in dataarray_kwargs.items():
+        if core_dim in value.dims:
+            raise ValueError(
+                f"`{name}` must not vary along the convolution dimension `{core_dim}`."
+            )
+
+    kw_names = tuple(kwargs)
+    broadcast_dims = xr.broadcast(x_darr, *dataarray_kwargs.values())[0].dims
+
+    def _wrapped(x_1d, *values):
+        return func(x_1d, **dict(zip(kw_names, values, strict=False)))
+
+    result = xr.apply_ufunc(
+        _wrapped,
+        x_darr,
+        *kwargs.values(),
+        input_core_dims=[[core_dim], *[[] for _ in kwargs]],
+        output_core_dims=[[core_dim]],
+        vectorize=True,
+        keep_attrs=True,
+        dask="parallelized",
+        output_dtypes=[np.float64],
+    )
+
+    if result.dims != broadcast_dims:
+        result = result.transpose(*broadcast_dims)
+    return result.rename(None)
 
 
 def do_convolve(
@@ -369,10 +452,12 @@ def fermi_dirac(
     return 1 / (1 + np.exp((1.0 * x - center) / _clip_tiny(temp * kb_eV)))
 
 
-@broadcast_args
 def fermi_dirac_broad(
-    x: npt.NDArray[np.float64], center: float, temp: float, resolution: float
-) -> npt.NDArray[np.float64]:
+    x: npt.NDArray[np.float64] | xr.DataArray,
+    center: float | xr.DataArray,
+    temp: float | xr.DataArray,
+    resolution: float | xr.DataArray,
+) -> npt.NDArray[np.float64] | xr.DataArray:
     r"""Resolution-broadened Fermi edge.
 
     The Fermi edge is calculated as:
@@ -397,18 +482,17 @@ def fermi_dirac_broad(
         The resolution of the Gaussian kernel in eV. Note that this is the FWHM of the
         Gaussian kernel, not the standard deviation.
     """
-    return do_convolve(
+    return _apply_ufunc_1d(
         x,
-        fermi_dirac,
-        resolution=resolution,
+        functools.partial(do_convolve, func=fermi_dirac),
         center=center,
         temp=temp,
+        resolution=resolution,
     )
 
 
 @broadcast_args
 # adapted and improved from KWAN Igor procedures
-@broadcast_args
 @numba.njit(cache=True)
 def fermi_dirac_linbkg(
     x: npt.NDArray[np.float64],
@@ -454,17 +538,16 @@ def fermi_dirac_linbkg(
     )
 
 
-@broadcast_args
 def fermi_dirac_linbkg_broad(
-    x: npt.NDArray[np.float64],
-    center: float,
-    temp: float,
-    resolution: float,
-    back0: float,
-    back1: float,
-    dos0: float,
-    dos1: float,
-) -> npt.NDArray[np.float64]:
+    x: npt.NDArray[np.float64] | xr.DataArray,
+    center: float | xr.DataArray,
+    temp: float | xr.DataArray,
+    resolution: float | xr.DataArray,
+    back0: float | xr.DataArray,
+    back1: float | xr.DataArray,
+    dos0: float | xr.DataArray,
+    dos1: float | xr.DataArray,
+) -> npt.NDArray[np.float64] | xr.DataArray:
     r"""Resolution-broadened Fermi edge with linear backgrounds.
 
     .. math::
@@ -473,12 +556,12 @@ def fermi_dirac_linbkg_broad(
         e^{(x-x_0)/k_B T}} \right] \otimes \text{g}(\sigma)
 
     """
-    return do_convolve(
+    return _apply_ufunc_1d(
         x,
-        fermi_dirac_linbkg,
-        resolution=resolution,
+        functools.partial(do_convolve, func=fermi_dirac_linbkg),
         center=center,
         temp=temp,
+        resolution=resolution,
         back0=back0,
         back1=back1,
         dos0=dos0,
@@ -526,16 +609,15 @@ def _tll_bare(x, amp=1.0, center=0.0, alpha=0.1, temp=10.0):
     )
 
 
-@broadcast_args
 def tll(
-    x: npt.NDArray[np.float64],
-    amp: float = 1.0,
-    center: float = 0.0,
-    alpha: float = 0.1,
-    temp: float = 10.0,
-    resolution: float = 0.01,
-    const_bkg: float = 0.0,
-) -> npt.NDArray[np.float64]:
+    x: npt.NDArray[np.float64] | xr.DataArray,
+    amp: float | xr.DataArray = 1.0,
+    center: float | xr.DataArray = 0.0,
+    alpha: float | xr.DataArray = 0.1,
+    temp: float | xr.DataArray = 10.0,
+    resolution: float | xr.DataArray = 0.01,
+    const_bkg: float | xr.DataArray = 0.0,
+) -> npt.NDArray[np.float64] | xr.DataArray:
     r"""Resolution-broadened Tomonaga-Luttinger liquid (TLL) spectral function.
 
     The TLL spectral function is calculated as :cite:p:`ohtsubo2015tll`:
@@ -574,15 +656,14 @@ def tll(
 
     """
     return (
-        do_convolve(
+        _apply_ufunc_1d(
             x,
-            _tll_bare,
-            resolution=resolution,
+            functools.partial(do_convolve, func=_tll_bare, oversample=5),
             amp=amp,
             center=center,
             alpha=alpha,
             temp=temp,
-            oversample=5,
+            resolution=resolution,
         )
         + const_bkg
     )
@@ -791,17 +872,16 @@ def _sc_spectral_function_bare(x, amp, gamma1, gamma0, delta, lin_bkg, const_bkg
     return amp * akw + (lin_bkg * np.abs(x) + const_bkg)
 
 
-@broadcast_args
 def sc_spectral_function(
-    x: npt.NDArray[np.float64],
-    amp: float = 1.0,
-    gamma1: float = 1e-5,
-    gamma0: float = 0.0,
-    delta: float = 0.0,
-    lin_bkg: float = 0.0,
-    const_bkg: float = 0.0,
-    resolution: float = 0.01,
-) -> npt.NDArray[np.float64]:
+    x: npt.NDArray[np.float64] | xr.DataArray,
+    amp: float | xr.DataArray = 1.0,
+    gamma1: float | xr.DataArray = 1e-5,
+    gamma0: float | xr.DataArray = 0.0,
+    delta: float | xr.DataArray = 0.0,
+    lin_bkg: float | xr.DataArray = 0.0,
+    const_bkg: float | xr.DataArray = 0.0,
+    resolution: float | xr.DataArray = 0.01,
+) -> npt.NDArray[np.float64] | xr.DataArray:
     r"""Resolution-broadened superconducting spectral function.
 
     The superconducting spectral function with a linear background is calculated as:
@@ -837,16 +917,16 @@ def sc_spectral_function(
         The broadening in eV. Note that this is the FWHM of the Gaussian kernel, not the
         standard deviation.
     """
-    return do_convolve(
+    return _apply_ufunc_1d(
         x,
-        _sc_spectral_function_bare,
-        resolution=resolution,
+        functools.partial(do_convolve, func=_sc_spectral_function_bare),
         amp=amp,
         gamma1=gamma1,
         gamma0=gamma0,
         delta=delta,
         lin_bkg=lin_bkg,
         const_bkg=const_bkg,
+        resolution=resolution,
     )
 
 

--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -551,20 +551,20 @@ class BetterColorBarItem(pg.PlotItem):
         # Add colorbar limit editor to context menu
         self.vb.menu.addSeparator()
         self._clim_menu: QtWidgets.QMenu = self.vb.menu.addMenu("Edit color limits")
-        clw = _ColorBarLimitWidget(self)
-        act = QtWidgets.QWidgetAction(self._clim_menu)
-        act.setDefaultWidget(clw)
-        self._clim_menu.addAction(act)
+        self._clim_widget = _ColorBarLimitWidget(self)
+        self._clim_action = QtWidgets.QWidgetAction(self._clim_menu)
+        self._clim_action.setDefaultWidget(self._clim_widget)
+        self._clim_menu.addAction(self._clim_action)
 
-        center_zero_action = self.vb.menu.addAction("Center zero")
-        center_zero_action.triggered.connect(clw.center_zero)
+        self._center_zero_action = self.vb.menu.addAction("Center zero")
+        self._center_zero_action.triggered.connect(self._clim_widget.center_zero)
 
         if show_colormap_edit_menu:
             self._cmap_menu: QtWidgets.QMenu = self.vb.menu.addMenu("Edit colormap")
-            cew = _ColorBarEditWidget(self)
-            act = QtWidgets.QWidgetAction(self._cmap_menu)
-            act.setDefaultWidget(cew)
-            self._cmap_menu.addAction(act)
+            self._cmap_widget = _ColorBarEditWidget(self)
+            self._cmap_action = QtWidgets.QWidgetAction(self._cmap_menu)
+            self._cmap_action.setDefaultWidget(self._cmap_widget)
+            self._cmap_menu.addAction(self._cmap_action)
 
         if image is not None:
             self.setImageItem(image)

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -30,7 +30,7 @@ import numpy as np
 import numpy.typing as npt
 import pyqtgraph as pg
 import xarray as xr
-from qtpy import PYQT6, QtCore, QtGui, QtWidgets, uic
+from qtpy import PYQT6, PYSIDE6, QtCore, QtGui, QtWidgets, uic
 
 import erlab
 
@@ -83,19 +83,45 @@ __all__ = [
 _LOAD_UI_LOCK = threading.RLock()
 
 
-try:
-    from shiboken6 import isValid as _qt_is_valid
-except Exception:  # pragma: no cover - varies by Qt binding
+def _qt_object_is_valid_fallback(arg__1: object) -> bool:
+    return arg__1 is not None
+
+
+def _make_qt_object_is_valid_from_sip(
+    sip_module: typing.Any,
+) -> Callable[[object], bool]:
+    def _qt_object_is_valid(arg__1: object) -> bool:
+        return arg__1 is not None and not sip_module.isdeleted(arg__1)
+
+    return _qt_object_is_valid
+
+
+_qt_object_is_valid: Callable[[object], bool] = _qt_object_is_valid_fallback
+
+
+if PYSIDE6:
     try:
-        import sip  # type: ignore[import-not-found]
+        from shiboken6 import isValid as _shiboken_is_valid
+    except Exception:  # pragma: no cover - varies by Qt binding
+        _qt_object_is_valid = _qt_object_is_valid_fallback
+    else:
 
-        def _qt_is_valid(arg__1: object) -> bool:
-            return arg__1 is not None and not sip.isdeleted(arg__1)
+        def _qt_object_is_valid(arg__1: object) -> bool:
+            return arg__1 is not None and _shiboken_is_valid(arg__1)
 
-    except Exception:  # pragma: no cover - fallback for unknown bindings
+elif PYQT6:
+    try:
+        from PyQt6 import sip as _pyqt6_sip
+    except Exception:  # pragma: no cover - fallback for older sip layouts
+        try:
+            import sip as _legacy_sip  # type: ignore[import-not-found]
+        except Exception:  # pragma: no cover - unknown binding layout
+            _qt_object_is_valid = _qt_object_is_valid_fallback
+        else:
+            _qt_object_is_valid = _make_qt_object_is_valid_from_sip(_legacy_sip)
 
-        def _qt_is_valid(arg__1: object) -> bool:
-            return arg__1 is not None
+    else:
+        _qt_object_is_valid = _make_qt_object_is_valid_from_sip(_pyqt6_sip)
 
 
 def qt_is_valid(*objects: object) -> bool:
@@ -103,14 +129,14 @@ def qt_is_valid(*objects: object) -> bool:
 
     For PySide, uses ``shiboken6.isValid`` to check validity.
 
-    For PyQt, uses ``sip.isdeleted``.
+    For PyQt6, uses ``PyQt6.sip.isdeleted``.
 
     Parameters
     ----------
     *objects
         Objects to validate. ``None`` values are ignored.
     """
-    return all(_qt_is_valid(obj) for obj in objects)
+    return all(obj is None or _qt_object_is_valid(obj) for obj in objects)
 
 
 def single_shot(

--- a/src/erlab/plotting/colors.py
+++ b/src/erlab/plotting/colors.py
@@ -455,7 +455,11 @@ class CenteredInversePowerNorm(CenteredPowerNorm):
 
 
 def get_mappable(
-    ax: matplotlib.axes.Axes, image_only: bool = False, silent: bool = False
+    ax: matplotlib.axes.Axes,
+    index: int = -1,
+    *,
+    image_only: bool = False,
+    silent: bool = False,
 ) -> matplotlib.cm.ScalarMappable | None:
     """Get the `matplotlib.cm.ScalarMappable` from a given `matplotlib.axes.Axes`.
 
@@ -463,6 +467,9 @@ def get_mappable(
     ----------
     ax
         Parent axes.
+    index
+        The index of the mappable to get. By default, the most recently added mappable
+        is returned.
     image_only
         Only consider images as a valid mappable, by default `False`.
     silent
@@ -476,13 +483,13 @@ def get_mappable(
     """
     if not image_only:
         try:
-            mappable: typing.Any = ax.collections[-1]
+            mappable: typing.Any = ax.collections[index]
         except (IndexError, AttributeError):
             mappable = None
 
     if image_only or mappable is None:
         try:
-            mappable = ax.get_images()[-1]
+            mappable = ax.get_images()[index]
         except (IndexError, AttributeError):
             mappable = None
 
@@ -565,6 +572,9 @@ def proportional_colorbar(
     mappable: matplotlib.cm.ScalarMappable | None = None,
     cax: matplotlib.axes.Axes | None = None,
     ax: matplotlib.axes.Axes | Iterable[matplotlib.axes.Axes] | None = None,
+    *,
+    index: int = -1,
+    image_only: bool = False,
     **kwargs,
 ) -> matplotlib.colorbar.Colorbar:
     """
@@ -580,11 +590,18 @@ def proportional_colorbar(
     cax
         Axes into which the colorbar will be drawn.
     ax
-        One or more parent axes from which space for a new colorbar axes
-        will be stolen, if `cax` is `None`.  This has no effect if `cax`
-        is set. If `mappable` is `None` and `ax` is given with more than
-        one Axes, the function will try to infer the mappable from the
-        first one.
+        One or more parent axes from which space for a new colorbar axes will be stolen,
+        if `cax` is `None`.  This has no effect if `cax` is set. If `mappable` is `None`
+        and `ax` is given with more than one Axes, the function will try to infer the
+        mappable from the first one.
+    index
+        If `mappable` is not provided, the index of the mappable to get from `ax`.
+        Passed to :func:`get_mappable`. Default is -1, i.e., the most recently added
+        mappable.
+    image_only
+        If `mappable` is not provided, whether to only consider images as valid
+        mappables when inferring from `ax`. Passed to :func:`get_mappable`. Default is
+        `False`.
     **kwargs
         Extra arguments to `matplotlib.pyplot.colorbar`: refer to the `matplotlib`
         documentation for a list of all possible arguments.
@@ -623,16 +640,21 @@ def proportional_colorbar(
         if cax is None:
             ax = plt.gca()
             if mappable is None:
-                mappable = get_mappable(ax)
+                mappable = get_mappable(ax, index=index, image_only=image_only)
     elif isinstance(ax, Iterable):
         if not isinstance(ax, np.ndarray):
             ax = np.array(ax, dtype=object)
         i = 0
         while mappable is None and i < len(ax.flat):
-            mappable = get_mappable(ax.flatten()[i], silent=(i != (len(ax.flat) - 1)))
+            mappable = get_mappable(
+                ax.flatten()[i],
+                silent=(i != (len(ax.flat) - 1)),
+                index=index,
+                image_only=image_only,
+            )
             i += 1
     elif mappable is None:
-        mappable = get_mappable(ax)
+        mappable = get_mappable(ax, index=index, image_only=image_only)
 
     if mappable is None:
         raise RuntimeError("No mappable was found to use for colorbar creation")

--- a/src/erlab/utils/array.py
+++ b/src/erlab/utils/array.py
@@ -58,6 +58,137 @@ def _coord_inc(darr: xr.DataArray, dim: Hashable) -> float:
     return 1.0
 
 
+def _broadcast_args_wrap_result(
+    result: typing.Any, broadcast_ref: xr.DataArray
+) -> typing.Any:
+    """Wrap broadcast-shaped NumPy outputs back into DataArray objects.
+
+    Parameters
+    ----------
+    result
+        Result returned by the decorated function.
+    broadcast_ref
+        Broadcasted reference array providing the output coordinates, dimensions, and
+        attributes.
+
+    Returns
+    -------
+    typing.Any
+        The original result, with broadcast-shaped NumPy arrays converted to
+        :class:`xarray.DataArray` objects.
+    """
+    if isinstance(result, np.ndarray) and result.shape == broadcast_ref.shape:
+        return xr.DataArray(
+            result,
+            coords=broadcast_ref.coords,
+            dims=broadcast_ref.dims,
+            attrs=broadcast_ref.attrs,
+        )
+
+    if isinstance(result, tuple):  # pragma: no branch
+        new_result = []
+        for value in result:
+            if isinstance(value, np.ndarray) and value.shape == broadcast_ref.shape:
+                value = xr.DataArray(
+                    value,
+                    coords=broadcast_ref.coords,
+                    dims=broadcast_ref.dims,
+                    attrs=broadcast_ref.attrs,
+                )
+            new_result.append(value)
+        return tuple(new_result)
+
+    return result
+
+
+def _broadcast_args_make_sample_args(
+    args: tuple[typing.Any, ...],
+    kwargs: dict[str, typing.Any],
+    broadcast_params: dict[int | str, xr.DataArray],
+    sample_shape: tuple[int, ...],
+) -> tuple[list[typing.Any], dict[str, typing.Any]]:
+    """Build sample NumPy arguments for output-shape and dtype inference.
+
+    Parameters
+    ----------
+    args
+        Positional arguments originally passed to the decorated function.
+    kwargs
+        Keyword arguments originally passed to the decorated function.
+    broadcast_params
+        Mapping of argument positions or names to broadcasted DataArray inputs.
+    sample_shape
+        Shape to use for synthetic NumPy arrays that replace DataArray inputs.
+
+    Returns
+    -------
+    tuple of list and dict
+        Positional and keyword arguments with broadcasted DataArray inputs replaced by
+        zero-filled NumPy arrays of the requested shape.
+    """
+    sample_args, sample_kwargs = list(args), dict(kwargs)
+    for key, value in broadcast_params.items():
+        sample_value = np.zeros(sample_shape, dtype=value.dtype)
+        if isinstance(key, int):
+            sample_args[key] = sample_value
+        else:
+            sample_kwargs[key] = sample_value
+    return sample_args, sample_kwargs
+
+
+def _broadcast_args_infer_output_metadata(
+    sample_result: typing.Any, broadcast_ref: xr.DataArray
+) -> tuple[list[tuple[()]], list[np.dtype]]:
+    """Infer gufunc output metadata for a broadcasted decorated function.
+
+    Parameters
+    ----------
+    sample_result
+        Result of calling the decorated function on synthetic NumPy inputs.
+    broadcast_ref
+        Broadcasted reference array used to validate output shapes.
+
+    Returns
+    -------
+    output_core_dims
+        Output core-dimension signatures for :func:`xarray.apply_ufunc`.
+    output_dtypes
+        Output dtypes for :func:`xarray.apply_ufunc`.
+
+    Raises
+    ------
+    TypeError
+        If the decorated function returns outputs that do not match the broadcasted
+        input shape, or returns a non-array result when DataArray inputs are present.
+    """
+    expected_shape = tuple(1 for _ in broadcast_ref.shape)
+
+    if isinstance(sample_result, np.ndarray):
+        if sample_result.shape != expected_shape:
+            raise TypeError(
+                "broadcast_args only supports array outputs with the same "
+                "broadcasted shape when DataArray inputs are provided."
+            )
+        return [()], [sample_result.dtype]
+
+    if isinstance(sample_result, tuple):
+        output_dtypes: list[np.dtype] = []
+        for value in sample_result:
+            if not isinstance(value, np.ndarray) or value.shape != expected_shape:
+                raise TypeError(
+                    "broadcast_args only supports tuple outputs whose arrays "
+                    "match the broadcasted input shape when DataArray inputs are "
+                    "provided."
+                )
+            output_dtypes.append(value.dtype)
+        return [()] * len(sample_result), output_dtypes
+
+    raise TypeError(
+        "broadcast_args only supports NumPy array outputs when DataArray inputs "
+        "are provided."
+    )
+
+
 def broadcast_args(func: Callable) -> Callable:
     """Decorate a function to broadcast all DataArray arguments.
 
@@ -77,6 +208,8 @@ def broadcast_args(func: Callable) -> Callable:
     - When used on numba functions in nopython mode, the decorated function will no
       longer be able to be called from another function compiled in nopython mode.
     - The decorated function will not be able to accept DataArray arguments.
+    - Dask-backed DataArray arguments are applied lazily so that the decorated function
+      still receives NumPy arrays.
     """
 
     @functools.wraps(func)
@@ -102,41 +235,50 @@ def broadcast_args(func: Callable) -> Callable:
         # Reference DataArray to use for creating the output DataArray
         broadcast_ref: xr.DataArray = next(iter(broadcast_params.values()))
 
-        # Replace DataArray arguments with their values
-        npy_args, npy_kwargs = list(args), dict(kwargs)
-        for k, v in broadcast_params.items():
-            if isinstance(k, int):
-                npy_args[k] = v.values
-            else:
-                npy_kwargs[k] = v.values
+        if all(v.chunks is None for v in broadcast_params.values()):
+            npy_args, npy_kwargs = list(args), dict(kwargs)
+            for k, v in broadcast_params.items():
+                if isinstance(k, int):
+                    npy_args[k] = v.data
+                else:
+                    npy_kwargs[k] = v.data
 
-        result = func(*npy_args, **npy_kwargs)
-
-        if isinstance(result, np.ndarray) and result.shape == broadcast_ref.shape:
-            result = xr.DataArray(
-                result,
-                coords=broadcast_ref.coords,
-                dims=broadcast_ref.dims,
-                attrs=broadcast_ref.attrs,
+            return _broadcast_args_wrap_result(
+                func(*npy_args, **npy_kwargs), broadcast_ref
             )
 
-        elif isinstance(result, tuple):  # pragma: no branch
-            # Support multiple return values
-            new_result = []
-            for r in result:
-                if (
-                    isinstance(r, np.ndarray) and r.shape == broadcast_ref.shape
-                ):  # pragma: no branch
-                    r = xr.DataArray(
-                        r,
-                        coords=broadcast_ref.coords,
-                        dims=broadcast_ref.dims,
-                        attrs=broadcast_ref.attrs,
-                    )
-                new_result.append(r)
-            result = tuple(new_result)
+        sample_args, sample_kwargs = _broadcast_args_make_sample_args(
+            args,
+            kwargs,
+            broadcast_params,
+            tuple(1 for _ in broadcast_ref.shape),
+        )
+        output_core_dims, output_dtypes = _broadcast_args_infer_output_metadata(
+            func(*sample_args, **sample_kwargs), broadcast_ref
+        )
+        ordered_keys = tuple(broadcast_params)
 
-        return result
+        def _apply_ufunc(*values):
+            block_args, block_kwargs = list(args), dict(kwargs)
+            for key, value in zip(ordered_keys, values, strict=False):
+                if isinstance(key, int):
+                    block_args[key] = value
+                else:
+                    block_kwargs[key] = value
+            return func(*block_args, **block_kwargs)
+
+        result = xr.apply_ufunc(
+            _apply_ufunc,
+            *broadcast_params.values(),
+            keep_attrs=True,
+            dask="parallelized",
+            output_core_dims=output_core_dims,
+            output_dtypes=output_dtypes,
+        )
+
+        if isinstance(result, tuple):
+            return tuple(value.rename(None) for value in result)
+        return result.rename(None)
 
     return _wrapper
 

--- a/tests/analysis/fit/test_functions_general.py
+++ b/tests/analysis/fit/test_functions_general.py
@@ -236,6 +236,53 @@ def test_fermi_dirac_broad_accepts_scalar_dataarray_param_with_numpy_x() -> None
     )
 
 
+def test_fermi_dirac_broad_accepts_dataarray_x_with_scalar_params() -> None:
+    x = xr.DataArray(
+        np.linspace(-0.1, 0.1, 31),
+        dims=("eV",),
+        coords={"eV": np.linspace(-0.1, 0.1, 31)},
+        attrs={"units": "eV"},
+    )
+
+    result = fermi_dirac_broad(x, center=0.0, temp=20.0, resolution=0.01)
+
+    xr.testing.assert_identical(
+        result,
+        xr.DataArray(
+            fermi_dirac_broad(x.values, center=0.0, temp=20.0, resolution=0.01),
+            dims=("eV",),
+            coords={"eV": x["eV"]},
+            attrs=x.attrs,
+        ),
+    )
+
+
+def test_fermi_dirac_broad_renames_numpy_core_dim_when_needed() -> None:
+    x = np.linspace(-0.1, 0.1, 31)
+    temp = xr.DataArray(
+        np.array([10.0, 20.0]),
+        dims=("x",),
+        coords={"x": np.array([20.0, 21.0])},
+        attrs={"source": "temperature"},
+    )
+
+    result = fermi_dirac_broad(x, center=0.0, temp=temp, resolution=0.01)
+
+    expected = xr.DataArray(
+        np.column_stack(
+            [
+                fermi_dirac_broad(x, center=0.0, temp=t, resolution=0.01)
+                for t in temp.values
+            ]
+        ),
+        dims=("_x", "x"),
+        coords={"_x": x, "x": temp["x"]},
+        attrs=temp.attrs,
+    )
+
+    xr.testing.assert_identical(result, expected)
+
+
 def test_fermi_dirac_broad_supports_dask_scalar_dataarray_param_with_numpy_x() -> None:
     x = np.linspace(-0.1, 0.1, 31)
     result = fermi_dirac_broad(
@@ -361,6 +408,13 @@ def test_fermi_dirac_broad_rejects_param_varying_along_core_dim() -> None:
         match=r"`temp` must not vary along the convolution dimension `eV`\.",
     ):
         fermi_dirac_broad(x, center=0.0, temp=temp, resolution=0.01)
+
+
+def test_fermi_dirac_broad_rejects_non_1d_dataarray_x() -> None:
+    x = xr.DataArray(np.zeros((2, 2)), dims=("row", "col"))
+
+    with pytest.raises(ValueError, match="`x` must be a 1-dimensional DataArray\\."):
+        fermi_dirac_broad(x, center=0.0, temp=20.0, resolution=0.01)
 
 
 def test_fermi_dirac_linbkg_broad() -> None:

--- a/tests/analysis/fit/test_functions_general.py
+++ b/tests/analysis/fit/test_functions_general.py
@@ -1,7 +1,9 @@
+import dask.array as da
 import numpy as np
 import pytest
 import scipy.signal
 import scipy.special
+import xarray as xr
 
 from erlab.analysis.fit.functions.general import (
     _gen_kernel,
@@ -181,6 +183,184 @@ def test_fermi_dirac_broad_descending_axis_matches_ascending() -> None:
     desc = fermi_dirac_broad(xd, center, temp, resolution)
 
     np.testing.assert_allclose(desc[::-1], asc, atol=1e-12, rtol=1e-9)
+
+
+def test_fermi_dirac_broad_broadcasts_dataarray_params() -> None:
+    x = xr.DataArray(
+        np.linspace(-0.1, 0.1, 31),
+        dims=("eV",),
+        coords={"eV": np.linspace(-0.1, 0.1, 31)},
+        attrs={"units": "eV"},
+    )
+    temp = xr.DataArray(
+        np.array([10.0, 20.0, 30.0, 40.0]),
+        dims=("hv",),
+        coords={"hv": np.array([20.0, 21.0, 22.0, 23.0])},
+    )
+
+    result = fermi_dirac_broad(x, center=0.0, temp=temp, resolution=0.01)
+
+    expected = xr.DataArray(
+        np.column_stack(
+            [
+                fermi_dirac_broad(x.values, center=0.0, temp=t, resolution=0.01)
+                for t in temp.values
+            ]
+        ),
+        dims=("eV", "hv"),
+        coords={"eV": x["eV"], "hv": temp["hv"]},
+        attrs=x.attrs,
+    )
+
+    xr.testing.assert_identical(result, expected)
+
+
+def test_fermi_dirac_broad_accepts_scalar_dataarray_param_with_numpy_x() -> None:
+    x = np.linspace(-0.1, 0.1, 31)
+
+    result = fermi_dirac_broad(
+        x,
+        center=0.0,
+        temp=xr.DataArray(20.0),
+        resolution=0.01,
+    )
+
+    assert isinstance(result, xr.DataArray)
+    xr.testing.assert_identical(
+        result,
+        xr.DataArray(
+            fermi_dirac_broad(x, center=0.0, temp=20.0, resolution=0.01),
+            dims=("x",),
+            coords={"x": x},
+        ),
+    )
+
+
+def test_fermi_dirac_broad_supports_dask_scalar_dataarray_param_with_numpy_x() -> None:
+    x = np.linspace(-0.1, 0.1, 31)
+    result = fermi_dirac_broad(
+        x,
+        center=0.0,
+        temp=xr.DataArray(da.from_array(np.array(20.0), chunks=())),
+        resolution=0.01,
+    )
+
+    assert isinstance(result, xr.DataArray)
+    assert result.chunks is not None
+    xr.testing.assert_identical(
+        result.compute(),
+        xr.DataArray(
+            fermi_dirac_broad(x, center=0.0, temp=20.0, resolution=0.01),
+            dims=("x",),
+            coords={"x": x},
+        ),
+    )
+
+
+def test_fermi_dirac_broad_supports_dask_dataarray_inputs() -> None:
+    x_vals = np.linspace(-0.1, 0.1, 31)
+    x = xr.DataArray(
+        da.from_array(x_vals, chunks=(x_vals.size,)),
+        dims=("eV",),
+        coords={"eV": x_vals},
+        attrs={"units": "eV"},
+    )
+    temp = xr.DataArray(
+        da.from_array(np.array([10.0, 20.0, 30.0, 40.0]), chunks=(2,)),
+        dims=("hv",),
+        coords={"hv": np.array([20.0, 21.0, 22.0, 23.0])},
+    )
+
+    result = fermi_dirac_broad(x, center=0.0, temp=temp, resolution=0.01)
+
+    assert isinstance(result, xr.DataArray)
+    assert result.chunks is not None
+
+    expected = xr.DataArray(
+        np.column_stack(
+            [
+                fermi_dirac_broad(x_vals, center=0.0, temp=t, resolution=0.01)
+                for t in temp.compute().values
+            ]
+        ),
+        dims=("eV", "hv"),
+        coords={"eV": x["eV"].compute(), "hv": temp["hv"].compute()},
+        attrs=x.attrs,
+    )
+
+    xr.testing.assert_identical(result.compute(), expected)
+
+
+def test_fermi_dirac_broad_supports_dask_x_with_scalar_params() -> None:
+    x_vals = np.linspace(-0.1, 0.1, 31)
+    x = xr.DataArray(
+        da.from_array(x_vals, chunks=(x_vals.size,)),
+        dims=("eV",),
+        coords={"eV": x_vals},
+        attrs={"units": "eV"},
+    )
+
+    result = fermi_dirac_broad(x, center=0.0, temp=20.0, resolution=0.01)
+
+    assert isinstance(result, xr.DataArray)
+    assert result.chunks is not None
+    xr.testing.assert_identical(
+        result.compute(),
+        xr.DataArray(
+            fermi_dirac_broad(x_vals, center=0.0, temp=20.0, resolution=0.01),
+            dims=("eV",),
+            coords={"eV": x["eV"].compute()},
+            attrs=x.attrs,
+        ),
+    )
+
+
+def test_fermi_dirac_broad_rejects_split_dask_x_with_scalar_params() -> None:
+    x_vals = np.linspace(-0.1, 0.1, 31)
+    x = xr.DataArray(
+        da.from_array(x_vals, chunks=(10,)),
+        dims=("eV",),
+        coords={"eV": x_vals},
+    )
+
+    with pytest.raises(ValueError, match="multiple chunks"):
+        fermi_dirac_broad(x, center=0.0, temp=20.0, resolution=0.01)
+
+
+def test_fermi_dirac_broad_rejects_split_dask_x_with_dataarray_params() -> None:
+    x_vals = np.linspace(-0.1, 0.1, 31)
+    x = xr.DataArray(
+        da.from_array(x_vals, chunks=(10,)),
+        dims=("eV",),
+        coords={"eV": x_vals},
+    )
+    temp = xr.DataArray(
+        da.from_array(np.array([10.0, 20.0, 30.0, 40.0]), chunks=(2,)),
+        dims=("hv",),
+        coords={"hv": np.array([20.0, 21.0, 22.0, 23.0])},
+    )
+
+    with pytest.raises(ValueError, match="multiple chunks"):
+        fermi_dirac_broad(x, center=0.0, temp=temp, resolution=0.01)
+
+
+def test_fermi_dirac_broad_rejects_param_varying_along_core_dim() -> None:
+    x = xr.DataArray(
+        np.linspace(-0.1, 0.1, 31),
+        dims=("eV",),
+        coords={"eV": np.linspace(-0.1, 0.1, 31)},
+    )
+    temp = xr.DataArray(
+        np.linspace(10.0, 40.0, x.size),
+        dims=("eV",),
+        coords={"eV": x["eV"]},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"`temp` must not vary along the convolution dimension `eV`\.",
+    ):
+        fermi_dirac_broad(x, center=0.0, temp=temp, resolution=0.01)
 
 
 def test_fermi_dirac_linbkg_broad() -> None:

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -181,6 +181,19 @@ def test_colorbar_edit_widget_populates_from_primary_image(qtbot):
     assert edit_widget._high_contrast_check.isChecked()
 
 
+def test_colorbar_keeps_menu_widget_action_references() -> None:
+    image = BetterImageItem(np.arange(16, dtype=float).reshape(4, 4))
+    image.set_colormap("viridis", gamma=1.0)
+    colorbar = BetterColorBarItem(image=image)
+
+    assert colorbar._clim_menu.actions()[0] is colorbar._clim_action
+    assert colorbar._clim_action.defaultWidget() is colorbar._clim_widget
+    assert colorbar._center_zero_action in colorbar.vb.menu.actions()
+
+    assert colorbar._cmap_menu.actions()[0] is colorbar._cmap_action
+    assert colorbar._cmap_action.defaultWidget() is colorbar._cmap_widget
+
+
 def test_colorbar_edit_widget_applies_changes_to_images(qtbot):
     data = np.linspace(0, 1, 25, dtype=float).reshape(5, 5)
     images = [BetterImageItem(data + offset) for offset in (0.0, 1.0)]

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1,8 +1,12 @@
+import importlib
+import sys
 import tempfile
+import types
 
 import lmfit
 import numpy as np
 import pytest
+import qtpy
 import xarray as xr
 from qtpy import PYQT6, QtCore, QtGui, QtWidgets
 
@@ -170,6 +174,11 @@ def test_qt_is_valid_ignores_none() -> None:
     assert qt_is_valid(None)
 
 
+def test_qt_object_is_valid_fallback() -> None:
+    assert erlab.interactive.utils._qt_object_is_valid_fallback(object())
+    assert not erlab.interactive.utils._qt_object_is_valid_fallback(None)
+
+
 def test_qt_is_valid_rejects_deleted_widget(qtbot) -> None:
     widget = QtWidgets.QWidget()
     widget.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
@@ -182,6 +191,33 @@ def test_qt_is_valid_rejects_deleted_widget(qtbot) -> None:
     QtWidgets.QApplication.processEvents()
 
     qtbot.wait_until(lambda: not qt_is_valid(widget), timeout=1000)
+
+
+def test_qt_object_is_valid_uses_shiboken_when_available(monkeypatch) -> None:
+    sentinel = object()
+    other = object()
+    calls: list[object] = []
+    fake_shiboken6 = types.ModuleType("shiboken6")
+
+    def _fake_is_valid(obj: object) -> bool:
+        calls.append(obj)
+        return obj is sentinel
+
+    fake_shiboken6.isValid = _fake_is_valid
+
+    with monkeypatch.context() as context:
+        context.setattr(qtpy, "PYSIDE6", True, raising=False)
+        context.setattr(qtpy, "PYQT6", False, raising=False)
+        context.setitem(sys.modules, "shiboken6", fake_shiboken6)
+
+        reloaded = importlib.reload(erlab.interactive.utils)
+
+        assert reloaded._qt_object_is_valid(sentinel)
+        assert not reloaded._qt_object_is_valid(other)
+        assert not reloaded._qt_object_is_valid(None)
+        assert calls == [sentinel, other]
+
+    importlib.reload(erlab.interactive.utils)
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -18,6 +18,7 @@ from erlab.interactive.utils import (
     generate_code,
     load_fit_ui,
     load_ui,
+    qt_is_valid,
     save_fit_ui,
     xImageItem,
 )
@@ -163,6 +164,24 @@ def test_load_ui_restores_autoconnect_after_error(monkeypatch) -> None:
 
     QtCore.QMetaObject.connectSlotsByName(object())
     assert len(restored_calls) == 1
+
+
+def test_qt_is_valid_ignores_none() -> None:
+    assert qt_is_valid(None)
+
+
+def test_qt_is_valid_rejects_deleted_widget(qtbot) -> None:
+    widget = QtWidgets.QWidget()
+    widget.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
+    widget.show()
+
+    assert qt_is_valid(widget, None)
+
+    widget.close()
+    QtWidgets.QApplication.sendPostedEvents(None, 0)
+    QtWidgets.QApplication.processEvents()
+
+    qtbot.wait_until(lambda: not qt_is_valid(widget), timeout=1000)
 
 
 @pytest.mark.parametrize(

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -250,6 +250,19 @@ def test_proportional_colorbar_respects_image_only() -> None:
     plt.close(fig)
 
 
+def test_proportional_colorbar_uses_current_axes_when_ax_is_none() -> None:
+    fig, ax = plt.subplots()
+    image = ax.imshow(np.arange(4).reshape(2, 2), cmap="viridis")
+    ax.scatter([0, 1], [0, 1], c=[10.0, 20.0], cmap="magma")
+    plt.sca(ax)
+
+    cbar = eplt.proportional_colorbar(index=0, image_only=True)
+
+    assert cbar.mappable is image
+
+    plt.close(fig)
+
+
 def test_proportional_colorbar_iterable_axes_respects_index() -> None:
     fig, axs = plt.subplots(1, 2)
     axs[0].scatter([0, 1], [0, 1], c=[0.0, 1.0], cmap="viridis")

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -161,6 +161,29 @@ def test_unify_clim_with_target() -> None:
     plt.close(fig)
 
 
+def test_get_mappable_respects_index_and_image_only() -> None:
+    fig, ax = plt.subplots()
+    scatter = ax.scatter([0, 1], [0, 1], c=[0.0, 1.0], cmap="viridis")
+    image0 = ax.imshow(
+        np.arange(4).reshape(2, 2),
+        extent=(0, 1, 0, 1),
+        cmap="magma",
+        alpha=0.5,
+    )
+    image1 = ax.imshow(
+        np.arange(4, 8).reshape(2, 2),
+        extent=(0, 1, 0, 1),
+        cmap="plasma",
+        alpha=0.5,
+    )
+
+    assert eplt.get_mappable(ax) is scatter
+    assert eplt.get_mappable(ax, image_only=True) is image1
+    assert eplt.get_mappable(ax, index=0, image_only=True) is image0
+
+    plt.close(fig)
+
+
 @pytest.mark.parametrize("orientation", ["vertical", "horizontal"])
 @pytest.mark.parametrize("floating", [False, True], ids=["no_floating", "floating"])
 @pytest.mark.parametrize("minmax", [False, True], ids=["minmax", "no_minmax"])
@@ -212,4 +235,29 @@ def test_nice_colorbar_box_aspect():
     # Check box aspect
     box_aspect = cbar.ax.get_box_aspect()
     assert box_aspect == 4
+    plt.close(fig)
+
+
+def test_proportional_colorbar_respects_image_only() -> None:
+    fig, ax = plt.subplots()
+    image = ax.imshow(np.arange(4).reshape(2, 2), cmap="viridis")
+    ax.scatter([0, 1], [0, 1], c=[10.0, 20.0], cmap="magma")
+
+    cbar = eplt.proportional_colorbar(ax=ax, image_only=True)
+
+    assert cbar.mappable is image
+
+    plt.close(fig)
+
+
+def test_proportional_colorbar_iterable_axes_respects_index() -> None:
+    fig, axs = plt.subplots(1, 2)
+    axs[0].scatter([0, 1], [0, 1], c=[0.0, 1.0], cmap="viridis")
+    image0 = axs[1].imshow(np.arange(4).reshape(2, 2), cmap="magma", alpha=0.5)
+    axs[1].imshow(np.arange(4, 8).reshape(2, 2), cmap="plasma", alpha=0.5)
+
+    cbar = eplt.proportional_colorbar(ax=axs, index=0, image_only=True)
+
+    assert cbar.mappable is image0
+
     plt.close(fig)

--- a/tests/utils/test_array.py
+++ b/tests/utils/test_array.py
@@ -5,6 +5,8 @@ import xarray as xr
 import xarray.testing
 
 from erlab.utils.array import (
+    _broadcast_args_infer_output_metadata,
+    _broadcast_args_wrap_result,
     apply_dataarray_func,
     broadcast_args,
     check_arg_has_no_nans,
@@ -119,6 +121,110 @@ def test_broadcast_args_supports_dask_tuple_outputs() -> None:
             coords={"x": x_val, "y": y_val},
         ),
     )
+
+
+def test_broadcast_args_supports_tuple_outputs_without_dask() -> None:
+    def testfunc(x, y):
+        return x + y, x - y
+
+    testfunc_ = broadcast_args(testfunc)
+
+    x_val = np.linspace(0, 1, 5)
+    y_val = np.linspace(2, 3, 10)
+    out_add, out_sub = testfunc_(
+        xr.DataArray(x_val, dims=("x",), coords={"x": x_val}),
+        xr.DataArray(y_val, dims=("y",), coords={"y": y_val}),
+    )
+
+    xr.testing.assert_identical(
+        out_add,
+        xr.DataArray(
+            x_val[:, np.newaxis] + y_val[np.newaxis, :],
+            dims=("x", "y"),
+            coords={"x": x_val, "y": y_val},
+        ),
+    )
+    xr.testing.assert_identical(
+        out_sub,
+        xr.DataArray(
+            x_val[:, np.newaxis] - y_val[np.newaxis, :],
+            dims=("x", "y"),
+            coords={"x": x_val, "y": y_val},
+        ),
+    )
+
+
+def test_broadcast_args_supports_keyword_dataarrays() -> None:
+    def testfunc(x, *, offset):
+        return x + offset
+
+    testfunc_ = broadcast_args(testfunc)
+
+    x_val = np.linspace(0, 1, 5)
+    offset_val = np.linspace(2, 3, 10)
+    result = testfunc_(
+        xr.DataArray(x_val, dims=("x",), coords={"x": x_val}),
+        offset=xr.DataArray(offset_val, dims=("y",), coords={"y": offset_val}),
+    )
+
+    xr.testing.assert_identical(
+        result,
+        xr.DataArray(
+            x_val[:, np.newaxis] + offset_val[np.newaxis, :],
+            dims=("x", "y"),
+            coords={"x": x_val, "y": offset_val},
+        ),
+    )
+
+
+def test_broadcast_args_supports_dask_keyword_dataarrays() -> None:
+    def testfunc(x, *, offset):
+        return x + offset
+
+    testfunc_ = broadcast_args(testfunc)
+
+    x_val = np.linspace(0, 1, 5)
+    offset_val = np.linspace(2, 3, 10)
+    result = testfunc_(
+        xr.DataArray(
+            da.from_array(x_val, chunks=(2,)),
+            dims=("x",),
+            coords={"x": x_val},
+        ),
+        offset=xr.DataArray(
+            da.from_array(offset_val, chunks=(4,)),
+            dims=("y",),
+            coords={"y": offset_val},
+        ),
+    )
+
+    assert result.chunks is not None
+    xr.testing.assert_identical(
+        result.compute(),
+        xr.DataArray(
+            x_val[:, np.newaxis] + offset_val[np.newaxis, :],
+            dims=("x", "y"),
+            coords={"x": x_val, "y": offset_val},
+        ),
+    )
+
+
+def test_broadcast_args_wrap_result_leaves_non_arrays_unchanged() -> None:
+    ref = xr.DataArray(np.zeros((2, 3)), dims=("x", "y"))
+    assert _broadcast_args_wrap_result("sentinel", ref) == "sentinel"
+
+
+def test_broadcast_args_infer_output_metadata_rejects_invalid_outputs() -> None:
+    ref = xr.DataArray(np.zeros((2, 3)), dims=("x", "y"))
+
+    with pytest.raises(TypeError, match="array outputs with the same broadcasted"):
+        _broadcast_args_infer_output_metadata(np.zeros((2, 1)), ref)
+
+    with pytest.raises(TypeError, match="tuple outputs whose arrays match"):
+        _broadcast_args_infer_output_metadata((np.zeros((1, 1)), np.zeros((2, 1))), ref)
+
+    with pytest.raises(TypeError, match="supports NumPy array outputs"):
+        _broadcast_args_infer_output_metadata(1, ref)
 
 
 def test_apply_dataarray_func_invalid_data_type() -> None:

--- a/tests/utils/test_array.py
+++ b/tests/utils/test_array.py
@@ -1,3 +1,4 @@
+import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
@@ -43,6 +44,80 @@ def test_broadcast_args() -> None:
             xr.DataArray(y_val, coords={"y": y_val}),
         ),
         expected,
+    )
+
+
+def test_broadcast_args_supports_dask_dataarrays() -> None:
+    def testfunc(x, y):
+        return x * (y + 1)
+
+    testfunc_ = broadcast_args(testfunc)
+
+    x_val = np.linspace(0, 1, 5)
+    y_val = np.linspace(2, 3, 10)
+    result = testfunc_(
+        xr.DataArray(
+            da.from_array(x_val, chunks=(2,)),
+            dims=("x",),
+            coords={"x": x_val},
+        ),
+        xr.DataArray(
+            da.from_array(y_val, chunks=(4,)),
+            dims=("y",),
+            coords={"y": y_val},
+        ),
+    )
+
+    assert isinstance(result, xr.DataArray)
+    assert result.chunks is not None
+    xr.testing.assert_identical(
+        result.compute(),
+        xr.DataArray(
+            testfunc(x_val[:, np.newaxis], y_val[np.newaxis, :]),
+            dims=("x", "y"),
+            coords={"x": x_val, "y": y_val},
+        ),
+    )
+
+
+def test_broadcast_args_supports_dask_tuple_outputs() -> None:
+    def testfunc(x, y):
+        return x + y, x - y
+
+    testfunc_ = broadcast_args(testfunc)
+
+    x_val = np.linspace(0, 1, 5)
+    y_val = np.linspace(2, 3, 10)
+    out_add, out_sub = testfunc_(
+        xr.DataArray(
+            da.from_array(x_val, chunks=(2,)),
+            dims=("x",),
+            coords={"x": x_val},
+        ),
+        xr.DataArray(
+            da.from_array(y_val, chunks=(4,)),
+            dims=("y",),
+            coords={"y": y_val},
+        ),
+    )
+
+    assert out_add.chunks is not None
+    assert out_sub.chunks is not None
+    xr.testing.assert_identical(
+        out_add.compute(),
+        xr.DataArray(
+            x_val[:, np.newaxis] + y_val[np.newaxis, :],
+            dims=("x", "y"),
+            coords={"x": x_val, "y": y_val},
+        ),
+    )
+    xr.testing.assert_identical(
+        out_sub.compute(),
+        xr.DataArray(
+            x_val[:, np.newaxis] - y_val[np.newaxis, :],
+            dims=("x", "y"),
+            coords={"x": x_val, "y": y_val},
+        ),
     )
 
 


### PR DESCRIPTION
- On systems with both `PyQt6` and `PySide6`, the object lifetime detection would just import `PyQt6` first, even after the qtpy initialization; this resulted in both libraries being loaded, leading to a crash.

- Functions that used gaussian convolution did not broadcast correctly. This was fixed by using a ufunc.

- Adds a new `index` parameter to `proportional_colorbar` and `nice_colorbar` that allows users to specify which mappable to use when multiple are present. Also adds an `image_only` parameter to restrict the selection to images. This provides more flexibility in cases where multiple mappables are present in a single axes.