### PR TITLE
feat(imagetool): plot multidimensional associated coordinates

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -140,7 +140,9 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
 - Dask-backed arrays are fully supported. The dedicated {guilabel}`Dask` menu exposes actions to compute the array into memory, rechunk automatically, or choose custom chunk shapes within ImageTool.
 
-- Overlay plots of non-dimensional coordinates (e.g., temperature) on the data from {guilabel}`View → Plot Associated Coordinates`.
+- Overlay plots of numeric non-dimensional coordinates (e.g., temperature) on profile plots from {guilabel}`View → Plot Associated Coordinates`. Multi-dimensional coordinates are sliced with the active cursor and averaged over binned hidden dimensions.
+
+- Use {guilabel}`View → Set Cursor Colors by Coordinate...` to color cursors by a dimension coordinate or numeric associated coordinate value at each cursor position.
 
 (imagetool-slicing)=
 

--- a/src/erlab/interactive/imagetool/_viewer_dialogs.py
+++ b/src/erlab/interactive/imagetool/_viewer_dialogs.py
@@ -26,13 +26,13 @@ class _AssociatedCoordsDialog(QtWidgets.QDialog):
         self.setLayout(self._layout)
 
         self._checks: dict[Hashable, QtWidgets.QCheckBox] = {}
-        for dim, coords in slicer_area.array_slicer.associated_coords.items():
-            for k in coords:
-                self._checks[k] = QtWidgets.QCheckBox(str(k))
-                self._checks[k].setChecked(
-                    k in slicer_area.array_slicer.twin_coord_names
-                )
-                self._layout.addRow(self._checks[k], QtWidgets.QLabel(f"({dim})"))
+        for name, dims in slicer_area.array_slicer.associated_coord_dims.items():
+            self._checks[name] = QtWidgets.QCheckBox(str(name))
+            self._checks[name].setChecked(
+                name in slicer_area.array_slicer.twin_coord_names
+            )
+            dim_label = ", ".join(str(dim) for dim in dims)
+            self._layout.addRow(self._checks[name], QtWidgets.QLabel(f"({dim_label})"))
 
         self._button_box = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
@@ -47,7 +47,7 @@ class _AssociatedCoordsDialog(QtWidgets.QDialog):
             QtWidgets.QMessageBox.warning(
                 self,
                 "No Associated Coordinates",
-                "No 1D non-dimension coordinates were found in the data.",
+                "No numeric non-dimension coordinates were found in the data.",
             )
             return QtWidgets.QDialog.DialogCode.Rejected
         return super().exec()
@@ -85,7 +85,7 @@ class _CursorColorCoordDialog(QtWidgets.QDialog):
     def choose_coord(self, coord_name: Hashable) -> None:
         self.coord_combo.setCurrentText(str(coord_name))
 
-    def get_checked_coord_name(self) -> tuple[Hashable, Hashable] | None:
+    def get_checked_coord_name(self) -> tuple[tuple[Hashable, ...], Hashable] | None:
         if not self.main_group.isChecked():
             return None
         slicer_area = self._slicer_area()
@@ -94,11 +94,10 @@ class _CursorColorCoordDialog(QtWidgets.QDialog):
         coord_name = self.coord_combo.currentText()
         for dim_name in slicer_area.data.dims:
             if coord_name == str(dim_name):
-                return dim_name, dim_name
-        for dim, coords in slicer_area.array_slicer.associated_coords.items():
-            for k in coords:
-                if coord_name == str(k):
-                    return dim, k
+                return (dim_name,), dim_name
+        for name, dims in slicer_area.array_slicer.associated_coord_dims.items():
+            if coord_name == str(name):
+                return dims, name
         return None
 
     def setup_ui(self):
@@ -125,9 +124,8 @@ class _CursorColorCoordDialog(QtWidgets.QDialog):
         for name in slicer_area.data.dims:
             self.coord_combo.addItem(str(name))
 
-        for coords in slicer_area.array_slicer.associated_coords.values():
-            for k in coords:
-                self.coord_combo.addItem(str(k))
+        for name in slicer_area.array_slicer.associated_coord_dims:
+            self.coord_combo.addItem(str(name))
 
         # Colormap selection
         cmap_group = QtWidgets.QGroupBox("Colormap parameters", self)
@@ -188,9 +186,9 @@ class _CursorColorCoordDialog(QtWidgets.QDialog):
             if dim_and_coord_names is None:
                 slicer_area.array_slicer._cursor_color_params = None
             else:
-                dim_name, coord_name = dim_and_coord_names
+                coord_dims, coord_name = dim_and_coord_names
                 slicer_area.array_slicer._cursor_color_params = (
-                    dim_name,
+                    coord_dims,
                     coord_name,
                     self.cmap_combo.currentText(),
                     self.reverse_check.isChecked(),

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -617,6 +617,9 @@ class ItoolPlotItem(pg.PlotItem):
             self.slicer_area.sigShapeChanged.connect(self.remove_guidelines)
             self.slicer_area.sigShapeChanged.connect(self.clear_rois)
         else:
+            self.slicer_area.sigIndexChanged.connect(self.update_twin_plots)
+            self.slicer_area.sigBinChanged.connect(self.update_twin_plots)
+            self.slicer_area.sigCurrentCursorChanged.connect(self.update_twin_plots)
             self.slicer_area.sigDataChanged.connect(self.update_twin_plots)
             self.slicer_area.sigShapeChanged.connect(self.update_twin_plots)
             self.slicer_area.sigTwinChanged.connect(self.update_twin_plots)
@@ -636,6 +639,9 @@ class ItoolPlotItem(pg.PlotItem):
             self.slicer_area.sigShapeChanged.disconnect(self.remove_guidelines)
             self.slicer_area.sigShapeChanged.disconnect(self.clear_rois)
         else:
+            self.slicer_area.sigIndexChanged.disconnect(self.update_twin_plots)
+            self.slicer_area.sigBinChanged.disconnect(self.update_twin_plots)
+            self.slicer_area.sigCurrentCursorChanged.disconnect(self.update_twin_plots)
             self.slicer_area.sigDataChanged.disconnect(self.update_twin_plots)
             self.slicer_area.sigShapeChanged.disconnect(self.update_twin_plots)
             self.slicer_area.sigTwinChanged.disconnect(self.update_twin_plots)
@@ -700,7 +706,10 @@ class ItoolPlotItem(pg.PlotItem):
             self.vb1.setRange(**kwargs)
 
     @QtCore.Slot()
-    def update_twin_plots(self) -> None:
+    @QtCore.Slot(int)
+    @QtCore.Slot(int, object)
+    @QtCore.Slot(object, object)
+    def update_twin_plots(self, *_args) -> None:
         if not self.isVisible():
             return
         if self.vb1 is None:
@@ -712,11 +721,6 @@ class ItoolPlotItem(pg.PlotItem):
                 # Defer setup until first use
                 return
 
-        display_dim: str = str(self.slicer_area.data.dims[self.display_axis[0]])
-        associated: dict[Hashable, tuple[npt.NDArray, npt.NDArray]] = (
-            self.array_slicer.associated_coords[display_dim]
-        )
-
         n_plots: int = 0
         labels: list[str] = []
         if self.vb1 is None:  # pragma: no cover
@@ -725,9 +729,13 @@ class ItoolPlotItem(pg.PlotItem):
                 "Please report a bug."
             )
 
+        coord_names = tuple(self.array_slicer.associated_coord_dims)
         for k in tuple(self.array_slicer.twin_coord_names):
-            if k in associated:
-                x, y = associated[k]
+            profile = self.array_slicer.associated_coord_profile(
+                k, self.slicer_area.current_cursor, self.display_axis
+            )
+            if profile is not None:
+                x, y = profile
                 if n_plots >= len(self.other_data_items):
                     item = pg.PlotDataItem()
                     self.other_data_items.append(item)
@@ -736,9 +744,8 @@ class ItoolPlotItem(pg.PlotItem):
                     item = self.other_data_items[n_plots]
 
                 clr: QtGui.QColor = self.slicer_area.TWIN_COLORS[
-                    tuple(associated.keys()).index(k)
-                    % len(self.slicer_area.TWIN_COLORS)
-                ]  # Color by index among coords associated with this dim
+                    coord_names.index(k) % len(self.slicer_area.TWIN_COLORS)
+                ]  # Color by index among associated coords
                 labels.append(
                     "<tr>"
                     f"<td style='color:{clr.name()}; text-align: center;'>{k}</td>"
@@ -759,6 +766,7 @@ class ItoolPlotItem(pg.PlotItem):
         ax.setStyle(showValues=self._twin_visible)
 
         if self._twin_visible:
+            self._update_twin_geometry()
             label_html = "<table cellspacing='0'>" + "".join(labels) + "</table>"
             ax.setLabel(text=label_html)
             ax.resizeEvent()

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -8,7 +8,6 @@ import typing
 
 import numpy as np
 import numpy.typing as npt
-import xarray as xr
 from qtpy import QtCore, QtWidgets
 
 import erlab
@@ -17,6 +16,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
 
     import dask.array
+    import xarray as xr
 
 
 class ArraySlicerState(typing.TypedDict):
@@ -29,7 +29,7 @@ class ArraySlicerState(typing.TypedDict):
     snap_to_data: bool
     twin_coord_names: typing.NotRequired[tuple[Hashable, ...]]
     cursor_color_params: typing.NotRequired[
-        tuple[Hashable, Hashable, str, bool, float, float] | None
+        tuple[tuple[Hashable, ...], Hashable, str, bool, float, float] | None
     ]
 
 
@@ -289,7 +289,7 @@ class ArraySlicer(QtCore.QObject):
             ]
             self._twin_coord_names = set()
             self._cursor_color_params: (
-                tuple[Hashable, Hashable, str, bool, float, float] | None
+                tuple[tuple[Hashable, ...], Hashable, str, bool, float, float] | None
             ) = None
             self.snap_to_data = False
         else:
@@ -299,34 +299,83 @@ class ArraySlicer(QtCore.QObject):
         return reset
 
     @functools.cached_property
-    def associated_coords(
-        self,
-    ) -> dict[
-        Hashable,
-        dict[Hashable, tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
-    ]:
-        out: dict[
-            Hashable,
-            dict[Hashable, tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
-        ] = {d: {} for d in self._obj.dims}
-        for k, coord in self._obj.coords.items():
-            # Select 1D coords that are not the dimension itself
+    def associated_coord_dims(self) -> dict[Hashable, tuple[Hashable, ...]]:
+        """Numeric non-dimension coordinates that can be plotted with data profiles."""
+        dims = set(self._obj.dims)
+        out: dict[Hashable, tuple[Hashable, ...]] = {}
+        for name, coord in self._obj.coords.items():
+            coord_dims = tuple(coord.dims)
             if (
-                isinstance(coord, xr.DataArray)
-                and len(coord.dims) == 1
-                and coord.dims[0] != k
+                name not in dims
+                and coord_dims
+                and set(coord_dims).issubset(dims)
+                and np.issubdtype(coord.dtype, np.number)
+                and not np.issubdtype(coord.dtype, np.complexfloating)
             ):
-                try:
-                    vals = coord.values.astype(np.float64)
-                except ValueError:
-                    # Cannot convert to float64, nontrivial to plot these coords so skip
-                    continue
-                else:
-                    out[coord.dims[0]][k] = (
-                        coord[coord.dims[0]].values.astype(np.float64),
-                        vals,
-                    )
+                out[name] = coord_dims
         return out
+
+    def associated_coord_profile(
+        self, coord_name: Hashable, cursor: int, display_axis: Sequence[int]
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]] | None:
+        """Return a 1D associated-coordinate profile for a profile plot."""
+        if len(display_axis) != 1:
+            return None
+
+        dims = self.associated_coord_dims.get(coord_name)
+        if dims is None:
+            return None
+
+        axis = display_axis[0]
+        display_dim = self._obj.dims[axis]
+        if display_dim not in dims:
+            return None
+
+        coord = self._obj.coords[coord_name]
+        isel_kw: dict[Hashable, slice | int] = {}
+        mean_dims: list[Hashable] = []
+        for dim in dims:
+            if dim == display_dim:
+                continue
+            axis_idx = self._dim_indices.get(dim)
+            if axis_idx is None:  # pragma: no cover
+                return None
+            if self._binned[cursor][axis_idx]:
+                isel_kw[dim] = self._bin_slice(cursor, axis_idx)
+                mean_dims.append(dim)
+            else:
+                isel_kw[dim] = self._indices[cursor][axis_idx]
+
+        selected = coord.isel(isel_kw)
+        if mean_dims:
+            selected = selected.mean(dim=mean_dims, skipna=True)
+        if set(selected.dims) != {display_dim}:
+            return None
+
+        return (
+            self.coords_uniform[axis].astype(np.float64),
+            selected.transpose(display_dim).values.astype(np.float64),
+        )
+
+    def cursor_color_coord(
+        self, cursor: int, coord_dims: tuple[Hashable, ...], coord_name: Hashable
+    ) -> tuple[tuple[Hashable, ...], npt.NDArray[np.float64], float] | None:
+        """Return dims, all values, and cursor value for coordinate-based coloring."""
+        if coord_name in self._dim_indices and coord_dims == (coord_name,):
+            axis_idx = self._dim_indices[coord_name]
+            values = self.coords[axis_idx].astype(np.float64)
+        else:
+            if self.associated_coord_dims.get(coord_name) != coord_dims:
+                return None
+            values = self._obj.coords[coord_name].values.astype(np.float64)
+
+        cursor_index: list[int] = []
+        for dim in coord_dims:
+            coord_axis_idx = self._dim_indices.get(dim)
+            if coord_axis_idx is None:  # pragma: no cover
+                return None
+            cursor_index.append(self._indices[cursor][coord_axis_idx])
+        return coord_dims, values, float(values[tuple(cursor_index)])
 
     @functools.cached_property
     def coords(self) -> tuple[npt.NDArray[np.floating], ...]:
@@ -463,7 +512,21 @@ class ArraySlicer(QtCore.QObject):
             # We call set_array below so use update=False
 
         self.twin_coord_names = set(state.get("twin_coord_names", set()))
-        self._cursor_color_params = state.get("cursor_color_params", None)
+        cursor_color_params = state.get("cursor_color_params", None)
+        if cursor_color_params is not None:
+            coord_dims, coord_name, cmap, reverse, vmin, vmax = cursor_color_params
+            if not isinstance(coord_dims, tuple):
+                coord_dims = (coord_dims,)
+            self._cursor_color_params = (
+                coord_dims,
+                coord_name,
+                cmap,
+                reverse,
+                vmin,
+                vmax,
+            )
+        else:
+            self._cursor_color_params = None
 
         self.set_array(self._obj, validate=False)
         # Not sure why the last line is needed but the cursor is not fully restored
@@ -582,7 +645,7 @@ class ArraySlicer(QtCore.QObject):
         """
         for prop in (
             "coords",
-            "associated_coords",
+            "associated_coord_dims",
             "coords_uniform",
             "incs",
             "incs_uniform",

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -349,8 +349,6 @@ class ArraySlicer(QtCore.QObject):
         selected = coord.isel(isel_kw)
         if mean_dims:
             selected = selected.mean(dim=mean_dims, skipna=True)
-        if set(selected.dims) != {display_dim}:
-            return None
 
         return (
             self.coords_uniform[axis].astype(np.float64),

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1429,11 +1429,12 @@ class ImageSlicerArea(QtWidgets.QWidget):
             cmap = erlab.interactive.colors.pg_colormap_from_name(cmap)
 
             for cursor_idx in cursor:
-                coord_info = self.array_slicer.cursor_color_coord(
-                    cursor_idx, coord_dims, coord_name
+                coord_info = typing.cast(
+                    "tuple[tuple[Hashable, ...], npt.NDArray[np.float64], float]",
+                    self.array_slicer.cursor_color_coord(
+                        cursor_idx, coord_dims, coord_name
+                    ),
                 )
-                if coord_info is None:
-                    continue
                 coord_value = coord_info[2]
                 value = (coord_value - mn) * scale_factor + vmin
                 if reverse:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1408,29 +1408,34 @@ class ImageSlicerArea(QtWidgets.QWidget):
     ) -> None:
         cursor_color_params = self.array_slicer._cursor_color_params
         if cursor_color_params is not None:
-            dim_name, coord_name, cmap, reverse, vmin, vmax = cursor_color_params
-            if (axes is not None) and (
-                dim_name not in tuple(self.data.dims[ax] for ax in axes)
-            ):
-                return
-
+            coord_dims, coord_name, cmap, reverse, vmin, vmax = cursor_color_params
             if isinstance(cursor, int):
                 cursor = (cursor,)
 
-            axis_idx = self.data.dims.index(dim_name)
-            if coord_name == dim_name:
-                target_coord = self.array_slicer.coords[axis_idx]
-            else:
-                target_coord = self.array_slicer.associated_coords[dim_name][
-                    coord_name
-                ][1]
+            coord_info = self.array_slicer.cursor_color_coord(
+                cursor[0], coord_dims, coord_name
+            )
+            if coord_info is None:
+                self.array_slicer._cursor_color_params = None
+                return
+            coord_dims, target_coord, _ = coord_info
+            if axes is not None and not any(
+                self.data.dims[ax] in coord_dims for ax in axes
+            ):
+                return
+
             mn, mx = np.min(target_coord), np.max(target_coord)
             scale_factor = (vmax - vmin) / (mx - mn)
             cmap = erlab.interactive.colors.pg_colormap_from_name(cmap)
 
             for cursor_idx in cursor:
-                value_idx: int = self.array_slicer.get_indices(cursor_idx)[axis_idx]
-                value = (target_coord[value_idx] - mn) * scale_factor + vmin
+                coord_info = self.array_slicer.cursor_color_coord(
+                    cursor_idx, coord_dims, coord_name
+                )
+                if coord_info is None:
+                    continue
+                coord_value = coord_info[2]
+                value = (coord_value - mn) * scale_factor + vmin
                 if reverse:
                     value = 1 - value
                 color = cmap.map(value, mode=cmap.QCOLOR)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -823,7 +823,14 @@ def test_cursor_colors_follow_coordinate(qtbot) -> None:
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     slicer = win.slicer_area
-    slicer.array_slicer._cursor_color_params = ("x", "x", "coolwarm", False, 0.0, 1.0)
+    slicer.array_slicer._cursor_color_params = (
+        ("x",),
+        "x",
+        "coolwarm",
+        False,
+        0.0,
+        1.0,
+    )
     slicer._refresh_cursor_colors(tuple(range(slicer.n_cursors)), None)
 
     cmap = erlab.interactive.colors.pg_colormap_from_name("coolwarm")
@@ -865,7 +872,14 @@ def test_cursor_colors_from_associated_coord(qtbot) -> None:
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     slicer = win.slicer_area
-    slicer.array_slicer._cursor_color_params = ("x", "temp", "viridis", True, 0.2, 0.8)
+    slicer.array_slicer._cursor_color_params = (
+        ("x",),
+        "temp",
+        "viridis",
+        True,
+        0.2,
+        0.8,
+    )
     slicer._refresh_cursor_colors(tuple(range(slicer.n_cursors)), None)
 
     cmap = erlab.interactive.colors.pg_colormap_from_name("viridis")
@@ -887,6 +901,108 @@ def test_cursor_colors_from_associated_coord(qtbot) -> None:
     win.close()
 
 
+def test_associated_coord_profile_nd_cursor_and_bins(qtbot) -> None:
+    x = np.arange(3, dtype=float)
+    y = np.arange(4, dtype=float)
+    z = np.arange(5, dtype=float)
+    plane = x[:, None] * 10.0 + y[None, :] ** 2
+    full = x[:, None, None] * 100.0 + y[None, :, None] * 10.0 + z[None, None, :]
+    data = xr.DataArray(
+        np.zeros((3, 4, 5), dtype=float),
+        dims=["x", "y", "z"],
+        coords={
+            "x": x,
+            "y": y,
+            "z": z,
+            "temp": ("x", x + 300.0),
+            "plane": (("x", "y"), plane),
+            "full": (("x", "y", "z"), full),
+            "label": ("x", ["a", "b", "c"]),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    slicer = win.slicer_area.array_slicer
+
+    assert slicer.associated_coord_dims == {
+        "temp": ("x",),
+        "plane": ("x", "y"),
+        "full": ("x", "y", "z"),
+    }
+
+    dialog = _AssociatedCoordsDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    assert set(dialog._checks) == {"temp", "plane", "full"}
+
+    x_profile, full_profile = slicer.associated_coord_profile("full", 0, (0,))
+    np.testing.assert_allclose(x_profile, x)
+    np.testing.assert_allclose(full_profile, x * 100.0 + 12.0)
+
+    slicer.set_index(0, 1, 2, update=False)
+    slicer.set_index(0, 2, 3, update=False)
+    _, full_profile = slicer.associated_coord_profile("full", 0, (0,))
+    np.testing.assert_allclose(full_profile, x * 100.0 + 23.0)
+
+    slicer.set_index(0, 1, 1, update=False)
+    slicer.set_bin(0, 1, 3, update=False)
+    _, plane_profile = slicer.associated_coord_profile("plane", 0, (0,))
+    np.testing.assert_allclose(plane_profile, x * 10.0 + np.mean([0.0, 1.0, 4.0]))
+
+    assert slicer.associated_coord_profile("plane", 0, (2,)) is None
+    win.close()
+
+
+def test_cursor_colors_from_nd_associated_coord(qtbot) -> None:
+    temp = np.arange(25, dtype=float).reshape(5, 5)
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={
+            "x": np.arange(5),
+            "y": np.arange(5),
+            "temp": (("x", "y"), temp),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    slicer = win.slicer_area
+
+    dialog = _CursorColorCoordDialog(slicer)
+    qtbot.addWidget(dialog)
+    assert "temp" in [
+        dialog.coord_combo.itemText(i) for i in range(dialog.coord_combo.count())
+    ]
+    dialog.main_group.setChecked(True)
+    dialog.coord_combo.setCurrentText("temp")
+    assert dialog.get_checked_coord_name() == (("x", "y"), "temp")
+
+    slicer.array_slicer._cursor_color_params = (
+        ("x", "y"),
+        "temp",
+        "viridis",
+        False,
+        0.2,
+        0.8,
+    )
+    slicer._refresh_cursor_colors(tuple(range(slicer.n_cursors)), None)
+
+    cmap = erlab.interactive.colors.pg_colormap_from_name("viridis")
+    mn, mx = np.min(temp), np.max(temp)
+    scale = (0.8 - 0.2) / (mx - mn)
+    idx_x, idx_y = slicer.array_slicer.get_indices(0)
+    raw = (temp[idx_x, idx_y] - mn) * scale + 0.2
+    expected = cmap.map(raw, mode=cmap.QCOLOR).name()
+    assert slicer.cursor_colors[0].name() == expected
+
+    slicer.set_value(axis=1, value=4.0, cursor=0)
+    idx_x, idx_y = slicer.array_slicer.get_indices(0)
+    raw = (temp[idx_x, idx_y] - mn) * scale + 0.2
+    expected = cmap.map(raw, mode=cmap.QCOLOR).name()
+    assert slicer.cursor_colors[0].name() == expected
+
+    win.close()
+
+
 def test_manual_cursor_colors_disable_coord_updates(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)),
@@ -896,7 +1012,14 @@ def test_manual_cursor_colors_disable_coord_updates(qtbot) -> None:
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     slicer = win.slicer_area
-    slicer.array_slicer._cursor_color_params = ("x", "x", "plasma", False, 0.0, 1.0)
+    slicer.array_slicer._cursor_color_params = (
+        ("x",),
+        "x",
+        "plasma",
+        False,
+        0.0,
+        1.0,
+    )
     slicer._refresh_cursor_colors(tuple(range(slicer.n_cursors)), None)
 
     slicer.set_value(axis=0, value=4.0, cursor=0)
@@ -927,7 +1050,14 @@ def test_cursor_color_coord_dialog_updates_params(
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     slicer = win.slicer_area
-    slicer.array_slicer._cursor_color_params = ("x", "temp", "magma", True, 0.1, 0.9)
+    slicer.array_slicer._cursor_color_params = (
+        ("x",),
+        "temp",
+        "magma",
+        True,
+        0.1,
+        0.9,
+    )
 
     called: dict[str, object] = {}
 
@@ -954,7 +1084,7 @@ def test_cursor_color_coord_dialog_updates_params(
     accept_dialog(slicer._set_cursor_colors_by_coord, pre_call=prepare)
 
     assert slicer.array_slicer._cursor_color_params == (
-        "x",
+        ("x",),
         "temp",
         "viridis",
         False,

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -918,6 +918,8 @@ def test_associated_coord_profile_nd_cursor_and_bins(qtbot) -> None:
             "plane": (("x", "y"), plane),
             "full": (("x", "y", "z"), full),
             "label": ("x", ["a", "b", "c"]),
+            "complex": ("x", np.arange(3, dtype=complex)),
+            "scalar": 1.0,
         },
     )
     win = itool(data, execute=False)
@@ -949,6 +951,37 @@ def test_associated_coord_profile_nd_cursor_and_bins(qtbot) -> None:
     np.testing.assert_allclose(plane_profile, x * 10.0 + np.mean([0.0, 1.0, 4.0]))
 
     assert slicer.associated_coord_profile("plane", 0, (2,)) is None
+    assert slicer.associated_coord_profile("plane", 0, (0, 1)) is None
+    assert slicer.associated_coord_profile("missing", 0, (0,)) is None
+    assert slicer.cursor_color_coord(0, ("y", "x"), "plane") is None
+    win.close()
+
+
+def test_associated_coord_dialog_empty_warning(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5), "y": np.arange(5)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = _AssociatedCoordsDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    assert dialog.exec() == QtWidgets.QDialog.DialogCode.Rejected
+    assert warnings == [
+        (
+            "No Associated Coordinates",
+            "No numeric non-dimension coordinates were found in the data.",
+        )
+    ]
     win.close()
 
 
@@ -975,6 +1008,15 @@ def test_cursor_colors_from_nd_associated_coord(qtbot) -> None:
     dialog.main_group.setChecked(True)
     dialog.coord_combo.setCurrentText("temp")
     assert dialog.get_checked_coord_name() == (("x", "y"), "temp")
+    dialog.coord_combo.setCurrentText("x")
+    assert dialog.get_checked_coord_name() == (("x",), "x")
+    dialog.main_group.setChecked(False)
+    assert dialog.get_checked_coord_name() is None
+    dialog.main_group.setChecked(True)
+    dialog.coord_combo.setEditable(True)
+    dialog.coord_combo.setCurrentText("missing")
+    assert dialog.get_checked_coord_name() is None
+    dialog.coord_combo.setCurrentText("temp")
 
     slicer.array_slicer._cursor_color_params = (
         ("x", "y"),
@@ -1000,6 +1042,100 @@ def test_cursor_colors_from_nd_associated_coord(qtbot) -> None:
     expected = cmap.map(raw, mode=cmap.QCOLOR).name()
     assert slicer.cursor_colors[0].name() == expected
 
+    win.close()
+
+
+def test_cursor_color_invalid_state_is_cleared(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5), "y": np.arange(5)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    slicer = win.slicer_area
+    slicer.array_slicer._cursor_color_params = (
+        ("x",),
+        "missing",
+        "viridis",
+        False,
+        0.0,
+        1.0,
+    )
+
+    slicer._refresh_cursor_colors(tuple(range(slicer.n_cursors)), None)
+
+    assert slicer.array_slicer._cursor_color_params is None
+    win.close()
+
+
+def test_cursor_color_dialog_accept_disabled_clears_params(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={
+            "x": np.arange(5),
+            "y": np.arange(5),
+            "temp": ("x", np.linspace(-1, 1, 5)),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    slicer = win.slicer_area
+    slicer.array_slicer._cursor_color_params = (
+        ("x",),
+        "temp",
+        "viridis",
+        False,
+        0.0,
+        1.0,
+    )
+    dialog = _CursorColorCoordDialog(slicer)
+    qtbot.addWidget(dialog)
+    dialog.main_group.setChecked(False)
+
+    dialog.accept()
+
+    assert slicer.array_slicer._cursor_color_params is None
+    win.close()
+
+
+def test_cursor_color_state_restores_legacy_dim(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={
+            "x": np.arange(5),
+            "y": np.arange(5),
+            "temp": ("x", np.linspace(-1, 1, 5)),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    state = win.slicer_area.array_slicer.state
+    state["cursor_color_params"] = ("x", "temp", "magma", True, 0.1, 0.9)
+
+    win.slicer_area.array_slicer.state = state
+
+    assert win.slicer_area.array_slicer._cursor_color_params == (
+        ("x",),
+        "temp",
+        "magma",
+        True,
+        0.1,
+        0.9,
+    )
+
+    state = win.slicer_area.array_slicer.state
+    win.slicer_area.array_slicer.state = state
+    assert win.slicer_area.array_slicer._cursor_color_params == (
+        ("x",),
+        "temp",
+        "magma",
+        True,
+        0.1,
+        0.9,
+    )
     win.close()
 
 


### PR DESCRIPTION
ImageTool can now plot numeric non-dimension coordinates with one or more dimensions from `View` → `Plot Associated Coordinates`. Multidimensional associated coordinates are sliced with the active cursor and averaged over binned hidden dimensions, so their profile overlays stay aligned with the displayed data slice. Cursor color mapping also supports multidimensional associated coordinates by sampling the coordinate value at each cursor position.