### PR TITLE
feat(imagetool): support Igor binary wave export

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -290,7 +290,7 @@ Python. See {ref}`workflow-bridge-operations` for the maintained crosswalk.
 
 ## Exporting and settings
 
-- {guilabel}`File → Save As…` exports the current data to NetCDF or HDF5.
+- {guilabel}`File → Save As…` exports the current data to NetCDF, HDF5, or Igor Binary Wave (`.ibw`).
 
 - {guilabel}`File → Move to Manager` hands the window off to the {ref}`ImageTool manager <imagetool-manager>`.
 

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -475,7 +475,7 @@ class ImageTool(BaseImageTool):
         if not native:
             dialog.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog)
 
-        # To avoid importing erlab.io, we define the following functions here
+        # Keep format-specific saver logic local to the export action.
         def _add_igor_scaling(darr: xr.DataArray) -> xr.DataArray:
             scaling = [[1, 0]]
             for i in range(darr.ndim):
@@ -493,12 +493,23 @@ class ImageTool(BaseImageTool):
         def _to_hdf5(darr: xr.DataArray, file: str, **kwargs) -> None:
             _to_netcdf(_add_igor_scaling(darr), file, **kwargs)
 
+        def _to_igor_wave(darr: xr.DataArray, file: str) -> None:
+            implicit_coords = {
+                dim: np.arange(darr.sizes[dim], dtype=np.float64)
+                for dim in darr.dims
+                if dim not in darr.coords
+            }
+            if implicit_coords:
+                darr = darr.assign_coords(implicit_coords)
+            erlab.io.igor.save_wave(darr, file)
+
         valid_savers: dict[str, tuple[Callable, dict[str, typing.Any]]] = {
             "xarray HDF5 Files (*.h5)": (
                 _to_hdf5,
                 {"engine": "h5netcdf", "invalid_netcdf": True},
             ),
             "NetCDF Files (*.nc *.nc4 *.cdf)": (_to_netcdf, {}),
+            "Igor Binary Waves (*.ibw)": (_to_igor_wave, {}),
         }
 
         dialog.setNameFilters(valid_savers.keys())

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1084,6 +1084,34 @@ def test_itool_save(qtbot, accept_dialog) -> None:
     win.close()
 
 
+def test_itool_save_igor_wave(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(25, dtype=np.float32).reshape((5, 5)), dims=["x", "y"], name="wave0"
+    )
+    expected = data.assign_coords(
+        {dim: np.arange(data.sizes[dim], dtype=np.float64) for dim in data.dims}
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        filename = f"{tmp_dir_name}/data.ibw"
+
+        def _go_to_file(dialog: QtWidgets.QFileDialog):
+            dialog.selectNameFilter("Igor Binary Waves (*.ibw)")
+            dialog.setDirectory(tmp_dir_name)
+            dialog.selectFile(filename)
+            focused = dialog.focusWidget()
+            if isinstance(focused, QtWidgets.QLineEdit):
+                focused.setText("data.ibw")
+
+        accept_dialog(lambda: win._export_file(native=False), pre_call=_go_to_file)
+        loaded = xr.load_dataarray(filename, engine="erlab-igor")
+        xr.testing.assert_allclose(loaded, expected, atol=1e-6)
+
+    win.close()
+
+
 @pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
 def test_itool_general(qtbot, move_and_compare_values, use_dask) -> None:
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])


### PR DESCRIPTION
ImageTool’s File -> Save As dialog now includes an Igor Binary Waves (`.ibw`) option. Exports use `erlab.io.igor.save_wave`, making it easier to save displayed data directly for use in Igor Pro.