### PR TITLE
feat(io.plugins.merlin): add support for loading beamline control system scans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ io = [
     "astropy>=5.1.1",
     "nexusformat>=1.0.6",
     "zarr>=3.1.2",
+    "pillow>=10.0.0",
 ]
 perf = ["numbagg>=0.8.1"]
 misc = ["iminuit>=2.25.2,!=2.31.2", "csaps>=1.1.0", "numdifftools>=0.9.42"]

--- a/src/erlab/io/plugins/merlin.py
+++ b/src/erlab/io/plugins/merlin.py
@@ -1,8 +1,10 @@
 """Data loader for beamline 4.0.3 at ALS."""
 
-__all__ = ["MERLINLoader"]
+__all__ = ["MERLINLoader", "load_bcs"]
 
+import csv
 import datetime
+import json
 import os
 import pathlib
 import re
@@ -16,6 +18,10 @@ import xarray as xr
 
 import erlab
 from erlab.io.dataloader import LoaderBase
+
+_BCSHeader = dict[str, typing.Any]
+_BCSRow = dict[str, str]
+_FloatArray = npt.NDArray[np.float64]
 
 
 def _format_polarization(val) -> str:
@@ -41,6 +47,212 @@ def _determine_kind(data: xr.DataArray) -> str:
     if "hv" in data.dims:
         data_type = "hvdep"
     return data_type
+
+
+def _unique_name(name: str, existing: set[str]) -> str:
+    if name not in existing:
+        existing.add(name)
+        return name
+
+    candidate = f"{name} raw"
+    if candidate not in existing:
+        existing.add(candidate)
+        return candidate
+
+    index = 1
+    while f"{candidate} {index}" in existing:
+        index += 1
+
+    unique = f"{candidate} {index}"
+    existing.add(unique)
+    return unique
+
+
+def load_bcs(path: str | os.PathLike) -> xr.DataArray | xr.DataTree:
+    """Load a beamline control system scan.
+
+    Parameters
+    ----------
+    path
+        Path to the BCS text file. The image files referenced by the data table are
+        resolved relative to the text file and, when needed, from a sibling directory
+        named ``"<text file stem> Images"``.
+
+    Returns
+    -------
+    xarray.DataArray or xarray.DataTree
+        A data array containing the compiled image stack for BCS files with one image
+        column. If a file contains multiple image columns, each image stream is loaded
+        into a separate child node of a data tree.
+    """
+    path = pathlib.Path(path)
+
+    lines = path.read_text(encoding="utf-8-sig").splitlines()
+    try:
+        header_start = next(
+            i for i, line in enumerate(lines) if line.strip() == "HEADER"
+        )
+        data_start = next(i for i, line in enumerate(lines) if line.strip() == "DATA")
+    except StopIteration as err:
+        raise ValueError(f"{path} is not a valid BCS data file") from err
+
+    if data_start <= header_start or data_start + 1 >= len(lines):
+        raise ValueError(f"{path} is missing BCS data table")
+
+    header = typing.cast(
+        "_BCSHeader",
+        json.loads("\n".join(lines[header_start + 1 : data_start]).strip()),
+    )
+    reader = csv.DictReader(lines[data_start + 1 :], delimiter="\t")
+    columns = list(reader.fieldnames or ())
+    rows = typing.cast("list[_BCSRow]", list(reader))
+    if not rows:
+        raise ValueError(f"{path} contains no BCS data rows")
+
+    image_columns = [
+        column
+        for column in columns
+        if any(str(row.get(column, "")).lower().endswith(".png") for row in rows)
+    ]
+    if not image_columns:
+        raise ValueError(f"{path} contains no BCS image columns")
+
+    numeric_columns: dict[str, _FloatArray] = {}
+    for column in columns:
+        if column in image_columns:
+            continue
+
+        values: list[float] = []
+        for row in rows:
+            value = row.get(column)
+            if value is None or value == "":
+                break
+            try:
+                values.append(float(value))
+            except ValueError:
+                break
+        else:
+            numeric_columns[column] = np.asarray(values, dtype=np.float64)
+
+    scan_type = header.get("Scan Type", "")
+    scan_info = header.get(scan_type, {})
+    scan_motor = scan_info.get("X Motor") if isinstance(scan_info, dict) else None
+    scan_dim = str(scan_motor) if scan_motor else "step"
+    goal_column: str | None = f"{scan_dim} Goal"
+    if goal_column in numeric_columns:
+        scan_values = numeric_columns[goal_column]
+    elif scan_dim in numeric_columns:
+        scan_values = numeric_columns[scan_dim]
+        goal_column = scan_dim
+    else:
+        scan_values = np.arange(len(rows), dtype=np.float64)
+        goal_column = None
+
+    constant_values: dict[str, float] = {}
+    varying_columns: dict[str, _FloatArray] = {}
+    for column, column_values in numeric_columns.items():
+        if column == goal_column:
+            continue
+        if np.all(column_values == column_values[0]):
+            constant_values[column] = float(column_values[0])
+        else:
+            varying_columns[column] = column_values
+
+    try:
+        from PIL import Image
+    except ImportError as err:
+        raise ImportError(
+            "PIL is required to load BCS files with image columns. "
+            "Please install `erlab[io]` or Pillow to use this feature."
+        ) from err
+
+    data: dict[str, xr.DataArray] = {}
+    for image_column in image_columns:
+        images: list[npt.NDArray[np.generic]] = []
+        for row in rows:
+            image_ref = row[image_column]
+            normalized_ref = pathlib.Path(image_ref.strip().replace("\\", "/"))
+            if normalized_ref.is_absolute():
+                candidates: tuple[pathlib.Path, ...] = (normalized_ref,)
+            else:
+                candidates = (
+                    path.parent / normalized_ref,
+                    path.parent / f"{path.stem} Images" / normalized_ref.name,
+                )
+
+            image_path = next(
+                (candidate for candidate in candidates if candidate.is_file()), None
+            )
+            if image_path is None:
+                raise FileNotFoundError(
+                    f"Could not find BCS image {image_ref!r} for {path.name}"
+                )
+
+            with Image.open(image_path) as image:
+                images.append(np.asarray(image).copy())
+
+        try:
+            image_stack = np.stack(images, axis=0)
+        except ValueError as err:
+            raise ValueError("All BCS images must have the same shape") from err
+
+        image_shape = image_stack.shape[1:]
+        if len(image_shape) == 2:
+            dims: tuple[str, ...] = (scan_dim, "y", "x")
+        elif len(image_shape) == 3:
+            dims = (scan_dim, "y", "x", "channel")
+        else:
+            raise ValueError("BCS images must be two-dimensional or RGB/RGBA images")
+
+        coords: dict[str, typing.Any] = {
+            scan_dim: scan_values,
+            "y": np.arange(image_shape[0]),
+            "x": np.arange(image_shape[1]),
+        }
+        existing_coords = set(coords)
+        if len(image_shape) == 3:
+            coords["channel"] = np.arange(image_shape[2])
+            existing_coords.add("channel")
+
+        for column, coord_values in varying_columns.items():
+            coords[_unique_name(column, existing_coords)] = (scan_dim, coord_values)
+
+        for column, coord_values in constant_values.items():
+            coords[_unique_name(column, existing_coords)] = coord_values
+
+        motors = header.get("Motors", {})
+        if isinstance(motors, dict):
+            for motor_name, motor_value in motors.items():
+                if motor_name not in existing_coords:
+                    coords[motor_name] = motor_value
+                    existing_coords.add(motor_name)
+
+        attrs: dict[str, typing.Any] = {}
+        existing_attrs = set(attrs)
+        for attr_name, attr_value in header.items():
+            if attr_name in {"General", "Motors"}:
+                continue
+            if attr_name not in existing_coords:
+                attrs[_unique_name(attr_name, existing_attrs)] = attr_value
+
+        data[image_column] = xr.DataArray(
+            image_stack,
+            dims=dims,
+            coords=coords,
+            name=image_column,
+            attrs=attrs,
+        )
+
+    if len(image_columns) == 1:
+        return data[image_columns[0]]
+
+    existing: set[str] = set()
+    return xr.DataTree.from_dict(
+        {
+            _unique_name(image_column.replace("/", "_"), existing): darr.to_dataset()
+            for image_column, darr in data.items()
+        }
+    )
 
 
 class MERLINLoader(LoaderBase):
@@ -115,6 +327,7 @@ class MERLINLoader(LoaderBase):
     def file_dialog_methods(self):
         return {
             "ALS BL4.0.3 Data (*.pxt *.ibw)": (self.load, {}),
+            "ALS BL4.0.3 BCS Data (*.txt)": (load_bcs, {}),
             "ALS BL4.0.3 Single File (*.pxt)": (self.load, {"single": True}),
         }
 

--- a/tests/io/plugins/test_merlin.py
+++ b/tests/io/plugins/test_merlin.py
@@ -1,9 +1,12 @@
+import json
 import shutil
 
+import numpy as np
 import pytest
 import xarray as xr
 
 import erlab
+from erlab.io.plugins.merlin import load_bcs
 
 
 @pytest.fixture(scope="module")
@@ -95,3 +98,108 @@ hv (hv): 100\nentrance slit (Entrance Slit): 70\nexit slit (Exit Slit): 70
 polar (beta): [-15.5, -15]\ntilt (xi): 0\nazi (delta): 3\nx (x): 2.487\ny (y): 0.578
 z (z): -1.12"""
     )
+
+
+def _write_bcs_scan(
+    tmp_path,
+    *,
+    image_columns: tuple[str, ...] = ("DiagOn YAG",),
+) -> tuple:
+    image_module = pytest.importorskip("PIL.Image")
+    scan_path = tmp_path / "Single Motor Scan 000001.txt"
+    image_dir = tmp_path / "Single Motor Scan 000001 Images"
+    image_dir.mkdir()
+
+    header = {
+        "Scan Type": "Single Motor Scan",
+        "Version": "4",
+        "General": {"Date": "Apr 22 2026, 02:44:50.789 -07:00:00"},
+        "Single Motor Scan": {"X Motor": "EPU Gap", "Start": 20.0, "Stop": 20.2},
+        "Motors": {
+            "EPU Gap": 999.0,
+            "Beamline Energy": 30.0,
+            "DiagOn Z": -48.0,
+        },
+        "Notes": {"operator": "test"},
+    }
+    columns = [
+        "Time (s)",
+        "EPU Gap Goal",
+        "EPU Gap Actual",
+        "EPU Gap",
+        "Beam Current",
+        "Const Trace",
+        *image_columns,
+    ]
+    rows = []
+    expected_images = {}
+    for i in range(2):
+        row = [
+            f"{float(i):.1f}",
+            f"{20.0 + 0.2 * i:.1f}",
+            f"{20.01 + 0.2 * i:.2f}",
+            "0.0",
+            f"{500.0 + i:.1f}",
+            "7.0",
+        ]
+        for image_column in image_columns:
+            values = np.arange(6, dtype=np.uint16).reshape(2, 3) + i * 10
+            if len(image_columns) > 1:
+                values = values + 100 * image_columns.index(image_column)
+            image_name = f"Single Motor Scan 000001 {image_column} {i:03d}.png"
+            image_module.fromarray(values).save(image_dir / image_name)
+            row.append(rf"..\Single Motor Scan 000001 Images\{image_name}")
+            expected_images.setdefault(image_column, []).append(values)
+        rows.append(row)
+
+    data_table = "\t".join(columns) + "\n" + "\n".join("\t".join(row) for row in rows)
+    scan_path.write_text(
+        f"HEADER\n{json.dumps(header, indent=4)}\nDATA\n{data_table}",
+        encoding="utf-8",
+    )
+    return scan_path, expected_images
+
+
+def test_load_bcs_dataarray(tmp_path) -> None:
+    scan_path, expected_images = _write_bcs_scan(tmp_path)
+
+    data = load_bcs(scan_path)
+
+    assert isinstance(data, xr.DataArray)
+    assert data.dims == ("EPU Gap", "y", "x")
+    assert data.dtype == np.uint16
+    np.testing.assert_array_equal(data.values, np.stack(expected_images["DiagOn YAG"]))
+    np.testing.assert_allclose(data["EPU Gap"].values, [20.0, 20.2])
+    np.testing.assert_allclose(data["EPU Gap Actual"].values, [20.01, 20.21])
+    np.testing.assert_allclose(data["Beam Current"].values, [500.0, 501.0])
+
+    assert data["Const Trace"].dims == ()
+    assert float(data["Const Trace"]) == 7.0
+    assert data["Beamline Energy"].dims == ()
+    assert float(data["Beamline Energy"]) == 30.0
+    assert data["DiagOn Z"].dims == ()
+    assert float(data["DiagOn Z"]) == -48.0
+    assert "EPU Gap raw" in data.coords
+    assert "General" not in data.attrs
+    assert "Motors" not in data.attrs
+    assert data.attrs["Scan Type"] == "Single Motor Scan"
+    assert data.attrs["Notes"] == {"operator": "test"}
+
+
+def test_load_bcs_multiple_image_columns(tmp_path) -> None:
+    scan_path, expected_images = _write_bcs_scan(
+        tmp_path, image_columns=("DiagOn YAG", "Camera 2")
+    )
+
+    data = load_bcs(scan_path)
+
+    assert isinstance(data, xr.DataTree)
+    assert set(data.children) == {"DiagOn YAG", "Camera 2"}
+    for image_column in expected_images:
+        arr = data[image_column].to_dataset()[image_column]
+        np.testing.assert_array_equal(
+            arr.values, np.stack(expected_images[image_column])
+        )
+        np.testing.assert_allclose(arr["EPU Gap"].values, [20.0, 20.2])
+        assert "General" not in arr.attrs
+        assert "Motors" not in arr.attrs

--- a/tests/io/plugins/test_merlin.py
+++ b/tests/io/plugins/test_merlin.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 import shutil
 
@@ -6,6 +7,7 @@ import pytest
 import xarray as xr
 
 import erlab
+from erlab.io.plugins import merlin as merlin_plugin
 from erlab.io.plugins.merlin import load_bcs
 
 
@@ -129,6 +131,8 @@ def _write_bcs_scan(
         "EPU Gap",
         "Beam Current",
         "Const Trace",
+        "Empty Trace",
+        "Text Trace",
         *image_columns,
     ]
     rows = []
@@ -141,6 +145,8 @@ def _write_bcs_scan(
             "0.0",
             f"{500.0 + i:.1f}",
             "7.0",
+            "",
+            "bad",
         ]
         for image_column in image_columns:
             values = np.arange(6, dtype=np.uint16).reshape(2, 3) + i * 10
@@ -158,6 +164,20 @@ def _write_bcs_scan(
         encoding="utf-8",
     )
     return scan_path, expected_images
+
+
+def _write_bcs_text(scan_path, header, columns, rows) -> None:
+    data_table = "\t".join(columns) + "\n" + "\n".join("\t".join(row) for row in rows)
+    scan_path.write_text(
+        f"HEADER\n{json.dumps(header, indent=4)}\nDATA\n{data_table}",
+        encoding="utf-8",
+    )
+
+
+def _save_png(path, values) -> None:
+    image_module = pytest.importorskip("PIL.Image")
+    path.parent.mkdir(exist_ok=True)
+    image_module.fromarray(np.asarray(values)).save(path)
 
 
 def test_load_bcs_dataarray(tmp_path) -> None:
@@ -180,6 +200,8 @@ def test_load_bcs_dataarray(tmp_path) -> None:
     assert data["DiagOn Z"].dims == ()
     assert float(data["DiagOn Z"]) == -48.0
     assert "EPU Gap raw" in data.coords
+    assert "Empty Trace" not in data.coords
+    assert "Text Trace" not in data.coords
     assert "General" not in data.attrs
     assert "Motors" not in data.attrs
     assert data.attrs["Scan Type"] == "Single Motor Scan"
@@ -203,3 +225,165 @@ def test_load_bcs_multiple_image_columns(tmp_path) -> None:
         np.testing.assert_allclose(arr["EPU Gap"].values, [20.0, 20.2])
         assert "General" not in arr.attrs
         assert "Motors" not in arr.attrs
+
+
+def test_load_bcs_scan_axis_fallbacks(tmp_path) -> None:
+    image_path = tmp_path / "fallback.png"
+    _save_png(image_path, np.arange(6, dtype=np.uint16).reshape(2, 3))
+
+    scan_path = tmp_path / "readback.txt"
+    _write_bcs_text(
+        scan_path,
+        {"Scan Type": "Single Motor Scan", "Single Motor Scan": {"X Motor": "Motor"}},
+        ["Motor", "Image"],
+        [["1.5", str(image_path)]],
+    )
+    data = load_bcs(scan_path)
+    assert data.dims == ("Motor", "y", "x")
+    np.testing.assert_allclose(data["Motor"].values, [1.5])
+
+    scan_path = tmp_path / "step.txt"
+    _write_bcs_text(
+        scan_path,
+        {
+            "Scan Type": "Single Motor Scan",
+            "Single Motor Scan": {"X Motor": "Missing"},
+            "Missing": "already a coord",
+            "Motors": None,
+        },
+        ["Image"],
+        [[str(image_path)]],
+    )
+    data = load_bcs(scan_path)
+    assert data.dims == ("Missing", "y", "x")
+    np.testing.assert_allclose(data["Missing"].values, [0.0])
+    assert "Missing" not in data.attrs
+    assert "Motors" not in data.attrs
+
+
+def test_load_bcs_absolute_rgb_images(tmp_path) -> None:
+    paths = [tmp_path / f"rgb_{i}.png" for i in range(2)]
+    for i, path in enumerate(paths):
+        _save_png(path, np.full((2, 3, 3), i, dtype=np.uint8))
+
+    scan_path = tmp_path / "rgb.txt"
+    _write_bcs_text(
+        scan_path,
+        {"Scan Type": "Single Motor Scan"},
+        ["Image"],
+        [[str(path)] for path in paths],
+    )
+
+    data = load_bcs(scan_path)
+
+    assert data.dims == ("step", "y", "x", "channel")
+    np.testing.assert_array_equal(data["step"].values, [0.0, 1.0])
+    np.testing.assert_array_equal(data["channel"].values, [0, 1, 2])
+    assert data.shape == (2, 2, 3, 3)
+
+
+@pytest.mark.parametrize(
+    ("text", "match"),
+    [
+        ("DATA\nx\n1\n", "not a valid BCS data file"),
+        ("HEADER\n{}\nDATA\n", "missing BCS data table"),
+        ("HEADER\n{}\nDATA\nx\n", "contains no BCS data rows"),
+        ("HEADER\n{}\nDATA\nx\n1\n", "contains no BCS image columns"),
+    ],
+)
+def test_load_bcs_invalid_files(tmp_path, text, match) -> None:
+    scan_path = tmp_path / "invalid.txt"
+    scan_path.write_text(text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=match):
+        load_bcs(scan_path)
+
+
+def test_load_bcs_missing_image(tmp_path) -> None:
+    scan_path = tmp_path / "missing_image.txt"
+    _write_bcs_text(
+        scan_path,
+        {"Scan Type": "Single Motor Scan"},
+        ["Image"],
+        [["missing.png"]],
+    )
+
+    with pytest.raises(FileNotFoundError, match="Could not find BCS image"):
+        load_bcs(scan_path)
+
+
+def test_load_bcs_mismatched_image_shapes(tmp_path) -> None:
+    image_dir = tmp_path / "shape Images"
+    _save_png(image_dir / "a.png", np.zeros((2, 3), dtype=np.uint16))
+    _save_png(image_dir / "b.png", np.zeros((3, 3), dtype=np.uint16))
+    scan_path = tmp_path / "shape.txt"
+    _write_bcs_text(
+        scan_path,
+        {"Scan Type": "Single Motor Scan"},
+        ["Image"],
+        [
+            [r"..\shape Images\a.png"],
+            [r"..\shape Images\b.png"],
+        ],
+    )
+
+    with pytest.raises(ValueError, match="All BCS images must have the same shape"):
+        load_bcs(scan_path)
+
+
+def test_load_bcs_invalid_image_dimensions(tmp_path, monkeypatch) -> None:
+    image_path = tmp_path / "image.png"
+    image_path.touch()
+    scan_path = tmp_path / "invalid_image_dims.txt"
+    _write_bcs_text(
+        scan_path,
+        {"Scan Type": "Single Motor Scan"},
+        ["Image"],
+        [[str(image_path)]],
+    )
+
+    image_module = pytest.importorskip("PIL.Image")
+
+    class ScalarImage:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def __array__(self):
+            return np.asarray(1, dtype=np.uint16)
+
+    monkeypatch.setattr(image_module, "open", lambda _: ScalarImage())
+    with pytest.raises(
+        ValueError, match="BCS images must be two-dimensional or RGB/RGBA images"
+    ):
+        load_bcs(scan_path)
+
+
+def test_load_bcs_pillow_missing(tmp_path, monkeypatch) -> None:
+    scan_path = tmp_path / "no_pillow.txt"
+    _write_bcs_text(
+        scan_path,
+        {"Scan Type": "Single Motor Scan"},
+        ["Image"],
+        [["image.png"]],
+    )
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globalns=None, localns=None, fromlist=(), level=0):
+        if name == "PIL":
+            raise ImportError("blocked")
+        return real_import(name, globalns, localns, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="PIL is required"):
+        load_bcs(scan_path)
+
+
+def test_load_bcs_private_name_deduplication() -> None:
+    existing = {"name", "name raw", "name raw 1"}
+
+    assert merlin_plugin._unique_name("name", existing) == "name raw 2"
+    assert "name raw 2" in existing

--- a/uv.lock
+++ b/uv.lock
@@ -904,11 +904,13 @@ complete = [
     { name = "nexusformat" },
     { name = "numbagg" },
     { name = "numdifftools" },
+    { name = "pillow" },
     { name = "zarr" },
 ]
 io = [
     { name = "astropy" },
     { name = "nexusformat" },
+    { name = "pillow" },
     { name = "zarr" },
 ]
 misc = [
@@ -1006,6 +1008,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pickleshare", specifier = ">=0.7.5" },
+    { name = "pillow", marker = "extra == 'io'", specifier = ">=10.0.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pygments", specifier = ">=2.11.0" },
     { name = "pyperclip", specifier = ">=1.8.2" },


### PR DESCRIPTION
Adds a new function `load_bcs` to the MERLIN plugin, which can load beamline control system (BCS) scan data from text files. Currently only tested with DiagOn images, but should be flexible enough to support other image columns and varying/constant numeric columns.

This adds Pillow as a new optional dependency which is required to load `.png` image files.