### PR TITLE
[codex] Make standalone windows close consistently

### DIFF
--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -854,7 +854,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
     @QtCore.Slot()
     def try_close(self) -> None:
         if self.isWindow() and not hasattr(self.parent(), "close_tab"):
-            self.hide()
+            erlab.interactive.utils._hide_or_close_with_manager(self)
         else:
             self.sigCloseRequested.emit(self)
 

--- a/src/erlab/interactive/explorer/_tabbed_explorer.py
+++ b/src/erlab/interactive/explorer/_tabbed_explorer.py
@@ -213,7 +213,7 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
     @QtCore.Slot(object)
     def close_tab(self, index: int | _DataExplorer) -> None:
         if self.tab_widget.count() == 1:
-            self.hide()
+            erlab.interactive.utils._hide_or_close_with_manager(self)
         else:
             if isinstance(index, _DataExplorer):
                 # If index is a DataExplorer instance, find its tab index by iteration

--- a/src/erlab/interactive/ptable/_window.py
+++ b/src/erlab/interactive/ptable/_window.py
@@ -454,8 +454,7 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         header_layout.addStretch(1)
         self.find_shortcut = QtGui.QShortcut(QtGui.QKeySequence.StandardKey.Find, self)
         self.find_shortcut.activated.connect(self._focus_search_edit)
-        self.close_shortcut = QtGui.QShortcut(QtGui.QKeySequence("Ctrl+W"), self)
-        self.close_shortcut.activated.connect(self.hide)
+        self.close_shortcut = erlab.interactive.utils._install_close_shortcut(self)
 
         self.notation_frame = QtWidgets.QFrame(self.header)
         notation_layout = QtWidgets.QHBoxLayout(self.notation_frame)
@@ -589,11 +588,13 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         self._application = (
             application if isinstance(application, QtWidgets.QApplication) else None
         )
+        self._application_events_connected = False
         if self._application is not None:
             self._application.installEventFilter(self)
             self._application.focusChanged.connect(
                 self._handle_application_focus_changed
             )
+            self._application_events_connected = True
 
         self._sync_vertical_minimum_height()
         self._apply_theme()
@@ -758,13 +759,23 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         if self.search_popup.isVisible():
             self._show_search_popup()
 
+    def showEvent(self, event: QtGui.QShowEvent | None) -> None:
+        super().showEvent(event)
+        if self._application is not None and not self._application_events_connected:
+            self._application.installEventFilter(self)
+            self._application.focusChanged.connect(
+                self._handle_application_focus_changed
+            )
+            self._application_events_connected = True
+
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
-        if self._application is not None:
+        if self._application is not None and self._application_events_connected:
             self._application.removeEventFilter(self)
             with contextlib.suppress(TypeError):
                 self._application.focusChanged.disconnect(
                     self._handle_application_focus_changed
                 )
+            self._application_events_connected = False
         self.category_legend.cleanup()
         self._hide_search_popup(reset_navigation=False)
         super().closeEvent(event)

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -11,6 +11,7 @@ import bisect
 import contextlib
 import enum
 import fnmatch
+import functools
 import importlib
 import inspect
 import itertools
@@ -203,6 +204,82 @@ def single_shot(
             raise
 
     QtCore.QTimer.singleShot(msec, _call)
+
+
+class _CloseShortcutEventFilter(QtCore.QObject):
+    def __init__(self, widget: QtWidgets.QWidget, callback: Callable[[], None]) -> None:
+        super().__init__(widget)
+        self._widget = widget
+        self._callback = callback
+
+    def eventFilter(
+        self,
+        watched: QtCore.QObject | None,
+        event: QtCore.QEvent | None,
+    ) -> bool:
+        if (
+            event is None
+            or event.type() != QtCore.QEvent.Type.KeyPress
+            or not isinstance(event, QtGui.QKeyEvent)
+        ):
+            return False
+
+        focused = watched if isinstance(watched, QtWidgets.QWidget) else None
+        if (
+            focused is None
+            or not self._widget.isVisible()
+            or (focused is not self._widget and focused.window() is not self._widget)
+        ):
+            return False
+
+        relevant_modifiers = (
+            QtCore.Qt.KeyboardModifier.ControlModifier
+            | QtCore.Qt.KeyboardModifier.ShiftModifier
+            | QtCore.Qt.KeyboardModifier.AltModifier
+            | QtCore.Qt.KeyboardModifier.MetaModifier
+        )
+        modifiers = event.modifiers() & relevant_modifiers
+        close_shortcut = event.matches(QtGui.QKeySequence.StandardKey.Close) or (
+            event.key() == QtCore.Qt.Key.Key_W
+            and modifiers == QtCore.Qt.KeyboardModifier.ControlModifier
+        )
+        if not close_shortcut:
+            return False
+
+        self._callback()
+        event.accept()
+        return True
+
+
+def _hide_or_close_with_manager(widget: QtWidgets.QWidget) -> None:
+    if erlab.interactive.imagetool.manager._manager_instance is None:
+        widget.close()
+    else:
+        widget.hide()
+
+
+def _install_close_shortcut(
+    widget: QtWidgets.QWidget, callback: Callable[[], None] | None = None
+) -> QtWidgets.QShortcut:
+    """Install robust Ctrl+W handling on a widget and its child widgets."""
+    if callback is None:
+        callback = functools.partial(_hide_or_close_with_manager, widget)
+
+    if isinstance(widget, QtWidgets.QMainWindow):
+        widget.menuBar()
+
+    shortcut = QtWidgets.QShortcut("Ctrl+W", widget, callback)
+    shortcut.setContext(QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut)
+
+    application = QtWidgets.QApplication.instance()
+    if isinstance(application, QtWidgets.QApplication):
+        shortcut_filter = _CloseShortcutEventFilter(widget, callback)
+        application.installEventFilter(shortcut_filter)
+        widget.destroyed.connect(lambda: application.removeEventFilter(shortcut_filter))
+        widget._erlab_close_shortcut_refs = (shortcut, shortcut_filter)  # type: ignore[attr-defined]
+    else:
+        widget._erlab_close_shortcut_refs = (shortcut,)  # type: ignore[attr-defined]
+    return shortcut
 
 
 @contextlib.contextmanager

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -1,6 +1,7 @@
 import ast
 import concurrent.futures
 import contextlib
+import dataclasses
 import enum
 import gc
 import io
@@ -7357,19 +7358,43 @@ def test_manager_explorer_launcher_reuses_instance_and_opens_directory_tabs(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    class _TrackingTabbedExplorer(_TabbedExplorer):
+        def __init__(self, *args, **kwargs) -> None:
+            self.close_event_count = 0
+            super().__init__(*args, **kwargs)
+
+        def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+            self.close_event_count += 1
+            super().closeEvent(event)
+
     with (
         manager_context() as manager,
         tempfile.TemporaryDirectory() as recent_dir,
         tempfile.TemporaryDirectory() as dropped_dir,
     ):
         manager._recent_directory = recent_dir
+        spec = manager._standalone_app_specs["explorer"]
+        manager._standalone_app_specs["explorer"] = dataclasses.replace(
+            spec,
+            factory=lambda: _TrackingTabbedExplorer(
+                root_path=manager._recent_directory,
+                loader_name=manager._recent_loader_name,
+            ),
+        )
 
         manager.ensure_explorer_initialized()
         explorer = manager.explorer
 
-        assert isinstance(explorer, _TabbedExplorer)
+        assert isinstance(explorer, _TrackingTabbedExplorer)
         assert hasattr(manager, "explorer")
         assert explorer.tab_widget.count() == 1
+
+        explorer.close_tab(0)
+        qtbot.wait_until(lambda: not explorer.isVisible())
+        assert explorer.close_event_count == 0
+        manager.show_explorer()
+        qtbot.wait_until(explorer.isVisible)
+        assert manager.explorer is explorer
 
         explorer.hide()
         manager.show_explorer()
@@ -7395,17 +7420,43 @@ def test_manager_ptable_launcher_reuses_instance_without_affecting_tree(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    class _TrackingPeriodicTableWindow(PeriodicTableWindow):
+        def __init__(self) -> None:
+            self.close_event_count = 0
+            super().__init__()
+
+        def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+            self.close_event_count += 1
+            super().closeEvent(event)
+
     with manager_context() as manager:
         initial_ntools = manager.ntools
         initial_rows = manager.tree_view.model().rowCount(QtCore.QModelIndex())
+        spec = manager._standalone_app_specs["ptable"]
+        manager._standalone_app_specs["ptable"] = dataclasses.replace(
+            spec,
+            factory=_TrackingPeriodicTableWindow,
+        )
 
         manager.show_ptable()
         ptable = manager.ptable_window
 
         qtbot.wait_until(ptable.isVisible)
-        assert isinstance(ptable, PeriodicTableWindow)
+        assert isinstance(ptable, _TrackingPeriodicTableWindow)
         assert manager.ntools == initial_ntools
         assert manager.tree_view.model().rowCount(QtCore.QModelIndex()) == initial_rows
+
+        ptable.search_edit.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+        qtbot.keyClick(
+            ptable.search_edit,
+            QtCore.Qt.Key.Key_W,
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+        )
+        qtbot.wait_until(lambda: not ptable.isVisible())
+        manager.show_ptable()
+        qtbot.wait_until(ptable.isVisible)
+        assert manager.ptable_window is ptable
+        assert ptable.close_event_count == 0
 
         ptable.hide()
         manager.show_ptable()

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -2,14 +2,35 @@ import pathlib
 import typing
 from collections.abc import Callable
 
-from qtpy import QtCore
+from qtpy import QtCore, QtGui
 
 import erlab
 from erlab.interactive.explorer._base_explorer import _DataExplorer, _ReprFetcher
+from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
 from erlab.interactive.imagetool.manager import _dialogs
 
-if typing.TYPE_CHECKING:
-    from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
+
+def test_explorer_last_tab_closes_without_manager(qtbot, tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(erlab.interactive.imagetool.manager, "_manager_instance", None)
+
+    class _TrackingTabbedExplorer(_TabbedExplorer):
+        def __init__(self, *args, **kwargs) -> None:
+            self.close_event_count = 0
+            super().__init__(*args, **kwargs)
+
+        def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+            self.close_event_count += 1
+            super().closeEvent(event)
+
+    win = _TrackingTabbedExplorer(root_path=tmp_path)
+    qtbot.addWidget(win)
+    with qtbot.waitExposed(win):
+        win.show()
+
+    win.close_tab(0)
+
+    qtbot.wait_until(lambda: not win.isVisible())
+    assert win.close_event_count == 1
 
 
 def test_explorer_general(

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -3691,10 +3691,11 @@ def test_ptable_find_shortcut_uses_search_controller(
     win.close()
 
 
-def test_ptable_close_shortcut_hides_window(
+def test_ptable_close_shortcut_closes_without_manager(
     qtbot,
     monkeypatch,
 ) -> None:
+    monkeypatch.setattr(erlab.interactive.imagetool.manager, "_manager_instance", None)
     monkeypatch.setattr(erlab.analysis.xps, "get_edge", lambda _symbol: {"1s": 10.0})
     monkeypatch.setattr(erlab.analysis.xps, "get_cross_section", _fake_cross_sections)
 
@@ -3707,22 +3708,27 @@ def test_ptable_close_shortcut_hides_window(
             self.close_event_count += 1
             super().closeEvent(event)
 
-    win = _TrackingPeriodicTableWindow()
-    _show_window(qtbot, win)
+    for focus_widget_name in ("search_edit", "hv_edit", "table_view"):
+        win = _TrackingPeriodicTableWindow()
+        _show_window(qtbot, win)
 
-    assert (
-        win.close_shortcut.key().toString(
-            QtGui.QKeySequence.SequenceFormat.PortableText
+        assert (
+            win.close_shortcut.key().toString(
+                QtGui.QKeySequence.SequenceFormat.PortableText
+            )
+            == "Ctrl+W"
         )
-        == "Ctrl+W"
-    )
+        focus_widget = getattr(win, focus_widget_name)
+        focus_widget.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
 
-    win.close_shortcut.activated.emit()
+        qtbot.keyClick(
+            focus_widget,
+            QtCore.Qt.Key.Key_W,
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+        )
+        qtbot.waitUntil(lambda win=win: not win.isVisible())
 
-    assert win.isVisible() is False
-    assert win.close_event_count == 0
-
-    win.close()
+        assert win.close_event_count == 1
 
 
 def test_ptable_keyboard_navigation_and_background_clear(

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -289,6 +289,33 @@ def test_qt_is_valid_rejects_deleted_widget(qtbot) -> None:
     qtbot.wait_until(lambda: not qt_is_valid(widget), timeout=1000)
 
 
+def test_close_shortcut_reaches_child_line_edit(qtbot) -> None:
+    window = QtWidgets.QMainWindow()
+    line_edit = QtWidgets.QLineEdit(window)
+    calls: list[str] = []
+    window.setCentralWidget(line_edit)
+    qtbot.addWidget(window)
+
+    shortcut = erlab.interactive.utils._install_close_shortcut(
+        window, lambda: calls.append("close")
+    )
+    with qtbot.waitExposed(window):
+        window.show()
+    line_edit.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+
+    qtbot.keyClick(
+        line_edit,
+        QtCore.Qt.Key.Key_W,
+        QtCore.Qt.KeyboardModifier.ControlModifier,
+    )
+
+    qtbot.waitUntil(lambda: calls == ["close"])
+    assert (
+        shortcut.key().toString(QtGui.QKeySequence.SequenceFormat.PortableText)
+        == "Ctrl+W"
+    )
+
+
 def test_qt_object_is_valid_uses_shiboken_when_available(monkeypatch) -> None:
     sentinel = object()
     other = object()


### PR DESCRIPTION
## Summary

Standalone Periodic Table and Data Explorer windows now close with Ctrl+W when run outside ImageTool Manager, while manager-launched instances hide so they can be reused.

Ctrl+W handling is shared for standalone interactive windows, including child widgets such as search fields.

## Validation

- `uv run ruff format src/erlab/interactive/utils.py src/erlab/interactive/ptable/_window.py src/erlab/interactive/explorer/_tabbed_explorer.py src/erlab/interactive/explorer/_base_explorer.py tests/interactive/test_utils.py tests/interactive/test_ptable.py tests/interactive/test_explorer.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run ruff check --fix src/erlab/interactive/utils.py src/erlab/interactive/ptable/_window.py src/erlab/interactive/explorer/_tabbed_explorer.py src/erlab/interactive/explorer/_base_explorer.py tests/interactive/test_utils.py tests/interactive/test_ptable.py tests/interactive/test_explorer.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run pytest tests/interactive/test_utils.py::test_close_shortcut_reaches_child_line_edit tests/interactive/test_ptable.py::test_ptable_close_shortcut_closes_without_manager tests/interactive/test_ptable.py::test_ptable_search_popup_hides_for_external_focus_and_clicks tests/interactive/test_explorer.py::test_explorer_last_tab_closes_without_manager tests/interactive/imagetool/test_imagetool_manager.py::test_manager_explorer_launcher_reuses_instance_and_opens_directory_tabs tests/interactive/imagetool/test_imagetool_manager.py::test_manager_ptable_launcher_reuses_instance_without_affecting_tree tests/interactive/test_explorer.py::test_explorer_general -q`
- pre-commit hooks during `git commit`