### PR TITLE
feat(manager): add guided loader extension editors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Use 4-space indentation, Ruff’s 88-character limit, and double quotes. Modules
 Prefer importing top-level `erlab` in modules that already use `lazy_loader`, even if a narrower import is possible.
 Follow package import conventions by preferring absolute imports over relative imports.
 Use modern typing syntax as a default rule: use built-in generics (`list[str]`, `dict[str, int]`) and `collections.abc` types (for example `Callable`), and avoid deprecated `typing` aliases (deprecated since Python 3.9).
+Typing rule: do not write `typing.Iterable`, `typing.Iterator`, `typing.Mapping`, `typing.Sequence`, `typing.Callable`, `typing.Dict`, `typing.List`, or `typing.Tuple`. Import abstract collection types from `collections.abc` (inside `if typing.TYPE_CHECKING:` when used only for annotations) and use built-in containers such as `list[str]` and `dict[str, int]`.
 
 ## Testing Guidelines
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -188,7 +188,9 @@ Once the manager is running, you can open ImageTools in several ways:
 
   In the dialog that appears, you can choose the plugin to use for loading the data.
   For plugin loaders, expand {guilabel}`Loader Extensions` to set literal
-  {func}`erlab.io.extend_loader` options.
+  {func}`erlab.io.extend_loader` options. The {guilabel}`name_map` and
+  {guilabel}`coordinate_attrs` rows also have buttons that inspect the first
+  selected file and help build the literal values interactively.
 
   :::{hint}
   For scans that are recorded across multiple files, drag and dropping any file in the scan will automatically load and concatenate the entire scan. If you want to load only the file you dropped, choose the plugin suffixed with {guilabel}`Single File` in the dialog.

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -1120,6 +1120,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
             self,
             {loader_name: (loader.load, kwargs)},
             loader_extensions={loader_name: extensions},
+            sample_paths=self._current_selection,
         )
         dialog.check_filter(loader_name)
 

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import html
 import inspect
+import pathlib
 import typing
 import weakref
 
@@ -14,7 +15,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable, Iterator
 
     import xarray
 
@@ -323,6 +324,83 @@ def _text_to_loader_extension_value(
     return {key: value}
 
 
+def _string_tuple_from_literal(key: str, text: str) -> tuple[str, ...]:
+    parsed = _text_to_loader_extension_value(key, text)
+    if parsed is None:
+        return ()
+    value = parsed[key]
+    if isinstance(value, str):
+        raise TypeError(f"{key} must be an iterable, not a string")
+    try:
+        return tuple(str(v) for v in value)
+    except TypeError as e:
+        raise TypeError(f"{key} must be an iterable") from e
+
+
+def _name_map_from_literal(text: str) -> dict[str, str | Iterable[str]]:
+    parsed = _text_to_loader_extension_value("name_map", text)
+    if parsed is None:
+        return {}
+    value = parsed["name_map"]
+    if not isinstance(value, dict):
+        raise TypeError("name_map must be a dict")
+    return value
+
+
+def _iter_name_map_pairs(
+    name_map: dict[str, str | Iterable[str]],
+) -> Iterator[tuple[str, str]]:
+    for new_name, originals in name_map.items():
+        if isinstance(originals, str):
+            yield str(new_name), originals
+        else:
+            for original in originals:
+                yield str(new_name), str(original)
+
+
+def _name_map_from_pairs(
+    pairs: Iterable[tuple[str, str]],
+) -> dict[str, str | Iterable[str]]:
+    grouped: dict[str, list[str]] = {}
+    for new_name, original in pairs:
+        values = grouped.setdefault(new_name, [])
+        if original not in values:
+            values.append(original)
+    out: dict[str, str | Iterable[str]] = {}
+    for new_name, originals in grouped.items():
+        out[new_name] = originals[0] if len(originals) == 1 else originals
+    return out
+
+
+def _name_map_literal(name_map: dict[str, str | Iterable[str]]) -> str:
+    return repr(name_map) if name_map else ""
+
+
+def _coordinate_attrs_literal(values: tuple[str, ...]) -> str:
+    return repr(list(values)) if values else ""
+
+
+def _coordinate_attrs_sample_attrs(
+    loader: erlab.io.dataloader.LoaderBase, sample_path: pathlib.Path
+) -> dict[str, typing.Any]:
+    load_kwargs: dict[str, typing.Any] = {}
+    load_single = getattr(loader, "_original_load_single", loader.load_single)
+    if erlab.utils.misc.accepts_kwarg(load_single, "without_values", strict=False):
+        load_kwargs["without_values"] = True
+
+    try:
+        data = loader.load_single(sample_path, **load_kwargs)
+    except TypeError:
+        if not load_kwargs:
+            raise
+        data = loader.load_single(sample_path)
+
+    attrs = getattr(data, "attrs", None)
+    if attrs is None:
+        return {}
+    return dict(attrs)
+
+
 def _tooltip_with_example(text: str, example: str) -> str:
     return f"<qt>{html.escape(text)}<br>Example: <tt>{html.escape(example)}</tt></qt>"
 
@@ -368,6 +446,271 @@ _LOADER_EXTENSION_TOOLTIPS = {
 }
 
 
+class _NameMapEditorDialog(QtWidgets.QDialog):
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget,
+        loader: erlab.io.dataloader.LoaderBase,
+        sample_path: pathlib.Path | None,
+        current_name_map: dict[str, str | Iterable[str]],
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Edit Name Map")
+        self._selected_name_map: dict[str, str | Iterable[str]] = current_name_map
+        self._rows: list[tuple[str, QtWidgets.QTableWidgetItem, bool]] = []
+        self._unmatched_pairs: tuple[tuple[str, str], ...] = ()
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        if sample_path is None:
+            layout.addWidget(QtWidgets.QLabel("No sample file is available."))
+            self._add_button_box(layout, editor_enabled=False)
+            return
+
+        try:
+            attrs = _coordinate_attrs_sample_attrs(loader, sample_path)
+        except Exception as e:
+            label = QtWidgets.QLabel(
+                "Could not inspect the selected file. Edit name_map directly instead."
+                f"\n\n{type(e).__name__}: {e}"
+            )
+            label.setWordWrap(True)
+            layout.addWidget(label)
+            self._add_button_box(layout, editor_enabled=False)
+            return
+
+        if not attrs:
+            layout.addWidget(
+                QtWidgets.QLabel("No attributes were found in the sample.")
+            )
+            self._add_button_box(layout, editor_enabled=False)
+            return
+
+        table = QtWidgets.QTableWidget(len(attrs), 2, self)
+        table.setHorizontalHeaderLabels(["File attribute", "Renamed to"])
+        table.setAlternatingRowColors(True)
+        table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        table.setEditTriggers(
+            QtWidgets.QAbstractItemView.EditTrigger.DoubleClicked
+            | QtWidgets.QAbstractItemView.EditTrigger.EditKeyPressed
+            | QtWidgets.QAbstractItemView.EditTrigger.SelectedClicked
+        )
+        layout.addWidget(table)
+        self._table = table
+
+        built_in_reversed = loader._reverse_mapping(loader.name_map)
+        current_reversed = loader._reverse_mapping(current_name_map)
+        represented_originals = set(attrs)
+        self._unmatched_pairs = tuple(
+            (new_name, original)
+            for new_name, original in _iter_name_map_pairs(current_name_map)
+            if original not in represented_originals
+        )
+
+        for row, original in enumerate(attrs):
+            built_in_new = built_in_reversed.get(original)
+            current_new = current_reversed.get(original)
+            target = built_in_new or current_new or ""
+            is_built_in = built_in_new is not None
+
+            original_item = QtWidgets.QTableWidgetItem(original)
+            target_item = QtWidgets.QTableWidgetItem(target)
+            if is_built_in:
+                flags = QtCore.Qt.ItemFlag.ItemIsSelectable
+                tooltip = f"{original} is already renamed to {built_in_new}"
+                original_item.setFlags(flags)
+                target_item.setFlags(flags)
+                original_item.setToolTip(tooltip)
+                target_item.setToolTip(tooltip)
+            else:
+                original_item.setFlags(
+                    QtCore.Qt.ItemFlag.ItemIsEnabled
+                    | QtCore.Qt.ItemFlag.ItemIsSelectable
+                )
+                target_item.setFlags(
+                    QtCore.Qt.ItemFlag.ItemIsEnabled
+                    | QtCore.Qt.ItemFlag.ItemIsSelectable
+                    | QtCore.Qt.ItemFlag.ItemIsEditable
+                )
+            table.setItem(row, 0, original_item)
+            table.setItem(row, 1, target_item)
+            self._rows.append((original, target_item, is_built_in))
+
+        table.resizeColumnsToContents()
+        header = table.horizontalHeader()
+        if header is not None:  # pragma: no branch
+            header.setStretchLastSection(True)
+        self._add_button_box(layout, editor_enabled=True)
+
+    def _add_button_box(
+        self, layout: QtWidgets.QVBoxLayout, *, editor_enabled: bool
+    ) -> None:
+        buttons = (
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+            if editor_enabled
+            else QtWidgets.QDialogButtonBox.StandardButton.Close
+        )
+        button_box = QtWidgets.QDialogButtonBox(buttons)
+        if editor_enabled:
+            button_box.accepted.connect(self.accept)
+            button_box.rejected.connect(self.reject)
+        else:
+            button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def selected_name_map(self) -> dict[str, str | Iterable[str]]:
+        return self._selected_name_map
+
+    def accept(self) -> None:
+        pairs = list(self._unmatched_pairs)
+        for original, target_item, is_built_in in self._rows:
+            if is_built_in:
+                continue
+            new_name = target_item.text().strip()
+            if new_name and new_name != original:
+                pairs.append((new_name, original))
+        self._selected_name_map = _name_map_from_pairs(pairs)
+        super().accept()
+
+
+class _CoordinateAttrsPickerDialog(QtWidgets.QDialog):
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget,
+        loader: erlab.io.dataloader.LoaderBase,
+        sample_path: pathlib.Path | None,
+        current_values: tuple[str, ...],
+        name_map: dict[str, str | Iterable[str]],
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Promote Attributes to Coordinates")
+        self._selected_values: tuple[str, ...] = current_values
+        self._items: list[QtWidgets.QTreeWidgetItem] = []
+        self._unmatched_values: tuple[str, ...] = ()
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        if sample_path is None:
+            layout.addWidget(QtWidgets.QLabel("No sample file is available."))
+            self._add_button_box(layout, picker_enabled=False)
+            return
+
+        try:
+            attrs = _coordinate_attrs_sample_attrs(loader, sample_path)
+        except Exception as e:
+            label = QtWidgets.QLabel(
+                "Could not inspect the selected file. "
+                "Edit coordinate_attrs directly instead.\n\n"
+                f"{type(e).__name__}: {e}"
+            )
+            label.setWordWrap(True)
+            layout.addWidget(label)
+            self._add_button_box(layout, picker_enabled=False)
+            return
+
+        if not attrs:
+            layout.addWidget(
+                QtWidgets.QLabel("No attributes were found in the sample.")
+            )
+            self._add_button_box(layout, picker_enabled=False)
+            return
+
+        tree = QtWidgets.QTreeWidget(self)
+        tree.setColumnCount(2)
+        tree.setHeaderLabels(["File attribute", "Renamed to"])
+        tree.setRootIsDecorated(False)
+        tree.setAlternatingRowColors(True)
+        tree.setUniformRowHeights(True)
+        layout.addWidget(tree)
+        self._tree = tree
+
+        built_in = set(loader.coordinate_attrs)
+        selected = set(current_values)
+        name_map_reversed = loader._reverse_mapping(loader.name_map | name_map)
+        represented_values: set[str] = set()
+
+        for original in attrs:
+            renamed = name_map_reversed.get(original, original)
+            renamed_text = renamed if renamed != original else ""
+            represented_values.add(renamed)
+            is_built_in = renamed in built_in
+            is_checked = is_built_in or renamed in selected or original in selected
+            item = QtWidgets.QTreeWidgetItem(tree, [original, renamed_text])
+            item.setData(0, QtCore.Qt.ItemDataRole.UserRole, renamed)
+            item.setData(0, QtCore.Qt.ItemDataRole.UserRole + 1, is_built_in)
+            item.setCheckState(
+                0,
+                QtCore.Qt.CheckState.Checked
+                if is_checked
+                else QtCore.Qt.CheckState.Unchecked,
+            )
+            flags = (
+                QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsSelectable
+            )
+            if not is_built_in:
+                flags |= QtCore.Qt.ItemFlag.ItemIsUserCheckable
+            item.setFlags(flags)
+            item.setDisabled(is_built_in)
+            if original != renamed:
+                item.setToolTip(0, f"{original} is renamed to {renamed}")
+                item.setToolTip(1, f"Original attribute: {original}")
+            if is_built_in:
+                item.setToolTip(
+                    0,
+                    "Already promoted by the selected loader"
+                    if original == renamed
+                    else f"{original} is renamed to {renamed} and already promoted "
+                    "by the selected loader",
+                )
+                item.setToolTip(1, "Already promoted by the selected loader")
+            self._items.append(item)
+
+        for column in range(tree.columnCount()):
+            tree.resizeColumnToContents(column)
+
+        self._unmatched_values = tuple(
+            v
+            for v in current_values
+            if v not in represented_values and v not in built_in
+        )
+        self._add_button_box(layout, picker_enabled=True)
+
+    def _add_button_box(
+        self, layout: QtWidgets.QVBoxLayout, *, picker_enabled: bool
+    ) -> None:
+        buttons = (
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+            if picker_enabled
+            else QtWidgets.QDialogButtonBox.StandardButton.Close
+        )
+        button_box = QtWidgets.QDialogButtonBox(buttons)
+        if picker_enabled:
+            button_box.accepted.connect(self.accept)
+            button_box.rejected.connect(self.reject)
+        else:
+            button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def selected_coordinate_attrs(self) -> tuple[str, ...]:
+        return self._selected_values
+
+    def accept(self) -> None:
+        values: list[str] = []
+        for item in self._items:
+            is_built_in = bool(item.data(0, QtCore.Qt.ItemDataRole.UserRole + 1))
+            if is_built_in:
+                continue
+            if item.checkState(0) == QtCore.Qt.CheckState.Checked:
+                values.append(str(item.data(0, QtCore.Qt.ItemDataRole.UserRole)))
+        values.extend(v for v in self._unmatched_values if v not in values)
+        self._selected_values = tuple(values)
+        super().accept()
+
+
 class _NameFilterDialog(QtWidgets.QDialog):
     def __init__(
         self,
@@ -375,12 +718,14 @@ class _NameFilterDialog(QtWidgets.QDialog):
         valid_loaders: dict[str, tuple[Callable, dict]],
         *,
         loader_extensions: dict[str, dict[str, typing.Any]] | None = None,
+        sample_paths: Iterable[str | pathlib.Path] | None = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Select Loader")
 
         self._valid_loaders = valid_loaders
         self._loader_extensions = loader_extensions or {}
+        self._sample_paths = tuple(pathlib.Path(p) for p in sample_paths or ())
         self._checked_kwargs: dict[str, typing.Any] | None = None
         self._checked_loader_extensions: dict[str, typing.Any] | None = None
         self._extensions_available = False
@@ -430,6 +775,9 @@ class _NameFilterDialog(QtWidgets.QDialog):
         self.loader_extension_highlighters: list[
             erlab.interactive.utils.PythonHighlighter
         ] = []
+        self.loader_extension_fields: dict[str, QtWidgets.QWidget] = {}
+        self.name_map_editor_button: QtWidgets.QToolButton | None = None
+        self.coordinate_attrs_picker_button: QtWidgets.QToolButton | None = None
         for key in inspect.signature(
             erlab.io.dataloader.LoaderBase.extend_loader
         ).parameters:
@@ -453,7 +801,37 @@ class _NameFilterDialog(QtWidgets.QDialog):
             line.setToolTip(tooltip)
             label = QtWidgets.QLabel(key)
             label.setToolTip(tooltip)
-            extensions_layout.addRow(label, line)
+            if key in {"name_map", "coordinate_attrs"}:
+                field = QtWidgets.QWidget()
+                field_layout = QtWidgets.QHBoxLayout(field)
+                field_layout.setContentsMargins(0, 0, 0, 0)
+                field_layout.setSpacing(4)
+                line.setSizePolicy(
+                    QtWidgets.QSizePolicy.Policy.Ignored,
+                    QtWidgets.QSizePolicy.Policy.Fixed,
+                )
+                field_layout.addWidget(line, 1)
+                button = QtWidgets.QToolButton()
+                if key == "name_map":
+                    button.setText("Edit...")
+                    button.setToolTip(
+                        "Inspect the selected file and edit attribute renames."
+                    )
+                    button.clicked.connect(self._open_name_map_editor)
+                    self.name_map_editor_button = button
+                else:
+                    button.setText("Edit...")
+                    button.setToolTip(
+                        "Inspect the selected file and choose coordinate attributes."
+                    )
+                    button.clicked.connect(self._open_coordinate_attrs_picker)
+                    self.coordinate_attrs_picker_button = button
+                field_layout.addWidget(button)
+            else:
+                field = line
+            field.setToolTip(tooltip)
+            self.loader_extension_fields[key] = field
+            extensions_layout.addRow(label, field)
         layout.addWidget(self.extensions_group)
         self.extensions_toggle.hide()
         self.extensions_group.hide()
@@ -499,6 +877,68 @@ class _NameFilterDialog(QtWidgets.QDialog):
         for key, line in self.loader_extension_lines.items():
             value = loader_extensions.get(key)
             line.setText("" if value is None else repr(value))
+
+    @QtCore.Slot()
+    def _open_name_map_editor(self) -> None:
+        line = self.loader_extension_lines["name_map"]
+        try:
+            current_name_map = _name_map_from_literal(line.text())
+        except Exception as e:
+            erlab.interactive.utils.MessageDialog.critical(
+                self,
+                "Error",
+                "Invalid loader arguments.",
+                str(e),
+            )
+            return
+
+        name_filter = list(self._valid_loaders.keys())[self._button_group.checkedId()]
+        func = self._valid_loaders[name_filter][0]
+        loader = getattr(func, "__self__", None)
+        if not isinstance(loader, erlab.io.dataloader.LoaderBase):
+            return
+
+        dialog = _NameMapEditorDialog(
+            self,
+            loader,
+            self._sample_paths[0] if self._sample_paths else None,
+            current_name_map,
+        )
+        if dialog.exec():
+            line.setText(_name_map_literal(dialog.selected_name_map()))
+
+    @QtCore.Slot()
+    def _open_coordinate_attrs_picker(self) -> None:
+        line = self.loader_extension_lines["coordinate_attrs"]
+        try:
+            current_values = _string_tuple_from_literal("coordinate_attrs", line.text())
+            name_map = _name_map_from_literal(
+                self.loader_extension_lines["name_map"].text()
+            )
+        except Exception as e:
+            erlab.interactive.utils.MessageDialog.critical(
+                self,
+                "Error",
+                "Invalid loader arguments.",
+                str(e),
+            )
+            return
+
+        name_filter = list(self._valid_loaders.keys())[self._button_group.checkedId()]
+        func = self._valid_loaders[name_filter][0]
+        loader = getattr(func, "__self__", None)
+        if not isinstance(loader, erlab.io.dataloader.LoaderBase):
+            return
+
+        dialog = _CoordinateAttrsPickerDialog(
+            self,
+            loader,
+            self._sample_paths[0] if self._sample_paths else None,
+            current_values,
+            name_map,
+        )
+        if dialog.exec():
+            line.setText(_coordinate_attrs_literal(dialog.selected_coordinate_attrs()))
 
     @QtCore.Slot(bool)
     def _set_extensions_expanded(self, expanded: bool) -> None:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -44,7 +44,7 @@ from erlab.interactive.imagetool.manager._wrapper import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
 
     from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
     from erlab.interactive.ptable import PeriodicTableWindow
@@ -1969,11 +1969,14 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self,
         valid_loaders: dict[str, tuple[Callable, dict]],
         name_filter: str | None = None,
+        *,
+        sample_paths: Iterable[str | pathlib.Path] | None = None,
     ) -> tuple[str, Callable, dict[str, typing.Any]] | None:
         dialog = _NameFilterDialog(
             self,
             valid_loaders,
             loader_extensions=self._recent_loader_extensions_by_filter,
+            sample_paths=sample_paths,
         )
         dialog.check_filter(name_filter or self._preferred_name_filter(valid_loaders))
 
@@ -2843,6 +2846,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 selected = self._select_loader_options(
                     {self._recent_name_filter: (func, kwargs)},
                     self._recent_name_filter,
+                    sample_paths=file_names,
                 )
                 if selected is None:
                     return
@@ -3285,14 +3289,16 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if len(valid_loaders) == 1:
             name_filter, (func, kargs) = next(iter(valid_loaders.items()))
             if _is_loader_func(func):
-                selected = self._select_loader_options(valid_loaders, name_filter)
+                selected = self._select_loader_options(
+                    valid_loaders, name_filter, sample_paths=queued
+                )
                 if selected is None:
                     return
                 self._recent_name_filter, func, kargs = selected
             else:
                 self._recent_name_filter = name_filter
         else:
-            selected = self._select_loader_options(valid_loaders)
+            selected = self._select_loader_options(valid_loaders, sample_paths=queued)
             if selected is None:
                 return
             self._recent_name_filter, func, kargs = selected

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -27,6 +27,7 @@ from IPython.core.interactiveshell import InteractiveShell
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
@@ -49,7 +50,9 @@ from erlab.interactive.imagetool.manager._console import (
 from erlab.interactive.imagetool.manager._dialogs import (
     _ChooseFromDataTreeDialog,
     _ConcatDialog,
+    _CoordinateAttrsPickerDialog,
     _NameFilterDialog,
+    _NameMapEditorDialog,
     _RenameDialog,
     _text_to_loader_extension_value,
 )
@@ -1817,12 +1820,24 @@ def test_name_filter_dialog_loader_extensions_toggle_resizes(
     extensions_layout = typing.cast(
         "QtWidgets.QFormLayout", dialog.extensions_group.layout()
     )
-    for field in dialog.loader_extension_lines.values():
+    for field in dialog.loader_extension_fields.values():
         label = extensions_layout.labelForField(field)
         assert label is not None
         assert field.toolTip()
         assert "<tt>" in field.toolTip()
         assert label.toolTip() == field.toolTip()
+    assert dialog.name_map_editor_button is not None
+    assert (
+        dialog.loader_extension_lines["name_map"].sizePolicy().horizontalPolicy()
+        == QtWidgets.QSizePolicy.Policy.Ignored
+    )
+    assert dialog.coordinate_attrs_picker_button is not None
+    assert (
+        dialog.loader_extension_lines["coordinate_attrs"]
+        .sizePolicy()
+        .horizontalPolicy()
+        == QtWidgets.QSizePolicy.Policy.Ignored
+    )
 
     dialog.extensions_toggle.setChecked(False)
     QtWidgets.QApplication.processEvents()
@@ -1833,6 +1848,573 @@ def test_name_filter_dialog_loader_extensions_toggle_resizes(
     filter_name, _func, kwargs = dialog.checked_filter()
     assert filter_name == "Example Raw Data (*.h5)"
     assert kwargs["loader_extensions"] == {"additional_coords": {"scan": 1}}
+
+
+def _tree_item_by_text(
+    tree: QtWidgets.QTreeWidget, column: int, text: str
+) -> QtWidgets.QTreeWidgetItem:
+    for i in range(tree.topLevelItemCount()):
+        item = tree.topLevelItem(i)
+        if item is not None and item.text(column) == text:
+            return item
+    raise AssertionError(f"Could not find tree item {text!r}")
+
+
+def _table_row_by_text(table: QtWidgets.QTableWidget, column: int, text: str) -> int:
+    for row in range(table.rowCount()):
+        item = table.item(row, column)
+        if item is not None and item.text() == text:
+            return row
+    raise AssertionError(f"Could not find table row {text!r}")
+
+
+def _dialog_label_text(dialog: QtWidgets.QDialog) -> str:
+    return "\n".join(label.text() for label in dialog.findChildren(QtWidgets.QLabel))
+
+
+def test_loader_extension_literal_helpers_handle_edge_cases() -> None:
+    assert manager_dialogs._string_tuple_from_literal("coordinate_attrs", "") == ()
+    with pytest.raises(TypeError, match="not a string"):
+        manager_dialogs._string_tuple_from_literal("coordinate_attrs", "'theta'")
+    with pytest.raises(TypeError, match=r"coordinate_attrs must be an iterable$"):
+        manager_dialogs._string_tuple_from_literal("coordinate_attrs", "1")
+
+    assert manager_dialogs._name_map_from_literal("") == {}
+    with pytest.raises(TypeError, match="name_map must be a dict"):
+        manager_dialogs._name_map_from_literal("['theta']")
+
+    assert list(
+        manager_dialogs._iter_name_map_pairs({"theta": ["Theta", "Angle"]})
+    ) == [("theta", "Theta"), ("theta", "Angle")]
+    assert manager_dialogs._name_map_from_pairs(
+        [("theta", "Theta"), ("theta", "Theta"), ("theta", "Angle")]
+    ) == {"theta": ["Theta", "Angle"]}
+    assert manager_dialogs._name_map_literal({}) == ""
+    assert manager_dialogs._coordinate_attrs_literal(()) == ""
+
+
+def test_coordinate_attrs_sample_attrs_handles_loader_variants() -> None:
+    class _PlainLoader:
+        def __init__(self) -> None:
+            self.paths: list[pathlib.Path] = []
+
+        def load_single(self, path: pathlib.Path) -> types.SimpleNamespace:
+            self.paths.append(path)
+            return types.SimpleNamespace(attrs={"LensMode": "Angular"})
+
+    plain_loader = _PlainLoader()
+    plain_path = pathlib.Path("plain.h5")
+    assert manager_dialogs._coordinate_attrs_sample_attrs(
+        typing.cast("erlab.io.dataloader.LoaderBase", plain_loader),
+        plain_path,
+    ) == {"LensMode": "Angular"}
+    assert plain_loader.paths == [plain_path]
+
+    class _RetryLoader:
+        def __init__(self) -> None:
+            self.calls: list[bool] = []
+
+        def load_single(
+            self, _path: pathlib.Path, *, without_values: bool = False
+        ) -> object:
+            self.calls.append(without_values)
+            if without_values:
+                raise TypeError("without_values is unavailable")
+            return object()
+
+    retry_loader = _RetryLoader()
+    assert (
+        manager_dialogs._coordinate_attrs_sample_attrs(
+            typing.cast("erlab.io.dataloader.LoaderBase", retry_loader),
+            pathlib.Path("retry.h5"),
+        )
+        == {}
+    )
+    assert retry_loader.calls == [True, False]
+
+    class _FailingLoader:
+        def load_single(self, _path: pathlib.Path) -> object:
+            raise TypeError("load failed")
+
+    with pytest.raises(TypeError, match="load failed"):
+        manager_dialogs._coordinate_attrs_sample_attrs(
+            typing.cast("erlab.io.dataloader.LoaderBase", _FailingLoader()),
+            pathlib.Path("failed.h5"),
+        )
+
+
+def test_name_map_editor_emits_custom_mapping_and_omits_blank_rows(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    editor = _NameMapEditorDialog(
+        None,
+        erlab.io.loaders["example"],
+        example_data_dir / "data_002.h5",
+        {},
+    )
+    qtbot.addWidget(editor)
+
+    table = editor.findChild(QtWidgets.QTableWidget)
+    assert table is not None
+
+    lens_mode_row = _table_row_by_text(table, 0, "LensMode")
+    lens_mode_target = table.item(lens_mode_row, 1)
+    assert lens_mode_target is not None
+    assert lens_mode_target.text() == ""
+    assert lens_mode_target.flags() & QtCore.Qt.ItemFlag.ItemIsEditable
+    lens_mode_target.setText("lens_mode")
+
+    temp_row = _table_row_by_text(table, 0, "TB")
+    temp_target = table.item(temp_row, 1)
+    assert temp_target is not None
+    assert temp_target.text() == "sample_temp"
+    assert not (temp_target.flags() & QtCore.Qt.ItemFlag.ItemIsEnabled)
+    assert not (temp_target.flags() & QtCore.Qt.ItemFlag.ItemIsEditable)
+
+    editor.accept()
+    assert editor.selected_name_map() == {"lens_mode": "LensMode"}
+
+
+def test_name_map_editor_prefills_and_preserves_unmatched_mappings(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    editor = _NameMapEditorDialog(
+        None,
+        erlab.io.loaders["example"],
+        example_data_dir / "data_002.h5",
+        {"lens_mode": "LensMode", "legacy": "MissingRaw"},
+    )
+    qtbot.addWidget(editor)
+
+    table = editor.findChild(QtWidgets.QTableWidget)
+    assert table is not None
+    lens_mode_row = _table_row_by_text(table, 0, "LensMode")
+    lens_mode_target = table.item(lens_mode_row, 1)
+    assert lens_mode_target is not None
+    assert lens_mode_target.text() == "lens_mode"
+
+    editor.accept()
+    assert editor.selected_name_map() == {
+        "legacy": "MissingRaw",
+        "lens_mode": "LensMode",
+    }
+
+
+def test_name_map_editor_disabled_sample_states(
+    qtbot,
+    monkeypatch,
+    example_loader,
+) -> None:
+    no_sample = _NameMapEditorDialog(
+        None,
+        erlab.io.loaders["example"],
+        None,
+        {"legacy": "MissingRaw"},
+    )
+    qtbot.addWidget(no_sample)
+    assert no_sample.findChild(QtWidgets.QTableWidget) is None
+    assert "No sample file is available." in _dialog_label_text(no_sample)
+    assert no_sample.selected_name_map() == {"legacy": "MissingRaw"}
+
+    def _raise_sample_attrs(*_args: object) -> dict[str, typing.Any]:
+        raise RuntimeError("sample failed")
+
+    monkeypatch.setattr(
+        manager_dialogs,
+        "_coordinate_attrs_sample_attrs",
+        _raise_sample_attrs,
+    )
+    failed_sample = _NameMapEditorDialog(
+        None,
+        erlab.io.loaders["example"],
+        pathlib.Path("bad.h5"),
+        {"legacy": "MissingRaw"},
+    )
+    qtbot.addWidget(failed_sample)
+    assert failed_sample.findChild(QtWidgets.QTableWidget) is None
+    failed_text = _dialog_label_text(failed_sample)
+    assert "Could not inspect the selected file." in failed_text
+    assert "RuntimeError: sample failed" in failed_text
+
+    monkeypatch.setattr(
+        manager_dialogs,
+        "_coordinate_attrs_sample_attrs",
+        lambda *_args: {},
+    )
+    empty_sample = _NameMapEditorDialog(
+        None,
+        erlab.io.loaders["example"],
+        pathlib.Path("empty.h5"),
+        {"legacy": "MissingRaw"},
+    )
+    qtbot.addWidget(empty_sample)
+    assert empty_sample.findChild(QtWidgets.QTableWidget) is None
+    assert "No attributes were found in the sample." in _dialog_label_text(empty_sample)
+
+
+def test_name_filter_dialog_name_map_editor_updates_literal(
+    qtbot,
+    monkeypatch,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    file_path = example_data_dir / "data_002.h5"
+    editor_calls: list[tuple[typing.Any, ...]] = []
+
+    class _FakeNameMapEditorDialog:
+        def __init__(
+            self,
+            parent,
+            loader,
+            sample_path,
+            current_name_map,
+        ) -> None:
+            editor_calls.append((parent, loader, sample_path, current_name_map))
+
+        def exec(self) -> bool:
+            return True
+
+        def selected_name_map(self) -> dict[str, str]:
+            return {"lens_mode": "LensMode"}
+
+    monkeypatch.setattr(
+        manager_dialogs,
+        "_NameMapEditorDialog",
+        _FakeNameMapEditorDialog,
+    )
+    dialog = _NameFilterDialog(
+        None,
+        {"Example Raw Data (*.h5)": (erlab.io.loaders["example"].load, {})},
+        sample_paths=[file_path],
+    )
+    qtbot.addWidget(dialog)
+    dialog.check_filter("Example Raw Data (*.h5)")
+    dialog.loader_extension_lines["name_map"].setText("{'old_name': 'Old Raw'}")
+
+    dialog._open_name_map_editor()
+
+    assert editor_calls == [
+        (
+            dialog,
+            erlab.io.loaders["example"],
+            file_path,
+            {"old_name": "Old Raw"},
+        )
+    ]
+    assert dialog.loader_extension_lines["name_map"].text() == (
+        "{'lens_mode': 'LensMode'}"
+    )
+
+
+def test_name_filter_dialog_invalid_name_map_editor_literal_shows_error(
+    qtbot,
+    monkeypatch,
+    example_loader,
+) -> None:
+    critical_calls: list[tuple[typing.Any, ...]] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        staticmethod(lambda *args: critical_calls.append(args) or 0),
+    )
+    dialog = _NameFilterDialog(
+        None,
+        {"Example Raw Data (*.h5)": (erlab.io.loaders["example"].load, {})},
+    )
+    qtbot.addWidget(dialog)
+    dialog.check_filter("Example Raw Data (*.h5)")
+    dialog.loader_extension_lines["name_map"].setText("dict(scan=1)")
+
+    dialog._open_name_map_editor()
+
+    assert critical_calls
+    assert critical_calls[0][1:4] == (
+        "Error",
+        "Invalid loader arguments.",
+        "Value for 'name_map' is not a valid literal",
+    )
+
+
+def test_name_filter_dialog_editor_cancel_leaves_literals(
+    qtbot,
+    monkeypatch,
+    example_loader,
+) -> None:
+    class _CancelNameMapEditorDialog:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def exec(self) -> bool:
+            return False
+
+        def selected_name_map(self) -> dict[str, str]:
+            raise AssertionError("selected_name_map must not be called")
+
+    class _CancelCoordinateAttrsPickerDialog:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def exec(self) -> bool:
+            return False
+
+        def selected_coordinate_attrs(self) -> tuple[str, ...]:
+            raise AssertionError("selected_coordinate_attrs must not be called")
+
+    monkeypatch.setattr(
+        manager_dialogs,
+        "_NameMapEditorDialog",
+        _CancelNameMapEditorDialog,
+    )
+    monkeypatch.setattr(
+        manager_dialogs,
+        "_CoordinateAttrsPickerDialog",
+        _CancelCoordinateAttrsPickerDialog,
+    )
+    dialog = _NameFilterDialog(
+        None,
+        {"Example Raw Data (*.h5)": (erlab.io.loaders["example"].load, {})},
+        sample_paths=[pathlib.Path("sample.h5")],
+    )
+    qtbot.addWidget(dialog)
+    dialog.check_filter("Example Raw Data (*.h5)")
+    dialog.loader_extension_lines["name_map"].setText("{'old_name': 'Old Raw'}")
+    dialog.loader_extension_lines["coordinate_attrs"].setText("['old_coord']")
+
+    dialog._open_name_map_editor()
+    dialog._open_coordinate_attrs_picker()
+
+    assert dialog.loader_extension_lines["name_map"].text() == "{'old_name': 'Old Raw'}"
+    assert dialog.loader_extension_lines["coordinate_attrs"].text() == "['old_coord']"
+
+
+def test_name_filter_dialog_editor_helpers_ignore_non_loader_functions(qtbot) -> None:
+    def non_loader(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    dialog = _NameFilterDialog(
+        None,
+        {"Plain Files (*.txt)": (non_loader, {})},
+        sample_paths=[pathlib.Path("plain.txt")],
+    )
+    qtbot.addWidget(dialog)
+    dialog.check_filter("Plain Files (*.txt)")
+    dialog.loader_extension_lines["name_map"].setText("{'old_name': 'Old Raw'}")
+    dialog.loader_extension_lines["coordinate_attrs"].setText("['old_coord']")
+
+    dialog._open_name_map_editor()
+    dialog._open_coordinate_attrs_picker()
+
+    assert dialog.loader_extension_lines["name_map"].text() == "{'old_name': 'Old Raw'}"
+    assert dialog.loader_extension_lines["coordinate_attrs"].text() == "['old_coord']"
+
+
+def test_name_filter_dialog_invalid_coordinate_attrs_picker_literal_shows_error(
+    qtbot,
+    monkeypatch,
+    example_loader,
+) -> None:
+    critical_calls: list[tuple[typing.Any, ...]] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        staticmethod(lambda *args: critical_calls.append(args) or 0),
+    )
+    dialog = _NameFilterDialog(
+        None,
+        {"Example Raw Data (*.h5)": (erlab.io.loaders["example"].load, {})},
+    )
+    qtbot.addWidget(dialog)
+    dialog.check_filter("Example Raw Data (*.h5)")
+    dialog.loader_extension_lines["coordinate_attrs"].setText("'LensMode'")
+
+    dialog._open_coordinate_attrs_picker()
+
+    assert critical_calls
+    assert critical_calls[0][1:4] == (
+        "Error",
+        "Invalid loader arguments.",
+        "coordinate_attrs must be an iterable, not a string",
+    )
+
+
+def test_coordinate_attrs_picker_shows_mapped_and_builtin_attrs(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    picker = _CoordinateAttrsPickerDialog(
+        None,
+        erlab.io.loaders["example"],
+        example_data_dir / "data_002.h5",
+        ("LensMode",),
+        {},
+    )
+    qtbot.addWidget(picker)
+
+    tree = picker.findChild(QtWidgets.QTreeWidget)
+    assert tree is not None
+
+    lens_mode_item = _tree_item_by_text(tree, 0, "LensMode")
+    assert lens_mode_item.text(1) == ""
+    assert lens_mode_item.checkState(0) == QtCore.Qt.CheckState.Checked
+    assert lens_mode_item.flags() & QtCore.Qt.ItemFlag.ItemIsUserCheckable
+
+    temp_item = _tree_item_by_text(tree, 0, "TB")
+    assert temp_item.text(1) == "sample_temp"
+    assert temp_item.checkState(0) == QtCore.Qt.CheckState.Checked
+    assert not (temp_item.flags() & QtCore.Qt.ItemFlag.ItemIsEnabled)
+    assert not (temp_item.flags() & QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+
+    picker.accept()
+    assert picker.selected_coordinate_attrs() == ("LensMode",)
+
+
+def test_coordinate_attrs_picker_uses_literal_name_map(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    picker = _CoordinateAttrsPickerDialog(
+        None,
+        erlab.io.loaders["example"],
+        example_data_dir / "data_002.h5",
+        (),
+        {"lens_mode": "LensMode"},
+    )
+    qtbot.addWidget(picker)
+
+    tree = picker.findChild(QtWidgets.QTreeWidget)
+    assert tree is not None
+    lens_mode_item = _tree_item_by_text(tree, 0, "LensMode")
+    assert lens_mode_item.text(1) == "lens_mode"
+
+    lens_mode_item.setCheckState(0, QtCore.Qt.CheckState.Checked)
+    picker.accept()
+    assert picker.selected_coordinate_attrs() == ("lens_mode",)
+
+
+def test_name_filter_dialog_coordinate_attrs_picker_updates_literal(
+    qtbot,
+    monkeypatch,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    file_path = example_data_dir / "data_002.h5"
+    picker_calls: list[tuple[typing.Any, ...]] = []
+
+    class _FakeCoordinateAttrsPickerDialog:
+        def __init__(
+            self,
+            parent,
+            loader,
+            sample_path,
+            current_values,
+            name_map,
+        ) -> None:
+            picker_calls.append((parent, loader, sample_path, current_values, name_map))
+
+        def exec(self) -> bool:
+            return True
+
+        def selected_coordinate_attrs(self) -> tuple[str, ...]:
+            return ("LensMode", "extra_coord")
+
+    monkeypatch.setattr(
+        manager_dialogs,
+        "_CoordinateAttrsPickerDialog",
+        _FakeCoordinateAttrsPickerDialog,
+    )
+    dialog = _NameFilterDialog(
+        None,
+        {"Example Raw Data (*.h5)": (erlab.io.loaders["example"].load, {})},
+        sample_paths=[file_path],
+    )
+    qtbot.addWidget(dialog)
+    dialog.check_filter("Example Raw Data (*.h5)")
+    dialog.loader_extension_lines["coordinate_attrs"].setText("['old_coord']")
+    dialog.loader_extension_lines["name_map"].setText("{'extra_coord': 'Extra Raw'}")
+
+    dialog._open_coordinate_attrs_picker()
+
+    assert picker_calls == [
+        (
+            dialog,
+            erlab.io.loaders["example"],
+            file_path,
+            ("old_coord",),
+            {"extra_coord": "Extra Raw"},
+        )
+    ]
+    assert (
+        dialog.loader_extension_lines["coordinate_attrs"].text()
+        == "['LensMode', 'extra_coord']"
+    )
+
+
+def test_coordinate_attrs_picker_failure_leaves_literal_editor(
+    qtbot,
+    example_loader,
+) -> None:
+    dialog = _NameFilterDialog(
+        None,
+        {"Example Raw Data (*.h5)": (erlab.io.loaders["example"].load, {})},
+        sample_paths=[pathlib.Path("missing.h5")],
+    )
+    qtbot.addWidget(dialog)
+    dialog.check_filter("Example Raw Data (*.h5)")
+    dialog.loader_extension_lines["coordinate_attrs"].setText("['LensMode']")
+
+    picker = _CoordinateAttrsPickerDialog(
+        dialog,
+        erlab.io.loaders["example"],
+        pathlib.Path("missing.h5"),
+        ("LensMode",),
+        {},
+    )
+    qtbot.addWidget(picker)
+
+    assert picker.findChild(QtWidgets.QTreeWidget) is None
+    assert picker.selected_coordinate_attrs() == ("LensMode",)
+    assert dialog.loader_extension_lines["coordinate_attrs"].text() == "['LensMode']"
+
+
+def test_coordinate_attrs_picker_disabled_sample_states(
+    qtbot,
+    monkeypatch,
+    example_loader,
+) -> None:
+    no_sample = _CoordinateAttrsPickerDialog(
+        None,
+        erlab.io.loaders["example"],
+        None,
+        ("legacy_coord",),
+        {},
+    )
+    qtbot.addWidget(no_sample)
+    assert no_sample.findChild(QtWidgets.QTreeWidget) is None
+    assert "No sample file is available." in _dialog_label_text(no_sample)
+    assert no_sample.selected_coordinate_attrs() == ("legacy_coord",)
+
+    monkeypatch.setattr(
+        manager_dialogs,
+        "_coordinate_attrs_sample_attrs",
+        lambda *_args: {},
+    )
+    empty_sample = _CoordinateAttrsPickerDialog(
+        None,
+        erlab.io.loaders["example"],
+        pathlib.Path("empty.h5"),
+        ("legacy_coord",),
+        {},
+    )
+    qtbot.addWidget(empty_sample)
+    assert empty_sample.findChild(QtWidgets.QTreeWidget) is None
+    assert "No attributes were found in the sample." in _dialog_label_text(empty_sample)
+    assert empty_sample.selected_coordinate_attrs() == ("legacy_coord",)
 
 
 def test_name_filter_dialog_without_loader_extensions_returns_kwargs(
@@ -5884,11 +6466,14 @@ def test_select_loader_options_cancel_keeps_recent_filter(
     example_loader,
 ) -> None:
     class _CancelNameFilterDialog:
-        def __init__(self, parent, valid_loaders, *, loader_extensions=None) -> None:
+        def __init__(
+            self, parent, valid_loaders, *, loader_extensions=None, sample_paths=None
+        ) -> None:
             assert valid_loaders == {
                 "Example Raw Data (*.h5)": (erlab.io.loaders["example"].load, {})
             }
             assert loader_extensions == {"Example Raw Data (*.h5)": {}}
+            assert sample_paths is None
             self.checked_name = None
 
         def check_filter(self, name_filter: str | None) -> None:
@@ -5989,8 +6574,11 @@ def test_open_multiple_files_preselects_default_loader_filter(
     dialogs = []
 
     class _CancelNameFilterDialog:
-        def __init__(self, parent, valid_loaders, *, loader_extensions=None) -> None:
+        def __init__(
+            self, parent, valid_loaders, *, loader_extensions=None, sample_paths=None
+        ) -> None:
             self.checked_name = None
+            assert list(sample_paths or ()) == [file_path]
             dialogs.append(self)
 
         def check_filter(self, name_filter: str | None) -> None:
@@ -6218,8 +6806,8 @@ def test_manager_open_loader_selection_branches(
     add_calls: list[tuple[tuple[typing.Any, ...], dict[str, typing.Any]]] = []
     select_calls: list[tuple[typing.Any, ...]] = []
 
-    def _select_loader_options(*args):
-        select_calls.append(args)
+    def _select_loader_options(*args, **kwargs):
+        select_calls.append((*args, kwargs))
 
     manager = types.SimpleNamespace(
         _recent_name_filter=None,
@@ -6250,6 +6838,7 @@ def test_manager_open_loader_selection_branches(
 
     if case == "loader_cancel":
         assert len(select_calls) == 1
+        assert list(select_calls[0][-1]["sample_paths"]) == [str(file_path)]
         assert add_calls == []
     else:
         assert select_calls == []
@@ -6300,10 +6889,10 @@ def test_open_multiple_files_loader_selection_branches(
             dict[str, typing.Any],
         ]
     ] = []
-    select_calls: list[tuple[list[str], str | None]] = []
+    select_calls: list[tuple[list[str], str | None, list[pathlib.Path]]] = []
 
-    def _select_loader_options(loaders, name_filter=None):
-        select_calls.append((list(loaders), name_filter))
+    def _select_loader_options(loaders, name_filter=None, *, sample_paths=None):
+        select_calls.append((list(loaders), name_filter, list(sample_paths or ())))
         return select_result
 
     def _retry_open_multiple_files(*_args, **_kwargs) -> None:
@@ -6333,17 +6922,17 @@ def test_open_multiple_files_loader_selection_branches(
         ]
     elif case == "single_loader_cancel":
         assert select_calls == [
-            (["Example Raw Data (*.h5)"], "Example Raw Data (*.h5)")
+            (["Example Raw Data (*.h5)"], "Example Raw Data (*.h5)", [file_path])
         ]
         assert add_calls == []
     elif case == "multiple_cancel":
         assert select_calls == [
-            (["Example Raw Data (*.h5)", "Plain Files (*.txt)"], None)
+            (["Example Raw Data (*.h5)", "Plain Files (*.txt)"], None, [file_path])
         ]
         assert add_calls == []
     else:
         assert select_calls == [
-            (["Example Raw Data (*.h5)", "Plain Files (*.txt)"], None)
+            (["Example Raw Data (*.h5)", "Plain Files (*.txt)"], None, [file_path])
         ]
         assert manager._recent_name_filter == "Plain Files (*.txt)"
         assert add_calls == [

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -256,7 +256,9 @@ def test_explorer_loader_options_dialog_updates_kwargs(
     exec_results = [False, True]
 
     class _FakeNameFilterDialog:
-        def __init__(self, parent, valid_loaders, *, loader_extensions=None) -> None:
+        def __init__(
+            self, parent, valid_loaders, *, loader_extensions=None, sample_paths=None
+        ) -> None:
             assert parent is explorer
             assert valid_loaders == {
                 "example": (erlab.io.loaders["example"].load, {"single": True})
@@ -264,6 +266,7 @@ def test_explorer_loader_options_dialog_updates_kwargs(
             assert loader_extensions == {
                 "example": {"coordinate_attrs": ("old_coord",)}
             }
+            assert list(sample_paths or ()) == []
             self.checked_name = None
             dialogs.append(self)
 


### PR DESCRIPTION
## Summary
- add guided editors for ImageTool manager loader extension fields `name_map` and `coordinate_attrs`
- keep literal editing as the source of truth while helper dialogs write values back into the existing fields
- sample the first selected file and show existing loader mappings as non-editable context

## Tests
- `uv run pytest tests/interactive/imagetool/test_imagetool_manager.py tests/interactive/test_explorer.py`
- `uv run ruff check src tests docs`
- `uv run ruff format --check src tests`