### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           Compress-Archive -Path $exeName -DestinationPath $zipName -Force
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: ImageTool Manager (${{ matrix.SUFFIX }})
           path: ${{ steps.info.outputs.FILENAME }}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,158 @@
-name: Test
+name: CI
 
 on:
   push:
     branches: ["main"]
   pull_request:
   workflow_dispatch:
-  schedule:
-    # Every friday at 22:00 UTC (Every saturday at 07:00 KST/JST)
-    - cron: "0 22 * * FRI"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 permissions:
   contents: read
+
 env:
   FORCE_COLOR: 1
 
 jobs:
-  test:
-    name: Test Python ${{ matrix.python-version }} [${{ matrix.qt-api }}]
+  partition-check:
+    name: Verify Test Partition
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Verify coverage shard partition
+        run: uv run --no-sync python -m scripts.ci_test_groups --check-partition
+
+  coverage:
+    name: Coverage ${{ matrix.group }}
+    needs: partition-check
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     env:
       DISPLAY: ":99.0"
-      COV_VERSION: "3.13"
-      COV_QT_API: "pyqt6"
+      QT_API: "pyqt6"
+      PYTEST_QT_API: "pyqt6"
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-        qt-api: ["pyqt6", "pyside6"]
+        include:
+          - group: "cov-core-a"
+            timeout-minutes: 25
+            use-xdist: true
+          - group: "cov-core-b"
+            timeout-minutes: 25
+            use-xdist: true
+          - group: "cov-io"
+            timeout-minutes: 25
+            use-xdist: false
+          - group: "cov-qt-imagetool"
+            timeout-minutes: 30
+            use-xdist: false
+          - group: "cov-qt-tools"
+            timeout-minutes: 25
+            use-xdist: false
+          - group: "cov-qt-ux"
+            timeout-minutes: 25
+            use-xdist: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pyvista/setup-headless-display-action@v4
+        with:
+          pyvista: false
+          qt: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.13"
+
+      - name: Install project with test dependencies
+        run: uv sync --all-extras --dev --group pyqt6
+
+      - name: Resolve test targets
+        run: uv run python -m scripts.ci_test_groups ${{ matrix.group }} > "$RUNNER_TEMP/targets.txt"
+
+      - name: Run coverage shard
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t targets < "$RUNNER_TEMP/targets.txt"
+          pytest_args=(
+            -o faulthandler_timeout=300
+            --cov erlab
+            --cov-report=
+            --junitxml "junit-${{ matrix.group }}.xml"
+            -o junit_family=legacy
+          )
+          if [[ "${{ matrix.use-xdist }}" == "true" ]]; then
+            pytest_args+=(-n auto --dist=worksteal)
+          fi
+          uv run pytest "${pytest_args[@]}" "${targets[@]}"
+
+      - name: Package shard artifacts
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="$RUNNER_TEMP/artifacts/${{ matrix.group }}"
+          mkdir -p "$artifact_dir"
+          cp "junit-${{ matrix.group }}.xml" "$artifact_dir/"
+          shopt -s nullglob
+          coverage_files=(.coverage*)
+          if ((${#coverage_files[@]} == 0)); then
+            echo "No coverage data files were produced." >&2
+            exit 1
+          fi
+          coverage_index=0
+          for coverage_file in "${coverage_files[@]}"; do
+            cp \
+              "$coverage_file" \
+              "$artifact_dir/coverage-data-${{ matrix.group }}-${coverage_index}"
+            coverage_index=$((coverage_index + 1))
+          done
+
+      - name: Upload coverage shard artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-${{ matrix.group }}
+          path: ${{ runner.temp }}/artifacts/${{ matrix.group }}/
+          if-no-files-found: error
+
+  smoke:
+    name: Smoke Python ${{ matrix.python-version }} [${{ matrix.qt-api }}]
+    needs: partition-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DISPLAY: ":99.0"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.11"
+            qt-api: "pyqt6"
+          - python-version: "3.14"
+            qt-api: "pyqt6"
+          - python-version: "3.11"
+            qt-api: "pyside6"
+          - python-version: "3.13"
+            qt-api: "pyside6"
+          - python-version: "3.14"
+            qt-api: "pyside6"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,29 +170,83 @@ jobs:
           cache-dependency-glob: "uv.lock"
           python-version: ${{ matrix.python-version }}
 
-      - name: Install project with all extras
+      - name: Install project with test dependencies
+        run: uv sync --all-extras --dev --group ${{ matrix.qt-api }}
+
+      - name: Resolve smoke targets
+        run: uv run python -m scripts.ci_test_groups compat > "$RUNNER_TEMP/targets.txt"
+
+      - name: Run compatibility smoke tests
+        shell: bash
         run: |
-          uv sync --all-extras --dev --group ${{ matrix.qt-api }} --upgrade
-          export QT_API=${{ matrix.qt-api }}
+          set -euo pipefail
+          mapfile -t targets < "$RUNNER_TEMP/targets.txt"
+          PYTEST_QT_API=${{ matrix.qt-api }} QT_API=${{ matrix.qt-api }} \
+            uv run pytest \
+            -m compat \
+            -o faulthandler_timeout=300 \
+            --junitxml "junit-smoke-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
+            -o junit_family=legacy \
+            "${targets[@]}"
 
-      - name: Test with pytest
-        if: ${{ matrix.python-version != env.COV_VERSION || matrix.qt-api != env.COV_QT_API }}
-        run: PYTEST_QT_API=${{ matrix.qt-api }} QT_API=${{ matrix.qt-api }} uv run pytest -v -s -o log_cli=1 --log-cli-level=INFO -o faulthandler_timeout=300
-        timeout-minutes: 20
+      - name: Upload smoke JUnit artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: smoke-${{ matrix.python-version }}-${{ matrix.qt-api }}
+          path: junit-smoke-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml
+          if-no-files-found: error
 
-      - name: Test with pytest with coverage
-        if: ${{ matrix.python-version == env.COV_VERSION && matrix.qt-api == env.COV_QT_API }}
-        run: PYTEST_QT_API=${{ matrix.qt-api }} QT_API=${{ matrix.qt-api }} uv run pytest -v -s -o log_cli=1 --log-cli-level=INFO -o faulthandler_timeout=300 --cov erlab --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
-        timeout-minutes: 20
+  coverage-combine:
+    name: Combine Coverage
+    needs: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.13"
+
+      - name: Install coverage dependencies
+        run: uv sync --dev
+
+      - name: Download coverage shard artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Combine coverage and JUnit reports
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t coverage_files < <(find artifacts -type f -name 'coverage-data-*' | sort)
+          mapfile -t junit_files < <(find artifacts -type f -name 'junit-*.xml' | sort)
+          if ((${#coverage_files[@]} == 0)); then
+            echo "No coverage files found." >&2
+            exit 1
+          fi
+          if ((${#junit_files[@]} == 0)); then
+            echo "No JUnit files found." >&2
+            exit 1
+          fi
+          uv run coverage combine "${coverage_files[@]}"
+          uv run coverage xml -o coverage.xml
+          uv run python -m scripts.merge_junit_xml "${junit_files[@]}" --output junit.xml
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.python-version == env.COV_VERSION && matrix.qt-api == env.COV_QT_API }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
 
       - name: Upload test results to Codecov
-        if: ${{ matrix.python-version == env.COV_VERSION && matrix.qt-api == env.COV_QT_API && !cancelled() }}
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -94,7 +272,7 @@ jobs:
         run: uv run mypy --install-types --non-interactive --html-report mypy-report .
 
       - name: Upload mypy results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: mypy-report

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,0 +1,66 @@
+name: Compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every friday at 22:00 UTC (Every saturday at 07:00 KST/JST)
+    - cron: "0 22 * * FRI"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  compat:
+    name: Compat Python ${{ matrix.python-version }} [${{ matrix.qt-api }}]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DISPLAY: ":99.0"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        qt-api: ["pyqt6", "pyside6"]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pyvista/setup-headless-display-action@v4
+        with:
+          pyvista: false
+          qt: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install project with upgraded dependencies
+        run: uv sync --all-extras --dev --group ${{ matrix.qt-api }} --upgrade
+
+      - name: Run compatibility suite
+        run: |
+          PYTEST_QT_API=${{ matrix.qt-api }} QT_API=${{ matrix.qt-api }} \
+            uv run pytest \
+            -v \
+            -o faulthandler_timeout=300 \
+            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
+            -o junit_family=legacy
+
+      - name: Upload compatibility JUnit artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: compat-${{ matrix.python-version }}-${{ matrix.qt-api }}
+          path: junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ Place runtime code in `src/erlab/` (analysis routines, interactive Qt tools, IO 
 
 - `uv sync --all-extras --dev --group pyqt6` — editable env with every optional feature and Qt bindings installed for GUI tests.
 - `uv run pytest` — whole suite with coverage configuration from `pyproject.toml`.
+- `uv run python -m scripts.ci_test_groups --check-partition` — verify that the fast CI coverage shards still cover every test file exactly once.
+- `uv run python -m scripts.ci_test_groups compat` — print the compatibility smoke targets used in non-primary CI lanes.
 - `uv run ruff format .` and `uv run ruff check --fix .` after every change to keep style consistent. Prefer automatic fixes instead of manual lint cleanups.
 - `uv run mypy src` — static typing pass.
 - `uv run pyinstaller manager.spec` — bundle the ImageTool manager app.
@@ -32,6 +34,11 @@ Use modern typing syntax as a default rule: use built-in generics (`list[str]`, 
 
 Pytest enforces strict markers and `xfail_strict`; name files `test_<feature>.py` beside the code they cover. Loader plugins need regression data in `tests/io/plugins/test_<plugin>.py`; set `ERLAB_TEST_DATA_DIR` to a local clone of `erlabpy-data` so fixtures resolve. Coverage already skips legacy updater code, so aim for branch coverage elsewhere and parametrize datasets to catch multidimensional regressions.
 
+- The fast PR workflow runs one fully covered, sharded `3.13 + pyqt6` lane plus smaller compatibility smoke jobs. The weekly compatibility workflow keeps the full upgraded `3.11-3.14 x pyqt6/pyside6` matrix.
+- Test grouping is centralized in `scripts/_ci_test_groups.py`. When adding a new top-level test module under `tests/analysis/`, `tests/interactive/`, `tests/io/`, or `tests/`, update that file so the new test lands in exactly one coverage shard and, if appropriate, in the compatibility smoke set.
+- `tests/conftest.py` assigns the `compat`, `gui`, and `serial` markers during collection based on the centralized grouping rules. Keep those markers semantically meaningful; do not scatter ad hoc CI-only marker assignments across unrelated test files.
+- Run `uv run python -m scripts.ci_test_groups --check-partition` after changing the test tree or CI grouping rules.
+
 ## Interactive Qt Notes
 
 - For tools launched from ImageTool, new actions that open/show data in ImageTool should be manager-aware (use manager flow when the parent tool is managed).
@@ -41,6 +48,7 @@ Pytest enforces strict markers and `xfail_strict`; name files `test_<feature>.py
 - `ImageToolManager.main()` inspects `sys.argv[1:]` as potential file paths. For manager tests, prefer explicit test node IDs over long `-k` expressions, or patch `sys.argv` in tests, to avoid accidental file-path parsing side effects.
 - ImageTool manager tests use a fixed ZMQ port (`45555`). If tests fail with `Address already in use` or timeout, check and terminate stale manager processes before rerunning.
 - Avoid running multiple manager test jobs in parallel on the same machine unless ports are isolated.
+- If a test only needs to cover manager integration branches, prefer patching `erlab.interactive.imagetool.manager.is_running` and `show_in_manager` over launching the real manager. Reserve `manager_context` for behavior that genuinely depends on a live manager instance.
 - For coverage runs, `--cov` is generally stable; if `--cov=<module path>` triggers local Qt import issues, use broader `--cov=erlab` and filter coverage output to target files.
 - Do not make runtime code behave differently under pytest (e.g., `PYTEST_VERSION`, `sys.modules["pytest"]`, or test-only env checks in `src/`). Keep production behavior explicit via function arguments/state, and implement test-specific behavior in tests/fixtures/monkeypatching instead.
 - If a code path already shows an explicit UI dialog (`MessageDialog`/`QMessageBox`), avoid duplicate manager alert popups by logging with `extra={"suppress_ui_alert": True}`.
@@ -50,5 +58,5 @@ Pytest enforces strict markers and `xfail_strict`; name files `test_<feature>.py
 
 ## Commit & Pull Request Guidelines
 
-Follow Conventional Commits with scopes (e.g., `feat(analysis.gold): support multi-angle Fermi fits`) and reference issues via `(#123)` when relevant. PRs should summarize behavior changes, list the commands you ran, and attach screenshots or GIFs for GUI tweaks. Run `uv run ruff check`, `uv run ruff format --check`, `uv run mypy src`, and `uv run pytest` before requesting review, and mention dependent data/doc PRs in the description.
+Follow Conventional Commits with scopes (e.g., `feat(analysis.gold): support multi-angle Fermi fits`) and reference issues via `(#123)` when relevant. PRs should summarize behavior changes, list the commands you ran, and attach screenshots or GIFs for GUI tweaks. Run `uv run ruff check`, `uv run ruff format --check`, `uv run mypy src`, `uv run pytest`, and `uv run python -m scripts.ci_test_groups --check-partition` when you change CI grouping or add new top-level test modules, and mention dependent data/doc PRs in the description.
 When a user asks for a commit message, provide a Conventional Commit subject and include a longer, user-facing description paragraph if there are user-visible changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ### ✨ Features
 
+- **ktool:** add symmetrization preview ([39cec40](https://github.com/kmnhan/erlabpy/commit/39cec40933d21e82538c2b01a3457bd0edb4c519))
+
+  Adds the ability to preview n-fold symmetrized constant-energy surfaces to `ktool`.
+
+- **interactive.ptable:** add periodic table app (#297) ([7e77064](https://github.com/kmnhan/erlabpy/commit/7e77064c3cfa6abffeddf2eb749c704834772de0))
+
+  Adds a new interactive periodic table app, `erlab.interactive.ptable`, that provides x-ray absorption edge tables, and photoionization cross-section plots. The app is also accessible from the ImageTool manager's `Apps` menu.
+
+- **analysis.xps:** add module that provides x-ray cross sections and absorption edge energies for core-level photoemission analysis (#296) ([dd7d824](https://github.com/kmnhan/erlabpy/commit/dd7d824f3284130f28308b1ebb692c4996b05490))
+
 - **kspace:** make cut conversion exact (#293) ([426ae22](https://github.com/kmnhan/erlabpy/commit/426ae225186ce9cdbced67d97b7b0a6bb2e1fb60))
 
   Momentum conversion for cuts previously approximated the momentum perpendicular to the slit as a single value across the cut. This is exact only for cuts passing through the origin in momentum space, but can lead to errors for off-center cuts. Now, the exact momentum coordinates are calculated for each point in the output grid, allowing for accurate conversion of arbitrary cuts. The cuts also contain correct momentum coordinates.
@@ -25,6 +35,8 @@
   Also adds support for lazy-computing dask-based inputs.
 
 ### 🐞 Bug Fixes
+
+- **analysis.gold:** fix regression where open bounds (`None`) was not avaliable in range slicing and plotting functions ([93dc2fb](https://github.com/kmnhan/erlabpy/commit/93dc2fb8d83165c97d8c45d9c3ce33bf697667ee))
 
 - **interactive:** better lifecycle management of colorbar menu widgets to prevent rare crashes due to garbage collection of menu widgets from worker threads during later allocations ([37f5cc4](https://github.com/kmnhan/erlabpy/commit/37f5cc4e1c3628874892db46851fe20944476dfc))
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -106,8 +106,13 @@ reflected in the package without having to reinstall it. Before installing:
 2. Run:
 
    ```sh
-   uv sync --all-extras --dev
+   uv sync --all-extras --dev --group pyqt6
    ```
+
+   This installs the default development environment used by local test runs, including
+   the primary Qt binding used in the fast CI workflow. If you need to reproduce the
+   weekly compatibility matrix locally with PySide6, add `--group pyside6` to the
+   command.
 
 ### Updating the editable installation
 
@@ -194,6 +199,37 @@ branch` in the GitHub repo.
 
 4. Build the documentation for documentation changes. See the [documentation section](#building-the-documentation-locally) for more information.
 
+### Running tests locally
+
+The repository uses two complementary CI workflows:
+
+- A fast PR workflow that runs the full suite once with coverage on locked dependencies
+  (`Python 3.13 + PyQt6`), split into multiple shards.
+- A weekly compatibility workflow that keeps the broader upgraded dependency matrix
+  (`Python 3.11-3.14 x PyQt6/PySide6`).
+
+For local development, the most useful commands are:
+
+```sh
+uv run pytest
+uv run pytest -m compat
+uv run python -m scripts.ci_test_groups --check-partition
+```
+
+The `compat` marker selects the compatibility smoke tests used on non-primary CI lanes.
+The partition check verifies that the fast CI coverage shards still cover every test
+file exactly once.
+
+The shard definitions live in `scripts/_ci_test_groups.py`. If you add a new top-level
+test module under `tests/analysis/`, `tests/interactive/`, `tests/io/`, or directly
+under `tests/`, update that file so the new module is assigned to exactly one coverage
+shard. Add it to the compatibility smoke targets only when it provides broad
+cross-version or cross-binding signal.
+
+`tests/conftest.py` assigns the `compat`, `gui`, and `serial` markers during collection
+from those centralized rules. Keep the grouping logic there rather than scattering CI
+only markers across unrelated test modules.
+
 ### Commit and push your changes
 
 1. To commit all modified files into the local copy of your repo, do `git commit -am 'A
@@ -253,6 +289,10 @@ these steps:
    ```sh
    uv run pytest tests/io/plugins/test_<plugin_name>.py
    ```
+
+   If the new test module is not under an already grouped directory such as
+   `tests/io/plugins/`, update `scripts/_ci_test_groups.py` so the fast CI coverage
+   partition stays complete.
 
 7. Now, it's time to apply your changes. First, push your changes to your fork of
    [erlabpy-data](https://github.com/kmnhan/erlabpy-data) and create a pull request to
@@ -318,7 +358,7 @@ these steps:
   - When using Qt Designer, place the `.ui` files in the same directory as the Python
     file that uses them. The files must be imported using `qtpy.uic.loadUiType`.
 
-    For instance, if you place `mywidget.py` and `mywidget.ui` in
+  - For instance, if you place `mywidget.py` and `mywidget.ui` in
     `src/erlab/interactive/`, `mywidget.py` should look like this:
 
     ```python
@@ -338,6 +378,11 @@ these steps:
             super().__init__()
             self.setupUi(self)
     ```
+
+  - For tests, only start the real ImageTool manager when the behavior under test
+    depends on an active manager instance. If you only need to cover manager-aware
+    dispatch paths, prefer patching `erlab.interactive.imagetool.manager.is_running`
+    and `show_in_manager` instead.
 
 (documentation)=
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ description = "Python package for ARPES data analysis and visualization."
 readme = "README.md"
 requires-python = ">=3.11"
 keywords = ["Condensed Matter Physics", "ARPES"]
-license = { file = "LICENSE" }
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Visualization",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -80,6 +80,7 @@ dev = [
     "pytest-datadir>=1.5.0",
     "pytest-env>=1.1.5",
     "pytest-qt>=4.4.0",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.15.1",
 ]
 docs = [
@@ -277,6 +278,11 @@ qt_log_ignore = [
     "This plugin does not support raise()",
     "This plugin does not support propagateSizeHints()",
     "Populating font family aliases.*",
+]
+markers = [
+    "compat: compatibility smoke tests for non-primary CI lanes",
+    "gui: tests that require Qt or GUI-related infrastructure",
+    "serial: tests that should not be run under pytest-xdist",
 ]
 
 [tool.pytest_env]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper scripts and shared CI utilities for the repository."""

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import pathlib
+from collections import Counter, defaultdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TESTS_ROOT = REPO_ROOT / "tests"
+
+COMPAT_TARGETS: tuple[str, ...] = (
+    "tests/accessors/test_fit.py",
+    "tests/accessors/test_general.py",
+    "tests/analysis/test_transform.py",
+    "tests/analysis/test_xps.py",
+    "tests/io/test_igor.py",
+    "tests/io/test_io_utils.py",
+    "tests/plotting/test_atoms.py",
+    "tests/plotting/test_general.py",
+    "tests/interactive/test_options.py",
+    "tests/interactive/test_colors.py",
+    "tests/interactive/imagetool/test_module_split.py",
+    "tests/interactive/imagetool/test_server_multipart.py",
+    "tests/interactive/imagetool/test_manager_warnings.py",
+    "tests/io/test_dataloader.py::test_loader",
+    "tests/utils/test_array.py",
+)
+
+COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
+    "cov-core-a": (
+        "tests/accessors",
+        "tests/analysis/test_kspace.py",
+    ),
+    "cov-core-b": (
+        "tests/analysis/fit",
+        "tests/analysis/test_gold.py",
+        "tests/analysis/test_correlation.py",
+        "tests/analysis/test_image.py",
+        "tests/analysis/test_image_savgol.py",
+        "tests/analysis/test_interpolate.py",
+        "tests/analysis/test_transform.py",
+        "tests/analysis/test_mask.py",
+        "tests/analysis/test_mesh.py",
+        "tests/analysis/test_xps.py",
+        "tests/plotting",
+        "tests/utils",
+        "tests/test_conftest.py",
+        "tests/test_constants.py",
+        "tests/test_lattice.py",
+    ),
+    "cov-io": ("tests/io",),
+    "cov-qt-imagetool": ("tests/interactive/imagetool",),
+    "cov-qt-tools": (
+        "tests/interactive/test_bzplot.py",
+        "tests/interactive/test_dask.py",
+        "tests/interactive/test_derivative.py",
+        "tests/interactive/test_explorer.py",
+        "tests/interactive/test_fastbinning.py",
+        "tests/interactive/test_fermiedge.py",
+        "tests/interactive/test_fit1d.py",
+        "tests/interactive/test_fit2d.py",
+        "tests/interactive/test_kspace.py",
+        "tests/interactive/test_magic.py",
+        "tests/interactive/test_mesh.py",
+    ),
+    "cov-qt-ux": (
+        "tests/interactive/test_colors.py",
+        "tests/interactive/test_options.py",
+        "tests/interactive/test_options_parameters.py",
+        "tests/interactive/test_options_tree.py",
+        "tests/interactive/test_ptable.py",
+        "tests/interactive/test_utils.py",
+    ),
+}
+
+GUI_PREFIXES: tuple[str, ...] = ("tests/interactive/",)
+GUI_TARGETS: tuple[str, ...] = ()
+
+SERIAL_PREFIXES: tuple[str, ...] = ("tests/interactive/imagetool/",)
+SERIAL_TARGETS: tuple[str, ...] = ()
+
+COMPAT_NODEIDS: frozenset[str] = frozenset(
+    target for target in COMPAT_TARGETS if "::" in target
+)
+COMPAT_FILES: frozenset[str] = frozenset(
+    target for target in COMPAT_TARGETS if "::" not in target
+)
+
+
+def _normalize_relative(path: pathlib.Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def iter_all_test_files() -> list[str]:
+    return sorted(_normalize_relative(path) for path in TESTS_ROOT.rglob("test_*.py"))
+
+
+def expand_targets(targets: Sequence[str]) -> list[str]:
+    expanded: list[str] = []
+    for target in targets:
+        if "::" in target:
+            file_target, _ = target.split("::", maxsplit=1)
+            file_path = REPO_ROOT / file_target
+            if not file_path.is_file():
+                raise ValueError(f"Unknown test node target: {target}")
+            expanded.append(target)
+            continue
+
+        path = REPO_ROOT / target
+        if path.is_dir():
+            expanded.extend(
+                sorted(
+                    _normalize_relative(file_path)
+                    for file_path in path.rglob("test_*.py")
+                )
+            )
+        elif path.is_file():
+            expanded.append(target)
+        else:
+            raise ValueError(f"Unknown test target: {target}")
+    return expanded
+
+
+def expand_file_targets(targets: Sequence[str]) -> list[str]:
+    return [target for target in expand_targets(targets) if "::" not in target]
+
+
+def get_group_targets(group: str) -> tuple[str, ...]:
+    if group == "compat":
+        return COMPAT_TARGETS
+    try:
+        return COVERAGE_GROUPS[group]
+    except KeyError as exc:
+        raise KeyError(f"Unknown test group: {group}") from exc
+
+
+def get_group_file_targets(group: str) -> list[str]:
+    return expand_file_targets(get_group_targets(group))
+
+
+def coverage_membership() -> dict[str, list[str]]:
+    membership: dict[str, list[str]] = defaultdict(list)
+    for group_name, targets in COVERAGE_GROUPS.items():
+        for file_target in expand_file_targets(targets):
+            membership[file_target].append(group_name)
+    return dict(membership)
+
+
+def check_coverage_partition() -> list[str]:
+    all_files = set(iter_all_test_files())
+    membership = coverage_membership()
+    counts = Counter(
+        {file_target: len(groups) for file_target, groups in membership.items()}
+    )
+
+    missing = sorted(all_files - counts.keys())
+    duplicate_members = {
+        file_target: groups
+        for file_target, groups in sorted(membership.items())
+        if len(groups) > 1
+    }
+    extras = sorted(counts.keys() - all_files)
+
+    errors: list[str] = []
+    if missing:
+        errors.append("Missing from coverage partition:")
+        errors.extend(f"  - {file_target}" for file_target in missing)
+    if duplicate_members:
+        errors.append("Covered by multiple groups:")
+        errors.extend(
+            f"  - {file_target}: {', '.join(groups)}"
+            for file_target, groups in duplicate_members.items()
+        )
+    if extras:
+        errors.append("Unknown files referenced by coverage groups:")
+        errors.extend(f"  - {file_target}" for file_target in extras)
+    return errors
+
+
+def is_gui_path(rel_path: str) -> bool:
+    return rel_path in GUI_TARGETS or rel_path.startswith(GUI_PREFIXES)
+
+
+def is_serial_path(rel_path: str) -> bool:
+    return rel_path in SERIAL_TARGETS or rel_path.startswith(SERIAL_PREFIXES)
+
+
+def is_compat_path(rel_path: str) -> bool:
+    return rel_path in COMPAT_FILES
+
+
+def is_compat_nodeid(nodeid: str) -> bool:
+    return nodeid in COMPAT_NODEIDS
+
+
+def iter_known_groups() -> Iterable[str]:
+    yield from COVERAGE_GROUPS
+    yield "compat"

--- a/scripts/ci_test_groups.py
+++ b/scripts/ci_test_groups.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+from scripts._ci_test_groups import (
+    check_coverage_partition,
+    get_group_targets,
+    iter_known_groups,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Print CI test group targets.")
+    parser.add_argument("group", nargs="?", choices=sorted(iter_known_groups()))
+    parser.add_argument(
+        "--check-partition",
+        action="store_true",
+        help="Verify that the coverage groups cover every test file exactly once.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.check_partition:
+        errors = check_coverage_partition()
+        if errors:
+            print("\n".join(errors), file=sys.stderr)
+            return 1
+        print("Coverage groups cover every test file exactly once.")
+        return 0
+
+    if args.group is None:
+        parser.error("either a group name or --check-partition is required")
+
+    print("\n".join(get_group_targets(args.group)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_junit_xml.py
+++ b/scripts/merge_junit_xml.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import pathlib
+import xml.etree.ElementTree as ET
+
+COUNT_ATTRS = ("tests", "failures", "errors", "skipped")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Merge multiple JUnit XML reports.")
+    parser.add_argument("inputs", nargs="+", help="Input JUnit XML files.")
+    parser.add_argument("--output", required=True, help="Output JUnit XML file.")
+    return parser
+
+
+def iter_suites(path: pathlib.Path) -> list[ET.Element]:
+    root = ET.parse(path).getroot()  # noqa: S314 - local CI artifacts only
+    if root.tag == "testsuite":
+        return [root]
+    if root.tag == "testsuites":
+        return [child for child in root if child.tag == "testsuite"]
+    raise ValueError(f"Unsupported JUnit XML root tag in {path}: {root.tag}")
+
+
+def merge_reports(inputs: list[pathlib.Path], output: pathlib.Path) -> None:
+    merged_root = ET.Element("testsuites")
+    totals = dict.fromkeys(COUNT_ATTRS, 0)
+    total_time = 0.0
+
+    for input_path in inputs:
+        for suite in iter_suites(input_path):
+            merged_root.append(copy.deepcopy(suite))
+            for attr in COUNT_ATTRS:
+                totals[attr] += int(float(suite.attrib.get(attr, "0")))
+            total_time += float(suite.attrib.get("time", "0"))
+
+    for attr in COUNT_ATTRS:
+        merged_root.set(attr, str(totals[attr]))
+    merged_root.set("time", f"{total_time:.3f}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    ET.ElementTree(merged_root).write(output, encoding="utf-8", xml_declaration=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    inputs = [pathlib.Path(path) for path in args.inputs]
+    output = pathlib.Path(args.output)
+    merge_reports(inputs, output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erlab/analysis/gold.py
+++ b/src/erlab/analysis/gold.py
@@ -50,15 +50,25 @@ def _eval_edge(modelresult: lmfit.model.ModelResult, *, evalute_at: npt.NDArray)
     return modelresult.eval(x=evalute_at)
 
 
+def _normalize_range_bounds(
+    value_range: tuple[float | None, float | None],
+) -> tuple[float | None, float | None]:
+    lower, upper = value_range
+    lower = None if lower is None else float(lower)
+    upper = None if upper is None else float(upper)
+    if lower is not None and upper is not None and lower > upper:
+        lower, upper = upper, lower
+    return lower, upper
+
+
 def _range_slice_for_coord(
-    coord: xr.DataArray, value_range: tuple[float, float]
+    coord: xr.DataArray, value_range: tuple[float | None, float | None]
 ) -> slice:
-    start, stop = map(float, value_range)
+    lower, upper = _normalize_range_bounds(value_range)
     values = np.asarray(coord.values)
 
     if values.size < 2:
-        lo, hi = sorted((start, stop))
-        return slice(lo, hi)
+        return slice(lower, upper)
 
     if not erlab.utils.array.is_monotonic(values):
         coord_name = str(coord.name) if coord.name is not None else "<unknown>"
@@ -68,10 +78,18 @@ def _range_slice_for_coord(
         )
 
     if values[0] <= values[-1]:
-        lo, hi = sorted((start, stop))
+        start, stop = lower, upper
     else:
-        lo, hi = sorted((start, stop), reverse=True)
-    return slice(lo, hi)
+        start, stop = upper, lower
+    return slice(start, stop)
+
+
+def _range_limits_for_coord(
+    coord: xr.DataArray, value_range: tuple[float | None, float | None]
+) -> tuple[float, float]:
+    coord_sel = coord.sel({coord.dims[0]: _range_slice_for_coord(coord, value_range)})
+    values = np.asarray(coord_sel.values, dtype=float)
+    return float(np.min(values)), float(np.max(values))
 
 
 def correct_with_edge(
@@ -528,10 +546,12 @@ def _plot_gold_fit(
     else:
         gold.T.qplot(ax=ax0, cmap="copper", gamma=0.5)
 
+    angle_lims = _range_limits_for_coord(gold[along], angle_range)
+    eV_lims = _range_limits_for_coord(gold["eV"], eV_range)
     rect = matplotlib.patches.Rectangle(
-        (angle_range[0], eV_range[0]),
-        np.diff(angle_range)[0],
-        np.diff(eV_range)[0],
+        (angle_lims[0], eV_lims[0]),
+        angle_lims[1] - angle_lims[0],
+        eV_lims[1] - eV_lims[0],
         ec="w",
         alpha=0.5,
         lw=0.75,
@@ -1095,10 +1115,12 @@ def resolution(
         plt.show()
         ax = plt.gca()
         gold_corr.qplot(ax=ax, cmap="copper", gamma=0.5)
+        angle_lims = _range_limits_for_coord(gold_corr["alpha"], angle_range)
+        eV_lims = _range_limits_for_coord(gold_roi["eV"], eV_range_fit)
         rect = matplotlib.patches.Rectangle(
-            (angle_range[0], eV_range_fit[0]),
-            np.diff(angle_range)[0],
-            np.diff(eV_range_fit)[0],
+            (angle_lims[0], eV_lims[0]),
+            angle_lims[1] - angle_lims[0],
+            eV_lims[1] - eV_lims[0],
             ec="w",
             alpha=0.5,
             lw=0.75,
@@ -1167,10 +1189,11 @@ def resolution_roi(
     if plot:
         ax = plt.gca()
         gold_roi.qplot(ax=ax, cmap="copper", gamma=0.5)
+        eV_lims = _range_limits_for_coord(gold_roi["eV"], eV_range)
         ax.fill_between(
             gold_roi.alpha,
-            eV_range[0],
-            eV_range[1],
+            eV_lims[0],
+            eV_lims[1],
             ec="w",
             fc="none",
             alpha=0.4,

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -140,6 +140,10 @@ class _MovableCircleROI(pg.CircleROI):
 
 
 class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
+    _PREVIEW_SYMMETRY_ABS_TOL = 0.05
+    _PREVIEW_SYMMETRY_REL_TOL = 0.02
+    _PREVIEW_SYMMETRY_ANGLE_TOL = 5.0
+
     def __init__(
         self,
         avec: npt.NDArray | None = None,
@@ -212,6 +216,7 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
 
         self._roi_list: list[_MovableCircleROI] = []
         self.add_circle_btn.clicked.connect(self._add_circle)
+        self.preview_symmetry_group.setEnabled(False)
 
         if rotate_bz is None:
             rotate_bz = opts.ktool.bz.default_rot
@@ -235,6 +240,10 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
                 opts.ktool.bz.default_gamma,
             )
         self._avec = avec
+        with QtCore.QSignalBlocker(self.preview_symmetry_fold_spin):
+            self.preview_symmetry_fold_spin.setValue(
+                self._default_preview_symmetry_fold()
+            )
 
     @property
     def _avec(self) -> npt.NDArray:
@@ -267,6 +276,24 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
             self.alpha_spin.setValue(alpha)
             self.beta_spin.setValue(beta)
             self.gamma_spin.setValue(gamma)
+
+    def _default_preview_symmetry_fold(self) -> int:
+        a, b, _, _, _, gamma = erlab.lattice.avec2abc(self._avec)
+        same_in_plane = np.isclose(
+            a,
+            b,
+            rtol=self._PREVIEW_SYMMETRY_REL_TOL,
+            atol=self._PREVIEW_SYMMETRY_ABS_TOL,
+        )
+        if same_in_plane and np.isclose(
+            gamma, 120.0, atol=self._PREVIEW_SYMMETRY_ANGLE_TOL
+        ):
+            return 6
+        if same_in_plane and np.isclose(
+            gamma, 90.0, atol=self._PREVIEW_SYMMETRY_ANGLE_TOL
+        ):
+            return 4
+        return 2
 
     @QtCore.Slot()
     def _add_circle(self) -> None:
@@ -355,6 +382,8 @@ class KspaceTool(KspaceToolGUI):
         cmap_gamma: float
         cmap_invert: bool
         cmap_highcontrast: bool
+        preview_symmetry_enabled: bool = False
+        preview_symmetry_fold: int | None = None
         show_angle_plot: bool
 
     @property
@@ -439,6 +468,8 @@ class KspaceTool(KspaceToolGUI):
             cmap_gamma=self.gamma_widget.value(),
             cmap_invert=self.invert_check.isChecked(),
             cmap_highcontrast=self.contrast_check.isChecked(),
+            preview_symmetry_enabled=self.preview_symmetry_group.isChecked(),
+            preview_symmetry_fold=self.preview_symmetry_fold_spin.value(),
             show_angle_plot=self.angle_plot_check.isChecked(),
         )
 
@@ -513,6 +544,14 @@ class KspaceTool(KspaceToolGUI):
             self.gamma_widget.setValue(status.cmap_gamma)
             self.invert_check.setChecked(status.cmap_invert)
             self.contrast_check.setChecked(status.cmap_highcontrast)
+
+        with (
+            QtCore.QSignalBlocker(self.preview_symmetry_group),
+            QtCore.QSignalBlocker(self.preview_symmetry_fold_spin),
+        ):
+            if status.preview_symmetry_fold is not None:
+                self.preview_symmetry_fold_spin.setValue(status.preview_symmetry_fold)
+            self.preview_symmetry_group.setChecked(status.preview_symmetry_enabled)
 
         self.update()
         self.update_bz()
@@ -619,6 +658,8 @@ class KspaceTool(KspaceToolGUI):
 
         self.bounds_supergroup.toggled.connect(self.queue_update)
         self.resolution_supergroup.toggled.connect(self.queue_update)
+        self.preview_symmetry_group.toggled.connect(self.queue_update)
+        self.preview_symmetry_fold_spin.valueChanged.connect(self.queue_update)
 
         self._offset_spins: dict[str, QtWidgets.QDoubleSpinBox] = {}
 
@@ -1015,6 +1056,39 @@ class KspaceTool(KspaceToolGUI):
     def _validate_kinetic_energy(self, data: xr.DataArray, *, context: str) -> None:
         data.kspace._check_kinetic_energy(context=context)
 
+    @staticmethod
+    def _preview_supports_symmetry(preview_data: xr.DataArray) -> bool:
+        return preview_data.ndim == 2 and set(preview_data.dims) == {"kx", "ky"}
+
+    def _set_preview_symmetry_available(self, available: bool) -> None:
+        if not available:
+            with QtCore.QSignalBlocker(self.preview_symmetry_group):
+                self.preview_symmetry_group.setChecked(False)
+        self.preview_symmetry_group.setEnabled(available)
+
+    def _symmetrized_preview(self, preview_data: xr.DataArray) -> xr.DataArray:
+        import xarray as xr
+
+        preview_data = preview_data.transpose("ky", "kx")
+        fold = self.preview_symmetry_fold_spin.value()
+        rotated = [
+            erlab.analysis.transform.rotate(
+                preview_data,
+                360.0 * idx / fold,
+                axes=("ky", "kx"),
+                center={"ky": 0.0, "kx": 0.0},
+                reshape=False,
+                order=1,
+                mode="constant",
+                cval=np.nan,
+                prefilter=False,
+            )
+            for idx in range(fold)
+        ]
+        return xr.concat(rotated, dim="_preview_symmetry").mean(
+            "_preview_symmetry", skipna=True, keep_attrs=True
+        )
+
     def get_data(self) -> tuple[xr.DataArray, xr.DataArray]:
         # Set angle offsets
         data_ang = self._assign_params(self._angle_data())
@@ -1033,8 +1107,13 @@ class KspaceTool(KspaceToolGUI):
     @QtCore.Slot()
     def update(self) -> None:
         ang, k = self.get_data()
+        k_preview = k.T
+        preview_symmetry_available = self._preview_supports_symmetry(k_preview)
+        self._set_preview_symmetry_available(preview_symmetry_available)
+        if preview_symmetry_available and self.preview_symmetry_group.isChecked():
+            k_preview = self._symmetrized_preview(k_preview)
         self.images[0].setDataArray(ang.T)
-        self.images[1].setDataArray(k.T)
+        self.images[1].setDataArray(k_preview)
         self.sigInfoChanged.emit()
         if self.bz_group.isChecked():
             self.update_bz()

--- a/src/erlab/interactive/ktool.ui
+++ b/src/erlab/interactive/ktool.ui
@@ -608,6 +608,41 @@
          </widget>
         </item>
         <item>
+         <widget class="QGroupBox" name="preview_symmetry_group">
+          <property name="title">
+           <string>Preview Symmetry</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QFormLayout" name="formLayout_6">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_14">
+             <property name="text">
+              <string>n-fold</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="preview_symmetry_fold_spin">
+             <property name="minimum">
+              <number>2</number>
+             </property>
+             <property name="maximum">
+              <number>12</number>
+             </property>
+             <property name="value">
+              <number>6</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QGroupBox" name="energy_group">
           <property name="title">
            <string>Energy</string>

--- a/src/erlab/io/exampledata.py
+++ b/src/erlab/io/exampledata.py
@@ -3,6 +3,7 @@
 __all__ = [
     "generate_data",
     "generate_data_angles",
+    "generate_data_dirac",
     "generate_gold_edge",
     "generate_hvdep_cuts",
     "make_mesh_pattern",
@@ -68,6 +69,71 @@ def _add_fd_norm(image, eV, temp=30, efermi=0, count=1e7, const_bkg=1e-3) -> Non
         image *= _fermi_dirac(eV - efermi, temp)[None, None, :]
     image *= count
     image += const_bkg * count
+
+
+def _dirac_matrix_element(
+    kx: np.ndarray,
+    ky: np.ndarray,
+    k_tot: np.ndarray,
+    alpha_coeff: float,
+    beta_coeff: float,
+    branch_sign: int,
+    spin: typing.Literal["integrated", "up", "down"],
+) -> np.ndarray:
+    """Angular part of the surface-state matrix element."""
+    inv_k_tot = np.divide(1.0, k_tot, out=np.zeros_like(k_tot), where=k_tot > 0)
+    inv_k_tot_sq = inv_k_tot**2
+    k_par_sq = kx**2 + ky**2
+
+    if spin == "integrated":
+        out = alpha_coeff**2 * (1 + branch_sign * kx * inv_k_tot)
+        out += (
+            0.5
+            * beta_coeff**2
+            * (
+                k_par_sq * inv_k_tot_sq
+                + branch_sign * (3 * ky**2 - kx**2) * kx * inv_k_tot_sq * inv_k_tot
+            )
+        )
+    else:
+        out = 0.5 * alpha_coeff**2
+        out += 0.25 * beta_coeff**2 * k_par_sq * inv_k_tot_sq
+        interference = (
+            alpha_coeff * beta_coeff / np.sqrt(2) * (kx**2 - ky**2) * inv_k_tot_sq
+        )
+        if spin == "up":
+            out += branch_sign * interference
+        else:
+            out -= branch_sign * interference
+
+    return np.clip(out, 0.0, None)
+
+
+def _surface_polarization_weight(
+    kx: np.ndarray,
+    ky: np.ndarray,
+    kinetic_energy: np.ndarray,
+    polarization: Sequence[float],
+    inner_potential: float,
+) -> np.ndarray:
+    """Free-electron final-state polarization factor."""
+    pol = np.asarray(polarization, dtype=float)
+    if pol.shape != (3,):
+        raise ValueError("polarization must be a length-3 vector")
+    pol_norm = np.linalg.norm(pol)
+    if pol_norm == 0:
+        raise ValueError("polarization vector must be non-zero")
+    pol /= pol_norm
+
+    c1, c2 = 143.0, 0.054
+    imfp = (c1 / (kinetic_energy**2) + c2 * np.sqrt(kinetic_energy)) * 10
+    kz = erlab.analysis.kspace.kz_func(kinetic_energy, inner_potential, kx, ky)
+    k_tot = erlab.constants.rel_kconv * np.sqrt(kinetic_energy)
+    k_perp = np.sqrt(np.clip(k_tot**2 - kx**2 - ky**2, a_min=0, a_max=None))
+
+    numerator = 1j * kx * pol[0] + 1j * ky * pol[1] + (1j * kz - 1 / imfp) * pol[2]
+    denominator = 1j * (k_perp - kz) + 1 / imfp
+    return np.abs(numerator / denominator) ** 2
 
 
 # Changing default values may break tests
@@ -394,6 +460,233 @@ def generate_data_angles(
     if assign_attributes:
         out = out.assign_attrs(
             configuration=int(configuration), sample_temp=temp, sample_workfunction=4.5
+        )
+
+    return out.squeeze()
+
+
+def generate_data_dirac(
+    shape: tuple[int, int, int] = (500, 60, 500),
+    *,
+    angrange: float | tuple[float, float] | dict[str, tuple[float, float]] = 15.0,
+    Erange: tuple[float, float] = (-0.45, 0.12),
+    hv: float = 50.0,
+    configuration: (
+        erlab.constants.AxesConfiguration | int
+    ) = erlab.constants.AxesConfiguration.Type1,
+    temp: float = 20.0,
+    dirac_velocity: float = 0.3,
+    curvature: float = 0.0,
+    gap: float = 0.0,
+    bandshift: float = 0.0,
+    Sreal: float = 0.0,
+    Simag: float = 0.03,
+    alpha_coeff: float = 1.0,
+    beta_coeff: float = 0.6,
+    branch: typing.Literal["both", "upper", "lower"] = "both",
+    spin: typing.Literal["integrated", "up", "down"] = "integrated",
+    angres: float = 0.1,
+    Eres: float = 10.0e-3,
+    noise: bool = True,
+    seed: int | None = None,
+    count: int = 100000000,
+    ccd_sigma: float = 0.6,
+    const_bkg: float = 1e-3,
+    assign_attributes: bool = False,
+    extended: bool = True,
+    polarization: Sequence[float] = (0.0, 0.0, 1.0),
+    inner_potential: float = 10.0,
+) -> xr.DataArray:
+    """Generate simulated topological surface-state ARPES data in angle space.
+
+    The surface-state dispersion follows a minimal Dirac/Rashba Hamiltonian with an
+    optional quadratic curvature and mass gap. The matrix-element texture follows the
+    spin-integrated and spin-filtered angular factors discussed by Moser for
+    spin-orbit-coupled surface states.
+
+    .. versionadded:: 3.21.0
+
+    Parameters
+    ----------
+    shape
+        The shape of the generated data as ``(alpha, beta, eV)``.
+    angrange
+        Angle range in degrees. Can be a single float, a tuple of floats representing
+        the range, or a dictionary with ``alpha`` and ``beta`` keys mapping to tuples
+        representing the range for each dimension, by default 15.0.
+    Erange
+        Binding energy range in electronvolts, by default (-0.45, 0.12).
+    hv
+        The photon energy in eV. The sample work function is assumed to be 4.5 eV.
+    configuration
+        The experimental configuration, by default ``Type1``.
+    temp
+        The temperature in kelvins for the Fermi-Dirac cutoff. If 0, no cutoff is
+        applied.
+    dirac_velocity
+        Linear Dirac or Rashba coefficient in eV A.
+    curvature
+        Quadratic curvature coefficient in eV A^2.
+    gap
+        Dirac mass term in eV. The full gap at the Dirac point is ``2 * gap``.
+    bandshift
+        The rigid energy shift in eV.
+    Sreal
+        The real part of the self energy.
+    Simag
+        The imaginary part of the self energy.
+    alpha_coeff
+        Weight of the out-of-plane ``spz`` orbital contribution in the matrix element.
+    beta_coeff
+        Weight of the in-plane orbital contribution in the matrix element.
+    branch
+        Which branch of the surface state to include: ``"upper"``, ``"lower"``, or
+        ``"both"``.
+    spin
+        Matrix-element channel: spin-integrated (default) or one spin-projected
+        component (``"up"`` or ``"down"``).
+    angres
+        Broadening in angle in degrees.
+    Eres
+        Broadening in energy in electronvolts.
+    noise
+        Whether to add noise to the generated data.
+    seed
+        Seed for the random number generator for the noise.
+    count
+        Determines the signal-to-noise ratio when ``noise`` is ``True``.
+    ccd_sigma
+        The sigma value for CCD noise generation when ``noise`` is ``True``.
+    const_bkg
+        Constant background as a fraction of the count.
+    assign_attributes
+        Whether to assign attributes to the generated data.
+    extended
+        Whether to include the free-electron final-state polarization prefactor.
+    polarization
+        Photon polarization vector. Only used if ``extended`` is ``True``.
+    inner_potential
+        Inner potential in eV. Only used if ``extended`` is ``True``.
+
+    Returns
+    -------
+    xarray.DataArray
+        The generated data with coordinates for alpha, beta, and eV.
+
+    """
+    if isinstance(angrange, dict):
+        alpha = np.linspace(*angrange["alpha"], shape[0])
+        beta = np.linspace(*angrange["beta"], shape[1])
+    elif isinstance(angrange, tuple):
+        alpha = np.linspace(*angrange, shape[0])
+        beta = np.linspace(*angrange, shape[1])
+    else:
+        alpha = np.linspace(-angrange, angrange, shape[0])
+        beta = np.linspace(-angrange, angrange, shape[1])
+
+    if branch not in {"both", "upper", "lower"}:
+        raise ValueError("branch must be 'both', 'upper', or 'lower'")
+    if spin not in {"integrated", "up", "down"}:
+        raise ValueError("spin must be 'integrated', 'up', or 'down'")
+
+    eV = np.linspace(*Erange, shape[2])
+    eV_extended, gaussian_kernel = erlab.analysis.fit.functions.general._gen_kernel(
+        eV, float(Eres), pad=5
+    )
+    kinetic_energy = hv - 4.5 + eV_extended[None, None, :]
+    if np.any(kinetic_energy <= 0):
+        raise ValueError(
+            "Photon energy and energy range must give positive photoelectron energy"
+        )
+
+    a_mesh, b_mesh = np.meshgrid(alpha, beta, indexing="ij")
+    a_mesh, b_mesh = a_mesh[:, :, None], b_mesh[:, :, None]
+    kxv, kyv = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        a_mesh, b_mesh, kinetic_energy
+    )
+
+    k_tot = erlab.constants.rel_kconv * np.sqrt(kinetic_energy)
+    k_par_sq = kxv**2 + kyv**2
+    k_par = np.sqrt(k_par_sq)
+    dirac_split = np.sqrt((dirac_velocity * k_par) ** 2 + gap**2)
+    energy_upper = curvature * k_par_sq + dirac_split
+    energy_lower = curvature * k_par_sq - dirac_split
+
+    spectral_upper = _spectral_function(
+        eV_extended, energy_upper + bandshift, Sreal, Simag
+    )
+    spectral_lower = _spectral_function(
+        eV_extended, energy_lower + bandshift, Sreal, Simag
+    )
+
+    if extended:
+        pol_weight = _surface_polarization_weight(
+            kxv, kyv, kinetic_energy, polarization, inner_potential
+        )
+    else:
+        pol_weight = np.ones_like(spectral_upper)
+
+    out = np.zeros_like(spectral_upper)
+    if branch in {"both", "upper"}:
+        out += spectral_upper * _dirac_matrix_element(
+            kxv, kyv, k_tot, alpha_coeff, beta_coeff, +1, spin
+        )
+    if branch in {"both", "lower"}:
+        out += spectral_lower * _dirac_matrix_element(
+            kxv, kyv, k_tot, alpha_coeff, beta_coeff, -1, spin
+        )
+    out *= pol_weight
+
+    out = scipy.ndimage.gaussian_filter(
+        out,
+        sigma=[
+            angres / (axis[1] - axis[0]) if len(axis) > 1 else 0
+            for axis in (alpha, beta)
+        ]
+        + [0],
+        truncate=5.0,
+    )
+
+    _add_fd_norm(
+        out,
+        eV_extended,
+        efermi=0,
+        temp=temp,
+        count=count * 1e-6,
+        const_bkg=const_bkg,
+    )
+    out = np.apply_along_axis(
+        lambda m: np.convolve(m, gaussian_kernel, mode="valid"), axis=-1, arr=out
+    )
+
+    if noise:
+        rng = np.random.default_rng(seed)
+        out = scipy.ndimage.gaussian_filter(
+            rng.poisson(out).astype(float), ccd_sigma, truncate=10.0, axes=(0, 2)
+        )
+
+    out = xr.DataArray(out, coords={"alpha": alpha, "beta": beta, "eV": eV})
+    out = out.assign_coords(xi=0.0, delta=0.0, hv=hv)
+
+    match configuration:
+        case (
+            erlab.constants.AxesConfiguration.Type1DA
+            | erlab.constants.AxesConfiguration.Type2DA
+        ):
+            out = out.assign_coords(chi=0.0)
+
+    if assign_attributes:
+        out = out.assign_attrs(
+            configuration=int(configuration),
+            sample_temp=temp,
+            sample_workfunction=4.5,
+            dirac_velocity=dirac_velocity,
+            curvature=curvature,
+            dirac_gap=gap,
+            dirac_branch=branch,
+            dirac_spin=spin,
+            dirac_alpha_coeff=alpha_coeff,
+            dirac_beta_coeff=beta_coeff,
         )
 
     return out.squeeze()

--- a/tests/accessors/test_kspace.py
+++ b/tests/accessors/test_kspace.py
@@ -706,26 +706,17 @@ def test_set_normal_missing_chi(anglemap) -> None:
         data.kspace.set_normal(0.0, 0.0)
 
 
-@pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no-dask"])
-@pytest.mark.parametrize("energy_axis", ["kinetic", "binding"])
-@pytest.mark.parametrize("data_type", ["anglemap", "cut", "hvdep"])
-@pytest.mark.parametrize(
-    "configuration", AxesConfiguration, ids=[c.name for c in AxesConfiguration]
-)
-@pytest.mark.parametrize("extra_dims", [0, 1, 2], ids=["extra0", "extra1", "extra2"])
-def test_kconv(
+def _assert_kconv_case(
+    request: pytest.FixtureRequest,
+    *,
     use_dask: bool,
     energy_axis: str,
     data_type: str,
     configuration: AxesConfiguration,
     extra_dims: int,
-    request,
+    expect_error: bool = False,
 ) -> None:
     data = request.getfixturevalue(data_type).copy(deep=True)
-
-    expected = request.getfixturevalue(
-        f"config_{configuration.value}_{data_type.replace('angle', 'k')}"
-    )
 
     if energy_axis == "kinetic":
         data = data.assign_coords(eV=data.hv - data.kspace.work_function + data.eV)
@@ -754,16 +745,20 @@ def test_kconv(
     if data_type == "hvdep":
         data.kspace.inner_potential = 10.0
 
-    if energy_axis == "kinetic":
-        if data_type == "hvdep":
-            with pytest.raises(
-                ValueError,
-                match=r"Energy axis of photon energy dependent data must be in "
-                r"binding energy.",
-            ):
-                kconv = data.kspace.convert(silent=False)
-            return
+    if expect_error:
+        with pytest.raises(
+            ValueError,
+            match=r"Energy axis of photon energy dependent data must be in "
+            r"binding energy.",
+        ):
+            data.kspace.convert(silent=False)
+        return
 
+    expected = request.getfixturevalue(
+        f"config_{configuration.value}_{data_type.replace('angle', 'k')}"
+    )
+
+    if energy_axis == "kinetic":
         with pytest.warns(
             UserWarning,
             match="The energy axis seems to be in terms of kinetic energy, "
@@ -807,6 +802,95 @@ def test_kconv(
 
     assert isinstance(kconv, xarray.DataArray)
     assert not kconv.isnull().all()
+
+
+@pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no-dask"])
+@pytest.mark.parametrize("energy_axis", ["kinetic", "binding"])
+@pytest.mark.parametrize("data_type", ["anglemap", "cut"])
+@pytest.mark.parametrize(
+    "configuration", AxesConfiguration, ids=[c.name for c in AxesConfiguration]
+)
+@pytest.mark.parametrize("extra_dims", [0, 1, 2], ids=["extra0", "extra1", "extra2"])
+def test_kconv(
+    use_dask: bool,
+    energy_axis: str,
+    data_type: str,
+    configuration: AxesConfiguration,
+    extra_dims: int,
+    request: pytest.FixtureRequest,
+) -> None:
+    _assert_kconv_case(
+        request,
+        use_dask=use_dask,
+        energy_axis=energy_axis,
+        data_type=data_type,
+        configuration=configuration,
+        extra_dims=extra_dims,
+    )
+
+
+@pytest.mark.parametrize(
+    ("configuration", "use_dask", "extra_dims"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            False,
+            0,
+            id="Type1-binding-no-dask-extra0",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            True,
+            1,
+            id="Type2DA-binding-dask-extra1",
+        ),
+    ],
+)
+def test_kconv_hvdep_binding_smoke(
+    configuration: AxesConfiguration,
+    use_dask: bool,
+    extra_dims: int,
+    request: pytest.FixtureRequest,
+) -> None:
+    _assert_kconv_case(
+        request,
+        use_dask=use_dask,
+        energy_axis="binding",
+        data_type="hvdep",
+        configuration=configuration,
+        extra_dims=extra_dims,
+    )
+
+
+@pytest.mark.parametrize(
+    ("configuration", "use_dask"),
+    [
+        pytest.param(
+            AxesConfiguration.Type1,
+            False,
+            id="Type1-kinetic-no-dask",
+        ),
+        pytest.param(
+            AxesConfiguration.Type2DA,
+            True,
+            id="Type2DA-kinetic-dask",
+        ),
+    ],
+)
+def test_kconv_hvdep_kinetic_rejects(
+    configuration: AxesConfiguration,
+    use_dask: bool,
+    request: pytest.FixtureRequest,
+) -> None:
+    _assert_kconv_case(
+        request,
+        use_dask=use_dask,
+        energy_axis="kinetic",
+        data_type="hvdep",
+        configuration=configuration,
+        extra_dims=0,
+        expect_error=True,
+    )
 
 
 @pytest.mark.parametrize("missing_coord", ["alpha", "beta", "chi", "xi", "eV", "hv"])

--- a/tests/analysis/test_gold.py
+++ b/tests/analysis/test_gold.py
@@ -57,6 +57,29 @@ def test_range_slice_for_coord_single_point_sorts_bounds() -> None:
     assert out == slice(-1.0, 1.0)
 
 
+@pytest.mark.parametrize(
+    ("coord_values", "value_range", "expected"),
+    [
+        ([-2.0, -1.0, 0.0, 1.0, 2.0], (None, 0.0), [-2.0, -1.0, 0.0]),
+        ([-2.0, -1.0, 0.0, 1.0, 2.0], (0.0, None), [0.0, 1.0, 2.0]),
+        ([2.0, 1.0, 0.0, -1.0, -2.0], (None, 0.0), [0.0, -1.0, -2.0]),
+        ([2.0, 1.0, 0.0, -1.0, -2.0], (0.0, None), [2.0, 1.0, 0.0]),
+    ],
+)
+def test_range_slice_for_coord_supports_open_bounds(
+    coord_values: list[float],
+    value_range: tuple[float | None, float | None],
+    expected: list[float],
+) -> None:
+    coord = xr.DataArray(
+        coord_values, dims=("x",), coords={"x": coord_values}, name="x"
+    )
+
+    out = coord.sel(x=gold_mod._range_slice_for_coord(coord, value_range))
+
+    assert out.x.values.tolist() == expected
+
+
 def test_range_slice_for_coord_nonmonotonic_raises() -> None:
     coord = xr.DataArray(
         [0.0, 2.0, 1.0], dims=("x",), coords={"x": [0.0, 2.0, 1.0]}, name="x"
@@ -331,6 +354,27 @@ def test_edge_range_selection_follows_descending_coordinate_order(gold) -> None:
     finite = np.isfinite(vals.values)
     assert finite.any()
     assert_allclose(vals.values[finite], 0.04, atol=1e-12)
+
+
+def test_poly_plot_supports_open_bounds(gold) -> None:
+    fig = plt.figure()
+
+    res = poly(
+        gold,
+        angle_range=(None, 15.0),
+        eV_range=(-0.2, None),
+        temp=100.0,
+        vary_temp=False,
+        degree=2,
+        fast=True,
+        plot=True,
+        fig=fig,
+        parallel_kw={"backend": "threading", "n_jobs": 1, "return_as": "list"},
+    )
+
+    assert isinstance(res, xr.Dataset)
+
+    plt.close(fig)
 
 
 def test_quick_fit_plot_fwhm_span_matches_resolution(gold) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import contextlib
 import csv
 import datetime
 import functools
+import importlib.util
 import logging
 import os
 import pathlib
@@ -50,6 +51,27 @@ DATA_KNOWN_HASH = "1236511ac3b6b6f85a07246f6df52db2580404a56679ac63cabe4dc246b2b
 """The SHA-256 checksum of the `.tar.gz` file."""
 
 log = logging.getLogger(__name__)
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_ci_test_groups_module():
+    module_path = REPO_ROOT / "scripts" / "_ci_test_groups.py"
+    spec = importlib.util.spec_from_file_location("_ci_test_groups", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(
+            f"Unable to load CI test group definitions from {module_path}"
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CI_TEST_GROUPS = _load_ci_test_groups_module()
+is_compat_nodeid = _CI_TEST_GROUPS.is_compat_nodeid
+is_compat_path = _CI_TEST_GROUPS.is_compat_path
+is_gui_path = _CI_TEST_GROUPS.is_gui_path
+is_serial_path = _CI_TEST_GROUPS.is_serial_path
 
 
 def _qt_msg_filter(msg_type, context, message):
@@ -79,6 +101,18 @@ dask.config.set(
 def _coverage_is_active(pytestconfig: pytest.Config) -> bool:
     """Return whether pytest-cov is actively collecting coverage."""
     return pytestconfig.pluginmanager.hasplugin("_cov")
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        rel_path = pathlib.Path(item.path).resolve().relative_to(REPO_ROOT).as_posix()
+
+        if is_gui_path(rel_path):
+            item.add_marker(pytest.mark.gui)
+        if is_serial_path(rel_path):
+            item.add_marker(pytest.mark.serial)
+        if is_compat_path(rel_path) or is_compat_nodeid(item.nodeid):
+            item.add_marker(pytest.mark.compat)
 
 
 @pytest.fixture(scope="session")

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -170,6 +170,11 @@ def test_ktool(qtbot, anglemap, wf, kind, assignment) -> None:
     roi_control_widget.r_spin.setValue(0.3)
     assert roi.get_position() == (0.0, 0.2, 0.3)
 
+    assert win.preview_symmetry_group.isEnabled()
+    win.preview_symmetry_fold_spin.setValue(4)
+    win.preview_symmetry_group.setChecked(True)
+    win.update()
+
     # Show imagetool
     win.show_converted()
     win._itool.show()
@@ -529,6 +534,100 @@ def test_ktool_descending_energy_axis_preview(qtbot, anglemap) -> None:
     expected_ang = win._assign_params(expected_ang)
 
     xr.testing.assert_allclose(ang, expected_ang)
+
+
+@pytest.mark.parametrize(
+    ("avec", "expected"),
+    [
+        pytest.param(erlab.lattice.abc2avec(3.5, 3.5, 5.0, 90.0, 90.0, 120.0), 6),
+        pytest.param(erlab.lattice.abc2avec(3.5, 3.5, 5.0, 90.0, 90.0, 90.0), 4),
+        pytest.param(erlab.lattice.abc2avec(3.5, 4.2, 5.0, 90.0, 90.0, 110.0), 2),
+    ],
+)
+def test_ktool_preview_symmetry_default_fold(qtbot, anglemap, avec, expected) -> None:
+    win = ktool(anglemap.qsel(eV=-0.1), avec=avec, execute=False)
+    qtbot.addWidget(win)
+
+    assert win.preview_symmetry_fold_spin.value() == expected
+
+
+def test_ktool_preview_symmetry_is_preview_only(qtbot, anglemap) -> None:
+    data = anglemap.qsel(eV=-0.1).copy(deep=True)
+    data.values[2, 7] += 500.0
+
+    win = ktool(data, execute=False)
+    qtbot.addWidget(win)
+
+    raw_k = win.get_data()[1]
+    raw_preview = raw_k.T
+
+    assert win.preview_symmetry_group.isEnabled()
+    win.preview_symmetry_group.setChecked(True)
+    win.update()
+
+    displayed_preview = win.images[1].data_array
+    assert displayed_preview is not None
+    assert not np.allclose(displayed_preview.values, raw_preview.values, equal_nan=True)
+    xr.testing.assert_allclose(win.get_data()[1], raw_k)
+
+    win.show_converted()
+    assert win._itool is not None
+    xr.testing.assert_allclose(win._itool.slicer_area.data, raw_k)
+    win._itool.close()
+
+
+def test_ktool_preview_symmetry_rotates_and_averages(
+    qtbot, anglemap, monkeypatch
+) -> None:
+    win = ktool(anglemap, execute=False)
+    qtbot.addWidget(win)
+
+    dummy_ang = anglemap.qsel(eV=-0.1)
+    raw_k = xr.DataArray(
+        np.zeros((5, 5), dtype=float),
+        dims=("kx", "ky"),
+        coords={
+            "kx": np.arange(-2.0, 3.0, dtype=float),
+            "ky": np.arange(-2.0, 3.0, dtype=float),
+        },
+    )
+    raw_k.loc[{"kx": 1.0, "ky": 0.0}] = 1.0
+
+    expected = xr.DataArray(
+        np.zeros((5, 5), dtype=float),
+        dims=("ky", "kx"),
+        coords={
+            "ky": np.arange(-2.0, 3.0, dtype=float),
+            "kx": np.arange(-2.0, 3.0, dtype=float),
+        },
+    )
+    for ky, kx in ((0.0, 1.0), (1.0, 0.0), (0.0, -1.0), (-1.0, 0.0)):
+        expected.loc[{"ky": ky, "kx": kx}] = 0.25
+
+    monkeypatch.setattr(win, "get_data", lambda: (dummy_ang, raw_k))
+
+    win.preview_symmetry_fold_spin.setValue(4)
+    win.preview_symmetry_group.setChecked(True)
+    win.update()
+
+    displayed_preview = win.images[1].data_array
+    assert displayed_preview is not None
+    xr.testing.assert_allclose(displayed_preview, expected)
+
+
+def test_ktool_preview_symmetry_disabled_for_non_in_plane_preview(qtbot) -> None:
+    data = generate_hvdep_cuts((15, 30, 20), hvrange=(20.0, 30.0), noise=False)
+
+    win = ktool(data, execute=False)
+    qtbot.addWidget(win)
+
+    assert not win.preview_symmetry_group.isEnabled()
+    assert not win.preview_symmetry_group.isChecked()
+
+    win.preview_symmetry_group.setChecked(True)
+    win.update()
+
+    assert not win.preview_symmetry_group.isChecked()
 
 
 def test_ktool_exact_hv_bz_overlay_uses_cache(qtbot, monkeypatch) -> None:

--- a/tests/io/test_dataloader.py
+++ b/tests/io/test_dataloader.py
@@ -4,6 +4,7 @@ import pathlib
 import re
 import threading
 import time
+import typing
 
 import numpy as np
 import pytest
@@ -12,9 +13,7 @@ import erlab
 from erlab.io.dataloader import LoaderNotFoundError, UnsupportedFileError
 
 
-def test_loader(
-    qtbot, example_loader, example_data_dir: pathlib.Path, manager_context
-) -> None:
+def test_loader(example_loader, example_data_dir: pathlib.Path, monkeypatch) -> None:
     wrong_file = example_data_dir / "data_010.nc"
 
     with erlab.io.loader_context("example", example_data_dir):
@@ -109,20 +108,23 @@ def test_loader(
     btn_box.children[1].click()  # next
     del box, btn_box
 
-    # Interactive summary with imagetool manager
-    with manager_context() as manager:
-        box = erlab.io.loaders.current_loader._isummarize(df)
-        btn_box = box.children[0].children[0]
-        assert len(btn_box.children) == 4  # prev, next, load full, imagetool
-        assert box.children[0].children[1].value == "data_001_S001"
-        btn_box.children[3].click()  # imagetool
+    shown_data: list[typing.Any] = []
 
-        qtbot.wait_until(lambda: manager.ntools == 1)
+    monkeypatch.setattr(erlab.interactive.imagetool.manager, "is_running", lambda: True)
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager,
+        "show_in_manager",
+        lambda data: shown_data.append(data),
+    )
 
-        # Archive nd remove
-        manager._imagetool_wrappers[0].archive()
-        manager.remove_imagetool(0)
-        qtbot.wait_until(lambda: manager.ntools == 0)
+    box = erlab.io.loaders.current_loader._isummarize(df)
+    btn_box = box.children[0].children[0]
+    assert len(btn_box.children) == 4  # prev, next, load full, imagetool
+    assert box.children[0].children[1].value == "data_001_S001"
+    btn_box.children[3].click()  # imagetool
+
+    assert len(shown_data) == 1
+    assert shown_data[0].name == "data_001_S001"
 
 
 def test_thread_safety():

--- a/tests/io/test_exampledata.py
+++ b/tests/io/test_exampledata.py
@@ -3,6 +3,7 @@ import numpy as np
 from erlab.io.exampledata import (
     generate_data,
     generate_data_angles,
+    generate_data_dirac,
     generate_gold_edge,
     generate_hvdep_cuts,
 )
@@ -125,3 +126,69 @@ def test_generate_hvdep_cuts() -> None:
     np.testing.assert_allclose(data.eV.values, np.array([-0.45, -0.165, 0.12]))
     np.testing.assert_allclose(data.hv.values, np.array([40, 50, 60]))
     np.testing.assert_allclose(data.alpha.values, np.array([-15.0, 0.0, 15.0]))
+
+
+def test_generate_data_dirac() -> None:
+    data = generate_data_dirac(
+        (3, 3, 3), noise=False, temp=0, seed=1, assign_attributes=True
+    )
+
+    np.testing.assert_allclose(
+        data.values,
+        np.array(
+            [
+                [
+                    [6656.18118342, 1343.59264981, 1426.80072988],
+                    [1656.67581261, 4968.02848953, 4148.18055093],
+                    [6656.18118342, 1343.59264981, 1426.80072988],
+                ],
+                [
+                    [2126.69563286, 6398.92197193, 3497.00148285],
+                    [736.99071449, 5380.40885929, 9984.87072098],
+                    [2126.69563286, 6398.92197193, 3497.00148285],
+                ],
+                [
+                    [11165.50429819, 1975.45108131, 1055.44064151],
+                    [2596.71545311, 7829.81545433, 2845.82241477],
+                    [11165.50429819, 1975.45108131, 1055.44064151],
+                ],
+            ]
+        ),
+    )
+    np.testing.assert_allclose(data.alpha.values, np.array([-15.0, 0.0, 15.0]))
+    np.testing.assert_allclose(data.beta.values, np.array([-15.0, 0.0, 15.0]))
+    np.testing.assert_allclose(data.eV.values, np.array([-0.45, -0.165, 0.12]))
+
+    assert data.attrs["dirac_branch"] == "both"
+    assert data.attrs["dirac_spin"] == "integrated"
+    assert data.attrs["dirac_velocity"] == 0.3
+    assert data.attrs["dirac_beta_coeff"] == 0.6
+
+
+def test_generate_data_dirac_spin_projection() -> None:
+    data = generate_data_dirac(
+        (3, 3, 3), noise=False, temp=0, spin="up", branch="upper"
+    )
+
+    np.testing.assert_allclose(
+        data.values,
+        np.array(
+            [
+                [
+                    [46.67909038, 109.71512571, 491.81472787],
+                    [70.40086871, 194.25547082, 1603.95759444],
+                    [46.67909038, 109.71512571, 491.81472787],
+                ],
+                [
+                    [62.92411626, 173.60633207, 1433.38152019],
+                    [184.32267862, 1345.17721482, 2496.29268024],
+                    [62.92411626, 173.60633207, 1433.38152019],
+                ],
+                [
+                    [46.67909038, 109.71512571, 491.81472787],
+                    [70.40086871, 194.25547082, 1603.95759444],
+                    [46.67909038, 109.71512571, 491.81472787],
+                ],
+            ]
+        ),
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -925,6 +925,7 @@ dev = [
     { name = "pytest-datadir" },
     { name = "pytest-env" },
     { name = "pytest-qt" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 docs = [
@@ -1023,6 +1024,7 @@ dev = [
     { name = "pytest-datadir", specifier = ">=1.5.0" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-qt", specifier = ">=4.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.15.1" },
 ]
 docs = [
@@ -1055,6 +1057,15 @@ pyinstaller = [
 ]
 pyqt6 = [{ name = "pyqt6", specifier = ">=6.8.0" }]
 pyside6 = [{ name = "pyside6", specifier = ">=6.8.1.1,!=6.9.1" }]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
 
 [[package]]
 name = "executing"
@@ -3868,6 +3879,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/61/8bdec02663c18bf5016709b909411dce04a868710477dc9b9844ffcf8dd2/pytest_qt-4.5.0.tar.gz", hash = "sha256:51620e01c488f065d2036425cbc1cbcf8a6972295105fd285321eb47e66a319f", size = 128702, upload-time = "2025-07-01T17:24:39.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/d0/8339b888ad64a3d4e508fed8245a402b503846e1972c10ad60955883dcbb/pytest_qt-4.5.0-py3-none-any.whl", hash = "sha256:ed21ea9b861247f7d18090a26bfbda8fb51d7a8a7b6f776157426ff2ccf26eff", size = 37214, upload-time = "2025-07-01T17:24:38.226Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Split CI into a fast locked-dependency workflow and a separate weekly upgraded compatibility matrix, add centralized pytest-native test grouping helpers, and merge coverage/JUnit artifacts from sharded coverage jobs.