### PR TITLE
[codex] Make ImageTool manager row badges consistently interactive

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -11,6 +11,7 @@ import math
 import os
 import typing
 import weakref
+from dataclasses import dataclass
 
 import qtawesome as qta
 from qtpy import QtCore, QtGui, QtWidgets
@@ -30,6 +31,21 @@ logger = logging.getLogger(__name__)
 
 _NODE_UID_ROLE = int(QtCore.Qt.ItemDataRole.UserRole) + 128
 _TOOL_TYPE_ROLE = int(QtCore.Qt.ItemDataRole.UserRole) + 129
+_RowBadgeKind = typing.Literal["dask", "link", "watched", "tool_type", "source_status"]
+
+
+@dataclass(frozen=True)
+class _RowBadge:
+    """Hit-test result for a painted manager-row badge.
+
+    The delegate paints badges manually, so Qt does not expose child widgets for them.
+    Keep this as the single payload passed from delegate hit-testing to tooltip and
+    click handling so their geometry cannot drift apart.
+    """
+
+    kind: _RowBadgeKind
+    rect: QtCore.QRect
+    tooltip: str
 
 
 def _fill_rounded_rect(
@@ -628,6 +644,102 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         rect_x = option.rect.right() - badge_width - self.icon_right_pad
         return QtCore.QRect(rect_x, rect_y, badge_width, rect_size), text, color
 
+    def _option_for_index(
+        self,
+        view: QtWidgets.QAbstractItemView,
+        index: QtCore.QModelIndex,
+    ) -> QtWidgets.QStyleOptionViewItem:
+        """Build the same style option used for painting a visible row.
+
+        Badge hit-testing must use the current visual row rectangle. Relying on a
+        default style option gives correct font/palette data but a stale rect,
+        especially after scrolling or expanding nested rows.
+        """
+        option = QtWidgets.QStyleOptionViewItem()
+        self.initStyleOption(option, index)
+        option.rect = view.visualRect(index)
+        option.widget = view
+        return option
+
+    def _badge_at(
+        self,
+        option: QtWidgets.QStyleOptionViewItem,
+        index: QtCore.QModelIndex,
+        pos: QtCore.QPoint,
+    ) -> _RowBadge | None:
+        """Return the badge under ``pos`` using the same geometry as painting.
+
+        The ordering here mirrors the visual layout. For top-level rows the badges are
+        right-aligned; for child rows the tool-type badge is checked before the
+        right-side source status badge. Tooltip, cursor, and click paths all call this
+        method so any badge geometry change has one source of truth.
+        """
+        if not index.isValid():
+            return None
+
+        node = index.internalPointer()
+        if isinstance(node, _ImageToolWrapper):
+            _, dask_rect, link_rect, watched_rect = self._compute_icons_info(
+                option, node
+            )
+            if dask_rect is not None and dask_rect.contains(pos):
+                return _RowBadge(
+                    "dask",
+                    dask_rect,
+                    "Dask-backed data. Click to open Dask and chunk controls.",
+                )
+            if link_rect is not None and link_rect.contains(pos):
+                proxy = node.slicer_area._linking_proxy
+                if proxy is not None:
+                    linker_index = self.manager._linkers.index(proxy)
+                    return _RowBadge(
+                        "link",
+                        link_rect,
+                        f"Linked (#{linker_index}). Click to unlink this window.",
+                    )
+            if watched_rect is not None and watched_rect.contains(pos):
+                varname = str(node._watched_varname)
+                return _RowBadge(
+                    "watched",
+                    watched_rect,
+                    f"Watching variable {varname!r}. Click for watch actions.",
+                )
+            return None
+
+        if not isinstance(node, str):
+            return None
+        try:
+            child_node = self.manager._child_node(node)
+        except KeyError:
+            return None
+
+        type_rect, type_text, _ = self._compute_tool_type_info(option, child_node)
+        if type_rect is not None and type_text is not None and type_rect.contains(pos):
+            return _RowBadge(
+                "tool_type",
+                type_rect,
+                f"Tool type: {type_text}. Click to show this tool.",
+            )
+
+        status_rect, _, _ = self._compute_child_status_info(option, child_node)
+        if status_rect is None or not status_rect.contains(pos):
+            return None
+        match child_node.source_state:
+            case "stale":
+                tooltip = (
+                    "Stale. Click to update this tool from the latest compatible data."
+                )
+            case "unavailable":
+                tooltip = (
+                    "Unavailable. Click to review why this tool cannot update from the "
+                    "current data."
+                )
+            case _:
+                tooltip = (
+                    "Automatic updates enabled. Click to configure automatic updates."
+                )
+        return _RowBadge("source_status", status_rect, tooltip)
+
     def eventFilter(
         self, obj: QtCore.QObject | None = None, event: QtCore.QEvent | None = None
     ) -> bool:
@@ -639,12 +751,24 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                     | QtCore.QEvent.Type.WindowStateChange
                 ):
                     self.preview_popup.hide()
+                    if isinstance(obj, QtWidgets.QWidget):
+                        obj.unsetCursor()
                 case QtCore.QEvent.Type.MouseMove:
-                    index = typing.cast(
-                        "_ImageToolWrapperTreeView", self.parent()
-                    ).indexAt(typing.cast("QtGui.QMouseEvent", event).pos())
+                    view = typing.cast("_ImageToolWrapperTreeView", self.parent())
+                    pos = typing.cast("QtGui.QMouseEvent", event).pos()
+                    index = view.indexAt(pos)
                     if not index.isValid():
                         self.preview_popup.hide()
+                    if isinstance(obj, QtWidgets.QWidget):
+                        if not index.isValid():
+                            badge = None
+                        else:
+                            option = self._option_for_index(view, index)
+                            badge = self._badge_at(option, index, pos)
+                        if badge is None:
+                            obj.unsetCursor()
+                        else:
+                            obj.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
 
         return super().eventFilter(obj, event)
 
@@ -662,80 +786,12 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         index: QtCore.QModelIndex,
     ) -> bool:
         if isinstance(event, QtGui.QHelpEvent) and index.isValid():
-            tool_wrapper = index.internalPointer()
-            if isinstance(tool_wrapper, _ImageToolWrapper):  # pragma: no branch
-                (
-                    _,
-                    dask_rect,
-                    link_rect,
-                    watched_rect,
-                ) = self._compute_icons_info(option, tool_wrapper)
-                pos = event.pos()
-                if dask_rect and dask_rect.contains(pos):
-                    QtWidgets.QToolTip.showText(
-                        event.globalPos(),
-                        "Dask-backed data (chunked array)",
-                        view,
-                        dask_rect,
-                    )
-                    return True
-                if link_rect and link_rect.contains(pos):
-                    proxy = tool_wrapper.slicer_area._linking_proxy
-                    if proxy:  # pragma: no branch
-                        linker_index = self.manager._linkers.index(proxy)
-                        QtWidgets.QToolTip.showText(
-                            event.globalPos(),
-                            f"Linked (#{linker_index})",
-                            view,
-                            link_rect,
-                        )
-                        return True
-                if watched_rect and watched_rect.contains(pos):
-                    QtWidgets.QToolTip.showText(
-                        event.globalPos(),
-                        "Variable synced with IPython",
-                        view,
-                        watched_rect,
-                    )
-                    return True
-            elif isinstance(tool_wrapper, str):
-                try:
-                    child_node = self.manager._child_node(tool_wrapper)
-                except KeyError:
-                    child_node = None
-                if child_node is not None:
-                    type_rect, type_text, _ = self._compute_tool_type_info(
-                        option, child_node
-                    )
-                    if type_rect and type_text and type_rect.contains(event.pos()):
-                        QtWidgets.QToolTip.showText(
-                            event.globalPos(),
-                            f"Tool type: {type_text}",
-                            view,
-                            type_rect,
-                        )
-                        return True
-                    status_rect, _, _ = self._compute_child_status_info(
-                        option, child_node
-                    )
-                    if status_rect and status_rect.contains(event.pos()):
-                        match child_node.source_state:
-                            case "stale":
-                                tooltip = (
-                                    "Click to update this tool from the latest "
-                                    "compatible data."
-                                )
-                            case "unavailable":
-                                tooltip = (
-                                    "Click to review why this tool cannot update from "
-                                    "the current data."
-                                )
-                            case _:
-                                tooltip = "Click to configure automatic updates."
-                        QtWidgets.QToolTip.showText(
-                            event.globalPos(), tooltip, view, status_rect
-                        )
-                        return True
+            badge = self._badge_at(option, index, event.pos())
+            if badge is not None:
+                QtWidgets.QToolTip.showText(
+                    event.globalPos(), badge.tooltip, view, badge.rect
+                )
+                return True
 
         return super().helpEvent(event, view, option, index)
 
@@ -1401,6 +1457,7 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
         self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self._show_menu)
         self._menu = QtWidgets.QMenu("Menu", self)
+        self._badge_menu: QtWidgets.QMenu | None = None
         self._menu.setToolTipsVisible(True)
         self._menu.addAction(manager.reindex_action)
         self._menu.addSeparator()
@@ -1474,25 +1531,117 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent | None) -> None:
         if event is not None and event.button() == QtCore.Qt.MouseButton.LeftButton:
             index = self.indexAt(event.pos())
-            if index.isValid() and isinstance(index.internalPointer(), str):
-                option = QtWidgets.QStyleOptionViewItem()
-                option.rect = self.visualRect(index)
-                option.font = self.font()
-                try:
-                    child_node = self._model.manager._child_node(
-                        index.internalPointer()
-                    )
-                except KeyError:
-                    child_node = None
-                if child_node is not None:
-                    status_rect, _, _ = self._delegate._compute_child_status_info(
-                        option, child_node
-                    )
-                    if status_rect and status_rect.contains(event.pos()):
-                        child_node.show_source_update_dialog(parent=self._model.manager)
-                        event.accept()
-                        return
+            if index.isValid():
+                option = self._delegate._option_for_index(self, index)
+                badge = self._delegate._badge_at(option, index, event.pos())
+                if badge is not None:
+                    self._handle_badge_click(index, badge)
+                    event.accept()
+                    return
         super().mouseReleaseEvent(event)
+
+    def _handle_badge_click(self, index: QtCore.QModelIndex, badge: _RowBadge) -> None:
+        """Dispatch a click on a painted badge to the row-specific action.
+
+        Badge clicks intentionally operate on the clicked row only. They do not reuse
+        selection-based actions because a selected group can contain unrelated rows,
+        while the badge affordance belongs to one painted row.
+        """
+        node = index.internalPointer()
+        match badge.kind:
+            case "dask":
+                if isinstance(node, _ImageToolWrapper):
+                    self._show_dask_badge_menu(node, badge.rect)
+            case "link":
+                if isinstance(node, _ImageToolWrapper):
+                    self._unlink_badge_target(node)
+            case "watched":
+                if isinstance(node, _ImageToolWrapper):
+                    self._show_watched_badge_menu(node, badge.rect)
+            case "tool_type":
+                if isinstance(node, str):
+                    self._model.manager.show_childtool(node)
+            case "source_status":
+                if isinstance(node, str):
+                    try:
+                        child_node = self._model.manager._child_node(node)
+                    except KeyError:
+                        return
+                    child_node.show_source_update_dialog(parent=self._model.manager)
+
+    def _show_dask_badge_menu(
+        self, wrapper: _ImageToolWrapper, badge_rect: QtCore.QRect
+    ) -> None:
+        """Open the clicked tool's Dask menu at the badge location."""
+        tool = wrapper.imagetool
+        if tool is None:
+            return
+        tool.slicer_area.compute_act.setEnabled(tool.slicer_area.data_chunked)
+        tool._dask_menu.update_actions_visibility()
+        viewport = self.viewport()
+        assert viewport is not None
+        tool._dask_menu.popup(viewport.mapToGlobal(badge_rect.bottomLeft()))
+
+    def _unlink_badge_target(self, wrapper: _ImageToolWrapper) -> None:
+        """Confirm and unlink only the ImageTool represented by ``wrapper``."""
+        if (
+            QtWidgets.QMessageBox.question(
+                self._model.manager,
+                "Unlink ImageTool?",
+                "Unlink this ImageTool from linked cursor and color updates?",
+                QtWidgets.QMessageBox.StandardButton.Yes
+                | QtWidgets.QMessageBox.StandardButton.Cancel,
+                QtWidgets.QMessageBox.StandardButton.Cancel,
+            )
+            != QtWidgets.QMessageBox.StandardButton.Yes
+        ):
+            return
+
+        wrapper.slicer_area.unlink()
+        self._model.manager._sigReloadLinkers.emit()
+        self.refresh(wrapper.index)
+
+    def _show_watched_badge_menu(
+        self, wrapper: _ImageToolWrapper, badge_rect: QtCore.QRect
+    ) -> None:
+        """Show per-row watch actions for the clicked watched-variable badge."""
+        menu = QtWidgets.QMenu("Watch", self)
+        menu.setToolTipsVisible(True)
+        refresh_action = menu.addAction("Refresh From Variable")
+        assert refresh_action is not None
+        refresh_action.setToolTip("Refresh this ImageTool from the watched variable")
+        refresh_action.triggered.connect(wrapper._trigger_watched_update)
+        stop_action = menu.addAction("Stop Watching...")
+        assert stop_action is not None
+        stop_action.setToolTip("Detach this ImageTool from the watched variable")
+        stop_action.triggered.connect(
+            lambda _checked=False, target=wrapper: self._stop_watching_badge_target(
+                target
+            )
+        )
+        self._badge_menu = menu
+        viewport = self.viewport()
+        assert viewport is not None
+        menu.popup(viewport.mapToGlobal(badge_rect.bottomLeft()))
+
+    def _stop_watching_badge_target(self, wrapper: _ImageToolWrapper) -> None:
+        """Confirm and detach the clicked ImageTool from its watched variable."""
+        varname = wrapper._watched_varname
+        if varname is None:
+            return
+        if (
+            QtWidgets.QMessageBox.question(
+                self._model.manager,
+                "Stop Watching Variable?",
+                f"Stop watching variable {varname!r} for this ImageTool?",
+                QtWidgets.QMessageBox.StandardButton.Yes
+                | QtWidgets.QMessageBox.StandardButton.Cancel,
+                QtWidgets.QMessageBox.StandardButton.Cancel,
+            )
+            != QtWidgets.QMessageBox.StandardButton.Yes
+        ):
+            return
+        wrapper.unwatch()
 
     def imagetool_added(self, index: int) -> None:
         """Update the list view when a new ImageTool is added to the manager.

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -119,6 +119,28 @@ def select_child_tool(
     )
 
 
+def click_tree_view_pos(
+    view: QtWidgets.QTreeView,
+    pos: QtCore.QPoint,
+) -> None:
+    global_pos = view.viewport().mapToGlobal(pos)
+    view.mouseReleaseEvent(
+        QtGui.QMouseEvent(
+            QtCore.QEvent.Type.MouseButtonRelease,
+            QtCore.QPointF(pos),
+            QtCore.QPointF(global_pos),
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+    )
+
+
+def assert_nonempty_tooltip(text: str | None) -> None:
+    assert isinstance(text, str)
+    assert text.strip()
+
+
 def child_status_badge(
     manager: ImageToolManager, uid: str
 ) -> tuple[QtCore.QRect, str | None, QtCore.QModelIndex]:
@@ -1005,7 +1027,22 @@ def test_manager_childtool_type_badge_only_for_tool_windows(
             manager.tree_view.viewport().mapToGlobal(type_rect.center()),
         )
         assert delegate.helpEvent(help_event, manager.tree_view, option, tool_index)
-        assert tooltip_text == f"Tool type: {tool.tool_name}"
+        assert_nonempty_tooltip(tooltip_text)
+
+        manager.tree_view.expand(root_index)
+        actual_option = QtWidgets.QStyleOptionViewItem()
+        delegate.initStyleOption(actual_option, tool_index)
+        actual_option.rect = manager.tree_view.visualRect(tool_index)
+        actual_type_rect, _, _ = delegate._compute_tool_type_info(
+            actual_option, tool_node
+        )
+        assert actual_type_rect is not None
+        show_calls: list[str] = []
+        monkeypatch.setattr(
+            manager, "show_childtool", lambda uid: show_calls.append(uid)
+        )
+        click_tree_view_pos(manager.tree_view, actual_type_rect.center())
+        assert show_calls == [tool_uid]
 
         editor = QtWidgets.QLineEdit(manager.tree_view.viewport())
         delegate.updateEditorGeometry(editor, option, tool_index)
@@ -1140,9 +1177,7 @@ def test_manager_childtool_source_updates(
             manager.tree_view.viewport().mapToGlobal(badge_rect.center()),
         )
         assert delegate.helpEvent(help_event, manager.tree_view, option, index)
-        assert (
-            tooltip_text == "Click to update this tool from the latest compatible data."
-        )
+        assert_nonempty_tooltip(tooltip_text)
         assert index == manager.tree_view.indexAt(badge_rect.center())
 
         def _enable_auto_update(dialog: QtWidgets.QDialog) -> None:
@@ -1186,7 +1221,7 @@ def test_manager_childtool_source_updates(
             manager.tree_view.viewport().mapToGlobal(auto_badge_rect.center()),
         )
         assert delegate.helpEvent(auto_help_event, manager.tree_view, option, index)
-        assert tooltip_text == "Click to configure automatic updates."
+        assert_nonempty_tooltip(tooltip_text)
 
         def _disable_auto_update(dialog: QtWidgets.QDialog) -> None:
             dialog.auto_update_check.setChecked(False)  # type: ignore[attr-defined]
@@ -6453,12 +6488,13 @@ def test_manager_hover_tooltip(
         manager.show()
         manager.activateWindow()
 
-        itool([test_data, test_data], link=True, manager=True)
+        itool([test_data, test_data, test_data], link=True, manager=True)
 
-        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
 
         manager.get_imagetool(0).slicer_area._auto_chunk()
         manager.get_imagetool(1).slicer_area._auto_chunk()
+        manager.get_imagetool(2).slicer_area._auto_chunk()
         select_tools(manager, [0])
         manager._update_info()
         assert "Chunks" in metadata_detail_map(manager)
@@ -6471,6 +6507,7 @@ def test_manager_hover_tooltip(
         index = model.index(0, 0)  # first tool
         option = QtWidgets.QStyleOptionViewItem()
         delegate.initStyleOption(option, index)
+        option.rect = view.visualRect(index)
         _, dask_rect, link_rect, _ = delegate._compute_icons_info(
             option, index.internalPointer()
         )
@@ -6491,7 +6528,14 @@ def test_manager_hover_tooltip(
         handled = delegate.helpEvent(event, view, option, index)
 
         assert handled
-        assert text == "Dask-backed data (chunked array)"
+        assert_nonempty_tooltip(text)
+
+        popup_positions: list[QtCore.QPoint] = []
+        dask_menu = manager.get_imagetool(0)._dask_menu
+        monkeypatch.setattr(dask_menu, "popup", popup_positions.append)
+        click_tree_view_pos(view, dask_rect.center())
+        assert popup_positions == [view.viewport().mapToGlobal(dask_rect.bottomLeft())]
+        assert manager.get_imagetool(0).slicer_area.data_chunked
 
         # Hover over link icon
         text = None
@@ -6502,7 +6546,69 @@ def test_manager_hover_tooltip(
         handled = delegate.helpEvent(event, view, option, index)
 
         assert handled
-        assert text == "Linked (#0)"
+        assert_nonempty_tooltip(text)
+
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        click_tree_view_pos(view, link_rect.center())
+        assert manager.get_imagetool(0).slicer_area.is_linked
+        assert manager.get_imagetool(1).slicer_area.is_linked
+        assert manager.get_imagetool(2).slicer_area.is_linked
+
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+        )
+        click_tree_view_pos(view, link_rect.center())
+        assert not manager.get_imagetool(0).slicer_area.is_linked
+        assert manager.get_imagetool(1).slicer_area.is_linked
+        assert manager.get_imagetool(2).slicer_area.is_linked
+
+        wrapper = manager._imagetool_wrappers[0]
+        wrapper._watched_varname = "sample"
+        wrapper._watched_uid = "sample kernel"
+        option = QtWidgets.QStyleOptionViewItem()
+        delegate.initStyleOption(option, index)
+        option.rect = view.visualRect(index)
+        _, _, _, watched_rect = delegate._compute_icons_info(option, wrapper)
+        assert watched_rect is not None
+
+        text = None
+        pos = watched_rect.center()
+        event = QtGui.QHelpEvent(
+            QtCore.QEvent.Type.ToolTip, pos, view.viewport().mapToGlobal(pos)
+        )
+        handled = delegate.helpEvent(event, view, option, index)
+        assert handled
+        assert_nonempty_tooltip(text)
+
+        click_tree_view_pos(view, watched_rect.center())
+        assert view._badge_menu is not None
+        refresh_action, stop_action = view._badge_menu.actions()
+        with qtbot.wait_signal(manager._sigWatchedDataEdited) as blocker:
+            refresh_action.trigger()
+        assert blocker.args == ["sample", "sample kernel", "updated"]
+
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        stop_action.trigger()
+        assert wrapper.watched
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+        )
+        with qtbot.wait_signal(manager._sigWatchedDataEdited) as blocker:
+            stop_action.trigger()
+        assert blocker.args == ["sample", "sample kernel", "removed"]
+        assert not wrapper.watched
 
         # Hover outside icons
         text = None

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -59,6 +59,7 @@ from erlab.interactive.imagetool.manager._modelview import (
     _TOOL_TYPE_ROLE,
     _ImageToolWrapperItemDelegate,
     _ImageToolWrapperItemModel,
+    _RowBadge,
 )
 from erlab.interactive.imagetool.manager._server import (
     AddDataPacket,
@@ -1253,6 +1254,25 @@ def test_manager_childtool_source_updates(
         assert refresh_calls == [uid, uid]
         assert child.source_state == "fresh"
         xr.testing.assert_identical(child.tool_data, replaced2.transpose("eV", "alpha"))
+
+        child._set_source_state("unavailable")
+        qtbot.wait_until(lambda: child.source_state == "unavailable", timeout=5000)
+        unavailable_badge_rect, unavailable_badge_text, _ = child_status_badge(
+            manager, uid
+        )
+        assert isinstance(unavailable_badge_text, str)
+        assert unavailable_badge_text.strip()
+
+        tooltip_text = None
+        unavailable_help_event = QtGui.QHelpEvent(
+            QtCore.QEvent.Type.ToolTip,
+            unavailable_badge_rect.center(),
+            manager.tree_view.viewport().mapToGlobal(unavailable_badge_rect.center()),
+        )
+        assert delegate.helpEvent(
+            unavailable_help_event, manager.tree_view, option, index
+        )
+        assert_nonempty_tooltip(tooltip_text)
 
 
 def test_manager_full_data_childtool_updates_follow_transposed_view(
@@ -6619,6 +6639,144 @@ def test_manager_hover_tooltip(
         handled = delegate.helpEvent(event, view, option, index)
         assert not handled
         assert text is None
+
+
+def test_manager_badge_hit_testing_edge_paths(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        manager.activateWindow()
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        view = manager.tree_view
+        model = view._model
+        delegate = view._delegate
+        index = model.index(0, 0)
+        wrapper = manager._imagetool_wrappers[0]
+
+        manager.get_imagetool(0).slicer_area._auto_chunk()
+        view.refresh(0)
+        option = delegate._option_for_index(view, index)
+        _, dask_rect, _, _ = delegate._compute_icons_info(option, wrapper)
+        assert dask_rect is not None
+
+        assert delegate._badge_at(option, QtCore.QModelIndex(), QtCore.QPoint()) is None
+        assert (
+            delegate._badge_at(
+                option, model.createIndex(0, 0, object()), option.rect.center()
+            )
+            is None
+        )
+        missing_child_index = model.createIndex(0, 0, "missing-child")
+        assert (
+            delegate._badge_at(option, missing_child_index, option.rect.center())
+            is None
+        )
+        view._handle_badge_click(
+            missing_child_index, _RowBadge("source_status", QtCore.QRect(), "")
+        )
+        for kind in ("dask", "link", "watched"):
+            view._handle_badge_click(
+                missing_child_index, _RowBadge(kind, QtCore.QRect(), "")
+            )
+        for kind in ("tool_type", "source_status"):
+            view._handle_badge_click(index, _RowBadge(kind, QtCore.QRect(), ""))
+
+        def _left_release(pos: QtCore.QPoint) -> QtGui.QMouseEvent:
+            global_pos = view.viewport().mapToGlobal(pos)
+            return QtGui.QMouseEvent(
+                QtCore.QEvent.Type.MouseButtonRelease,
+                QtCore.QPointF(pos),
+                QtCore.QPointF(global_pos),
+                QtCore.Qt.MouseButton.LeftButton,
+                QtCore.Qt.MouseButton.LeftButton,
+                QtCore.Qt.KeyboardModifier.NoModifier,
+            )
+
+        view.mouseReleaseEvent(_left_release(QtCore.QPoint(-10, -10)))
+        view.mouseReleaseEvent(_left_release(option.rect.center()))
+
+        def _mouse_move(pos: QtCore.QPoint) -> QtGui.QMouseEvent:
+            global_pos = view.viewport().mapToGlobal(pos)
+            return QtGui.QMouseEvent(
+                QtCore.QEvent.Type.MouseMove,
+                QtCore.QPointF(pos),
+                QtCore.QPointF(global_pos),
+                QtCore.Qt.MouseButton.NoButton,
+                QtCore.Qt.MouseButton.NoButton,
+                QtCore.Qt.KeyboardModifier.NoModifier,
+            )
+
+        delegate.eventFilter(view.viewport(), _mouse_move(dask_rect.center()))
+        assert (
+            view.viewport().cursor().shape() == QtCore.Qt.CursorShape.PointingHandCursor
+        )
+
+        delegate.eventFilter(view.viewport(), _mouse_move(option.rect.center()))
+        assert (
+            view.viewport().cursor().shape() != QtCore.Qt.CursorShape.PointingHandCursor
+        )
+
+        delegate.eventFilter(view.viewport(), _mouse_move(QtCore.QPoint(-10, -10)))
+        assert (
+            view.viewport().cursor().shape() != QtCore.Qt.CursorShape.PointingHandCursor
+        )
+
+        delegate.eventFilter(view.viewport(), QtCore.QEvent(QtCore.QEvent.Type.Leave))
+        assert (
+            view.viewport().cursor().shape() != QtCore.Qt.CursorShape.PointingHandCursor
+        )
+        delegate.eventFilter(None, QtCore.QEvent(QtCore.QEvent.Type.Leave))
+        delegate.eventFilter(None, _mouse_move(dask_rect.center()))
+
+        fake_link_rect = QtCore.QRect(
+            option.rect.left() + 4, option.rect.top() + 4, 16, 16
+        )
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                delegate,
+                "_compute_icons_info",
+                lambda option_arg, wrapper_arg: (16, None, fake_link_rect, None),
+            )
+            patch.setattr(wrapper.slicer_area, "_linking_proxy", None)
+            assert delegate._badge_at(option, index, fake_link_rect.center()) is None
+
+        view._show_dask_badge_menu(
+            types.SimpleNamespace(imagetool=None),
+            QtCore.QRect(),
+        )
+        view._stop_watching_badge_target(wrapper)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(lambda: len(wrapper._childtool_indices) == 1, timeout=5000)
+        child_uid = wrapper._childtool_indices[0]
+        child_index = model._row_index(child_uid)
+        child_node = manager._child_node(child_uid)
+        child_option = delegate._option_for_index(view, child_index)
+        assert (
+            delegate._badge_at(child_option, child_index, child_option.rect.center())
+            is None
+        )
+
+        source_dialog_parents: list[ImageToolManager] = []
+        monkeypatch.setattr(
+            child_node,
+            "show_source_update_dialog",
+            lambda *, parent: source_dialog_parents.append(parent),
+        )
+        view._handle_badge_click(
+            child_index, _RowBadge("source_status", QtCore.QRect(), "")
+        )
+        assert source_dialog_parents == [manager]
 
 
 def test_warning_alert(

--- a/tests/interactive/imagetool/test_watcher.py
+++ b/tests/interactive/imagetool/test_watcher.py
@@ -720,6 +720,7 @@ def test_watcher_real(
         index = manager.tree_view._model.index(0, 0)  # first tool
         option = QtWidgets.QStyleOptionViewItem()
         manager.tree_view._delegate.initStyleOption(option, index)
+        option.rect = manager.tree_view.visualRect(index)
         _, _, _, watched_rect = manager.tree_view._delegate._compute_icons_info(
             option, index.internalPointer()
         )
@@ -734,7 +735,8 @@ def test_watcher_real(
         )
 
         assert handled
-        assert text == "Variable synced with IPython"
+        assert isinstance(text, str)
+        assert text.strip()
 
         # Update data
         with qtbot.wait_signal(manager.server.sigWatchedVarChanged, timeout=10000):


### PR DESCRIPTION
## Summary
- Normalize ImageTool manager row badges so Dask, link, watched-variable, tool-type, and source-status indicators all provide tooltips and click behavior.
- Route badge clicks to row-specific actions while preserving existing row selection, double-click, and inline rename behavior.
- Add focused Qt coverage without depending on exact tooltip copy.

## Validation
- `uv run ruff check src/erlab/interactive/imagetool/manager/_modelview.py tests/interactive/imagetool/test_imagetool_manager.py tests/interactive/imagetool/test_watcher.py`
- `uv run ruff format src/erlab/interactive/imagetool/manager/_modelview.py tests/interactive/imagetool/test_imagetool_manager.py tests/interactive/imagetool/test_watcher.py`
- `uv run mypy src`
- `uv run pytest tests/interactive/imagetool/test_imagetool_manager.py::test_manager_hover_tooltip tests/interactive/imagetool/test_imagetool_manager.py::test_manager_childtool_type_badge_only_for_tool_windows tests/interactive/imagetool/test_watcher.py::test_watcher_real`
- `uv run pytest tests/interactive/imagetool/test_watcher.py tests/interactive/imagetool/test_imagetool_manager.py`