### PR TITLE
Add multiple GUI dialogs that map to more xarray methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ### ✨ Features
 
-- **ktool:** add symmetrization preview ([39cec40](https://github.com/kmnhan/erlabpy/commit/39cec40933d21e82538c2b01a3457bd0edb4c519))
+- **imagetool:** add Gaussian filter (#301) ([9d2e49a](https://github.com/kmnhan/erlabpy/commit/9d2e49a4ae8cd68192b4d9b96482c1686687c7f3))
+
+  Adds a Gaussian filter dialog with the same preview/reset behavior as the normalization dialog.
+
+- **imagetool:** make rotation guidelines more useful ([e30341a](https://github.com/kmnhan/erlabpy/commit/e30341adf92251f77f8ccb747053f24dad9a81dd))
+
+  Rotation guidelines now move together with the cursor by default, making it easier to manipulate them. The guidelines can still be used as fixed reference lines when the "Follow Active Cursor" option is disabled.
+
+  Also, the center and angle of the rotation guidelins are now also fed into `ktool` as normal emission angles and azimuthal offset if a `ktool` is opened from an ImageTool window with a visible rotation guideline on a `alpha`-`beta` slice.
+
+- **imagetool:** make rotation guidelines undoable and restorable ([3217138](https://github.com/kmnhan/erlabpy/commit/3217138fa01d06c33eaa009942102e111c7ffddc))
+
+- **ktool:** add symmetrization preview ([522f554](https://github.com/kmnhan/erlabpy/commit/522f5543b6edb3ca5b7689031f83fb66e65df0f8))
 
   Adds the ability to preview n-fold symmetrized constant-energy surfaces to `ktool`.
 
@@ -36,7 +48,7 @@
 
 ### 🐞 Bug Fixes
 
-- **analysis.gold:** fix regression where open bounds (`None`) was not avaliable in range slicing and plotting functions ([93dc2fb](https://github.com/kmnhan/erlabpy/commit/93dc2fb8d83165c97d8c45d9c3ce33bf697667ee))
+- **analysis.gold:** fix regression where open bounds (`None`) was not avaliable in range slicing and plotting functions ([4fdc856](https://github.com/kmnhan/erlabpy/commit/4fdc856bfa1907d4f1e07cfbc8e0f2de78b3082b))
 
 - **interactive:** better lifecycle management of colorbar menu widgets to prevent rare crashes due to garbage collection of menu widgets from worker threads during later allocations ([37f5cc4](https://github.com/kmnhan/erlabpy/commit/37f5cc4e1c3628874892db46851fe20944476dfc))
 

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -130,6 +130,8 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
 - Use {guilabel}`Edit → Edit Coordinates` to open the {guilabel}`Coordinate Editor` dialog. This is just a GUI for {meth}`xarray.DataArray.assign_coords` that lets you specify start/end values or per-point overrides.
 
+- Use {guilabel}`Edit → Swap Dimensions` to open the {guilabel}`Swap Dimensions` dialog. This is an interface for {meth}`xarray.DataArray.swap_dims`.
+
 - Dask-backed arrays are fully supported. The dedicated {guilabel}`Dask` menu exposes actions to compute the array into memory, rechunk automatically, or choose custom chunk shapes within ImageTool.
 
 - Overlay plots of non-dimensional coordinates (e.g., temperature) on the data from {guilabel}`View → Plot Associated Coordinates`.
@@ -203,7 +205,6 @@ Editing dialogs live under the {guilabel}`Edit` and {guilabel}`View` menus. Most
 - {guilabel}`Edit → Correct With Edge...` opens the {guilabel}`Edge Correction` dialog. If your data exposes an `eV` axis, ImageTool can import a previously fitted edge via {func}`xarray_lmfit.load_fit` and shift the spectrum accordingly.
 - {guilabel}`View → Normalize` opens the {guilabel}`Normalize` dialog, a non-destructive filter that supports area normalization, min-max scaling, and baseline subtraction.
 - {guilabel}`View → Gaussian Filter` opens the {guilabel}`Gaussian Filter` dialog, a non-destructive filter that applies coordinate-aware Gaussian broadening along selected dimensions.
-- {guilabel}`Edit → Edit Coordinates` opens the {guilabel}`Coordinate Editor` dialog for precise coordinate reassignment, including non-uniform axes.
 
 Use {guilabel}`Edit → Undo` and {guilabel}`Edit → Redo` to walk changes back, and {guilabel}`View → Reset` to remove any currently applied filter function. ImageTool also keeps track of additional helper windows opened from the context menus, so everything is closed cleanly when the main window exits.
 

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -207,11 +207,12 @@ Editing dialogs live under the {guilabel}`Edit` and {guilabel}`View` menus. Most
 - {guilabel}`Edit → Rotate` opens the {guilabel}`Rotate` dialog. Enter the angle, center, interpolation order, and whether to reshape the image. If a rotation guideline is active, the dialog pre-fills the angle and center from the guideline.
 - {guilabel}`Edit → Average` opens the {guilabel}`Average Over Dimensions` dialog. Select any set of dimensions to average via {meth}`xarray.DataArray.qsel.average`.
 - {guilabel}`Edit → Coarsen` opens the {guilabel}`Coarsen` dialog. Select window sizes for one or more dimensions, choose the `boundary`, `side`, and coordinate reduction function for {meth}`xarray.DataArray.coarsen`, then apply a reducer such as `mean`, `sum`, or `median`.
+- {guilabel}`Edit → Thin` opens the {guilabel}`Thin Data` dialog which uses {meth}`xarray.DataArray.thin`.
 - {guilabel}`Edit → Symmetrize` opens the {guilabel}`Symmetrize` dialog. Mirror a selected dimension about a specified center with additive or subtractive symmetry, `valid` or `full` overlap, and one-sided or two-sided output.
 - {guilabel}`Edit → Crop` opens the {guilabel}`Crop Between Cursors` dialog, while {guilabel}`Edit → Crop to View` opens the {guilabel}`Crop to View` dialog.
 - {guilabel}`Edit → Correct With Edge...` opens the {guilabel}`Edge Correction` dialog. If your data exposes an `eV` axis, ImageTool can import a previously fitted edge via {func}`xarray_lmfit.load_fit` and shift the spectrum accordingly.
-- {guilabel}`View → Normalize` opens the {guilabel}`Normalize` dialog, a non-destructive filter that supports area normalization, min-max scaling, and baseline subtraction.
-- {guilabel}`View → Gaussian Filter` opens the {guilabel}`Gaussian Filter` dialog, a non-destructive filter that applies coordinate-aware Gaussian broadening along selected dimensions.
+- {guilabel}`View → Normalize` opens the {guilabel}`Normalize` dialog, which applies a non-destructive filter that supports area normalization, min-max scaling, and baseline subtraction.
+- {guilabel}`View → Gaussian Filter` opens the {guilabel}`Gaussian Filter` dialog, which applies a non-destructive filter that applies coordinate-aware Gaussian broadening along selected dimensions.
 
 Use {guilabel}`Edit → Undo` and {guilabel}`Edit → Redo` to walk changes back, and {guilabel}`View → Reset` to remove any currently applied filter function. ImageTool also keeps track of additional helper windows opened from the context menus, so everything is closed cleanly when the main window exits.
 

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -146,6 +146,12 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
 - When binning is enabled, the data shown are an average over the specified bin widths, which are indicated by shaded regions near the cursor lines.
 
+  :::{hint}
+
+  To reduce the underlying data instead of displaying binned slices, use the {guilabel}`Edit → Average` dialog or the {guilabel}`Coarsen` dialog for more options.
+
+  :::
+
 - When comparing data in several ImageTool windows, you can link them either at creation (`eri.itool([data1, data2], link=True)`) or inside the manager. Linked windows maintain synchronized slicing positions, bin widths, and cursor counts.
 
 (imagetool-cursors)=
@@ -200,6 +206,7 @@ Editing dialogs live under the {guilabel}`Edit` and {guilabel}`View` menus. Most
 
 - {guilabel}`Edit → Rotate` opens the {guilabel}`Rotate` dialog. Enter the angle, center, interpolation order, and whether to reshape the image. If a rotation guideline is active, the dialog pre-fills the angle and center from the guideline.
 - {guilabel}`Edit → Average` opens the {guilabel}`Average Over Dimensions` dialog. Select any set of dimensions to average via {meth}`xarray.DataArray.qsel.average`.
+- {guilabel}`Edit → Coarsen` opens the {guilabel}`Coarsen` dialog. Select window sizes for one or more dimensions, choose the `boundary`, `side`, and coordinate reduction function for {meth}`xarray.DataArray.coarsen`, then apply a reducer such as `mean`, `sum`, or `median`.
 - {guilabel}`Edit → Symmetrize` opens the {guilabel}`Symmetrize` dialog. Mirror a selected dimension about a specified center with additive or subtractive symmetry, `valid` or `full` overlap, and one-sided or two-sided output.
 - {guilabel}`Edit → Crop` opens the {guilabel}`Crop Between Cursors` dialog, while {guilabel}`Edit → Crop to View` opens the {guilabel}`Crop to View` dialog.
 - {guilabel}`Edit → Correct With Edge...` opens the {guilabel}`Edge Correction` dialog. If your data exposes an `eV` axis, ImageTool can import a previously fitted edge via {func}`xarray_lmfit.load_fit` and shift the spectrum accordingly.

--- a/docs/source/user-guide/workflow-bridge.md
+++ b/docs/source/user-guide/workflow-bridge.md
@@ -49,6 +49,9 @@ code for reproducibility and batch processing.
 - - Reassign coordinates
   - {ref}`Coordinate editing dialog <imagetool-data>`
   - {meth}`xarray.DataArray.assign_coords`
+- - Swap dimensions
+  - {ref}`Coordinate editing dialog <imagetool-data>`
+  - {meth}`xarray.DataArray.swap_dims`
 - - Normalize interactively
   - {ref}`ImageTool normalization dialog <imagetool-editing>`
   - Expressions like `data / data.mean(...)`

--- a/docs/source/user-guide/workflow-bridge.md
+++ b/docs/source/user-guide/workflow-bridge.md
@@ -39,10 +39,13 @@ code for reproducibility and batch processing.
 - - Average over dimensions
   - {ref}`Averaging dialog <imagetool-editing>`
   - {meth}`xarray.DataArray.qsel.average`
-- - Coarsen data in blocks
+- - Coarsen data
   - {ref}`Coarsen dialog <imagetool-editing>`
   - {meth}`xarray.DataArray.coarsen` followed by a reducer such as `.mean()` or
     `.sum()`
+- - Thin data
+  - {ref}`Thin dialog <imagetool-editing>`
+  - {meth}`xarray.DataArray.thin`
 - - Crop data
   - {ref}`Crop dialogs <imagetool-editing>`
   - {meth}`xarray.DataArray.sel`, {meth}`xarray.DataArray.isel`

--- a/docs/source/user-guide/workflow-bridge.md
+++ b/docs/source/user-guide/workflow-bridge.md
@@ -39,6 +39,10 @@ code for reproducibility and batch processing.
 - - Average over dimensions
   - {ref}`Averaging dialog <imagetool-editing>`
   - {meth}`xarray.DataArray.qsel.average`
+- - Coarsen data in blocks
+  - {ref}`Coarsen dialog <imagetool-editing>`
+  - {meth}`xarray.DataArray.coarsen` followed by a reducer such as `.mean()` or
+    `.sum()`
 - - Crop data
   - {ref}`Crop dialogs <imagetool-editing>`
   - {meth}`xarray.DataArray.sel`, {meth}`xarray.DataArray.isel`

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -535,6 +535,9 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                     },
                     "Edit Coordinates": {
                         "triggered": self._assign_coords,
+                    },
+                    "Swap Dimensions": {
+                        "triggered": self._swap_dims,
                         "sep_after": True,
                     },
                     "Rotate": {"triggered": self._rotate},
@@ -740,6 +743,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     @QtCore.Slot()
     def _assign_coords(self) -> None:
         self.execute_dialog(erlab.interactive.imagetool.dialogs.AssignCoordsDialog)
+
+    @QtCore.Slot()
+    def _swap_dims(self) -> None:
+        self.execute_dialog(erlab.interactive.imagetool.dialogs.SwapDimsDialog)
 
     @QtCore.Slot()
     def _reset_filters(self) -> None:

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -559,6 +559,7 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                     },
                     "Average": {"triggered": self._average},
                     "Coarsen": {"triggered": self._coarsen},
+                    "Thin": {"triggered": self._thin},
                     "Symmetrize": {"triggered": self._symmetrize},
                     "Correct With Edge...": {"triggered": self._correct_with_edge},
                 },
@@ -724,6 +725,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     @QtCore.Slot()
     def _coarsen(self) -> None:
         self.execute_dialog(erlab.interactive.imagetool.dialogs.CoarsenDialog)
+
+    @QtCore.Slot()
+    def _thin(self) -> None:
+        self.execute_dialog(erlab.interactive.imagetool.dialogs.ThinDialog)
 
     @QtCore.Slot()
     def _symmetrize(self) -> None:

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -558,6 +558,7 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                         "tooltip": "Crop to the current axes view range",
                     },
                     "Average": {"triggered": self._average},
+                    "Coarsen": {"triggered": self._coarsen},
                     "Symmetrize": {"triggered": self._symmetrize},
                     "Correct With Edge...": {"triggered": self._correct_with_edge},
                 },
@@ -719,6 +720,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     @QtCore.Slot()
     def _average(self) -> None:
         self.execute_dialog(erlab.interactive.imagetool.dialogs.AverageDialog)
+
+    @QtCore.Slot()
+    def _coarsen(self) -> None:
+        self.execute_dialog(erlab.interactive.imagetool.dialogs.CoarsenDialog)
 
     @QtCore.Slot()
     def _symmetrize(self) -> None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -635,6 +635,142 @@ class CoarsenDialog(DataTransformDialog):
         )
 
 
+class ThinDialog(DataTransformDialog):
+    title = "Thin Data"
+    suffix = "_thin"
+    enable_copy = True
+    apply_on_nonuniform_data = True
+
+    def setup_widgets(self) -> None:
+        self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+            self.slicer_area.data
+        )
+
+        mode_group = QtWidgets.QGroupBox("Mode")
+        mode_layout = QtWidgets.QVBoxLayout()
+        mode_group.setLayout(mode_layout)
+
+        self.per_dim_radio = QtWidgets.QRadioButton("Thin selected dimensions")
+        self.global_radio = QtWidgets.QRadioButton("Thin all dimensions equally")
+        self.per_dim_radio.setChecked(True)
+
+        mode_layout.addWidget(self.per_dim_radio)
+        mode_layout.addWidget(self.global_radio)
+
+        self._mode_group = QtWidgets.QButtonGroup(self)
+        self._mode_group.addButton(self.per_dim_radio)
+        self._mode_group.addButton(self.global_radio)
+
+        dim_group = QtWidgets.QGroupBox("Dimensions")
+        dim_layout = QtWidgets.QGridLayout()
+        dim_group.setLayout(dim_layout)
+
+        dim_layout.addWidget(QtWidgets.QLabel("Dimension"), 0, 0)
+        dim_layout.addWidget(QtWidgets.QLabel("Factor"), 0, 1)
+
+        self.dim_group = dim_group
+        self.dim_checks: dict[Hashable, QtWidgets.QCheckBox] = {}
+        self.factor_spins: dict[Hashable, QtWidgets.QSpinBox] = {}
+
+        for row, dim in enumerate(self._source_data.dims, start=1):
+            check = QtWidgets.QCheckBox(str(dim))
+            spin = QtWidgets.QSpinBox()
+            spin.setRange(1, 2_147_483_647)
+            spin.setValue(2)
+            spin.setEnabled(False)
+            check.toggled.connect(spin.setEnabled)
+
+            self.dim_checks[dim] = check
+            self.factor_spins[dim] = spin
+
+            dim_layout.addWidget(check, row, 0)
+            dim_layout.addWidget(spin, row, 1)
+
+        global_group = QtWidgets.QGroupBox("Global Factor")
+        global_layout = QtWidgets.QFormLayout()
+        global_group.setLayout(global_layout)
+
+        self.global_group = global_group
+        self.global_spin = QtWidgets.QSpinBox()
+        self.global_spin.setRange(1, 2_147_483_647)
+        self.global_spin.setValue(2)
+        global_layout.addRow("Factor", self.global_spin)
+
+        self.per_dim_radio.toggled.connect(self._update_mode)
+        self.global_radio.toggled.connect(self._update_mode)
+
+        self.layout_.addRow(mode_group)
+        self.layout_.addRow(dim_group)
+        self.layout_.addRow(global_group)
+        self._update_mode()
+
+    @property
+    def _use_global_mode(self) -> bool:
+        return self.global_radio.isChecked()
+
+    @property
+    def _selected_factors(self) -> dict[Hashable, int]:
+        return {
+            dim: self.factor_spins[dim].value()
+            for dim, check in self.dim_checks.items()
+            if check.isChecked()
+        }
+
+    @property
+    def _effective_factors(self) -> dict[Hashable, int]:
+        if self._use_global_mode:
+            return {
+                dim: self.global_spin.value()
+                for dim in self._source_data.dims
+                if self.global_spin.value() > 1
+            }
+        return {
+            dim: factor for dim, factor in self._selected_factors.items() if factor > 1
+        }
+
+    @QtCore.Slot()
+    def _update_mode(self) -> None:
+        self.dim_group.setEnabled(not self._use_global_mode)
+        self.global_group.setEnabled(self._use_global_mode)
+
+    def process_data(self, data: xr.DataArray) -> xr.DataArray:
+        if self._use_global_mode:
+            return data.thin(self.global_spin.value())
+        return data.thin(self._effective_factors)
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        if not self._use_global_mode and not self._selected_factors:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Dimensions Selected",
+                "You need to select at least one dimension.",
+            )
+            return
+
+        if not self._effective_factors:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Thinning Requested",
+                "Choose at least one thinning factor greater than 1.",
+            )
+            return
+
+        super().accept()
+
+    def make_code(self) -> str:
+        placeholder = self.slicer_area.watched_data_name or ""
+        if self._use_global_mode:
+            if self.global_spin.value() <= 1:
+                return ""
+            return f"{placeholder}.thin({self.global_spin.value()})"
+
+        if not self._effective_factors:
+            return ""
+        kwargs = erlab.interactive.utils.format_kwargs(self._effective_factors)
+        return f"{placeholder}.thin({kwargs})"
+
+
 class SymmetrizeDialog(DataTransformDialog):
     title = "Symmetrize"
     enable_copy = True

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -455,6 +455,186 @@ class AverageDialog(DataTransformDialog):
         return f".qsel.average({arg})"
 
 
+class CoarsenDialog(DataTransformDialog):
+    title = "Coarsen"
+    enable_copy = True
+    apply_on_nonuniform_data = True
+
+    _REDUCERS: tuple[str, ...] = (
+        "all",
+        "any",
+        "count",
+        "max",
+        "mean",
+        "median",
+        "min",
+        "prod",
+        "std",
+        "sum",
+        "var",
+    )
+
+    @property
+    def suffix(self) -> str:
+        return f"_coarsen_{self._reducer}"
+
+    @suffix.setter
+    def suffix(self, value: str) -> None:
+        # To satisfy mypy
+        pass
+
+    def setup_widgets(self) -> None:
+        self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+            self.slicer_area.data
+        )
+
+        dim_group = QtWidgets.QGroupBox("Dimensions")
+        dim_layout = QtWidgets.QGridLayout()
+        dim_group.setLayout(dim_layout)
+
+        dim_layout.addWidget(QtWidgets.QLabel("Dimension"), 0, 0)
+        dim_layout.addWidget(QtWidgets.QLabel("Window Size"), 0, 1)
+
+        self.dim_checks: dict[Hashable, QtWidgets.QCheckBox] = {}
+        self.window_spins: dict[Hashable, QtWidgets.QSpinBox] = {}
+
+        for row, dim in enumerate(self._source_data.dims, start=1):
+            check = QtWidgets.QCheckBox(str(dim))
+            spin = QtWidgets.QSpinBox()
+            spin.setRange(1, 2_147_483_647)
+            spin.setValue(3)
+            spin.setEnabled(False)
+            check.toggled.connect(spin.setEnabled)
+
+            self.dim_checks[dim] = check
+            self.window_spins[dim] = spin
+
+            dim_layout.addWidget(check, row, 0)
+            dim_layout.addWidget(spin, row, 1)
+
+        options_group = QtWidgets.QGroupBox("Options")
+        options_layout = QtWidgets.QFormLayout()
+        options_group.setLayout(options_layout)
+
+        self.boundary_combo = QtWidgets.QComboBox()
+        self.boundary_combo.addItems(["exact", "trim", "pad"])
+        self.boundary_combo.setCurrentText("trim")
+        options_layout.addRow("Boundary", self.boundary_combo)
+
+        self.side_combo = QtWidgets.QComboBox()
+        self.side_combo.addItems(["left", "right"])
+        options_layout.addRow("Side", self.side_combo)
+
+        self.coord_func_combo = QtWidgets.QComboBox()
+        self.coord_func_combo.addItems(
+            ["mean", "median", "min", "max", "first", "last"]
+        )
+        self.coord_func_combo.setCurrentText("mean")
+        options_layout.addRow("Coordinate Function", self.coord_func_combo)
+
+        self.reducer_combo = QtWidgets.QComboBox()
+        self.reducer_combo.addItems(list(self._REDUCERS))
+        self.reducer_combo.setCurrentText("mean")
+        options_layout.addRow("Reducer", self.reducer_combo)
+
+        self.layout_.addRow(dim_group)
+        self.layout_.addRow(options_group)
+
+    @property
+    def _selected_windows(self) -> dict[Hashable, int]:
+        return {
+            dim: self.window_spins[dim].value()
+            for dim, check in self.dim_checks.items()
+            if check.isChecked()
+        }
+
+    @property
+    def _coord_func(self) -> str:
+        return self.coord_func_combo.currentText().strip()
+
+    @property
+    def _reducer(self) -> str:
+        return self.reducer_combo.currentText()
+
+    @property
+    def _coarsen_kwargs(self) -> dict[str, typing.Any]:
+        kwargs: dict[str, typing.Any] = {}
+        kwargs["dim"] = self._selected_windows
+        kwargs["boundary"] = self.boundary_combo.currentText()
+        kwargs["side"] = self.side_combo.currentText()
+        kwargs["coord_func"] = self._coord_func
+        return kwargs
+
+    def process_data(self, data: xr.DataArray) -> xr.DataArray:
+        coarsened = data.coarsen(**self._coarsen_kwargs)
+        return typing.cast("xr.DataArray", getattr(coarsened, self._reducer)())
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        if not self._selected_windows:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Dimensions Selected",
+                "You need to select at least one dimension.",
+            )
+            return
+
+        if self.boundary_combo.currentText() == "exact":
+            invalid_dims = [
+                str(dim)
+                for dim, window in self._selected_windows.items()
+                if self._source_data.sizes[dim] % window != 0
+            ]
+            if invalid_dims:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Incompatible Window Size",
+                    "Window sizes must evenly divide the selected dimensions when "
+                    "boundary is exact: "
+                    f"{', '.join(invalid_dims)}. Try trim or pad instead.",
+                )
+                return
+
+        if self.boundary_combo.currentText() == "trim":
+            empty_dims = [
+                str(dim)
+                for dim, window in self._selected_windows.items()
+                if self._source_data.sizes[dim] // window == 0
+            ]
+            if empty_dims:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "No Output Blocks",
+                    "Trim boundary would remove all data along: "
+                    f"{', '.join(empty_dims)}.",
+                )
+                return
+
+        super().accept()
+
+    def make_code(self) -> str:
+        if not self._selected_windows:
+            return ""
+        placeholder = self.slicer_area.watched_data_name or ""
+
+        kwargs = self._coarsen_kwargs.copy()
+        if all(
+            isinstance(k, str) for k in self._coarsen_kwargs["dim"]
+        ):  # pragma: no branch
+            window_kwargs = kwargs.pop("dim")
+            kwargs = dict(**window_kwargs, **kwargs)
+
+        return (
+            erlab.interactive.utils.generate_code(
+                type(self._source_data).coarsen,
+                args=[],
+                kwargs=kwargs,
+                module=placeholder,
+            )
+            + f".{self._reducer}()"
+        )
+
+
 class SymmetrizeDialog(DataTransformDialog):
     title = "Symmetrize"
     enable_copy = True
@@ -1119,9 +1299,10 @@ class SwapDimsDialog(DataTransformDialog):
     def make_code(self) -> str:
         if not self._swap_mapping:
             return ""
-        return (
-            f".swap_dims({erlab.interactive.utils.format_kwargs(self._swap_mapping)})"
-        )
+
+        placeholder = self.slicer_area.watched_data_name or ""
+        kwargs = erlab.interactive.utils.format_kwargs(self._swap_mapping)
+        return f"{placeholder}.swap_dims({kwargs})"
 
 
 class _CoordinateWidget(QtWidgets.QWidget):

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -1016,6 +1016,114 @@ class GaussianFilterDialog(DataFilterDialog):
         )
 
 
+class SwapDimsDialog(DataTransformDialog):
+    title = "Swap Dimensions"
+    enable_copy = True
+    apply_on_nonuniform_data = True
+
+    def setup_widgets(self) -> None:
+        self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+            self.slicer_area.data
+        )
+        public_dims = tuple(
+            dim.removesuffix("_idx")
+            if isinstance(dim, str) and dim.endswith("_idx")
+            else dim
+            for dim in self.slicer_area.data.dims
+        )
+        if tuple(self._source_data.dims) != public_dims and set(
+            self._source_data.dims
+        ) == set(public_dims):
+            self._source_data = self._source_data.transpose(*public_dims)
+
+        dim_group = QtWidgets.QGroupBox("Dimensions")
+        dim_layout = QtWidgets.QGridLayout()
+        dim_group.setLayout(dim_layout)
+
+        dim_layout.addWidget(QtWidgets.QLabel("Dimension"), 0, 0)
+        dim_layout.addWidget(QtWidgets.QLabel("Target"), 0, 1)
+
+        self.source_labels: dict[Hashable, QtWidgets.QLabel] = {}
+        self.target_combos: dict[Hashable, QtWidgets.QComboBox] = {}
+        self.target_options: dict[Hashable, tuple[Hashable, ...]] = {}
+
+        for row, dim in enumerate(self._source_data.dims, start=1):
+            label = QtWidgets.QLabel(str(dim))
+            combo = QtWidgets.QComboBox()
+
+            targets = [dim]
+            targets.extend(
+                name
+                for name, coord in self._source_data.coords.items()
+                if name != dim and coord.ndim == 1 and coord.dims == (dim,)
+            )
+            self.target_options[dim] = tuple(targets)
+
+            for target in self.target_options[dim]:
+                combo.addItem(str(target), userData=target)
+
+            if len(self.target_options[dim]) == 1:
+                tooltip = (
+                    "No compatible 1D coordinates are available for this dimension."
+                )
+                label.setToolTip(tooltip)
+                combo.setToolTip(tooltip)
+                combo.setEnabled(False)
+
+            self.source_labels[dim] = label
+            self.target_combos[dim] = combo
+
+            dim_layout.addWidget(label, row, 0)
+            dim_layout.addWidget(combo, row, 1)
+
+        self.layout_.addRow(dim_group)
+
+    @property
+    def _swap_mapping(self) -> dict[Hashable, Hashable]:
+        mapping: dict[Hashable, Hashable] = {}
+        for dim, combo in self.target_combos.items():
+            if not combo.isEnabled():
+                continue
+            target = typing.cast(
+                "Hashable | None",
+                combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
+            )
+            if target is not None and target != dim:
+                mapping[dim] = target
+        return mapping
+
+    def _validate(self) -> QtWidgets.QDialog.DialogCode:
+        if not any(combo.isEnabled() for combo in self.target_combos.values()):
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Nothing to Swap",
+                "No compatible 1D coordinates are available for any dimension.",
+            )
+            return QtWidgets.QDialog.DialogCode.Rejected
+        return super()._validate()
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        if not self._swap_mapping:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Dimensions Changed",
+                "Choose at least one dimension to swap.",
+            )
+            return
+        super().accept()
+
+    def process_data(self, data: xr.DataArray) -> xr.DataArray:
+        return data.swap_dims(self._swap_mapping)
+
+    def make_code(self) -> str:
+        if not self._swap_mapping:
+            return ""
+        return (
+            f".swap_dims({erlab.interactive.utils.format_kwargs(self._swap_mapping)})"
+        )
+
+
 class _CoordinateWidget(QtWidgets.QWidget):
     def __init__(self, values: npt.NDArray) -> None:
         super().__init__()

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -998,7 +998,7 @@ class KspaceTool(KspaceToolGUI):
         alpha, beta = erlab.analysis.kspace._normal_emission_from_angle_params(
             self.data.kspace.configuration, angle_params
         )
-        return float(alpha), float(beta)
+        return float(np.round(alpha, 5)), float(np.round(beta, 5))
 
     @QtCore.Slot()
     def _sync_normal_emission_spins(self) -> None:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -886,6 +886,11 @@ def _handle_xarray_dict_or_kwargs(
     arg_name = param_order[0]
     kwarg_name = param_order[0] + "_kwargs"
 
+    if func.__name__ == "coarsen" and arg_name == "dim" and kwarg_name not in params:
+        # DataArray.coarsen is a special case where the positional arg is 'dim' but the
+        # kwargs name is 'window_kwargs'
+        kwarg_name = "window_kwargs"
+
     if (
         (kwarg_name not in params)
         or (params[kwarg_name].kind != inspect.Parameter.VAR_KEYWORD)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -30,6 +30,7 @@ from erlab.interactive.imagetool.dialogs import (
     ROIMaskDialog,
     ROIPathDialog,
     RotationDialog,
+    SwapDimsDialog,
     SymmetrizeDialog,
 )
 from erlab.interactive.imagetool.plot_items import _PolyROIEditDialog
@@ -2547,6 +2548,162 @@ def test_itool_assign_coords(qtbot, accept_dialog) -> None:
 
     accept_dialog(win.mnb._assign_coords, pre_call=_set_dialog_params, timeout=10.0)
     np.testing.assert_allclose(win.slicer_area._data.t.values, np.arange(3) + 1.0)
+
+
+def test_itool_swap_dims(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(24).reshape((2, 3, 4)).astype(float),
+        dims=["x", "y", "z"],
+        coords={
+            "x": np.arange(2),
+            "y": np.arange(3),
+            "z": np.arange(4),
+            "u": ("x", [5.0, 6.0]),
+            "v": ("y", [10.0, 11.0, 12.0]),
+            "w": ("z", [20.0, 21.0, 22.0, 23.0]),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: SwapDimsDialog) -> None:
+        dialog.target_combos["x"].setCurrentText("u")
+        dialog.new_window_check.setChecked(False)
+
+    accept_dialog(win.mnb._swap_dims, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None), data.swap_dims({"x": "u"})
+    )
+
+    win.close()
+
+
+def test_itool_swap_dims_multiple_and_code(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(24).reshape((2, 3, 4)).astype(float),
+        dims=["x", "y", "z"],
+        coords={
+            "x": np.arange(2),
+            "y": np.arange(3),
+            "z": np.arange(4),
+            "u": ("x", [5.0, 6.0]),
+            "v": ("y", [10.0, 11.0, 12.0]),
+            "w": ("z", [20.0, 21.0, 22.0, 23.0]),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: SwapDimsDialog) -> None:
+        dialog.target_combos["x"].setCurrentText("u")
+        dialog.target_combos["y"].setCurrentText("v")
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+        dialog.new_window_check.setChecked(False)
+
+    accept_dialog(win.mnb._swap_dims, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None), data.swap_dims({"x": "u", "y": "v"})
+    )
+
+    code = pyperclip.paste()
+    assert code == '.swap_dims(x="u", y="v")'
+    assert "z=" not in code
+    assert '"z"' not in code
+
+    win.close()
+
+
+def test_itool_swap_dims_nonuniform_public_dims(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(15).reshape((3, 5)).astype(float),
+        dims=["x", "y"],
+        coords={
+            "x": np.array([0.0, 0.4, 1.0]),
+            "y": np.arange(5),
+            "temperature": ("x", [100.0, 101.0, 102.0]),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    assert win.slicer_area.data.dims == ("x_idx", "y")
+
+    def _set_dialog_params(dialog: SwapDimsDialog) -> None:
+        assert "x" in dialog.target_combos
+        assert "x_idx" not in dialog.target_combos
+        dialog.target_combos["x"].setCurrentText("temperature")
+        dialog.new_window_check.setChecked(False)
+
+    accept_dialog(win.mnb._swap_dims, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None), data.swap_dims({"x": "temperature"})
+    )
+
+    win.close()
+
+
+def test_swap_dims_dialog_rejects_unswappable_data(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(12).reshape((3, 4)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(3), "y": np.arange(4)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = SwapDimsDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    assert dialog._validate() == QtWidgets.QDialog.DialogCode.Rejected
+    assert warnings == [
+        (
+            "Nothing to Swap",
+            "No compatible 1D coordinates are available for any dimension.",
+        )
+    ]
+
+    dialog.close()
+    win.close()
+
+
+def test_swap_dims_dialog_accept_requires_changes(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(12).reshape((3, 4)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(3), "y": np.arange(4), "u": ("x", [5.0, 6.0, 7.0])},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = SwapDimsDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    dialog.accept()
+
+    assert warnings == [
+        ("No Dimensions Changed", "Choose at least one dimension to swap.")
+    ]
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
+
+    dialog.close()
+    win.close()
 
 
 @pytest.mark.parametrize("option", [0, 1, 2, 3])

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -33,6 +33,7 @@ from erlab.interactive.imagetool.dialogs import (
     RotationDialog,
     SwapDimsDialog,
     SymmetrizeDialog,
+    ThinDialog,
 )
 from erlab.interactive.imagetool.plot_items import _PolyROIEditDialog
 from erlab.interactive.imagetool.viewer import (
@@ -2486,6 +2487,87 @@ def test_coarsen_dialog_make_code_uses_watched_data_name(qtbot, monkeypatch) -> 
     win.close()
 
 
+def test_itool_thin(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(120).reshape((5, 6, 4)).astype(float),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(5), "y": np.arange(6), "z": np.arange(4)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: ThinDialog) -> None:
+        dialog.dim_checks["x"].setChecked(True)
+        dialog.factor_spins["x"].setValue(1)
+        dialog.dim_checks["y"].setChecked(True)
+        dialog.factor_spins["y"].setValue(3)
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+        dialog.new_window_check.setChecked(False)
+
+    accept_dialog(win.mnb._thin, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None),
+        data.thin(y=3),
+    )
+
+    assert pyperclip.paste() == ".thin(y=3)"
+    win.close()
+
+
+def test_itool_thin_global_factor(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(120).reshape((5, 6, 4)).astype(float),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(5), "y": np.arange(6), "z": np.arange(4)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: ThinDialog) -> None:
+        dialog.global_radio.setChecked(True)
+        dialog.global_spin.setValue(2)
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+        dialog.new_window_check.setChecked(False)
+
+    accept_dialog(win.mnb._thin, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None),
+        data.thin(2),
+    )
+
+    assert pyperclip.paste() == ".thin(2)"
+    win.close()
+
+
+def test_itool_thin_nonuniform_public_dims(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(30).reshape((5, 6)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.array([0.0, 0.3, 0.9, 1.4, 2.2]), "y": np.arange(6)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    assert win.slicer_area.data.dims == ("x_idx", "y")
+
+    def _set_dialog_params(dialog: ThinDialog) -> None:
+        assert "x" in dialog.dim_checks
+        assert "x_idx" not in dialog.dim_checks
+        dialog.dim_checks["x"].setChecked(True)
+        dialog.factor_spins["x"].setValue(2)
+        dialog.new_window_check.setChecked(False)
+
+    accept_dialog(win.mnb._thin, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None),
+        data.thin(x=2),
+    )
+
+    win.close()
+
+
 def test_itool_symmetrize(qtbot, accept_dialog) -> None:
     data = xr.DataArray(
         np.arange(60).reshape((3, 4, 5)).astype(float),
@@ -2877,6 +2959,71 @@ def test_coarsen_dialog_rejects_trim_without_output_blocks(qtbot, monkeypatch) -
 
     assert warnings == [
         ("No Output Blocks", "Trim boundary would remove all data along: x.")
+    ]
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
+
+    dialog.close()
+    win.close()
+
+
+def test_thin_dialog_requires_selected_dimension(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(12).reshape((3, 4)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = ThinDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    dialog.accept()
+
+    assert warnings == [
+        ("No Dimensions Selected", "You need to select at least one dimension.")
+    ]
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
+
+    dialog.close()
+    win.close()
+
+
+@pytest.mark.parametrize("global_mode", [False, True], ids=["per_dim", "global"])
+def test_thin_dialog_rejects_noop_factors(qtbot, monkeypatch, global_mode) -> None:
+    data = xr.DataArray(np.arange(12).reshape((3, 4)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = ThinDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    if global_mode:
+        dialog.global_radio.setChecked(True)
+        dialog.global_spin.setValue(1)
+    else:
+        dialog.dim_checks["x"].setChecked(True)
+        dialog.factor_spins["x"].setValue(1)
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    dialog.accept()
+
+    assert warnings == [
+        (
+            "No Thinning Requested",
+            "Choose at least one thinning factor greater than 1.",
+        )
     ]
     xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -22,6 +22,7 @@ from erlab.interactive.imagetool.controls import ItoolColormapControls
 from erlab.interactive.imagetool.dialogs import (
     AssignCoordsDialog,
     AverageDialog,
+    CoarsenDialog,
     CropDialog,
     CropToViewDialog,
     EdgeCorrectionDialog,
@@ -2399,6 +2400,92 @@ def test_itool_average(qtbot, accept_dialog) -> None:
     win.close()
 
 
+def test_itool_coarsen(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(120).reshape((5, 6, 4)).astype(float),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(5), "y": np.arange(6), "z": np.arange(4)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: CoarsenDialog) -> None:
+        dialog.dim_checks["x"].setChecked(True)
+        dialog.dim_checks["y"].setChecked(True)
+        dialog.window_spins["x"].setValue(2)
+        dialog.window_spins["y"].setValue(4)
+        dialog.boundary_combo.setCurrentText("trim")
+        dialog.side_combo.setCurrentText("right")
+        dialog.coord_func_combo.setCurrentText("min")
+        dialog.reducer_combo.setCurrentText("sum")
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+        dialog.new_window_check.setChecked(False)
+
+    accept_dialog(win.mnb._coarsen, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None),
+        data.coarsen(x=2, y=4, boundary="trim", side="right", coord_func="min").sum(),
+    )
+
+    assert (
+        pyperclip.paste()
+        == '.coarsen(x=2, y=4, boundary="trim", side="right", coord_func="min").sum()'
+    )
+    win.close()
+
+
+def test_itool_coarsen_nonuniform_public_dims(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(30).reshape((5, 6)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.array([0.0, 0.3, 0.9, 1.4, 2.2]), "y": np.arange(6)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    assert win.slicer_area.data.dims == ("x_idx", "y")
+
+    def _set_dialog_params(dialog: CoarsenDialog) -> None:
+        assert "x" in dialog.dim_checks
+        assert "x_idx" not in dialog.dim_checks
+        dialog.dim_checks["x"].setChecked(True)
+        dialog.window_spins["x"].setValue(2)
+        assert dialog.boundary_combo.currentText() == "trim"
+        assert dialog.coord_func_combo.currentText() == "mean"
+        dialog.new_window_check.setChecked(False)
+
+    accept_dialog(win.mnb._coarsen, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None),
+        data.coarsen(x=2, boundary="trim", side="left", coord_func="mean").mean(),
+    )
+
+    win.close()
+
+
+def test_coarsen_dialog_make_code_uses_watched_data_name(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(12).reshape((3, 4)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = CoarsenDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    dialog.dim_checks["x"].setChecked(True)
+    dialog.window_spins["x"].setValue(2)
+
+    monkeypatch.setattr(
+        type(win.slicer_area),
+        "watched_data_name",
+        property(lambda _self: "my_data"),
+    )
+
+    assert dialog.make_code() == 'my_data.coarsen(x=2, boundary="trim").mean()'
+
+    dialog.close()
+    win.close()
+
+
 def test_itool_symmetrize(qtbot, accept_dialog) -> None:
     data = xr.DataArray(
         np.arange(60).reshape((3, 4, 5)).astype(float),
@@ -2699,6 +2786,97 @@ def test_swap_dims_dialog_accept_requires_changes(qtbot, monkeypatch) -> None:
 
     assert warnings == [
         ("No Dimensions Changed", "Choose at least one dimension to swap.")
+    ]
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
+
+    dialog.close()
+    win.close()
+
+
+def test_coarsen_dialog_requires_selected_dimension(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(12).reshape((3, 4)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = CoarsenDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    dialog.accept()
+
+    assert warnings == [
+        ("No Dimensions Selected", "You need to select at least one dimension.")
+    ]
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
+
+    dialog.close()
+    win.close()
+
+
+def test_coarsen_dialog_rejects_exact_incompatible_windows(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(10).reshape((5, 2)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = CoarsenDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    dialog.dim_checks["x"].setChecked(True)
+    dialog.window_spins["x"].setValue(3)
+    dialog.boundary_combo.setCurrentText("exact")
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    dialog.accept()
+
+    assert warnings == [
+        (
+            "Incompatible Window Size",
+            "Window sizes must evenly divide the selected dimensions when boundary "
+            "is exact: x. Try trim or pad instead.",
+        )
+    ]
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
+
+    dialog.close()
+    win.close()
+
+
+def test_coarsen_dialog_rejects_trim_without_output_blocks(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(4).reshape((2, 2)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = CoarsenDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    dialog.dim_checks["x"].setChecked(True)
+    dialog.window_spins["x"].setValue(3)
+    dialog.boundary_combo.setCurrentText("trim")
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    dialog.accept()
+
+    assert warnings == [
+        ("No Output Blocks", "Trim boundary would remove all data along: x.")
     ]
     xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
 

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -411,7 +411,9 @@ def test_ktool_copy_code_uses_set_normal(
         bounds=win.bounds, resolution=win.resolution
     )
     for key, value in reference_offsets.items():
-        assert namespace[input_name].kspace.offsets[key] == pytest.approx(value)
+        assert np.round(namespace[input_name].kspace.offsets[key], 5) == pytest.approx(
+            value
+        )
 
     xr.testing.assert_allclose(expected, namespace[f"{input_name}_kconv"])
 


### PR DESCRIPTION
- Add an `Edit → Swap Dimensions` dialog as a GUI for `DataArray.swap_dims`.
- Add an `Edit → Coarsen` dialog as as a GUI for `DataArray.coarsen`.
- Add an `Edit → Thin` dialog as as a GUI for `DataArray.thin`.