### PR TITLE
feat(imagetool): add divide-by-coordinate data operation

### DIFF
--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -610,6 +610,7 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                         "tooltip": "Crop to the current axes view range",
                     },
                     "Average": {"triggered": self._average},
+                    "Divide by Coordinate...": {"triggered": self._divide_by_coord},
                     "Coarsen": {"triggered": self._coarsen},
                     "Thin": {"triggered": self._thin},
                     "Symmetrize": {
@@ -778,6 +779,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     @QtCore.Slot()
     def _average(self) -> None:
         self.execute_dialog(erlab.interactive.imagetool.dialogs.AverageDialog)
+
+    @QtCore.Slot()
+    def _divide_by_coord(self) -> None:
+        self.execute_dialog(erlab.interactive.imagetool.dialogs.DivideByCoordDialog)
 
     @QtCore.Slot()
     def _coarsen(self) -> None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import math
+import re
 import typing
 import weakref
 
@@ -1579,6 +1580,126 @@ class NormalizeDialog(DataFilterDialog):
             return data - minimum
 
         return (data - minimum) / area
+
+
+class DivideByCoordDialog(DataTransformDialog):
+    title = "Divide by Coordinate"
+    enable_copy = True
+    apply_on_nonuniform_data = True
+
+    def setup_widgets(self) -> None:
+        self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+            self.slicer_area.data
+        )
+        self.coord_combo = QtWidgets.QComboBox()
+        self.coord_dims_label = QtWidgets.QLabel()
+
+        data_dims = set(self._source_data.dims)
+        for name, coord in self._source_data.coords.items():
+            coord_dims = tuple(coord.dims)
+            if (
+                set(coord_dims).issubset(data_dims)
+                and np.issubdtype(coord.dtype, np.number)
+                and not np.issubdtype(coord.dtype, np.complexfloating)
+            ):
+                self.coord_combo.addItem(str(name), userData=name)
+
+        self.coord_combo.currentIndexChanged.connect(self._update_coord_dims_label)
+        self.layout_.addRow("Coordinate", self.coord_combo)
+        self.layout_.addRow("Coordinate Dims", self.coord_dims_label)
+        self._update_coord_dims_label()
+
+    @property
+    def _selected_coord_name(self) -> Hashable | None:
+        if self.coord_combo.currentIndex() < 0:
+            return None
+        return typing.cast(
+            "Hashable",
+            self.coord_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
+        )
+
+    @property
+    def suffix(self) -> str:
+        coord_name = self._selected_coord_name
+        suffix = "" if coord_name is None else str(coord_name)
+        suffix = re.sub(r"[^0-9A-Za-z_]+", "_", suffix).strip("_")
+        if not suffix:
+            suffix = "coord"
+        elif suffix[0].isdigit():
+            suffix = f"coord_{suffix}"
+        return f"_div_{suffix}"
+
+    @suffix.setter
+    def suffix(self, value: str) -> None:
+        # To satisfy mypy
+        pass
+
+    @QtCore.Slot()
+    @QtCore.Slot(int)
+    def _update_coord_dims_label(self, index: int | None = None) -> None:
+        coord_name = self._selected_coord_name
+        if coord_name is None:
+            self.coord_dims_label.setText("")
+            return
+        coord_dims = self._source_data.coords[coord_name].dims
+        self.coord_dims_label.setText(
+            "scalar" if not coord_dims else ", ".join(str(dim) for dim in coord_dims)
+        )
+
+    def _validate(self) -> QtWidgets.QDialog.DialogCode:
+        if self.coord_combo.count() == 0:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Coordinates",
+                "No numeric coordinates that can be broadcast to the data were found.",
+            )
+            return QtWidgets.QDialog.DialogCode.Rejected
+        return super()._validate()
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        coord_name = self._selected_coord_name
+        if coord_name is None:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Coordinate Selected",
+                "Choose a coordinate to divide by.",
+            )
+            return
+        coord = self._source_data.coords[coord_name]
+        try:
+            erlab.interactive.imagetool.provenance.DivideByCoordOperation._raise_if_zero(
+                coord
+            )
+        except ValueError:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Zero Coordinate Values",
+                "The selected coordinate contains zero values and cannot be used as a "
+                "divisor.",
+            )
+            return
+        super().accept()
+
+    def source_transform_operation(
+        self,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation:
+        coord_name = self._selected_coord_name
+        if coord_name is None:
+            raise ValueError("No coordinate selected")
+        return erlab.interactive.imagetool.provenance.DivideByCoordOperation(
+            coord_name=coord_name
+        )
+
+    def make_code(self) -> str:
+        coord_name = self._selected_coord_name
+        if coord_name is None:
+            return ""
+        placeholder = self.slicer_area.watched_data_name or "data"
+        operation = erlab.interactive.imagetool.provenance.DivideByCoordOperation(
+            coord_name=coord_name
+        )
+        return f"{placeholder} / {operation.divisor_code(placeholder)}"
 
 
 class GaussianFilterDialog(DataFilterDialog):

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -65,6 +65,7 @@ __all__ = [
     "CoarsenOperation",
     "CorrectWithEdgeOperation",
     "DerivationEntry",
+    "DivideByCoordOperation",
     "IselOperation",
     "MaskWithPolygonOperation",
     "QSelOperation",
@@ -1447,6 +1448,41 @@ class AverageOperation(ToolProvenanceOperation):
         return DerivationEntry(
             f"Average({_format_derivation_value(label_kwargs)})",
             f"derived = derived.qsel.average({arg})",
+            True,
+        )
+
+
+class DivideByCoordOperation(ToolProvenanceOperation):
+    op: typing.Literal["divide_by_coord"] = "divide_by_coord"
+    coord_name: ProvenanceHashable
+
+    @staticmethod
+    def _raise_if_zero(coord: xr.DataArray) -> None:
+        if np.any(np.asarray(coord.values) == 0):
+            raise ValueError("Coordinate contains zero values and cannot be a divisor.")
+
+    def divisor_code(self, data_name: str) -> str:
+        if (
+            isinstance(self.coord_name, str)
+            and self.coord_name.isidentifier()
+            and not keyword.iskeyword(self.coord_name)
+            and not self.coord_name.startswith("_")
+            and not hasattr(xr.DataArray, self.coord_name)
+        ):
+            return f"{data_name}.{self.coord_name}"
+        coord_name = erlab.interactive.utils._parse_single_arg(self.coord_name)
+        return f"{data_name}.coords[{coord_name}]"
+
+    def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
+        coord = data.coords[self.coord_name]
+        self._raise_if_zero(coord)
+        return data / coord
+
+    def derivation_entry(self) -> DerivationEntry:
+        label_kwargs = {"coord_name": self.coord_name}
+        return DerivationEntry(
+            f"Divide by Coordinate({_format_derivation_value(label_kwargs)})",
+            f"derived = derived / {self.divisor_code('derived')}",
             True,
         )
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -26,6 +26,7 @@ from erlab.interactive.imagetool.dialogs import (
     CoarsenDialog,
     CropDialog,
     CropToViewDialog,
+    DivideByCoordDialog,
     EdgeCorrectionDialog,
     GaussianFilterDialog,
     NormalizeDialog,
@@ -3830,6 +3831,121 @@ def test_itool_normalize(qtbot, accept_dialog, option) -> None:
         accept_call=lambda d: d.reject(),
     )
     xarray.testing.assert_identical(win.slicer_area.data, data)
+
+    win.close()
+
+
+def test_itool_divide_by_coord(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(12, dtype=float).reshape((3, 4)) + 1.0,
+        dims=["x", "y"],
+        coords={
+            "x": np.arange(3),
+            "y": np.arange(4),
+            "mesh_current": ("x", [1.0, 2.0, 4.0]),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: DivideByCoordDialog) -> None:
+        dialog.coord_combo.setCurrentText("mesh_current")
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._divide_by_coord, pre_call=_set_dialog_params)
+
+    expected = (data / data.mesh_current).rename("scan_div_mesh_current")
+    xarray.testing.assert_identical(win.slicer_area._data, expected)
+    copied_code = pyperclip.paste()
+    assert "data.mesh_current" in copied_code
+    namespace: dict[str, typing.Any] = {"data": data.copy(deep=True)}
+    exec(f"result = {copied_code}", {}, namespace)  # noqa: S102
+    xarray.testing.assert_identical(
+        namespace["result"].rename(None), expected.rename(None)
+    )
+
+    win.close()
+
+
+def test_itool_divide_by_coord_rejects_zero_values(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(12, dtype=float).reshape((3, 4)) + 1.0,
+        dims=["x", "y"],
+        coords={
+            "x": np.arange(3),
+            "y": np.arange(4),
+            "mesh_current": ("x", [1.0, 0.0, 4.0]),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = DivideByCoordDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    dialog.coord_combo.setCurrentText("mesh_current")
+    dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    dialog.accept()
+
+    assert warnings == [
+        (
+            "Zero Coordinate Values",
+            "The selected coordinate contains zero values and cannot be used as a "
+            "divisor.",
+        )
+    ]
+    xarray.testing.assert_identical(win.slicer_area._data, data)
+
+    dialog.close()
+    win.close()
+
+
+def test_itool_divide_by_coord_nonuniform_generated_code(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(12, dtype=float).reshape((3, 4)) + 1.0,
+        dims=["x", "y"],
+        coords={
+            "x": np.array([0.0, 0.4, 1.0]),
+            "y": np.arange(4),
+            "mesh_current": ("x", [1.0, 2.0, 4.0]),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: DivideByCoordDialog) -> None:
+        assert "x_idx" not in dialog.coord_dims_label.text()
+        dialog.coord_combo.setCurrentText("mesh_current")
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._divide_by_coord, pre_call=_set_dialog_params)
+
+    restored = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+        win.slicer_area._data.rename(None)
+    )
+    xarray.testing.assert_identical(restored, (data / data.mesh_current).rename(None))
+    assert win.provenance_spec is not None
+    display_code = win.provenance_spec.display_code()
+    assert display_code is not None
+    assert "mesh_current" in display_code
+    assert "x_idx" not in display_code
+    namespace = {"data": data.copy(deep=True)}
+    exec(display_code, {}, namespace)  # noqa: S102
+    xarray.testing.assert_identical(
+        namespace["derived"].rename(None), (data / data.mesh_current).rename(None)
+    )
 
     win.close()
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -3911,6 +3911,73 @@ def test_itool_divide_by_coord_rejects_zero_values(qtbot, monkeypatch) -> None:
     win.close()
 
 
+def test_divide_by_coord_dialog_edge_paths(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(12, dtype=float).reshape((3, 4)) + 1.0,
+        dims=["x", "y"],
+        coords={
+            "x": np.arange(3),
+            "y": np.arange(4),
+            "2 current": ("x", [1.0, 2.0, 4.0]),
+            "scalar_current": 2.0,
+            "label": ("x", ["a", "b", "c"]),
+            "complex_current": ("x", [1.0 + 0.0j, 2.0 + 0.0j, 4.0 + 0.0j]),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = DivideByCoordDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    coord_names = {
+        dialog.coord_combo.itemData(i, QtCore.Qt.ItemDataRole.UserRole)
+        for i in range(dialog.coord_combo.count())
+    }
+    assert "label" not in coord_names
+    assert "complex_current" not in coord_names
+
+    dialog.coord_combo.setCurrentText("scalar_current")
+    assert dialog.coord_dims_label.text() == "scalar"
+    assert dialog.suffix == "_div_scalar_current"
+    dialog.suffix = ""
+
+    dialog.coord_combo.setCurrentText("2 current")
+    assert dialog.suffix == "_div_coord_2_current"
+
+    warnings: list[tuple[str, str]] = []
+
+    def _record_warning(_parent, title, message, *args, **kwargs):
+        warnings.append((title, message))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+
+    dialog.coord_combo.setCurrentIndex(-1)
+    dialog._update_coord_dims_label()
+    assert dialog.coord_dims_label.text() == ""
+    assert dialog.suffix == "_div_coord"
+    assert dialog.make_code() == ""
+    with pytest.raises(ValueError, match="No coordinate selected"):
+        dialog.source_transform_operation()
+
+    dialog.accept()
+    assert warnings == [("No Coordinate Selected", "Choose a coordinate to divide by.")]
+
+    warnings.clear()
+    dialog.coord_combo.clear()
+    assert dialog._validate() == QtWidgets.QDialog.DialogCode.Rejected
+    assert warnings == [
+        (
+            "No Coordinates",
+            "No numeric coordinates that can be broadcast to the data were found.",
+        )
+    ]
+
+    dialog.close()
+    win.close()
+
+
 def test_itool_divide_by_coord_nonuniform_generated_code(qtbot, accept_dialog) -> None:
     data = xr.DataArray(
         np.arange(12, dtype=float).reshape((3, 4)) + 1.0,

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -4045,6 +4045,90 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert manager._build_metadata_derivation_menu() is None
 
 
+def test_manager_divide_by_coord_child_refresh_and_code(
+    qtbot,
+    accept_dialog,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(12, dtype=float).reshape((3, 4)) + 1.0,
+        dims=["x", "y"],
+        coords={
+            "x": np.arange(3),
+            "y": np.arange(4),
+            "mesh_current": ("x", [1.0, 2.0, 4.0]),
+        },
+        name="scan",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+
+        def _nest_divide(dialog) -> None:
+            assert dialog.launch_mode == "nest"
+            dialog.coord_combo.setCurrentText("mesh_current")
+
+        accept_dialog(parent_tool.mnb._divide_by_coord, pre_call=_nest_divide)
+
+        parent = manager._imagetool_wrappers[0]
+        qtbot.wait_until(lambda: len(parent._childtool_indices) == 1, timeout=5000)
+        child_uid = parent._childtool_indices[0]
+        child_node = manager._child_node(child_uid)
+        child_tool = manager.get_imagetool(child_uid)
+
+        expected = (data / data.mesh_current).rename("scan_div_mesh_current")
+        xr.testing.assert_identical(child_tool.slicer_area._data, expected)
+        assert child_node.source_spec is not None
+        operations = [
+            op for op in child_node.source_spec.operations if op.op == "divide_by_coord"
+        ]
+        assert len(operations) == 1
+        assert operations[0].coord_name == "mesh_current"
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        manager._update_info(uid=child_uid)
+        derivation = metadata_derivation_texts(manager)
+        assert any("Divide by Coordinate" in line for line in derivation)
+
+        copied: list[str] = []
+        monkeypatch.setattr(
+            erlab.interactive.utils,
+            "copy_to_clipboard",
+            lambda text: copied.append(text) or text,
+        )
+        menu = manager._build_metadata_derivation_menu()
+        assert menu is not None
+        action_map(menu)["Copy Full Code"].trigger()
+        assert "derived.mesh_current" in copied[-1]
+
+        namespace = _exec_generated_code(copied[-1], {"data": data.copy(deep=True)})
+        xr.testing.assert_identical(
+            namespace["derived"].rename(None), expected.rename(None)
+        )
+
+        updated = data.copy(deep=True)
+        updated.data = np.asarray(updated.data) * 2
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+
+        qtbot.wait_until(lambda: child_node.source_state == "stale", timeout=5000)
+        assert child_node._update_from_parent_source() is True
+        xr.testing.assert_identical(
+            child_tool.slicer_area._data.rename(None),
+            (updated / updated.mesh_current).rename(None),
+        )
+
+
 def test_wrapper_source_data_replaced_uses_parent_fallback_and_skips_missing_child(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -279,6 +279,67 @@ def test_tool_provenance_apply_selection_and_xarray_operations() -> None:
     xr.testing.assert_identical(assigned, expected_assigned)
 
 
+def test_tool_provenance_divide_by_coord_operation() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data().assign_coords(mesh_current=("x", [1.0, 2.0, 4.0]))
+
+    spec = prov.full_data(prov.DivideByCoordOperation(coord_name="mesh_current"))
+    xr.testing.assert_identical(spec.apply(data), data / data.mesh_current)
+    code = spec.derivation_code()
+    assert code is not None
+    assert "derived.mesh_current" in code
+    namespace = _exec_generated_code(code, {"data": data})
+    xr.testing.assert_identical(namespace["derived"], data / data.mesh_current)
+
+    reparsed = prov.parse_tool_provenance_spec(spec.model_dump(mode="json"))
+    assert reparsed == spec
+    xr.testing.assert_identical(reparsed.apply(data), data / data.mesh_current)
+
+
+def test_tool_provenance_divide_by_coord_fallback_code_and_broadcast() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data().assign_coords(
+        {
+            "mesh current": ("x", [1.0, 2.0, 4.0]),
+            "mesh_map": (
+                ("x", "y"),
+                np.arange(12, dtype=float).reshape(3, 4) + 1.0,
+            ),
+            "mean": ("x", [1.0, 2.0, 4.0]),
+        }
+    )
+
+    spaced_spec = prov.full_data(prov.DivideByCoordOperation(coord_name="mesh current"))
+    spaced_code = spaced_spec.derivation_code()
+    assert spaced_code is not None
+    assert 'derived.coords["mesh current"]' in spaced_code
+    namespace = _exec_generated_code(spaced_code, {"data": data})
+    xr.testing.assert_identical(
+        namespace["derived"], data / data.coords["mesh current"]
+    )
+
+    conflict_spec = prov.full_data(prov.DivideByCoordOperation(coord_name="mean"))
+    conflict_code = conflict_spec.derivation_code()
+    assert conflict_code is not None
+    assert 'derived.coords["mean"]' in conflict_code
+    namespace = _exec_generated_code(conflict_code, {"data": data})
+    xr.testing.assert_identical(namespace["derived"], data / data.coords["mean"])
+
+    broadcast_spec = prov.full_data(prov.DivideByCoordOperation(coord_name="mesh_map"))
+    xr.testing.assert_identical(
+        broadcast_spec.apply(data), data / data.coords["mesh_map"]
+    )
+
+
+def test_tool_provenance_divide_by_coord_rejects_zero_values() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data().assign_coords(mesh_current=("x", [1.0, 0.0, 4.0]))
+    spec = prov.full_data(prov.DivideByCoordOperation(coord_name="mesh_current"))
+
+    with pytest.raises(ValueError, match="zero values"):
+        spec.apply(data)
+
+
 def test_tool_provenance_public_data_replays_on_restored_nonuniform_dims() -> None:
     prov = erlab.interactive.imagetool.provenance
     public = xr.DataArray(


### PR DESCRIPTION
Add an ImageTool Edit menu action for dividing data by a selected numeric coordinate, such as mesh current.