### PR TITLE
[codex] Replace Qt CI setup with pyvista headless display action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tlambert03/setup-qt-libs@v1
-      - name: Setup for Qt testing
-        run: |
-          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+      - uses: pyvista/setup-headless-display-action@v3
+        with:
+          pyvista: false
+          qt: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tlambert03/setup-qt-libs@v1
-      - name: Setup for Qt testing
-        run: |
-          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+      - uses: pyvista/setup-headless-display-action@v3
+        with:
+          pyvista: false
+          qt: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary
- replace `tlambert03/setup-qt-libs` in the Linux GitHub Actions workflows with `pyvista/setup-headless-display-action`
- enable the action's `qt` option so it installs the Qt runtime dependencies those jobs need
- disable the action's PyVista-specific environment setup to keep the CI behavior focused on headless Qt testing

## Why
The workflows were managing Qt libraries and the headless X display separately. `pyvista/setup-headless-display-action` already covers both concerns on Linux, so switching to it removes the custom Xvfb bootstrap and keeps the setup aligned with the supported action interface.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; [".github/workflows/ci.yml", ".github/workflows/debug.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- repository commit hooks during `git commit`

## Notes
GitHub Actions itself was not run locally from this environment.