### PR TITLE
feat(manager): let child tools refresh after source data changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Pytest enforces strict markers and `xfail_strict`; name files `test_<feature>.py
 
 ## Interactive Qt Notes
 
+- All Qt-facing runtime code and tests must behave the same under both PyQt6 and PySide6. Prefer `qtpy` APIs that are binding-neutral, avoid binding-specific signal/metaobject assumptions, and when lower-level Qt behavior is unavoidable, add a compatibility helper and validate the touched path under both bindings.
 - For tools launched from ImageTool, new actions that open/show data in ImageTool should be manager-aware (use manager flow when the parent tool is managed).
 - For new context-menu or file-dialog features, add tests for both accept and cancel dialog paths.
 - Prefer `accept_dialog` for real dialog interactions; use monkeypatch stubs to target hard-to-hit branches.

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -170,6 +170,12 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
   On image plots, the context menu can launch {ref}`goldtool <guide-goldtool>`, {ref}`restool <guide-restool>`, {ref}`dtool <guide-dtool>`, and {ref}`ftool <guide-ftool>`. On line plots, the context menu offers {ref}`ftool <guide-ftool>`.
 
+  Helper tools opened from ImageTool keep track of the slice or selection that created
+  them. If the parent ImageTool is updated with compatible data, the child tool shows a
+  stale marker instead of silently keeping outdated input. Click the marker inside the
+  tool window to refresh it from the latest compatible data, or enable automatic updates
+  for future source replacements.
+
   :::{hint}
   Holding {kbd}`Alt` while opening the menu switches many actions to cropped mode, which crops the data to what is currently visible in the plot before performing the action. This is useful for conducting analysis on a specific region.
   :::

--- a/docs/source/user-guide/interactive/index.md
+++ b/docs/source/user-guide/interactive/index.md
@@ -11,6 +11,8 @@ corresponding public Python APIs and explains how to round-trip between them.
 - [ImageTool](imagetool.md) is the primary GUI for inspecting multidimensional {class}`xarray.DataArray` objects. It includes navigation with multiple cursors, colormap controls, destructive and non-destructive edits, and quick access to analysis and plotting tools.
 - [ImageTool manager](manager.md) sits on top of ImageTool and provides long-running project management: loader integration, cursor linking, notebook synchronization, and savable workspaces. It can also manage other interactive tools, keeping them organized and accessible.
 - Specialized helpers such as {ref}`ktool <guide-ktool>` (momentum conversion), {ref}`dtool <guide-dtool>` (derivative plotting), and the {ref}`data explorer <guide-data-explorer>` integrate with both ImageTool and the manager for specific analysis tasks. These are described in {ref}`interactive-misc-tools`. Each tool can be launched directly or from the relevant ImageTool menu or context menu, and the manager can keep them alongside ImageTool windows when you need a shared workspace.
+- Experienced users who want to build or contribute a new GUI should continue to
+  {ref}`interactive-tool-authoring`.
 
 :::{tip}
 
@@ -28,4 +30,5 @@ imagetool
 manager
 misc-tools
 options
+tool-authoring
 ```

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -114,6 +114,8 @@ The left pane lists every ImageTool window by index and optional name (`index: n
 Enable {guilabel}`View → Preview on Hover` to see thumbnails while moving the mouse over the list.
 :::
 
+Child analysis windows opened from an ImageTool appear as nested rows under their parent.
+
 The following lists common actions included in the {guilabel}`File`, {guilabel}`Edit`, and right-click context menus:
 
 - {guilabel}`Show` / {guilabel}`Hide` / {guilabel}`Remove` – Use the toolbar buttons or {kbd}`Return`, {kbd}`Ctrl+W`, and {kbd}`Del` to bring windows to the front, hide them, or remove them entirely. These controls live in {guilabel}`File`.
@@ -127,7 +129,9 @@ The following lists common actions included in the {guilabel}`File`, {guilabel}`
 - {guilabel}`Concatenate` – Combine selected data with {func}`xarray.concat` and open the result in a new ImageTool window.
 - {guilabel}`Reload Data` – Re-fetches data from disk using the original loader function. Handy when data is updated during acquisition.
 
-Icons next to each entry indicate special states: linked windows share a colored badge, chunked Dask arrays show the dask icon, and watched variables display their notebook name. Right-click to see all context-sensitive actions.
+Icons next to each entry indicate special states: linked windows share a colored badge, chunked Dask arrays show the dask icon, and watched variables display their notebook name.
+
+Child tools may also show {guilabel}`Stale` or {guilabel}`Unavailable` badges after the parent source data changes. Click those badges in the tree to open the same update dialog that appears inside the child tool itself, refresh from the latest compatible data, and optionally enable automatic updates for future replacements.
 
 (imagetool-manager-archive-workspace)=
 

--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -1,0 +1,302 @@
+(interactive-tool-authoring)=
+
+# Authoring interactive tools
+
+This section is aimed at experienced users who are already comfortable with Qt,
+`xarray`, and ERLabPy's analysis model, and want to contribute a new interactive tool to
+{mod}`erlab.interactive`.
+
+It focuses on ERLab-specific integration points: the `ToolWindow` class, manager
+support, source updates, public launch paths, and the test/docs work expected in a
+contribution. For general repository conventions, see the [contributing
+guide](../../contributing.md).
+
+## Start with the right shape
+
+Most user-facing ERLabPy GUIs should inherit from
+{class}`erlab.interactive.utils.ToolWindow` for it to correctly integrate with the
+{ref}`ImageTool manager <imagetool-manager>`.
+
+In practice, `ToolWindow` enables several things:
+
+- save/restore support through `to_dataset()`, `from_dataset()`, `to_file()`, and
+  `from_file()`, using `tool_data`, `StateModel`, and `tool_status`;
+- integration with the ImageTool manager, including tool naming, preview images, rich
+  info text, and manager refresh notifications through `sigInfoChanged`;
+- binding to ImageTool source data, including persisted source metadata, stale or
+  unavailable status tracking, and the built-in source-update dialog; and
+- the update hooks used by source-aware tools, such as `validate_update_data()`,
+  `update_data()`, and `_cancel_background_work()`.
+
+Use `ToolWindow` when your tool should do any of the following:
+
+- accept an `xarray.DataArray` as its main input;
+- round-trip through `to_dataset()` / `from_dataset()`;
+- appear as a child tool inside the {ref}`ImageTool manager <imagetool-manager>` or
+- refresh itself when the source ImageTool data changes.
+
+`ToolWindow` assumes a few things about your implementation:
+
+- The constructor accepts `data` as its single positional input. Additional options can
+  be keyword arguments.
+- The nested `StateModel` contains everything needed to restore the UI state.
+- `tool_data` returns the main `DataArray`.
+- `tool_status` serializes and reapplies the live widget state.
+
+If your tool is a quick internal prototype or does not need save/restore support, a
+plain Qt widget may be enough. For anything that should behave like `dtool`, `ftool`,
+`goldtool`, or `ktool`, start from `ToolWindow`.
+
+## Build a minimal `ToolWindow`
+
+Create the runtime module in `src/erlab/interactive/` and keep any `.ui` file (if you
+use Qt Designer) next to it. A minimal skeleton looks like this:
+
+```python
+import pydantic
+import pyqtgraph as pg
+import xarray as xr
+from qtpy import QtWidgets
+
+import erlab
+
+
+class MyTool(erlab.interactive.utils.ToolWindow):
+    tool_name = "mytool"
+
+    class StateModel(pydantic.BaseModel):
+        data_name: str
+        sigma: float = 1.0
+        show_reference: bool = False
+
+    def __init__(self, data: xr.DataArray, *, data_name: str | None = None) -> None:
+        super().__init__()
+
+        self._data = self.validate_update_data(data)
+        self._data_name = data_name or (self._data.name or "data")
+
+        root = QtWidgets.QWidget(self)
+        layout = QtWidgets.QVBoxLayout(root)
+        self.setCentralWidget(root)
+
+        self.plot = pg.PlotWidget()
+        self.sigma_spin = QtWidgets.QDoubleSpinBox()
+        self.reference_check = QtWidgets.QCheckBox("Show reference")
+
+        self.sigma_spin.setRange(0.0, 100.0)
+        self.sigma_spin.setValue(1.0)
+        self.sigma_spin.valueChanged.connect(self._refresh)
+        self.reference_check.toggled.connect(self._refresh)
+
+        layout.addWidget(self.plot)
+        layout.addWidget(self.sigma_spin)
+        layout.addWidget(self.reference_check)
+
+        self._refresh()
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    @property
+    def tool_status(self) -> StateModel:
+        return self.StateModel(
+            data_name=self._data_name,
+            sigma=float(self.sigma_spin.value()),
+            show_reference=self.reference_check.isChecked(),
+        )
+
+    @tool_status.setter
+    def tool_status(self, status: StateModel) -> None:
+        self._data_name = status.data_name
+        self.sigma_spin.setValue(status.sigma)
+        self.reference_check.setChecked(status.show_reference)
+        self._refresh()
+
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(new_data)
+        if data.ndim != 2:
+            raise ValueError("`data` must be 2D")
+        return data
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        status = self.tool_status
+        self._data = self.validate_update_data(new_data)
+        self.tool_status = status
+        self.sigInfoChanged.emit()
+
+    def _refresh(self) -> None:
+        ...
+```
+
+Some implementation details matter:
+
+- Call `super().__init__()` before creating your UI. `ToolWindow` installs the manager
+  status banner and keyboard shortcuts.
+- Always use `self.setCentralWidget(...)`, not `QtWidgets.QMainWindow.setCentralWidget`.
+  `ToolWindow` wraps the actual content widget so it can show source-update status above
+  it.
+- Keep `StateModel` focused on UI state. The main data already comes from `tool_data`
+  and is stored separately when the tool is archived.
+- Make the `tool_status` getter and setter a true round trip. A restored tool should
+  look the same as one configured interactively.
+
+`DerivativeTool` in `erlab.interactive.derivative` is a good synchronous example:
+`tool_status` captures the preprocessing controls, and `update_data()` swaps in the new
+array while preserving the current settings.
+
+## Add manager-facing metadata
+
+The ImageTool manager can display a preview image and rich HTML summary for child tools.
+These are optional, but tools feel much more integrated when they provide them.
+
+Implement these properties when they make sense:
+
+- `preview_imageitem`: return the `pyqtgraph.ImageItem` that should be rendered in the
+  manager tree.
+- `info_text`: return a short HTML summary of the current tool state.
+
+Whenever the preview or info text changes, emit `sigInfoChanged`. This is what causes
+the manager to refresh its side panel and thumbnails. `KspaceToolGUI` and
+`DerivativeTool` are good references for this pattern.
+
+## Support source updates from ImageTool
+
+If a tool can be launched from ImageTool or tracked by the manager, it should usually be
+able to react when the parent data changes.
+
+`ToolWindow` gives you three hooks for this:
+
+- `validate_update_data(new_data)`: normalize or reject replacement data before it
+  reaches the live UI.
+- `update_data(new_data)`: apply the new data without creating a brand-new window.
+- `_cancel_background_work(timeout_ms=...)`: stop worker threads or queued tasks before
+  mutating the UI, if your tool fits in the background.
+
+There are three common update strategies in the current codebase:
+
+1. In-place updates for simple tools.
+
+   `DerivativeTool` and `KspaceToolGUI` validate the new array, preserve `tool_status`,
+   replace their cached data, and recompute the plots.
+
+2. Rebuild-and-restore updates for tools whose UI depends heavily on the input data.
+
+   `Fit1DTool` and `Fit2DTool` snapshot `tool_status`, tear down the central widget,
+   rebuild the UI, then restore the saved state. In that case, prefer
+   `self._perform_source_update(...)` so validation and background-task cancellation
+   stay in one place.
+
+3. Deferred updates for tools that cannot apply the data immediately.
+
+   `ResolutionTool.update_data()` queues the request, aborts any in-flight fit, and
+   returns `False` while work is still draining. Returning `False` keeps the tool marked
+   as stale until the update actually completes.
+
+When your tool has worker threads, a typical pattern is:
+
+```python
+def _cancel_background_work(self, *, timeout_ms: int) -> bool:
+    return self._threadpool.waitForDone(timeout_ms)
+
+
+def update_data(self, new_data: xr.DataArray) -> bool:
+    status = self.tool_status
+    old_geom = self.saveGeometry()
+
+    def _apply_update(validated: xr.DataArray) -> None:
+        self._data = validated
+        self._rebuild_ui()
+        self.tool_status = status
+        self.restoreGeometry(old_geom)
+        self.sigInfoChanged.emit()
+
+    return self._perform_source_update(new_data, apply_update=_apply_update)
+```
+
+If the tool is launched from an ImageTool selection, the launch site should also bind
+the tool back to its source data:
+
+- Use `ItoolPlotItem.make_tool_source_spec(...)` when the tool is created from the
+  active cursor or cropped selection.
+- Use {func}`erlab.interactive.utils.make_tool_source_spec` with `"full_data"` when the
+  whole current array is the logical source.
+- Ensure the caller sets `set_source_binding(...)`; the manager wrapper will provide
+  `set_source_parent_fetcher(...)` when the tool is attached to a managed ImageTool.
+
+The relevant examples live in `erlab.interactive.imagetool.plot_items.ItoolPlotItem` and
+`erlab.interactive.imagetool.viewer.ImageSlicerArea` as methods named
+`open_in_<tool-name>`.
+
+## Expose the tool cleanly
+
+After the widget exists, add a public launcher function that users can call directly:
+
+```python
+def mytool(
+    data: xr.DataArray, data_name: str | None = None, *, execute: bool | None = None
+) -> MyTool:
+    with erlab.interactive.utils.setup_qapp(execute):
+        win = MyTool(data, data_name=data_name)
+        win.show()
+        win.raise_()
+        win.activateWindow()
+    return win
+```
+
+This launcher is what should get the user-facing docstring.
+
+To make the tool discoverable across ERLabPy, update the relevant entry points:
+
+- export it from `src/erlab/interactive/__init__.pyi`;
+- add an IPython line magic in `src/erlab/interactive/_magic.py` if the tool is useful
+  from notebooks;
+- add ImageTool menu or context-menu actions if the tool operates on the current view or
+  selection; and
+- update the user guide so people can find it without reading the source.
+
+If the tool should be available from a managed ImageTool, check both the unmanaged and
+managed launch paths. Manager-aware flows are slightly different because the child tool
+can be hidden, archived, restored, or rebound to watched notebook data.
+
+## Test and document the contribution
+
+Before opening a PR, make sure the new tool behaves like an ERLabPy tool, not just like
+a local Qt app.
+
+At minimum, add tests in `tests/interactive/test_<tool>.py` that cover:
+
+- construction and basic interaction;
+- `tool_status` round-tripping;
+- `to_dataset()` / `from_dataset()` if the tool is savable;
+- `validate_update_data()` and `update_data()` branches, including stale or unavailable
+  source cases when relevant;
+- dialog accept and cancel paths for any new dialogs; and
+- manager-aware dispatch paths, preferably by patching manager helpers unless a live
+  manager is required.
+
+If you add a new top-level test module, also update `scripts/_ci_test_groups.py` so the
+CI shards still partition the suite correctly.
+
+Document the new public entry point in two places:
+
+- the launcher function and any public class docstrings; and
+- the user guide page where users would naturally look for the tool.
+
+For GUI-facing contributions, include screenshots or a short recording in the PR, and
+run the same checks expected for all contributions:
+
+- `uv run ruff format .`
+- `uv run ruff check --fix .`
+- `uv run mypy src`
+- `uv run pytest`
+- `uv run python -m scripts.ci_test_groups --check-partition`
+
+If you follow the patterns above, your tool will fit naturally into the existing
+interactive ecosystem instead of becoming a one-off window that only works from a local
+script.
+
+## Next steps
+
+Once you have a working tool, you may want to contribute it to the repository. See the
+[contributing guide](../../contributing.md) for details on how to submit a pull request.

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -57,6 +57,8 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
 - Search `ImageTool`, `ImageTool Manager`, `%watch`, `fetch`,
   `show_in_manager`, `load_in_manager`, or `workflow-bridge` for notebook and
   interactive-workflow questions.
+- Search `interactive-tool-authoring`, `ToolWindow`, `tool_status`, or
+  `update_data` for contributor questions about adding new interactive tools.
 - Search `plot_array`, `plot_slices`, `qplot`, `fermiline`, `nice_colorbar`,
   or `plot_bz` for plotting questions.
 

--- a/src/erlab/interactive/__init__.py
+++ b/src/erlab/interactive/__init__.py
@@ -9,11 +9,10 @@ Commonly used tools are available directly in the ``erlab.interactive`` namespac
 regular users should not need to import the submodules directly.
 
 Documentation of classes and functions in submodules mostly contain implementation
-details for advanced users who want to create new interactive tools. A user guide for
-creating new interactive tools will be available in the future. In the meantime, take a
-look at the source code of :mod:`erlab.interactive.utils` and
-:mod:`erlab.interactive.colors` which provide general utility functions for creating new
-interactive tools.
+details for advanced users who want to create new interactive tools. See
+:ref:`interactive-tool-authoring` for a contributor-oriented walkthrough, and use the
+source code of :mod:`erlab.interactive.utils` and :mod:`erlab.interactive.colors` as the
+main reference implementations.
 
 .. rubric:: Modules
 

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -2577,22 +2577,27 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         )
         if hasattr(thread, "setServiceLevel"):
             thread.setServiceLevel(QtCore.QThread.QualityOfService.High)
-        thread.finished.connect(self._finalize_fit_thread)
+        thread.finished.connect(lambda thread=thread: self._finalize_fit_thread(thread))
 
-        def _queue_success(result_ds: xr.Dataset) -> None:
-            self._queue_fit_action(lambda: on_success(result_ds))
+        def _queue_success(
+            result_ds: xr.Dataset, *, thread: _FitWorker = thread
+        ) -> None:
+            self._queue_fit_action(thread, lambda: on_success(result_ds))
 
-        def _queue_error(message: str) -> None:
+        def _queue_error(message: str, *, thread: _FitWorker = thread) -> None:
             self._queue_fit_action(
-                lambda: on_error(erlab.interactive.utils._format_traceback(message))
+                thread,
+                lambda: on_error(erlab.interactive.utils._format_traceback(message)),
             )
 
         thread.sigFinished.connect(_queue_success)
-        thread.sigTimedOut.connect(lambda: self._queue_fit_action(on_timeout))
+        thread.sigTimedOut.connect(
+            lambda thread=thread: self._queue_fit_action(thread, on_timeout)
+        )
         thread.sigErrored.connect(_queue_error)
         thread.sigCancelled.connect(
-            lambda: self._queue_fit_action(
-                self._fit_cancelled, allow_when_cancelled=True
+            lambda thread=thread: self._queue_fit_action(
+                thread, self._fit_cancelled, allow_when_cancelled=True
             )
         )
 
@@ -2602,10 +2607,13 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     def _queue_fit_action(
         self,
+        thread: _FitWorker,
         action: Callable[[], None],
         *,
         allow_when_cancelled: bool = False,
     ) -> None:
+        if self._fit_thread is not thread:
+            return
         if self._fit_cancel_requested and not allow_when_cancelled:
             return
         self._pending_fit_action = action
@@ -2613,8 +2621,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self._pending_fit_action = None
             action()
 
-    def _finalize_fit_thread(self) -> None:
-        thread = self._fit_thread
+    def _finalize_fit_thread(self, thread: _FitWorker) -> None:
+        if self._fit_thread is not thread:
+            return
         action = self._pending_fit_action
         self._pending_fit_action = None
         self._fit_thread = None
@@ -2627,8 +2636,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_cancel_requested = False
         if action is not None:
             action()
-        if thread is not None:
-            thread.deleteLater()
+        thread.deleteLater()
 
     def _fit_cancelled(self) -> None:
         if self._fit_multi_total is not None:
@@ -3357,38 +3365,42 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             raise ValueError("`data` must be a 1D DataArray")
         return data
 
-    def update_data(self, new_data: xr.DataArray) -> None:
-        new_data = self.validate_update_data(new_data)
+    def _cancel_background_work(self, *, timeout_ms: int) -> bool:
+        return self._cancel_fit(wait=True, timeout_ms=timeout_ms)
+
+    def update_data(self, new_data: xr.DataArray) -> bool:
         had_fit = self._last_result_ds is not None
         status = self.tool_status
         old_geom = self.saveGeometry()
-        self._cancel_fit(wait=True, timeout_ms=None)
 
-        old_cw = self.centralWidget()
-        if old_cw is not None:
-            old_cw.setParent(None)
-            old_cw.deleteLater()
+        def _apply_update(validated: xr.DataArray) -> None:
+            old_cw = self.centralWidget()
+            if old_cw is not None:
+                old_cw.setParent(None)
+                old_cw.deleteLater()
 
-        self._reset_fit_state(
-            new_data,
-            self._model,
-            self._params.copy(),
-            data_name=self._data_name,
-            model_name=self._model_name,
-        )
-        self._build_ui()
-        with self._history_suppressed():
-            self.tool_status = status
-        self._set_fit_stats(None)
-        self._update_fit_curve()
-        self._write_history = True
-        self._reset_history_stack()
-        self._mark_fit_stale()
-        self.restoreGeometry(old_geom)
-        self.sigInfoChanged.emit()
+            self._reset_fit_state(
+                validated,
+                self._model,
+                self._params.copy(),
+                data_name=self._data_name,
+                model_name=self._model_name,
+            )
+            self._build_ui()
+            with self._history_suppressed():
+                self.tool_status = status
+            self._set_fit_stats(None)
+            self._update_fit_curve()
+            self._write_history = True
+            self._reset_history_stack()
+            self._mark_fit_stale()
+            self.restoreGeometry(old_geom)
+            self.sigInfoChanged.emit()
 
-        if had_fit and self.refit_on_source_update_check.isChecked():
-            self._run_fit()
+            if had_fit and self.refit_on_source_update_check.isChecked():
+                self._run_fit()
+
+        return self._perform_source_update(new_data, apply_update=_apply_update)
 
     def _show_warning(self, title: str, text: str) -> None:
         QtWidgets.QMessageBox.warning(self, title, text)
@@ -3411,15 +3423,17 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         super().closeEvent(event)
 
     def _cancel_fit(self, *, wait: bool = False, timeout_ms: int | None = 5000) -> bool:
-        if self._fit_thread is not None:
-            self._fit_thread.cancel()
-            self._fit_thread.requestInterruption()
+        thread = self._fit_thread
+        if thread is not None:
+            thread.cancel()
+            thread.requestInterruption()
         self._fit_cancel_requested = True
         self.cancel_fit_button.setEnabled(False)
         self.cancel_fit_button.setText("Canceling...")
         self._pending_fit_action = None
-        if wait and self._fit_thread is not None:
-            if timeout_ms is None:
-                return self._fit_thread.wait()
-            return self._fit_thread.wait(timeout_ms)
+        if wait and thread is not None:
+            finished = thread.wait() if timeout_ms is None else thread.wait(timeout_ms)
+            if finished:
+                self._finalize_fit_thread(thread)
+            return finished
         return True

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -3361,7 +3361,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         had_fit = self._last_result_ds is not None
         status = self.tool_status
         old_geom = self.saveGeometry()
-        self._cancel_fit(wait=True)
+        self._cancel_fit(wait=True, timeout_ms=None)
 
         old_cw = self.centralWidget()
         if old_cw is not None:
@@ -3409,7 +3409,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             return
         super().closeEvent(event)
 
-    def _cancel_fit(self, *, wait: bool = False, timeout_ms: int = 5000) -> bool:
+    def _cancel_fit(self, *, wait: bool = False, timeout_ms: int | None = 5000) -> bool:
         if self._fit_thread is not None:
             self._fit_thread.cancel()
             self._fit_thread.requestInterruption()
@@ -3418,5 +3418,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self.cancel_fit_button.setText("Canceling...")
         self._pending_fit_action = None
         if wait and self._fit_thread is not None:
+            if timeout_ms is None:
+                return self._fit_thread.wait()
             return self._fit_thread.wait(timeout_ms)
         return True

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -560,6 +560,7 @@ class _State2D(pydantic.BaseModel):
     current_idx: int
     data_name_full: str
     params_full: list[list[tuple[typing.Any, ...]] | None]
+    initial_params_full: list[list[tuple[typing.Any, ...]] | None] | None = None
     params_from_coord_full: list[dict[str, str]]
     fill_mode: typing.Literal["previous", "extrapolate", "none"]
     y_limits: tuple[int, int] | None = None

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -730,6 +730,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         domain: tuple[float, float] | None = None
         normalize_mean: bool = False
         show_components: bool
+        refit_on_source_update: bool = False
         timeout: float
         max_nfev: int
         method: str
@@ -1189,10 +1190,17 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             ]
         )
         self.method_combo.setCurrentText("least_squares")
+        self.refit_on_source_update_check = QtWidgets.QCheckBox(
+            "Refit on source update"
+        )
+        self.refit_on_source_update_check.setToolTip(
+            "If checked, rerun the fit when this tool refreshes from ImageTool."
+        )
 
         fit_layout.addRow("Timeout", self.timeout_spin)
         fit_layout.addRow("Max nfev", self.nfev_spin)
         fit_layout.addRow("Method", self.method_combo)
+        fit_layout.addRow(self.refit_on_source_update_check)
         self._fit_tab_layout.addWidget(fit_group)
 
         self.fit_buttons = QtWidgets.QGridLayout()
@@ -1820,6 +1828,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             domain=self._fit_domain(),
             normalize_mean=self.normalize_check.isChecked(),
             show_components=self.components_check.isChecked(),
+            refit_on_source_update=self.refit_on_source_update_check.isChecked(),
             timeout=self.timeout_spin.value(),
             max_nfev=self.nfev_spin.value(),
             method=self.method_combo.currentText(),
@@ -1852,6 +1861,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self.set_model(model, model_load_path=status.model_load_path)
 
             self.components_check.setChecked(status.show_components)
+            self.refit_on_source_update_check.setChecked(status.refit_on_source_update)
             self.timeout_spin.setValue(status.timeout)
             self.nfev_spin.setValue(status.max_nfev)
             self.method_combo.setCurrentText(status.method)
@@ -3331,6 +3341,38 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_is_current = True
         self.save_button.setEnabled(True)
         self.copy_button.setEnabled(True)
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        had_fit = self._last_result_ds is not None
+        status = self.tool_status
+        old_geom = self.saveGeometry()
+        self._cancel_fit(wait=True)
+
+        old_cw = self.centralWidget()
+        if old_cw is not None:
+            old_cw.setParent(None)
+            old_cw.deleteLater()
+
+        self._reset_fit_state(
+            new_data,
+            self._model,
+            self._params.copy(),
+            data_name=self._data_name,
+            model_name=self._model_name,
+        )
+        self._build_ui()
+        with self._history_suppressed():
+            self.tool_status = status
+        self._set_fit_stats(None)
+        self._update_fit_curve()
+        self._write_history = True
+        self._reset_history_stack()
+        self._mark_fit_stale()
+        self.restoreGeometry(old_geom)
+        self.sigInfoChanged.emit()
+
+        if had_fit and self.refit_on_source_update_check.isChecked():
+            self._run_fit()
 
     def _show_warning(self, title: str, text: str) -> None:
         QtWidgets.QMessageBox.warning(self, title, text)

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -3342,7 +3342,14 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self.save_button.setEnabled(True)
         self.copy_button.setEnabled(True)
 
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(new_data)
+        if data.ndim != 1:
+            raise ValueError("`data` must be a 1D DataArray")
+        return data
+
     def update_data(self, new_data: xr.DataArray) -> None:
+        new_data = self.validate_update_data(new_data)
         had_fit = self._last_result_ds is not None
         status = self.tool_status
         old_geom = self.saveGeometry()

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -866,6 +866,14 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         )
         self._write_history = False
 
+    def _connect_fit_finished_once(self, slot: Callable[..., typing.Any]) -> None:
+        with contextlib.suppress(TypeError, RuntimeError):
+            self.sigFitFinished.disconnect(slot)
+        self.sigFitFinished.connect(slot)
+
+    def _ensure_fit_finished_connections(self) -> None:
+        self._connect_fit_finished_once(self._replace_last_state)
+
     def _build_ui(self) -> None:
         self.resize(987, 610)
 
@@ -1003,7 +1011,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self.param_model.sigParamsChanged.connect(self._refresh_slider_from_model)
         self.param_model.sigParamsChanged.connect(self._mark_fit_stale)
         self.param_model.sigParamsChanged.connect(self._write_state)
-        self.sigFitFinished.connect(self._replace_last_state)
+        self._ensure_fit_finished_connections()
 
         self.param_view = QtWidgets.QTableView()
         self.param_view.setModel(self.param_model)

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -771,6 +771,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         model_name: str | None = None,
     ) -> None:
         super().__init__()
+        self._fit_finished_connection_keys: set[tuple[object | None, object]] = set()
         self._reset_fit_state(
             data,
             model,
@@ -867,10 +868,18 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         )
         self._write_history = False
 
+    def _fit_finished_connection_key(
+        self, slot: Callable[..., typing.Any]
+    ) -> tuple[object | None, object]:
+        return getattr(slot, "__self__", None), getattr(slot, "__func__", slot)
+
     def _connect_fit_finished_once(self, slot: Callable[..., typing.Any]) -> None:
-        with contextlib.suppress(TypeError, RuntimeError):
-            self.sigFitFinished.disconnect(slot)
+        key = self._fit_finished_connection_key(slot)
+        if key in self._fit_finished_connection_keys:
+            return
+
         self.sigFitFinished.connect(slot)
+        self._fit_finished_connection_keys.add(key)
 
     def _ensure_fit_finished_connections(self) -> None:
         self._connect_fit_finished_once(self._replace_last_state)

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -1878,12 +1878,14 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 self.normalize_check.setChecked(status.normalize_mean)
 
             self._slider_widths = dict(status.slider_widths)
-            self._params_from_coord = dict(status.params_from_coord)
 
             if status.params:
                 self._params = self._deserialize_params(status.params)
                 self._initial_params = self._params.copy()
-                self.param_model.set_params(self._params, self._params_from_coord)
+            self._params_from_coord = self._sanitize_params_from_coord(
+                status.params_from_coord
+            )
+            self.param_model.set_params(self._params, self._params_from_coord)
             self._refresh_slider_from_model()
             self._mark_fit_stale()
 
@@ -1895,6 +1897,19 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                     self.domain_min_spin.setValue(status.domain[0])
                     self.domain_max_spin.setValue(status.domain[1])
             self._domain_changed()
+
+    def _sanitize_params_from_coord(
+        self, params_from_coord: Mapping[str, str]
+    ) -> dict[str, str]:
+        """Drop coord-backed parameter bindings incompatible with current data."""
+        sanitized: dict[str, str] = {}
+        for param_name, coord_name in params_from_coord.items():
+            if param_name not in self._params or coord_name not in self._data.coords:
+                continue
+            if self._data.coords[coord_name].size != 1:
+                continue
+            sanitized[str(param_name)] = str(coord_name)
+        return sanitized
 
     def _schedule_table_width_init(self) -> None:
         if self._table_widths_initialized:

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -1392,41 +1392,42 @@ class Fit2DTool(Fit1DTool):
             raise ValueError("`data` must be a 2D DataArray")
         return data
 
-    def update_data(self, new_data: xr.DataArray) -> None:
-        new_data = self.validate_update_data(new_data)
+    def update_data(self, new_data: xr.DataArray) -> bool:
         had_fit = self._last_result_ds is not None
         status = self.tool_status
         old_geom = self.saveGeometry()
-        self._cancel_fit(wait=True, timeout_ms=None)
 
-        old_cw = self.centralWidget()
-        if old_cw is not None:
-            old_cw.setParent(None)
-            old_cw.deleteLater()
+        def _apply_update(validated: xr.DataArray) -> None:
+            old_cw = self.centralWidget()
+            if old_cw is not None:
+                old_cw.setParent(None)
+                old_cw.deleteLater()
 
-        self._init_full_data_state(new_data, data_name=self._data_name_full)
-        self._reset_fit_state(
-            self._data_full.isel({self._y_dim_name: self._current_idx}),
-            self._model,
-            self._params.copy(),
-            data_name=self._data_name,
-            model_name=self._model_name,
-        )
-        self._build_ui()
-        self.param_model.sigParamsChanged.connect(self._update_params_full)
-        with self._history_suppressed():
-            self.tool_status = status
-        self._refresh_main_image()
-        self._refresh_contents_from_index()
-        self._update_param_plot()
-        self._write_history = True
-        self._reset_history_stack()
-        self._mark_fit_stale()
-        self.restoreGeometry(old_geom)
-        self.sigInfoChanged.emit()
+            self._init_full_data_state(validated, data_name=self._data_name_full)
+            self._reset_fit_state(
+                self._data_full.isel({self._y_dim_name: self._current_idx}),
+                self._model,
+                self._params.copy(),
+                data_name=self._data_name,
+                model_name=self._model_name,
+            )
+            self._build_ui()
+            self.param_model.sigParamsChanged.connect(self._update_params_full)
+            with self._history_suppressed():
+                self.tool_status = status
+            self._refresh_main_image()
+            self._refresh_contents_from_index()
+            self._update_param_plot()
+            self._write_history = True
+            self._reset_history_stack()
+            self._mark_fit_stale()
+            self.restoreGeometry(old_geom)
+            self.sigInfoChanged.emit()
 
-        if had_fit and self.refit_on_source_update_check.isChecked():
-            self._run_fit()
+            if had_fit and self.refit_on_source_update_check.isChecked():
+                self._run_fit()
+
+        return self._perform_source_update(new_data, apply_update=_apply_update)
 
     def _update_full_fit_saveable(self) -> None:
         can_save: bool = self._fit_is_current and not any(

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -76,8 +76,6 @@ def _rebuild_ui(
                 # Rebuild UI and refresh views.
                 self._build_ui()
                 self.param_model.sigParamsChanged.connect(self._update_params_full)
-                self.sigFitFinished.connect(self._update_params_full)
-                self.sigFitFinished.connect(self._update_ds_full)
                 self._update_fit_curve()
                 self._write_history = True
                 self._write_state()
@@ -256,8 +254,6 @@ class Fit2DTool(Fit1DTool):
         )
 
         self.param_model.sigParamsChanged.connect(self._update_params_full)
-        self.sigFitFinished.connect(self._update_params_full)
-        self.sigFitFinished.connect(self._update_ds_full)
         self._refresh_contents_from_index()
         self._reset_history_stack()
 
@@ -285,6 +281,11 @@ class Fit2DTool(Fit1DTool):
 
     def _update_ds_full(self) -> None:
         self._result_ds_full[self._current_idx] = self._last_result_ds
+
+    def _ensure_fit_finished_connections(self) -> None:
+        super()._ensure_fit_finished_connections()
+        self._connect_fit_finished_once(self._update_params_full)
+        self._connect_fit_finished_once(self._update_ds_full)
 
     def _build_ui(self) -> None:
         super()._build_ui()

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -576,6 +576,11 @@ class Fit2DTool(Fit1DTool):
                 self._serialize_params(params) if params is not None else None
                 for params in self._params_full
             ],
+            initial_params_full=(
+                [self._serialize_params(params) for params in self._initial_params_full]
+                if self._initial_params_full is not None
+                else None
+            ),
             params_from_coord_full=self._params_from_coord_full.copy(),
             fill_mode=typing.cast(
                 'typing.Literal["previous", "extrapolate", "none"]',
@@ -601,6 +606,16 @@ class Fit2DTool(Fit1DTool):
             self._params_full = [None] * y_size
             for i, params in enumerate(restored_params_full[:y_size]):
                 self._params_full[i] = params
+
+            self._initial_params_full = None
+            if state2d.initial_params_full is not None:
+                self._initial_params_full = [
+                    self._initial_params.copy() for _ in range(y_size)
+                ]
+                for i, params in enumerate(state2d.initial_params_full[:y_size]):
+                    restored = self._deserialize_params(params)
+                    if restored is not None:
+                        self._initial_params_full[i] = restored
 
             self._params_from_coord_full = [{} for _ in range(y_size)]
             for i, mapping in enumerate(state2d.params_from_coord_full[:y_size]):

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -592,22 +592,33 @@ class Fit2DTool(Fit1DTool):
         )
         state2d = status.state2d
         if state2d is not None:  # pragma: no branch
+            y_size = int(self._data_full.sizes[self._y_dim_name])
             self._data_name_full = state2d.data_name_full
-            self._params_from_coord_full = state2d.params_from_coord_full.copy()
-            self._params_full = [
+            restored_params_full = [
                 self._deserialize_params(params) for params in state2d.params_full
             ]
+            self._params_full = [None] * y_size
+            for i, params in enumerate(restored_params_full[:y_size]):
+                self._params_full[i] = params
+
+            self._params_from_coord_full = [{} for _ in range(y_size)]
+            for i, mapping in enumerate(state2d.params_from_coord_full[:y_size]):
+                self._params_from_coord_full[i] = mapping.copy()
+
             self.fill_mode_combo.setCurrentText(state2d.fill_mode.capitalize())
             self._apply_param_plot_overlay_states(state2d.param_plot_overlay_states)
             if state2d.y_limits is not None:  # pragma: no branch
+                max_idx = y_size - 1
+                y_min = min(max(state2d.y_limits[0], 0), max_idx)
+                y_max = min(max(state2d.y_limits[1], 0), max_idx)
                 with (
                     QtCore.QSignalBlocker(self.y_min_spin),
                     QtCore.QSignalBlocker(self.y_max_spin),
                 ):
-                    self.y_min_spin.setValue(state2d.y_limits[0])
-                    self.y_max_spin.setValue(state2d.y_limits[1])
+                    self.y_min_spin.setValue(min(y_min, y_max))
+                    self.y_max_spin.setValue(max(y_min, y_max))
                 self._y_minmax_changed()
-            self._current_idx = state2d.current_idx
+            self._current_idx = min(max(state2d.current_idx, 0), y_size - 1)
         self.y_index_spin.setValue(self._current_idx)
 
     @QtCore.Slot()
@@ -1358,6 +1369,44 @@ class Fit2DTool(Fit1DTool):
     def _mark_fit_fresh(self) -> None:
         super()._mark_fit_fresh()
         self._update_full_fit_saveable()
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        had_fit = self._last_result_ds is not None
+        status = self.tool_status
+        old_geom = self.saveGeometry()
+        self._cancel_fit(wait=True)
+
+        old_cw = self.centralWidget()
+        if old_cw is not None:
+            old_cw.setParent(None)
+            old_cw.deleteLater()
+
+        if new_data.ndim != 2:
+            raise ValueError("`data` must be a 2D DataArray")
+
+        self._init_full_data_state(new_data, data_name=self._data_name_full)
+        self._reset_fit_state(
+            self._data_full.isel({self._y_dim_name: self._current_idx}),
+            self._model,
+            self._params.copy(),
+            data_name=self._data_name,
+            model_name=self._model_name,
+        )
+        self._build_ui()
+        self.param_model.sigParamsChanged.connect(self._update_params_full)
+        with self._history_suppressed():
+            self.tool_status = status
+        self._refresh_main_image()
+        self._refresh_contents_from_index()
+        self._update_param_plot()
+        self._write_history = True
+        self._reset_history_stack()
+        self._mark_fit_stale()
+        self.restoreGeometry(old_geom)
+        self.sigInfoChanged.emit()
+
+        if had_fit and self.refit_on_source_update_check.isChecked():
+            self._run_fit()
 
     def _update_full_fit_saveable(self) -> None:
         can_save: bool = self._fit_is_current and not any(

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -1370,7 +1370,14 @@ class Fit2DTool(Fit1DTool):
         super()._mark_fit_fresh()
         self._update_full_fit_saveable()
 
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(new_data)
+        if data.ndim != 2:
+            raise ValueError("`data` must be a 2D DataArray")
+        return data
+
     def update_data(self, new_data: xr.DataArray) -> None:
+        new_data = self.validate_update_data(new_data)
         had_fit = self._last_result_ds is not None
         status = self.tool_status
         old_geom = self.saveGeometry()
@@ -1380,9 +1387,6 @@ class Fit2DTool(Fit1DTool):
         if old_cw is not None:
             old_cw.setParent(None)
             old_cw.deleteLater()
-
-        if new_data.ndim != 2:
-            raise ValueError("`data` must be a 2D DataArray")
 
         self._init_full_data_state(new_data, data_name=self._data_name_full)
         self._reset_fit_state(

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -1382,7 +1382,7 @@ class Fit2DTool(Fit1DTool):
         had_fit = self._last_result_ds is not None
         status = self.tool_status
         old_geom = self.saveGeometry()
-        self._cancel_fit(wait=True)
+        self._cancel_fit(wait=True, timeout_ms=None)
 
         old_cw = self.centralWidget()
         if old_cw is not None:

--- a/src/erlab/interactive/_mesh.py
+++ b/src/erlab/interactive/_mesh.py
@@ -403,6 +403,31 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
             self.mesh_image.setDataArray(mesh.T, update_labels=False)
             self.corr_fft_image.setImage(log_magnitude_corr)
 
+    def update_data(self, new_data: xr.DataArray) -> None:
+        status = self.tool_status
+        if not all(dim in new_data.dims for dim in {"alpha", "eV"}):
+            raise ValueError("Input DataArray must have 'alpha' and 'eV' dimensions.")
+
+        self._data = new_data
+        self._corrected = None
+        self._mesh = None
+        self.__dict__.pop("_data_averaged", None)
+
+        max_alpha = self._data.alpha.size - 1
+        max_ev = self._data.eV.size - 1
+        for spin, maximum in (
+            (self.p0_spin0, max_alpha),
+            (self.p1_spin0, max_alpha),
+            (self.p0_spin1, max_ev),
+            (self.p1_spin1, max_ev),
+        ):
+            spin.setMaximum(maximum)
+
+        self.tool_status = status
+        self.set_data_beforecalc(initial=True)
+        self._update_target_pos()
+        self.sigInfoChanged.emit()
+
     @QtCore.Slot()
     def _corr_itool(self) -> None:
         if self._corrected is not None:  # pragma: no branch

--- a/src/erlab/interactive/_mesh.py
+++ b/src/erlab/interactive/_mesh.py
@@ -405,8 +405,7 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
 
     def update_data(self, new_data: xr.DataArray) -> None:
         status = self.tool_status
-        if not all(dim in new_data.dims for dim in {"alpha", "eV"}):
-            raise ValueError("Input DataArray must have 'alpha' and 'eV' dimensions.")
+        new_data = self.validate_update_data(new_data)
 
         self._data = new_data
         self._corrected = None
@@ -427,6 +426,12 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
         self.set_data_beforecalc(initial=True)
         self._update_target_pos()
         self.sigInfoChanged.emit()
+
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(new_data)
+        if not all(dim in data.dims for dim in {"alpha", "eV"}):
+            raise ValueError("Input DataArray must have 'alpha' and 'eV' dimensions.")
+        return data
 
     @QtCore.Slot()
     def _corr_itool(self) -> None:

--- a/src/erlab/interactive/derivative.py
+++ b/src/erlab/interactive/derivative.py
@@ -436,9 +436,7 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
 
     def update_data(self, new_data: xr.DataArray) -> None:
         status = self.tool_status
-        data = erlab.interactive.utils.parse_data(new_data)
-        if data.ndim != 2:
-            raise ValueError("Input DataArray must be 2D")
+        data = self.validate_update_data(new_data)
 
         self.data_has_nan = bool(data.isnull().any())
         if self.data_has_nan:
@@ -451,6 +449,12 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
         self.__dict__.pop("processed_data", None)
         self.tool_status = status
         self.update_preprocess()
+
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(new_data)
+        if data.ndim != 2:
+            raise ValueError("Input DataArray must be 2D")
+        return data
 
     def copy_code(self) -> str:
         lines: list[str] = []

--- a/src/erlab/interactive/derivative.py
+++ b/src/erlab/interactive/derivative.py
@@ -434,6 +434,24 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
             self.result = self.process_func(self.processed_data, **self.process_kwargs)
             self.sigInfoChanged.emit()
 
+    def update_data(self, new_data: xr.DataArray) -> None:
+        status = self.tool_status
+        data = erlab.interactive.utils.parse_data(new_data)
+        if data.ndim != 2:
+            raise ValueError("Input DataArray must be 2D")
+
+        self.data_has_nan = bool(data.isnull().any())
+        if self.data_has_nan:
+            data = data.fillna(0.0)
+
+        self.data = data
+        self._result = self.data.copy()
+        self.xdim = self.data.dims[1]
+        self.ydim = self.data.dims[0]
+        self.__dict__.pop("processed_data", None)
+        self.tool_status = status
+        self.update_preprocess()
+
     def copy_code(self) -> str:
         lines: list[str] = []
 

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -1,5 +1,6 @@
 __all__ = ["goldtool", "restool"]
 
+import contextlib
 import importlib.resources
 import logging
 import os
@@ -363,6 +364,13 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
         self.controls.addWidget(self.params_roi)
         self.controls.addWidget(self.params_edge)
+        self.refit_on_source_update_check = QtWidgets.QCheckBox(
+            "Refit on source update"
+        )
+        self.refit_on_source_update_check.setToolTip(
+            "If checked, rerun the edge fit when this tool refreshes from ImageTool."
+        )
+        self.controls.addWidget(self.refit_on_source_update_check)
 
         self.params_tab = QtWidgets.QTabWidget()
         self.params_tab.addTab(self.params_poly, "Polynomial")
@@ -441,6 +449,90 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
         # Initialize fit result
         self.result: scipy.interpolate.BSpline | xr.Dataset | None = None
+
+    def _clear_edge_fit_results(self) -> None:
+        self.result = None
+        self._fit_task = None
+        self.progress.reset()
+        self.params_poly.setDisabled(True)
+        self.params_spl.setDisabled(True)
+        self.params_tab.setDisabled(True)
+        self.aw.axes[1].setVisible(False)
+        self.aw.hists[1].setVisible(False)
+        self.aw.axes[2].setVisible(False)
+        self.aw.hists[2].setVisible(False)
+        for scatter, errorbar, curve in zip(
+            self.scatterplots, self.errorbars, self.polycurves, strict=True
+        ):
+            scatter.setData(x=np.array([]), y=np.array([]))
+            errorbar.setData(
+                x=np.array([]), y=np.array([]), height=np.array([], dtype=float)
+            )
+            curve.setData(x=np.array([]), y=np.array([]))
+        with contextlib.suppress(AttributeError):
+            del self.edge_center
+        with contextlib.suppress(AttributeError):
+            del self.edge_stderr
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        had_fit = hasattr(self, "edge_center")
+        roi_limits = self.params_roi.roi_limits
+        tab_index = self.params_tab.currentIndex()
+        edge_values = dict(self.params_edge.values)
+        poly_values = dict(self.params_poly.values)
+        spline_values = dict(self.params_spl.values)
+        refit = self.refit_on_source_update_check.isChecked()
+
+        self._stop_server()
+
+        if new_data.ndim != 2 or "eV" not in new_data.dims:
+            raise ValueError("`data` must be a 2D DataArray with an `eV` dimension")
+        data = new_data if new_data.dims[0] == "eV" else new_data.copy().T
+
+        self._clear_edge_fit_results()
+        self.data = data
+        self._along_dim = str(self.data.dims[1])
+        self.aw.set_input(self.data)
+        self.aw.axes[0].autoRange()
+
+        roi_rect = self.aw.axes[0].getViewBox().itemBoundingRect(self.aw.images[0])
+        self.params_roi.roi.maxBounds = roi_rect
+        self.params_roi._x_decimals = erlab.utils.array.effective_decimals(
+            self.data[self._along_dim].values
+        )
+        self.params_roi._y_decimals = erlab.utils.array.effective_decimals(
+            self.data.eV.values
+        )
+        xm, ym, xM, yM = self.params_roi.max_bounds
+        for name in ("x0", "x1"):
+            spin = typing.cast(
+                "QtWidgets.QDoubleSpinBox", self.params_roi.widgets[name]
+            )
+            spin.setRange(xm, xM)
+            spin.setDecimals(self.params_roi._x_decimals)
+        for name in ("y0", "y1"):
+            spin = typing.cast(
+                "QtWidgets.QDoubleSpinBox", self.params_roi.widgets[name]
+            )
+            spin.setRange(ym, yM)
+            spin.setDecimals(self.params_roi._y_decimals)
+        self.params_roi.modify_roi(*roi_limits)
+        self.params_roi.update_pos()
+
+        with (
+            QtCore.QSignalBlocker(self.params_edge),
+            QtCore.QSignalBlocker(self.params_poly),
+            QtCore.QSignalBlocker(self.params_spl),
+            QtCore.QSignalBlocker(self.params_tab),
+        ):
+            self.params_edge.set_values(**edge_values)
+            self.params_poly.set_values(**poly_values)
+            self.params_spl.set_values(**spline_values)
+            self.params_tab.setCurrentIndex(tab_index)
+        self._toggle_fast()
+
+        if had_fit and refit:
+            self.perform_edge_fit()
 
     def _toggle_fast(self) -> None:
         self.params_edge.widgets["T (K)"].setDisabled(
@@ -790,6 +882,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         y0: float
         y1: float
         live_fit: bool
+        refit_on_source_update: bool
         temp: float
         fix_temp: bool
         center: float
@@ -857,6 +950,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
             y0=self.y0_spin.value(),
             y1=self.y1_spin.value(),
             live_fit=self.live_check.isChecked(),
+            refit_on_source_update=self.refit_on_source_update_check.isChecked(),
             temp=self.temp_spin.value(),
             fix_temp=self.fix_temp_check.isChecked(),
             center=self.center_spin.value(),
@@ -887,6 +981,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self.y0_spin.setValue(status.y0)
         self.y1_spin.setValue(status.y1)
         self.live_check.setChecked(status.live_fit)
+        self.refit_on_source_update_check.setChecked(status.refit_on_source_update)
 
         self.temp_spin.setValue(status.temp)
         self.fix_temp_check.setChecked(status.fix_temp)
@@ -922,6 +1017,17 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
             self,
         )
         self.setWindowTitle("")
+
+        self.refit_on_source_update_check = QtWidgets.QCheckBox(
+            "Refit on source update", self.groupBox_2
+        )
+        self.refit_on_source_update_check.setToolTip(
+            "If checked, rerun the resolution fit when this tool refreshes from "
+            "ImageTool."
+        )
+        typing.cast("QtWidgets.QGridLayout", self.groupBox_2.layout()).addWidget(
+            self.refit_on_source_update_check, 10, 0, 1, 4
+        )
 
         if data.dims.index("eV") != 1:
             data = data.T
@@ -1023,6 +1129,59 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self._fit_signature_current: tuple[typing.Any, ...] | None = None
         self._fit_signature_displayed: tuple[typing.Any, ...] | None = None
 
+    def _configure_data(self, data: xr.DataArray) -> None:
+        if (data.ndim != 2) or ("eV" not in data.dims):
+            raise ValueError("Data must be 2D and have an 'eV' dimension.")
+        if data.dims.index("eV") != 1:
+            data = data.T
+
+        self.data = data
+        self.y_dim = str(data.dims[0])
+
+        x_coords = data["eV"].values
+        y_coords = data[self.y_dim].values
+
+        self._x_range = x_coords.min(), x_coords.max()
+        self._y_range = y_coords.min(), y_coords.max()
+
+        self._x_decimals = erlab.utils.array.effective_decimals(x_coords)
+        self._y_decimals = erlab.utils.array.effective_decimals(y_coords)
+
+        self.x0_spin.setRange(*self._x_range)
+        self.x1_spin.setRange(*self._x_range)
+        self.y0_spin.setRange(*self._y_range)
+        self.y1_spin.setRange(*self._y_range)
+        self.x0_spin.setDecimals(self._x_decimals)
+        self.x1_spin.setDecimals(self._x_decimals)
+        self.y0_spin.setDecimals(self._y_decimals)
+        self.y1_spin.setDecimals(self._y_decimals)
+        self.x0_spin.setSingleStep(10 ** -(self._x_decimals - 1))
+        self.x1_spin.setSingleStep(10 ** -(self._x_decimals - 1))
+        self.y0_spin.setSingleStep(10 ** -(self._y_decimals - 1))
+        self.y1_spin.setSingleStep(10 ** -(self._y_decimals - 1))
+
+        self.res_spin.setDecimals(self._x_decimals + 1)
+        self.res_spin.setSingleStep(10 ** -(self._x_decimals - 1))
+        self.center_spin.setRange(*self._x_range)
+        self.center_spin.setDecimals(self._x_decimals + 1)
+        self.center_spin.setSingleStep(10 ** -(self._x_decimals - 1))
+
+        self.image.setDataArray(self.data, update_labels=True)
+        self.plot0.autoRange()
+        self.x_region.setBounds(self._x_range)
+        self.y_region.setBounds(self._y_range)
+
+    def _clear_fit_outputs(self) -> None:
+        self._result_ds = None
+        self._fit_signature_current = None
+        self._fit_signature_displayed = None
+        self.edc_fit.setData(x=[], y=[])
+        self.overview_label.setText("No fit results")
+        self.temp_val.setText("—")
+        self.center_val.setText("—")
+        self.res_val.setText("—")
+        self.redchi_val.setText("—")
+
     @property
     def _x_range_ui(self) -> tuple[float, float]:
         x0 = round(self.x0_spin.value(), self._x_decimals)
@@ -1078,6 +1237,20 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
                 event.ignore()
             return
         super().closeEvent(event)
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        had_fit = self._result_ds is not None
+        status = self.tool_status.model_copy(
+            update={"results": ("No fit results", "—", "—", "—", "—")}
+        )
+        self._cancel_fit(wait=True)
+        self._configure_data(new_data)
+        self._clear_fit_outputs()
+        self.tool_status = status
+        self.sigInfoChanged.emit()
+
+        if had_fit and self.refit_on_source_update_check.isChecked():
+            self.do_fit()
 
     def _update_edc(self) -> None:
         """Calculate averaged EDC and update the plot."""

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -589,15 +589,17 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             return
         self._pending_update_request = None
         self._apply_update_request(request)
+        self._set_source_state("fresh")
 
-    def update_data(self, new_data: xr.DataArray) -> None:
+    def update_data(self, new_data: xr.DataArray) -> bool:
         data = self.validate_update_data(new_data)
         self._pending_update_request = self._make_update_request(data)
         self._abort_fit_task()
         if self._threadpool.activeThreadCount():
             self._pending_update_timer.start(50)
-            return
+            return False
         self._flush_pending_update()
+        return True
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
         data = erlab.interactive.utils.parse_data(new_data)

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -475,6 +475,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             del self.edge_stderr
 
     def update_data(self, new_data: xr.DataArray) -> None:
+        data = self.validate_update_data(new_data)
         had_fit = hasattr(self, "edge_center")
         roi_limits = self.params_roi.roi_limits
         tab_index = self.params_tab.currentIndex()
@@ -484,10 +485,6 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         refit = self.refit_on_source_update_check.isChecked()
 
         self._stop_server()
-
-        if new_data.ndim != 2 or "eV" not in new_data.dims:
-            raise ValueError("`data` must be a 2D DataArray with an `eV` dimension")
-        data = new_data if new_data.dims[0] == "eV" else new_data.copy().T
 
         self._clear_edge_fit_results()
         self.data = data
@@ -533,6 +530,14 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
         if had_fit and refit:
             self.perform_edge_fit()
+
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(new_data)
+        if data.ndim != 2 or "eV" not in data.dims:
+            raise ValueError("`data` must be a 2D DataArray with an `eV` dimension")
+        if data.dims[0] != "eV":
+            data = data.copy().T
+        return data
 
     def _toggle_fast(self) -> None:
         self.params_edge.widgets["T (K)"].setDisabled(
@@ -1239,6 +1244,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         super().closeEvent(event)
 
     def update_data(self, new_data: xr.DataArray) -> None:
+        new_data = self.validate_update_data(new_data)
         had_fit = self._result_ds is not None
         status = self.tool_status.model_copy(
             update={"results": ("No fit results", "—", "—", "—", "—")}
@@ -1251,6 +1257,14 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
 
         if had_fit and self.refit_on_source_update_check.isChecked():
             self.do_fit()
+
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(new_data)
+        if (data.ndim != 2) or ("eV" not in data.dims):
+            raise ValueError("Data must be 2D and have an 'eV' dimension.")
+        if data.dims.index("eV") != 1:
+            data = data.T
+        return data
 
     def _update_edc(self) -> None:
         """Calculate averaged EDC and update the plot."""

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -887,7 +887,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         y0: float
         y1: float
         live_fit: bool
-        refit_on_source_update: bool
+        refit_on_source_update: bool = False
         temp: float
         fix_temp: bool
         center: float

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -1315,7 +1315,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         # just-starting thread.
         return self._fit_thread is not None
 
-    def _cancel_fit(self, *, wait: bool = False, timeout_ms: int = 5000) -> bool:
+    def _cancel_fit(self, *, wait: bool = False, timeout_ms: int | None = 5000) -> bool:
         if self._fit_thread is not None:
             self._fit_thread.cancel()
             self._fit_thread.requestInterruption()
@@ -1323,6 +1323,8 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self._fit_queued = False
         self._pending_fit_action = None
         if wait and self._fit_thread is not None:
+            if timeout_ms is None:
+                return self._fit_thread.wait()
             return self._fit_thread.wait(timeout_ms)
         return True
 
@@ -1343,7 +1345,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         status = self.tool_status.model_copy(
             update={"results": ("No fit results", "—", "—", "—", "—")}
         )
-        self._cancel_fit(wait=True)
+        self._cancel_fit(wait=True, timeout_ms=None)
         self._configure_data(new_data)
         self._clear_fit_outputs()
         self.tool_status = status

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -1,6 +1,7 @@
 __all__ = ["goldtool", "restool"]
 
 import contextlib
+import dataclasses
 import importlib.resources
 import logging
 import os
@@ -135,6 +136,18 @@ class EdgeFitTask(QtCore.QRunnable):
             self.signals.sigFinished.emit(edge_center, edge_stderr)
         except Exception:  # pragma: no cover - defensive for worker thread
             self.signals.sigFailed.emit(traceback.format_exc())
+
+
+@dataclasses.dataclass(slots=True)
+class _GoldUpdateRequest:
+    data: xr.DataArray
+    had_fit: bool
+    roi_limits: tuple[float, float, float, float]
+    tab_index: int
+    edge_values: dict[str, typing.Any]
+    poly_values: dict[str, typing.Any]
+    spline_values: dict[str, typing.Any]
+    refit: bool
 
 
 class GoldTool(erlab.interactive.utils.AnalysisWindow):
@@ -432,6 +445,10 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         self._threadpool = QtCore.QThreadPool(self)
         self._fit_task: EdgeFitTask | None = None
         self.sigAbortFitting.connect(self._abort_fit_task)
+        self._pending_update_request: _GoldUpdateRequest | None = None
+        self._pending_update_timer = QtCore.QTimer(self)
+        self._pending_update_timer.setSingleShot(True)
+        self._pending_update_timer.timeout.connect(self._flush_pending_update)
 
         # Resize roi to data bounds
         eV_span = self.data.eV.values[-1] - self.data.eV.values[0]
@@ -474,20 +491,49 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         with contextlib.suppress(AttributeError):
             del self.edge_stderr
 
-    def update_data(self, new_data: xr.DataArray) -> None:
-        data = self.validate_update_data(new_data)
-        had_fit = hasattr(self, "edge_center")
-        roi_limits = self.params_roi.roi_limits
-        tab_index = self.params_tab.currentIndex()
-        edge_values = dict(self.params_edge.values)
-        poly_values = dict(self.params_poly.values)
-        spline_values = dict(self.params_spl.values)
-        refit = self.refit_on_source_update_check.isChecked()
+    @staticmethod
+    def _clamp_roi_interval(
+        start: float, stop: float, lower: float, upper: float
+    ) -> tuple[float, float]:
+        lower, upper = min(lower, upper), max(lower, upper)
+        available = upper - lower
+        lo, hi = min(start, stop), max(start, stop)
+        width = hi - lo
 
-        self._stop_server()
+        if available <= 0:
+            return lower, upper
+        if width <= 0 or width >= available:
+            return lower, upper
 
+        lo = min(max(lo, lower), upper - width)
+        return lo, lo + width
+
+    def _clamp_roi_limits_to_bounds(
+        self, roi_limits: tuple[float, float, float, float]
+    ) -> tuple[float, float, float, float]:
+        x0, x1 = self._clamp_roi_interval(
+            roi_limits[0], roi_limits[2], *self.params_roi.max_bounds[::2]
+        )
+        y0, y1 = self._clamp_roi_interval(
+            roi_limits[1], roi_limits[3], *self.params_roi.max_bounds[1::2]
+        )
+        return x0, y0, x1, y1
+
+    def _make_update_request(self, data: xr.DataArray) -> _GoldUpdateRequest:
+        return _GoldUpdateRequest(
+            data=data,
+            had_fit=hasattr(self, "edge_center"),
+            roi_limits=self.params_roi.roi_limits,
+            tab_index=self.params_tab.currentIndex(),
+            edge_values=dict(self.params_edge.values),
+            poly_values=dict(self.params_poly.values),
+            spline_values=dict(self.params_spl.values),
+            refit=self.refit_on_source_update_check.isChecked(),
+        )
+
+    def _apply_update_request(self, request: _GoldUpdateRequest) -> None:
         self._clear_edge_fit_results()
-        self.data = data
+        self.data = request.data
         self._along_dim = str(self.data.dims[1])
         self.aw.set_input(self.data)
         self.aw.axes[0].autoRange()
@@ -513,7 +559,9 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             )
             spin.setRange(ym, yM)
             spin.setDecimals(self.params_roi._y_decimals)
-        self.params_roi.modify_roi(*roi_limits)
+        self.params_roi.modify_roi(
+            *self._clamp_roi_limits_to_bounds(request.roi_limits)
+        )
         self.params_roi.update_pos()
 
         with (
@@ -522,14 +570,34 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             QtCore.QSignalBlocker(self.params_spl),
             QtCore.QSignalBlocker(self.params_tab),
         ):
-            self.params_edge.set_values(**edge_values)
-            self.params_poly.set_values(**poly_values)
-            self.params_spl.set_values(**spline_values)
-            self.params_tab.setCurrentIndex(tab_index)
+            self.params_edge.set_values(**request.edge_values)
+            self.params_poly.set_values(**request.poly_values)
+            self.params_spl.set_values(**request.spline_values)
+            self.params_tab.setCurrentIndex(request.tab_index)
         self._toggle_fast()
 
-        if had_fit and refit:
+        if request.had_fit and request.refit:
             self.perform_edge_fit()
+
+    @QtCore.Slot()
+    def _flush_pending_update(self) -> None:
+        request = self._pending_update_request
+        if request is None:
+            return
+        if self._threadpool.activeThreadCount():
+            self._pending_update_timer.start(50)
+            return
+        self._pending_update_request = None
+        self._apply_update_request(request)
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        data = self.validate_update_data(new_data)
+        self._pending_update_request = self._make_update_request(data)
+        self._abort_fit_task()
+        if self._threadpool.activeThreadCount():
+            self._pending_update_timer.start(50)
+            return
+        self._flush_pending_update()
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
         data = erlab.interactive.utils.parse_data(new_data)
@@ -547,8 +615,9 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             bool(self.params_edge.values["Fast"])
         )
 
-    @QtCore.Slot(int)
-    def iterated(self, n: int) -> None:
+    def iterated(self, n: int, *, task: EdgeFitTask | None = None) -> None:
+        if task is not None and task is not self._fit_task:
+            return
         if n == 0:
             self.progress.setLabelText("")
         elif n == 2:
@@ -574,6 +643,8 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     @QtCore.Slot()
     def perform_edge_fit(self) -> None:
+        if self._pending_update_request is not None:
+            return
         self.progress.setVisible(True)
         self.params_roi.draw_button.setChecked(False)
         x0, y0, x1, y1 = self.roi_limits_ordered
@@ -587,18 +658,33 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         self.progress.setMaximum(n_total)
         self._abort_fit_task()
         task = EdgeFitTask(self.data, self._along_dim, x0, y0, x1, y1, params)
-        task.signals.sigIterated.connect(self.iterated)
-        task.signals.sigFinished.connect(self.post_fit)
-        task.signals.sigFailed.connect(self._handle_fit_failed)
         self._fit_task = task
+        task.signals.sigIterated.connect(
+            lambda n, task=task: self.iterated(n, task=task)
+        )
+        task.signals.sigFinished.connect(
+            lambda edge_center, edge_stderr, task=task: self.post_fit(
+                edge_center, edge_stderr, task=task
+            )
+        )
+        task.signals.sigFailed.connect(
+            lambda message, task=task: self._handle_fit_failed(message, task=task)
+        )
         self._threadpool.start(task)
 
     @QtCore.Slot()
     def abort_fit(self) -> None:
         self.sigAbortFitting.emit()
 
-    @QtCore.Slot(object, object)
-    def post_fit(self, edge_center: xr.DataArray, edge_stderr: xr.DataArray) -> None:
+    def post_fit(
+        self,
+        edge_center: xr.DataArray,
+        edge_stderr: xr.DataArray,
+        *,
+        task: EdgeFitTask | None = None,
+    ) -> None:
+        if task is not None and task is not self._fit_task:
+            return
         self.progress.reset()
         self.edge_center, self.edge_stderr = edge_center, edge_stderr
         self._fit_task = None
@@ -616,12 +702,18 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     @QtCore.Slot()
     def _abort_fit_task(self) -> None:
-        if self._fit_task is None:
+        task = self._fit_task
+        if task is None:
             return
-        self._fit_task.abort_fit()
+        self._fit_task = None
+        task.abort_fit()
+        self.progress.reset()
 
-    @QtCore.Slot(str)
-    def _handle_fit_failed(self, message: str) -> None:
+    def _handle_fit_failed(
+        self, message: str, *, task: EdgeFitTask | None = None
+    ) -> None:
+        if task is not None and task is not self._fit_task:
+            return
         self.progress.reset()
         self._fit_task = None
         erlab.interactive.utils.MessageDialog.critical(
@@ -787,10 +879,12 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     def _stop_server(self) -> None:
         """Stop the fitter thread properly."""
+        self._pending_update_request = None
+        self._pending_update_timer.stop()
         self._abort_fit_task()
         if self._threadpool.activeThreadCount():
             if hasattr(self._threadpool, "waitForDone"):  # Qt 6.8+
-                self._threadpool.waitForDone(5000)
+                self._threadpool.waitForDone()
             else:  # pragma: no cover
                 import contextlib
 

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -1253,6 +1253,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self._configure_data(new_data)
         self._clear_fit_outputs()
         self.tool_status = status
+        self._update_edc()
         self.sigInfoChanged.emit()
 
         if had_fit and self.refit_on_source_update_check.isChecked():

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -879,24 +879,25 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         erlab.interactive.utils.copy_to_clipboard(code_str)
         return code_str
 
-    def _stop_server(self) -> None:
+    def _stop_server(self) -> bool:
         """Stop the fitter thread properly."""
         self._pending_update_request = None
         self._pending_update_timer.stop()
         self._abort_fit_task()
-        if self._threadpool.activeThreadCount():
-            if hasattr(self._threadpool, "waitForDone"):  # Qt 6.8+
-                self._threadpool.waitForDone()
-            else:  # pragma: no cover
-                import contextlib
-
-                with contextlib.suppress(KeyboardInterrupt):
-                    while self._threadpool.activeThreadCount() > 0:
-                        QtCore.QThread.msleep(100)
+        return self._wait_for_threadpool(
+            self._threadpool,
+            timeout_ms=self.BACKGROUND_TASK_TIMEOUT_MS,
+        )
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """Overridden close event to ensure proper cleanup."""
-        self._stop_server()
+        if not self._stop_server():
+            logger.warning(
+                "Gold fit worker did not stop within timeout; aborting window close"
+            )
+            if event is not None:
+                event.ignore()
+            return
         super().closeEvent(event)
 
 
@@ -1318,16 +1319,18 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         return self._fit_thread is not None
 
     def _cancel_fit(self, *, wait: bool = False, timeout_ms: int | None = 5000) -> bool:
-        if self._fit_thread is not None:
-            self._fit_thread.cancel()
-            self._fit_thread.requestInterruption()
+        thread = self._fit_thread
+        if thread is not None:
+            thread.cancel()
+            thread.requestInterruption()
         self._fit_cancel_requested = True
         self._fit_queued = False
         self._pending_fit_action = None
-        if wait and self._fit_thread is not None:
-            if timeout_ms is None:
-                return self._fit_thread.wait()
-            return self._fit_thread.wait(timeout_ms)
+        if wait and thread is not None:
+            finished = thread.wait() if timeout_ms is None else thread.wait(timeout_ms)
+            if finished:
+                self._finalize_fit_thread(thread)
+            return finished
         return True
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
@@ -1341,21 +1344,26 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
             return
         super().closeEvent(event)
 
-    def update_data(self, new_data: xr.DataArray) -> None:
-        new_data = self.validate_update_data(new_data)
+    def _cancel_background_work(self, *, timeout_ms: int) -> bool:
+        return self._cancel_fit(wait=True, timeout_ms=timeout_ms)
+
+    def update_data(self, new_data: xr.DataArray) -> bool:
         had_fit = self._result_ds is not None
         status = self.tool_status.model_copy(
             update={"results": ("No fit results", "—", "—", "—", "—")}
         )
-        self._cancel_fit(wait=True, timeout_ms=None)
-        self._configure_data(new_data)
-        self._clear_fit_outputs()
-        self.tool_status = status
-        self._update_edc()
-        self.sigInfoChanged.emit()
 
-        if had_fit and self.refit_on_source_update_check.isChecked():
-            self.do_fit()
+        def _apply_update(validated: xr.DataArray) -> None:
+            self._configure_data(validated)
+            self._clear_fit_outputs()
+            self.tool_status = status
+            self._update_edc()
+            self.sigInfoChanged.emit()
+
+            if had_fit and self.refit_on_source_update_check.isChecked():
+                self.do_fit()
+
+        return self._perform_source_update(new_data, apply_update=_apply_update)
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
         data = erlab.interactive.utils.parse_data(new_data)
@@ -1448,10 +1456,13 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
 
     def _queue_fit_action(
         self,
+        thread: ResolutionFitThread,
         action: Callable[[], None],
         *,
         allow_when_cancelled: bool = False,
     ) -> None:
+        if self._fit_thread is not thread:
+            return
         if self._fit_cancel_requested and not allow_when_cancelled:
             return
         self._pending_fit_action = action
@@ -1459,8 +1470,9 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
             self._pending_fit_action = None
             action()
 
-    def _finalize_fit_thread(self) -> None:
-        thread = self._fit_thread
+    def _finalize_fit_thread(self, thread: ResolutionFitThread) -> None:
+        if self._fit_thread is not thread:
+            return
         action = self._pending_fit_action
         self._pending_fit_action = None
         self._fit_thread = None
@@ -1471,8 +1483,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         if self._fit_queued and not was_cancelled:
             self._fit_queued = False
             self._start_fit_worker()
-        if thread is not None:
-            thread.deleteLater()
+        thread.deleteLater()
 
     def _start_fit_worker(self) -> bool:
         if self._fit_thread is not None:
@@ -1489,26 +1500,27 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         )
         if hasattr(thread, "setServiceLevel"):
             thread.setServiceLevel(QtCore.QThread.QualityOfService.High)
-        thread.finished.connect(self._finalize_fit_thread)
+        thread.finished.connect(lambda thread=thread: self._finalize_fit_thread(thread))
 
         thread.sigFinished.connect(
-            lambda result_ds, fit_time: self._queue_fit_action(
-                lambda: self._handle_fit_success(result_ds, fit_time, fit_signature)
+            lambda result_ds, fit_time, thread=thread: self._queue_fit_action(
+                thread,
+                lambda: self._handle_fit_success(result_ds, fit_time, fit_signature),
             )
         )
         thread.sigTimedOut.connect(
-            lambda elapsed: self._queue_fit_action(
-                lambda: self._handle_fit_timeout(elapsed, fit_signature)
+            lambda elapsed, thread=thread: self._queue_fit_action(
+                thread, lambda: self._handle_fit_timeout(elapsed, fit_signature)
             )
         )
         thread.sigErrored.connect(
-            lambda message: self._queue_fit_action(
-                lambda: self._handle_fit_error(message, fit_signature)
+            lambda message, thread=thread: self._queue_fit_action(
+                thread, lambda: self._handle_fit_error(message, fit_signature)
             )
         )
         thread.sigCancelled.connect(
-            lambda: self._queue_fit_action(
-                self._handle_fit_cancelled, allow_when_cancelled=True
+            lambda thread=thread: self._queue_fit_action(
+                thread, self._handle_fit_cancelled, allow_when_cancelled=True
             )
         )
 

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -410,8 +410,10 @@ class ImageTool(BaseImageTool):
 
             try:
                 with erlab.interactive.utils.wait_dialog(self, "Loading..."):
-                    self.slicer_area.set_data(
-                        fn(fname, **kargs), file_path=fname, load_func=(fn, kargs, 0)
+                    self.slicer_area.replace_source_data(
+                        fn(fname, **kargs),
+                        file_path=fname,
+                        load_func=(fn, kargs, 0),
                     )
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -241,8 +241,7 @@ class DataTransformDialog(_DataManipulationDialog):
 
                 erlab.interactive.itool(**itool_kw)
             else:
-                self.slicer_area.set_data(processed)
-                self.slicer_area.sigDataEdited.emit()
+                self.slicer_area.replace_source_data(processed, emit_edited=True)
 
             del processed
 

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -64,8 +64,7 @@ class ToolNamespace:
 
     @data.setter
     def data(self, value: xr.DataArray) -> None:
-        self.tool.slicer_area.set_data(value)
-        self.tool.slicer_area.sigDataEdited.emit()
+        self.tool.slicer_area.replace_source_data(value, emit_edited=True)
 
     def _get_data_item(self, key):
         """Return a subset of the tool data for rewritten console assignments."""

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1811,7 +1811,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 # If not yet created, add new tool
                 self._data_recv([darr], {})
                 continue
-            self.get_imagetool(idx).slicer_area.set_data(darr)
+            self.get_imagetool(idx).slicer_area.replace_source_data(darr)
         self._sigDataReplaced.emit()
 
     def _find_watched_idx(self, uid: str) -> int | None:
@@ -1854,7 +1854,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             self._data_recv([darr], {}, watched_var=(varname, uid))
         else:
             # Update data in the existing tool
-            self.get_imagetool(idx).slicer_area.set_data(darr)
+            self.get_imagetool(idx).slicer_area.replace_source_data(darr)
 
     @QtCore.Slot(str)
     def _data_unwatch(self, uid: str) -> None:

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -75,6 +75,8 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
 
     watched_rect_hpad: int = 5
     watched_font_scale: float = 0.9
+    child_status_rect_hpad: int = 5
+    child_status_font_scale: float = 0.85
 
     def __init__(
         self, manager: ImageToolManager, parent: _ImageToolWrapperTreeView
@@ -407,6 +409,18 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         )
 
         selected: bool = QtWidgets.QStyle.StateFlag.State_Selected in option.state
+        child_tool: erlab.interactive.utils.ToolWindow | None = None
+        status_rect: QtCore.QRect | None = None
+        status_text: str | None = None
+        status_color: QtGui.QColor | None = None
+        try:
+            child_tool = self.manager.get_childtool(index.internalPointer())
+        except KeyError:
+            child_tool = None
+        else:
+            status_rect, status_text, status_color = self._compute_child_status_info(
+                option, child_tool
+            )
 
         if not is_editing:  # pragma: no branch
             role = (
@@ -420,7 +434,12 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             elided_text = QtGui.QFontMetrics(option.font).elidedText(
                 index.data(role=QtCore.Qt.ItemDataRole.DisplayRole),
                 view.textElideMode(),
-                option.rect.width(),
+                option.rect.width()
+                - (
+                    status_rect.width() + self.icon_right_pad
+                    if status_rect is not None
+                    else 0
+                ),
             )
             painter.drawText(
                 option.rect,
@@ -428,6 +447,29 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 | QtCore.Qt.AlignmentFlag.AlignLeft,
                 elided_text,
             )
+            if status_rect and status_text and status_color:
+                _fill_rounded_rect(
+                    painter,
+                    status_rect,
+                    facecolor=option.palette.base(),
+                    edgecolor=status_color,
+                    linewidth=self.icon_border_width,
+                    radius=self.icon_corner_radius,
+                )
+                status_font = QtGui.QFont(option.font)
+                status_font.setPointSizeF(
+                    self._font_size * self.child_status_font_scale
+                )
+                painter.save()
+                painter.setFont(status_font)
+                painter.setPen(status_color)
+                painter.drawText(
+                    status_rect,
+                    QtCore.Qt.AlignmentFlag.AlignVCenter
+                    | QtCore.Qt.AlignmentFlag.AlignCenter,
+                    status_text,
+                )
+                painter.restore()
 
         # Show preview on hover
         if (
@@ -438,9 +480,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 or self._force_hover
             )
         ):
-            try:
-                child_tool = self.manager.get_childtool(index.internalPointer())
-            except KeyError:
+            if child_tool is None:
                 self.preview_popup.hide()
                 return
 
@@ -474,6 +514,32 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 pixmap.transformed(QtGui.QTransform().scale(1.0, -1.0)),
                 option,
             )
+
+    def _compute_child_status_info(
+        self,
+        option: QtWidgets.QStyleOptionViewItem,
+        child_tool: erlab.interactive.utils.ToolWindow,
+    ) -> tuple[QtCore.QRect | None, str | None, QtGui.QColor | None]:
+        match child_tool.source_state:
+            case "stale":
+                text = "Stale"
+                color = QtGui.QColor("#b26a00")
+            case "unavailable":
+                text = "Unavailable"
+                color = QtGui.QColor("#b24444")
+            case _:
+                return None, None, None
+
+        rect_size = self.icon_size + 2 * self.icon_inner_pad
+        rect_y = option.rect.center().y() - (rect_size // 2)
+        badge_font = QtGui.QFont(option.font)
+        badge_font.setPointSizeF(self._font_size * self.child_status_font_scale)
+        badge_width = (
+            QtGui.QFontMetrics(badge_font).boundingRect(text).width()
+            + self.child_status_rect_hpad * 2
+        )
+        rect_x = option.rect.right() - badge_width - self.icon_right_pad
+        return QtCore.QRect(rect_x, rect_y, badge_width, rect_size), text, color
 
     def eventFilter(
         self, obj: QtCore.QObject | None = None, event: QtCore.QEvent | None = None
@@ -542,6 +608,26 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                         watched_rect,
                     )
                     return True
+            elif isinstance(tool_wrapper, str):
+                try:
+                    child_tool = self.manager.get_childtool(tool_wrapper)
+                except KeyError:
+                    child_tool = None
+                if child_tool is not None:
+                    status_rect, _, _ = self._compute_child_status_info(
+                        option, child_tool
+                    )
+                    if status_rect and status_rect.contains(event.pos()):
+                        tooltip = (
+                            "Click to update this tool from the latest ImageTool data."
+                            if child_tool.source_state == "stale"
+                            else "Click to review why this tool cannot update from the "
+                            "current ImageTool data."
+                        )
+                        QtWidgets.QToolTip.showText(
+                            event.globalPos(), tooltip, view, status_rect
+                        )
+                        return True
 
         return super().helpEvent(event, view, option, index)
 
@@ -603,6 +689,8 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
                         0,
                         self._row_index(tool_idx),
                     )
+            return QtCore.QModelIndex()
+        if index_or_uid not in self.manager._displayed_indices:
             return QtCore.QModelIndex()
         return self.index(self.manager._displayed_indices.index(index_or_uid), 0)
 
@@ -1168,7 +1256,8 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
 
     @QtCore.Slot()
     @QtCore.Slot(int)
-    def refresh(self, idx: int | None = None) -> None:
+    @QtCore.Slot(str)
+    def refresh(self, idx: int | str | None = None) -> None:
         """Trigger a refresh of the contents."""
         if idx is None:
             top = self._model.index(0, 0)
@@ -1176,10 +1265,32 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
             if top.isValid() and bottom.isValid():  # pragma: no branch
                 self._model.dataChanged.emit(top, bottom)
         else:
-            if idx in self._model.manager._displayed_indices:
-                row_idx = self._model._row_index(idx)
-                if row_idx.isValid():  # pragma: no branch
-                    self._model.dataChanged.emit(row_idx, row_idx)
+            row_idx = self._model._row_index(idx)
+            if row_idx.isValid():  # pragma: no branch
+                self._model.dataChanged.emit(row_idx, row_idx)
+
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent | None) -> None:
+        if event is not None and event.button() == QtCore.Qt.MouseButton.LeftButton:
+            index = self.indexAt(event.pos())
+            if index.isValid() and isinstance(index.internalPointer(), str):
+                option = QtWidgets.QStyleOptionViewItem()
+                option.rect = self.visualRect(index)
+                option.font = self.font()
+                try:
+                    child_tool = self._model.manager.get_childtool(
+                        index.internalPointer()
+                    )
+                except KeyError:
+                    child_tool = None
+                if child_tool is not None:
+                    status_rect, _, _ = self._delegate._compute_child_status_info(
+                        option, child_tool
+                    )
+                    if status_rect and status_rect.contains(event.pos()):
+                        child_tool.show_source_update_dialog(parent=self._model.manager)
+                        event.accept()
+                        return
+        super().mouseReleaseEvent(event)
 
     def imagetool_added(self, index: int) -> None:
         """Update the list view when a new ImageTool is added to the manager.

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -410,7 +410,7 @@ class _ImageToolWrapper(QtCore.QObject):
     @QtCore.Slot(object)
     def _handle_source_data_replaced(self, parent_data: object) -> None:
         if not isinstance(parent_data, xr.DataArray):
-            parent_data = self.slicer_area._data.copy(deep=False)
+            parent_data = self.slicer_area._tool_source_parent_data()
         for uid in list(self._childtool_indices):
             tool = self._childtools.get(uid)
             if tool is None or not erlab.interactive.utils.qt_is_valid(tool):
@@ -427,7 +427,9 @@ class _ImageToolWrapper(QtCore.QObject):
         if not tool._tool_display_name:
             tool._tool_display_name = str(self.name)
 
-        tool.set_source_parent_fetcher(lambda: self.slicer_area._data.copy(deep=False))
+        tool.set_source_parent_fetcher(
+            lambda: self.slicer_area._tool_source_parent_data()
+        )
         tool.sigInfoChanged.connect(lambda u=uid: self.manager._update_info(uid=u))
         tool.sigInfoChanged.connect(lambda u=uid: self.manager.tree_view.refresh(u))
         tool.destroyed.connect(lambda _=None, u=uid: self.manager._remove_childtool(u))

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -11,6 +11,7 @@ import typing
 import uuid
 import weakref
 
+import xarray as xr
 from qtpy import QtCore, QtGui
 
 import erlab
@@ -177,6 +178,9 @@ class _ImageToolWrapper(QtCore.QObject):
             self._imagetool.slicer_area.sigDataEdited.disconnect(
                 self._trigger_watched_update
             )
+            self._imagetool.slicer_area.sigSourceDataReplaced.disconnect(
+                self._handle_source_data_replaced
+            )
             self._imagetool.destroyed.connect(self._destroyed_callback)
             self._imagetool.close()
 
@@ -185,6 +189,9 @@ class _ImageToolWrapper(QtCore.QObject):
             value.installEventFilter(self)
             value.sigTitleChanged.connect(self.update_title)
             value.slicer_area.sigDataEdited.connect(self._trigger_watched_update)
+            value.slicer_area.sigSourceDataReplaced.connect(
+                self._handle_source_data_replaced
+            )
             value.slicer_area._in_manager = True
 
         self._imagetool = value
@@ -400,6 +407,17 @@ class _ImageToolWrapper(QtCore.QObject):
         """Reload the data from the original source."""
         self.slicer_area.reload()
 
+    @QtCore.Slot(object)
+    def _handle_source_data_replaced(self, parent_data: object) -> None:
+        if not isinstance(parent_data, xr.DataArray):
+            parent_data = self.slicer_area._data.copy(deep=False)
+        for uid in list(self._childtool_indices):
+            tool = self._childtools.get(uid)
+            if tool is None or not erlab.interactive.utils.qt_is_valid(tool):
+                continue
+            tool.handle_parent_source_replaced(parent_data)
+            self.manager.tree_view.refresh(uid)
+
     def _add_childtool(
         self, tool: erlab.interactive.utils.ToolWindow, *, show: bool = True
     ) -> str:
@@ -409,7 +427,9 @@ class _ImageToolWrapper(QtCore.QObject):
         if not tool._tool_display_name:
             tool._tool_display_name = str(self.name)
 
+        tool.set_source_parent_fetcher(lambda: self.slicer_area._data.copy(deep=False))
         tool.sigInfoChanged.connect(lambda u=uid: self.manager._update_info(uid=u))
+        tool.sigInfoChanged.connect(lambda u=uid: self.manager.tree_view.refresh(u))
         tool.destroyed.connect(lambda _=None, u=uid: self.manager._remove_childtool(u))
 
         if show:
@@ -423,5 +443,6 @@ class _ImageToolWrapper(QtCore.QObject):
         if uid in self._childtools:
             tool = self._childtools.pop(uid)
             if erlab.interactive.utils.qt_is_valid(tool):
+                tool.set_source_parent_fetcher(None)
                 tool.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
                 tool.close()

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -1004,6 +1004,79 @@ class ItoolPlotItem(pg.PlotItem):
         sel_code: str = self.selection_code_for_cursor(self.slicer_area.current_cursor)
         return f"{data_name}{sel_code}"
 
+    def make_tool_source_spec(
+        self, *, transpose: bool = False, squeeze: bool = False
+    ) -> dict[str, typing.Any]:
+        cursor = self.slicer_area.current_cursor
+        alt_pressed: bool = (
+            QtCore.Qt.KeyboardModifier.AltModifier
+            in QtWidgets.QApplication.queryKeyboardModifiers()
+        )
+        selection_code = self.selection_code_for_cursor(cursor)
+        if selection_code.startswith(".qsel"):
+            operations: list[dict[str, typing.Any]] = [
+                {
+                    "op": "qsel",
+                    "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                        self.array_slicer.qsel_args(cursor, self.display_axis)
+                    ),
+                }
+            ]
+        else:
+            operations = [
+                {
+                    "op": "isel",
+                    "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                        self.array_slicer.isel_args(
+                            cursor, self.display_axis, int_if_one=True
+                        )
+                    ),
+                }
+            ]
+
+        if alt_pressed:
+            crop_indexers = dict(self._crop_indexers)
+            isel_indexers: dict[str, slice] = {}
+            for key in list(crop_indexers.keys()):
+                key_str = str(key)
+                if key_str.endswith("_idx"):
+                    isel_indexers[key_str.removesuffix("_idx")] = crop_indexers.pop(key)
+
+            if crop_indexers:
+                operations.append(
+                    {
+                        "op": "sel",
+                        "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                            crop_indexers
+                        ),
+                    }
+                )
+            if isel_indexers:
+                operations.append(
+                    {
+                        "op": "isel",
+                        "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                            isel_indexers
+                        ),
+                    }
+                )
+
+        operations.append({"op": "sort_coord_order"})
+        if transpose:
+            operations.append(
+                {
+                    "op": "transpose",
+                    "dims": erlab.interactive.utils._encode_tool_source_value(
+                        list(reversed(self.current_data.dims))
+                    ),
+                }
+            )
+        if squeeze:
+            operations.append({"op": "squeeze"})
+        return erlab.interactive.utils.make_tool_source_spec(
+            "selection", operations=operations
+        )
+
     @property
     def is_guidelines_visible(self) -> bool:
         return len(self._guidelines_items) != 0
@@ -1814,11 +1887,12 @@ class ItoolPlotItem(pg.PlotItem):
         if self.is_image:  # pragma: no branch
             data = self.current_data
             try:
-                self.slicer_area.add_tool_window(
-                    erlab.interactive.goldtool(
-                        data, data_name=self.get_selection_code(), execute=False
-                    )
+                tool = erlab.interactive.goldtool(
+                    data, data_name=self.get_selection_code(), execute=False
                 )
+                if isinstance(tool, erlab.interactive.utils.ToolWindow):
+                    tool.set_source_binding(self.make_tool_source_spec())
+                self.slicer_area.add_tool_window(tool)
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(
                     None, "Error", "An error occurred while opening goldtool."
@@ -1839,28 +1913,32 @@ class ItoolPlotItem(pg.PlotItem):
             tool = erlab.interactive.restool(
                 data, data_name=self.get_selection_code(), execute=False
             )
+            if isinstance(tool, erlab.interactive.utils.ToolWindow):
+                tool.set_source_binding(self.make_tool_source_spec())
             self.slicer_area.add_tool_window(tool)
 
     @QtCore.Slot()
     def open_in_dtool(self) -> None:
         if self.is_image:  # pragma: no branch
-            self.slicer_area.add_tool_window(
-                erlab.interactive.dtool(
-                    self.current_data.T,
-                    data_name=self.get_selection_code(),
-                    execute=False,
-                )
-            )
-
-    @QtCore.Slot()
-    def open_in_ftool(self) -> None:
-        self.slicer_area.add_tool_window(
-            erlab.interactive.ftool(
-                self.current_data.squeeze(),
+            tool = erlab.interactive.dtool(
+                self.current_data.T,
                 data_name=self.get_selection_code(),
                 execute=False,
             )
+            if isinstance(tool, erlab.interactive.utils.ToolWindow):
+                tool.set_source_binding(self.make_tool_source_spec(transpose=True))
+            self.slicer_area.add_tool_window(tool)
+
+    @QtCore.Slot()
+    def open_in_ftool(self) -> None:
+        tool = erlab.interactive.ftool(
+            self.current_data.squeeze(),
+            data_name=self.get_selection_code(),
+            execute=False,
         )
+        if isinstance(tool, erlab.interactive.utils.ToolWindow):
+            tool.set_source_binding(self.make_tool_source_spec(squeeze=True))
+        self.slicer_area.add_tool_window(tool)
 
     @QtCore.Slot()
     def normalize_to_current_view(self) -> None:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -479,6 +479,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     sigDataEdited()
         Signal to track when the data has been modified by user actions.
+    sigSourceDataReplaced()
+        Signal emitted when the underlying source data is replaced with a new
+        DataArray, such as file open, reload, or manager-driven replacement.
     sigPointValueChanged(value)
         Signal emitted when the point value at the current cursor has been computed.
         Only emitted for dask-backed data.
@@ -521,6 +524,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
     sigWriteHistory = QtCore.Signal()  #: :meta private:
     sigCursorColorsChanged = QtCore.Signal()  #: :meta private:
     sigDataEdited = QtCore.Signal()  #: :meta private:
+    sigSourceDataReplaced = QtCore.Signal(object)  #: :meta private:
     sigPointValueChanged = QtCore.Signal(float)  #: :meta private:
 
     @property
@@ -1577,6 +1581,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
         file_path: str | os.PathLike | None = None,
         load_func: tuple[Callable | str, dict[str, typing.Any], int] | None = None,
         auto_compute: bool = True,
+        *,
+        source_replaced: bool = False,
     ) -> None:
         """Set the data to be displayed.
 
@@ -1728,6 +1734,35 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.levels = cached_levels
 
         self.flush_history()
+        if source_replaced:
+            self.sigSourceDataReplaced.emit(self._data.copy(deep=False))
+
+    def replace_source_data(
+        self,
+        data: xr.DataArray | npt.NDArray,
+        rad2deg: bool | Iterable[str] = False,
+        file_path: str | os.PathLike | None = None,
+        load_func: tuple[Callable | str, dict[str, typing.Any], int] | None = None,
+        auto_compute: bool = True,
+        *,
+        emit_edited: bool = False,
+    ) -> None:
+        """Replace the underlying source data and notify bound child tools.
+
+        Parameters are the same as :meth:`set_data`, with the addition of
+        ``emit_edited`` to indicate that the replacement should also be treated as a
+        user edit for watcher propagation.
+        """
+        self.set_data(
+            data,
+            rad2deg=rad2deg,
+            file_path=file_path,
+            load_func=load_func,
+            auto_compute=auto_compute,
+            source_replaced=True,
+        )
+        if emit_edited:
+            self.sigDataEdited.emit()
 
     def _update_if_delayed(self) -> None:
         if self._update_delayed:
@@ -1786,7 +1821,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """
         if self.reloadable:  # pragma: no branch
             try:
-                self.set_data(
+                self.replace_source_data(
                     self._fetch_for_reload(),
                     file_path=self._file_path,
                     load_func=self._load_func,
@@ -2348,6 +2383,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
                     manager.add_widget(widget)
                 return
 
+        if isinstance(widget, erlab.interactive.utils.ToolWindow):
+            widget.set_source_parent_fetcher(lambda: self._data.copy(deep=False))
+            self.sigSourceDataReplaced.connect(widget.handle_parent_source_replaced)
+
         uid: str = str(uuid.uuid4())
         with self._assoc_tools_lock:
             self._associated_tools[uid] = widget  # Store reference to prevent gc
@@ -2421,26 +2460,32 @@ class ImageSlicerArea(QtWidgets.QWidget):
             initial_normal_emission = None
             initial_delta = None
 
-        self.add_tool_window(
-            erlab.interactive.ktool(
-                self.data,
-                cmap=cmap,
-                gamma=gamma,
-                data_name=self.watched_data_name,
-                initial_normal_emission=initial_normal_emission,
-                initial_delta=initial_delta,
-                execute=False,
-            )
+        tool = erlab.interactive.ktool(
+            self.data,
+            cmap=cmap,
+            gamma=gamma,
+            data_name=self.watched_data_name,
+            initial_normal_emission=initial_normal_emission,
+            initial_delta=initial_delta,
+            execute=False,
         )
+        if isinstance(tool, erlab.interactive.utils.ToolWindow):
+            tool.set_source_binding(
+                erlab.interactive.utils.make_tool_source_spec("full_data")
+            )
+        self.add_tool_window(tool)
 
     @QtCore.Slot()
     def open_in_meshtool(self) -> None:
         """Open the interactive mesh removal tool."""
-        self.add_tool_window(
-            erlab.interactive.meshtool(
-                self.data, data_name=self.watched_data_name, execute=False
-            )
+        tool = erlab.interactive.meshtool(
+            self.data, data_name=self.watched_data_name, execute=False
         )
+        if isinstance(tool, erlab.interactive.utils.ToolWindow):
+            tool.set_source_binding(
+                erlab.interactive.utils.make_tool_source_spec("full_data")
+            )
+        self.add_tool_window(tool)
 
     def adjust_layout(
         self,

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -480,8 +480,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
     sigDataEdited()
         Signal to track when the data has been modified by user actions.
     sigSourceDataReplaced()
-        Signal emitted when the underlying source data is replaced with a new
-        DataArray, such as file open, reload, or manager-driven replacement.
+        Signal emitted when the underlying source data is replaced or otherwise
+        changed at the source level, such as file open, reload, manager-driven
+        replacement, or in-place console edits.
     sigPointValueChanged(value)
         Signal emitted when the point value at the current cursor has been computed.
         Only emitted for dask-backed data.
@@ -1075,13 +1076,17 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if need_restore and not restored_obj:
             self._restore_obj_from_source(update=False)
 
+        updated = False
         try:
             self._data[key] = value
+            updated = True
         finally:
             self.array_slicer.clear_val_cache()
             self.refresh_all(only_plots=True)
             self.lock_levels(self.levels_locked)
-            self.sigDataEdited.emit()
+            if updated:
+                self.sigSourceDataReplaced.emit(self._data.copy(deep=False))
+                self.sigDataEdited.emit()
 
     @property
     def undoable(self) -> bool:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1528,7 +1528,6 @@ class ImageSlicerArea(QtWidgets.QWidget):
         with self._assoc_tools_lock:
             for tool in dict(self._associated_tools).values():
                 tool.close()
-                tool.deleteLater()
 
     @QtCore.Slot()
     @QtCore.Slot(tuple)
@@ -2403,11 +2402,12 @@ class ImageSlicerArea(QtWidgets.QWidget):
         old_close_event = widget.closeEvent
 
         def new_close_event(event: QtGui.QCloseEvent) -> None:
-            with self._assoc_tools_lock:
-                if uid in self._associated_tools:
-                    tool = self._associated_tools.pop(uid)
-                    tool.deleteLater()
             old_close_event(event)
+            if event.isAccepted():
+                with self._assoc_tools_lock:
+                    if uid in self._associated_tools:
+                        tool = self._associated_tools.pop(uid)
+                        tool.deleteLater()
 
         widget.closeEvent = new_close_event  # type: ignore[assignment]
         widget.show()

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1025,6 +1025,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def data(self) -> xr.DataArray:
         return self.array_slicer._obj
 
+    def _tool_source_parent_data(self) -> xr.DataArray:
+        """Return the current slicer view used for source-bound child tools."""
+        return self.data.copy(deep=False)
+
     @staticmethod
     def _owned_values_copy(darr: xr.DataArray) -> typing.Any:
         """Return a writable owned copy of the underlying values buffer."""
@@ -1085,7 +1089,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.refresh_all(only_plots=True)
             self.lock_levels(self.levels_locked)
             if updated:
-                self.sigSourceDataReplaced.emit(self._data.copy(deep=False))
+                self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
                 self.sigDataEdited.emit()
 
     @property
@@ -1740,7 +1744,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         self.flush_history()
         if source_replaced:
-            self.sigSourceDataReplaced.emit(self._data.copy(deep=False))
+            self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
 
     def replace_source_data(
         self,
@@ -2389,7 +2393,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 return
 
         if isinstance(widget, erlab.interactive.utils.ToolWindow):
-            widget.set_source_parent_fetcher(lambda: self._data.copy(deep=False))
+            widget.set_source_parent_fetcher(lambda: self._tool_source_parent_data())
             self.sigSourceDataReplaced.connect(widget.handle_parent_source_replaced)
 
         uid: str = str(uuid.uuid4())

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -646,12 +646,12 @@ class KspaceTool(KspaceToolGUI):
             rateLimit=self._UPDATE_LIMIT_HZ,
             slot=self._flush_debounced_update,
         )
+        self._energy_controls_connected: bool = False
 
         if self.data.kspace._has_eV and self.data.eV.size > 1:
             self._update_energy_controls()
             self.width_spin.setRange(1, len(self.data.eV))
-            self.center_spin.valueChanged.connect(self.queue_update)
-            self.width_spin.valueChanged.connect(self.queue_update)
+            self._ensure_energy_control_connections()
         else:
             if "eV" in self.data.coords and self.data["eV"].size == 1:
                 fixed_energy = float(self.data.eV)
@@ -800,6 +800,13 @@ class KspaceTool(KspaceToolGUI):
         if avec is not None:
             self.bz_group.setChecked(True)
 
+    def _ensure_energy_control_connections(self) -> None:
+        if self._energy_controls_connected:
+            return
+        self.center_spin.valueChanged.connect(self.queue_update)
+        self.width_spin.valueChanged.connect(self.queue_update)
+        self._energy_controls_connected = True
+
     def update_data(self, new_data: xr.DataArray) -> None:
         status = self.tool_status
         new_data = self.validate_update_data(new_data)
@@ -816,6 +823,7 @@ class KspaceTool(KspaceToolGUI):
             self.energy_group.setDisabled(False)
             self._update_energy_controls()
             self.width_spin.setRange(1, len(self.data.eV))
+            self._ensure_energy_control_connections()
         else:
             if "eV" in self.data.coords and self.data["eV"].size == 1:
                 fixed_energy = float(self.data.eV)

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -802,19 +802,7 @@ class KspaceTool(KspaceToolGUI):
 
     def update_data(self, new_data: xr.DataArray) -> None:
         status = self.tool_status
-        current_offset_keys = tuple(self.data.kspace._valid_offset_keys)
-        current_momentum_axes = tuple(self.data.kspace.momentum_axes)
-        current_configuration = int(self.data.kspace.configuration)
-        current_has_hv = self.data.kspace._has_hv
-
-        if tuple(new_data.kspace._valid_offset_keys) != current_offset_keys:
-            raise ValueError("Updated data has incompatible offset coordinates.")
-        if tuple(new_data.kspace.momentum_axes) != current_momentum_axes:
-            raise ValueError("Updated data has incompatible momentum axes.")
-        if int(new_data.kspace.configuration) != current_configuration:
-            raise ValueError("Updated data has incompatible analyzer configuration.")
-        if new_data.kspace._has_hv != current_has_hv:
-            raise ValueError("Updated data has incompatible photon-energy dimensions.")
+        new_data = self.validate_update_data(new_data)
 
         self.data = new_data.copy(deep=True)
         self._bz_cache_key = None
@@ -837,6 +825,23 @@ class KspaceTool(KspaceToolGUI):
 
         self.tool_status = status
         self.sigInfoChanged.emit()
+
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(new_data)
+        current_offset_keys = tuple(self.data.kspace._valid_offset_keys)
+        current_momentum_axes = tuple(self.data.kspace.momentum_axes)
+        current_configuration = int(self.data.kspace.configuration)
+        current_has_hv = self.data.kspace._has_hv
+
+        if tuple(data.kspace._valid_offset_keys) != current_offset_keys:
+            raise ValueError("Updated data has incompatible offset coordinates.")
+        if tuple(data.kspace.momentum_axes) != current_momentum_axes:
+            raise ValueError("Updated data has incompatible momentum axes.")
+        if int(data.kspace.configuration) != current_configuration:
+            raise ValueError("Updated data has incompatible analyzer configuration.")
+        if data.kspace._has_hv != current_has_hv:
+            raise ValueError("Updated data has incompatible photon-energy dimensions.")
+        return data
 
     def _binding_energy(self) -> npt.NDArray[np.floating]:
         if hasattr(self, "_offset_spins") and "wf" in self._offset_spins:

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -529,6 +529,10 @@ class KspaceTool(KspaceToolGUI):
             self.points_check.setChecked(status.points)
 
         # Restore circle ROIs
+        for roi in list(self._roi_list):
+            self.plotitems[1].removeItem(roi)
+            roi.deleteLater()
+        self._roi_list.clear()
         for x0, y0, radius in status.circle_rois:
             self._add_circle()
             self._roi_list[-1].set_position((x0, y0), radius)
@@ -795,6 +799,44 @@ class KspaceTool(KspaceToolGUI):
 
         if avec is not None:
             self.bz_group.setChecked(True)
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        status = self.tool_status
+        current_offset_keys = tuple(self.data.kspace._valid_offset_keys)
+        current_momentum_axes = tuple(self.data.kspace.momentum_axes)
+        current_configuration = int(self.data.kspace.configuration)
+        current_has_hv = self.data.kspace._has_hv
+
+        if tuple(new_data.kspace._valid_offset_keys) != current_offset_keys:
+            raise ValueError("Updated data has incompatible offset coordinates.")
+        if tuple(new_data.kspace.momentum_axes) != current_momentum_axes:
+            raise ValueError("Updated data has incompatible momentum axes.")
+        if int(new_data.kspace.configuration) != current_configuration:
+            raise ValueError("Updated data has incompatible analyzer configuration.")
+        if new_data.kspace._has_hv != current_has_hv:
+            raise ValueError("Updated data has incompatible photon-energy dimensions.")
+
+        self.data = new_data.copy(deep=True)
+        self._bz_cache_key = None
+        self._bz_cache_value = None
+        self.config_label.setText(
+            f"Configuration {int(self.data.kspace.configuration)} "
+            f"({self.data.kspace.configuration.name})"
+        )
+
+        if self.data.kspace._has_eV and self.data.eV.size > 1:
+            self.energy_group.setDisabled(False)
+            self._update_energy_controls()
+            self.width_spin.setRange(1, len(self.data.eV))
+        else:
+            if "eV" in self.data.coords and self.data["eV"].size == 1:
+                fixed_energy = float(self.data.eV)
+                self.center_spin.setRange(fixed_energy - 0.1, fixed_energy + 0.1)
+                self.center_spin.setValue(fixed_energy)
+            self.energy_group.setDisabled(True)
+
+        self.tool_status = status
+        self.sigInfoChanged.emit()
 
     def _binding_energy(self) -> npt.NDArray[np.floating]:
         if hasattr(self, "_offset_spins") and "wf" in self._offset_spins:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -703,7 +703,13 @@ def _resolve_tool_source_spec(
     if kind != "selection":
         raise ValueError(f"Unsupported tool source kind: {kind!r}")
 
-    data = parent_data.copy(deep=False)
+    # Source specs are recorded against ImageTool's public data model, which restores
+    # non-uniform dimensions from their internal ``*_idx`` representation. Rebuild that
+    # public view before replaying selection operations so recorded dimension names
+    # continue to resolve after source data refreshes.
+    data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+        parent_data.copy(deep=False)
+    )
     for operation in spec.get("operations", []):
         op_name = operation.get("op", "")
         kwargs = _decode_tool_source_value(operation.get("kwargs", {}))
@@ -2746,12 +2752,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
             return False
 
         try:
-            self.update_data(resolved)
+            update_complete = self.update_data(resolved)
         except Exception:
             logger.exception(
                 "Failed to update %s from ImageTool source data", self.tool_name
             )
             self._set_source_state("unavailable")
+            return False
+        if update_complete is False:
+            self._set_source_state("stale")
             return False
         self._set_source_state("fresh")
         return True
@@ -2773,13 +2782,16 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
 
         if self._source_auto_update:
             try:
-                self.update_data(resolved)
+                update_complete = self.update_data(resolved)
             except Exception:
                 logger.exception(
                     "Failed to auto-update %s from ImageTool source data",
                     self.tool_name,
                 )
                 self._set_source_state("unavailable")
+                return
+            if update_complete is False:
+                self._set_source_state("stale")
                 return
             self._set_source_state("fresh")
         else:
@@ -2803,7 +2815,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
                 self._update_from_parent_source()
         return result
 
-    def update_data(self, new_data: xr.DataArray) -> None:
+    def update_data(self, new_data: xr.DataArray) -> bool | None:
         raise NotImplementedError(
             "Subclasses of ToolWindow must implement update_data() to support "
             "ImageTool source updates."

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -784,6 +784,7 @@ class _ToolSourceUpdateDialog(QtWidgets.QDialog):
             ),
         )
         self.update_button.setEnabled(state == "stale")
+        self.auto_update_check.setEnabled(self.update_button.isEnabled())
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
         layout.addWidget(self.button_box)
@@ -2722,6 +2723,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
             raise RuntimeError("Tool is not bound to an ImageTool source.")
         return _resolve_tool_source_spec(parent_data, self._source_spec)
 
+    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        return new_data
+
     def _update_from_parent_source(self) -> bool:
         if self._source_parent_fetcher is None:
             return False
@@ -2731,6 +2735,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
             return False
         try:
             resolved = self._resolve_source_data(parent_data)
+        except Exception:
+            self._set_source_state("unavailable")
+            return False
+
+        try:
+            resolved = self.validate_update_data(resolved)
         except Exception:
             self._set_source_state("unavailable")
             return False
@@ -2751,6 +2761,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
             return
         try:
             resolved = self._resolve_source_data(parent_data)
+        except Exception:
+            self._set_source_state("unavailable")
+            return
+
+        try:
+            resolved = self.validate_update_data(resolved)
         except Exception:
             self._set_source_state("unavailable")
             return

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -12,7 +12,9 @@ import fnmatch
 import importlib
 import inspect
 import itertools
+import json
 import keyword
+import logging
 import os
 import pathlib
 import re
@@ -81,6 +83,7 @@ __all__ = [
 ]
 
 _LOAD_UI_LOCK = threading.RLock()
+logger = logging.getLogger(__name__)
 
 
 def _qt_object_is_valid_fallback(arg__1: object) -> bool:
@@ -645,6 +648,145 @@ def copy_to_clipboard(content: str | list[str]) -> str:
         content = "\n".join(content)
     pyperclip.copy(str(content))
     return content
+
+
+_TOOL_SOURCE_SPEC_ATTR = "tool_source_spec"
+_TOOL_SOURCE_STATE_ATTR = "tool_source_state"
+_TOOL_SOURCE_AUTO_UPDATE_ATTR = "tool_source_auto_update"
+_TOOL_SOURCE_SLICE_MARKER = "__erlab_slice__"
+
+
+def _encode_tool_source_value(value: typing.Any) -> typing.Any:
+    if isinstance(value, slice):
+        return {
+            _TOOL_SOURCE_SLICE_MARKER: [
+                _encode_tool_source_value(value.start),
+                _encode_tool_source_value(value.stop),
+                _encode_tool_source_value(value.step),
+            ]
+        }
+    if isinstance(value, tuple):
+        return [_encode_tool_source_value(item) for item in value]
+    if isinstance(value, list):
+        return [_encode_tool_source_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): _encode_tool_source_value(item) for key, item in value.items()
+        }
+    return erlab.utils.misc._convert_to_native(value)
+
+
+def _decode_tool_source_value(value: typing.Any) -> typing.Any:
+    if isinstance(value, dict):
+        if _TOOL_SOURCE_SLICE_MARKER in value:
+            start, stop, step = value[_TOOL_SOURCE_SLICE_MARKER]
+            return slice(
+                _decode_tool_source_value(start),
+                _decode_tool_source_value(stop),
+                _decode_tool_source_value(step),
+            )
+        return {
+            str(key): _decode_tool_source_value(item) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_decode_tool_source_value(item) for item in value]
+    return value
+
+
+def _resolve_tool_source_spec(
+    parent_data: xr.DataArray, spec: dict[str, typing.Any]
+) -> xr.DataArray:
+    kind = spec.get("kind", "")
+    if kind == "full_data":
+        return parent_data.copy(deep=False)
+
+    if kind != "selection":
+        raise ValueError(f"Unsupported tool source kind: {kind!r}")
+
+    data = parent_data.copy(deep=False)
+    for operation in spec.get("operations", []):
+        op_name = operation.get("op", "")
+        kwargs = _decode_tool_source_value(operation.get("kwargs", {}))
+        if op_name == "qsel":
+            data = data.qsel(**kwargs)
+        elif op_name == "isel":
+            data = data.isel(kwargs)
+        elif op_name == "sel":
+            data = data.sel(kwargs)
+        elif op_name == "sort_coord_order":
+            data = erlab.utils.array.sort_coord_order(data, parent_data.coords.keys())
+        elif op_name == "transpose":
+            dims = typing.cast("list[typing.Any] | None", operation.get("dims"))
+            if dims:
+                data = data.transpose(*dims)
+            else:
+                data = data.transpose(*reversed(data.dims))
+        elif op_name == "squeeze":
+            data = data.squeeze()
+        else:
+            raise ValueError(f"Unsupported tool source operation: {op_name!r}")
+    return data
+
+
+def make_tool_source_spec(
+    kind: typing.Literal["full_data", "selection"],
+    *,
+    operations: list[dict[str, typing.Any]] | None = None,
+) -> dict[str, typing.Any]:
+    spec: dict[str, typing.Any] = {"kind": kind}
+    if operations:
+        spec["operations"] = operations
+    return spec
+
+
+class _ToolSourceUpdateDialog(QtWidgets.QDialog):
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget | None,
+        *,
+        state: typing.Literal["stale", "unavailable"],
+        auto_update: bool,
+    ) -> None:
+        super().__init__(parent)
+        self.setModal(True)
+        self.setWindowTitle("Update Tool Data")
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        label = QtWidgets.QLabel(self)
+        label.setWordWrap(True)
+        if state == "stale":
+            label.setText(
+                "This tool was created from ImageTool data that has since changed. "
+                "Update it to fetch the latest compatible selection."
+            )
+        else:
+            label.setText(
+                "This tool was created from a selection that is not available in the "
+                "current ImageTool data. Reopen the tool from ImageTool after the "
+                "selection becomes compatible again."
+            )
+        layout.addWidget(label)
+
+        self.auto_update_check = QtWidgets.QCheckBox(
+            "Update this tool automatically", self
+        )
+        self.auto_update_check.setChecked(auto_update)
+        layout.addWidget(self.auto_update_check)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Cancel, self
+        )
+        self.update_button = typing.cast(
+            "QtWidgets.QPushButton",
+            self.button_box.addButton(
+                "Update", QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole
+            ),
+        )
+        self.update_button.setEnabled(state == "stale")
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
 
 
 def format_kwargs(d: dict[Hashable, typing.Any]) -> str:
@@ -2339,6 +2481,34 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
+        self._tool_root_widget = QtWidgets.QWidget(self)
+        self._tool_root_layout = QtWidgets.QVBoxLayout(self._tool_root_widget)
+        self._tool_root_layout.setContentsMargins(0, 0, 0, 0)
+        self._tool_root_layout.setSpacing(0)
+        self._tool_content_widget: QtWidgets.QWidget | None = None
+
+        self._source_status_bar = QtWidgets.QFrame(self._tool_root_widget)
+        self._source_status_bar.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self._source_status_bar.hide()
+        self._source_status_layout = QtWidgets.QHBoxLayout(self._source_status_bar)
+        self._source_status_layout.setContentsMargins(8, 6, 8, 0)
+        self._source_status_layout.setSpacing(0)
+        self._source_status_button = QtWidgets.QPushButton(self._source_status_bar)
+        self._source_status_button.setFlat(True)
+        self._source_status_button.setCursor(
+            QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor)
+        )
+        self._source_status_button.clicked.connect(self.show_source_update_dialog)
+        self._source_status_layout.addWidget(self._source_status_button, 0)
+        self._source_status_layout.addStretch(1)
+        self._tool_root_layout.addWidget(self._source_status_bar, 0)
+        QtWidgets.QMainWindow.setCentralWidget(self, self._tool_root_widget)
+
+        self._source_spec: dict[str, typing.Any] | None = None
+        self._source_state: typing.Literal["fresh", "stale", "unavailable"] = "fresh"
+        self._source_auto_update: bool = False
+        self._source_parent_fetcher: Callable[[], xr.DataArray] | None = None
+
         # Initialize a menu bar to correctly apply keyboard shortcuts on some platforms
         self.menuBar()
 
@@ -2355,6 +2525,27 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         self.__remove_shortcut.setContext(
             QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
         )
+
+    def centralWidget(self) -> QtWidgets.QWidget | None:
+        if self._tool_content_widget is not None:
+            return self._tool_content_widget
+        return QtWidgets.QMainWindow.centralWidget(self)
+
+    def setCentralWidget(self, widget: QtWidgets.QWidget | None) -> None:
+        if widget is self._tool_root_widget:
+            QtWidgets.QMainWindow.setCentralWidget(self, widget)
+            return
+
+        current = self._tool_content_widget
+        if current is widget:
+            return
+        if current is not None:
+            self._tool_root_layout.removeWidget(current)
+            current.setParent(None)
+
+        self._tool_content_widget = widget
+        if widget is not None:
+            self._tool_root_layout.addWidget(widget, 1)
 
     def _is_in_manager(self) -> bool:
         """Check whether this tool window is currently owned by ImageTool manager."""
@@ -2437,6 +2628,168 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         )
 
     @property
+    def source_spec(self) -> dict[str, typing.Any] | None:
+        if self._source_spec is None:
+            return None
+        return json.loads(json.dumps(self._source_spec))
+
+    @property
+    def source_state(self) -> typing.Literal["fresh", "stale", "unavailable"]:
+        return self._source_state
+
+    @property
+    def source_auto_update(self) -> bool:
+        return self._source_auto_update
+
+    @property
+    def has_source_binding(self) -> bool:
+        return self._source_spec is not None
+
+    @property
+    def source_status_text(self) -> str:
+        if self._source_state == "stale":
+            return "Source Update Available"
+        if self._source_state == "unavailable":
+            return "Source Update Unavailable"
+        return ""
+
+    def set_source_binding(
+        self,
+        source_spec: dict[str, typing.Any] | None,
+        *,
+        auto_update: bool = False,
+        state: typing.Literal["fresh", "stale", "unavailable"] = "fresh",
+    ) -> None:
+        self._source_spec = (
+            json.loads(json.dumps(source_spec)) if source_spec is not None else None
+        )
+        self._source_auto_update = bool(auto_update)
+        self._set_source_state(state if self._source_spec is not None else "fresh")
+
+    def set_source_parent_fetcher(
+        self, fetcher: Callable[[], xr.DataArray] | None
+    ) -> None:
+        self._source_parent_fetcher = fetcher
+
+    def _set_source_auto_update(self, value: bool) -> None:
+        self._source_auto_update = bool(value)
+        self._refresh_source_status_widget()
+        self.sigInfoChanged.emit()
+
+    def _set_source_state(
+        self, state: typing.Literal["fresh", "stale", "unavailable"]
+    ) -> None:
+        self._source_state = state
+        self._refresh_source_status_widget()
+        self.sigInfoChanged.emit()
+
+    def _refresh_source_status_widget(self) -> None:
+        if self._source_spec is None or self._source_state == "fresh":
+            self._source_status_bar.hide()
+            self._source_status_button.setToolTip("")
+            return
+
+        if self._source_state == "stale":
+            bgcolor = "#f4c26b"
+            fgcolor = "#2d2212"
+            tooltip = "Click to review or apply the latest source data."
+        else:
+            bgcolor = "#ef8a8a"
+            fgcolor = "#3b1111"
+            tooltip = (
+                "Click to review why this tool can no longer update from the "
+                "current ImageTool data."
+            )
+        if self._source_auto_update:
+            tooltip += " Automatic updates are enabled."
+        self._source_status_button.setText(self.source_status_text)
+        self._source_status_button.setToolTip(tooltip)
+        self._source_status_button.setStyleSheet(
+            "QPushButton {"
+            f"background-color: {bgcolor};"
+            f"color: {fgcolor};"
+            "border: 1px solid transparent;"
+            "border-radius: 4px;"
+            "padding: 4px 8px;"
+            "font-weight: 600;"
+            "text-align: left;"
+            "}"
+        )
+        self._source_status_bar.show()
+
+    def _resolve_source_data(self, parent_data: xr.DataArray) -> xr.DataArray:
+        if self._source_spec is None:
+            raise RuntimeError("Tool is not bound to an ImageTool source.")
+        return _resolve_tool_source_spec(parent_data, self._source_spec)
+
+    def _update_from_parent_source(self) -> bool:
+        if self._source_parent_fetcher is None:
+            return False
+        try:
+            resolved = self._resolve_source_data(self._source_parent_fetcher())
+        except Exception:
+            self._set_source_state("unavailable")
+            return False
+
+        try:
+            self.update_data(resolved)
+        except Exception:
+            logger.exception(
+                "Failed to update %s from ImageTool source data", self.tool_name
+            )
+            self._set_source_state("unavailable")
+            return False
+        self._set_source_state("fresh")
+        return True
+
+    def handle_parent_source_replaced(self, parent_data: xr.DataArray) -> None:
+        if self._source_spec is None:
+            return
+        try:
+            resolved = self._resolve_source_data(parent_data)
+        except Exception:
+            self._set_source_state("unavailable")
+            return
+
+        if self._source_auto_update:
+            try:
+                self.update_data(resolved)
+            except Exception:
+                logger.exception(
+                    "Failed to auto-update %s from ImageTool source data",
+                    self.tool_name,
+                )
+                self._set_source_state("unavailable")
+                return
+            self._set_source_state("fresh")
+        else:
+            self._set_source_state("stale")
+
+    def show_source_update_dialog(
+        self, *, parent: QtWidgets.QWidget | None = None
+    ) -> int:
+        if self._source_spec is None or self._source_state == "fresh":
+            return int(QtWidgets.QDialog.DialogCode.Rejected)
+
+        dialog = _ToolSourceUpdateDialog(
+            parent if parent is not None else self,
+            state=self._source_state,
+            auto_update=self._source_auto_update,
+        )
+        result = dialog.exec()
+        if result == int(QtWidgets.QDialog.DialogCode.Accepted):
+            self._set_source_auto_update(dialog.auto_update_check.isChecked())
+            if self._source_state == "stale":
+                self._update_from_parent_source()
+        return result
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        raise NotImplementedError(
+            "Subclasses of ToolWindow must implement update_data() to support "
+            "ImageTool source updates."
+        )
+
+    @property
     def preview_imageitem(self) -> pg.ImageItem | None:
         """Get the ImageItem to be used for preview in the ImageTool manager."""
         return None
@@ -2456,7 +2809,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         data_name = self.tool_data.name
         if data_name is None:
             data_name = "<none-value>"
-        return {
+        attrs = {
             "tool_state": self.tool_status.model_dump_json(),
             "tool_data_name": str(data_name),
             "tool_title": self.windowTitle(),
@@ -2466,6 +2819,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
             "tool_visible": bool(self.isVisible()),
             "erlab_version": erlab.__version__,
         }
+        if self._source_spec is not None:
+            attrs[_TOOL_SOURCE_SPEC_ATTR] = json.dumps(self._source_spec)
+            attrs[_TOOL_SOURCE_STATE_ATTR] = self._source_state
+            attrs[_TOOL_SOURCE_AUTO_UPDATE_ATTR] = bool(self._source_auto_update)
+        return attrs
 
     @classmethod
     def can_save_and_load(cls) -> bool:
@@ -2528,6 +2886,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
             ds.attrs["tool_state"]
         )
         tool._tool_display_name = ds.attrs.get("tool_display_name", "")
+        if _TOOL_SOURCE_SPEC_ATTR in ds.attrs:
+            tool.set_source_binding(
+                json.loads(ds.attrs[_TOOL_SOURCE_SPEC_ATTR]),
+                auto_update=bool(ds.attrs.get(_TOOL_SOURCE_AUTO_UPDATE_ATTR, False)),
+                state=typing.cast(
+                    "typing.Literal['fresh', 'stale', 'unavailable']",
+                    ds.attrs.get(_TOOL_SOURCE_STATE_ATTR, "fresh"),
+                ),
+            )
         tool.setWindowTitle(ds.attrs["tool_title"])
         tool.setGeometry(*ds.attrs["tool_rect"])
         return tool

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -2726,7 +2726,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         if self._source_parent_fetcher is None:
             return False
         try:
-            resolved = self._resolve_source_data(self._source_parent_fetcher())
+            parent_data = self._source_parent_fetcher()
+        except Exception:
+            return False
+        try:
+            resolved = self._resolve_source_data(parent_data)
         except Exception:
             self._set_source_state("unavailable")
             return False

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -20,6 +20,7 @@ import pathlib
 import re
 import sys
 import threading
+import time
 import traceback
 import types
 import typing
@@ -2460,6 +2461,20 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
       :class:`xarray.DataArray` being analyzed, which will be passed to the constructor
       of the subclass when restoring from a file.
 
+    For tools that support refreshing their data from an ImageTool source, subclasses
+    should also override the following hooks:
+
+    - `update_data` must apply replacement data to the existing window without
+      recreating it. Return `False` when the incoming data is recognized but cannot be
+      applied yet, so the tool remains marked as stale.
+
+    - `validate_update_data` can normalize or reject incoming source data before
+      `update_data` runs. Raise an exception to mark the source as unavailable.
+
+    - `_cancel_background_work` can stop worker threads or other asynchronous work
+      before `update_data` mutates the tool state. Override
+      `BACKGROUND_TASK_TIMEOUT_MS` as needed to change the default wait timeout.
+
     For full compatibility with the ImageTool manager, the following optional attributes
     or properties can also be set:
 
@@ -2479,6 +2494,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
     """
 
     tool_name: str = "tool"
+    BACKGROUND_TASK_TIMEOUT_MS: typing.ClassVar[int] = 5000
     __tool_display_name: str = ""
 
     StateModel: type[M]
@@ -2534,11 +2550,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         )
 
     def centralWidget(self) -> QtWidgets.QWidget | None:
+        """Return the content widget shown below the source-status banner."""
         if self._tool_content_widget is not None:
             return self._tool_content_widget
         return QtWidgets.QMainWindow.centralWidget(self)
 
     def setCentralWidget(self, widget: QtWidgets.QWidget | None) -> None:
+        """Set the main content widget while preserving the source-status banner."""
         if widget is self._tool_root_widget:
             QtWidgets.QMainWindow.setCentralWidget(self, widget)
             return
@@ -2636,24 +2654,29 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
 
     @property
     def source_spec(self) -> dict[str, typing.Any] | None:
+        """Return a detached copy of the current ImageTool source specification."""
         if self._source_spec is None:
             return None
         return json.loads(json.dumps(self._source_spec))
 
     @property
     def source_state(self) -> typing.Literal["fresh", "stale", "unavailable"]:
+        """Return whether the bound ImageTool source is fresh, stale, or unavailable."""
         return self._source_state
 
     @property
     def source_auto_update(self) -> bool:
+        """Return whether compatible source changes should be applied automatically."""
         return self._source_auto_update
 
     @property
     def has_source_binding(self) -> bool:
+        """Return `True` when this tool is bound to ImageTool source data."""
         return self._source_spec is not None
 
     @property
     def source_status_text(self) -> str:
+        """Return the status label shown for non-fresh source bindings."""
         if self._source_state == "stale":
             return "Source Update Available"
         if self._source_state == "unavailable":
@@ -2667,6 +2690,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         auto_update: bool = False,
         state: typing.Literal["fresh", "stale", "unavailable"] = "fresh",
     ) -> None:
+        """Bind this tool to an ImageTool source specification and status state."""
         self._source_spec = (
             json.loads(json.dumps(source_spec)) if source_spec is not None else None
         )
@@ -2676,9 +2700,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
     def set_source_parent_fetcher(
         self, fetcher: Callable[[], xr.DataArray] | None
     ) -> None:
+        """Set the callback used to fetch the latest parent ImageTool data."""
         self._source_parent_fetcher = fetcher
 
     def _set_source_auto_update(self, value: bool) -> None:
+        """Update the auto-refresh flag and notify manager-facing UI state."""
         self._source_auto_update = bool(value)
         self._refresh_source_status_widget()
         self.sigInfoChanged.emit()
@@ -2686,11 +2712,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
     def _set_source_state(
         self, state: typing.Literal["fresh", "stale", "unavailable"]
     ) -> None:
+        """Update the source state, refresh the banner, and emit info changes."""
         self._source_state = state
         self._refresh_source_status_widget()
         self.sigInfoChanged.emit()
 
     def _refresh_source_status_widget(self) -> None:
+        """Refresh the inline banner that reports source update availability."""
         if self._source_spec is None or self._source_state == "fresh":
             self._source_status_bar.hide()
             self._source_status_button.setToolTip("")
@@ -2725,14 +2753,73 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         self._source_status_bar.show()
 
     def _resolve_source_data(self, parent_data: xr.DataArray) -> xr.DataArray:
+        """Resolve the current source specification against replacement parent data."""
         if self._source_spec is None:
             raise RuntimeError("Tool is not bound to an ImageTool source.")
         return _resolve_tool_source_spec(parent_data, self._source_spec)
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        """Validate or normalize source data before `update_data` consumes it.
+
+        Subclasses can override this to enforce dimension, coordinate, or metadata
+        requirements for refreshed source data. Raise an exception to mark the source as
+        unavailable.
+        """
         return new_data
 
+    def _cancel_background_work(self, *, timeout_ms: int) -> bool:
+        """Stop any running background work before mutating the tool state.
+
+        Subclasses should override this when source updates must wait for worker
+        shutdown before tearing down widgets or replacing internal state.
+        """
+        return True
+
+    def _perform_source_update(
+        self,
+        new_data: xr.DataArray,
+        *,
+        apply_update: Callable[[xr.DataArray], None],
+        timeout_ms: int | None = None,
+    ) -> bool:
+        """Run a source update without tearing down the UI while workers are alive."""
+        validated = self.validate_update_data(new_data)
+        if timeout_ms is None:
+            timeout_ms = self.BACKGROUND_TASK_TIMEOUT_MS
+        if not self._cancel_background_work(timeout_ms=timeout_ms):
+            logger.warning(
+                "Timed out waiting for background work to stop while updating %s",
+                self.tool_name,
+            )
+            return False
+        apply_update(validated)
+        return True
+
+    @staticmethod
+    def _wait_for_threadpool(
+        threadpool: QtCore.QThreadPool,
+        *,
+        timeout_ms: int,
+        poll_interval_ms: int = 100,
+    ) -> bool:
+        """Wait for a QThreadPool to quiesce within a bounded timeout."""
+        if threadpool.activeThreadCount() == 0:
+            return True
+
+        if not hasattr(
+            threadpool, "waitForDone"
+        ):  # pragma: no cover - Qt 6.8+ has waitForDone
+            deadline = time.monotonic() + max(timeout_ms, 0) / 1000
+            while threadpool.activeThreadCount() > 0:
+                remaining_ms = int((deadline - time.monotonic()) * 1000)
+                if remaining_ms <= 0:
+                    return False
+                QtCore.QThread.msleep(min(poll_interval_ms, remaining_ms))
+            return True
+        return bool(threadpool.waitForDone(timeout_ms))
+
     def _update_from_parent_source(self) -> bool:
+        """Fetch the latest parent data and apply it through `update_data`."""
         if self._source_parent_fetcher is None:
             return False
         try:
@@ -2766,6 +2853,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         return True
 
     def handle_parent_source_replaced(self, parent_data: xr.DataArray) -> None:
+        """React to replacement of the parent ImageTool data source."""
         if self._source_spec is None:
             return
         try:
@@ -2800,6 +2888,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
     def show_source_update_dialog(
         self, *, parent: QtWidgets.QWidget | None = None
     ) -> int:
+        """Show the source update dialog and apply the user's selection."""
         if self._source_spec is None or self._source_state == "fresh":
             return int(QtWidgets.QDialog.DialogCode.Rejected)
 
@@ -2816,6 +2905,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M]):
         return result
 
     def update_data(self, new_data: xr.DataArray) -> bool | None:
+        """Apply refreshed source data to the existing tool window.
+
+        Subclasses must override this when they support ImageTool source updates. Return
+        `False` to leave the tool marked as stale when the new data is recognized but
+        cannot be applied immediately.
+        """
         raise NotImplementedError(
             "Subclasses of ToolWindow must implement update_data() to support "
             "ImageTool source updates."

--- a/tests/_qt_helpers.py
+++ b/tests/_qt_helpers.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from qtpy import QtCore
+
+
+def signal_receiver_count(obj: QtCore.QObject, signal: object, signal_name: str) -> int:
+    try:
+        return obj.receivers(signal)
+    except TypeError:
+        return obj.receivers(_encoded_signal_signature(obj, signal, signal_name))
+
+
+def _encoded_signal_signature(
+    obj: QtCore.QObject, signal: object, signal_name: str
+) -> str:
+    from_signal = getattr(QtCore.QMetaMethod, "fromSignal", None)
+    if from_signal is not None:
+        method = from_signal(signal)
+        if method.isValid():
+            return f"2{bytes(method.methodSignature()).decode()}"
+
+    meta = obj.metaObject()
+
+    for method_index in range(meta.methodCount()):
+        method = meta.method(method_index)
+        if method.methodType() != QtCore.QMetaMethod.MethodType.Signal:
+            continue
+
+        signature = bytes(method.methodSignature()).decode()
+        if signature.startswith(f"{signal_name}("):
+            return f"2{signature}"
+
+    raise ValueError(f"Could not resolve Qt signal signature for {signal_name!r}")

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1247,6 +1247,29 @@ def test_image_slicer_area_history_and_manual_limits(qtbot):
     win.close()
 
 
+def test_itool_keeps_child_tool_registered_when_close_is_ignored(
+    qtbot, monkeypatch
+) -> None:
+    win = itool(_TEST_DATA["2D"].copy(), execute=False)
+    qtbot.addWidget(win)
+
+    child = erlab.interactive.goldtool(_TEST_DATA["2D"].copy(), execute=False)
+    monkeypatch.setattr(child, "_stop_server", lambda: False)
+
+    win.slicer_area.add_tool_window(child)
+    qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000)
+
+    assert child.close() is False
+    assert len(win.slicer_area._associated_tools) == 1
+    assert next(iter(win.slicer_area._associated_tools.values())) is child
+    assert child.isVisible()
+
+    monkeypatch.setattr(child, "_stop_server", lambda: True)
+    assert child.close() is True
+    qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 0, timeout=5000)
+    win.close()
+
+
 def test_itool_load_compat(qtbot) -> None:
     original = xr.DataArray(
         np.arange(25).reshape((5, 5)),

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2432,7 +2432,9 @@ def test_itool_average(qtbot, accept_dialog) -> None:
     win.close()
 
 
-def test_itool_average_marks_child_tools_stale(qtbot, accept_dialog) -> None:
+def test_itool_average_marks_incompatible_child_tools_unavailable(
+    qtbot, accept_dialog
+) -> None:
     data = _TEST_DATA["2D"].copy()
     win = itool(data, execute=False)
     qtbot.addWidget(win)
@@ -2452,9 +2454,43 @@ def test_itool_average_marks_child_tools_stale(qtbot, accept_dialog) -> None:
     xarray.testing.assert_identical(
         win.slicer_area._data.rename(None), data.qsel.average("alpha")
     )
-    qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
+    qtbot.wait_until(lambda: child.source_state == "unavailable", timeout=5000)
 
     win.close()
+
+
+def test_itool_full_data_child_updates_follow_transposed_view(qtbot) -> None:
+    data = _TEST_DATA["2D"].copy(deep=True)
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.slicer_area.transpose_main_image()
+    assert win.slicer_area.data.dims == ("eV", "alpha")
+
+    win.slicer_area.open_in_meshtool()
+    qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000)
+    child = next(iter(win.slicer_area._associated_tools.values()))
+    xarray.testing.assert_identical(child.tool_data, win.slicer_area.data)
+
+    replaced = data.copy(deep=True)
+    replaced.data = np.asarray(replaced.data) * 2
+
+    with qtbot.wait_signal(win.slicer_area.sigSourceDataReplaced):
+        win.slicer_area.replace_source_data(replaced)
+
+    qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
+    assert child._update_from_parent_source() is True
+    xarray.testing.assert_identical(child.tool_data, win.slicer_area.data)
+
+    child.set_source_binding(child.source_spec, auto_update=True, state="fresh")
+    replaced2 = replaced.copy(deep=True)
+    replaced2.data = np.asarray(replaced2.data) + 5
+
+    with qtbot.wait_signal(win.slicer_area.sigSourceDataReplaced):
+        win.slicer_area.replace_source_data(replaced2)
+
+    qtbot.wait_until(lambda: child.source_state == "fresh", timeout=5000)
+    xarray.testing.assert_identical(child.tool_data, win.slicer_area.data)
 
 
 def test_itool_coarsen(qtbot, accept_dialog) -> None:

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1268,6 +1268,36 @@ def test_itool_load_compat(qtbot) -> None:
     win.close()
 
 
+def test_itool_child_tool_source_specs_and_non_source_updates(qtbot) -> None:
+    data = _TEST_DATA["2D"]
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    selection_spec = win.slicer_area.images[0].make_tool_source_spec(
+        transpose=True, squeeze=True
+    )
+    assert selection_spec["kind"] == "selection"
+    assert [op["op"] for op in selection_spec["operations"]] == [
+        "isel",
+        "sort_coord_order",
+        "transpose",
+        "squeeze",
+    ]
+
+    win.slicer_area.open_in_meshtool()
+    qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000)
+    child = next(iter(win.slicer_area._associated_tools.values()))
+    assert child.source_spec == erlab.interactive.utils.make_tool_source_spec(
+        "full_data"
+    )
+    assert child.source_state == "fresh"
+
+    new_data = data.copy(deep=True)
+    new_data.data = np.asarray(new_data.data) * 2
+    win.slicer_area.set_data(new_data)
+    assert child.source_state == "fresh"
+
+
 def test_parse_input() -> None:
     data_1d = xr.DataArray(np.arange(5), dims=["x"])
     parsed = _parse_input(xr.Dataset({"data1d": data_1d, "data0d": 1}))
@@ -2399,6 +2429,31 @@ def test_itool_average(qtbot, accept_dialog) -> None:
     )
 
     assert pyperclip.paste() == '.qsel.average("x")'
+    win.close()
+
+
+def test_itool_average_marks_child_tools_stale(qtbot, accept_dialog) -> None:
+    data = _TEST_DATA["2D"].copy()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.slicer_area.open_in_meshtool()
+    qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000)
+    child = next(iter(win.slicer_area._associated_tools.values()))
+    assert child.source_state == "fresh"
+
+    def _set_dialog_params(dialog: AverageDialog) -> None:
+        dialog.dim_checks["alpha"].setChecked(True)
+        dialog.new_window_check.setChecked(False)
+
+    with qtbot.wait_signal(win.slicer_area.sigSourceDataReplaced):
+        accept_dialog(win.mnb._average, pre_call=_set_dialog_params)
+
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None), data.qsel.average("alpha")
+    )
+    qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
+
     win.close()
 
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -15,7 +15,7 @@ from numpy.testing import assert_almost_equal
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
-from erlab.interactive.derivative import DerivativeTool
+from erlab.interactive.derivative import DerivativeTool, dtool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
 from erlab.interactive.imagetool import ImageTool, itool
 from erlab.interactive.imagetool.controls import ItoolColormapControls
@@ -1298,6 +1298,39 @@ def test_itool_child_tool_source_specs_and_non_source_updates(qtbot) -> None:
     assert child.source_state == "fresh"
 
 
+def test_itool_make_tool_source_spec_includes_alt_crop_indexers(
+    qtbot, monkeypatch
+) -> None:
+    win = itool(_TEST_DATA["2D"].copy(), execute=False)
+    qtbot.addWidget(win)
+
+    image = win.slicer_area.images[0]
+    monkeypatch.setattr(
+        type(image),
+        "_crop_indexers",
+        property(lambda self: {"alpha": slice(1, 4), "eV_idx": slice(0, 2)}),
+    )
+
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "queryKeyboardModifiers",
+        staticmethod(lambda: QtCore.Qt.KeyboardModifier.AltModifier),
+    )
+
+    spec = image.make_tool_source_spec()
+    sel_kwargs = erlab.interactive.utils._decode_tool_source_value(
+        next(op["kwargs"] for op in spec["operations"] if op["op"] == "sel")
+    )
+    isel_kwargs = erlab.interactive.utils._decode_tool_source_value(
+        [op["kwargs"] for op in spec["operations"] if op["op"] == "isel"][-1]
+    )
+
+    assert sel_kwargs == {"alpha": slice(1, 4)}
+    assert isel_kwargs == {"eV": slice(0, 2)}
+
+    win.close()
+
+
 def test_parse_input() -> None:
     data_1d = xr.DataArray(np.arange(5), dims=["x"])
     parsed = _parse_input(xr.Dataset({"data1d": data_1d, "data0d": 1}))
@@ -1801,6 +1834,23 @@ def test_itool_open_in_ktool_uses_active_cursor_seed(qtbot, monkeypatch) -> None
     win.close()
 
 
+def test_itool_open_in_ktool_sets_full_data_source_binding(qtbot, monkeypatch) -> None:
+    win = itool(_TEST_DATA["3D"].copy(), execute=False)
+    qtbot.addWidget(win)
+
+    child = dtool(_TEST_DATA["2D"].copy(), execute=False)
+    monkeypatch.setattr(erlab.interactive, "ktool", lambda *args, **kwargs: child)
+
+    win.slicer_area.open_in_ktool()
+
+    assert child.source_spec == erlab.interactive.utils.make_tool_source_spec(
+        "full_data"
+    )
+    assert child.source_state == "fresh"
+
+    win.close()
+
+
 def test_itool_open_in_ktool_uses_guideline_seed_on_alpha_beta_plane(
     qtbot, monkeypatch
 ) -> None:
@@ -1857,6 +1907,22 @@ def test_itool_open_in_ktool_ignores_non_alpha_beta_guidelines(
 
     assert captured["kwargs"]["initial_normal_emission"] == (4.0, 1.0)
     assert captured["kwargs"]["initial_delta"] is None
+
+    win.close()
+
+
+def test_itool_open_in_ftool_sets_squeezed_source_binding(qtbot, monkeypatch) -> None:
+    win = itool(_TEST_DATA["2D"].copy(), execute=False)
+    qtbot.addWidget(win)
+
+    child = dtool(_TEST_DATA["2D"].copy(), execute=False)
+    monkeypatch.setattr(erlab.interactive, "ftool", lambda *args, **kwargs: child)
+
+    image = win.slicer_area.images[0]
+    image.open_in_ftool()
+
+    assert child.source_spec == image.make_tool_source_spec(squeeze=True)
+    assert child.source_state == "fresh"
 
     win.close()
 

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -1476,6 +1476,65 @@ def test_tool_namespace_set_data_replaces_source(
         qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
 
 
+def test_tool_namespace_set_data_item_marks_child_tools_stale(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        manager.activateWindow()
+
+        itool([test_data], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1, timeout=5000
+        )
+
+        namespace = ToolNamespace(manager._imagetool_wrappers[0])
+        child = next(iter(manager._imagetool_wrappers[0]._childtools.values()))
+
+        namespace._set_data_item((0, 0), -5.0)
+
+        assert float(parent_tool.slicer_area._data.values[0, 0]) == -5.0
+        qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
+
+
+def test_tool_namespace_set_data_item_failure_keeps_child_tools_fresh(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        manager.activateWindow()
+
+        itool([test_data], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1, timeout=5000
+        )
+
+        namespace = ToolNamespace(manager._imagetool_wrappers[0])
+        child = next(iter(manager._imagetool_wrappers[0]._childtools.values()))
+
+        with pytest.raises(IndexError, match="too many indices"):
+            namespace._set_data_item((0, 0, 0), -5.0)
+
+        assert child.source_state == "fresh"
+        assert float(parent_tool.slicer_area._data.values[0, 0]) == 0.0
+
+
 def test_console_assignment_transformer_match_helpers() -> None:
     plain_name = typing.cast("ast.Expr", ast.parse("value").body[0]).value
     attr_without_subscript = typing.cast(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -658,6 +658,53 @@ def test_manager_childtool_source_updates(
         xr.testing.assert_identical(child.tool_data, replaced2.transpose("eV", "alpha"))
 
 
+def test_manager_full_data_childtool_updates_follow_transposed_view(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.transpose_main_image()
+        assert parent_tool.slicer_area.data.dims == ("eV", "alpha")
+
+        parent_tool.slicer_area.open_in_meshtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1, timeout=5000
+        )
+
+        child = next(iter(manager._imagetool_wrappers[0]._childtools.values()))
+        xarray.testing.assert_identical(child.tool_data, parent_tool.slicer_area.data)
+
+        replaced = test_data.copy(deep=True)
+        replaced.data = np.asarray(replaced.data) * 2
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            itool(replaced, manager=True, replace=0)
+
+        qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
+        assert child._update_from_parent_source() is True
+        xarray.testing.assert_identical(child.tool_data, parent_tool.slicer_area.data)
+
+        child.set_source_binding(child.source_spec, auto_update=True, state="fresh")
+        replaced2 = replaced.copy(deep=True)
+        replaced2.data = np.asarray(replaced2.data) + 5
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            itool(replaced2, manager=True, replace=0)
+
+        qtbot.wait_until(lambda: child.source_state == "fresh", timeout=5000)
+        xarray.testing.assert_identical(child.tool_data, parent_tool.slicer_area.data)
+
+
 def test_manager_reindex(
     qtbot,
     test_data,

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -572,6 +572,92 @@ def test_manager_replace(
         assert manager.get_imagetool(1).array_slicer.point_value(0) == 12.0
 
 
+def test_manager_childtool_source_updates(
+    qtbot,
+    accept_dialog,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1, timeout=5000
+        )
+
+        wrapper = manager._imagetool_wrappers[0]
+        uid, child = next(iter(wrapper._childtools.items()))
+        assert isinstance(child, DerivativeTool)
+        assert child.source_spec is not None
+
+        initial = test_data.transpose("eV", "alpha")
+        xr.testing.assert_identical(child.tool_data, initial)
+
+        replaced = test_data.copy(deep=True)
+        replaced.data = np.asarray(replaced.data) * 3
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            itool(replaced, manager=True, replace=0)
+
+        qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
+        xr.testing.assert_identical(child.tool_data, initial)
+
+        delegate = typing.cast(
+            "_ImageToolWrapperItemDelegate", manager.tree_view.itemDelegate()
+        )
+        model = typing.cast("_ImageToolWrapperItemModel", manager.tree_view.model())
+        manager.tree_view.expand(model._row_index(0))
+        index = model._row_index(uid)
+        manager.tree_view.scrollTo(index)
+        option = QtWidgets.QStyleOptionViewItem()
+        option.rect = manager.tree_view.visualRect(index)
+        option.font = manager.tree_view.font()
+        badge_rect, badge_text, _ = delegate._compute_child_status_info(option, child)
+        assert badge_rect is not None
+        assert badge_text == "Stale"
+        click_pos = badge_rect.center()
+        assert model._row_index(uid) == manager.tree_view.indexAt(click_pos)
+        global_click_pos = manager.tree_view.viewport().mapToGlobal(click_pos)
+
+        def _enable_auto_update(dialog: QtWidgets.QDialog) -> None:
+            dialog.auto_update_check.setChecked(True)  # type: ignore[attr-defined]
+
+        accept_dialog(
+            lambda: manager.tree_view.mouseReleaseEvent(
+                QtGui.QMouseEvent(
+                    QtCore.QEvent.Type.MouseButtonRelease,
+                    QtCore.QPointF(click_pos),
+                    QtCore.QPointF(global_click_pos),
+                    QtCore.Qt.MouseButton.LeftButton,
+                    QtCore.Qt.MouseButton.LeftButton,
+                    QtCore.Qt.KeyboardModifier.NoModifier,
+                )
+            ),
+            pre_call=_enable_auto_update,
+        )
+
+        assert child.source_state == "fresh"
+        assert child.source_auto_update is True
+        xr.testing.assert_identical(child.tool_data, replaced.transpose("eV", "alpha"))
+
+        replaced2 = replaced.copy(deep=True)
+        replaced2.data = np.asarray(replaced2.data) + 5
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            itool(replaced2, manager=True, replace=0)
+
+        qtbot.wait_until(lambda: child.source_state == "fresh", timeout=5000)
+        xr.testing.assert_identical(child.tool_data, replaced2.transpose("eV", "alpha"))
+
+
 def test_manager_reindex(
     qtbot,
     test_data,
@@ -1358,6 +1444,36 @@ def test_tool_namespace_get_data_item(
         xr.testing.assert_identical(
             namespace._get_data_item((slice(None), 0)), test_data[:, 0]
         )
+
+
+def test_tool_namespace_set_data_replaces_source(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        manager.activateWindow()
+
+        itool([test_data], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1, timeout=5000
+        )
+
+        namespace = ToolNamespace(manager._imagetool_wrappers[0])
+        child = next(iter(manager._imagetool_wrappers[0]._childtools.values()))
+        updated = (test_data * 2).rename(test_data.name)
+
+        namespace.data = updated
+
+        xr.testing.assert_identical(parent_tool.slicer_area.data, updated)
+        qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
 
 
 def test_console_assignment_transformer_match_helpers() -> None:

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -575,6 +575,7 @@ def test_manager_replace(
 def test_manager_childtool_source_updates(
     qtbot,
     accept_dialog,
+    monkeypatch,
     test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -623,6 +624,22 @@ def test_manager_childtool_source_updates(
         badge_rect, badge_text, _ = delegate._compute_child_status_info(option, child)
         assert badge_rect is not None
         assert badge_text == "Stale"
+        tooltip_text = None
+
+        def _show_tooltip(*args, **kwargs) -> None:
+            nonlocal tooltip_text
+            tooltip_text = args[1]
+
+        monkeypatch.setattr(QtWidgets.QToolTip, "showText", _show_tooltip)
+        help_event = QtGui.QHelpEvent(
+            QtCore.QEvent.Type.ToolTip,
+            badge_rect.center(),
+            manager.tree_view.viewport().mapToGlobal(badge_rect.center()),
+        )
+        assert delegate.helpEvent(help_event, manager.tree_view, option, index)
+        assert (
+            tooltip_text == "Click to update this tool from the latest ImageTool data."
+        )
         click_pos = badge_rect.center()
         assert model._row_index(uid) == manager.tree_view.indexAt(click_pos)
         global_click_pos = manager.tree_view.viewport().mapToGlobal(click_pos)
@@ -705,6 +722,46 @@ def test_manager_full_data_childtool_updates_follow_transposed_view(
         xarray.testing.assert_identical(child.tool_data, parent_tool.slicer_area.data)
 
 
+def test_wrapper_source_data_replaced_uses_parent_fallback_and_skips_missing_child(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1, timeout=5000
+        )
+
+        wrapper = manager._imagetool_wrappers[0]
+        _, child = next(iter(wrapper._childtools.items()))
+        updated = test_data.copy(deep=True)
+        updated.data = np.asarray(updated.data) * 7
+        handled: list[xr.DataArray] = []
+
+        monkeypatch.setattr(
+            wrapper.slicer_area, "_tool_source_parent_data", lambda: updated
+        )
+        monkeypatch.setattr(
+            child, "handle_parent_source_replaced", lambda data: handled.append(data)
+        )
+        wrapper._childtool_indices.append("missing")
+
+        wrapper._handle_source_data_replaced(object())
+
+        assert handled == [updated]
+
+
 def test_manager_reindex(
     qtbot,
     test_data,
@@ -753,6 +810,30 @@ def test_manager_server_show_remove(
         # Remove tool at index 0
         _remove_idx(0)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+
+def test_manager_data_watched_update_replaces_existing_tool_source_data(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager._data_recv([test_data], {}, watched_var=("data", "kernel-0"))
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        tool = manager.get_imagetool(0)
+        updated = test_data.copy(deep=True)
+        updated.data = np.asarray(updated.data) * 11
+
+        with qtbot.wait_signal(tool.slicer_area.sigSourceDataReplaced):
+            manager._data_watched_update("data", "kernel-0", updated)
+
+        xr.testing.assert_identical(tool.slicer_area.data, updated)
 
 
 def test_manager_duplicate(

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -126,3 +126,64 @@ def test_dtool_source_update_marks_unavailable_for_incompatible_data(qtbot) -> N
 
     assert win.source_state == "unavailable"
     xr.testing.assert_identical(win.tool_data, data)
+
+
+def test_dtool_restored_source_binding_without_parent_stays_stale(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    win: DerivativeTool = dtool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec("full_data"),
+        auto_update=True,
+        state="stale",
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        filename = f"{tmp_dir_name}/tool_save.h5"
+        win.to_file(filename)
+
+        win_restored = erlab.interactive.utils.ToolWindow.from_file(filename)
+        qtbot.addWidget(win_restored)
+        assert isinstance(win_restored, DerivativeTool)
+        assert win_restored.source_state == "stale"
+
+        assert win_restored._update_from_parent_source() is False
+        assert win_restored.source_state == "stale"
+
+
+def test_dtool_source_update_with_temporarily_missing_parent_stays_stale(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    updated = xr.DataArray(
+        np.arange(25, 50).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    win: DerivativeTool = dtool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec("full_data"),
+        auto_update=True,
+        state="stale",
+    )
+
+    available = False
+
+    def fetcher() -> xr.DataArray:
+        if not available:
+            raise LookupError("Parent tool is temporarily unavailable")
+        return updated
+
+    win.set_source_parent_fetcher(fetcher)
+
+    assert win._update_from_parent_source() is False
+    assert win.source_state == "stale"
+
+    available = True
+
+    assert win._update_from_parent_source() is True
+    assert win.source_state == "fresh"
+    xr.testing.assert_identical(win.tool_data, updated)

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -128,6 +128,27 @@ def test_dtool_source_update_marks_unavailable_for_incompatible_data(qtbot) -> N
     xr.testing.assert_identical(win.tool_data, data)
 
 
+def test_dtool_full_data_source_update_marks_unavailable_for_incompatible_data(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    win: DerivativeTool = dtool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec("full_data"),
+        auto_update=False,
+    )
+
+    parent_data = xr.DataArray(np.arange(5), dims=("x",), name="data")
+    win.handle_parent_source_replaced(parent_data)
+
+    assert win.source_state == "unavailable"
+    xr.testing.assert_identical(win.tool_data, data)
+
+
 def test_dtool_restored_source_binding_without_parent_stays_stale(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
@@ -187,3 +208,13 @@ def test_dtool_source_update_with_temporarily_missing_parent_stays_stale(qtbot) 
     assert win._update_from_parent_source() is True
     assert win.source_state == "fresh"
     xr.testing.assert_identical(win.tool_data, updated)
+
+
+def test_source_update_dialog_disables_auto_update_without_update_action(qtbot) -> None:
+    dialog = erlab.interactive.utils._ToolSourceUpdateDialog(
+        None, state="unavailable", auto_update=True
+    )
+    qtbot.addWidget(dialog)
+
+    assert dialog.update_button.isEnabled() is False
+    assert dialog.auto_update_check.isEnabled() is False

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -318,6 +318,45 @@ def test_tool_source_spec_helpers_roundtrip_and_resolve_selection() -> None:
         resolved_squeezed, parent.isel({"z": 0}).transpose("y", "x").squeeze()
     )
 
+    parent_nonuniform_public = xr.DataArray(
+        np.arange(24).reshape((4, 3, 2)),
+        dims=("alpha", "eV", "beta"),
+        coords={
+            "alpha": [0.0, 0.6, 1.7, 3.0],
+            "eV": [-0.2, 0.0, 0.2],
+            "beta": [1.0, 2.0],
+        },
+        name="data",
+    )
+    parent_nonuniform = erlab.interactive.imagetool.slicer.make_dims_uniform(
+        parent_nonuniform_public
+    )
+    resolved_nonuniform = erlab.interactive.utils._resolve_tool_source_spec(
+        parent_nonuniform,
+        erlab.interactive.utils.make_tool_source_spec(
+            "selection",
+            operations=[
+                {
+                    "op": "qsel",
+                    "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                        {"beta": 2.0}
+                    ),
+                },
+                {
+                    "op": "isel",
+                    "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                        {"alpha": slice(1, 3)}
+                    ),
+                },
+                {"op": "sort_coord_order"},
+            ],
+        ),
+    )
+    xr.testing.assert_identical(
+        resolved_nonuniform,
+        parent_nonuniform_public.qsel(beta=2.0).isel({"alpha": slice(1, 3)}),
+    )
+
     with pytest.raises(ValueError, match="Unsupported tool source kind"):
         erlab.interactive.utils._resolve_tool_source_spec(parent, {"kind": "invalid"})
 

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -49,6 +49,11 @@ def test_dtool(qtbot, interpmode, smoothmode, nsmooth, method_idx) -> None:
         win.curv_factor_spin.setValue(40)
 
     check_generated_code(win)
+    win.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec("full_data"),
+        auto_update=True,
+        state="stale",
+    )
 
     # Test save & restore
     with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -61,4 +66,63 @@ def test_dtool(qtbot, interpmode, smoothmode, nsmooth, method_idx) -> None:
 
         assert win.tool_status == win_restored.tool_status
         assert str(win_restored.info_text) == str(win.info_text)
+        assert win_restored.source_spec == win.source_spec
+        assert win_restored.source_auto_update is True
+        assert win_restored.source_state == "stale"
         check_generated_code(win_restored)
+
+
+def test_dtool_update_data_preserves_state(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    new_data = xr.DataArray(
+        np.arange(25, 50).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    win: DerivativeTool = dtool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.interp_group.setChecked(True)
+    win.nx_spin.setValue(7)
+    win.ny_spin.setValue(9)
+    win.smooth_group.setChecked(True)
+    win.smooth_combo.setCurrentIndex(1)
+    win.sx_spin.setValue(2)
+    win.sy_spin.setValue(3)
+    win.sn_spin.setValue(2)
+    win.tab_widget.setCurrentIndex(3)
+    win.curv_a0_spin.setValue(1.5)
+    win.curv_factor_spin.setValue(12.0)
+
+    status = win.tool_status
+    win.update_data(new_data)
+
+    assert win.tool_status == status
+    xr.testing.assert_identical(win.tool_data, new_data)
+    assert win.result.shape == win.processed_data.shape
+
+
+def test_dtool_source_update_marks_unavailable_for_incompatible_data(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    win: DerivativeTool = dtool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec(
+            "selection", operations=[{"op": "transpose"}]
+        ),
+        auto_update=True,
+    )
+
+    parent_data = xr.DataArray(
+        np.arange(125).reshape((5, 5, 5)),
+        dims=("x", "y", "z"),
+        coords={"x": np.arange(5), "y": np.arange(5), "z": np.arange(5)},
+        name="data",
+    )
+    win.handle_parent_source_replaced(parent_data)
+
+    assert win.source_state == "unavailable"
+    xr.testing.assert_identical(win.tool_data, data)

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -1,8 +1,11 @@
 import tempfile
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 import xarray as xr
+from pydantic import BaseModel
+from qtpy import QtWidgets
 
 import erlab
 from erlab.interactive.derivative import DerivativeTool, dtool
@@ -218,3 +221,257 @@ def test_source_update_dialog_disables_auto_update_without_update_action(qtbot) 
 
     assert dialog.update_button.isEnabled() is False
     assert dialog.auto_update_check.isEnabled() is False
+
+
+def test_tool_source_spec_helpers_roundtrip_and_resolve_selection() -> None:
+    encoded = erlab.interactive.utils._encode_tool_source_value(
+        {
+            "outer": {
+                "sel": slice(0.5, 2.5),
+                "items": (slice(1, 4, 2), [np.int64(3)], {"beta": np.float64(1.5)}),
+            }
+        }
+    )
+
+    decoded = erlab.interactive.utils._decode_tool_source_value(encoded)
+    assert decoded == {
+        "outer": {
+            "sel": slice(0.5, 2.5),
+            "items": [slice(1, 4, 2), [3], {"beta": 1.5}],
+        }
+    }
+
+    parent = xr.DataArray(
+        np.arange(24).reshape((3, 4, 2)),
+        dims=("x", "y", "z"),
+        coords={"x": [0.0, 1.0, 2.0], "y": [10.0, 11.0, 12.0, 13.0], "z": [5.0, 6.0]},
+        name="data",
+    )
+
+    resolved_full = erlab.interactive.utils._resolve_tool_source_spec(
+        parent, erlab.interactive.utils.make_tool_source_spec("full_data")
+    )
+    xr.testing.assert_identical(resolved_full, parent)
+
+    resolved_qsel = erlab.interactive.utils._resolve_tool_source_spec(
+        parent,
+        erlab.interactive.utils.make_tool_source_spec(
+            "selection",
+            operations=[
+                {
+                    "op": "qsel",
+                    "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                        {"x": 1.0, "x_width": 1.0}
+                    ),
+                }
+            ],
+        ),
+    )
+    xr.testing.assert_identical(resolved_qsel, parent.qsel(x=1.0, x_width=1.0))
+
+    resolved_selection = erlab.interactive.utils._resolve_tool_source_spec(
+        parent,
+        erlab.interactive.utils.make_tool_source_spec(
+            "selection",
+            operations=[
+                {
+                    "op": "isel",
+                    "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                        {"x": slice(1, None), "z": 1}
+                    ),
+                },
+                {
+                    "op": "sel",
+                    "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                        {"y": slice(11.0, 12.0)}
+                    ),
+                },
+                {"op": "sort_coord_order"},
+                {"op": "transpose", "dims": ["y", "x"]},
+            ],
+        ),
+    )
+    xr.testing.assert_identical(
+        resolved_selection,
+        parent.isel({"x": slice(1, None), "z": 1})
+        .sel({"y": slice(11.0, 12.0)})
+        .transpose("y", "x"),
+    )
+
+    resolved_squeezed = erlab.interactive.utils._resolve_tool_source_spec(
+        parent,
+        erlab.interactive.utils.make_tool_source_spec(
+            "selection",
+            operations=[
+                {
+                    "op": "isel",
+                    "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                        {"z": 0}
+                    ),
+                },
+                {"op": "transpose"},
+                {"op": "squeeze"},
+            ],
+        ),
+    )
+    xr.testing.assert_identical(
+        resolved_squeezed, parent.isel({"z": 0}).transpose("y", "x").squeeze()
+    )
+
+    with pytest.raises(ValueError, match="Unsupported tool source kind"):
+        erlab.interactive.utils._resolve_tool_source_spec(parent, {"kind": "invalid"})
+
+    with pytest.raises(ValueError, match="Unsupported tool source operation"):
+        erlab.interactive.utils._resolve_tool_source_spec(
+            parent,
+            erlab.interactive.utils.make_tool_source_spec(
+                "selection", operations=[{"op": "invalid"}]
+            ),
+        )
+
+
+def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
+    class _DummyState(BaseModel):
+        value: int = 0
+
+    class _DummyTool(erlab.interactive.utils.ToolWindow[_DummyState]):
+        StateModel = _DummyState
+        tool_name = "dummy"
+
+        def __init__(self, data: xr.DataArray) -> None:
+            super().__init__()
+            self._data = data
+            self._value = 0
+            self.fail_validate = False
+            self.fail_update = False
+
+        @property
+        def tool_status(self) -> _DummyState:
+            return _DummyState(value=self._value)
+
+        @tool_status.setter
+        def tool_status(self, status: _DummyState) -> None:
+            self._value = status.value
+
+        @property
+        def tool_data(self) -> xr.DataArray:
+            return self._data
+
+        def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+            if self.fail_validate:
+                raise ValueError("invalid update")
+            return super().validate_update_data(new_data)
+
+        def update_data(self, new_data: xr.DataArray) -> None:
+            if self.fail_update:
+                raise RuntimeError("update failed")
+            self._data = new_data
+
+    data = xr.DataArray(np.arange(9).reshape((3, 3)), dims=("x", "y"), name="data")
+    updated = xr.DataArray(
+        np.arange(9, 18).reshape((3, 3)), dims=("x", "y"), name="data"
+    )
+    tool = _DummyTool(data)
+    qtbot.addWidget(tool)
+
+    original = QtWidgets.QLabel("original")
+    replacement = QtWidgets.QLabel("replacement")
+    tool.setCentralWidget(original)
+    assert tool.centralWidget() is original
+    tool.setCentralWidget(tool._tool_root_widget)
+    tool._tool_content_widget = None
+    assert tool.centralWidget() is tool._tool_root_widget
+    tool._tool_content_widget = original
+    tool.setCentralWidget(replacement)
+    tool.setCentralWidget(replacement)
+    assert tool.centralWidget() is replacement
+
+    spec = erlab.interactive.utils.make_tool_source_spec(
+        "selection",
+        operations=[
+            {
+                "op": "isel",
+                "kwargs": erlab.interactive.utils._encode_tool_source_value(
+                    {"x": slice(0, 2)}
+                ),
+            }
+        ],
+    )
+    tool.set_source_binding(spec, auto_update=True, state="stale")
+    assert tool.has_source_binding is True
+    assert tool.source_status_text == "Source Update Available"
+    assert "Automatic updates are enabled." in tool._source_status_button.toolTip()
+    copied_spec = tool.source_spec
+    assert copied_spec is not None
+    copied_spec["kind"] = "changed"
+    assert tool.source_spec == spec
+
+    tool._set_source_state("unavailable")
+    assert tool.source_status_text == "Source Update Unavailable"
+    assert "can no longer update" in tool._source_status_button.toolTip()
+
+    tool.set_source_binding(None, auto_update=True, state="stale")
+    assert tool.source_spec is None
+    assert tool.has_source_binding is False
+    assert tool.source_status_text == ""
+    assert tool._source_status_bar.isHidden()
+
+    with pytest.raises(RuntimeError, match="not bound to an ImageTool source"):
+        tool._resolve_source_data(updated)
+
+    tool._set_source_state("fresh")
+    tool.handle_parent_source_replaced(updated)
+    assert tool.source_state == "fresh"
+
+    tool.set_source_binding({"kind": "selection", "operations": [{"op": "invalid"}]})
+    tool.set_source_parent_fetcher(lambda: updated)
+    assert tool._update_from_parent_source() is False
+    assert tool.source_state == "unavailable"
+
+    tool.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec("full_data"), auto_update=True
+    )
+    tool.fail_validate = True
+    assert tool._update_from_parent_source() is False
+    assert tool.source_state == "unavailable"
+    tool.fail_validate = False
+
+    tool.fail_update = True
+    assert tool._update_from_parent_source() is False
+    assert tool.source_state == "unavailable"
+    tool.fail_update = False
+
+    assert tool._update_from_parent_source() is True
+    assert tool.source_state == "fresh"
+    xr.testing.assert_identical(tool.tool_data, updated)
+
+    tool.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec("full_data"), auto_update=False
+    )
+    tool.handle_parent_source_replaced(updated * 2)
+    assert tool.source_state == "stale"
+
+    tool.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec("full_data"), auto_update=True
+    )
+    tool.fail_validate = True
+    tool.handle_parent_source_replaced(updated)
+    assert tool.source_state == "unavailable"
+    tool.fail_validate = False
+
+    tool.fail_update = True
+    tool.handle_parent_source_replaced(updated)
+    assert tool.source_state == "unavailable"
+    tool.fail_update = False
+
+    bad_parent = SimpleNamespace(
+        kspace=SimpleNamespace(
+            _valid_offset_keys=(),
+            momentum_axes=(),
+            configuration=0,
+            _has_hv=False,
+        )
+    )
+    tool.set_source_binding({"kind": "selection", "operations": [{"op": "invalid"}]})
+    tool.handle_parent_source_replaced(bad_parent)
+    assert tool.source_state == "unavailable"

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -253,6 +253,24 @@ def test_goldtool_auto_source_update_stays_stale_until_deferred_refresh_applies(
     xr.testing.assert_identical(win.data, new_gold)
 
 
+def test_goldtool_close_event_ignored_if_threadpool_does_not_quiesce(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    monkeypatch.setattr(
+        type(win),
+        "_wait_for_threadpool",
+        staticmethod(lambda *args, **kwargs: False),
+    )
+
+    event = QtGui.QCloseEvent()
+    assert event.isAccepted()
+    win.closeEvent(event)
+    assert not event.isAccepted()
+
+
 def test_goldtool_update_data_clamps_roi_to_non_empty_bounds(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
@@ -452,6 +470,133 @@ def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -
     xr.testing.assert_identical(
         fit_inputs[0], newer_gold.sel({win.y_dim: slice(*win.y_range)}).mean(win.y_dim)
     )
+
+
+def test_restool_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+    original = win.tool_data.copy(deep=True)
+
+    class _StuckThread:
+        def __init__(self) -> None:
+            self.cancel_called = False
+            self.interrupted = False
+            self.wait_timeout_ms: int | None = None
+
+        def cancel(self) -> None:
+            self.cancel_called = True
+
+        def isRunning(self) -> bool:
+            return True
+
+        def requestInterruption(self) -> None:
+            self.interrupted = True
+
+        def wait(self, timeout_ms: int) -> bool:
+            self.wait_timeout_ms = timeout_ms
+            return False
+
+    stuck_thread = _StuckThread()
+    win._fit_thread = stuck_thread  # type: ignore[assignment]
+
+    updated = gold.copy(deep=True)
+    updated.data = np.asarray(updated.data) * 1.01
+
+    assert win.update_data(updated) is False
+    assert stuck_thread.cancel_called
+    assert stuck_thread.interrupted
+    assert stuck_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
+    xr.testing.assert_identical(win.tool_data, original)
+    win._fit_thread = None
+
+
+def test_restool_update_data_auto_refit_after_waiting_cancelled_thread(
+    qtbot, monkeypatch
+) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _FinishedThread:
+        def __init__(self) -> None:
+            self.cancel_called = False
+            self.interrupted = False
+            self.wait_timeout_ms: int | None = None
+            self.deleted = False
+
+        def cancel(self) -> None:
+            self.cancel_called = True
+
+        def requestInterruption(self) -> None:
+            self.interrupted = True
+
+        def wait(self, timeout_ms: int) -> bool:
+            self.wait_timeout_ms = timeout_ms
+            return True
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    old_thread = _FinishedThread()
+    win._fit_thread = old_thread  # type: ignore[assignment]
+    win._result_ds = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+
+    started: list[bool] = []
+
+    def _start_fit_worker() -> bool:
+        started.append(True)
+        assert win._fit_thread is None
+        return True
+
+    monkeypatch.setattr(win, "_start_fit_worker", _start_fit_worker)
+
+    updated = gold.copy(deep=True)
+    updated.data = np.asarray(updated.data) * 1.01
+
+    assert win.update_data(updated) is True
+    assert started == [True]
+    assert old_thread.cancel_called
+    assert old_thread.interrupted
+    assert old_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
+    assert old_thread.deleted is True
+
+
+def test_restool_queue_fit_action_ignores_stale_thread(qtbot) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _ThreadPlaceholder:
+        def cancel(self) -> None:
+            return
+
+        def requestInterruption(self) -> None:
+            return
+
+        def wait(self, timeout_ms: int) -> bool:
+            return True
+
+        def deleteLater(self) -> None:
+            return
+
+    stale_thread = _ThreadPlaceholder()
+    current_thread = _ThreadPlaceholder()
+    win._fit_thread = typing.cast("typing.Any", current_thread)
+
+    called: list[str] = []
+    win._queue_fit_action(
+        typing.cast("typing.Any", stale_thread), lambda: called.append("stale")
+    )
+    assert called == []
+    assert win._pending_fit_action is None
 
 
 def test_restool_validate_update_data_transposes_and_rejects_invalid(qtbot) -> None:
@@ -743,6 +888,7 @@ def test_restool_cancel_fit_waits_without_timeout(qtbot) -> None:
             self.cancel_called = False
             self.interrupted = False
             self.wait_args: tuple[object, ...] | None = None
+            self.deleted = False
 
         def cancel(self) -> None:
             self.cancel_called = True
@@ -757,6 +903,9 @@ def test_restool_cancel_fit_waits_without_timeout(qtbot) -> None:
             self.wait_args = args
             return True
 
+        def deleteLater(self) -> None:
+            self.deleted = True
+
     dummy_thread = _DummyThread()
     win._fit_thread = dummy_thread  # type: ignore[assignment]
 
@@ -764,6 +913,7 @@ def test_restool_cancel_fit_waits_without_timeout(qtbot) -> None:
     assert dummy_thread.cancel_called
     assert dummy_thread.interrupted
     assert dummy_thread.wait_args == ()
+    assert dummy_thread.deleted
 
 
 def test_restool_clear_fit_preview_keeps_line_when_live(qtbot) -> None:
@@ -853,6 +1003,9 @@ def test_restool_do_fit_queues_when_thread_object_exists(qtbot, monkeypatch) -> 
         def wait(self, timeout_ms: int) -> bool:
             return True
 
+        def deleteLater(self) -> None:
+            return
+
     called: list[bool] = []
 
     def _start_fit_worker() -> bool:
@@ -879,7 +1032,7 @@ def test_restool_queue_fit_action_drops_when_cancel_requested(qtbot) -> None:
     called = {"value": False}
     win._fit_cancel_requested = True
     win._pending_fit_action = None
-    win._queue_fit_action(lambda: called.__setitem__("value", True))
+    win._queue_fit_action(None, lambda: called.__setitem__("value", True))  # type: ignore[arg-type]
 
     assert not called["value"]
     assert win._pending_fit_action is None
@@ -896,7 +1049,7 @@ def test_restool_queue_fit_action_runs_immediately_when_no_thread(qtbot) -> None
     win._fit_cancel_requested = False
     win._fit_thread = None
     win._pending_fit_action = None
-    win._queue_fit_action(lambda: called.__setitem__("value", True))
+    win._queue_fit_action(None, lambda: called.__setitem__("value", True))  # type: ignore[arg-type]
 
     assert called["value"]
     assert win._pending_fit_action is None
@@ -918,6 +1071,9 @@ def test_restool_start_fit_worker_returns_false_when_thread_exists(qtbot) -> Non
 
         def wait(self, timeout_ms: int) -> bool:
             return True
+
+        def deleteLater(self) -> None:
+            return
 
     win._fit_thread = _ThreadPlaceholder()  # type: ignore[assignment]
     assert not win._start_fit_worker()

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -689,6 +689,41 @@ def test_restool_close_event_ignored_if_fit_thread_stuck(qtbot) -> None:
     assert stuck_thread.wait_timeout_ms == 5000
 
 
+def test_restool_cancel_fit_waits_without_timeout(qtbot) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _DummyThread:
+        def __init__(self) -> None:
+            self.cancel_called = False
+            self.interrupted = False
+            self.wait_args: tuple[object, ...] | None = None
+
+        def cancel(self) -> None:
+            self.cancel_called = True
+
+        def isRunning(self) -> bool:
+            return True
+
+        def requestInterruption(self) -> None:
+            self.interrupted = True
+
+        def wait(self, *args) -> bool:
+            self.wait_args = args
+            return True
+
+    dummy_thread = _DummyThread()
+    win._fit_thread = dummy_thread  # type: ignore[assignment]
+
+    assert win._cancel_fit(wait=True, timeout_ms=None)
+    assert dummy_thread.cancel_called
+    assert dummy_thread.interrupted
+    assert dummy_thread.wait_args == ()
+
+
 def test_restool_clear_fit_preview_keeps_line_when_live(qtbot) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -1,5 +1,6 @@
 import tempfile
 import time
+import typing
 
 import joblib
 import numpy as np
@@ -7,7 +8,7 @@ import pytest
 import scipy
 import xarray as xr
 import xarray_lmfit as xlm
-from qtpy import QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive.fermiedge import (
@@ -92,6 +93,49 @@ def test_goldtool_roi_limits_descending_coords(qtbot, gold) -> None:
     assert y1 == pytest.approx(-0.5)
 
 
+def test_goldtool_update_data_invalidates_fit_and_can_refit(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    win.params_edge.widgets["T (K)"].setValue(45.0)
+    degree_widget = typing.cast("QtWidgets.QSpinBox", win.params_poly.widgets["Degree"])
+    with QtCore.QSignalBlocker(win.params_poly):
+        degree_widget.setValue(3)
+    win.params_roi.modify_roi(x0=-8.0, x1=8.0, y0=-0.2, y1=0.1)
+    win.params_poly.setDisabled(False)
+    win.params_spl.setDisabled(False)
+    win.params_tab.setDisabled(False)
+    win.edge_center = gold.mean("eV")
+    win.edge_stderr = xr.ones_like(win.edge_center)
+    win.result = xr.Dataset()
+
+    called: list[bool] = []
+    monkeypatch.setattr(win, "perform_edge_fit", lambda: called.append(True))
+
+    new_gold = gold.copy(deep=True)
+    new_gold.data = np.asarray(new_gold.data) * 1.05
+    win.update_data(new_gold)
+
+    assert win.params_edge.values["T (K)"] == pytest.approx(45.0)
+    assert win.params_poly.values["Degree"] == 3
+    assert win.result is None
+    assert win.params_tab.isEnabled() is False
+    assert not called
+
+    win.edge_center = new_gold.mean("eV")
+    win.edge_stderr = xr.ones_like(win.edge_center)
+    win.result = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+
+    newer_gold = new_gold.copy(deep=True)
+    newer_gold.data = np.asarray(newer_gold.data) * 1.02
+    win.update_data(newer_gold)
+
+    assert called == [True]
+
+
 def test_restool(qtbot) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
@@ -173,6 +217,54 @@ def test_restool_timeout_cleans_up_worker(qtbot, monkeypatch) -> None:
     assert not win.live_check.isChecked()
     assert win._fit_thread is None
     assert win._result_ds is None
+
+
+def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    win.x0_spin.setValue(-0.2)
+    win.x1_spin.setValue(0.2)
+    win.y0_spin.setValue(-10.0)
+    win.y1_spin.setValue(10.0)
+    win.live_check.setChecked(True)
+    win.temp_spin.setValue(90.0)
+    win.fix_temp_check.setChecked(False)
+    win.center_spin.setValue(-0.01)
+    win.fix_center_check.setChecked(True)
+    win.res_spin.setValue(0.015)
+    win.fix_res_check.setChecked(True)
+    win.slope_check.setChecked(False)
+    win.timeout_spin.setValue(2.5)
+    win.nfev_spin.setValue(250)
+    win.refit_on_source_update_check.setChecked(False)
+    win._result_ds = xr.Dataset()
+
+    called: list[bool] = []
+    monkeypatch.setattr(win, "do_fit", lambda: called.append(True))
+
+    status = win.tool_status
+    new_gold = gold.copy(deep=True)
+    new_gold.data = np.asarray(new_gold.data) * 1.03
+    win.update_data(new_gold)
+
+    expected = status.model_copy(
+        update={"results": ("No fit results", "—", "—", "—", "—")}
+    )
+    assert win.tool_status == expected
+    assert win._result_ds is None
+    assert not called
+
+    win._result_ds = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+    newer_gold = new_gold.copy(deep=True)
+    newer_gold.data = np.asarray(newer_gold.data) * 1.01
+    win.update_data(newer_gold)
+
+    assert called == [True]
 
 
 def test_restool_fit_thread_loads_result_before_emit(monkeypatch) -> None:

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import time
 import typing
@@ -136,6 +137,19 @@ def test_goldtool_update_data_invalidates_fit_and_can_refit(
     assert called == [True]
 
 
+def test_goldtool_validate_update_data_transposes_and_rejects_invalid(
+    qtbot, gold
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    transposed = win.validate_update_data(gold.transpose(*reversed(gold.dims)))
+    assert transposed.dims[0] == "eV"
+
+    with pytest.raises(ValueError, match="2D DataArray with an `eV` dimension"):
+        win.validate_update_data(xr.DataArray(np.arange(5), dims=("alpha",)))
+
+
 def test_restool(qtbot) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
@@ -166,7 +180,7 @@ def test_restool(qtbot) -> None:
         assert win.fit_params[k] == v
 
     def check_generated_code(w: ResolutionTool) -> None:
-        namespace = {"era": erlab.analysis, "gold": gold, "result": None}
+        namespace = {"era": erlab.analysis, "gold": gold, "data": gold, "result": None}
         code = "result = " + w.copy_code().replace("quick_resolution", "quick_fit")
         exec(code, {"__builtins__": {"slice": slice}}, namespace)  # noqa: S102
 
@@ -217,6 +231,32 @@ def test_restool_timeout_cleans_up_worker(qtbot, monkeypatch) -> None:
     assert not win.live_check.isChecked()
     assert win._fit_thread is None
     assert win._result_ds is None
+
+
+def test_restool_loads_legacy_saved_state_without_source_update_flag(qtbot) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        filename = f"{tmp_dir_name}/tool_save.h5"
+        win.to_file(filename)
+
+        with xr.load_dataset(filename, engine="h5netcdf") as ds:
+            legacy_ds = ds.load()
+
+        legacy_state = json.loads(legacy_ds.attrs["tool_state"])
+        legacy_state.pop("refit_on_source_update", None)
+        legacy_ds.attrs["tool_state"] = json.dumps(legacy_state)
+        legacy_ds.to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
+
+        win_restored = erlab.interactive.utils.ToolWindow.from_file(filename)
+        qtbot.addWidget(win_restored)
+        assert isinstance(win_restored, ResolutionTool)
+        assert win_restored.tool_status.refit_on_source_update is False
+        assert win_restored.refit_on_source_update_check.isChecked() is False
 
 
 def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -> None:
@@ -273,6 +313,20 @@ def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -
     xr.testing.assert_identical(
         fit_inputs[0], newer_gold.sel({win.y_dim: slice(*win.y_range)}).mean(win.y_dim)
     )
+
+
+def test_restool_validate_update_data_transposes_and_rejects_invalid(qtbot) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    transposed = win.validate_update_data(gold.transpose(*reversed(gold.dims)))
+    assert transposed.dims[-1] == "eV"
+
+    with pytest.raises(ValueError, match="2D and have an 'eV' dimension"):
+        win.validate_update_data(xr.DataArray(np.arange(5), dims=("alpha",)))
 
 
 def test_restool_fit_thread_loads_result_before_emit(monkeypatch) -> None:

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -137,6 +137,103 @@ def test_goldtool_update_data_invalidates_fit_and_can_refit(
     assert called == [True]
 
 
+def test_goldtool_update_data_ignores_late_results_from_aborted_task(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _DummyTask:
+        def __init__(self) -> None:
+            self.aborted = False
+
+        def abort_fit(self) -> None:
+            self.aborted = True
+
+    stale_task = _DummyTask()
+    win._fit_task = stale_task
+
+    perform_called: list[bool] = []
+    monkeypatch.setattr(win, "perform_fit", lambda: perform_called.append(True))
+
+    new_gold = gold.copy(deep=True)
+    new_gold.data = np.asarray(new_gold.data) * 1.01
+    win.update_data(new_gold)
+
+    assert stale_task.aborted is True
+    assert win._fit_task is None
+    assert not hasattr(win, "edge_center")
+    assert not perform_called
+
+    stale_center = gold.mean("eV")
+    stale_stderr = xr.ones_like(stale_center)
+    win.post_fit(stale_center, stale_stderr, task=stale_task)
+
+    assert not hasattr(win, "edge_center")
+    assert not perform_called
+
+
+def test_goldtool_update_data_defers_until_fit_worker_drains(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _DummyTask:
+        def __init__(self) -> None:
+            self.aborted = False
+
+        def abort_fit(self) -> None:
+            self.aborted = True
+
+    stale_task = _DummyTask()
+    win._fit_task = stale_task
+
+    active_counts = iter((1, 0))
+    monkeypatch.setattr(
+        win._threadpool,
+        "activeThreadCount",
+        lambda: next(active_counts, 0),
+    )
+
+    new_gold = gold.copy(deep=True)
+    new_gold.data = np.asarray(new_gold.data) * 1.02
+    win.update_data(new_gold)
+
+    assert stale_task.aborted is True
+    assert win._pending_update_request is not None
+    xr.testing.assert_identical(win.data, gold)
+
+    win._pending_update_timer.stop()
+    win._flush_pending_update()
+
+    assert win._pending_update_request is None
+    xr.testing.assert_identical(win.data, new_gold)
+
+
+def test_goldtool_update_data_clamps_roi_to_non_empty_bounds(qtbot, gold) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    win.params_roi.modify_roi(x0=-12.0, x1=-8.0, y0=-0.45, y1=-0.3)
+    narrowed = gold.sel(alpha=slice(-2.5, 2.5), eV=slice(-0.1, 0.05))
+
+    win.update_data(narrowed)
+
+    x0, y0, x1, y1 = win.params_roi.roi_limits
+    xmin, ymin, xmax, ymax = win.params_roi.max_bounds
+    assert xmin <= x0 < x1 <= xmax
+    assert y0 < y1 <= ymax
+    assert y0 >= ymin - 1e-3
+
+    sel_x0, sel_y0, sel_x1, sel_y1 = win.roi_limits_ordered
+    selected = win.data.sel(
+        {win._along_dim: slice(sel_x0, sel_x1), "eV": slice(sel_y0, sel_y1)}
+    )
+    assert selected.sizes[win._along_dim] > 0
+    assert selected.sizes["eV"] > 0
+
+
 def test_goldtool_validate_update_data_transposes_and_rejects_invalid(
     qtbot, gold
 ) -> None:

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -211,6 +211,48 @@ def test_goldtool_update_data_defers_until_fit_worker_drains(
     xr.testing.assert_identical(win.data, new_gold)
 
 
+def test_goldtool_auto_source_update_stays_stale_until_deferred_refresh_applies(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+    win.set_source_binding(
+        erlab.interactive.utils.make_tool_source_spec("full_data"),
+        auto_update=True,
+    )
+
+    class _DummyTask:
+        def __init__(self) -> None:
+            self.aborted = False
+
+        def abort_fit(self) -> None:
+            self.aborted = True
+
+    stale_task = _DummyTask()
+    win._fit_task = stale_task
+
+    active_counts = iter((1, 0))
+    monkeypatch.setattr(
+        win._threadpool,
+        "activeThreadCount",
+        lambda: next(active_counts, 0),
+    )
+
+    new_gold = gold.copy(deep=True)
+    new_gold.data = np.asarray(new_gold.data) * 1.02
+    win.handle_parent_source_replaced(new_gold)
+
+    assert stale_task.aborted is True
+    assert win.source_state == "stale"
+    xr.testing.assert_identical(win.data, gold)
+
+    win._pending_update_timer.stop()
+    win._flush_pending_update()
+
+    assert win.source_state == "fresh"
+    xr.testing.assert_identical(win.data, new_gold)
+
+
 def test_goldtool_update_data_clamps_roi_to_non_empty_bounds(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -243,8 +243,10 @@ def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -
     win.refit_on_source_update_check.setChecked(False)
     win._result_ds = xr.Dataset()
 
-    called: list[bool] = []
-    monkeypatch.setattr(win, "do_fit", lambda: called.append(True))
+    fit_inputs: list[xr.DataArray] = []
+    monkeypatch.setattr(
+        win, "do_fit", lambda: fit_inputs.append(win.averaged_edc.copy(deep=True))
+    )
 
     status = win.tool_status
     new_gold = gold.copy(deep=True)
@@ -256,7 +258,11 @@ def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -
     )
     assert win.tool_status == expected
     assert win._result_ds is None
-    assert not called
+    xr.testing.assert_identical(
+        win.averaged_edc,
+        new_gold.sel({win.y_dim: slice(*win.y_range)}).mean(win.y_dim),
+    )
+    assert not fit_inputs
 
     win._result_ds = xr.Dataset()
     win.refit_on_source_update_check.setChecked(True)
@@ -264,7 +270,9 @@ def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -
     newer_gold.data = np.asarray(newer_gold.data) * 1.01
     win.update_data(newer_gold)
 
-    assert called == [True]
+    xr.testing.assert_identical(
+        fit_inputs[0], newer_gold.sel({win.y_dim: slice(*win.y_range)}).mean(win.y_dim)
+    )
 
 
 def test_restool_fit_thread_loads_result_before_emit(monkeypatch) -> None:

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -141,6 +141,51 @@ def test_fit1d_open_saved_fit_dataset(qtbot, exp_decay_model) -> None:
     assert isinstance(win_restored._model, type(exp_decay_model))
 
 
+def test_fit1d_update_data_preserves_state_and_refit(
+    qtbot, exp_decay_model, monkeypatch
+):
+    data = _make_1d_data()
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        data, model=exp_decay_model, params=params, execute=False
+    )
+    qtbot.addWidget(win)
+
+    win.normalize_check.setChecked(True)
+    win.components_check.setChecked(True)
+    win.domain_min_spin.setValue(-0.5)
+    win.domain_max_spin.setValue(0.5)
+    win.timeout_spin.setValue(3.0)
+    win.nfev_spin.setValue(250)
+    win.refit_on_source_update_check.setChecked(False)
+    win._last_result_ds = xr.Dataset()
+
+    called: list[bool] = []
+    monkeypatch.setattr(win, "_run_fit", lambda: called.append(True) or True)
+
+    status = win.tool_status
+    new_data = xr.DataArray(
+        np.linspace(0.5, 1.5, data.size),
+        dims=data.dims,
+        coords=data.coords,
+        name=data.name,
+    )
+    win.update_data(new_data)
+
+    assert win.tool_status == status
+    xr.testing.assert_identical(win.tool_data, new_data)
+    assert win._fit_is_current is False
+    assert not called
+
+    win._last_result_ds = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+    newer_data = new_data.copy(deep=True)
+    newer_data.data = np.asarray(newer_data.data) * 1.1
+    win.update_data(newer_data)
+
+    assert called == [True]
+
+
 def test_parameter_table_model_and_delegate(qtbot) -> None:
     params = lmfit.Parameters()
     params.add("amp", value=1.0, min=-1.0, max=2.0, vary=True)

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -204,6 +204,33 @@ def test_fit1d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     xr.testing.assert_identical(win.tool_data, data)
 
 
+def test_fit1d_update_data_drops_missing_coord_backed_param_bindings(qtbot) -> None:
+    data = _make_1d_data().assign_coords(offset=1.25)
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    win.param_view.selectRow(0)
+    qtbot.waitUntil(lambda: win._current_row == 0)
+
+    param_name = win.param_model.param_name(0)
+    win._params_from_coord[param_name] = "offset"
+    win._params[param_name].value = float(data["offset"].values)
+    win._params[param_name].vary = False
+    win.param_model.set_params(win._params, win._params_from_coord)
+
+    value_index = win.param_model.index(0, 1)
+    assert not (win.param_model.flags(value_index) & QtCore.Qt.ItemFlag.ItemIsEditable)
+
+    new_data = data.drop_vars("offset")
+    win.update_data(new_data)
+
+    assert param_name not in win._params_from_coord
+    value_index = win.param_model.index(0, 1)
+    assert win.param_model.flags(value_index) & QtCore.Qt.ItemFlag.ItemIsEditable
+    assert win.param_mode_combo.currentText() == "Manual"
+
+
 def test_fit1d_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
     data = _make_1d_data()
     win = erlab.interactive.ftool(data, execute=False)

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -742,6 +742,39 @@ def test_fit1d_cancel_fit_waits_for_thread(qtbot) -> None:
     assert dummy_thread.wait_timeout_ms == 5000
 
 
+def test_fit1d_cancel_fit_waits_without_timeout(qtbot) -> None:
+    data = _make_1d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+
+    class _DummyThread:
+        def __init__(self) -> None:
+            self.cancel_called = False
+            self.interrupted = False
+            self.wait_args: tuple[object, ...] | None = None
+
+        def cancel(self) -> None:
+            self.cancel_called = True
+
+        def isRunning(self) -> bool:
+            return True
+
+        def requestInterruption(self) -> None:
+            self.interrupted = True
+
+        def wait(self, *args) -> bool:
+            self.wait_args = args
+            return True
+
+    dummy_thread = _DummyThread()
+    win._fit_thread = dummy_thread  # type: ignore[assignment]
+
+    assert win._cancel_fit(wait=True, timeout_ms=None)
+    assert dummy_thread.cancel_called
+    assert dummy_thread.interrupted
+    assert dummy_thread.wait_args == ()
+
+
 def test_fit1d_close_event_ignored_if_thread_does_not_stop(qtbot) -> None:
     data = _make_1d_data()
     win = erlab.interactive.ftool(data, execute=False)

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -204,6 +204,20 @@ def test_fit1d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     xr.testing.assert_identical(win.tool_data, data)
 
 
+def test_fit1d_update_data_keeps_fit_finished_receivers_constant(qtbot) -> None:
+    data = _make_1d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+
+    initial_receivers = win.receivers(win.sigFitFinished)
+
+    for scale in (1.1, 1.2, 1.3):
+        updated = data.copy(deep=True)
+        updated.data = np.asarray(data.data) * scale
+        win.update_data(updated)
+        assert win.receivers(win.sigFitFinished) == initial_receivers
+
+
 def test_parameter_table_model_and_delegate(qtbot) -> None:
     params = lmfit.Parameters()
     params.add("amp", value=1.0, min=-1.0, max=2.0, vary=True)

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -11,6 +11,7 @@ from erlab.interactive._fit1d import (
     _ParameterEditDelegate,
     _ParameterTableModel,
 )
+from tests._qt_helpers import signal_receiver_count
 
 
 def _make_1d_data() -> xr.DataArray:
@@ -282,13 +283,16 @@ def test_fit1d_update_data_keeps_fit_finished_receivers_constant(qtbot) -> None:
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
 
-    initial_receivers = win.receivers(win.sigFitFinished)
+    initial_receivers = signal_receiver_count(win, win.sigFitFinished, "sigFitFinished")
 
     for scale in (1.1, 1.2, 1.3):
         updated = data.copy(deep=True)
         updated.data = np.asarray(data.data) * scale
         win.update_data(updated)
-        assert win.receivers(win.sigFitFinished) == initial_receivers
+        assert (
+            signal_receiver_count(win, win.sigFitFinished, "sigFitFinished")
+            == initial_receivers
+        )
 
 
 def test_fit1d_update_data_auto_refit_after_waiting_cancelled_thread(

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -186,6 +186,24 @@ def test_fit1d_update_data_preserves_state_and_refit(
     assert called == [True]
 
 
+def test_fit1d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
+    data = _make_1d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    old_central = win.centralWidget()
+    bad_data = xr.DataArray(np.arange(6).reshape((2, 3)), dims=("y", "x"))
+
+    with pytest.raises(ValueError, match="1D DataArray"):
+        win.update_data(bad_data)
+
+    assert win.centralWidget() is old_central
+    assert old_central is not None
+    assert old_central.parent() is not None
+    xr.testing.assert_identical(win.tool_data, data)
+
+
 def test_parameter_table_model_and_delegate(qtbot) -> None:
     params = lmfit.Parameters()
     params.add("amp", value=1.0, min=-1.0, max=2.0, vary=True)

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -204,6 +204,52 @@ def test_fit1d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     xr.testing.assert_identical(win.tool_data, data)
 
 
+def test_fit1d_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
+    data = _make_1d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    class _StuckThread:
+        def __init__(self) -> None:
+            self.cancel_called = False
+            self.interrupted = False
+            self.wait_timeout_ms: int | None = None
+
+        def cancel(self) -> None:
+            self.cancel_called = True
+
+        def isRunning(self) -> bool:
+            return True
+
+        def requestInterruption(self) -> None:
+            self.interrupted = True
+
+        def wait(self, timeout_ms: int) -> bool:
+            self.wait_timeout_ms = timeout_ms
+            return False
+
+    stuck_thread = _StuckThread()
+    win._fit_thread = stuck_thread  # type: ignore[assignment]
+    old_central = win.centralWidget()
+
+    new_data = xr.DataArray(
+        np.linspace(0.5, 1.5, data.size),
+        dims=data.dims,
+        coords=data.coords,
+        name=data.name,
+    )
+
+    assert win.update_data(new_data) is False
+    assert stuck_thread.cancel_called
+    assert stuck_thread.interrupted
+    assert stuck_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
+    assert win.centralWidget() is old_central
+    assert old_central is not None
+    assert old_central.parent() is not None
+    xr.testing.assert_identical(win.tool_data, data)
+
+
 def test_fit1d_update_data_keeps_fit_finished_receivers_constant(qtbot) -> None:
     data = _make_1d_data()
     win = erlab.interactive.ftool(data, execute=False)
@@ -216,6 +262,91 @@ def test_fit1d_update_data_keeps_fit_finished_receivers_constant(qtbot) -> None:
         updated.data = np.asarray(data.data) * scale
         win.update_data(updated)
         assert win.receivers(win.sigFitFinished) == initial_receivers
+
+
+def test_fit1d_update_data_auto_refit_after_waiting_cancelled_thread(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_1d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    class _FinishedThread:
+        def __init__(self) -> None:
+            self.cancel_called = False
+            self.interrupted = False
+            self.wait_timeout_ms: int | None = None
+            self.deleted = False
+
+        def cancel(self) -> None:
+            self.cancel_called = True
+
+        def requestInterruption(self) -> None:
+            self.interrupted = True
+
+        def wait(self, timeout_ms: int) -> bool:
+            self.wait_timeout_ms = timeout_ms
+            return True
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    old_thread = _FinishedThread()
+    win._fit_thread = old_thread  # type: ignore[assignment]
+    win._last_result_ds = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+
+    started: list[bool] = []
+
+    def _start_fit_worker(*args, **kwargs) -> bool:
+        started.append(True)
+        assert win._fit_thread is None
+        return True
+
+    monkeypatch.setattr(win, "_start_fit_worker", _start_fit_worker)
+
+    updated = data.copy(deep=True)
+    updated.data = np.asarray(updated.data) * 1.1
+
+    assert win.update_data(updated) is True
+    assert started == [True]
+    assert old_thread.cancel_called
+    assert old_thread.interrupted
+    assert old_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
+    assert old_thread.deleted is True
+
+
+def test_fit1d_queue_fit_action_ignores_stale_thread(qtbot) -> None:
+    data = _make_1d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    class _ThreadPlaceholder:
+        def cancel(self) -> None:
+            return
+
+        def requestInterruption(self) -> None:
+            return
+
+        def wait(self, timeout_ms: int) -> bool:
+            return True
+
+        def deleteLater(self) -> None:
+            return
+
+    stale_thread = _ThreadPlaceholder()
+    current_thread = _ThreadPlaceholder()
+    win._fit_thread = current_thread  # type: ignore[assignment]
+
+    called: list[str] = []
+    win._queue_fit_action(
+        stale_thread,  # type: ignore[arg-type]
+        lambda: called.append("stale"),
+    )
+    assert called == []
+    assert win._pending_fit_action is None
 
 
 def test_parameter_table_model_and_delegate(qtbot) -> None:
@@ -682,7 +813,7 @@ def test_fit1d_queue_fit_action_no_thread(qtbot) -> None:
         called.append(True)
 
     win._fit_thread = None
-    win._queue_fit_action(_action)
+    win._queue_fit_action(None, _action)  # type: ignore[arg-type]
     assert called
 
 
@@ -719,6 +850,7 @@ def test_fit1d_cancel_fit_waits_for_thread(qtbot) -> None:
             self.cancel_called = False
             self.interrupted = False
             self.wait_timeout_ms: int | None = None
+            self.deleted = False
 
         def cancel(self) -> None:
             self.cancel_called = True
@@ -733,6 +865,9 @@ def test_fit1d_cancel_fit_waits_for_thread(qtbot) -> None:
             self.wait_timeout_ms = timeout_ms
             return True
 
+        def deleteLater(self) -> None:
+            self.deleted = True
+
     dummy_thread = _DummyThread()
     win._fit_thread = dummy_thread  # type: ignore[assignment]
 
@@ -740,6 +875,7 @@ def test_fit1d_cancel_fit_waits_for_thread(qtbot) -> None:
     assert dummy_thread.cancel_called
     assert dummy_thread.interrupted
     assert dummy_thread.wait_timeout_ms == 5000
+    assert dummy_thread.deleted
 
 
 def test_fit1d_cancel_fit_waits_without_timeout(qtbot) -> None:
@@ -752,6 +888,7 @@ def test_fit1d_cancel_fit_waits_without_timeout(qtbot) -> None:
             self.cancel_called = False
             self.interrupted = False
             self.wait_args: tuple[object, ...] | None = None
+            self.deleted = False
 
         def cancel(self) -> None:
             self.cancel_called = True
@@ -766,6 +903,9 @@ def test_fit1d_cancel_fit_waits_without_timeout(qtbot) -> None:
             self.wait_args = args
             return True
 
+        def deleteLater(self) -> None:
+            self.deleted = True
+
     dummy_thread = _DummyThread()
     win._fit_thread = dummy_thread  # type: ignore[assignment]
 
@@ -773,6 +913,7 @@ def test_fit1d_cancel_fit_waits_without_timeout(qtbot) -> None:
     assert dummy_thread.cancel_called
     assert dummy_thread.interrupted
     assert dummy_thread.wait_args == ()
+    assert dummy_thread.deleted
 
 
 def test_fit1d_close_event_ignored_if_thread_does_not_stop(qtbot) -> None:
@@ -1064,7 +1205,7 @@ def test_fit1d_finalize_fit_thread_cancelled_deletes_thread(qtbot) -> None:
     win._fit_cancel_requested = True
     win._fit_cancelled = lambda: cancelled.__setitem__("value", True)  # type: ignore[method-assign]
 
-    win._finalize_fit_thread()
+    win._finalize_fit_thread(thread)  # type: ignore[arg-type]
 
     assert cancelled["value"]
     assert thread.deleted

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -216,6 +216,78 @@ def test_fit2d_run_fit(qtbot, exp_decay_model, monkeypatch) -> None:
     assert ".isel(" in code
 
 
+def test_fit2d_update_data_preserves_state_and_refit(
+    qtbot, exp_decay_model, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        data, model=exp_decay_model, params=params, execute=False
+    )
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    win.y_index_spin.setValue(1)
+    index = win.param_model.index(0, 1)
+    assert win.param_model.setData(index, "2.0", QtCore.Qt.ItemDataRole.EditRole)
+    win.y_min_spin.setValue(1)
+    win.y_max_spin.setValue(2)
+    win.refit_on_source_update_check.setChecked(False)
+    win._last_result_ds = xr.Dataset()
+
+    called: list[bool] = []
+    monkeypatch.setattr(win, "_run_fit", lambda: called.append(True) or True)
+
+    status = win.tool_status
+    new_data = data.copy(deep=True)
+    new_data.data = np.asarray(new_data.data) * 1.1
+    win.update_data(new_data)
+
+    assert win.tool_status == status
+    xr.testing.assert_identical(win.tool_data, new_data)
+    assert win._fit_is_current is False
+    assert not called
+
+    win._last_result_ds = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+    newer_data = new_data.copy(deep=True)
+    newer_data.data = np.asarray(newer_data.data) * 1.05
+    win.update_data(newer_data)
+
+    assert called == [True]
+
+
+def test_fit2d_update_data_resizes_slice_state_and_keeps_param_sync(
+    qtbot, exp_decay_model
+) -> None:
+    data = _make_2d_data()
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        data, model=exp_decay_model, params=params, execute=False
+    )
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    win.y_index_spin.setValue(2)
+    win.y_min_spin.setValue(1)
+    win.y_max_spin.setValue(2)
+
+    new_data = data.isel(y=slice(0, 2)).copy(deep=True)
+    new_data.data = np.asarray(new_data.data) * 1.1
+    win.update_data(new_data)
+
+    assert win._current_idx == 1
+    assert len(win._params_full) == 2
+    assert len(win._params_from_coord_full) == 2
+    assert win.y_index_spin.maximum() == 1
+    xr.testing.assert_identical(win.tool_data, new_data)
+
+    index = win.param_model.index(0, 1)
+    assert win.param_model.setData(index, "3.0", QtCore.Qt.ItemDataRole.EditRole)
+    assert win._params_full[win._current_idx] is not None
+    assert win._params_full[win._current_idx]["n0"].value == pytest.approx(3.0)
+
+
 def test_fit2d_next_step_is_deferred(qtbot, monkeypatch) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -306,6 +306,23 @@ def test_fit2d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     xr.testing.assert_identical(win.tool_data, data)
 
 
+def test_fit2d_rebuild_paths_keep_fit_finished_receivers_constant(qtbot) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    initial_receivers = win.receivers(win.sigFitFinished)
+
+    updated = data.copy(deep=True)
+    updated.data = np.asarray(updated.data) * 1.1
+    win.update_data(updated)
+    assert win.receivers(win.sigFitFinished) == initial_receivers
+
+    win._do_transpose()
+    assert win.receivers(win.sigFitFinished) == initial_receivers
+
+
 def test_fit2d_next_step_is_deferred(qtbot, monkeypatch) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -288,6 +288,49 @@ def test_fit2d_update_data_resizes_slice_state_and_keeps_param_sync(
     assert win._params_full[win._current_idx]["n0"].value == pytest.approx(3.0)
 
 
+def test_fit2d_update_data_preserves_initial_params_full_for_reset_all(
+    qtbot, exp_decay_model, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        data, model=exp_decay_model, params=params, execute=False
+    )
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    first_params = win._params.copy()
+    first_params["n0"].set(value=1.0)
+    second_params = win._params.copy()
+    second_params["n0"].set(value=2.0)
+    win._params_full = [first_params.copy(), second_params.copy(), None]
+    win._initial_params_full = [
+        first_params.copy(),
+        second_params.copy(),
+        win._params.copy(),
+    ]
+
+    updated = data.copy(deep=True)
+    updated.data = np.asarray(updated.data) * 1.1
+    win.update_data(updated)
+
+    assert win._initial_params_full is not None
+    assert win._initial_params_full[0]["n0"].value == pytest.approx(1.0)
+    assert win._initial_params_full[1]["n0"].value == pytest.approx(2.0)
+
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+    win._reset_params_all()
+
+    assert win._params_full[0] is not None
+    assert win._params_full[1] is not None
+    assert win._params_full[0]["n0"].value == pytest.approx(1.0)
+    assert win._params_full[1]["n0"].value == pytest.approx(2.0)
+
+
 def test_fit2d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -10,6 +10,7 @@ from qtpy import QtCore, QtWidgets
 
 import erlab
 from erlab.interactive._fit2d import Fit2DTool
+from tests._qt_helpers import signal_receiver_count
 
 
 def _make_1d_data() -> xr.DataArray:
@@ -397,15 +398,21 @@ def test_fit2d_rebuild_paths_keep_fit_finished_receivers_constant(qtbot) -> None
     qtbot.addWidget(win)
     assert isinstance(win, Fit2DTool)
 
-    initial_receivers = win.receivers(win.sigFitFinished)
+    initial_receivers = signal_receiver_count(win, win.sigFitFinished, "sigFitFinished")
 
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.1
     win.update_data(updated)
-    assert win.receivers(win.sigFitFinished) == initial_receivers
+    assert (
+        signal_receiver_count(win, win.sigFitFinished, "sigFitFinished")
+        == initial_receivers
+    )
 
     win._do_transpose()
-    assert win.receivers(win.sigFitFinished) == initial_receivers
+    assert (
+        signal_receiver_count(win, win.sigFitFinished, "sigFitFinished")
+        == initial_receivers
+    )
 
 
 def test_fit2d_update_data_auto_refit_after_waiting_cancelled_thread(

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -288,6 +288,24 @@ def test_fit2d_update_data_resizes_slice_state_and_keeps_param_sync(
     assert win._params_full[win._current_idx]["n0"].value == pytest.approx(3.0)
 
 
+def test_fit2d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    old_central = win.centralWidget()
+    bad_data = _make_1d_data()
+
+    with pytest.raises(ValueError, match="2D DataArray"):
+        win.update_data(bad_data)
+
+    assert win.centralWidget() is old_central
+    assert old_central is not None
+    assert old_central.parent() is not None
+    xr.testing.assert_identical(win.tool_data, data)
+
+
 def test_fit2d_next_step_is_deferred(qtbot, monkeypatch) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -349,6 +349,48 @@ def test_fit2d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     xr.testing.assert_identical(win.tool_data, data)
 
 
+def test_fit2d_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    class _StuckThread:
+        def __init__(self) -> None:
+            self.cancel_called = False
+            self.interrupted = False
+            self.wait_timeout_ms: int | None = None
+
+        def cancel(self) -> None:
+            self.cancel_called = True
+
+        def isRunning(self) -> bool:
+            return True
+
+        def requestInterruption(self) -> None:
+            self.interrupted = True
+
+        def wait(self, timeout_ms: int) -> bool:
+            self.wait_timeout_ms = timeout_ms
+            return False
+
+    stuck_thread = _StuckThread()
+    win._fit_thread = stuck_thread  # type: ignore[assignment]
+    old_central = win.centralWidget()
+
+    updated = data.copy(deep=True)
+    updated.data = np.asarray(updated.data) * 1.1
+
+    assert win.update_data(updated) is False
+    assert stuck_thread.cancel_called
+    assert stuck_thread.interrupted
+    assert stuck_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
+    assert win.centralWidget() is old_central
+    assert old_central is not None
+    assert old_central.parent() is not None
+    xr.testing.assert_identical(win.tool_data, data)
+
+
 def test_fit2d_rebuild_paths_keep_fit_finished_receivers_constant(qtbot) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)
@@ -364,6 +406,59 @@ def test_fit2d_rebuild_paths_keep_fit_finished_receivers_constant(qtbot) -> None
 
     win._do_transpose()
     assert win.receivers(win.sigFitFinished) == initial_receivers
+
+
+def test_fit2d_update_data_auto_refit_after_waiting_cancelled_thread(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    class _FinishedThread:
+        def __init__(self) -> None:
+            self.cancel_called = False
+            self.interrupted = False
+            self.wait_timeout_ms: int | None = None
+            self.deleted = False
+
+        def cancel(self) -> None:
+            self.cancel_called = True
+
+        def requestInterruption(self) -> None:
+            self.interrupted = True
+
+        def wait(self, timeout_ms: int) -> bool:
+            self.wait_timeout_ms = timeout_ms
+            return True
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    old_thread = _FinishedThread()
+    win._fit_thread = old_thread  # type: ignore[assignment]
+    win._last_result_ds = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+
+    started: list[bool] = []
+
+    def _start_fit_worker(*args, **kwargs) -> bool:
+        started.append(True)
+        assert win._fit_thread is None
+        return True
+
+    monkeypatch.setattr(win, "_start_fit_worker", _start_fit_worker)
+
+    updated = data.copy(deep=True)
+    updated.data = np.asarray(updated.data) * 1.1
+
+    assert win.update_data(updated) is True
+    assert started == [True]
+    assert old_thread.cancel_called
+    assert old_thread.interrupted
+    assert old_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
+    assert old_thread.deleted is True
 
 
 def test_fit2d_next_step_is_deferred(qtbot, monkeypatch) -> None:

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -811,3 +811,34 @@ def test_get_bz_lines_uses_legacy_hv_path_for_scalar_other_axis(monkeypatch) -> 
     assert np.allclose(lines[0], expected_lines[0])
     assert np.allclose(vertices, expected_vertices)
     assert np.allclose(midpoints, expected_midpoints)
+
+
+def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
+    data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5)).copy(
+        deep=True
+    )
+    win = ktool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.center_spin.setValue(float(data.eV.values[2]))
+    win.width_spin.setValue(3)
+    win.bounds_supergroup.setChecked(True)
+    win.resolution_supergroup.setChecked(True)
+    win.preview_symmetry_group.setChecked(True)
+    win.preview_symmetry_fold_spin.setValue(4)
+    win._offset_spins["delta"].setValue(5.0)
+    win._offset_spins["wf"].setValue(4.6)
+    if "beta" in win._offset_spins:
+        win._offset_spins["beta"].setValue(-1.5)
+    win.add_circle_btn.click()
+    win._roi_list[0].set_position((0.1, 0.2), 0.25)
+
+    status = win.tool_status
+    new_data = data.copy(deep=True)
+    new_data.data = np.asarray(new_data.data) * 1.1
+    win.update_data(new_data)
+
+    assert win.tool_status == status
+    xr.testing.assert_identical(win.tool_data, new_data)
+    assert win.images[0].data_array is not None
+    assert win.images[1].data_array is not None

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -842,3 +842,58 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
     xr.testing.assert_identical(win.tool_data, new_data)
     assert win.images[0].data_array is not None
     assert win.images[1].data_array is not None
+
+
+def test_ktool_update_data_with_single_energy_disables_energy_group(
+    qtbot, anglemap
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(1, 2)).copy(
+        deep=True
+    )
+    win = ktool(data, execute=False)
+    qtbot.addWidget(win)
+
+    fixed_energy = float(data.eV.values[0])
+    assert win.energy_group.isEnabled() is False
+    assert win.center_spin.value() == pytest.approx(fixed_energy, abs=1e-3)
+    assert win.center_spin.minimum() == pytest.approx(fixed_energy - 0.1, abs=1e-3)
+    assert win.center_spin.maximum() == pytest.approx(fixed_energy + 0.1, abs=1e-3)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        (
+            "_valid_offset_keys",
+            ("delta",),
+            "incompatible offset coordinates",
+        ),
+        ("momentum_axes", ("kx",), "incompatible momentum axes"),
+        ("configuration", 999, "incompatible analyzer configuration"),
+        ("_has_hv", True, "incompatible photon-energy dimensions"),
+    ],
+)
+def test_ktool_validate_update_data_rejects_incompatible_metadata(
+    qtbot, anglemap, monkeypatch, field, value, match
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5)).copy(
+        deep=True
+    )
+    win = ktool(data, execute=False)
+    qtbot.addWidget(win)
+
+    fake_kspace = SimpleNamespace(
+        _valid_offset_keys=tuple(win.data.kspace._valid_offset_keys),
+        momentum_axes=tuple(win.data.kspace.momentum_axes),
+        configuration=int(win.data.kspace.configuration),
+        _has_hv=win.data.kspace._has_hv,
+    )
+    setattr(fake_kspace, field, value)
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "parse_data",
+        lambda _: SimpleNamespace(kspace=fake_kspace),
+    )
+
+    with pytest.raises(ValueError, match=match):
+        win.validate_update_data(object())

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -860,6 +860,39 @@ def test_ktool_update_data_with_single_energy_disables_energy_group(
     assert win.center_spin.maximum() == pytest.approx(fixed_energy + 0.1, abs=1e-3)
 
 
+def test_ktool_update_data_reconnects_energy_controls_after_single_energy(
+    qtbot, anglemap, monkeypatch
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(1, 2)).copy(
+        deep=True
+    )
+    updated = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5)).copy(
+        deep=True
+    )
+    win = ktool(data, execute=False)
+    qtbot.addWidget(win)
+
+    update_calls: list[None] = []
+    original_update = win.update
+
+    def _wrapped_update() -> None:
+        update_calls.append(None)
+        original_update()
+
+    monkeypatch.setattr(win, "update", _wrapped_update)
+
+    win.update_data(updated)
+    assert win.energy_group.isEnabled() is True
+
+    update_calls.clear()
+    win.center_spin.setValue(float(updated.eV.values[2]))
+    qtbot.wait_until(lambda: len(update_calls) > 0, timeout=5000)
+
+    update_calls.clear()
+    win.width_spin.setValue(3)
+    qtbot.wait_until(lambda: len(update_calls) > 0, timeout=5000)
+
+
 @pytest.mark.parametrize(
     ("field", "value", "match"),
     [

--- a/tests/interactive/test_mesh.py
+++ b/tests/interactive/test_mesh.py
@@ -219,3 +219,35 @@ def test_meshtool_autofind_invalid_peaks_reraises_in_manager(
     assert win.p0_spin1.value() == 12
     assert win.p1_spin0.value() == 10
     assert win.p1_spin1.value() == 20
+
+
+def test_meshtool_update_data_preserves_state(qtbot, meshy_data) -> None:
+    win: MeshTool = meshtool(meshy_data, execute=False)
+    qtbot.addWidget(win)
+
+    win.order_spin.setValue(2)
+    win.n_pad_spin.setValue(1)
+    win.roi_hw_spin.setValue(6)
+    win.k_spin.setValue(0.2)
+    win.feather_spin.setValue(0.5)
+    win.undo_edge_correction_check.setChecked(True)
+    win.method_combo.setCurrentText("gaussian")
+    win.p0_spin0.setValue(12)
+    win.p0_spin1.setValue(18)
+    win.p1_spin0.setValue(20)
+    win.p1_spin1.setValue(10)
+
+    status = win.tool_status
+    new_data = meshy_data.copy(deep=True)
+    new_data.data = np.asarray(new_data.data) * 1.2
+    win.update()
+    assert win._corrected is not None
+    assert win._mesh is not None
+
+    win.update_data(new_data)
+
+    assert win.tool_status == status
+    xr.testing.assert_identical(win.tool_data, new_data)
+    assert win._corrected is None
+    assert win._mesh is None
+    assert win.main_image.data_array is not None


### PR DESCRIPTION
Child tools opened from ImageTool, such as `dtool`, `goldtool`, `restool`, `ktool`, and `meshtool`, now keep track of the selection they were opened from. When the parent ImageTool is updated with compatible new data, for example after reload, replace, watch updates, or in-place editing dialogs, those tools no longer silently stay on outdated data. Instead, they are marked as stale or unavailable in both the tool window and the ImageTool manager. Users can click the marker to refresh the tool from the latest source data, and can optionally enable automatic updates for future replacements. This makes real-time and iterative analysis much smoother because helper tools no longer need to be reopened every time the parent data changes.