### PR TITLE
feat(kspace): make cut conversion exact

### DIFF
--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -92,8 +92,6 @@ def _hv_to_kz_root_candidates_1d(
     for i0 in brackets:
         kz0, kz1 = kz_valid[int(i0)], kz_valid[int(i0) + 1]
         f0, f1 = residual[int(i0)], residual[int(i0) + 1]
-        if np.isclose(f0, f1, atol=0.0, rtol=0.0):
-            continue
         candidates.append(float(kz0 - f0 * (kz1 - kz0) / (f1 - f0)))
     return np.asarray(candidates, dtype=float)
 

--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -31,6 +31,124 @@ class IncompleteDataError(ValueError):
         return f"{kind_str} '{name}' is required for momentum conversion."
 
 
+def _kxy_components(
+    slit_axis: typing.Literal["kx", "ky"],
+    slit_momentum,
+    other_momentum,
+) -> tuple[float | np.ndarray, float | np.ndarray]:
+    return (
+        (slit_momentum, other_momentum)
+        if slit_axis == "kx"
+        else (other_momentum, slit_momentum)
+    )
+
+
+def _hv_to_kz_root_candidates_1d(
+    kz_grid: np.ndarray,
+    other_momentum: np.ndarray,
+    kinetic_energy,
+    slit_momentum,
+    *,
+    inner_potential: float,
+    slit_axis: typing.Literal["kx", "ky"],
+) -> np.ndarray:
+    kz_grid = np.asarray(kz_grid, dtype=float)
+    other_momentum = np.asarray(other_momentum, dtype=float)
+    kinetic = float(kinetic_energy)
+    slit = float(slit_momentum)
+
+    if not np.isfinite(kinetic) or not np.isfinite(slit):
+        return np.array([], dtype=float)
+
+    mask = np.isfinite(kz_grid) & np.isfinite(other_momentum)
+    if not np.any(mask):
+        return np.array([], dtype=float)
+
+    kz_valid = kz_grid[mask]
+    other_valid = other_momentum[mask]
+    order = np.argsort(kz_valid)
+    kz_valid = kz_valid[order]
+    other_valid = other_valid[order]
+
+    kx, ky = _kxy_components(slit_axis, slit, other_valid)
+    residual = (
+        erlab.analysis.kspace.kz_func(kinetic, inner_potential, kx, ky) - kz_valid
+    )
+
+    exact = np.isclose(residual, 0.0, atol=1e-12, rtol=0.0)
+    candidates: list[float] = []
+
+    exact_idx = np.flatnonzero(exact)
+    if exact_idx.size:
+        split_idx = np.flatnonzero(np.diff(exact_idx) != 1) + 1
+        candidates.extend(
+            float(np.mean(kz_valid[group])) for group in np.split(exact_idx, split_idx)
+        )
+
+    brackets = np.flatnonzero(
+        ((residual[:-1] < 0.0) & (residual[1:] > 0.0))
+        | ((residual[:-1] > 0.0) & (residual[1:] < 0.0))
+    )
+    for i0 in brackets:
+        kz0, kz1 = kz_valid[int(i0)], kz_valid[int(i0) + 1]
+        f0, f1 = residual[int(i0)], residual[int(i0) + 1]
+        if np.isclose(f0, f1, atol=0.0, rtol=0.0):
+            continue
+        candidates.append(float(kz0 - f0 * (kz1 - kz0) / (f1 - f0)))
+    return np.asarray(candidates, dtype=float)
+
+
+def _solve_hv_to_kz_roots_2d(
+    kz_grid: np.ndarray,
+    other_momentum: np.ndarray,
+    kinetic_energy,
+    slit_momentum: np.ndarray,
+    *,
+    inner_potential: float,
+    slit_axis: typing.Literal["kx", "ky"],
+) -> np.ndarray:
+    other_momentum = np.asarray(other_momentum, dtype=float)
+    slit_momentum = np.asarray(slit_momentum, dtype=float)
+
+    roots = np.full(slit_momentum.shape, np.nan, dtype=float)
+    candidates = [
+        _hv_to_kz_root_candidates_1d(
+            kz_grid,
+            other_momentum[i],
+            kinetic_energy,
+            slit_momentum[i],
+            inner_potential=inner_potential,
+            slit_axis=slit_axis,
+        )
+        for i in range(slit_momentum.size)
+    ]
+
+    unique_indices = [i for i, values in enumerate(candidates) if values.size == 1]
+    if not unique_indices:
+        return roots
+
+    center = (slit_momentum.size - 1) / 2.0
+    seed = min(unique_indices, key=lambda i: abs(i - center))
+    roots[seed] = candidates[seed][0]
+
+    def _propagate(indices: range) -> None:
+        ref = roots[seed]
+        for i in indices:
+            values = candidates[i]
+            if values.size == 0:
+                continue
+            if values.size == 1 or not np.isfinite(ref):
+                roots[i] = values[0]
+            else:
+                roots[i] = values[np.argmin(np.abs(values - ref))]
+            ref = roots[i]
+
+    _propagate(range(seed + 1, slit_momentum.size))
+    _propagate(range(seed - 1, -1, -1))
+
+    return roots
+
+
 def _only_angles(method):
     """Decorate methods that require data to be in angle space.
 
@@ -650,17 +768,17 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         r"""Set offsets from normal emission angles.
 
         This method sets the angle offsets so that the provided normal emission angles
-        :math:`(\\alpha, \\beta)` in the data map to :math:`(k_x, k_y) = (0, 0)` in
+        :math:`(\alpha, \beta)` in the data map to :math:`(k_x, k_y) = (0, 0)` in
         momentum space.
 
         Parameters
         ----------
         alpha
-            Angle :math:`\\alpha` in degrees corresponding to sample normal emission.
+            Angle :math:`\alpha` in degrees corresponding to sample normal emission.
         beta
-            Angle :math:`\\beta` in degrees corresponding to sample normal emission.
+            Angle :math:`\beta` in degrees corresponding to sample normal emission.
         delta
-            Optional azimuthal offset :math:`\\delta` in degrees. If omitted, the
+            Optional azimuthal offset :math:`\delta` in degrees. If omitted, the
             existing ``delta`` offset is preserved.
 
         Examples
@@ -897,6 +1015,83 @@ class MomentumAccessor(ERLabDataArrayAccessor):
             kx, ky, kperp, self._kinetic_energy, **self.angle_params
         )
 
+    def _broadcast_exact_targets(
+        self, out_dict: dict[str, xr.DataArray], other_coord: xr.DataArray
+    ) -> dict[str, xr.DataArray]:
+        keys = tuple(out_dict)
+        broadcasted = xr.broadcast(*(out_dict[key] for key in keys))
+        if not self._has_beta:
+            broadcasted = tuple(
+                value.squeeze("beta", drop=True) if "beta" in value.dims else value
+                for value in broadcasted
+            )
+            if "beta" in other_coord.dims:
+                other_coord = other_coord.squeeze("beta", drop=True)
+        finite_other = np.asarray(other_coord.values, dtype=float)
+        finite_other = finite_other[np.isfinite(finite_other)]
+        if finite_other.size and np.allclose(finite_other, 0.0, atol=1e-10, rtol=0.0):
+            other_coord = xr.DataArray(0.0)
+        else:
+            other_coord = other_coord.broadcast_like(broadcasted[0]).reset_coords(
+                drop=True
+            )
+        return {
+            key: value.assign_coords({self.other_axis: other_coord})
+            for key, value in zip(keys, broadcasted, strict=True)
+        }
+
+    def _inverse_exact_cut(self, slit_momentum) -> dict[str, xr.DataArray]:
+        slit_axis = self.slit_axis
+        slit_value = xr.DataArray(
+            slit_momentum, dims=slit_axis, coords={slit_axis: slit_momentum}
+        )
+        alpha = erlab.analysis.kspace.exact_cut_alpha(
+            slit_value,
+            self._beta,
+            self._kinetic_energy,
+            self._alpha,
+            self.configuration,
+            **self.angle_params,
+        )
+        other_momentum = erlab.analysis.kspace._exact_other_axis_momentum(
+            alpha,
+            self._beta,
+            self._kinetic_energy,
+            self.configuration,
+            **self.angle_params,
+        )
+
+        out_dict: dict[str, xr.DataArray] = {"alpha": alpha}
+        if self._has_eV:
+            out_dict["eV"] = self._binding_energy
+
+        return self._broadcast_exact_targets(out_dict, other_momentum)
+
+    def _inverse_exact_hv_cut(self, slit_momentum, kz) -> dict[str, xr.DataArray]:
+        slit_axis = self.slit_axis
+        slit_value = xr.DataArray(
+            slit_momentum, dims=slit_axis, coords={slit_axis: slit_momentum}
+        )
+        kz_value = xr.DataArray(kz, dims="kz", coords={"kz": kz})
+
+        alpha, hv, other_momentum = erlab.analysis.kspace.exact_hv_cut_coords(
+            slit_value,
+            kz_value,
+            self._beta,
+            self._hv,
+            self._kinetic_energy,
+            self._alpha,
+            self.configuration,
+            self.inner_potential,
+            **self.angle_params,
+        )
+
+        out_dict: dict[str, xr.DataArray] = {"alpha": alpha, "hv": hv}
+        if self._has_eV:
+            out_dict["eV"] = self._binding_energy
+
+        return self._broadcast_exact_targets(out_dict, other_momentum)
+
     def _inverse_broadcast(self, kx, ky, kz=None) -> dict[str, xr.DataArray]:
         kxval = xr.DataArray(kx, dims="kx", coords={"kx": kx})
         kyval = xr.DataArray(ky, dims="ky", coords={"ky": ky})
@@ -1092,11 +1287,20 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         if not silent:
             print("Calculating destination coordinates")
 
-        target_dict: dict[str, xr.DataArray] = self._inverse_broadcast(
-            momentum_coords.get("kx"),
-            momentum_coords.get("ky"),
-            momentum_coords.get("kz"),
-        )
+        target_dict: dict[str, xr.DataArray]
+        if not (self._has_beta and not self._has_hv):
+            if self._has_hv:
+                target_dict = self._inverse_exact_hv_cut(
+                    momentum_coords[self.slit_axis], momentum_coords["kz"]
+                )
+            else:
+                target_dict = self._inverse_exact_cut(momentum_coords[self.slit_axis])
+        else:
+            target_dict = self._inverse_broadcast(
+                momentum_coords.get("kx"),
+                momentum_coords.get("ky"),
+                momentum_coords.get("kz"),
+            )
 
         # Coords of first value in target_dict. Output of inverse_broadcast are all
         # broadcasted to each other, so all values will have same coords
@@ -1160,6 +1364,14 @@ class MomentumAccessor(ERLabDataArrayAccessor):
             keep_attrs=True,
             output_dtypes=[np.float64],
         ).assign_coords({k: v.squeeze() for k, v in coords_for_transform.items()})
+        if not self._has_beta and "beta" in out.dims:
+            out = out.squeeze("beta", drop=True)
+        if (
+            not self._has_beta
+            and "beta" in self._obj.coords
+            and "beta" not in out.coords
+        ):
+            out = out.assign_coords(beta=self._beta.squeeze(drop=True))
 
         if not silent:
             print(f"Interpolated in {time.perf_counter() - t_start:.3f} s")
@@ -1202,9 +1414,55 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         """
         return erlab.analysis.kspace.change_configuration(self._obj, configuration)
 
+    def _hv_to_kz_legacy(self, kinetic: xr.DataArray) -> xr.DataArray:
+        ang2k, k2ang = erlab.analysis.kspace.get_kconv_func(
+            kinetic, self.configuration, self.angle_params
+        )
+        kx, ky = ang2k(*k2ang(self._obj.kx, self._obj.ky))
+        return erlab.analysis.kspace.kz_func(kinetic, self.inner_potential, kx, ky)
+
+    def _hv_to_kz_from_stored_coords(
+        self, kinetic: xr.DataArray
+    ) -> xr.DataArray | None:
+        target_order = tuple(
+            dim
+            for dim in ("hv", "eV", self.slit_axis)
+            if dim in kinetic.dims or dim == self.slit_axis
+        )
+        if self.other_axis not in self._obj.coords:
+            return None
+
+        slit_coord = self._obj[self.slit_axis]
+        other_coord = self._obj[self.other_axis]
+
+        if "kz" not in other_coord.dims:
+            kx, ky = _kxy_components(self.slit_axis, slit_coord, other_coord)
+            out = erlab.analysis.kspace.kz_func(kinetic, self.inner_potential, kx, ky)
+            return out.transpose(*target_order)
+
+        kz_coord = self._obj["kz"]
+        kz_root = xr.apply_ufunc(
+            functools.partial(
+                _solve_hv_to_kz_roots_2d,
+                inner_potential=self.inner_potential,
+                slit_axis=self.slit_axis,
+            ),
+            kz_coord,
+            other_coord,
+            kinetic,
+            slit_coord,
+            input_core_dims=[("kz",), (self.slit_axis, "kz"), (), (self.slit_axis,)],
+            output_core_dims=[(self.slit_axis,)],
+            vectorize=True,
+            dask="parallelized",
+            dask_gufunc_kwargs={"output_sizes": {self.slit_axis: slit_coord.size}},
+            output_dtypes=[np.float64],
+        )
+        return kz_root.transpose(*target_order)
+
     @_only_momentum
     def hv_to_kz(self, hv: float | Iterable[float]) -> xr.DataArray:
-        """Return :math:`k_z` for a given photon energy.
+        r"""Return :math:`k_z` for a given photon energy.
 
         Useful when creating overlays on :math:`hν`-dependent data.
 
@@ -1215,9 +1473,31 @@ class MomentumAccessor(ERLabDataArrayAccessor):
 
         Note
         ----
-        This will be inexact for hv-dependent cuts that do not pass through the BZ
-        center since we lost the exact angle values, i.e. the exact momentum
-        perpendicular to the slit, during momentum conversion.
+        This method returns an overlay curve :math:`k_z(hν)` for converted momentum
+        data. The returned values depend on the requested photon energies, binding
+        energy, and in-plane momentum coordinates, but never on the converted data's
+        current ``kz`` grid.
+
+        If the carried in-plane momentum perpendicular to the slit is independent of the
+        converted ``kz`` axis, :math:`k_z` is evaluated directly from
+
+        .. math::
+
+            k_z = \sqrt{\frac{2 m_e}{\hbar^2}(E_k + V_0) - k_x^2 - k_y^2}.
+
+        If that carried orthogonal momentum depends on the converted ``kz`` axis, the
+        method solves the sampled fixed-point relation
+
+        .. math::
+
+            k_z = \sqrt{\frac{2 m_e}{\hbar^2}(E_k + V_0) - k_{\mathrm{slit}}^2 -
+            k_{\mathrm{other}}(k_z)^2}
+
+        on the stored ``kz`` grid. If several sampled roots are present, a continuous
+        branch is selected across the momentum axis along the slit. Slices with no
+        sampled solution are returned as ``NaN``. The legacy angle-roundtrip path is
+        only used when the orthogonal in-plane momentum coordinate is unavailable.
+
         """
         if isinstance(hv, Iterable) and not isinstance(hv, xr.DataArray):
             hv = xr.DataArray(np.asarray(hv), coords={"hv": hv})
@@ -1228,15 +1508,13 @@ class MomentumAccessor(ERLabDataArrayAccessor):
             context="calculating kz from photon energy",
             kinetic_energy=kinetic,
         )
-
-        # Get momentum conversion functions
-
-        ang2k, k2ang = erlab.analysis.kspace.get_kconv_func(
-            kinetic, self.configuration, self.angle_params
-        )
-
-        # Transformation yields in-plane momentum at given photon energy
-        kx, ky = ang2k(*k2ang(self._obj.kx, self._obj.ky))
-
-        # Calculate kz
-        return erlab.analysis.kspace.kz_func(kinetic, self.inner_potential, kx, ky)
+        direct = self._hv_to_kz_from_stored_coords(kinetic)
+        if direct is not None:
+            return direct
+        try:
+            return self._hv_to_kz_legacy(kinetic)
+        except (AttributeError, KeyError) as exc:
+            raise ValueError(
+                "`hv_to_kz` requires the orthogonal in-plane momentum coordinate or "
+                "enough metadata to reconstruct it."
+            ) from exc

--- a/src/erlab/analysis/kspace.py
+++ b/src/erlab/analysis/kspace.py
@@ -619,7 +619,7 @@ def exact_cut_alpha(
                 source_dim=alpha_dim,
                 target_dim=slit_dim,
             )
-        case _:
+        case _:  # pragma: no cover - all normalized enum values are handled above
             raise InvalidConfigurationError(  # pragma: no cover
                 configuration
             )
@@ -868,7 +868,7 @@ def _offsets_from_normal_emission(
             chi_delta = np.rad2deg(np.arctan2(y, z))
 
             return {"xi": xi - xi_delta, "chi": chi - chi_delta}
-        case _:
+        case _:  # pragma: no cover - all enum values are handled above
             raise InvalidConfigurationError(  # pragma: no cover
                 configuration
             )
@@ -903,7 +903,7 @@ def _normal_emission_from_angle_params(
             if configuration == AxesConfiguration.Type1DA:
                 return beta, -alpha
             return alpha, beta
-        case _:
+        case _:  # pragma: no cover - all enum values are handled above
             raise InvalidConfigurationError(  # pragma: no cover
                 configuration
             )
@@ -1152,7 +1152,7 @@ def _fixed_beta_slit_coefficients(
             return sd * sb + cd * sx * cb, -cd * cx
         case AxesConfiguration.Type2:
             return -cd * sx + sd * sb * cx, cd * cx + sd * sb * sx
-        case _:
+        case _:  # pragma: no cover - all normalized enum values are handled above
             raise InvalidConfigurationError(  # pragma: no cover
                 configuration
             )

--- a/src/erlab/analysis/kspace.py
+++ b/src/erlab/analysis/kspace.py
@@ -11,7 +11,10 @@ Angle conventions and function forms are based on Ref. :cite:p:`ishida2018kconv`
 """
 
 __all__ = [
+    "InvalidConfigurationError",
     "change_configuration",
+    "exact_cut_alpha",
+    "exact_hv_cut_coords",
     "get_kconv_forward",
     "get_kconv_func",
     "get_kconv_inverse",
@@ -28,9 +31,73 @@ import numpy as np
 import numpy.typing as npt
 import xarray
 
+import erlab
 import erlab.constants
 from erlab.constants import AxesConfiguration
 from erlab.utils.array import broadcast_args
+
+_EXACT_CUT_METADATA_HINT = (
+    " For normal ARPES data this usually indicates a non-physical angle value or "
+    "offset in the metadata; check the angular coordinates and offsets."
+)
+
+
+class InvalidConfigurationError(ValueError):
+    """Raised when a momentum-conversion routine receives an invalid configuration."""
+
+    def __init__(
+        self,
+        configuration,
+        *,
+        context: str | None = None,
+    ) -> None:
+        supported_str = ", ".join(cfg.name for cfg in AxesConfiguration)
+
+        try:
+            normalized = AxesConfiguration(configuration)
+        except ValueError:
+            if context is None:
+                message = (
+                    f"Invalid configuration {configuration!r}. Valid configurations "
+                    f"are: {supported_str}."
+                )
+            else:
+                message = (
+                    f"{context} received invalid configuration {configuration!r}. "
+                    f"Valid configurations are: {supported_str}."
+                )
+        else:
+            if context is None:
+                message = f"Unexpected configuration {normalized.name}."
+            else:
+                message = (
+                    f"{context} received unexpected configuration {normalized.name}."
+                )
+
+        super().__init__(message)
+        self.configuration = configuration
+        self.context = context
+
+
+def _normalize_configuration(
+    configuration: AxesConfiguration | int,
+    *,
+    context: str | None = None,
+) -> AxesConfiguration:
+    try:
+        normalized = AxesConfiguration(configuration)
+    except ValueError as exc:
+        raise InvalidConfigurationError(configuration, context=context) from exc
+
+    return normalized
+
+
+def _slit_axis_name(configuration: AxesConfiguration) -> str:
+    return (
+        "kx"
+        if configuration in (AxesConfiguration.Type1, AxesConfiguration.Type1DA)
+        else "ky"
+    )
 
 
 @numba.vectorize
@@ -63,7 +130,10 @@ def change_configuration(
 
     """
     current: AxesConfiguration = darr.kspace.configuration
-    new: AxesConfiguration = AxesConfiguration(configuration)
+    new: AxesConfiguration = _normalize_configuration(
+        configuration,
+        context="change_configuration",
+    )
 
     if current == new:
         return darr.copy()
@@ -250,7 +320,11 @@ def get_kconv_forward(configuration: AxesConfiguration | int) -> Callable:
         chi0, xi, xi0``. All angle parameters have default values of zero.
 
     """
-    match configuration:
+    configuration = _normalize_configuration(
+        configuration,
+        context="get_kconv_forward",
+    )
+    match configuration:  # pragma: no branch
         case AxesConfiguration.Type1:
             return _kconv_forward_type1
         case AxesConfiguration.Type2:
@@ -260,7 +334,9 @@ def get_kconv_forward(configuration: AxesConfiguration | int) -> Callable:
         case AxesConfiguration.Type2DA:
             return _kconv_forward_type2_da
         case _:
-            raise ValueError(f"Invalid configuration {configuration}")
+            raise InvalidConfigurationError(  # pragma: no cover
+                configuration, context="get_kconv_forward"
+            )
 
 
 def get_kconv_inverse(configuration: AxesConfiguration | int) -> Callable:
@@ -294,7 +370,11 @@ def get_kconv_inverse(configuration: AxesConfiguration | int) -> Callable:
 
         If ``kperp`` is `None`, it will be computed from ``kinetic_energy``.
     """
-    match configuration:
+    configuration = _normalize_configuration(
+        configuration,
+        context="get_kconv_inverse",
+    )
+    match configuration:  # pragma: no branch
         case AxesConfiguration.Type1:
             return _kconv_inverse_type1
         case AxesConfiguration.Type2:
@@ -304,7 +384,455 @@ def get_kconv_inverse(configuration: AxesConfiguration | int) -> Callable:
         case AxesConfiguration.Type2DA:
             return _kconv_inverse_type2_da
         case _:
-            raise ValueError(f"Invalid configuration {configuration}")
+            raise InvalidConfigurationError(  # pragma: no cover
+                configuration, context="get_kconv_inverse"
+            )
+
+
+def exact_cut_alpha(
+    slit_momentum,
+    beta,
+    kinetic_energy,
+    alpha_reference,
+    configuration: AxesConfiguration | int,
+    *,
+    delta=0.0,
+    chi=0.0,
+    chi0=0.0,
+    xi=0.0,
+    xi0=0.0,
+    beta0=0.0,
+):
+    r"""Return the exact sampled :math:`\alpha(k_{\mathrm{slit}}, E_k)` for 2D cuts.
+
+    This function exposes the exact one-dimensional cut inverse used by
+    :meth:`xarray.DataArray.kspace.convert` when the dataset has no ``beta`` dimension.
+
+    For slit analyzers (`Type1` / `Type2`), Appendix A of :cite:t:`ishida2018kconv`
+    reduces the slit-axis momentum to
+
+    .. math::
+
+        k_{\mathrm{slit}} = k (A \cos \alpha + B \sin \alpha),
+
+    where
+
+    .. math::
+
+        k = \frac{\sqrt{2 m_e E_k}}{\hbar},
+
+    and the coefficients depend only on the geometry and fixed :math:`\bar{\beta} =
+    \beta - \beta_0`, :math:`\bar{\xi} = \xi - \xi_0`. The implemented coefficients are
+
+    .. math::
+
+        \text{Type1}: \qquad A = \sin\delta \sin\bar{\beta} + \cos\delta \sin\bar{\xi}
+        \cos\bar{\beta}, \qquad B = -\cos\delta \cos\bar{\xi},
+
+    .. math::
+
+        \text{Type2}: \qquad A = -\cos\delta \sin\bar{\xi} + \sin\delta \sin\bar{\beta}
+        \cos\bar{\xi}, \qquad B = \cos\delta \cos\bar{\xi} + \sin\delta \sin\bar{\beta}
+        \sin\bar{\xi}.
+
+    Writing
+
+    .. math::
+
+        A \cos \alpha + B \sin \alpha = R \cos(\alpha - \psi),
+
+    with :math:`R = \sqrt{A^2 + B^2}` and :math:`\psi = \operatorname{atan}(B, A)`,
+    gives the explicit inverse
+
+    .. math::
+
+        \alpha = \psi \pm \cos^{-1}\left(\frac{k_{\mathrm{slit}}}{k R}\right).
+
+    The sign is determined from the measured ``alpha`` interval by replaying the
+    normalized source relation on ``alpha_reference``. If the sampled source
+    :math:`k_{\mathrm{slit}}(\alpha)` turns around within the measured interval, the
+    inverse is multi-valued and the function raises.
+
+    For deflector analyzers (`Type1DA` / `Type2DA`), the exact inverse is written in a
+    rotated frame. If the measured momentum vector is rotated back into the deflector
+    frame, let :math:`(P_1, P_2, P_3)` denote the resulting momentum components along
+    that frame's three orthogonal axes. The implemented DA inverse uses the identities
+
+    .. math::
+
+        P_1 = -k \beta \operatorname{sinc}\eta, \qquad P_2 =  k \alpha
+        \operatorname{sinc}\eta, \qquad P_3 =  k \cos\eta,
+
+    with :math:`\eta = \sqrt{\alpha^2 + \beta^2}` where :math:`0 \le \eta < \pi` due to
+    the photoemission horizon. For fixed :math:`\beta`, the slit-axis component has the
+    form
+
+    .. math::
+
+        k_{\mathrm{slit}} = k \left[A \cos\eta + \left(B \alpha + C
+        \beta\right)\operatorname{sinc}\eta\right],
+
+    which does not reduce to an elementary explicit inverse
+    :math:`\alpha(k_{\mathrm{slit}})`. The deflector implementation therefore evaluates
+    the exact slit-axis curve on the measured ``alpha`` interval and interpolates target
+    slit-momentum values onto that monotonic sampled source curve. This is still exact
+    in the sense that it does not use small-angle or other geometric approximations; the
+    only requirement is that the measured source curve be one-to-one on
+    ``alpha_reference``.
+
+    Parameters
+    ----------
+    slit_momentum
+        Target slit-axis momentum values in Å⁻¹. For ``Type1`` and ``Type1DA`` this is
+        :math:`k_x`; for ``Type2`` and ``Type2DA`` it is :math:`k_y`.
+    beta
+        Analyzer angle :math:`\beta` in degrees on the source grid. This may be a
+        scalar, an array-like object, or an :class:`xarray.DataArray`. For
+        :math:`h\nu`-dependent cuts, ``beta`` may vary along the source ``hv`` axis.
+    kinetic_energy
+        Kinetic energy :math:`E_k` in eV on the source grid. This may be scalar,
+        array-like, or an :class:`xarray.DataArray`.
+    alpha_reference
+        Measured source ``alpha`` coordinate in degrees. The exact inverse is defined on
+        this sampled interval, so branch selection and invertibility are determined from
+        this coordinate.
+    configuration
+        Experimental configuration, one of :class:`erlab.constants.AxesConfiguration`.
+    delta
+        Sample azimuth :math:`\delta` in degrees.
+    chi
+        Deflector rotation angle :math:`\chi` in degrees. Used only for ``Type1DA`` and
+        ``Type2DA``.
+    chi0
+        Offset :math:`\chi_0` in degrees. Used only for ``Type1DA`` and ``Type2DA``.
+    xi
+        Sample tilt :math:`\xi` in degrees.
+    xi0
+        Offset :math:`\xi_0` in degrees.
+    beta0
+        Offset :math:`\beta_0` in degrees. Used only for ``Type1`` and ``Type2``.
+
+    Returns
+    -------
+    xarray.DataArray or numpy.ndarray
+        Exact sampled :math:`\alpha` values on the target slit-momentum grid. The return
+        type follows ``slit_momentum``: if it is a DataArray, a DataArray is returned;
+        otherwise a NumPy array is returned.
+
+    Raises
+    ------
+    ValueError
+        If the exact source relation is not invertible on the measured interval, if the
+        slit-axis momentum becomes effectively constant, or if the target slit momentum
+        lies outside the physically reachable domain.
+
+    """
+    configuration = _normalize_configuration(
+        configuration,
+    )
+    slit_axis = _slit_axis_name(configuration)
+
+    alpha_reference, alpha_dim = _exact_1d_coord(
+        alpha_reference,
+        name="alpha_reference",
+        default_dim="alpha",
+        context="exact cut conversion",
+    )
+
+    match configuration:  # pragma: no branch
+        case AxesConfiguration.Type1 | AxesConfiguration.Type2:
+            slit_momentum, target_is_dataarray = _exact_array(
+                slit_momentum,
+                name="slit_momentum",
+                default_dim=slit_axis,
+            )
+            A, B = _fixed_beta_slit_coefficients(
+                configuration, beta, delta=delta, xi=xi, xi0=xi0, beta0=beta0
+            )
+            R = np.hypot(A, B)
+            degenerate = np.isclose(R, 0.0)
+            if isinstance(degenerate, xarray.DataArray):
+                has_degenerate_slice = bool(degenerate.any())
+            else:
+                has_degenerate_slice = bool(np.any(degenerate))
+            if has_degenerate_slice:
+                raise ValueError(
+                    "Exact slit-cut conversion is ill-defined because the slit-axis "
+                    "momentum does not vary with alpha for the current geometry."
+                    + _EXACT_CUT_METADATA_HINT
+                )
+
+            alpha_reference_values = np.asarray(alpha_reference, dtype=float)
+            alpha_reference_r = np.deg2rad(alpha_reference)
+            psi = np.arctan2(B, A)
+            u_reference = A * np.cos(alpha_reference_r) + B * np.sin(alpha_reference_r)
+            branch_sign = xarray.apply_ufunc(
+                _select_slit_branch_1d,
+                alpha_reference_r,
+                u_reference / R,
+                psi,
+                input_core_dims=[[alpha_dim], [alpha_dim], []],
+                output_core_dims=[[]],
+                dask="parallelized",
+                vectorize=True,
+                output_dtypes=[np.int8],
+            )
+
+            reference_center = float(
+                np.deg2rad(
+                    np.mean([alpha_reference_values[0], alpha_reference_values[-1]])
+                )
+            )
+
+            k_tot = erlab.constants.rel_kconv * np.sqrt(kinetic_energy)
+            u = slit_momentum / (k_tot * R)
+            tol = 1e-12
+            valid = np.isfinite(u) & (np.abs(u) <= 1.0 + tol)
+            alpha = _candidate_alpha_from_slit(np.clip(u, -1.0, 1.0), psi, branch_sign)
+            alpha = _align_periodic_radians(alpha, reference_center)
+            alpha = xarray.where(valid, alpha, np.nan)
+            alpha_target = np.rad2deg(alpha)
+        case AxesConfiguration.Type1DA | AxesConfiguration.Type2DA:
+            slit_momentum, slit_dim, target_is_dataarray = _exact_slit_target_coord(
+                slit_momentum,
+                slit_axis=slit_axis,
+                context="exact cut conversion",
+            )
+            forward = get_kconv_forward(configuration)
+            kx_source, ky_source = forward(
+                alpha_reference,
+                beta,
+                kinetic_energy,
+                delta=delta,
+                chi=chi,
+                chi0=chi0,
+                xi=xi,
+                xi0=xi0,
+            )
+            slit_source = (
+                kx_source if configuration == AxesConfiguration.Type1DA else ky_source
+            )
+            alpha_target = _interp_exact_source_curve(
+                slit_source,
+                alpha_reference,
+                slit_momentum,
+                source_dim=alpha_dim,
+                target_dim=slit_dim,
+            )
+        case _:
+            raise InvalidConfigurationError(  # pragma: no cover
+                configuration
+            )
+
+    return _unwrap_exact_result(alpha_target, target_is_dataarray=target_is_dataarray)
+
+
+def exact_hv_cut_coords(
+    slit_momentum,
+    kz,
+    beta,
+    hv,
+    kinetic_energy,
+    alpha_reference,
+    configuration: AxesConfiguration | int,
+    inner_potential,
+    *,
+    delta=0.0,
+    chi=0.0,
+    chi0=0.0,
+    xi=0.0,
+    xi0=0.0,
+    beta0=0.0,
+):
+    r"""Return exact ``alpha``, ``hv``, and carried momentum targets for 2D cuts.
+
+    This function exposes the exact :math:`h\nu`-dependent cut inversion used by
+    :meth:`xarray.DataArray.kspace.convert` when the dataset has no ``beta`` dimension.
+
+    The calculation proceeds in three exact sampled steps.
+
+    1. Recover :math:`\alpha_{\mathrm{source}}(h\nu)` on the measured source grid with
+       :func:`exact_cut_alpha`.
+    2. Reconstruct the in-plane momentum perpendicular to the slit on that same source
+       grid. For slit analyzers this is
+
+       .. math::
+
+           k_{\mathrm{other}} = k(C \cos\alpha + D \sin\alpha),
+
+       with geometry-dependent coefficients :math:`C` and :math:`D`. For deflector
+       analyzers, :math:`k_x` and :math:`k_y` are reconstructed directly from the exact
+       forward transform.
+    3. Build the exact sampled out-of-plane source curve from the free-electron
+       final-state relation
+
+    .. math::
+
+        k_z(h\nu)^2 = \frac{2 m_e}{\hbar^2}\left(E_k(h\nu) + V_0\right) - k_x(h\nu)^2 -
+        k_y(h\nu)^2,
+
+    with
+
+    .. math::
+
+        E_k(h\nu) = h\nu - \Phi + E_b,
+
+    where :math:`\Phi` is the work function and :math:`E_b` is the binding energy.
+
+    The implementation then inverts the sampled monotonic curve :math:`k_z(h\nu)` along
+    the measured ``hv`` axis to obtain ``hv_target`` and uses the same interpolation to
+    obtain ``alpha_target`` and the carried orthogonal in-plane momentum
+    ``other_target`` on the target grid. As with :func:`exact_cut_alpha`, invertibility
+    still requires the sampled source relation to remain one-to-one over the measured
+    interval.
+
+    Parameters
+    ----------
+    slit_momentum
+        Target slit-axis momentum values in Å⁻¹. For ``Type1`` and ``Type1DA`` this is
+        :math:`k_x`; for ``Type2`` and ``Type2DA`` it is :math:`k_y`.
+    kz
+        Target :math:`k_z` values in Å⁻¹.
+    beta
+        Analyzer angle :math:`\beta` in degrees on the source grid. This may be a
+        scalar, an array-like object, or an :class:`xarray.DataArray`.
+    hv
+        Measured photon-energy coordinate in eV. This defines the sampled source axis
+        along which the exact :math:`k_z(h\nu)` relation is inverted.
+    kinetic_energy
+        Kinetic energy :math:`E_k` in eV on the source grid.
+    alpha_reference
+        Measured source ``alpha`` coordinate in degrees.
+    configuration
+        Experimental configuration, one of :class:`erlab.constants.AxesConfiguration`.
+    inner_potential
+        Inner potential :math:`V_0` in eV.
+    delta
+        Sample azimuth :math:`\delta` in degrees.
+    chi
+        Deflector rotation angle :math:`\chi` in degrees. Used only for ``Type1DA`` and
+        ``Type2DA``.
+    chi0
+        Offset :math:`\chi_0` in degrees. Used only for ``Type1DA`` and ``Type2DA``.
+    xi
+        Sample tilt :math:`\xi` in degrees.
+    xi0
+        Offset :math:`\xi_0` in degrees.
+    beta0
+        Offset :math:`\beta_0` in degrees. Used only for ``Type1`` and ``Type2``.
+
+    Returns
+    -------
+    tuple of xarray.DataArray
+        ``(alpha_target, hv_target, other_target)`` where ``other_target`` is the
+        carried in-plane momentum perpendicular to the slit.
+
+    Raises
+    ------
+    ValueError
+        If the exact sampled source relation is not invertible on the measured interval.
+
+    """
+    configuration = _normalize_configuration(configuration)
+
+    slit_axis = _slit_axis_name(configuration)
+    slit_momentum, _, _ = _exact_slit_target_coord(
+        slit_momentum,
+        slit_axis=slit_axis,
+        context="exact hv-cut conversion",
+    )
+    hv, hv_dim = _exact_1d_coord(
+        hv,
+        name="hv",
+        default_dim="hv",
+        context="exact hv-cut conversion",
+    )
+    kz, kz_dim = _exact_1d_coord(
+        kz,
+        name="kz",
+        default_dim="kz",
+        context="exact hv-cut conversion",
+    )
+
+    alpha_source = exact_cut_alpha(
+        slit_momentum,
+        beta,
+        kinetic_energy,
+        alpha_reference,
+        configuration,
+        delta=delta,
+        chi=chi,
+        chi0=chi0,
+        xi=xi,
+        xi0=xi0,
+        beta0=beta0,
+    )
+    other_source = _exact_other_axis_momentum(
+        alpha_source,
+        beta,
+        kinetic_energy,
+        configuration,
+        delta=delta,
+        chi=chi,
+        chi0=chi0,
+        xi=xi,
+        xi0=xi0,
+        beta0=beta0,
+    )
+
+    if slit_axis == "kx":
+        kx_source = slit_momentum
+        ky_source = other_source
+    else:
+        kx_source = other_source
+        ky_source = slit_momentum
+
+    kz_source = kz_func(kinetic_energy, inner_potential, kx_source, ky_source)
+    hv_target = _interp_exact_source_curve(
+        kz_source,
+        hv,
+        kz,
+        source_dim=hv_dim,
+        target_dim=kz_dim,
+    )
+    alpha_target = _interp_exact_source_curve(
+        kz_source,
+        alpha_source,
+        kz,
+        source_dim=hv_dim,
+        target_dim=kz_dim,
+    )
+
+    alpha_target = _transpose_exact_target(
+        alpha_target,
+        slit_axis,
+        kz_dim,
+        kinetic_energy,
+        excluded_dim=hv_dim,
+    )
+    hv_target = _transpose_exact_target(
+        hv_target,
+        slit_axis,
+        kz_dim,
+        kinetic_energy,
+        excluded_dim=hv_dim,
+    )
+    carried_source = ky_source if slit_axis == "kx" else kx_source
+    other_target = _transpose_exact_target(
+        _interp_exact_source_curve(
+            kz_source,
+            carried_source,
+            kz,
+            source_dim=hv_dim,
+            target_dim=kz_dim,
+        ),
+        slit_axis,
+        kz_dim,
+        kinetic_energy,
+        excluded_dim=hv_dim,
+    )
+
+    return alpha_target, hv_target, other_target
 
 
 def _offsets_from_normal_emission(
@@ -315,9 +843,9 @@ def _offsets_from_normal_emission(
     xi: float,
     chi: float | None = None,
 ) -> dict[str, float]:
-    configuration = AxesConfiguration(configuration)
+    configuration = _normalize_configuration(configuration)
 
-    match configuration:
+    match configuration:  # pragma: no branch
         case AxesConfiguration.Type1 | AxesConfiguration.Type2:
             return {"xi": xi - alpha, "beta": beta}
         case AxesConfiguration.Type1DA | AxesConfiguration.Type2DA:
@@ -341,16 +869,18 @@ def _offsets_from_normal_emission(
 
             return {"xi": xi - xi_delta, "chi": chi - chi_delta}
         case _:
-            raise ValueError(f"Invalid configuration {configuration}")
+            raise InvalidConfigurationError(  # pragma: no cover
+                configuration
+            )
 
 
 def _normal_emission_from_angle_params(
     configuration: AxesConfiguration | int,
     angle_params: dict[str, float],
 ) -> tuple[float, float]:
-    configuration = AxesConfiguration(configuration)
+    configuration = _normalize_configuration(configuration)
 
-    match configuration:
+    match configuration:  # pragma: no branch
         case AxesConfiguration.Type1 | AxesConfiguration.Type2:
             return angle_params["xi"] - angle_params["xi0"], angle_params["beta0"]
         case AxesConfiguration.Type1DA | AxesConfiguration.Type2DA:
@@ -374,7 +904,9 @@ def _normal_emission_from_angle_params(
                 return beta, -alpha
             return alpha, beta
         case _:
-            raise ValueError(f"Invalid configuration {configuration}")
+            raise InvalidConfigurationError(  # pragma: no cover
+                configuration
+            )
 
 
 # To use both numexpr and xarray broadcasting, we use the decorator to broadcast all
@@ -568,3 +1100,420 @@ def _kconv_inverse_type1_da(
         kx, ky, kperp, kinetic_energy, delta, chi, chi0, xi, xi0
     )
     return beta, -alpha
+
+
+def _fixed_beta_slit_coefficients(
+    configuration: AxesConfiguration | int,
+    beta,
+    *,
+    delta=0.0,
+    xi=0.0,
+    xi0=0.0,
+    beta0=0.0,
+):
+    r"""Return the slit-axis coefficients for fixed-:math:`\beta` cuts.
+
+    Parameters
+    ----------
+    configuration
+        Experimental configuration. Only type I and type II are supported.
+    beta
+        Fixed analyzer angle :math:`\beta` in degrees.
+    delta
+        Sample azimuth :math:`\delta` in degrees.
+    xi
+        Sample tilt :math:`\xi` in degrees.
+    xi0
+        Offset :math:`\xi_0` in degrees.
+    beta0
+        Offset :math:`\beta_0` in degrees.
+
+    Returns
+    -------
+    tuple
+        The coefficients :math:`A` and :math:`B` such that the slit-axis momentum is
+        :math:`k_{\mathrm{slit}} = k (A \cos \alpha + B \sin \alpha)`. If any input is
+        an :class:`xarray.DataArray`, the returned coefficients preserve its labeled
+        broadcast dimensions.
+
+    """
+    configuration = AxesConfiguration(configuration)
+
+    delta_r = np.deg2rad(delta)
+    beta_bar = np.deg2rad(beta - beta0)
+    xi_bar = np.deg2rad(xi - xi0)
+
+    cd, sd = np.cos(delta_r), np.sin(delta_r)
+    cb, sb = np.cos(beta_bar), np.sin(beta_bar)
+    cx, sx = np.cos(xi_bar), np.sin(xi_bar)
+
+    match configuration:  # pragma: no branch
+        case AxesConfiguration.Type1:
+            return sd * sb + cd * sx * cb, -cd * cx
+        case AxesConfiguration.Type2:
+            return -cd * sx + sd * sb * cx, cd * cx + sd * sb * sx
+        case _:
+            raise InvalidConfigurationError(  # pragma: no cover
+                configuration
+            )
+
+
+def _fixed_beta_other_axis_coefficients(
+    configuration: AxesConfiguration | int,
+    beta,
+    *,
+    delta=0.0,
+    xi=0.0,
+    xi0=0.0,
+    beta0=0.0,
+):
+    r"""Return coefficients for the in-plane momentum perpendicular to the slit.
+
+    The returned coefficients :math:`C` and :math:`D` satisfy
+
+    .. math::
+
+        k_{\mathrm{other}} = k (C \cos\alpha + D \sin\alpha)
+
+    for fixed :math:`\beta`.
+    """
+    configuration = AxesConfiguration(configuration)
+
+    delta_r = np.deg2rad(delta)
+    beta_bar = np.deg2rad(beta - beta0)
+    xi_bar = np.deg2rad(xi - xi0)
+
+    cd, sd = np.cos(delta_r), np.sin(delta_r)
+    cb, sb = np.cos(beta_bar), np.sin(beta_bar)
+    cx, sx = np.cos(xi_bar), np.sin(xi_bar)
+
+    match configuration:  # pragma: no branch
+        case AxesConfiguration.Type1:
+            return -cd * sb + sd * sx * cb, -sd * cx
+        case AxesConfiguration.Type2:
+            return sd * sx + cd * sb * cx, -sd * cx + cd * sb * sx
+        case _:
+            raise InvalidConfigurationError(  # pragma: no cover
+                configuration
+            )
+
+
+def _align_periodic_radians(angle, reference):
+    return angle + 2 * np.pi * np.round((reference - angle) / (2 * np.pi))
+
+
+def _candidate_alpha_from_slit(u, psi: float, sign: int, reference=None):
+    alpha = psi + sign * np.arccos(np.clip(u, -1.0, 1.0))
+    if reference is not None:
+        return _align_periodic_radians(alpha, reference)
+    return alpha
+
+
+def _select_slit_branch_1d(alpha_reference_r, u_reference_norm, psi) -> np.int8:
+    alpha_reference_r = np.asarray(alpha_reference_r, dtype=float)
+    u_reference_norm = np.asarray(u_reference_norm, dtype=float)
+    psi = float(np.asarray(psi, dtype=float))
+
+    if alpha_reference_r.ndim != 1 or u_reference_norm.ndim != 1:
+        raise ValueError(
+            "_select_slit_branch_1d expects one-dimensional reference slices."
+        )
+    if alpha_reference_r.shape != u_reference_norm.shape:
+        raise ValueError(
+            "Reference alpha and normalized slit momentum must have matching shapes."
+        )
+    if alpha_reference_r.size < 2:
+        raise ValueError(
+            "Exact slit-cut conversion requires at least two alpha reference points."
+        )
+
+    du = np.diff(u_reference_norm, axis=-1)
+    tol = 1e-12
+    if not (np.all(du >= -tol) or np.all(du <= tol)):
+        raise ValueError(
+            "Exact slit-cut conversion is not invertible over the measured alpha "
+            "range because the slit-axis momentum turns around within that interval."
+            + _EXACT_CUT_METADATA_HINT
+        )
+    if np.all(np.abs(du) <= tol):
+        raise ValueError(
+            "Exact slit-cut conversion is ill-defined because the measured alpha range "
+            "maps to an effectively constant slit momentum." + _EXACT_CUT_METADATA_HINT
+        )
+
+    ref_plus = _candidate_alpha_from_slit(u_reference_norm, psi, 1, alpha_reference_r)
+    ref_minus = _candidate_alpha_from_slit(u_reference_norm, psi, -1, alpha_reference_r)
+
+    err_plus = np.nanmax(np.abs(ref_plus - alpha_reference_r))
+    err_minus = np.nanmax(np.abs(ref_minus - alpha_reference_r))
+    if not np.isfinite(err_plus) or not np.isfinite(err_minus):
+        raise ValueError(
+            "Exact slit-cut conversion could not determine a valid inverse branch."
+            + _EXACT_CUT_METADATA_HINT
+        )
+
+    return np.int8(1 if err_plus <= err_minus else -1)
+
+
+def _select_slit_branch(alpha_reference_r, u_reference_norm, psi) -> np.ndarray:
+    return np.vectorize(_select_slit_branch_1d, signature="(n),(n),()->()")(
+        alpha_reference_r,
+        u_reference_norm,
+        psi,
+    ).astype(np.int8)
+
+
+def _interp_monotonic_interpn_1d(
+    source_coord, source_values, target_coord
+) -> np.ndarray:
+    source_coord = np.asarray(source_coord, dtype=float)
+    source_values = np.asarray(source_values, dtype=float)
+    target_coord = np.asarray(target_coord, dtype=float)
+
+    out = np.full(target_coord.shape, np.nan, dtype=float)
+
+    finite = np.isfinite(source_coord) & np.isfinite(source_values)
+    source_coord = source_coord[finite]
+    source_values = source_values[finite]
+
+    if source_coord.size < 2:
+        return out
+
+    dif = np.diff(source_coord)
+    tol = 1e-12
+    if not erlab.utils.array.is_monotonic(source_coord, strict=True):
+        if np.all(np.abs(dif) <= tol):
+            raise ValueError(
+                "Exact cut conversion is ill-defined because the exact sampled "
+                "source curve is effectively constant over the measured interval."
+                + _EXACT_CUT_METADATA_HINT
+            )
+        if not (np.all(dif >= -tol) or np.all(dif <= tol)):
+            raise ValueError(
+                "Exact cut conversion is not invertible because the exact sampled "
+                "source curve turns around over the measured interval."
+                + _EXACT_CUT_METADATA_HINT
+            )
+        raise ValueError(
+            "Exact cut conversion is ill-defined because the exact sampled source "
+            "curve is not strictly monotonic over the measured interval."
+            + _EXACT_CUT_METADATA_HINT
+        )
+
+    if source_coord[0] > source_coord[-1]:
+        source_coord = source_coord[::-1]
+        source_values = source_values[::-1]
+
+    return np.interp(
+        target_coord,
+        source_coord,
+        source_values,
+        left=np.nan,
+        right=np.nan,
+    )
+
+
+def _interp_exact_source_curve(
+    source_coord: xarray.DataArray,
+    source_values,
+    target_coord: xarray.DataArray,
+    *,
+    source_dim: str,
+    target_dim: str | None,
+) -> xarray.DataArray:
+    input_core_dims: list[list[str]] = [[source_dim], [source_dim], []]
+    output_core_dims: list[list[str]] = [[]]
+    dask_gufunc_kwargs: dict[str, dict[str, int]] | None = None
+    if target_dim is not None:
+        input_core_dims[2] = [target_dim]
+        output_core_dims[0] = [target_dim]
+        dask_gufunc_kwargs = {
+            "output_sizes": {target_dim: target_coord.sizes[target_dim]}
+        }
+
+    return xarray.apply_ufunc(
+        _interp_monotonic_interpn_1d,
+        source_coord,
+        source_values,
+        target_coord,
+        input_core_dims=input_core_dims,
+        output_core_dims=output_core_dims,
+        vectorize=True,
+        dask="parallelized",
+        dask_gufunc_kwargs=dask_gufunc_kwargs,
+        output_dtypes=[np.float64],
+    )
+
+
+def _exact_1d_coord(
+    values,
+    *,
+    name: str,
+    default_dim: str,
+    context: str,
+) -> tuple[xarray.DataArray, str]:
+    if isinstance(values, xarray.DataArray):
+        if values.ndim != 1:
+            raise ValueError(f"`{name}` must be one-dimensional for {context}.")
+        return values, str(values.dims[0])
+
+    values = np.asarray(values, dtype=float)
+    if values.ndim != 1:
+        raise ValueError(f"`{name}` must be one-dimensional for {context}.")
+    return xarray.DataArray(values, dims=(default_dim,)), default_dim
+
+
+def _exact_array(
+    values,
+    *,
+    name: str,
+    default_dim: str,
+) -> tuple[xarray.DataArray, bool]:
+    if isinstance(values, xarray.DataArray):
+        return values, True
+
+    values = np.asarray(values, dtype=float)
+    if values.ndim == 0:
+        return xarray.DataArray(values), False
+    if values.ndim == 1:
+        return xarray.DataArray(values, dims=(default_dim,)), False
+    return (
+        xarray.DataArray(
+            values,
+            dims=tuple(f"_{name}_dim_{i}" for i in range(values.ndim)),
+        ),
+        False,
+    )
+
+
+def _exact_slit_target_coord(
+    slit_momentum,
+    *,
+    slit_axis: str,
+    context: str,
+) -> tuple[xarray.DataArray, str | None, bool]:
+    if isinstance(slit_momentum, xarray.DataArray):
+        if slit_axis in slit_momentum.dims:
+            return slit_momentum, slit_axis, True
+        if slit_momentum.ndim == 1:
+            return slit_momentum, str(slit_momentum.dims[0]), True
+        raise ValueError(
+            "`slit_momentum` must be one-dimensional or contain the slit-axis "
+            f"target dimension for {context}."
+        )
+
+    slit_momentum, _ = _exact_array(
+        slit_momentum,
+        name=f"{slit_axis}_target",
+        default_dim=slit_axis,
+    )
+    return slit_momentum, (slit_axis if slit_momentum.ndim == 1 else None), False
+
+
+def _unwrap_exact_result(result, *, target_is_dataarray: bool):
+    if target_is_dataarray:
+        return result
+    if isinstance(result, xarray.DataArray):
+        return result.values
+    return result
+
+
+def _transpose_exact_target(
+    target: xarray.DataArray,
+    primary_dim: str,
+    secondary_dim: str | None,
+    kinetic_energy,
+    *,
+    excluded_dim: str,
+) -> xarray.DataArray:
+    preferred_dims: list[str] = []
+    if primary_dim in target.dims:
+        preferred_dims.append(primary_dim)
+    if secondary_dim is not None and secondary_dim in target.dims:
+        preferred_dims.append(secondary_dim)
+    if isinstance(kinetic_energy, xarray.DataArray):
+        preferred_dims.extend(
+            [
+                str(d)
+                for d in kinetic_energy.dims
+                if d != excluded_dim and d in target.dims and d not in preferred_dims
+            ]
+        )
+    preferred_dims.extend([str(d) for d in target.dims if d not in preferred_dims])
+    return target.transpose(*preferred_dims)
+
+
+def _fixed_beta_other_axis_momentum(
+    alpha,
+    beta,
+    kinetic_energy,
+    configuration: AxesConfiguration | int,
+    *,
+    delta=0.0,
+    xi=0.0,
+    xi0=0.0,
+    beta0=0.0,
+):
+    r"""Return the in-plane momentum perpendicular to the slit for fixed-:math:`\beta`.
+
+    This evaluates
+
+    .. math::
+
+        k_{\mathrm{other}} = k (C \cos\alpha + D \sin\alpha)
+
+    using the exact type-I/type-II coefficients for fixed-:math:`\beta` slit cuts.
+    Inputs may be NumPy arrays or :class:`xarray.DataArray` objects; labeled
+    broadcasting is preserved when available.
+    """
+    C, D = _fixed_beta_other_axis_coefficients(
+        configuration, beta, delta=delta, xi=xi, xi0=xi0, beta0=beta0
+    )
+    k_tot = erlab.constants.rel_kconv * np.sqrt(kinetic_energy)
+    alpha_r = np.deg2rad(alpha)
+    return k_tot * (C * np.cos(alpha_r) + D * np.sin(alpha_r))
+
+
+def _exact_other_axis_momentum(
+    alpha,
+    beta,
+    kinetic_energy,
+    configuration: AxesConfiguration | int,
+    *,
+    delta=0.0,
+    chi=0.0,
+    chi0=0.0,
+    xi=0.0,
+    xi0=0.0,
+    beta0=0.0,
+):
+    """Return the carried in-plane momentum perpendicular to the slit for exact cuts."""
+    configuration = _normalize_configuration(configuration)
+    match configuration:  # pragma: no branch
+        case AxesConfiguration.Type1 | AxesConfiguration.Type2:
+            return _fixed_beta_other_axis_momentum(
+                alpha,
+                beta,
+                kinetic_energy,
+                configuration,
+                delta=delta,
+                xi=xi,
+                xi0=xi0,
+                beta0=beta0,
+            )
+        case AxesConfiguration.Type1DA | AxesConfiguration.Type2DA:
+            kx, ky = get_kconv_forward(configuration)(
+                alpha,
+                beta,
+                kinetic_energy,
+                delta=delta,
+                chi=chi,
+                chi0=chi0,
+                xi=xi,
+                xi0=xi0,
+            )
+            return ky if configuration == AxesConfiguration.Type1DA else kx
+        case _:
+            raise InvalidConfigurationError(  # pragma: no cover
+                configuration
+            )

--- a/src/erlab/interactive/imagetool/manager/_watcher/_core.py
+++ b/src/erlab/interactive/imagetool/manager/_watcher/_core.py
@@ -312,22 +312,26 @@ class _Watcher:
             f"↩️ Updated <code>{varname}</code> from ImageTool",
         )
 
-    def shutdown(self) -> None:
+    def _shutdown(self, *, emit_timeout_warnings: bool) -> None:
         self._stop.set()
         self._poll_stop.set()
 
         if self._watcher_thread is not None and self._watcher_thread.is_alive():
             self._watcher_thread.join(timeout=2.0)
-            if self._watcher_thread.is_alive():
+            if emit_timeout_warnings and self._watcher_thread.is_alive():
                 logger.warning("Watcher thread did not stop within timeout")
         if self._poll_thread is not None and self._poll_thread.is_alive():
             self._poll_thread.join(timeout=2.0)
-            if self._poll_thread.is_alive():
+            if emit_timeout_warnings and self._poll_thread.is_alive():
                 logger.warning("Watcher poll thread did not stop within timeout")
         self._thread_started = False
 
+    def shutdown(self) -> None:
+        self._shutdown(emit_timeout_warnings=True)
+
     def __del__(self):
-        self.shutdown()
+        with contextlib.suppress(Exception):
+            self._shutdown(emit_timeout_warnings=False)
 
 
 def _infer_caller_namespace(stacklevel: int = 2) -> NamespaceType:

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 __all__ = ["ktool"]
 
+import hashlib
 import importlib.resources
 import typing
 import warnings
@@ -563,6 +564,15 @@ class KspaceTool(KspaceToolGUI):
         self._argnames: dict[str, str] = {}
 
         self._itool: QtWidgets.QWidget | None = None
+        self._bz_cache_key: typing.Any = None
+        self._bz_cache_value: (
+            tuple[
+                list[npt.NDArray[np.floating]],
+                npt.NDArray[np.floating],
+                npt.NDArray[np.floating],
+            ]
+            | None
+        ) = None
 
         if data_name is None:
             try:
@@ -1029,10 +1039,89 @@ class KspaceTool(KspaceToolGUI):
         if self.bz_group.isChecked():
             self.update_bz()
 
+    @staticmethod
+    def _bz_digest_array(values: npt.ArrayLike) -> bytes:
+        """Return a compact digest for cached BZ geometry inputs."""
+        arr = np.ascontiguousarray(np.asarray(values, dtype=float))
+        digest = hashlib.blake2b(digest_size=16)
+        digest.update(np.asarray(arr.shape, dtype=np.int64).tobytes())
+        digest.update(arr.tobytes())
+        return digest.digest()
+
+    def _bz_cache_token(self, converted_slice: xr.DataArray) -> tuple[typing.Any, ...]:
+        """Build a cache key for the currently displayed BZ overlay geometry."""
+        lattice_token = tuple(np.round(self._avec.ravel(), 8))
+        base_token: tuple[typing.Any, ...] = (
+            lattice_token,
+            self.centering_combo.currentText(),
+            round(self.rot_spin.value(), 6),
+            tuple(converted_slice.dims),
+        )
+
+        if self.data.kspace._has_hv:
+            kp_dim = next(d for d in converted_slice.dims if d != "kz")
+            other = "kx" if kp_dim == "ky" else "ky"
+            return (
+                *base_token,
+                kp_dim,
+                self._bz_digest_array(converted_slice[kp_dim].values),
+                self._bz_digest_array(converted_slice["kz"].values),
+                self._bz_digest_array(converted_slice[other].values),
+            )
+
+        return (
+            *base_token,
+            round(self.kz_spin.value(), 6),
+            self._bz_digest_array(converted_slice["kx"].values),
+            self._bz_digest_array(converted_slice["ky"].values),
+        )
+
+    def _exact_hv_bz_surface(
+        self, converted_slice: xr.DataArray
+    ) -> tuple[
+        str,
+        npt.NDArray[np.floating],
+        npt.NDArray[np.floating],
+        npt.NDArray[np.floating],
+    ]:
+        """Build the sampled 3D momentum surface used for exact ``hv`` BZ overlays."""
+        kp_dim = next(d for d in converted_slice.dims if d != "kz")
+        plot_dims = ("kz", kp_dim)
+        kx_vals = np.asarray(
+            converted_slice["kx"]
+            .broadcast_like(converted_slice)
+            .reset_coords(drop=True)
+            .transpose(*plot_dims),
+            dtype=float,
+        )
+        ky_vals = np.asarray(
+            converted_slice["ky"]
+            .broadcast_like(converted_slice)
+            .reset_coords(drop=True)
+            .transpose(*plot_dims),
+            dtype=float,
+        )
+        kz_vals = np.asarray(
+            converted_slice["kz"]
+            .broadcast_like(converted_slice)
+            .reset_coords(drop=True)
+            .transpose(*plot_dims),
+            dtype=float,
+        )
+        surface = np.stack([kx_vals, ky_vals, kz_vals], axis=-1)
+        return (
+            typing.cast("str", kp_dim),
+            np.asarray(converted_slice[kp_dim].values, dtype=float),
+            np.asarray(converted_slice["kz"].values, dtype=float),
+            surface,
+        )
+
     def get_bz_lines(
         self,
     ) -> tuple[
-        npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]
+        list[npt.NDArray[np.floating]],
+        npt.NDArray[np.floating],
+        npt.NDArray[np.floating],
     ]:
         avec_primitive = erlab.lattice.to_primitive(
             self._avec, centering_type=self.centering_combo.currentText()
@@ -1040,35 +1129,70 @@ class KspaceTool(KspaceToolGUI):
         bvec = erlab.lattice.to_reciprocal(avec_primitive)
         converted_slice: xr.DataArray | None = self.images[1].data_array
         if converted_slice is None:
-            return np.zeros((0, 2)), np.zeros((0, 2)), np.zeros((0, 2))
+            return [], np.zeros((0, 2)), np.zeros((0, 2))
+
+        cache_token = self._bz_cache_token(converted_slice)
+        if cache_token == self._bz_cache_key and self._bz_cache_value is not None:
+            return self._bz_cache_value
 
         rot: float = self.rot_spin.value()
 
         if self.data.kspace._has_hv:
             kp_dim = next(d for d in converted_slice.dims if d != "kz")
             other = "kx" if kp_dim == "ky" else "ky"
-
-            kp_vals = converted_slice[kp_dim].values
-            kz_vals = converted_slice["kz"].values
-            lines, vertices, midpoints = erlab.lattice.get_out_of_plane_bz(
-                bvec,
-                k_parallel=float(converted_slice[other]),
-                angle=rot,
-                bounds=(kp_vals.min(), kp_vals.max(), kz_vals.min(), kz_vals.max()),
-                return_midpoints=True,
-            )
+            other_values = np.asarray(converted_slice[other].values, dtype=float)
+            if other_values.ndim == 0 or other_values.size == 1:
+                kp_vals = np.asarray(converted_slice[kp_dim].values, dtype=float)
+                kz_vals = np.asarray(converted_slice["kz"].values, dtype=float)
+                legacy_lines, vertices, midpoints = erlab.lattice.get_out_of_plane_bz(
+                    bvec,
+                    k_parallel=float(other_values.reshape(-1)[0]),
+                    angle=rot,
+                    bounds=(
+                        float(np.nanmin(kp_vals)),
+                        float(np.nanmax(kp_vals)),
+                        float(np.nanmin(kz_vals)),
+                        float(np.nanmax(kz_vals)),
+                    ),
+                    return_midpoints=True,
+                )
+                lines = [np.asarray(line, dtype=float) for line in legacy_lines]
+            else:
+                theta = np.deg2rad(rot)
+                bvec = bvec @ np.array(
+                    [
+                        [np.cos(theta), np.sin(theta), 0.0],
+                        [-np.sin(theta), np.cos(theta), 0.0],
+                        [0.0, 0.0, 1.0],
+                    ]
+                )
+                _, plot_x, plot_y, surface = self._exact_hv_bz_surface(converted_slice)
+                lines, vertices, midpoints = typing.cast(
+                    "tuple[list[npt.NDArray[np.floating]],"
+                    " npt.NDArray[np.floating], npt.NDArray[np.floating]]",
+                    erlab.lattice.get_surface_bz(
+                        bvec,
+                        plot_x,
+                        plot_y,
+                        surface,
+                        return_midpoints=True,
+                    ),
+                )
         else:
             kx_vals = converted_slice["kx"].values
             ky_vals = converted_slice["ky"].values
-            lines, vertices, midpoints = erlab.lattice.get_in_plane_bz(
+            legacy_lines, vertices, midpoints = erlab.lattice.get_in_plane_bz(
                 bvec,
                 kz=self.kz_spin.value() * np.pi / self.c_spin.value(),
                 angle=rot,
                 bounds=(kx_vals.min(), kx_vals.max(), ky_vals.min(), ky_vals.max()),
                 return_midpoints=True,
             )
+            lines = [np.asarray(line, dtype=float) for line in legacy_lines]
 
-        return lines, vertices, midpoints
+        self._bz_cache_key = cache_token
+        self._bz_cache_value = (lines, vertices, midpoints)
+        return self._bz_cache_value
 
 
 def ktool(

--- a/src/erlab/lattice.py
+++ b/src/erlab/lattice.py
@@ -14,6 +14,7 @@ __all__ = [
     "get_bz_slice",
     "get_in_plane_bz",
     "get_out_of_plane_bz",
+    "get_surface_bz",
     "to_primitive",
     "to_real",
     "to_reciprocal",
@@ -556,6 +557,597 @@ def _deduplicate_and_exclude(points, bounds, tolerance):
     xmin, xmax, ymin, ymax = bounds
     mask = (xmin <= x) & (x <= xmax) & (ymin <= y) & (y <= ymax)
     return deduplicated[mask]
+
+
+def _surface_bz_translation_grid(
+    bvec: npt.NDArray[np.floating],
+    surface: npt.NDArray[np.floating],
+    *,
+    pad_cells: int,
+) -> npt.NDArray[np.floating]:
+    """Return the reciprocal translations needed by :func:`get_surface_bz`.
+
+    This helper is useful when the displayed momentum slice is sampled on a curved
+    surface, such as the exact ``hv`` preview used by
+    :func:`erlab.interactive.ktool`. It expands only the repeated reciprocal cells
+    needed to cover the visible sampled surface, which keeps later distance evaluation
+    bounded to the cells that can actually contribute visible BZ boundaries.
+
+    Parameters
+    ----------
+    bvec
+        Reciprocal lattice basis vectors.
+    surface
+        Sampled momentum surface with shape ``(ny, nx, 3)``.
+    pad_cells
+        Number of extra integer cell translations to include beyond the surface-derived
+        bounds.
+
+    Returns
+    -------
+    ndarray
+        Reciprocal-lattice translation vectors with shape ``(nshift, 3)``.
+    """
+    frac = np.linalg.solve(bvec.T, np.reshape(surface, (-1, 3)).T).T
+    lo = np.floor(np.nanmin(frac, axis=0)).astype(int) - pad_cells
+    hi = np.ceil(np.nanmax(frac, axis=0)).astype(int) + pad_cells
+    grid = np.stack(
+        np.meshgrid(
+            np.arange(lo[0], hi[0] + 1, dtype=int),
+            np.arange(lo[1], hi[1] + 1, dtype=int),
+            np.arange(lo[2], hi[2] + 1, dtype=int),
+            indexing="ij",
+        ),
+        axis=-1,
+    )
+    return grid.reshape(-1, 3) @ bvec
+
+
+def _surface_bz_active_pair_bounds(
+    owner: npt.NDArray[np.integer],
+) -> dict[tuple[int, int], tuple[int, int, int, int]]:
+    """Return active owner pairs and local contour bounds for :func:`get_surface_bz`.
+
+    This helper is useful in the exact surface-BZ path because it replaces an expensive
+    full-grid rescan for every active pair. It records where neighboring owner labels
+    actually change on the display grid, then compresses those crossings into a compact
+    row/column bounding box that `get_surface_bz` can contour locally.
+
+    Parameters
+    ----------
+    owner
+        Integer owner-label grid returned by ``argmin`` over reciprocal-cell distances.
+
+    Returns
+    -------
+    dict
+        Mapping from sorted owner-pair labels to inclusive
+        ``(row_min, row_max, col_min, col_max)`` bounds on the display grid.
+    """
+    pair_bounds: dict[tuple[int, int], list[int]] = {}
+
+    def _update_pair_bounds(
+        first_grid: npt.NDArray[np.integer],
+        second_grid: npt.NDArray[np.integer],
+        *,
+        row_delta: int,
+        col_delta: int,
+    ) -> None:
+        rows, cols = np.nonzero(first_grid != second_grid)
+        for row, col, first, second in zip(
+            rows,
+            cols,
+            first_grid[rows, cols],
+            second_grid[rows, cols],
+            strict=False,
+        ):
+            row = int(row)
+            col = int(col)
+            first_i = int(first)
+            second_i = int(second)
+            pair: tuple[int, int] = (
+                (first_i, second_i) if first_i <= second_i else (second_i, first_i)
+            )
+            bounds = pair_bounds.setdefault(
+                pair, [row, row + row_delta, col, col + col_delta]
+            )
+            bounds[0] = min(bounds[0], row)
+            bounds[1] = max(bounds[1], row + row_delta)
+            bounds[2] = min(bounds[2], col)
+            bounds[3] = max(bounds[3], col + col_delta)
+
+    _update_pair_bounds(owner[:, :-1], owner[:, 1:], row_delta=0, col_delta=1)
+    _update_pair_bounds(owner[:-1, :], owner[1:, :], row_delta=1, col_delta=0)
+
+    return {
+        pair: (bounds[0], bounds[1], bounds[2], bounds[3])
+        for pair, bounds in pair_bounds.items()
+    }
+
+
+def _polyline_segment_signature(
+    line: npt.NDArray[np.floating], tol: float
+) -> bytes | None:
+    """Return a stable segment signature for contour deduplication.
+
+    This helper is useful after `contourpy` extraction in :func:`get_surface_bz`,
+    where the same BZ boundary can be emitted more than once from neighboring active
+    cell pairs. It converts a polyline into a direction-independent byte signature so
+    duplicate segments can be removed cheaply without solving a more expensive geometric
+    matching problem.
+
+    Parameters
+    ----------
+    line
+        Polyline vertices in display coordinates.
+    tol
+        Quantization tolerance used to normalize nearly identical segments.
+
+    Returns
+    -------
+    bytes or None
+        Direction-independent signature for the polyline, or `None` for degenerate
+        single-point lines.
+    """
+    if line.shape[0] < 2:
+        return None
+
+    segs = _dedup_segments_2d(np.stack([line[:-1], line[1:]], axis=1), tol=tol)
+    q = np.rint(segs / tol).astype(np.int64)
+    a, b = q[:, 0], q[:, 1]
+    swap = (a[:, 0] > b[:, 0]) | ((a[:, 0] == b[:, 0]) & (a[:, 1] > b[:, 1]))
+    q[swap] = q[swap][:, ::-1]
+    key = q.reshape(len(q), 4)
+    key = key[np.lexsort((key[:, 3], key[:, 2], key[:, 1], key[:, 0]))]
+    return key.tobytes()
+
+
+def _endpoint_tangent(
+    line: npt.NDArray[np.floating], endpoint_idx: int
+) -> npt.NDArray[np.floating] | None:
+    """Return the inward tangent used by the cheap endpoint snap heuristic.
+
+    This helper is useful in :func:`_snap_polyline_endpoints`, where nearby endpoints
+    must be classified as true segment continuations or unrelated crossings without
+    running an expensive global reconstruction pass. The normalized inward tangent gives
+    a fast local direction test for that decision.
+
+    Parameters
+    ----------
+    line
+        Polyline vertices in display coordinates.
+    endpoint_idx
+        Endpoint index, typically ``0`` or ``-1``.
+
+    Returns
+    -------
+    ndarray or None
+        Unit tangent vector pointing inward from the endpoint, or `None` for degenerate
+        segments.
+    """
+    if line.shape[0] < 2:
+        return None
+    tangent = line[1] - line[0] if endpoint_idx == 0 else line[-2] - line[-1]
+    norm = float(np.linalg.norm(tangent))
+    if norm <= 0:
+        return None
+    return tangent / norm
+
+
+def _pair_labels_form_cycle(pair_labels: set[tuple[int, int]]) -> bool:
+    """Return whether close owner-pair labels form a valid local BZ junction.
+
+    This helper is useful in :func:`_snap_polyline_endpoints`, where a cluster of close
+    contour endpoints should only be merged when its owner-pair graph matches a small
+    Voronoi-style cycle. That keeps exact ``hv`` overlays visually connected while
+    avoiding accidental merges of unrelated nearby vertices.
+
+    Parameters
+    ----------
+    pair_labels
+        Sorted owner-pair labels attached to candidate contour endpoints.
+
+    Returns
+    -------
+    bool
+        `True` when every participating owner has degree two and the labels form a
+        simple cycle.
+    """
+    if len(pair_labels) < 3:
+        return False
+
+    degree: dict[int, int] = {}
+    for first, second in pair_labels:
+        degree[first] = degree.get(first, 0) + 1
+        degree[second] = degree.get(second, 0) + 1
+    return len(degree) == len(pair_labels) and all(val == 2 for val in degree.values())
+
+
+def _snap_polyline_endpoints(
+    lines: list[npt.NDArray[np.floating]],
+    line_pairs: list[tuple[int, int]],
+    snap_tol: float,
+    sig_tol: float,
+) -> list[npt.NDArray[np.floating]]:
+    """Snap contour endpoints using a fast local topology check.
+
+    This helper is useful for exact surface overlays returned by
+    :func:`get_surface_bz`, especially in the interactive ``hv`` path used by
+    :func:`erlab.interactive.ktool`. `contourpy` can leave nearly coincident segment
+    endpoints that should meet at one displayed vertex, but a full geometric stitcher is
+    too expensive for live updates. This routine keeps the cost low by only merging
+    mutual same-pair continuations and small owner-cycle junctions.
+
+    Parameters
+    ----------
+    lines
+        Contour polylines in display coordinates.
+    line_pairs
+        Sorted owner-pair labels corresponding to ``lines``.
+    snap_tol
+        Maximum endpoint separation allowed for snapping.
+    sig_tol
+        Quantization tolerance used when deduplicating snapped contours.
+
+    Returns
+    -------
+    list of ndarray
+        Snapped and deduplicated contour polylines.
+    """
+    if len(lines) < 2 or snap_tol <= 0:
+        return lines
+
+    refs = [
+        (line_idx, endpoint_idx)
+        for line_idx in range(len(lines))
+        for endpoint_idx in (0, -1)
+    ]
+    endpoints = np.asarray([lines[i][j] for i, j in refs], dtype=float)
+    endpoint_pairs = [line_pairs[line_idx] for line_idx, _ in refs]
+    tangents = [_endpoint_tangent(lines[i], j) for i, j in refs]
+    line_ids = [line_idx for line_idx, _ in refs]
+
+    dist_sq = np.sum((endpoints[:, None, :] - endpoints[None, :, :]) ** 2, axis=-1)
+    pair_groups: dict[tuple[int, int], list[int]] = {}
+    for endpoint_idx, pair in enumerate(endpoint_pairs):
+        pair_groups.setdefault(pair, []).append(endpoint_idx)
+
+    snapped_lines = [line.copy() for line in lines]
+    used: set[int] = set()
+    same_pair_matches: list[tuple[float, int, int]] = []
+
+    for indices in pair_groups.values():
+        if len(indices) < 2:
+            continue
+
+        nearest: dict[int, int] = {}
+        for idx in indices:
+            candidates = [
+                other
+                for other in indices
+                if other != idx and line_ids[other] != line_ids[idx]
+            ]
+            if not candidates:
+                continue
+            nearest_idx = min(candidates, key=lambda other: float(dist_sq[idx, other]))
+            nearest[idx] = nearest_idx
+
+        for idx, nearest_idx in nearest.items():
+            if nearest.get(nearest_idx) != idx:
+                continue
+            if dist_sq[idx, nearest_idx] > snap_tol**2:
+                continue
+            tangent_i = tangents[idx]
+            tangent_j = tangents[nearest_idx]
+            if tangent_i is None or tangent_j is None:
+                continue
+            if float(np.dot(tangent_i, tangent_j)) > -0.95:
+                continue
+            same_pair_matches.append(
+                (float(dist_sq[idx, nearest_idx]), idx, nearest_idx)
+            )
+
+    for _, idx, nearest_idx in sorted(same_pair_matches):
+        if idx in used or nearest_idx in used:
+            continue
+        used.update((idx, nearest_idx))
+        snapped = np.mean(endpoints[[idx, nearest_idx]], axis=0)
+        for member in (idx, nearest_idx):
+            line_idx, endpoint_idx = refs[member]
+            snapped_lines[line_idx][endpoint_idx] = snapped
+
+    neighbors: dict[int, set[int]] = {
+        idx: set() for idx in range(len(refs)) if idx not in used
+    }
+    for i, j in zip(*np.triu_indices(len(refs), k=1), strict=True):
+        if i in used or j in used:
+            continue
+        if endpoint_pairs[i] == endpoint_pairs[j]:
+            continue
+        if dist_sq[i, j] > snap_tol**2:
+            continue
+        if len(set(endpoint_pairs[i]) & set(endpoint_pairs[j])) != 1:
+            continue
+        tangent_i = tangents[i]
+        tangent_j = tangents[j]
+        if (
+            tangent_i is not None
+            and tangent_j is not None
+            and abs(float(np.dot(tangent_i, tangent_j))) > 0.95
+        ):
+            continue
+        neighbors[i].add(int(j))
+        neighbors[j].add(int(i))
+
+    seen: set[int] = set()
+    components: list[list[int]] = []
+    for idx in sorted(neighbors):
+        if idx in seen:
+            continue
+        stack = [idx]
+        component: list[int] = []
+        seen.add(idx)
+        while stack:
+            current = stack.pop()
+            component.append(current)
+            for other in neighbors[current]:
+                if other in seen:
+                    continue
+                seen.add(other)
+                stack.append(other)
+        components.append(sorted(component))
+
+    cycle_matches: list[tuple[float, tuple[int, ...]]] = []
+    for component in components:
+        for size in (3, 4):
+            if len(component) < size:
+                continue
+            for members in itertools.combinations(component, size):
+                if len({line_ids[member] for member in members}) != size:
+                    continue
+                if any(
+                    dist_sq[i, j] > snap_tol**2
+                    for i, j in itertools.combinations(members, 2)
+                ):
+                    continue
+                pair_labels = {endpoint_pairs[member] for member in members}
+                if len(pair_labels) != size or not _pair_labels_form_cycle(pair_labels):
+                    continue
+                center = np.mean(endpoints[list(members)], axis=0)
+                max_line_distance = 0.25 * snap_tol
+                valid_center = True
+                for member in members:
+                    tangent = tangents[member]
+                    if tangent is None:
+                        valid_center = False
+                        break
+                    offset = endpoints[member] - center
+                    line_distance = abs(
+                        float(offset[0] * tangent[1] - offset[1] * tangent[0])
+                    )
+                    if line_distance > max_line_distance:
+                        valid_center = False
+                        break
+                if not valid_center:
+                    continue
+                cycle_matches.append(
+                    (
+                        float(
+                            max(
+                                dist_sq[i, j]
+                                for i, j in itertools.combinations(members, 2)
+                            )
+                        ),
+                        members,
+                    )
+                )
+
+    for _, members in sorted(cycle_matches):
+        if any(member in used for member in members):
+            continue
+        used.update(members)
+        snapped = np.mean(endpoints[list(members)], axis=0)
+        for member in members:
+            line_idx, endpoint_idx = refs[member]
+            snapped_lines[line_idx][endpoint_idx] = snapped
+
+    deduped: list[npt.NDArray[np.floating]] = []
+    seen_signatures: set[bytes] = set()
+    for line in snapped_lines:
+        if line.shape[0] < 2:
+            continue
+        signature = _polyline_segment_signature(line, sig_tol)
+        if signature is None or signature in seen_signatures:
+            continue
+        seen_signatures.add(signature)
+        deduped.append(line)
+
+    return deduped
+
+
+def get_surface_bz(
+    bvec: npt.NDArray[np.floating],
+    plot_x: npt.ArrayLike,
+    plot_y: npt.ArrayLike,
+    surface: npt.NDArray[np.floating],
+    *,
+    pad_cells: int = 1,
+    eps: float = 1e-10,
+    return_midpoints: bool = False,
+) -> (
+    tuple[list[npt.NDArray[np.floating]], npt.NDArray[np.floating]]
+    | tuple[
+        list[npt.NDArray[np.floating]],
+        npt.NDArray[np.floating],
+        npt.NDArray[np.floating],
+    ]
+):
+    """Get Brillouin zone boundaries on an arbitrary sampled 2D momentum surface.
+
+    .. versionadded:: 3.21.0
+
+        Support for exact Brillouin-zone overlays on sampled curved momentum surfaces
+        such as ``hv``-dependent cuts in :func:`erlab.interactive.ktool`.
+
+    This function evaluates the repeated-zone Brillouin-zone boundaries on a regular
+    2D display grid whose points are embedded in 3D momentum space. Unlike
+    :func:`get_bz_slice`, the sampled surface does not need to be planar; each point in
+    ``surface`` may have its own ``(kx, ky, kz)`` coordinates.
+
+    It is primarily useful for exact overlays on displays whose carried momentum
+    coordinates are no longer scalar, such as ``hv``-dependent previews in
+    :func:`erlab.interactive.ktool`. Those previews cannot be described by a single
+    constant-``k_parallel`` plane, so the BZ boundary must be evaluated on the sampled
+    surface itself.
+
+    The algorithm computes the nearest reciprocal-lattice point for every sampled
+    surface point, detects only the neighboring reciprocal cells that are actually
+    adjacent on the displayed grid, and contours the exact equality
+    :math:`d_i^2 - d_j^2 = 0` for those active pairs. A short endpoint-snapping pass is
+    applied afterward so neighboring contour segments meet cleanly on the display grid.
+
+    Parameters
+    ----------
+    bvec
+        Reciprocal lattice basis vectors.
+    plot_x, plot_y
+        One-dimensional display coordinates for the surface grid. The returned polylines
+        are expressed in this coordinate system.
+    surface
+        Sampled momentum surface with shape ``(len(plot_y), len(plot_x), 3)``. The last
+        axis contains the 3D momentum coordinates corresponding to each display-grid
+        point.
+    pad_cells
+        Extra integer padding on the reciprocal-lattice translation grid used to ensure
+        coverage near the displayed surface boundary.
+    eps
+        Numerical tolerance used when deduplicating contour segments and derived marker
+        points.
+    return_midpoints
+        If `True`, an empty midpoint array is returned for API compatibility. Unlike
+        planar BZ slices, curved surface intersections do not have a well-defined
+        reciprocal-space midpoint between symmetry points.
+
+    Returns
+    -------
+    lines
+        A list of polyline arrays in ``(plot_x, plot_y)`` coordinates.
+    vertices
+        Deduplicated contour endpoints that lie within the displayed bounds. Closed
+        loops contribute no endpoints.
+    midpoints
+        Empty ``(0, 2)`` array returned only if ``return_midpoints`` is `True`.
+
+    Notes
+    -----
+    For planar slices, :func:`get_bz_slice`, :func:`get_in_plane_bz`, or
+    :func:`get_out_of_plane_bz` are usually cheaper and return analytically cleaner
+    segment geometry. This function is intended for cases where the displayed
+    coordinates correspond to a curved or otherwise non-planar sampled surface.
+    """
+    plot_x = np.asarray(plot_x, dtype=float)
+    plot_y = np.asarray(plot_y, dtype=float)
+    surface = np.asarray(surface, dtype=float)
+
+    if plot_x.ndim != 1 or plot_y.ndim != 1:
+        raise ValueError("`plot_x` and `plot_y` must be one-dimensional arrays.")
+    if surface.shape != (plot_y.size, plot_x.size, 3):
+        raise ValueError("`surface` must have shape (len(plot_y), len(plot_x), 3).")
+
+    import contourpy
+
+    tol = 10 * eps
+    step_x = float(np.nanmedian(np.abs(np.diff(plot_x)))) if plot_x.size > 1 else 0.0
+    step_y = float(np.nanmedian(np.abs(np.diff(plot_y)))) if plot_y.size > 1 else 0.0
+    snap_tol = float(np.hypot(step_x, step_y))
+    shifts = _surface_bz_translation_grid(bvec, surface, pad_cells=pad_cells)
+    surface_sq = np.sum(surface * surface, axis=-1)
+    shift_sq = np.sum(shifts * shifts, axis=1)[:, None, None]
+    dist_sq = shift_sq - 2.0 * np.tensordot(shifts, surface, axes=([1], [2]))
+    dist_sq += surface_sq[None, ...]
+    owner = np.argmin(dist_sq, axis=0)
+
+    lines: list[npt.NDArray[np.floating]] = []
+    line_pairs: list[tuple[int, int]] = []
+    seen_signatures: set[bytes] = set()
+
+    for (i, j), (row_min, row_max, col_min, col_max) in _surface_bz_active_pair_bounds(
+        owner
+    ).items():
+        r0 = max(row_min - 1, 0)
+        r1 = min(row_max + 2, owner.shape[0])
+        c0 = max(col_min - 1, 0)
+        c1 = min(col_max + 2, owner.shape[1])
+
+        local_owner = owner[r0:r1, c0:c1]
+        local_mask = (local_owner == i) | (local_owner == j)
+        delta = dist_sq[i, r0:r1, c0:c1] - dist_sq[j, r0:r1, c0:c1]
+        contours = contourpy.contour_generator(
+            x=plot_x[c0:c1],
+            y=plot_y[r0:r1],
+            z=np.ma.array(delta, mask=~local_mask),
+        ).lines(0.0)
+
+        for contour_line in contours:
+            arr = np.asarray(contour_line, dtype=float)
+            if arr.shape[0] < 2:
+                continue
+            signature = _polyline_segment_signature(arr, tol)
+            if signature is None or signature in seen_signatures:
+                continue
+            seen_signatures.add(signature)
+            lines.append(arr)
+            line_pairs.append((i, j))
+
+    lines = _snap_polyline_endpoints(lines, line_pairs, snap_tol, tol)
+
+    bounds = (
+        float(plot_x.min()),
+        float(plot_x.max()),
+        float(plot_y.min()),
+        float(plot_y.max()),
+    )
+    endpoint_groups: dict[
+        tuple[int, ...],
+        list[tuple[npt.NDArray[np.floating], npt.NDArray[np.floating] | None]],
+    ] = {}
+    for polyline in lines:
+        if np.allclose(polyline[0], polyline[-1], atol=tol, rtol=0.0):
+            continue
+        for endpoint_idx in (0, -1):
+            point = polyline[endpoint_idx]
+            key = tuple(np.rint(point / tol).astype(np.int64))
+            endpoint_groups.setdefault(key, []).append(
+                (point, _endpoint_tangent(polyline, endpoint_idx))
+            )
+
+    vertex_keys: set[tuple[int, ...]] = set()
+    vertex_values: list[npt.NDArray[np.floating]] = []
+    for key, group in endpoint_groups.items():
+        if len(group) < 2:
+            continue
+        if len(group) == 2:
+            tangent0 = group[0][1]
+            tangent1 = group[1][1]
+            if (
+                tangent0 is not None
+                and tangent1 is not None
+                and float(np.dot(tangent0, tangent1)) < -0.95
+            ):
+                continue
+        vertex_keys.add(key)
+        vertex_values.append(np.mean([point for point, _ in group], axis=0))
+
+    vertices = (
+        _deduplicate_and_exclude(np.asarray(vertex_values, dtype=float), bounds, tol)
+        if vertex_values
+        else np.empty((0, 2), dtype=float)
+    )
+
+    if return_midpoints:
+        return lines, vertices, np.empty((0, 2), dtype=float)
+
+    return lines, vertices
 
 
 def get_bz_slice(

--- a/tests/accessors/test_kspace.py
+++ b/tests/accessors/test_kspace.py
@@ -1486,3 +1486,184 @@ def test_hv_to_kz_accepts_iterable_hv(config_1_hvdep) -> None:
     assert out.dims == ("hv", "eV", converted.kspace.slit_axis)
     assert out.hv.size == 3
     xarray.testing.assert_allclose(out, expected)
+
+
+def test_hv_to_kz_root_candidates_1d_rejects_nonfinite_inputs() -> None:
+    out = erlab.accessors.kspace._hv_to_kz_root_candidates_1d(
+        np.array([0.0, 1.0]),
+        np.array([0.0, 0.0]),
+        np.nan,
+        0.0,
+        inner_potential=10.0,
+        slit_axis="kx",
+    )
+
+    assert out.size == 0
+
+
+def test_hv_to_kz_root_candidates_1d_groups_exact_segments(monkeypatch) -> None:
+    def _mock_kz_func(kinetic, inner_potential, kx, ky):
+        return np.array([0.0, 1.0, 6.0, 3.0, 8.0], dtype=float)
+
+    monkeypatch.setattr(erlab.analysis.kspace, "kz_func", _mock_kz_func)
+
+    out = erlab.accessors.kspace._hv_to_kz_root_candidates_1d(
+        np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
+        np.zeros(5),
+        25.0,
+        0.0,
+        inner_potential=10.0,
+        slit_axis="kx",
+    )
+
+    assert np.allclose(out, [0.5, 3.0])
+
+
+def test_solve_hv_to_kz_roots_2d_returns_nan_without_unique_seed(monkeypatch) -> None:
+    lookup = {
+        0.0: np.array([], dtype=float),
+        1.0: np.array([0.25, 1.25], dtype=float),
+        2.0: np.array([0.5, 1.5], dtype=float),
+    }
+
+    def _mock_candidates(
+        kz_grid,
+        other_momentum,
+        kinetic_energy,
+        slit_momentum,
+        *,
+        inner_potential: float,
+        slit_axis: str,
+    ) -> np.ndarray:
+        return lookup[float(slit_momentum)]
+
+    monkeypatch.setattr(
+        erlab.accessors.kspace, "_hv_to_kz_root_candidates_1d", _mock_candidates
+    )
+
+    out = erlab.accessors.kspace._solve_hv_to_kz_roots_2d(
+        np.array([0.0]),
+        np.zeros((3, 1)),
+        30.0,
+        np.array([0.0, 1.0, 2.0]),
+        inner_potential=10.0,
+        slit_axis="kx",
+    )
+
+    assert np.isnan(out).all()
+
+
+def test_solve_hv_to_kz_roots_2d_propagates_closest_branch(monkeypatch) -> None:
+    lookup = {
+        0.0: np.array([0.2, 2.2], dtype=float),
+        1.0: np.array([1.0], dtype=float),
+        2.0: np.array([0.9, 3.5], dtype=float),
+        3.0: np.array([], dtype=float),
+    }
+
+    def _mock_candidates(
+        kz_grid,
+        other_momentum,
+        kinetic_energy,
+        slit_momentum,
+        *,
+        inner_potential: float,
+        slit_axis: str,
+    ) -> np.ndarray:
+        return lookup[float(slit_momentum)]
+
+    monkeypatch.setattr(
+        erlab.accessors.kspace, "_hv_to_kz_root_candidates_1d", _mock_candidates
+    )
+
+    out = erlab.accessors.kspace._solve_hv_to_kz_roots_2d(
+        np.array([0.0]),
+        np.zeros((4, 1)),
+        30.0,
+        np.array([0.0, 1.0, 2.0, 3.0]),
+        inner_potential=10.0,
+        slit_axis="kx",
+    )
+
+    assert np.allclose(out[:3], [0.2, 1.0, 0.9])
+    assert np.isnan(out[3])
+
+
+def test_inverse_exact_cut_without_energy_axis_omits_ev_output(
+    cut, monkeypatch
+) -> None:
+    data = _make_alpha_field_cut(
+        cut,
+        AxesConfiguration.Type1,
+        xi=0.0,
+        offsets={"delta": 0.0, "xi": 0.0, "beta": 0.0},
+        beta=0.0,
+    ).isel(eV=0, drop=True)
+
+    slit_axis = data.kspace.slit_axis
+    alpha = xarray.DataArray([0.0], dims=(slit_axis,), coords={slit_axis: [0.0]})
+    other = xarray.DataArray(0.0)
+
+    monkeypatch.setattr(
+        erlab.accessors.kspace.MomentumAccessor,
+        "_kinetic_energy",
+        property(lambda self: xarray.DataArray(20.0)),
+    )
+    monkeypatch.setattr(
+        erlab.analysis.kspace,
+        "exact_cut_alpha",
+        lambda *args, **kwargs: alpha,
+    )
+    monkeypatch.setattr(
+        erlab.analysis.kspace,
+        "_exact_other_axis_momentum",
+        lambda *args, **kwargs: other,
+    )
+    monkeypatch.setattr(
+        erlab.accessors.kspace.MomentumAccessor,
+        "_broadcast_exact_targets",
+        lambda self, out_dict, other_momentum: out_dict,
+    )
+
+    out = data.kspace._inverse_exact_cut(np.array([0.0]))
+
+    assert "eV" not in out
+    assert set(out) == {"alpha"}
+
+
+def test_hv_to_kz_from_stored_coords_returns_none_without_other_axis(
+    config_1_hvdep,
+) -> None:
+    converted = _overlay_subset(config_1_hvdep)
+    converted = converted.drop_vars(converted.kspace.other_axis)
+    kinetic = (
+        xarray.DataArray([30.0], dims=("hv",), coords={"hv": [30.0]})
+        - converted.kspace.work_function
+        + converted.eV
+    )
+
+    out = converted.kspace._hv_to_kz_from_stored_coords(kinetic)
+
+    assert out is None
+
+
+def test_hv_to_kz_raises_without_stored_coord_or_legacy_metadata(
+    config_1_hvdep, monkeypatch
+) -> None:
+    converted = _overlay_subset(config_1_hvdep)
+    converted = converted.drop_vars(converted.kspace.other_axis)
+
+    def _raise(self, kinetic):
+        raise KeyError("missing-coordinate")
+
+    monkeypatch.setattr(
+        erlab.accessors.kspace.MomentumAccessor,
+        "_hv_to_kz_legacy",
+        _raise,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="requires the orthogonal in-plane momentum coordinate or enough metadata",
+    ):
+        converted.kspace.hv_to_kz([30.0])

--- a/tests/accessors/test_kspace.py
+++ b/tests/accessors/test_kspace.py
@@ -1,3 +1,4 @@
+import functools
 import re
 
 import numpy as np
@@ -6,6 +7,7 @@ import scipy.optimize
 import xarray
 import xarray.testing
 
+import erlab.accessors.kspace
 import erlab.analysis.kspace
 from erlab.accessors.kspace import IncompleteDataError
 from erlab.constants import AxesConfiguration
@@ -14,7 +16,7 @@ from erlab.io.exampledata import generate_hvdep_cuts
 
 @pytest.fixture(scope="module")
 def hvdep():
-    data = generate_hvdep_cuts((50, 250, 300), seed=1)
+    data = generate_hvdep_cuts((24, 120, 140), seed=1)
     data.kspace.inner_potential = 10.0
     return data
 
@@ -180,6 +182,281 @@ def _solve_normal_emission_angles(
 
     assert result.success, result.message
     return float(result.x[0]), float(result.x[1])
+
+
+def _make_alpha_field_cut(
+    cut: xarray.DataArray,
+    configuration: AxesConfiguration,
+    *,
+    xi: float,
+    offsets: dict[str, float],
+    beta: float | None = None,
+    chi: float | None = None,
+) -> xarray.DataArray:
+    data = cut.copy(deep=True)
+    data.attrs["configuration"] = int(configuration)
+    data = data.assign_coords(xi=xi)
+    if chi is not None:
+        data = data.assign_coords(chi=chi)
+    if beta is not None:
+        data = data.assign_coords(beta=beta)
+
+    alpha_grid = xarray.broadcast(data.eV, data.alpha)[1].transpose(*data.dims)
+    data = data.copy(data=alpha_grid.values.astype(float))
+    data.kspace.offsets = offsets
+    return data
+
+
+def _exact_cut_target_alpha(
+    data: xarray.DataArray, slit_momentum: np.ndarray
+) -> xarray.DataArray:
+    slit_axis = data.kspace.slit_axis
+    slit_value = xarray.DataArray(
+        slit_momentum, dims=slit_axis, coords={slit_axis: slit_momentum}
+    )
+    return erlab.analysis.kspace.exact_cut_alpha(
+        slit_value,
+        data.beta,
+        data.kspace._kinetic_energy,
+        data.alpha,
+        data.kspace.configuration,
+        **data.kspace.angle_params,
+    )
+
+
+def _legacy_cut_target_alpha(
+    data: xarray.DataArray, slit_momentum: np.ndarray
+) -> xarray.DataArray:
+    slit_axis = data.kspace.slit_axis
+    other_axis = data.kspace.other_axis
+    other_lims = data.kspace.estimate_bounds()[other_axis]
+    other_mean = np.array([(other_lims[0] + other_lims[1]) / 2.0])
+
+    slit_value = xarray.DataArray(
+        slit_momentum, dims=slit_axis, coords={slit_axis: slit_momentum}
+    )
+    other_value = xarray.DataArray(
+        other_mean, dims=other_axis, coords={other_axis: other_mean}
+    )
+
+    if slit_axis == "kx":
+        alpha, _ = data.kspace._inverse_func(slit_value, other_value)
+    else:
+        alpha, _ = data.kspace._inverse_func(other_value, slit_value)
+
+    return alpha.squeeze(other_axis, drop=True)
+
+
+def _mask_alpha_domain(
+    data: xarray.DataArray, target_alpha: xarray.DataArray
+) -> xarray.DataArray:
+    alpha_min = float(data.alpha.min())
+    alpha_max = float(data.alpha.max())
+    tol = 1e-9
+    valid = (target_alpha >= alpha_min - tol) & (target_alpha <= alpha_max + tol)
+    return target_alpha.where(valid)
+
+
+def _make_field_hvdep_cut(
+    hvdep: xarray.DataArray,
+    configuration: AxesConfiguration,
+    *,
+    field: str,
+    xi: float,
+    offsets: dict[str, float],
+    chi: float | None = None,
+) -> xarray.DataArray:
+    data = hvdep.copy(deep=True)
+    data.attrs["configuration"] = int(configuration)
+    data = data.assign_coords(xi=xi)
+    if chi is not None:
+        data = data.assign_coords(chi=chi)
+
+    alpha_grid, _, hv_grid = xarray.broadcast(data.alpha, data.eV, data.hv)
+    match field:
+        case "alpha":
+            values = alpha_grid
+        case "hv":
+            values = hv_grid
+        case _:
+            raise ValueError(f"Unsupported field '{field}'")
+
+    data = data.copy(data=values.transpose(*data.dims).values.astype(float))
+    data.kspace.offsets = offsets
+    data.kspace.inner_potential = 10.0
+    return data
+
+
+def _exact_hvdep_targets(
+    data: xarray.DataArray, slit_momentum: np.ndarray, kz: np.ndarray
+) -> tuple[xarray.DataArray, xarray.DataArray]:
+    slit_axis = data.kspace.slit_axis
+    slit_value = xarray.DataArray(
+        slit_momentum, dims=slit_axis, coords={slit_axis: slit_momentum}
+    )
+    kz_value = xarray.DataArray(kz, dims="kz", coords={"kz": kz})
+    alpha, hv, _ = erlab.analysis.kspace.exact_hv_cut_coords(
+        slit_value,
+        kz_value,
+        data.beta,
+        data.hv,
+        data.kspace._kinetic_energy,
+        data.alpha,
+        data.kspace.configuration,
+        data.kspace.inner_potential,
+        **data.kspace.angle_params,
+    )
+    return alpha, hv
+
+
+def _exact_cut_other_coord(
+    data: xarray.DataArray,
+    alpha_target: xarray.DataArray,
+    *,
+    hv_target: xarray.DataArray | None = None,
+) -> xarray.DataArray:
+    if hv_target is None:
+        beta_target = data.beta
+        kinetic_target = data.kspace._kinetic_energy
+    else:
+        hv_dim = str(data.hv.dims[0])
+        if hv_dim in data.beta.dims:
+            beta_target = data.beta.interp({hv_dim: hv_target})
+        else:
+            beta_target = data.beta.broadcast_like(hv_target)
+        kinetic_target = (
+            hv_target - data.kspace.work_function + data.kspace._binding_energy
+        )
+
+    return erlab.analysis.kspace._exact_other_axis_momentum(
+        alpha_target,
+        beta_target,
+        kinetic_target,
+        data.kspace.configuration,
+        **data.kspace.angle_params,
+    )
+
+
+def _exact_hvdep_other_coord(
+    data: xarray.DataArray, slit_momentum: np.ndarray, kz: np.ndarray
+) -> xarray.DataArray:
+    slit_axis = data.kspace.slit_axis
+    slit_value = xarray.DataArray(
+        slit_momentum, dims=slit_axis, coords={slit_axis: slit_momentum}
+    )
+    kz_value = xarray.DataArray(kz, dims="kz", coords={"kz": kz})
+    return erlab.analysis.kspace.exact_hv_cut_coords(
+        slit_value,
+        kz_value,
+        data.beta,
+        data.hv,
+        data.kspace._kinetic_energy,
+        data.alpha,
+        data.kspace.configuration,
+        data.kspace.inner_potential,
+        **data.kspace.angle_params,
+    )[2]
+
+
+def _overlay_subset(data: xarray.DataArray) -> xarray.DataArray:
+    slit_axis = data.kspace.slit_axis
+    slit_idx = np.unique(np.linspace(0, data.sizes[slit_axis] - 1, 4, dtype=int))
+    eV_idx = np.unique(np.linspace(0, data.sizes["eV"] - 1, 3, dtype=int))
+    return data.isel({slit_axis: slit_idx, "eV": eV_idx})
+
+
+def _legacy_hv_to_kz(data: xarray.DataArray, hv_values) -> xarray.DataArray:
+    hv = xarray.DataArray(np.asarray(hv_values), dims="hv", coords={"hv": hv_values})
+    kinetic = hv - data.kspace.work_function + data.eV
+    ang2k, k2ang = erlab.analysis.kspace.get_kconv_func(
+        kinetic, data.kspace.configuration, data.kspace.angle_params
+    )
+    kx, ky = ang2k(*k2ang(data.kx, data.ky))
+    return erlab.analysis.kspace.kz_func(kinetic, data.kspace.inner_potential, kx, ky)
+
+
+def _self_consistent_hv_to_kz(data: xarray.DataArray, hv_values) -> xarray.DataArray:
+    hv = xarray.DataArray(np.asarray(hv_values), dims="hv", coords={"hv": hv_values})
+    kinetic = hv - data.kspace.work_function + data.eV
+    slit_coord = data[data.kspace.slit_axis]
+    other_coord = data.coords[data.kspace.other_axis]
+    target_order = ("hv", "eV", data.kspace.slit_axis)
+
+    if "kz" not in other_coord.dims:
+        if data.kspace.slit_axis == "kx":
+            return erlab.analysis.kspace.kz_func(
+                kinetic, data.kspace.inner_potential, slit_coord, other_coord
+            ).transpose(*target_order)
+        return erlab.analysis.kspace.kz_func(
+            kinetic, data.kspace.inner_potential, other_coord, slit_coord
+        ).transpose(*target_order)
+
+    root = xarray.apply_ufunc(
+        functools.partial(
+            erlab.accessors.kspace._solve_hv_to_kz_roots_2d,
+            inner_potential=data.kspace.inner_potential,
+            slit_axis=data.kspace.slit_axis,
+        ),
+        data.kz,
+        other_coord,
+        kinetic,
+        slit_coord,
+        input_core_dims=[
+            ("kz",),
+            (data.kspace.slit_axis, "kz"),
+            (),
+            (data.kspace.slit_axis,),
+        ],
+        output_core_dims=[(data.kspace.slit_axis,)],
+        vectorize=True,
+        dask="parallelized",
+        dask_gufunc_kwargs={"output_sizes": {data.kspace.slit_axis: slit_coord.size}},
+        output_dtypes=[np.float64],
+    )
+    return root.transpose(*target_order)
+
+
+def _legacy_hvdep_targets(
+    data: xarray.DataArray, slit_momentum: np.ndarray, kz: np.ndarray
+) -> tuple[xarray.DataArray, xarray.DataArray]:
+    slit_axis = data.kspace.slit_axis
+    other_axis = data.kspace.other_axis
+    other_lims = data.kspace.estimate_bounds()[other_axis]
+    other_mean = np.array([(other_lims[0] + other_lims[1]) / 2.0])
+
+    slit_value = xarray.DataArray(
+        slit_momentum, dims=slit_axis, coords={slit_axis: slit_momentum}
+    )
+    other_value = xarray.DataArray(
+        other_mean, dims=other_axis, coords={other_axis: other_mean}
+    )
+    kz_value = xarray.DataArray(kz, dims="kz", coords={"kz": kz})
+    kperp = erlab.analysis.kspace.kperp_from_kz(kz_value, data.kspace.inner_potential)
+
+    if slit_axis == "kx":
+        alpha, _ = data.kspace._inverse_func(slit_value, other_value, kperp)
+        hv = erlab.analysis.kspace.hv_func(
+            slit_value,
+            other_value,
+            kz_value,
+            data.kspace.inner_potential,
+            data.kspace.work_function,
+            data.kspace._binding_energy,
+        )
+    else:
+        alpha, _ = data.kspace._inverse_func(other_value, slit_value, kperp)
+        hv = erlab.analysis.kspace.hv_func(
+            other_value,
+            slit_value,
+            kz_value,
+            data.kspace.inner_potential,
+            data.kspace.work_function,
+            data.kspace._binding_energy,
+        )
+
+    hv = hv.squeeze(other_axis, drop=True)
+    alpha = alpha.squeeze(other_axis, drop=True).broadcast_like(hv)
+    return alpha, hv
 
 
 @pytest.mark.parametrize("data_type", ["anglemap", "cut", "hvdep"])
@@ -524,9 +801,9 @@ def test_kconv(
     elif data_type == "hvdep":
         assert len(kconv.shape) == 3 + extra_dims
         if extra_dims == 0:
-            assert set(kconv.shape) == {637, 63, 300}
+            assert set(kconv.shape) == set(expected.shape)
         else:
-            assert set(kconv.shape) == {637, 63, 300, 2}
+            assert set(kconv.shape) == {*expected.shape, 2}
 
     assert isinstance(kconv, xarray.DataArray)
     assert not kconv.isnull().all()
@@ -677,9 +954,535 @@ def test_convert_coords_assigns_momentum_coords(anglemap) -> None:
     assert np.isfinite(out.ky.values).all()
 
 
-def test_hv_to_kz_accepts_iterable_hv(config_1_hvdep) -> None:
-    out = config_1_hvdep.kspace.hv_to_kz([30.0, 45.0, 60.0])
+@pytest.mark.parametrize(
+    ("configuration", "xi", "offsets"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            7.25,
+            {"delta": 12.5, "xi": 2.5, "beta": -3.75},
+            id="type1",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2,
+            -6.5,
+            {"delta": -8.0, "xi": -1.75, "beta": 2.25},
+            id="type2",
+        ),
+    ],
+)
+def test_convert_cut_uses_exact_slit_inverse_for_alpha_field(
+    cut,
+    configuration: AxesConfiguration,
+    xi: float,
+    offsets: dict[str, float],
+) -> None:
+    data = _make_alpha_field_cut(cut, configuration, xi=xi, offsets=offsets)
 
-    assert "hv" in out.dims
+    converted = data.kspace.convert(silent=True)
+    slit_axis = data.kspace.slit_axis
+
+    expected_alpha = _exact_cut_target_alpha(data, converted[slit_axis].values)
+    expected = _mask_alpha_domain(data, expected_alpha).transpose(*converted.dims)
+    legacy = _mask_alpha_domain(
+        data, _legacy_cut_target_alpha(data, converted[slit_axis].values)
+    ).transpose(*converted.dims)
+
+    finite = np.isfinite(converted.values)
+    assert finite.any()
+    assert np.allclose(converted.values[finite], expected.values[finite])
+    assert not np.allclose(
+        converted.values[finite],
+        legacy.values[finite],
+        equal_nan=True,
+    )
+    xarray.testing.assert_allclose(
+        converted.coords[data.kspace.other_axis].reset_coords(drop=True),
+        _exact_cut_other_coord(data, expected_alpha)
+        .transpose(*converted.coords[data.kspace.other_axis].dims)
+        .reset_coords(drop=True),
+    )
+
+
+def test_convert_cut_exact_slit_inverse_raises_when_multivalued(cut) -> None:
+    data = _make_alpha_field_cut(
+        cut,
+        AxesConfiguration.Type1,
+        xi=90.0,
+        offsets={"delta": 0.0, "xi": 0.0, "beta": 0.0},
+        beta=0.0,
+    )
+
+    with pytest.raises(ValueError, match="non-physical angle value or offset"):
+        data.kspace.convert(silent=True)
+
+
+def test_convert_cut_exact_slit_inverse_returns_nan_out_of_domain(cut) -> None:
+    data = _make_alpha_field_cut(
+        cut,
+        AxesConfiguration.Type1,
+        xi=7.25,
+        offsets={"delta": 12.5, "xi": 2.5, "beta": -3.75},
+    )
+
+    lims = data.kspace.estimate_bounds()["kx"]
+    out = data.kspace.convert(
+        silent=True, kx=np.linspace(lims[0] - 0.1, lims[1] + 0.1, 64)
+    )
+
+    assert out.isel(kx=0).isnull().all()
+    assert out.isel(kx=-1).isnull().all()
+    assert not out.isel(kx=slice(1, -1)).isnull().all()
+
+
+def test_convert_cut_with_singleton_beta_dim_uses_exact_path(cut) -> None:
+    data = _make_alpha_field_cut(
+        cut,
+        AxesConfiguration.Type1,
+        xi=7.25,
+        offsets={"delta": 12.5, "xi": 2.5, "beta": -3.75},
+    )
+    with_beta_dim = data.expand_dims(beta=[float(data.beta)])
+
+    converted = with_beta_dim.kspace.convert(silent=True)
+    reference = data.kspace.convert(silent=True)
+
+    assert "beta" not in converted.dims
+    xarray.testing.assert_allclose(converted, reference)
+
+
+def test_convert_cut_with_zero_other_axis_collapses_coord_to_scalar(cut) -> None:
+    data = _make_alpha_field_cut(
+        cut,
+        AxesConfiguration.Type1,
+        xi=0.0,
+        offsets={"delta": 0.0, "xi": 0.0, "beta": 0.0},
+        beta=0.0,
+    )
+
+    converted = data.kspace.convert(silent=True)
+    other_coord = converted.coords[data.kspace.other_axis]
+
+    assert other_coord.ndim == 0
+    assert np.isclose(float(other_coord), 0.0)
+
+
+@pytest.mark.parametrize(
+    ("configuration", "xi", "chi", "offsets"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1DA,
+            5.25,
+            6.5,
+            {"delta": 9.0, "chi": 2.0, "xi": 1.75},
+            id="type1da",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            6.75,
+            -4.0,
+            {"delta": -5.0, "chi": 1.25, "xi": 0.75},
+            id="type2da",
+        ),
+    ],
+)
+def test_convert_cut_uses_exact_da_inverse_for_alpha_field(
+    cut,
+    configuration: AxesConfiguration,
+    xi: float,
+    chi: float,
+    offsets: dict[str, float],
+) -> None:
+    data = _make_alpha_field_cut(cut, configuration, xi=xi, chi=chi, offsets=offsets)
+
+    converted = data.kspace.convert(silent=True)
+    slit_axis = data.kspace.slit_axis
+
+    expected_alpha = _mask_alpha_domain(
+        data, _exact_cut_target_alpha(data, converted[slit_axis].values)
+    ).transpose(*converted.dims)
+
+    finite = np.isfinite(converted.values)
+    assert finite.any()
+    assert np.allclose(converted.values[finite], expected_alpha.values[finite])
+    xarray.testing.assert_allclose(
+        converted.coords[data.kspace.other_axis].reset_coords(drop=True),
+        _exact_cut_other_coord(data, expected_alpha).reset_coords(drop=True),
+    )
+
+
+def test_convert_cut_exact_da_inverse_raises_when_noninvertible(
+    cut, monkeypatch
+) -> None:
+    data = _make_alpha_field_cut(
+        cut,
+        AxesConfiguration.Type1DA,
+        xi=5.25,
+        chi=6.5,
+        offsets={"delta": 9.0, "chi": 2.0, "xi": 1.75},
+    )
+
+    def _raise(*args, **kwargs):
+        raise ValueError(
+            "Exact cut conversion is multi-valued over the measured interval."
+        )
+
+    monkeypatch.setattr(erlab.analysis.kspace, "exact_cut_alpha", _raise)
+
+    with pytest.raises(ValueError, match="multi-valued"):
+        data.kspace.convert(silent=True)
+
+
+@pytest.mark.parametrize(
+    ("configuration", "xi", "offsets"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            0.0,
+            {"delta": 0.0, "xi": 0.0, "beta": 0.0},
+            id="type1",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2,
+            0.0,
+            {"delta": 0.0, "xi": 0.0, "beta": 0.0},
+            id="type2",
+        ),
+    ],
+)
+def test_convert_hv_cut_uses_exact_slit_inverse_for_alpha_field(
+    hvdep,
+    configuration: AxesConfiguration,
+    xi: float,
+    offsets: dict[str, float],
+) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep, configuration, field="alpha", xi=xi, offsets=offsets
+    )
+
+    converted = data.kspace.convert(silent=True)
+    slit_axis = data.kspace.slit_axis
+
+    expected_alpha, legacy_alpha = (
+        _exact_hvdep_targets(data, converted[slit_axis].values, converted.kz.values)[0],
+        _legacy_hvdep_targets(data, converted[slit_axis].values, converted.kz.values)[
+            0
+        ],
+    )
+
+    expected = expected_alpha.transpose(*converted.dims)
+    legacy = legacy_alpha.transpose(*converted.dims)
+
+    finite = np.isfinite(converted.values)
+    assert finite.any()
+    assert np.allclose(converted.values[finite], expected.values[finite])
+    assert not np.allclose(
+        converted.values[finite],
+        legacy.values[finite],
+        equal_nan=True,
+    )
+    xarray.testing.assert_allclose(
+        converted.coords[data.kspace.other_axis].reset_coords(drop=True),
+        _exact_hvdep_other_coord(
+            data, converted[slit_axis].values, converted.kz.values
+        ).reset_coords(drop=True),
+    )
+
+
+@pytest.mark.parametrize(
+    ("configuration", "xi", "offsets"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            0.0,
+            {"delta": 0.0, "xi": 0.0, "beta": 0.0},
+            id="type1",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2,
+            0.0,
+            {"delta": 0.0, "xi": 0.0, "beta": 0.0},
+            id="type2",
+        ),
+    ],
+)
+def test_convert_hv_cut_uses_exact_slit_inverse_for_hv_field(
+    hvdep,
+    configuration: AxesConfiguration,
+    xi: float,
+    offsets: dict[str, float],
+) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep, configuration, field="hv", xi=xi, offsets=offsets
+    )
+
+    converted = data.kspace.convert(silent=True)
+    slit_axis = data.kspace.slit_axis
+
+    expected_hv, legacy_hv = (
+        _exact_hvdep_targets(data, converted[slit_axis].values, converted.kz.values)[1],
+        _legacy_hvdep_targets(data, converted[slit_axis].values, converted.kz.values)[
+            1
+        ],
+    )
+
+    expected = expected_hv.transpose(*converted.dims)
+    legacy = legacy_hv.transpose(*converted.dims)
+
+    finite = np.isfinite(converted.values)
+    assert finite.any()
+    assert np.allclose(converted.values[finite], expected.values[finite])
+    assert not np.allclose(
+        converted.values[finite],
+        legacy.values[finite],
+        equal_nan=True,
+    )
+
+
+def test_convert_hv_cut_exact_slit_inverse_raises_when_exact_hv_path_fails(
+    hvdep, monkeypatch
+) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep,
+        AxesConfiguration.Type1,
+        field="alpha",
+        xi=0.0,
+        offsets={"delta": 0.0, "xi": 0.0, "beta": 0.0},
+    )
+
+    def _raise(*args, **kwargs):
+        raise ValueError(
+            "Exact hv-cut conversion is multi-valued over the measured hv range."
+        )
+
+    monkeypatch.setattr(erlab.analysis.kspace, "exact_hv_cut_coords", _raise)
+
+    with pytest.raises(ValueError, match="multi-valued"):
+        data.kspace.convert(silent=True)
+
+
+def test_convert_hv_cut_exact_slit_inverse_returns_nan_out_of_domain(hvdep) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep,
+        AxesConfiguration.Type1,
+        field="hv",
+        xi=0.0,
+        offsets={"delta": 0.0, "xi": 0.0, "beta": 0.0},
+    )
+
+    lims = data.kspace.estimate_bounds()["kz"]
+    out = data.kspace.convert(
+        silent=True, kz=np.linspace(lims[0] - 0.2, lims[1] + 0.2, 64)
+    )
+
+    assert out.isel(kz=0).isnull().all()
+    assert out.isel(kz=-1).isnull().all()
+    assert not out.isel(kz=slice(1, -1)).isnull().all()
+
+
+@pytest.mark.parametrize(
+    ("configuration", "xi", "chi", "offsets"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1DA,
+            5.25,
+            6.5,
+            {"delta": 9.0, "chi": 2.0, "xi": 1.75},
+            id="type1da",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            6.75,
+            -4.0,
+            {"delta": -5.0, "chi": 1.25, "xi": 0.75},
+            id="type2da",
+        ),
+    ],
+)
+def test_convert_hv_cut_uses_exact_da_inverse_for_alpha_field(
+    hvdep,
+    configuration: AxesConfiguration,
+    xi: float,
+    chi: float,
+    offsets: dict[str, float],
+) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep, configuration, field="alpha", xi=xi, chi=chi, offsets=offsets
+    )
+
+    converted = data.kspace.convert(silent=True)
+    slit_axis = data.kspace.slit_axis
+    expected_alpha, _ = _exact_hvdep_targets(
+        data, converted[slit_axis].values, converted.kz.values
+    )
+    expected = expected_alpha.transpose(*converted.dims)
+
+    finite = np.isfinite(converted.values)
+    assert finite.any()
+    assert np.allclose(converted.values[finite], expected.values[finite])
+    xarray.testing.assert_allclose(
+        converted.coords[data.kspace.other_axis].reset_coords(drop=True),
+        _exact_hvdep_other_coord(
+            data, converted[slit_axis].values, converted.kz.values
+        ).reset_coords(drop=True),
+    )
+
+
+@pytest.mark.parametrize(
+    ("configuration", "xi", "chi", "offsets"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1DA,
+            5.25,
+            6.5,
+            {"delta": 9.0, "chi": 2.0, "xi": 1.75},
+            id="type1da",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            6.75,
+            -4.0,
+            {"delta": -5.0, "chi": 1.25, "xi": 0.75},
+            id="type2da",
+        ),
+    ],
+)
+def test_convert_hv_cut_uses_exact_da_inverse_for_hv_field(
+    hvdep,
+    configuration: AxesConfiguration,
+    xi: float,
+    chi: float,
+    offsets: dict[str, float],
+) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep, configuration, field="hv", xi=xi, chi=chi, offsets=offsets
+    )
+
+    converted = data.kspace.convert(silent=True)
+    slit_axis = data.kspace.slit_axis
+    expected_hv = _exact_hvdep_targets(
+        data, converted[slit_axis].values, converted.kz.values
+    )[1].transpose(*converted.dims)
+
+    finite = np.isfinite(converted.values)
+    assert finite.any()
+    assert np.allclose(converted.values[finite], expected_hv.values[finite])
+
+
+def test_convert_hv_cut_exact_da_inverse_raises_when_noninvertible(
+    hvdep, monkeypatch
+) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep,
+        AxesConfiguration.Type1DA,
+        field="alpha",
+        xi=5.25,
+        chi=6.5,
+        offsets={"delta": 9.0, "chi": 2.0, "xi": 1.75},
+    )
+
+    def _raise(*args, **kwargs):
+        raise ValueError(
+            "Exact cut conversion is multi-valued over the measured interval."
+        )
+
+    monkeypatch.setattr(erlab.analysis.kspace, "exact_hv_cut_coords", _raise)
+
+    with pytest.raises(ValueError, match="multi-valued"):
+        data.kspace.convert(silent=True)
+
+
+@pytest.mark.parametrize(
+    ("configuration", "xi", "chi", "offsets"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            0.0,
+            None,
+            {"delta": 0.0, "xi": 0.0, "beta": 0.0},
+            id="type1",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            6.75,
+            -4.0,
+            {"delta": -5.0, "chi": 1.25, "xi": 0.75},
+            id="type2da",
+        ),
+    ],
+)
+def test_hv_to_kz_exact_off_center_cut_returns_overlay_curve(
+    hvdep,
+    configuration: AxesConfiguration,
+    xi: float,
+    chi: float | None,
+    offsets: dict[str, float],
+) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep, configuration, field="alpha", xi=xi, chi=chi, offsets=offsets
+    )
+    converted = _overlay_subset(data.kspace.convert(silent=True))
+    hv_values = [30.0, 45.0, 60.0]
+
+    assert "kz" in converted.coords[converted.kspace.other_axis].dims
+
+    out = converted.kspace.hv_to_kz(hv_values)
+    expected = _self_consistent_hv_to_kz(converted, hv_values)
+
+    assert "kz" not in out.dims
+    xarray.testing.assert_allclose(out, expected)
+
+
+def test_hv_to_kz_direct_formula_for_scalar_other_axis(cut) -> None:
+    data = _make_alpha_field_cut(
+        cut,
+        AxesConfiguration.Type1,
+        xi=0.0,
+        offsets={"delta": 0.0, "xi": 0.0, "beta": 0.0},
+        beta=0.0,
+    )
+    data.kspace.inner_potential = 10.0
+    converted = data.kspace.convert(silent=True)
+    hv_values = [25.0, 35.0, 45.0]
+
+    out = converted.kspace.hv_to_kz(hv_values)
+    expected = _self_consistent_hv_to_kz(converted, hv_values)
+
+    assert "kz" not in out.dims
+    assert converted.coords[data.kspace.other_axis].ndim == 0
+    xarray.testing.assert_allclose(out, expected)
+
+
+def test_hv_to_kz_falls_back_to_legacy_when_stored_coord_path_is_unavailable(
+    hvdep, monkeypatch
+) -> None:
+    data = _make_field_hvdep_cut(
+        hvdep,
+        AxesConfiguration.Type1,
+        field="alpha",
+        xi=0.0,
+        offsets={"delta": 0.0, "xi": 0.0, "beta": 0.0},
+    )
+    converted = _overlay_subset(data.kspace.convert(silent=True))
+    hv_values = [30.0, 45.0, 60.0]
+
+    monkeypatch.setattr(
+        erlab.accessors.kspace.MomentumAccessor,
+        "_hv_to_kz_from_stored_coords",
+        lambda self, kinetic: None,
+    )
+
+    out = converted.kspace.hv_to_kz(hv_values)
+    expected = _legacy_hv_to_kz(converted, hv_values)
+
+    xarray.testing.assert_allclose(out, expected)
+
+
+def test_hv_to_kz_accepts_iterable_hv(config_1_hvdep) -> None:
+    converted = _overlay_subset(config_1_hvdep)
+    out = converted.kspace.hv_to_kz([30.0, 45.0, 60.0])
+    expected = _self_consistent_hv_to_kz(converted, [30.0, 45.0, 60.0])
+
+    assert out.dims == ("hv", "eV", converted.kspace.slit_axis)
     assert out.hv.size == 3
-    assert np.isfinite(out.values).all()
+    xarray.testing.assert_allclose(out, expected)

--- a/tests/analysis/test_kspace.py
+++ b/tests/analysis/test_kspace.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable
 
 import numpy as np
@@ -93,6 +94,36 @@ def test_invalid_configuration_error_for_invalid_value() -> None:
         match="get_kconv_forward received invalid configuration 999",
     ):
         erlab.analysis.kspace.get_kconv_forward(999)
+
+
+@pytest.mark.parametrize(
+    ("configuration", "context", "expected"),
+    [
+        pytest.param(
+            999, None, "Invalid configuration 999.", id="invalid-without-context"
+        ),
+        pytest.param(
+            AxesConfiguration.Type1,
+            None,
+            "Unexpected configuration Type1.",
+            id="unexpected-without-context",
+        ),
+        pytest.param(
+            AxesConfiguration.Type1,
+            "exact cut conversion",
+            "exact cut conversion received unexpected configuration Type1.",
+            id="unexpected-with-context",
+        ),
+    ],
+)
+def test_invalid_configuration_error_message_variants(
+    configuration, context: str | None, expected: str
+) -> None:
+    err = erlab.analysis.kspace.InvalidConfigurationError(
+        configuration, context=context
+    )
+
+    assert str(err).startswith(expected)
 
 
 def test_inverse_type1_beta_uses_quadrant_from_arctan2() -> None:
@@ -675,6 +706,159 @@ def test_interp_monotonic_interpn_1d_rejects_constant_curve() -> None:
             np.array([1.0, 2.0, 3.0]),
             np.array([1.0]),
         )
+
+
+def test_interp_monotonic_interpn_1d_rejects_repeated_monotonic_curve() -> None:
+    with pytest.raises(ValueError, match="not strictly monotonic"):
+        erlab.analysis.kspace._interp_monotonic_interpn_1d(
+            np.array([0.0, 1.0, 1.0, 2.0]),
+            np.array([0.0, 1.0, 2.0, 3.0]),
+            np.array([1.5]),
+        )
+
+
+def test_exact_cut_alpha_rejects_degenerate_dataarray_geometry(monkeypatch) -> None:
+    alpha_reference = xr.DataArray(np.linspace(-5.0, 5.0, 5), dims=("alpha",))
+    slit_target = xr.DataArray([0.0], dims=("kx",), coords={"kx": [0.0]})
+    beta = xr.DataArray([0.0, 1.0], dims=("hv",), coords={"hv": [24.0, 32.0]})
+    kinetic_energy = xr.DataArray([20.0, 24.0], dims=("hv",), coords={"hv": beta.hv})
+    zeros = xr.zeros_like(beta)
+
+    monkeypatch.setattr(
+        erlab.analysis.kspace,
+        "_fixed_beta_slit_coefficients",
+        lambda *args, **kwargs: (zeros, zeros),
+    )
+
+    with pytest.raises(ValueError, match="slit-axis momentum does not vary with alpha"):
+        erlab.analysis.kspace.exact_cut_alpha(
+            slit_target,
+            beta,
+            kinetic_energy,
+            alpha_reference,
+            AxesConfiguration.Type1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("alpha_reference_r", "u_reference_norm", "match"),
+    [
+        pytest.param(
+            np.zeros((2, 2)),
+            np.zeros(4),
+            "expects one-dimensional",
+            id="ndim-mismatch",
+        ),
+        pytest.param(
+            np.zeros(3),
+            np.zeros(2),
+            "matching shapes",
+            id="shape-mismatch",
+        ),
+        pytest.param(
+            np.zeros(1),
+            np.zeros(1),
+            "at least two alpha reference points",
+            id="too-short",
+        ),
+    ],
+)
+def test_select_slit_branch_1d_validates_reference_inputs(
+    alpha_reference_r: np.ndarray, u_reference_norm: np.ndarray, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        erlab.analysis.kspace._select_slit_branch_1d(
+            alpha_reference_r, u_reference_norm, 0.0
+        )
+
+
+def test_select_slit_branch_1d_rejects_effectively_constant_slit_curve() -> None:
+    with pytest.raises(ValueError, match="effectively constant slit momentum"):
+        erlab.analysis.kspace._select_slit_branch_1d(
+            np.array([0.0, 1.0]),
+            np.array([0.3, 0.3]),
+            0.0,
+        )
+
+
+def test_select_slit_branch_1d_rejects_nonfinite_inverse_branch(monkeypatch) -> None:
+    monkeypatch.setattr(
+        erlab.analysis.kspace,
+        "_candidate_alpha_from_slit",
+        lambda *args, **kwargs: np.array([np.nan, np.nan]),
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with pytest.raises(
+            ValueError, match="could not determine a valid inverse branch"
+        ):
+            erlab.analysis.kspace._select_slit_branch_1d(
+                np.array([0.0, 1.0]),
+                np.array([0.0, 0.1]),
+                0.0,
+            )
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(
+            xr.DataArray(np.zeros((2, 2)), dims=("alpha", "hv")), id="dataarray"
+        ),
+        pytest.param(np.zeros((2, 2)), id="ndarray"),
+    ],
+)
+def test_exact_1d_coord_requires_one_dimensional_inputs(values) -> None:
+    with pytest.raises(ValueError, match="one-dimensional"):
+        erlab.analysis.kspace._exact_1d_coord(
+            values,
+            name="alpha_reference",
+            default_dim="alpha",
+            context="exact cut conversion",
+        )
+
+
+def test_exact_slit_target_coord_handles_alternate_dim_and_rejects_multidim() -> None:
+    alt_dim_target = xr.DataArray([0.1, 0.2], dims=("momentum",))
+    result, dim, is_dataarray = erlab.analysis.kspace._exact_slit_target_coord(
+        alt_dim_target,
+        slit_axis="kx",
+        context="exact cut conversion",
+    )
+
+    assert result.identical(alt_dim_target)
+    assert dim == "momentum"
+    assert is_dataarray
+
+    with pytest.raises(ValueError, match="one-dimensional or contain the slit-axis"):
+        erlab.analysis.kspace._exact_slit_target_coord(
+            xr.DataArray(np.zeros((2, 2)), dims=("row", "col")),
+            slit_axis="kx",
+            context="exact cut conversion",
+        )
+
+
+def test_exact_result_helpers_preserve_plain_arrays_and_skip_missing_dims() -> None:
+    values = np.array([1.0, 2.0])
+    assert (
+        erlab.analysis.kspace._unwrap_exact_result(values, target_is_dataarray=False)
+        is values
+    )
+
+    target = xr.DataArray(
+        np.arange(6).reshape(2, 3),
+        dims=("secondary", "primary"),
+    )
+    transposed = erlab.analysis.kspace._transpose_exact_target(
+        target,
+        primary_dim="primary",
+        secondary_dim="missing",
+        kinetic_energy=1.0,
+        excluded_dim="hv",
+    )
+
+    assert transposed.dims == ("primary", "secondary")
 
 
 @pytest.mark.parametrize(

--- a/tests/analysis/test_kspace.py
+++ b/tests/analysis/test_kspace.py
@@ -1,10 +1,39 @@
 from collections.abc import Callable
 
 import numpy as np
+import pytest
+import xarray as xr
 
 import erlab.analysis
+import erlab.constants
+from erlab.constants import AxesConfiguration
 
 kinetic = np.array([1.0, 2.0, 3.0])
+
+
+def _manual_monotonic_interp(
+    source_coord: np.ndarray, source_values: np.ndarray, target_coord: np.ndarray
+) -> np.ndarray:
+    finite = np.isfinite(source_coord) & np.isfinite(source_values)
+    source_coord = np.asarray(source_coord[finite], dtype=float)
+    source_values = np.asarray(source_values[finite], dtype=float)
+    target_coord = np.asarray(target_coord, dtype=float)
+
+    out = np.full(target_coord.shape, np.nan, dtype=float)
+    if source_coord.size < 2:
+        return out
+
+    if source_coord[0] > source_coord[-1]:
+        source_coord = source_coord[::-1]
+        source_values = source_values[::-1]
+
+    return np.interp(
+        target_coord,
+        source_coord,
+        source_values,
+        left=np.nan,
+        right=np.nan,
+    )
 
 
 def _generate_funclist() -> list[tuple[Callable, Callable]]:
@@ -58,6 +87,14 @@ def test_transform() -> None:
         assert np.allclose(ky, 0.2)
 
 
+def test_invalid_configuration_error_for_invalid_value() -> None:
+    with pytest.raises(
+        erlab.analysis.kspace.InvalidConfigurationError,
+        match="get_kconv_forward received invalid configuration 999",
+    ):
+        erlab.analysis.kspace.get_kconv_forward(999)
+
+
 def test_inverse_type1_beta_uses_quadrant_from_arctan2() -> None:
     kx, ky = 3.0, -1.0
     k_sq, k = 25.0, 5.0
@@ -77,3 +114,919 @@ def test_inverse_type1_beta_uses_quadrant_from_arctan2() -> None:
     assert np.isclose(beta, expected)
     # This case previously landed in the wrong branch near -14.5°.
     assert beta > 90.0
+
+
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "beta"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            {"delta": 12.5, "xi": 7.25, "xi0": 2.5, "beta0": -3.75},
+            4.5,
+            id="type1",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2,
+            {"delta": -8.0, "xi": -6.5, "xi0": -1.75, "beta0": 2.25},
+            -3.0,
+            id="type2",
+        ),
+    ],
+)
+def test_fixed_beta_slit_coefficients_reduce_forward_equation(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    beta: float,
+) -> None:
+    alpha = np.linspace(-15.0, 15.0, 51)
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha, beta, 1.0, **angle_params
+    )
+    slit_axis = "kx" if configuration == AxesConfiguration.Type1 else "ky"
+    slit_values = kx if slit_axis == "kx" else ky
+
+    A, B = erlab.analysis.kspace._fixed_beta_slit_coefficients(
+        configuration, beta, **angle_params
+    )
+    k_tot = erlab.constants.rel_kconv
+    expected = k_tot * (A * np.cos(np.deg2rad(alpha)) + B * np.sin(np.deg2rad(alpha)))
+
+    assert np.allclose(slit_values, expected)
+
+
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "beta"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            {"delta": 12.5, "xi": 7.25, "xi0": 2.5, "beta0": -3.75},
+            4.5,
+            id="type1",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2,
+            {"delta": -8.0, "xi": -6.5, "xi0": -1.75, "beta0": 2.25},
+            -3.0,
+            id="type2",
+        ),
+    ],
+)
+def test_fixed_beta_other_axis_coefficients_reduce_forward_equation(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    beta: float,
+) -> None:
+    alpha = np.linspace(-15.0, 15.0, 51)
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha, beta, 1.0, **angle_params
+    )
+    other_values = ky if configuration == AxesConfiguration.Type1 else kx
+
+    C, D = erlab.analysis.kspace._fixed_beta_other_axis_coefficients(
+        configuration, beta, **angle_params
+    )
+    k_tot = erlab.constants.rel_kconv
+    expected = k_tot * (C * np.cos(np.deg2rad(alpha)) + D * np.sin(np.deg2rad(alpha)))
+
+    assert np.allclose(other_values, expected)
+
+
+@pytest.mark.parametrize("descending", [False, True], ids=["ascending", "descending"])
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "beta"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            {"delta": 12.5, "xi": 7.25, "xi0": 2.5, "beta0": -3.75},
+            4.5,
+            id="type1",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2,
+            {"delta": -8.0, "xi": -6.5, "xi0": -1.75, "beta0": 2.25},
+            -3.0,
+            id="type2",
+        ),
+    ],
+)
+def test_exact_slit_cut_alpha_roundtrips_reference_cut(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    beta: float,
+    descending: bool,
+) -> None:
+    alpha = np.linspace(-15.0, 15.0, 61)
+    if descending:
+        alpha = alpha[::-1]
+
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha, beta, 1.0, **angle_params
+    )
+    slit_values = kx if configuration == AxesConfiguration.Type1 else ky
+
+    recovered = erlab.analysis.kspace.exact_cut_alpha(
+        slit_values,
+        beta,
+        1.0,
+        alpha,
+        configuration,
+        **angle_params,
+    )
+
+    assert np.allclose(recovered, alpha)
+
+
+def test_exact_slit_cut_alpha_returns_nan_out_of_domain() -> None:
+    recovered = erlab.analysis.kspace.exact_cut_alpha(
+        np.array([0.0, 10.0]),
+        4.5,
+        1.0,
+        np.linspace(-10.0, 10.0, 21),
+        AxesConfiguration.Type1,
+        delta=12.5,
+        xi=7.25,
+        xi0=2.5,
+        beta0=-3.75,
+    )
+
+    assert np.isfinite(recovered[0])
+    assert np.isnan(recovered[1])
+
+
+def test_exact_slit_cut_alpha_rejects_multivalued_reference_cut() -> None:
+    alpha = np.linspace(-15.0, 15.0, 61)
+    kx, _ = erlab.analysis.kspace.get_kconv_forward(AxesConfiguration.Type1)(
+        alpha,
+        0.0,
+        1.0,
+        delta=0.0,
+        xi=90.0,
+        xi0=0.0,
+        beta0=0.0,
+    )
+
+    with pytest.raises(ValueError, match="non-physical angle value or offset"):
+        erlab.analysis.kspace.exact_cut_alpha(
+            kx,
+            0.0,
+            1.0,
+            alpha,
+            AxesConfiguration.Type1,
+            delta=0.0,
+            xi=90.0,
+            xi0=0.0,
+            beta0=0.0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "descending"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            {"delta": 12.5, "xi": 7.25, "xi0": 2.5, "beta0": -3.75},
+            False,
+            id="type1-ascending",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2,
+            {"delta": -80.0, "xi": -80.0, "xi0": 0.0, "beta0": 0.0},
+            True,
+            id="type2-descending",
+        ),
+    ],
+)
+def test_exact_slit_cut_alpha_broadcasts_over_beta_and_kinetic_energy(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    descending: bool,
+) -> None:
+    alpha_reference = xr.DataArray(np.linspace(-15.0, 15.0, 61), dims=("alpha",))
+    if descending:
+        alpha_reference = alpha_reference[::-1]
+
+    beta = xr.DataArray(
+        np.array([-20.0, -5.0, 10.0]),
+        dims=("hv",),
+        coords={"hv": [20, 30, 40]},
+    )
+    kinetic_energy = xr.DataArray(
+        np.array([[22.0, 22.5, 23.0], [24.0, 24.5, 25.0], [26.0, 26.5, 27.0]]),
+        dims=("hv", "eV"),
+        coords={"hv": beta.hv, "eV": [-0.1, 0.0, 0.1]},
+    )
+
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha_reference,
+        beta,
+        kinetic_energy,
+        **angle_params,
+    )
+    slit_values = kx if configuration == AxesConfiguration.Type1 else ky
+
+    recovered = erlab.analysis.kspace.exact_cut_alpha(
+        slit_values,
+        beta,
+        kinetic_energy,
+        alpha_reference,
+        configuration,
+        **angle_params,
+    )
+    expected = xr.broadcast(kinetic_energy, alpha_reference)[1]
+
+    xr.testing.assert_allclose(
+        recovered.transpose("hv", "eV", "alpha"),
+        expected.transpose("hv", "eV", "alpha"),
+    )
+
+
+def test_exact_slit_cut_alpha_rejects_multivalued_broadcast_slice() -> None:
+    alpha_reference = xr.DataArray(np.linspace(-15.0, 15.0, 61), dims=("alpha",))
+    beta = xr.DataArray(np.array([-5.0, 0.0]), dims=("hv",), coords={"hv": [20, 30]})
+    kinetic_energy = xr.DataArray(
+        np.array([[22.0, 22.5], [24.0, 24.5]]),
+        dims=("hv", "eV"),
+        coords={"hv": beta.hv, "eV": [-0.05, 0.05]},
+    )
+
+    kx, _ = erlab.analysis.kspace.get_kconv_forward(AxesConfiguration.Type1)(
+        alpha_reference,
+        beta,
+        kinetic_energy,
+        delta=-85.0,
+        xi=-85.0,
+        xi0=0.0,
+        beta0=0.0,
+    )
+
+    with pytest.raises(ValueError, match="non-physical angle value or offset"):
+        erlab.analysis.kspace.exact_cut_alpha(
+            kx,
+            beta,
+            kinetic_energy,
+            alpha_reference,
+            AxesConfiguration.Type1,
+            delta=-85.0,
+            xi=-85.0,
+            xi0=0.0,
+            beta0=0.0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("configuration", "angle_params"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1DA,
+            {"delta": 9.0, "chi": 6.5, "chi0": 2.0, "xi": 5.25, "xi0": 1.75},
+            id="type1da",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            {"delta": -5.0, "chi": -4.0, "chi0": 1.25, "xi": 6.75, "xi0": 0.75},
+            id="type2da",
+        ),
+    ],
+)
+def test_da_forward_inverse_roundtrips_principal_branch(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+) -> None:
+    alpha = np.array([-12.0, -5.0, 0.0, 6.0, 11.0])
+    beta = np.array([-6.0, -2.0, 0.0, 3.0, 7.0])
+    kinetic_energy = np.linspace(21.0, 25.0, alpha.size)
+
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha, beta, kinetic_energy, **angle_params
+    )
+    recovered_alpha, recovered_beta = erlab.analysis.kspace.get_kconv_inverse(
+        configuration
+    )(kx, ky, None, kinetic_energy, **angle_params)
+
+    assert np.allclose(recovered_alpha, alpha)
+    assert np.allclose(recovered_beta, beta)
+
+
+@pytest.mark.parametrize("descending", [False, True], ids=["ascending", "descending"])
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "beta"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1DA,
+            {"delta": 9.0, "chi": 6.5, "chi0": 2.0, "xi": 5.25, "xi0": 1.75},
+            4.5,
+            id="type1da",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            {"delta": -5.0, "chi": -4.0, "chi0": 1.25, "xi": 6.75, "xi0": 0.75},
+            -3.0,
+            id="type2da",
+        ),
+    ],
+)
+def test_exact_da_cut_alpha_roundtrips_reference_cut(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    beta: float,
+    descending: bool,
+) -> None:
+    alpha = np.linspace(-15.0, 15.0, 61)
+    if descending:
+        alpha = alpha[::-1]
+
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha, beta, 24.0, **angle_params
+    )
+    slit_values = kx if configuration == AxesConfiguration.Type1DA else ky
+
+    recovered = erlab.analysis.kspace.exact_cut_alpha(
+        slit_values,
+        beta,
+        24.0,
+        alpha,
+        configuration,
+        **angle_params,
+    )
+
+    assert np.allclose(recovered, alpha)
+
+
+def test_exact_da_cut_alpha_returns_nan_out_of_domain() -> None:
+    alpha_reference = np.linspace(-12.0, 12.0, 49)
+    kx, _ = erlab.analysis.kspace.get_kconv_forward(AxesConfiguration.Type1DA)(
+        alpha_reference,
+        4.5,
+        24.0,
+        delta=9.0,
+        chi=6.5,
+        chi0=2.0,
+        xi=5.25,
+        xi0=1.75,
+    )
+    recovered = erlab.analysis.kspace.exact_cut_alpha(
+        np.array([0.5 * float(kx.min() + kx.max()), float(kx.max()) + 0.1]),
+        4.5,
+        24.0,
+        alpha_reference,
+        AxesConfiguration.Type1DA,
+        delta=9.0,
+        chi=6.5,
+        chi0=2.0,
+        xi=5.25,
+        xi0=1.75,
+    )
+
+    assert np.isfinite(recovered[0])
+    assert np.isnan(recovered[1])
+
+
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "beta"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1DA,
+            {"delta": 9.0, "chi": 6.5, "chi0": 2.0, "xi": 5.25, "xi0": 1.75},
+            4.5,
+            id="type1da",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            {"delta": -5.0, "chi": -4.0, "chi0": 1.25, "xi": 6.75, "xi0": 0.75},
+            -3.0,
+            id="type2da",
+        ),
+    ],
+)
+def test_exact_da_cut_alpha_accepts_scalar_and_ndarray_targets(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    beta: float,
+) -> None:
+    alpha_reference = np.linspace(-15.0, 15.0, 61)
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha_reference, beta, 24.0, **angle_params
+    )
+    slit_values = kx if configuration == AxesConfiguration.Type1DA else ky
+
+    scalar_index = 17
+    scalar_recovered = erlab.analysis.kspace.exact_cut_alpha(
+        float(slit_values[scalar_index]),
+        beta,
+        24.0,
+        alpha_reference,
+        configuration,
+        **angle_params,
+    )
+
+    assert np.asarray(scalar_recovered).shape == ()
+    assert np.isclose(
+        float(np.asarray(scalar_recovered)), alpha_reference[scalar_index]
+    )
+
+    grid_index = np.array([[5, 11], [19, 27]])
+    grid_targets = np.asarray(slit_values[grid_index], dtype=float)
+    grid_recovered = erlab.analysis.kspace.exact_cut_alpha(
+        grid_targets,
+        beta,
+        24.0,
+        alpha_reference,
+        configuration,
+        **angle_params,
+    )
+
+    assert grid_recovered.shape == grid_targets.shape
+    assert np.allclose(grid_recovered, alpha_reference[grid_index])
+
+
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "descending"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1DA,
+            {"delta": 9.0, "chi": 6.5, "chi0": 2.0, "xi": 5.25, "xi0": 1.75},
+            False,
+            id="type1da-ascending",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            {"delta": -5.0, "chi": -4.0, "chi0": 1.25, "xi": 6.75, "xi0": 0.75},
+            True,
+            id="type2da-descending",
+        ),
+    ],
+)
+def test_exact_da_cut_alpha_broadcasts_over_beta_and_kinetic_energy(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    descending: bool,
+) -> None:
+    alpha_reference = xr.DataArray(np.linspace(-15.0, 15.0, 61), dims=("alpha",))
+    if descending:
+        alpha_reference = alpha_reference[::-1]
+
+    beta = xr.DataArray(
+        np.array([-6.0, -1.0, 4.0]),
+        dims=("hv",),
+        coords={"hv": [20.0, 30.0, 40.0]},
+    )
+    kinetic_energy = xr.DataArray(
+        np.array([[22.0, 22.5], [24.0, 24.5], [26.0, 26.5]]),
+        dims=("hv", "eV"),
+        coords={"hv": beta.hv, "eV": [-0.05, 0.05]},
+    )
+
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha_reference,
+        beta,
+        kinetic_energy,
+        **angle_params,
+    )
+    slit_axis = "kx" if configuration == AxesConfiguration.Type1DA else "ky"
+    slit_values = (kx if configuration == AxesConfiguration.Type1DA else ky).rename(
+        {"alpha": slit_axis}
+    )
+
+    recovered = erlab.analysis.kspace.exact_cut_alpha(
+        slit_values,
+        beta,
+        kinetic_energy,
+        alpha_reference,
+        configuration,
+        **angle_params,
+    )
+    expected = xr.broadcast(
+        kinetic_energy, alpha_reference.rename({"alpha": slit_axis})
+    )[1]
+
+    xr.testing.assert_allclose(
+        recovered.transpose("hv", "eV", slit_axis),
+        expected.transpose("hv", "eV", slit_axis),
+    )
+
+
+def test_exact_da_cut_alpha_rejects_multivalued_reference_cut(monkeypatch) -> None:
+    alpha_reference = xr.DataArray(np.linspace(-5.0, 5.0, 11), dims=("alpha",))
+
+    def _mock_forward(alpha, beta, kinetic_energy, configuration, **kwargs):
+        slit_source = xr.DataArray(
+            np.array([0.0, 0.6, 1.0, 0.6, 0.0, -0.4, -0.8, -0.4, 0.0, 0.3, 0.1]),
+            dims=("alpha",),
+            coords={"alpha": alpha_reference.alpha},
+        )
+        zeros = xr.zeros_like(slit_source)
+        if configuration == AxesConfiguration.Type1DA:
+            return slit_source, zeros
+        return zeros, slit_source
+
+    def _mock_get_forward(configuration):
+        def _forward(alpha, beta, kinetic_energy, **kwargs):
+            return _mock_forward(alpha, beta, kinetic_energy, configuration, **kwargs)
+
+        return _forward
+
+    monkeypatch.setattr(erlab.analysis.kspace, "get_kconv_forward", _mock_get_forward)
+
+    with pytest.raises(ValueError, match="non-physical angle value or offset"):
+        erlab.analysis.kspace.exact_cut_alpha(
+            np.array([0.1]),
+            0.0,
+            24.0,
+            alpha_reference,
+            AxesConfiguration.Type1DA,
+        )
+
+
+@pytest.mark.parametrize("descending", [False, True], ids=["ascending", "descending"])
+def test_interp_monotonic_interpn_1d_handles_orientation_and_domain(
+    descending: bool,
+) -> None:
+    source_coord = np.array([0.0, 1.0, 2.0])
+    source_values = np.array([10.0, 20.0, 30.0])
+    if descending:
+        source_coord = source_coord[::-1]
+        source_values = source_values[::-1]
+
+    target = np.array([-1.0, 0.5, 1.5, 3.0])
+
+    out = erlab.analysis.kspace._interp_monotonic_interpn_1d(
+        source_coord, source_values, target
+    )
+
+    assert np.isnan(out[0])
+    assert np.isclose(out[1], 15.0)
+    assert np.isclose(out[2], 25.0)
+    assert np.isnan(out[3])
+
+
+def test_interp_monotonic_interpn_1d_rejects_non_monotonic() -> None:
+    with pytest.raises(ValueError, match="non-physical angle value or offset"):
+        erlab.analysis.kspace._interp_monotonic_interpn_1d(
+            np.array([0.0, 2.0, 1.0]),
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1.5]),
+        )
+
+
+def test_interp_monotonic_interpn_1d_rejects_constant_curve() -> None:
+    with pytest.raises(ValueError, match="effectively constant"):
+        erlab.analysis.kspace._interp_monotonic_interpn_1d(
+            np.array([1.0, 1.0, 1.0]),
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1.0]),
+        )
+
+
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "beta_range"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            {"delta": 12.5, "xi": 7.25, "xi0": 2.5, "beta0": -3.75},
+            (-10.0, -4.0),
+            id="type1",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2,
+            {"delta": -8.0, "xi": -6.5, "xi0": -1.75, "beta0": 2.25},
+            (-8.0, -2.0),
+            id="type2",
+        ),
+    ],
+)
+def test_exact_hv_slit_cut_coords_matches_manual_inversion(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    beta_range: tuple[float, float],
+) -> None:
+    alpha_reference = xr.DataArray(np.linspace(-15.0, 15.0, 61), dims=("alpha",))
+    hv = xr.DataArray(
+        np.linspace(24.0, 60.0, 9),
+        dims=("hv",),
+        coords={"hv": np.linspace(24.0, 60.0, 9)},
+    )
+    eV = xr.DataArray(
+        np.linspace(-0.2, 0.1, 4),
+        dims=("eV",),
+        coords={"eV": np.linspace(-0.2, 0.1, 4)},
+    )
+    beta = xr.DataArray(
+        np.linspace(*beta_range, hv.size),
+        dims=("hv",),
+        coords={"hv": hv.values},
+    )
+    kinetic_energy = hv - 4.5 + eV
+
+    slit_axis = "kx" if configuration == AxesConfiguration.Type1 else "ky"
+    trial_alpha = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha_reference, beta, kinetic_energy, **angle_params
+    )[0 if slit_axis == "kx" else 1]
+    slit_min = float(trial_alpha.min())
+    slit_max = float(trial_alpha.max())
+    slit_value = xr.DataArray(
+        np.linspace(slit_min * 0.6, slit_max * 0.6, 4),
+        dims=(slit_axis,),
+        coords={slit_axis: np.linspace(slit_min * 0.6, slit_max * 0.6, 4)},
+    )
+
+    alpha_source = erlab.analysis.kspace.exact_cut_alpha(
+        slit_value,
+        beta,
+        kinetic_energy,
+        alpha_reference,
+        configuration,
+        **angle_params,
+    )
+    other_momentum = erlab.analysis.kspace._fixed_beta_other_axis_momentum(
+        alpha_source,
+        beta,
+        kinetic_energy,
+        configuration,
+        **angle_params,
+    )
+
+    if configuration == AxesConfiguration.Type1:
+        kx_source = slit_value
+        ky_source = other_momentum
+    else:
+        kx_source = other_momentum
+        ky_source = slit_value
+
+    kz_source = erlab.analysis.kspace.kz_func(
+        kinetic_energy, 10.0, kx_source, ky_source
+    )
+    kz_min = float(kz_source.min())
+    kz_max = float(kz_source.max())
+    kz_value = xr.DataArray(
+        np.linspace(
+            kz_min + 0.1 * (kz_max - kz_min), kz_max - 0.1 * (kz_max - kz_min), 7
+        ),
+        dims=("kz",),
+        coords={
+            "kz": np.linspace(
+                kz_min + 0.1 * (kz_max - kz_min), kz_max - 0.1 * (kz_max - kz_min), 7
+            )
+        },
+    )
+
+    alpha_target, hv_target, _ = erlab.analysis.kspace.exact_hv_cut_coords(
+        slit_value,
+        kz_value,
+        beta,
+        hv,
+        kinetic_energy,
+        alpha_reference,
+        configuration,
+        10.0,
+        **angle_params,
+    )
+
+    expected_alpha = np.empty((slit_value.size, kz_value.size, eV.size), dtype=float)
+    expected_hv = np.empty_like(expected_alpha)
+    kz_by_slice = kz_source.transpose(slit_axis, "eV", "hv").values
+    alpha_by_slice = alpha_source.transpose(slit_axis, "eV", "hv").values
+
+    for i in range(slit_value.size):
+        for j in range(eV.size):
+            expected_alpha[i, :, j] = _manual_monotonic_interp(
+                kz_by_slice[i, j], alpha_by_slice[i, j], kz_value.values
+            )
+            expected_hv[i, :, j] = _manual_monotonic_interp(
+                kz_by_slice[i, j], hv.values, kz_value.values
+            )
+
+    expected_alpha_da = xr.DataArray(
+        expected_alpha,
+        dims=(slit_axis, "kz", "eV"),
+        coords={slit_axis: slit_value.values, "kz": kz_value.values, "eV": eV.values},
+    )
+    expected_hv_da = xr.DataArray(
+        expected_hv,
+        dims=(slit_axis, "kz", "eV"),
+        coords={slit_axis: slit_value.values, "kz": kz_value.values, "eV": eV.values},
+    )
+
+    xr.testing.assert_allclose(alpha_target, expected_alpha_da)
+    xr.testing.assert_allclose(hv_target, expected_hv_da)
+
+
+def test_exact_hv_slit_cut_coords_accepts_scalar_slit_target() -> None:
+    alpha_reference = xr.DataArray(np.linspace(-15.0, 15.0, 61), dims=("alpha",))
+    hv = xr.DataArray(
+        np.linspace(24.0, 60.0, 9),
+        dims=("hv",),
+        coords={"hv": np.linspace(24.0, 60.0, 9)},
+    )
+    eV = xr.DataArray(
+        np.linspace(-0.2, 0.1, 4),
+        dims=("eV",),
+        coords={"eV": np.linspace(-0.2, 0.1, 4)},
+    )
+    beta = xr.DataArray(
+        np.linspace(-10.0, -4.0, hv.size),
+        dims=("hv",),
+        coords={"hv": hv.values},
+    )
+    kinetic_energy = hv - 4.5 + eV
+    angle_params = {"delta": 12.5, "xi": 7.25, "xi0": 2.5, "beta0": -3.75}
+
+    slit_values = erlab.analysis.kspace.get_kconv_forward(AxesConfiguration.Type1)(
+        alpha_reference, beta, kinetic_energy, **angle_params
+    )[0]
+    slit_target = float(
+        np.linspace(float(slit_values.min()) * 0.6, float(slit_values.max()) * 0.6, 4)[
+            2
+        ]
+    )
+
+    alpha_source = erlab.analysis.kspace.exact_cut_alpha(
+        xr.DataArray([slit_target], dims=("kx",), coords={"kx": [slit_target]}),
+        beta,
+        kinetic_energy,
+        alpha_reference,
+        AxesConfiguration.Type1,
+        **angle_params,
+    )
+    other_momentum = erlab.analysis.kspace._fixed_beta_other_axis_momentum(
+        alpha_source,
+        beta,
+        kinetic_energy,
+        AxesConfiguration.Type1,
+        **angle_params,
+    )
+    kz_source = erlab.analysis.kspace.kz_func(
+        kinetic_energy, 10.0, slit_target, other_momentum
+    )
+    kz_value = xr.DataArray(
+        np.linspace(
+            float(kz_source.min()) + 0.1 * float(kz_source.max() - kz_source.min()),
+            float(kz_source.max()) - 0.1 * float(kz_source.max() - kz_source.min()),
+            7,
+        ),
+        dims=("kz",),
+        coords={
+            "kz": np.linspace(
+                float(kz_source.min()) + 0.1 * float(kz_source.max() - kz_source.min()),
+                float(kz_source.max()) - 0.1 * float(kz_source.max() - kz_source.min()),
+                7,
+            )
+        },
+    )
+
+    alpha_scalar, hv_scalar, other_scalar = erlab.analysis.kspace.exact_hv_cut_coords(
+        slit_target,
+        kz_value,
+        beta,
+        hv,
+        kinetic_energy,
+        alpha_reference,
+        AxesConfiguration.Type1,
+        10.0,
+        **angle_params,
+    )
+    alpha_vector, hv_vector, other_vector = erlab.analysis.kspace.exact_hv_cut_coords(
+        xr.DataArray([slit_target], dims=("kx",), coords={"kx": [slit_target]}),
+        kz_value,
+        beta,
+        hv,
+        kinetic_energy,
+        alpha_reference,
+        AxesConfiguration.Type1,
+        10.0,
+        **angle_params,
+    )
+
+    xr.testing.assert_allclose(alpha_scalar, alpha_vector.squeeze("kx", drop=True))
+    xr.testing.assert_allclose(hv_scalar, hv_vector.squeeze("kx", drop=True))
+    xr.testing.assert_allclose(other_scalar, other_vector.squeeze("kx", drop=True))
+
+
+@pytest.mark.parametrize(
+    ("configuration", "angle_params", "beta_range"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1DA,
+            {"delta": 9.0, "chi": 6.5, "chi0": 2.0, "xi": 5.25, "xi0": 1.75},
+            (-6.0, 2.0),
+            id="type1da",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            {"delta": -5.0, "chi": -4.0, "chi0": 1.25, "xi": 6.75, "xi0": 0.75},
+            (-4.0, 4.0),
+            id="type2da",
+        ),
+    ],
+)
+def test_exact_hv_da_cut_coords_matches_manual_inversion(
+    configuration: AxesConfiguration,
+    angle_params: dict[str, float],
+    beta_range: tuple[float, float],
+) -> None:
+    alpha_reference = xr.DataArray(np.linspace(-15.0, 15.0, 61), dims=("alpha",))
+    hv = xr.DataArray(
+        np.linspace(24.0, 54.0, 7),
+        dims=("hv",),
+        coords={"hv": np.linspace(24.0, 54.0, 7)},
+    )
+    eV = xr.DataArray(
+        np.linspace(-0.15, 0.1, 3),
+        dims=("eV",),
+        coords={"eV": np.linspace(-0.15, 0.1, 3)},
+    )
+    beta = xr.DataArray(
+        np.linspace(*beta_range, hv.size),
+        dims=("hv",),
+        coords={"hv": hv.values},
+    )
+    kinetic_energy = hv - 4.5 + eV
+
+    slit_axis = "kx" if configuration == AxesConfiguration.Type1DA else "ky"
+    trial_slit = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha_reference, beta, kinetic_energy, **angle_params
+    )[0 if slit_axis == "kx" else 1]
+    slit_value = xr.DataArray(
+        np.linspace(float(trial_slit.min()) * 0.6, float(trial_slit.max()) * 0.6, 4),
+        dims=(slit_axis,),
+        coords={
+            slit_axis: np.linspace(
+                float(trial_slit.min()) * 0.6, float(trial_slit.max()) * 0.6, 4
+            )
+        },
+    )
+
+    alpha_source = erlab.analysis.kspace.exact_cut_alpha(
+        slit_value,
+        beta,
+        kinetic_energy,
+        alpha_reference,
+        configuration,
+        **angle_params,
+    )
+    other_momentum = erlab.analysis.kspace._exact_other_axis_momentum(
+        alpha_source,
+        beta,
+        kinetic_energy,
+        configuration,
+        **angle_params,
+    )
+
+    if configuration == AxesConfiguration.Type1DA:
+        kx_source = slit_value
+        ky_source = other_momentum
+    else:
+        kx_source = other_momentum
+        ky_source = slit_value
+
+    kz_source = erlab.analysis.kspace.kz_func(
+        kinetic_energy, 10.0, kx_source, ky_source
+    )
+    kz_value = xr.DataArray(
+        np.linspace(float(kz_source.min()) + 0.05, float(kz_source.max()) - 0.05, 7),
+        dims=("kz",),
+        coords={
+            "kz": np.linspace(
+                float(kz_source.min()) + 0.05, float(kz_source.max()) - 0.05, 7
+            )
+        },
+    )
+
+    alpha_target, hv_target, _ = erlab.analysis.kspace.exact_hv_cut_coords(
+        slit_value,
+        kz_value,
+        beta,
+        hv,
+        kinetic_energy,
+        alpha_reference,
+        configuration,
+        10.0,
+        **angle_params,
+    )
+
+    expected_alpha = np.empty((slit_value.size, kz_value.size, eV.size), dtype=float)
+    expected_hv = np.empty_like(expected_alpha)
+    kz_by_slice = kz_source.transpose(slit_axis, "eV", "hv").values
+    alpha_by_slice = alpha_source.transpose(slit_axis, "eV", "hv").values
+
+    for i in range(slit_value.size):
+        for j in range(eV.size):
+            expected_alpha[i, :, j] = _manual_monotonic_interp(
+                kz_by_slice[i, j], alpha_by_slice[i, j], kz_value.values
+            )
+            expected_hv[i, :, j] = _manual_monotonic_interp(
+                kz_by_slice[i, j], hv.values, kz_value.values
+            )
+
+    expected_alpha_da = xr.DataArray(
+        expected_alpha,
+        dims=(slit_axis, "kz", "eV"),
+        coords={slit_axis: slit_value.values, "kz": kz_value.values, "eV": eV.values},
+    )
+    expected_hv_da = xr.DataArray(
+        expected_hv,
+        dims=(slit_axis, "kz", "eV"),
+        coords={slit_axis: slit_value.values, "kz": kz_value.values, "eV": eV.values},
+    )
+
+    xr.testing.assert_allclose(alpha_target, expected_alpha_da)
+    xr.testing.assert_allclose(hv_target, expected_hv_da)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,11 @@ dask.config.set(
 )
 
 
+def _coverage_is_active(pytestconfig: pytest.Config) -> bool:
+    """Return whether pytest-cov is actively collecting coverage."""
+    return pytestconfig.pluginmanager.hasplugin("_cov")
+
+
 @pytest.fixture(scope="session")
 def cluster():
     with LocalCluster(
@@ -500,14 +505,15 @@ def move_and_compare_values():
 
 
 @pytest.fixture(autouse=True)
-def cover_qthreads(monkeypatch, qtbot):
+def cover_qthreads(monkeypatch, qtbot, pytestconfig):
     # https://github.com/nedbat/coveragepy/issues/686#issuecomment-2286288111
     from qtpy.QtCore import QThread
 
     base_constructor = QThread.__init__
+    coverage_active = _coverage_is_active(pytestconfig)
 
     def run_with_trace(self):  # pragma: no cover
-        if "coverage" in sys.modules:
+        if coverage_active:
             # https://github.com/nedbat/coveragepy/issues/686#issuecomment-634932753
             sys.settrace(threading._trace_hook)
         self._base_run()
@@ -521,15 +527,16 @@ def cover_qthreads(monkeypatch, qtbot):
 
 
 @pytest.fixture(autouse=True)
-def cover_qthreadpool(monkeypatch, qtbot):
+def cover_qthreadpool(monkeypatch, qtbot, pytestconfig):
     # https://github.com/nedbat/coveragepy/issues/686#issuecomment-2435049275
     from qtpy.QtCore import QThreadPool
 
     base_start = QThreadPool.start
     QThreadPool.globalInstance().setMaxThreadCount(1)
+    coverage_active = _coverage_is_active(pytestconfig)
 
     def start_with_trace(self, runnable, *args, **kwargs):
-        if "coverage" in sys.modules:
+        if coverage_active:
             original_run = runnable.run
 
             def wrapped_run(*a, **kw):

--- a/tests/interactive/imagetool/test_watcher.py
+++ b/tests/interactive/imagetool/test_watcher.py
@@ -1,4 +1,5 @@
 import builtins
+import logging
 import threading
 import types
 import typing
@@ -596,6 +597,27 @@ def test_start_polling_and_poll_loop_branches(fake_shell, monkeypatch):
     monkeypatch.setattr(watcher, "_maybe_push", _count_call)
     watcher._poll_loop()
     assert calls["count"] == 1
+
+
+def test_watcher_del_suppresses_timeout_warnings(fake_shell, caplog):
+    watcher = _Watcher(fake_shell)
+
+    watcher._watcher_thread = type(
+        "AliveThread",
+        (),
+        {"is_alive": lambda self: True, "join": lambda self, timeout=None: None},
+    )()
+    watcher._poll_thread = type(
+        "AlivePollThread",
+        (),
+        {"is_alive": lambda self: True, "join": lambda self, timeout=None: None},
+    )()
+
+    with caplog.at_level(logging.WARNING, logger=watcher_core.logger.name):
+        watcher.__del__()
+
+    assert "Watcher thread did not stop within timeout" not in caplog.text
+    assert "Watcher poll thread did not stop within timeout" not in caplog.text
 
 
 def test_callback_registration_failure_and_enable_auto_push_error(

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -1,4 +1,5 @@
 import tempfile
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -572,3 +573,61 @@ def test_ktool_exact_hv_bz_overlay_uses_cache(qtbot, monkeypatch) -> None:
 
     win.points_check.setChecked(not win.points_check.isChecked())
     assert call_count == call_count_before
+
+
+def test_get_bz_lines_returns_empty_without_converted_slice() -> None:
+    stub = SimpleNamespace(
+        _avec=np.eye(3),
+        centering_combo=SimpleNamespace(currentText=lambda: "P"),
+        images=[None, SimpleNamespace(data_array=None)],
+    )
+
+    lines, vertices, midpoints = KspaceTool.get_bz_lines(stub)
+
+    assert lines == []
+    assert vertices.shape == (0, 2)
+    assert midpoints.shape == (0, 2)
+
+
+def test_get_bz_lines_uses_legacy_hv_path_for_scalar_other_axis(monkeypatch) -> None:
+    converted = xr.DataArray(
+        np.zeros((3, 4), dtype=float),
+        dims=("kz", "kx"),
+        coords={
+            "kz": [-1.0, 0.0, 1.0],
+            "kx": [-0.5, 0.0, 0.5, 1.0],
+            "ky": 0.25,
+        },
+    )
+    expected_lines = [np.array([[0.0, 0.0], [1.0, 1.0]], dtype=float)]
+    expected_vertices = np.array([[0.25, 0.5]], dtype=float)
+    expected_midpoints = np.array([[0.5, 0.5]], dtype=float)
+
+    def _mock_get_out_of_plane_bz(
+        bvec, *, k_parallel: float, angle: float, bounds, return_midpoints: bool
+    ):
+        assert np.isclose(k_parallel, 0.25)
+        assert np.isclose(angle, 15.0)
+        assert bounds == (-0.5, 1.0, -1.0, 1.0)
+        assert return_midpoints
+        return expected_lines, expected_vertices, expected_midpoints
+
+    monkeypatch.setattr(erlab.lattice, "get_out_of_plane_bz", _mock_get_out_of_plane_bz)
+
+    stub = SimpleNamespace(
+        _avec=np.eye(3),
+        centering_combo=SimpleNamespace(currentText=lambda: "P"),
+        images=[None, SimpleNamespace(data_array=converted)],
+        _bz_cache_token=lambda data: ("cache", data.sizes["kx"], data.sizes["kz"]),
+        _bz_cache_key=None,
+        _bz_cache_value=None,
+        rot_spin=SimpleNamespace(value=lambda: 15.0),
+        data=SimpleNamespace(kspace=SimpleNamespace(_has_hv=True)),
+    )
+
+    lines, vertices, midpoints = KspaceTool.get_bz_lines(stub)
+
+    assert len(lines) == 1
+    assert np.allclose(lines[0], expected_lines[0])
+    assert np.allclose(vertices, expected_vertices)
+    assert np.allclose(midpoints, expected_midpoints)

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -528,3 +528,47 @@ def test_ktool_descending_energy_axis_preview(qtbot, anglemap) -> None:
     expected_ang = win._assign_params(expected_ang)
 
     xr.testing.assert_allclose(ang, expected_ang)
+
+
+def test_ktool_exact_hv_bz_overlay_uses_cache(qtbot, monkeypatch) -> None:
+    data = generate_hvdep_cuts((15, 30, 20), hvrange=(20.0, 30.0), noise=False)
+
+    call_count = 0
+    original = erlab.lattice.get_surface_bz
+
+    def _counting_surface_bz(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(erlab.lattice, "get_surface_bz", _counting_surface_bz)
+
+    win = ktool(
+        data,
+        avec=erlab.lattice.abc2avec(6.97, 6.97, 8.685, 90, 90, 120),
+        rotate_bz=30.0,
+        execute=False,
+    )
+    qtbot.addWidget(win)
+
+    converted = win.images[1].data_array
+    assert converted is not None
+    kp_dim = next(d for d in converted.dims if d != "kz")
+    other = "kx" if kp_dim == "ky" else "ky"
+
+    assert converted[other].ndim == 2
+    assert call_count >= 1
+
+    call_count_before = call_count
+    lines, vertices, midpoints = win.get_bz_lines()
+    assert call_count == call_count_before
+    assert len(lines) > 0
+    assert all(np.isfinite(line).all() for line in lines)
+    assert vertices.size == 0 or np.isfinite(vertices).all()
+    assert midpoints.shape == (0, 2)
+
+    win.update_bz()
+    assert call_count == call_count_before
+
+    win.points_check.setChecked(not win.points_check.isChecked())
+    assert call_count == call_count_before

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,0 +1,34 @@
+import importlib.util
+import pathlib
+import types
+
+
+def _load_conftest_module() -> types.ModuleType:
+    path = pathlib.Path(__file__).with_name("conftest.py")
+    spec = importlib.util.spec_from_file_location("tests_conftest_module", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CONFTEST = _load_conftest_module()
+
+
+class _DummyPluginManager:
+    def __init__(self, plugins: set[str]) -> None:
+        self._plugins = plugins
+
+    def hasplugin(self, name: str) -> bool:
+        return name in self._plugins
+
+
+class _DummyPytestConfig:
+    def __init__(self, plugins: set[str]) -> None:
+        self.pluginmanager = _DummyPluginManager(plugins)
+
+
+def test_coverage_is_active_requires_internal_cov_plugin() -> None:
+    assert not _CONFTEST._coverage_is_active(_DummyPytestConfig({"pytest_cov"}))
+    assert _CONFTEST._coverage_is_active(_DummyPytestConfig({"pytest_cov", "_cov"}))

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -2,13 +2,41 @@ import numpy as np
 import pytest
 
 from erlab.lattice import (
+    _dedup_segments_2d,
+    _plane_frame,
+    _snap_polyline_endpoints,
+    _surface_bz_active_pair_bounds,
+    _surface_bz_translation_grid,
     get_bz_edge,
     get_bz_slice,
     get_in_plane_bz,
     get_out_of_plane_bz,
+    get_surface_bz,
     to_primitive,
     to_reciprocal,
 )
+
+
+def _surface_from_plane(plane_point, plane_normal, xvals, yvals):
+    _, u, v = _plane_frame(plane_normal)
+    return (
+        plane_point[None, None, :]
+        + xvals[None, :, None] * u[None, None, :]
+        + yvals[:, None, None] * v[None, None, :]
+    )
+
+
+def _segmentize_polylines(lines):
+    if not lines:
+        return np.empty((0, 2, 2), dtype=float)
+    return np.concatenate(
+        [
+            np.stack([line[:-1], line[1:]], axis=1)
+            for line in lines
+            if line.shape[0] > 1
+        ],
+        axis=0,
+    )
 
 
 def test_get_bz_edge_square_lattice():
@@ -207,3 +235,279 @@ def test_get_out_of_plane_bz_basic():
     assert unique.shape[0] == 4
     radii = np.sqrt(np.sum(unique**2, axis=1))
     assert np.allclose(radii, np.sqrt(2) * np.pi, atol=1e-6)
+
+
+def test_get_surface_bz_matches_planar_out_of_plane_slice():
+    bvec = to_reciprocal(np.eye(3))
+    k_parallel = 0.5
+    angle = 30.0
+    bounds = (-3.5, 3.5, -3.5, 3.5)
+    theta = np.deg2rad(angle)
+    plane_point = np.array(
+        [k_parallel * np.cos(theta), k_parallel * np.sin(theta), 0.0], dtype=float
+    )
+    plane_normal = np.array([np.cos(theta), np.sin(theta), 0.0], dtype=float)
+    plot_x = np.linspace(bounds[0], bounds[1], 501)
+    plot_y = np.linspace(bounds[2], bounds[3], 501)
+    surface = _surface_from_plane(plane_point, plane_normal, plot_x, plot_y)
+
+    lines, vertices, midpoints = get_surface_bz(
+        bvec, plot_x, plot_y, surface, return_midpoints=True
+    )
+    legacy_lines, legacy_vertices, legacy_midpoints = get_out_of_plane_bz(
+        bvec,
+        k_parallel=k_parallel,
+        angle=angle,
+        bounds=bounds,
+        return_midpoints=True,
+    )
+
+    assert len(lines) == legacy_lines.shape[0]
+    for expected in legacy_vertices:
+        assert any(
+            np.min(np.linalg.norm(line - expected, axis=1)) < 2e-2 for line in lines
+        )
+    for expected in legacy_midpoints:
+        assert any(
+            np.min(np.linalg.norm(line - expected, axis=1)) < 2e-2 for line in lines
+        )
+    for vertex in vertices:
+        assert np.min(np.linalg.norm(legacy_vertices - vertex, axis=1)) < 2e-2
+    assert legacy_midpoints.shape[0] > 0
+    assert midpoints.shape == (0, 2)
+
+    endpoints = np.asarray([point for line in lines for point in (line[0], line[-1])])
+    pair_dist = np.sqrt(
+        np.sum((endpoints[:, None, :] - endpoints[None, :, :]) ** 2, axis=-1)
+    )
+    close_but_distinct = (pair_dist > 1e-8) & (pair_dist < 2e-2)
+    assert not np.any(close_but_distinct)
+
+
+def test_get_surface_bz_omits_midpoints_for_clipped_planar_segments():
+    bvec = to_reciprocal(np.eye(3))
+    k_parallel = 0.5
+    angle = 30.0
+    bounds = (-3.5, 3.5, -1.0, 1.0)
+    theta = np.deg2rad(angle)
+    plane_point = np.array(
+        [k_parallel * np.cos(theta), k_parallel * np.sin(theta), 0.0], dtype=float
+    )
+    plane_normal = np.array([np.cos(theta), np.sin(theta), 0.0], dtype=float)
+    plot_x = np.linspace(bounds[0], bounds[1], 401)
+    plot_y = np.linspace(bounds[2], bounds[3], 201)
+    surface = _surface_from_plane(plane_point, plane_normal, plot_x, plot_y)
+
+    lines, vertices, midpoints = get_surface_bz(
+        bvec, plot_x, plot_y, surface, return_midpoints=True
+    )
+    legacy_lines, legacy_vertices, legacy_midpoints = get_out_of_plane_bz(
+        bvec,
+        k_parallel=k_parallel,
+        angle=angle,
+        bounds=bounds,
+        return_midpoints=True,
+    )
+
+    assert len(lines) == legacy_lines.shape[0] == 1
+    assert vertices.shape == legacy_vertices.shape
+    assert legacy_midpoints.shape == (1, 2)
+    assert midpoints.shape == (0, 2)
+
+
+def test_get_surface_bz_spans_multiple_repeated_zones_without_duplicates():
+    bvec = to_reciprocal(np.eye(3))
+    bounds = (-7.5, 7.5, -7.5, 7.5)
+    plot_x = np.linspace(bounds[0], bounds[1], 601)
+    plot_y = np.linspace(bounds[2], bounds[3], 601)
+    surface = _surface_from_plane(
+        np.array([0.0, 0.0, 0.0], dtype=float),
+        np.array([0.0, 1.0, 0.0], dtype=float),
+        plot_x,
+        plot_y,
+    )
+
+    lines, vertices, midpoints = get_surface_bz(
+        bvec, plot_x, plot_y, surface, return_midpoints=True
+    )
+    segments = _segmentize_polylines(lines)
+
+    assert len(lines) > 4
+    assert np.array_equal(_dedup_segments_2d(segments, tol=1e-8), segments)
+    assert vertices.shape[0] >= 4
+    assert midpoints.shape == (0, 2)
+
+
+def test_get_surface_bz_only_contours_active_owner_pairs(monkeypatch):
+    import contourpy
+
+    bvec = to_reciprocal(np.eye(3))
+    bounds = (-7.5, 7.5, -7.5, 7.5)
+    plot_x = np.linspace(bounds[0], bounds[1], 201)
+    plot_y = np.linspace(bounds[2], bounds[3], 201)
+    surface = _surface_from_plane(
+        np.array([0.0, 0.0, 0.0], dtype=float),
+        np.array([0.0, 1.0, 0.0], dtype=float),
+        plot_x,
+        plot_y,
+    )
+
+    shifts = _surface_bz_translation_grid(bvec, surface, pad_cells=1)
+    dist_sq = np.sum((surface[None, ...] - shifts[:, None, None, :]) ** 2, axis=-1)
+    owner = np.argmin(dist_sq, axis=0)
+    expected_pairs = sorted(_surface_bz_active_pair_bounds(owner))
+
+    call_count = 0
+    original = contourpy.contour_generator
+
+    def _counting_generator(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(contourpy, "contour_generator", _counting_generator)
+
+    get_surface_bz(bvec, plot_x, plot_y, surface, return_midpoints=True)
+
+    assert call_count == len(expected_pairs)
+    assert call_count < len(shifts)
+
+
+def test_snap_polyline_endpoints_does_not_merge_unrelated_pairs():
+    lines = [
+        np.array([[0.0, 0.0], [1.0, 0.0]], dtype=float),
+        np.array([[1.02, 0.02], [2.02, 0.02]], dtype=float),
+    ]
+
+    snapped = _snap_polyline_endpoints(
+        lines,
+        [(0, 1), (2, 3)],
+        snap_tol=0.05,
+        sig_tol=1e-10,
+    )
+
+    assert np.allclose(snapped[0], lines[0])
+    assert np.allclose(snapped[1], lines[1])
+
+
+def test_snap_polyline_endpoints_does_not_merge_parallel_same_pair_segments():
+    lines = [
+        np.array([[0.0, 0.0], [1.0, 0.0]], dtype=float),
+        np.array([[0.05, 0.08], [1.05, 0.08]], dtype=float),
+    ]
+
+    snapped = _snap_polyline_endpoints(
+        lines,
+        [(0, 1), (0, 1)],
+        snap_tol=0.2,
+        sig_tol=1e-10,
+    )
+
+    assert np.allclose(snapped[0], lines[0])
+    assert np.allclose(snapped[1], lines[1])
+
+
+def test_snap_polyline_endpoints_separates_nearby_distinct_vertices():
+    lines = [
+        np.array([[-1.0, 0.0], [0.00, 0.00]], dtype=float),
+        np.array([[0.0, -1.0], [0.01, 0.00]], dtype=float),
+        np.array([[1.0, -1.0], [0.00, 0.01]], dtype=float),
+        np.array([[0.04, -1.0], [0.04, 0.00]], dtype=float),
+        np.array([[1.0, 0.0], [0.05, 0.00]], dtype=float),
+        np.array([[1.0, 1.0], [0.04, 0.01]], dtype=float),
+    ]
+
+    snapped = _snap_polyline_endpoints(
+        lines,
+        [(0, 1), (0, 2), (1, 2), (0, 1), (0, 3), (1, 3)],
+        snap_tol=0.05,
+        sig_tol=1e-10,
+    )
+
+    endpoints = np.asarray([line[-1] for line in snapped], dtype=float)
+    first = endpoints[:3]
+    second = endpoints[3:]
+
+    assert np.allclose(first, first[0])
+    assert np.allclose(second, second[0])
+    assert not np.allclose(first[0], second[0])
+
+
+def test_snap_polyline_endpoints_rejects_nonlocal_cycle_cluster():
+    lines = [
+        np.array([[-1.0, 0.0], [0.00, 0.00]], dtype=float),
+        np.array([[0.04, -1.0], [0.04, 0.00]], dtype=float),
+        np.array([[1.04, 0.04], [0.04, 0.04]], dtype=float),
+        np.array([[0.08, 1.04], [0.08, 0.04]], dtype=float),
+    ]
+
+    snapped = _snap_polyline_endpoints(
+        lines,
+        [(0, 1), (0, 2), (1, 3), (2, 3)],
+        snap_tol=0.1,
+        sig_tol=1e-10,
+    )
+
+    for line, original in zip(snapped, lines, strict=True):
+        assert np.allclose(line, original)
+
+
+def test_snap_polyline_endpoints_does_not_collapse_single_short_segment():
+    lines = [
+        np.array([[0.0, 0.0], [0.0, 0.2]], dtype=float),
+        np.array([[1.0, 0.0], [2.0, 0.0]], dtype=float),
+    ]
+
+    snapped = _snap_polyline_endpoints(
+        lines,
+        [(0, 1), (2, 3)],
+        snap_tol=0.5,
+        sig_tol=1e-10,
+    )
+
+    assert np.allclose(snapped[0], lines[0])
+    assert np.allclose(snapped[1], lines[1])
+
+
+def test_get_surface_bz_sparse_grid_preserves_short_segments():
+    bvec = to_reciprocal(np.eye(3))
+    k_parallel = 0.5
+    angle = 30.0
+    bounds = (-3.5, 3.5, -3.5, 3.5)
+    theta = np.deg2rad(angle)
+    plane_point = np.array(
+        [k_parallel * np.cos(theta), k_parallel * np.sin(theta), 0.0], dtype=float
+    )
+    plane_normal = np.array([np.cos(theta), np.sin(theta), 0.0], dtype=float)
+    plot_x = np.linspace(bounds[0], bounds[1], 61)
+    plot_y = np.linspace(bounds[2], bounds[3], 61)
+    surface = _surface_from_plane(plane_point, plane_normal, plot_x, plot_y)
+
+    lines, _, _ = get_surface_bz(bvec, plot_x, plot_y, surface, return_midpoints=True)
+    line_lengths = np.array([np.linalg.norm(line[-1] - line[0]) for line in lines])
+
+    assert len(lines) == 7
+    assert np.all(line_lengths > 1e-8)
+
+
+def test_get_surface_bz_covers_interior_extrema_with_default_padding():
+    bvec = to_reciprocal(np.eye(3))
+    plot = np.linspace(-1.0, 1.0, 101)
+    xvals, yvals = np.meshgrid(plot, plot)
+    surface = np.zeros((plot.size, plot.size, 3), dtype=float)
+    surface[..., 0] = 20.0 * np.exp(-(xvals**2 + yvals**2) / 0.1)
+    surface[..., 1] = 0.1 * xvals
+    surface[..., 2] = 0.1 * yvals
+
+    lines_default, vertices_default = get_surface_bz(
+        bvec, plot, plot, surface, pad_cells=1
+    )
+    lines_padded, vertices_padded = get_surface_bz(
+        bvec, plot, plot, surface, pad_cells=3
+    )
+
+    assert len(lines_default) == len(lines_padded)
+    assert sum(max(len(line) - 1, 0) for line in lines_default) == sum(
+        max(len(line) - 1, 0) for line in lines_padded
+    )
+    assert vertices_default.shape == vertices_padded.shape


### PR DESCRIPTION
Momentum conversion for cuts previously approximated the momentum perpendicular to the slit as a single value across the cut. This is exact only for cuts passing through the origin in momentum space, but can lead to errors for off-center cuts. Now, the exact momentum coordinates are calculated for each point in the output grid, allowing for accurate conversion of arbitrary cuts. The cuts also contain correct momentum coordinates.

This should not affect most use cases since many cuts of interest are taken near normal emission, and the deviation from the approximation is small for typical angles and kinetic energy ranges.

This also covers hv-dependent cuts that are measured while varying the map angle (beta). Also in this case, the Brillouin Zone overlay of `ktool` is now plotted by slicing with a curved surface in momentum space rather than a flat plane, so the overlay is more accurate for off-center cuts.

This change only affects cuts (i.e., data with only one in-plane momentum axis) since for full 2D momentum maps, the exact momentum coordinates are always calculated. Cuts through the origin are also unaffected.