### PR TITLE
feat(imagetool): add a way to view associated coordinate values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Pytest enforces strict markers and `xfail_strict`; name files `test_<feature>.py
 - `tests/conftest.py` assigns the `compat`, `gui`, and `serial` markers during collection based on the centralized grouping rules. Keep those markers semantically meaningful; do not scatter ad hoc CI-only marker assignments across unrelated test files.
 - Run `uv run python -m scripts.ci_test_groups --check-partition` after changing the test tree or CI grouping rules.
 - Tests and monkeypatched stubs must implement the current runtime contract. Do not add production fallbacks or compatibility branches only to accommodate outdated fake objects in tests.
+- Do not assert user-facing text label content in tests; prefer stable metadata, object names, roles, or behavioral state. When testing copied code, execute the copied code with `exec()` in an explicit namespace and assert the produced object/value exactly matches the expected result instead of comparing raw text.
 
 ## Interactive Qt Notes
 

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -140,7 +140,7 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
 - Dask-backed arrays are fully supported. The dedicated {guilabel}`Dask` menu exposes actions to compute the array into memory, rechunk automatically, or choose custom chunk shapes within ImageTool.
 
-- Overlay plots of numeric non-dimensional coordinates (e.g., temperature) on profile plots from {guilabel}`View → Plot Associated Coordinates`. Multi-dimensional coordinates are sliced with the active cursor and averaged over binned hidden dimensions.
+- Overlay plots of numeric non-dimensional coordinates (e.g., temperature) on profile plots from {guilabel}`View → Plot Associated Coordinates`. Multi-dimensional coordinates are sliced with the active cursor and averaged over binned hidden dimensions. Right-click a profile plot to open associated coordinates in a new ImageTool window.
 
 - Use {guilabel}`View → Set Cursor Colors by Coordinate...` to color cursors by a dimension coordinate or numeric associated coordinate value at each cursor position.
 
@@ -169,6 +169,8 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 - Hover over any toolbar icon to see a short description of its function.
 
 - Copy the numeric readouts at any time with {kbd}`Ctrl+Shift+C` (cursor values) or {kbd}`Ctrl+Alt+C` (cursor indices). ImageTool copies native Python literals so you can paste them directly into scripts.
+
+- Right-click the data value readout in the cursor panel to switch it between the data value and any currently plotted associated coordinate value at the active cursor.
 
 - Multiple cursors can be added to the image using the {material-regular}`add` button in the cursor panel. They can each be dragged independently, and their bin widths can be set separately in the binning panel. To switch the active cursor, simply click on it or select it from dropdown menu in the cursor panel.
 

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -533,26 +533,26 @@ class ItoolCrosshairControls(ItoolControlsBase):
         menu = QtWidgets.QMenu(self.spin_dat)
         line_edit = self.spin_dat.lineEdit()
 
-        copy_action = menu.addAction("Copy")
+        copy_action = typing.cast("QtGui.QAction", menu.addAction("Copy"))
         copy_action.setData(("copy", None))
         copy_action.setEnabled(line_edit is not None and line_edit.hasSelectedText())
         if line_edit is not None:
             copy_action.triggered.connect(line_edit.copy)
 
-        select_all_action = menu.addAction("Select All")
+        select_all_action = typing.cast("QtGui.QAction", menu.addAction("Select All"))
         select_all_action.setData(("select_all", None))
         select_all_action.setEnabled(line_edit is not None)
         if line_edit is not None:
             select_all_action.triggered.connect(line_edit.selectAll)
 
         menu.addSeparator()
-        display_header = menu.addSection("Display Value")
+        display_header = typing.cast("QtGui.QAction", menu.addSection("Display Value"))
         display_header.setData(("display_header", None))
 
         action_group = QtGui.QActionGroup(menu)
         action_group.setExclusive(True)
 
-        data_action = menu.addAction("Data")
+        data_action = typing.cast("QtGui.QAction", menu.addAction("Data"))
         data_action.setData(("data", None))
         data_action.setCheckable(True)
         data_action.setChecked(self._readout_source is None)
@@ -560,7 +560,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
         data_action.triggered.connect(lambda: self._set_readout_source(None))
 
         for coord_name in _plotted_associated_coord_names(self.array_slicer):
-            coord_action = menu.addAction(str(coord_name))
+            coord_action = typing.cast("QtGui.QAction", menu.addAction(str(coord_name)))
             coord_action.setData(("coord", coord_name))
             coord_action.setCheckable(True)
             coord_action.setChecked(self._readout_source == coord_name)

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -13,6 +13,11 @@ import numpy as np
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+from erlab.interactive.imagetool.viewer import (
+    _associated_coord_color,
+    _associated_coord_icon,
+    _plotted_associated_coord_names,
+)
 
 if typing.TYPE_CHECKING:
     import xarray as xr
@@ -210,6 +215,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
     def __init__(
         self, *args, orientation=QtCore.Qt.Orientation.Vertical, **kwargs
     ) -> None:
+        self._readout_source: typing.Hashable | None = None
         self.orientation = orientation
         super().__init__(*args, **kwargs)
 
@@ -264,6 +270,22 @@ class ItoolCrosshairControls(ItoolControlsBase):
         self.spin_dat = erlab.interactive.utils.BetterSpinBox(
             self.values_groups[-1], discrete=False, scientific=True, readOnly=True
         )
+        self.spin_dat.setContextMenuPolicy(
+            QtCore.Qt.ContextMenuPolicy.CustomContextMenu
+        )
+        self.spin_dat.customContextMenuRequested.connect(
+            self._show_point_value_context_menu
+        )
+        self._spin_dat_line_edit = self.spin_dat.lineEdit()
+        self._spin_dat_text_margins: QtCore.QMargins | None = None
+        if self._spin_dat_line_edit is not None:
+            self._spin_dat_text_margins = self._spin_dat_line_edit.textMargins()
+            self._spin_dat_line_edit.installEventFilter(self)
+        self._readout_source_indicator = QtWidgets.QFrame(self.spin_dat)
+        self._readout_source_indicator.setObjectName("associatedCoordValueIndicator")
+        self._readout_source_indicator.setFixedSize(9, 9)
+        self._readout_source_indicator.hide()
+        self.spin_dat.installEventFilter(self)
         try:
             with np.errstate(divide="ignore"):
                 approx_abs_max = np.nanmax(
@@ -374,7 +396,8 @@ class ItoolCrosshairControls(ItoolControlsBase):
         self.slicer_area.sigIndexChanged.connect(self.update_spins)
         self.slicer_area.sigBinChanged.connect(self.update_spins)
         self.slicer_area.sigCursorColorsChanged.connect(self.update_colors)
-        self.slicer_area.sigPointValueChanged.connect(self.spin_dat.setValue)
+        self.slicer_area.sigTwinChanged.connect(self.update_point_value_readout)
+        self.slicer_area.sigPointValueChanged.connect(self._set_computed_point_value)
 
     def disconnect_signals(self) -> None:
         super().disconnect_signals()
@@ -385,7 +408,8 @@ class ItoolCrosshairControls(ItoolControlsBase):
         self.slicer_area.sigIndexChanged.disconnect(self.update_spins)
         self.slicer_area.sigBinChanged.disconnect(self.update_spins)
         self.slicer_area.sigCursorColorsChanged.disconnect(self.update_colors)
-        self.slicer_area.sigPointValueChanged.disconnect(self.spin_dat.setValue)
+        self.slicer_area.sigTwinChanged.disconnect(self.update_point_value_readout)
+        self.slicer_area.sigPointValueChanged.disconnect(self._set_computed_point_value)
 
     @QtCore.Slot()
     def update_colors(self) -> None:
@@ -394,6 +418,170 @@ class ItoolCrosshairControls(ItoolControlsBase):
             self.cb_cursors.setItemIcon(i, self.slicer_area._cursor_icon(i))
             self.cb_cursors.setItemText(i, self.slicer_area._cursor_name(i))
         self.cb_cursors.setCurrentIndex(self.current_cursor)
+
+    def eventFilter(
+        self, obj: QtCore.QObject | None, event: QtCore.QEvent | None
+    ) -> bool:
+        if (
+            obj in (self.spin_dat, self._spin_dat_line_edit)
+            and event is not None
+            and event.type()
+            in (
+                QtCore.QEvent.Type.Resize,
+                QtCore.QEvent.Type.Show,
+                QtCore.QEvent.Type.LayoutRequest,
+            )
+        ):
+            self._position_readout_source_indicator()
+        return super().eventFilter(obj, event)
+
+    def _position_readout_source_indicator(self) -> None:
+        if self._spin_dat_line_edit is None:
+            return
+        rect = self._spin_dat_line_edit.geometry()
+        self._readout_source_indicator.move(
+            rect.left() + 5,
+            rect.top() + (rect.height() - self._readout_source_indicator.height()) // 2,
+        )
+        self._readout_source_indicator.raise_()
+
+    def _set_readout_source_indicator(self, coord_name: typing.Hashable | None) -> None:
+        if (
+            self._spin_dat_line_edit is not None
+            and self._spin_dat_text_margins is not None
+        ):
+            base = self._spin_dat_text_margins
+            margins = QtCore.QMargins(
+                base.left(), base.top(), base.right(), base.bottom()
+            )
+            if coord_name is not None:
+                margins.setLeft(margins.left() + 16)
+            self._spin_dat_line_edit.setTextMargins(margins)
+
+        if coord_name is None:
+            self._readout_source_indicator.setToolTip("")
+            self._readout_source_indicator.hide()
+            return
+
+        color = _associated_coord_color(self.slicer_area, coord_name)
+        self._readout_source_indicator.setStyleSheet(
+            "QFrame#associatedCoordValueIndicator {"
+            f"background-color: {color.name()};"
+            f"border: 1px solid {color.darker(130).name()};"
+            "border-radius: 4px;"
+            "}"
+        )
+        self._readout_source_indicator.setToolTip(
+            f"Associated coordinate: {coord_name}"
+        )
+        self._position_readout_source_indicator()
+        self._readout_source_indicator.show()
+
+    @staticmethod
+    def _readout_value_to_float(value: object) -> float | None:
+        if value is None:
+            return None
+        compute = getattr(value, "compute", None)
+        if callable(compute):
+            value = compute()
+        arr = np.asarray(value)
+        if arr.size == 0:
+            return None
+        if arr.size != 1:
+            with np.errstate(all="ignore"):
+                return float(np.nanmean(arr))
+        return float(arr.reshape(()))
+
+    def _set_spin_dat_value(self, value: object) -> None:
+        readout_value = self._readout_value_to_float(value)
+        if readout_value is not None:
+            self.spin_dat.setValue(readout_value)
+
+    def _set_readout_source(self, source: typing.Hashable | None) -> None:
+        self._readout_source = source
+        self.update_point_value_readout()
+
+    @QtCore.Slot(float)
+    def _set_computed_point_value(self, value: object) -> None:
+        if self._readout_source is None:
+            self._set_spin_dat_value(value)
+
+    @QtCore.Slot()
+    def update_point_value_readout(self, *_args) -> None:
+        plotted_coords = _plotted_associated_coord_names(self.array_slicer)
+        if (
+            self._readout_source is not None
+            and self._readout_source not in plotted_coords
+        ):
+            self._readout_source = None
+        self._set_readout_source_indicator(self._readout_source)
+
+        if self._readout_source is None:
+            if not self.slicer_area.data_chunked:
+                self._set_spin_dat_value(
+                    self.array_slicer.point_value(self.current_cursor, binned=True)
+                )
+            return
+
+        self._set_spin_dat_value(
+            self.array_slicer.associated_coord_point_value(
+                self._readout_source, self.current_cursor, binned=True
+            )
+        )
+
+    def _build_point_value_context_menu(self) -> QtWidgets.QMenu:
+        menu = QtWidgets.QMenu(self.spin_dat)
+        line_edit = self.spin_dat.lineEdit()
+
+        copy_action = menu.addAction("Copy")
+        copy_action.setData(("copy", None))
+        copy_action.setEnabled(line_edit is not None and line_edit.hasSelectedText())
+        if line_edit is not None:
+            copy_action.triggered.connect(line_edit.copy)
+
+        select_all_action = menu.addAction("Select All")
+        select_all_action.setData(("select_all", None))
+        select_all_action.setEnabled(line_edit is not None)
+        if line_edit is not None:
+            select_all_action.triggered.connect(line_edit.selectAll)
+
+        menu.addSeparator()
+        display_header = menu.addSection("Display Value")
+        display_header.setData(("display_header", None))
+
+        action_group = QtGui.QActionGroup(menu)
+        action_group.setExclusive(True)
+
+        data_action = menu.addAction("Data")
+        data_action.setData(("data", None))
+        data_action.setCheckable(True)
+        data_action.setChecked(self._readout_source is None)
+        data_action.setActionGroup(action_group)
+        data_action.triggered.connect(lambda: self._set_readout_source(None))
+
+        for coord_name in _plotted_associated_coord_names(self.array_slicer):
+            coord_action = menu.addAction(str(coord_name))
+            coord_action.setData(("coord", coord_name))
+            coord_action.setCheckable(True)
+            coord_action.setChecked(self._readout_source == coord_name)
+            coord_action.setActionGroup(action_group)
+            coord_action.setIcon(
+                _associated_coord_icon(
+                    _associated_coord_color(self.slicer_area, coord_name)
+                )
+            )
+            coord_action.setIconVisibleInMenu(True)
+            coord_action.triggered.connect(
+                lambda _checked=False, name=coord_name: self._set_readout_source(name)
+            )
+
+        return menu
+
+    @QtCore.Slot(QtCore.QPoint)
+    def _show_point_value_context_menu(self, position: QtCore.QPoint) -> None:
+        menu = self._build_point_value_context_menu()
+        menu.exec(self.spin_dat.mapToGlobal(position))
+        menu.deleteLater()
 
     @QtCore.Slot()
     def update_content(self) -> None:
@@ -435,9 +623,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
                 self.spin_dat.setDecimals(round(abs(np.log10(approx_abs_max)) + 1))
         except Exception:
             self.spin_dat.setDecimals(4)
-        self.spin_dat.setValue(
-            self.array_slicer.point_value(self.current_cursor, binned=True)
-        )
+        self.update_point_value_readout()
 
     def update_spins(self, *, axes=None) -> None:
         if axes is None:
@@ -456,10 +642,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
 
         # For chunked data, updating the point value is expensive, we let slicer_area
         # emit sigPointValueChanged after computation is done
-        if not self.slicer_area.data_chunked:
-            self.spin_dat.setValue(
-                self.array_slicer.point_value(self.current_cursor, binned=True)
-            )
+        self.update_point_value_readout()
 
     @QtCore.Slot(int)
     def update_cursor_count(self, count: int) -> None:

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -601,7 +601,9 @@ class ItoolPlotItem(pg.PlotItem):
             self._associated_coord_menu = self.vb.menu.addMenu(
                 "Open Associated Coordinate"
             )
-            self._associated_coord_menu.menuAction().setVisible(False)
+            typing.cast(
+                "QtGui.QAction", self._associated_coord_menu.menuAction()
+            ).setVisible(False)
             self._associated_coord_menu_separator_below = self.vb.menu.addSeparator()
             self._associated_coord_menu_separator_below.setVisible(False)
             self.vb.menu.aboutToShow.connect(self._refresh_associated_coord_menu)
@@ -747,7 +749,7 @@ class ItoolPlotItem(pg.PlotItem):
         menu.clear()
         coord_profiles = self._displayed_associated_coord_profiles()
         has_coord_profiles = bool(coord_profiles)
-        menu.menuAction().setVisible(has_coord_profiles)
+        typing.cast("QtGui.QAction", menu.menuAction()).setVisible(has_coord_profiles)
         for separator in (
             self._associated_coord_menu_separator_above,
             self._associated_coord_menu_separator_below,
@@ -756,7 +758,9 @@ class ItoolPlotItem(pg.PlotItem):
                 separator.setVisible(has_coord_profiles)
         for coord_name, _profile in coord_profiles:
             if len(self.array_slicer.associated_coord_dims[coord_name]) == 1:
-                coord_action = menu.addAction(str(coord_name))
+                coord_action = typing.cast(
+                    "QtGui.QAction", menu.addAction(str(coord_name))
+                )
                 coord_action.setData(("associated_coord_open", coord_name))
                 coord_action.setIcon(
                     _associated_coord_icon(
@@ -771,16 +775,19 @@ class ItoolPlotItem(pg.PlotItem):
                 )
                 continue
 
-            coord_menu = menu.addMenu(str(coord_name))
-            coord_menu.menuAction().setData(("associated_coord", coord_name))
-            coord_menu.menuAction().setIcon(
+            coord_menu = typing.cast("QtWidgets.QMenu", menu.addMenu(str(coord_name)))
+            coord_menu_action = typing.cast("QtGui.QAction", coord_menu.menuAction())
+            coord_menu_action.setData(("associated_coord", coord_name))
+            coord_menu_action.setIcon(
                 _associated_coord_icon(
                     _associated_coord_color(self.slicer_area, coord_name)
                 )
             )
-            coord_menu.menuAction().setIconVisibleInMenu(True)
+            coord_menu_action.setIconVisibleInMenu(True)
 
-            full_action = coord_menu.addAction("Full Coordinate")
+            full_action = typing.cast(
+                "QtGui.QAction", coord_menu.addAction("Full Coordinate")
+            )
             full_action.setData(("associated_coord_full", coord_name))
             full_action.triggered.connect(
                 lambda _checked=False, name=coord_name: self.open_associated_coord(
@@ -788,7 +795,9 @@ class ItoolPlotItem(pg.PlotItem):
                 )
             )
 
-            profile_action = coord_menu.addAction("Displayed Profile")
+            profile_action = typing.cast(
+                "QtGui.QAction", coord_menu.addAction("Displayed Profile")
+            )
             profile_action.setData(("associated_coord_profile", coord_name))
             profile_action.triggered.connect(
                 lambda _checked=False, name=coord_name: self.open_associated_coord(

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -20,7 +20,10 @@ import erlab
 from erlab.interactive.imagetool.viewer import (
     GuidelineState,
     PlotItemState,
+    _associated_coord_color,
+    _associated_coord_icon,
     _make_cursor_colors,
+    _plotted_associated_coord_names,
     record_history,
     suppress_history,
     suppressnanwarning,
@@ -475,6 +478,9 @@ class ItoolPlotItem(pg.PlotItem):
         self._roi_list: list[ItoolPolyLineROI] = []
 
     def setup_actions(self) -> None:
+        self._associated_coord_menu: QtWidgets.QMenu | None = None
+        self._associated_coord_menu_separator_above: QtGui.QAction | None = None
+        self._associated_coord_menu_separator_below: QtGui.QAction | None = None
         for act in ["Transforms", "Downsample", "Average", "Alpha", "Points"]:
             self.setContextMenuActionVisible(act, False)
 
@@ -589,7 +595,19 @@ class ItoolPlotItem(pg.PlotItem):
             norm_action.setCheckable(True)
             norm_action.setChecked(False)
             norm_action.toggled.connect(self.set_normalize)
-        self.vb.menu.addSeparator()
+
+            self._associated_coord_menu_separator_above = self.vb.menu.addSeparator()
+            self._associated_coord_menu_separator_above.setVisible(False)
+            self._associated_coord_menu = self.vb.menu.addMenu(
+                "Open Associated Coordinate"
+            )
+            self._associated_coord_menu.menuAction().setVisible(False)
+            self._associated_coord_menu_separator_below = self.vb.menu.addSeparator()
+            self._associated_coord_menu_separator_below.setVisible(False)
+            self.vb.menu.aboutToShow.connect(self._refresh_associated_coord_menu)
+
+        if self.is_image:
+            self.vb.menu.addSeparator()
 
         self._menu_filter = _OptionKeyMenuFilter(self.vb.menu, croppable_actions)
         self.vb.menu.installEventFilter(self._menu_filter)
@@ -705,6 +723,79 @@ class ItoolPlotItem(pg.PlotItem):
                     kwargs["yRange"] = [full_bounds.bottom(), full_bounds.top()]
             self.vb1.setRange(**kwargs)
 
+    def _displayed_associated_coord_profiles(
+        self,
+    ) -> tuple[
+        tuple[Hashable, tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
+        ...,
+    ]:
+        profiles = []
+        for name in _plotted_associated_coord_names(self.array_slicer):
+            profile = self.array_slicer.associated_coord_profile(
+                name, self.slicer_area.current_cursor, self.display_axis
+            )
+            if profile is not None:
+                profiles.append((name, profile))
+        return tuple(profiles)
+
+    @QtCore.Slot()
+    def _refresh_associated_coord_menu(self) -> None:
+        menu = self._associated_coord_menu
+        if menu is None:
+            return
+
+        menu.clear()
+        coord_profiles = self._displayed_associated_coord_profiles()
+        has_coord_profiles = bool(coord_profiles)
+        menu.menuAction().setVisible(has_coord_profiles)
+        for separator in (
+            self._associated_coord_menu_separator_above,
+            self._associated_coord_menu_separator_below,
+        ):
+            if separator is not None:
+                separator.setVisible(has_coord_profiles)
+        for coord_name, _profile in coord_profiles:
+            if len(self.array_slicer.associated_coord_dims[coord_name]) == 1:
+                coord_action = menu.addAction(str(coord_name))
+                coord_action.setData(("associated_coord_open", coord_name))
+                coord_action.setIcon(
+                    _associated_coord_icon(
+                        _associated_coord_color(self.slicer_area, coord_name)
+                    )
+                )
+                coord_action.setIconVisibleInMenu(True)
+                coord_action.triggered.connect(
+                    lambda _checked=False, name=coord_name: self.open_associated_coord(
+                        name, displayed_profile=False
+                    )
+                )
+                continue
+
+            coord_menu = menu.addMenu(str(coord_name))
+            coord_menu.menuAction().setData(("associated_coord", coord_name))
+            coord_menu.menuAction().setIcon(
+                _associated_coord_icon(
+                    _associated_coord_color(self.slicer_area, coord_name)
+                )
+            )
+            coord_menu.menuAction().setIconVisibleInMenu(True)
+
+            full_action = coord_menu.addAction("Full Coordinate")
+            full_action.setData(("associated_coord_full", coord_name))
+            full_action.triggered.connect(
+                lambda _checked=False, name=coord_name: self.open_associated_coord(
+                    name, displayed_profile=False
+                )
+            )
+
+            profile_action = coord_menu.addAction("Displayed Profile")
+            profile_action.setData(("associated_coord_profile", coord_name))
+            profile_action.triggered.connect(
+                lambda _checked=False, name=coord_name: self.open_associated_coord(
+                    name, displayed_profile=True
+                )
+            )
+
     @QtCore.Slot()
     @QtCore.Slot(int)
     @QtCore.Slot(int, object)
@@ -729,36 +820,26 @@ class ItoolPlotItem(pg.PlotItem):
                 "Please report a bug."
             )
 
-        coord_names = tuple(self.array_slicer.associated_coord_dims)
-        for k in tuple(self.array_slicer.twin_coord_names):
-            profile = self.array_slicer.associated_coord_profile(
-                k, self.slicer_area.current_cursor, self.display_axis
+        for k, (x, y) in self._displayed_associated_coord_profiles():
+            if n_plots >= len(self.other_data_items):
+                item = pg.PlotDataItem()
+                self.other_data_items.append(item)
+                self.vb1.addItem(item)
+            else:
+                item = self.other_data_items[n_plots]
+
+            clr = _associated_coord_color(self.slicer_area, k)
+            labels.append(
+                f"<tr><td style='color:{clr.name()}; text-align: center;'>{k}</td></tr>"
             )
-            if profile is not None:
-                x, y = profile
-                if n_plots >= len(self.other_data_items):
-                    item = pg.PlotDataItem()
-                    self.other_data_items.append(item)
-                    self.vb1.addItem(item)
-                else:
-                    item = self.other_data_items[n_plots]
 
-                clr: QtGui.QColor = self.slicer_area.TWIN_COLORS[
-                    coord_names.index(k) % len(self.slicer_area.TWIN_COLORS)
-                ]  # Color by index among associated coords
-                labels.append(
-                    "<tr>"
-                    f"<td style='color:{clr.name()}; text-align: center;'>{k}</td>"
-                    "</tr>"
-                )
-
-                x, y = _pad_1d_plot(x, y)
-                if self.slicer_data_items[-1].is_vertical:
-                    item.setData(y, x)
-                else:
-                    item.setData(x, y)
-                item.setPen(width=2, color=clr)
-                n_plots += 1
+            x, y = _pad_1d_plot(x, y)
+            if self.slicer_data_items[-1].is_vertical:
+                item.setData(y, x)
+            else:
+                item.setData(x, y)
+            item.setPen(width=2, color=clr)
+            n_plots += 1
 
         self._twin_visible = n_plots > 0
         ax = self.getAxis(self.twin_axes_location)
@@ -1881,26 +1962,35 @@ class ItoolPlotItem(pg.PlotItem):
                 item.normalize = normalize
                 item.refresh_data()
 
-    @QtCore.Slot()
-    def open_in_new_window(self) -> None:
-        """Open the current data in a new window."""
-        data = self.current_data
+    def _open_data_in_new_window(
+        self,
+        data: xr.DataArray,
+        source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
+        *,
+        use_parent_colormap: bool,
+    ) -> None:
+        itool_kw: dict[str, typing.Any] = {"data": data, "execute": False}
 
-        color_props = self.slicer_area.colormap_properties
-        itool_kw: dict[str, typing.Any] = {
-            "data": data,
-            "cmap": color_props["cmap"],
-            "gamma": color_props["gamma"],
-            "high_contrast": color_props["high_contrast"],
-            "zero_centered": color_props["zero_centered"],
-            "transpose": (self.is_image and data.dims[0] != self.axis_dims[0]),
-            "file_path": self.slicer_area._file_path,
-            "execute": False,
-        }
-        if color_props["levels_locked"]:
-            itool_kw["vmin"], itool_kw["vmax"] = color_props["levels"]
-        if color_props["reverse"] and isinstance(itool_kw["cmap"], str):
-            itool_kw["cmap"] = f"{itool_kw['cmap']}_r"
+        if use_parent_colormap:
+            color_props = self.slicer_area.colormap_properties
+            itool_kw.update(
+                {
+                    "cmap": color_props["cmap"],
+                    "gamma": color_props["gamma"],
+                    "high_contrast": color_props["high_contrast"],
+                    "zero_centered": color_props["zero_centered"],
+                    "transpose": (
+                        self.is_image
+                        and len(data.dims) >= 2
+                        and data.dims[0] != self.axis_dims[0]
+                    ),
+                    "file_path": self.slicer_area._file_path,
+                }
+            )
+            if color_props["levels_locked"]:
+                itool_kw["vmin"], itool_kw["vmax"] = color_props["levels"]
+            if color_props["reverse"] and isinstance(itool_kw["cmap"], str):
+                itool_kw["cmap"] = f"{itool_kw['cmap']}_r"
 
         if self.slicer_area._in_manager:
             manager = self.slicer_area._manager_instance
@@ -1915,11 +2005,7 @@ class ItoolPlotItem(pg.PlotItem):
                     erlab.interactive.itool(manager=False, **itool_kw),
                 )
                 if tool is not None:  # pragma: no branch
-                    manager.add_imagetool_child(
-                        tool,
-                        target,
-                        source_spec=self.make_tool_source_spec(),
-                    )
+                    manager.add_imagetool_child(tool, target, source_spec=source_spec)
                 return
 
         tool_window = erlab.interactive.itool(**itool_kw)
@@ -1927,12 +2013,41 @@ class ItoolPlotItem(pg.PlotItem):
             tool_window.set_provenance_spec(
                 erlab.interactive.imagetool.provenance.compose_display_provenance(
                     self.slicer_area.provenance_spec,
-                    self.make_tool_source_spec(),
+                    source_spec,
                     parent_data=self.slicer_area._tool_source_parent_data(),
                 )
             )
         if isinstance(tool_window, QtWidgets.QWidget):  # pragma: no branch
             self.slicer_area.add_tool_window(tool_window)
+
+    @QtCore.Slot()
+    def open_in_new_window(self) -> None:
+        """Open the current data in a new window."""
+        data = self.current_data
+        self._open_data_in_new_window(
+            data,
+            self.make_tool_source_spec(),
+            use_parent_colormap=True,
+        )
+
+    @QtCore.Slot(object)
+    def open_associated_coord(
+        self, coord_name: Hashable, *, displayed_profile: bool
+    ) -> None:
+        operation = erlab.interactive.imagetool.provenance.SelectCoordOperation(
+            coord_name=coord_name
+        )
+        source_spec = (
+            self.make_tool_source_spec().append_operations(operation)
+            if displayed_profile
+            else erlab.interactive.imagetool.provenance.public_data(operation)
+        )
+        data = source_spec.apply(self.slicer_area._tool_source_parent_data())
+        self._open_data_in_new_window(
+            data,
+            source_spec,
+            use_parent_colormap=False,
+        )
 
     @QtCore.Slot()
     def open_in_goldtool(self) -> None:

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -74,6 +74,7 @@ __all__ = [
     "RotateOperation",
     "ScriptCodeOperation",
     "SelOperation",
+    "SelectCoordOperation",
     "SliceAlongPathOperation",
     "SortCoordOrderOperation",
     "SqueezeOperation",
@@ -1320,6 +1321,23 @@ class SortCoordOrderOperation(ToolProvenanceOperation):
         return DerivationEntry(
             "Sort coordinates to parent order",
             "derived = erlab.utils.array.sort_coord_order(derived, data.coords.keys())",
+            True,
+        )
+
+
+class SelectCoordOperation(ToolProvenanceOperation):
+    op: typing.Literal["select_coord"] = "select_coord"
+    coord_name: ProvenanceHashable
+
+    def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
+        return data.coords[self.coord_name].copy(deep=False)
+
+    def derivation_entry(self) -> DerivationEntry:
+        coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
+        label_kwargs = {"coord_name": self.coord_name}
+        return DerivationEntry(
+            f"Select Coordinate({_format_derivation_value(label_kwargs)})",
+            f"derived = derived.coords[{coord_name_code}]",
             True,
         )
 

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -355,6 +355,32 @@ class ArraySlicer(QtCore.QObject):
             selected.transpose(display_dim).values.astype(np.float64),
         )
 
+    def associated_coord_point_value(
+        self, coord_name: Hashable, cursor: int, binned: bool = True
+    ) -> np.floating | dask.array.Array | None:
+        """Return an associated-coordinate value at the cursor position."""
+        dims = self.associated_coord_dims.get(coord_name)
+        if dims is None:
+            return None
+
+        coord = self._obj.coords[coord_name]
+        isel_kw: dict[Hashable, slice | int] = {}
+        mean_dims: list[Hashable] = []
+        for dim in dims:
+            axis_idx = self._dim_indices.get(dim)
+            if axis_idx is None:  # pragma: no cover
+                return None
+            if binned and self._binned[cursor][axis_idx]:
+                isel_kw[dim] = self._bin_slice(cursor, axis_idx)
+                mean_dims.append(dim)
+            else:
+                isel_kw[dim] = self._indices[cursor][axis_idx]
+
+        selected = coord.isel(isel_kw)
+        if mean_dims:
+            selected = selected.mean(dim=mean_dims, skipna=True)
+        return selected.data
+
     def cursor_color_coord(
         self, cursor: int, coord_dims: tuple[Hashable, ...], coord_name: Hashable
     ) -> tuple[tuple[Hashable, ...], npt.NDArray[np.float64], float] | None:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -44,7 +44,7 @@ if typing.TYPE_CHECKING:
         ItoolImageItem,
         ItoolPlotItem,
     )
-    from erlab.interactive.imagetool.slicer import ArraySlicerState
+    from erlab.interactive.imagetool.slicer import ArraySlicer, ArraySlicerState
 else:
     import lazy_loader as _lazy
 
@@ -140,6 +140,35 @@ def _make_cursor_colors(
     clr_span_edge.setAlphaF(0.35)
 
     return clr, clr_cursor, clr_cursor_hover, clr_span, clr_span_edge
+
+
+def _plotted_associated_coord_names(
+    array_slicer: ArraySlicer,
+) -> tuple[Hashable, ...]:
+    plotted = array_slicer.twin_coord_names
+    return tuple(name for name in array_slicer.associated_coord_dims if name in plotted)
+
+
+def _associated_coord_color(
+    slicer_area: ImageSlicerArea, coord_name: Hashable
+) -> QtGui.QColor:
+    coord_names = tuple(slicer_area.array_slicer.associated_coord_dims)
+    return slicer_area.TWIN_COLORS[
+        coord_names.index(coord_name) % len(slicer_area.TWIN_COLORS)
+    ]
+
+
+def _associated_coord_icon(color: QtGui.QColor) -> QtGui.QIcon:
+    img = QtGui.QImage(16, 16, QtGui.QImage.Format.Format_RGBA64)
+    img.fill(QtCore.Qt.GlobalColor.transparent)
+
+    painter = QtGui.QPainter(img)
+    painter.setRenderHints(QtGui.QPainter.RenderHint.Antialiasing, True)
+    painter.setPen(QtCore.Qt.PenStyle.NoPen)
+    painter.setBrush(color)
+    painter.drawEllipse(2, 2, 12, 12)
+    painter.end()
+    return QtGui.QIcon(QtGui.QPixmap.fromImage(img))
 
 
 def _parse_input(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -19,7 +19,10 @@ import erlab
 from erlab.interactive.derivative import DerivativeTool, dtool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
 from erlab.interactive.imagetool import ImageTool, itool
-from erlab.interactive.imagetool.controls import ItoolColormapControls
+from erlab.interactive.imagetool.controls import (
+    ItoolColormapControls,
+    ItoolCrosshairControls,
+)
 from erlab.interactive.imagetool.dialogs import (
     AssignCoordsDialog,
     AverageDialog,
@@ -122,6 +125,12 @@ def _exec_data_fragment(
     return result
 
 
+def _menu_action_by_data(menu: QtWidgets.QMenu, data: object) -> QtGui.QAction:
+    matches = [action for action in menu.actions() if action.data() == data]
+    assert len(matches) == 1
+    return matches[0]
+
+
 def _assert_guideline_state(
     plot_item,
     *,
@@ -188,9 +197,6 @@ def test_itool_tools(qtbot, test_data_type, condition, use_dask) -> None:
                 QtCore.QEvent.KeyPress, QtCore.Qt.Key_Alt, QtCore.Qt.AltModifier
             ),
         )
-        for action in main_image.vb.menu.actions():
-            if action.text().startswith("goldtool"):
-                action.text().endswith("(Crop)")
 
         logger.info("Check access to cropped data")
         assert isinstance(main_image._current_data_cropped, xr.DataArray)
@@ -264,7 +270,11 @@ def test_copy_selection_code_includes_crop_with_alt(qtbot, monkeypatch) -> None:
     monkeypatch.setattr(erlab.interactive.utils, "copy_to_clipboard", fake_copy)
 
     main_image.copy_selection_code()
-    assert copied == [".sel(x=slice(1.0, 3.0), y=slice(0.0, 2.0))"]
+    assert len(copied) == 1
+    xr.testing.assert_identical(
+        _exec_data_fragment(data, copied[0]),
+        data.sel(x=slice(1.0, 3.0), y=slice(0.0, 2.0)),
+    )
     win.close()
 
 
@@ -290,7 +300,11 @@ def test_copy_selection_code_descending_coords(qtbot, monkeypatch) -> None:
     monkeypatch.setattr(erlab.interactive.utils, "copy_to_clipboard", fake_copy)
 
     main_image.copy_selection_code()
-    assert copied == [".sel(x=slice(3.0, 1.0), y=slice(2.0, 0.0))"]
+    assert len(copied) == 1
+    xr.testing.assert_identical(
+        _exec_data_fragment(data, copied[0]),
+        data.sel(x=slice(3.0, 1.0), y=slice(2.0, 0.0)),
+    )
     win.close()
 
 
@@ -791,6 +805,8 @@ def test_plot_with_matplotlib_executes_in_manager(qtbot, monkeypatch) -> None:
 
 
 def test_copy_matplotlib_code_uses_generated_output(qtbot, monkeypatch) -> None:
+    import matplotlib.pyplot as plt
+
     data = _TEST_DATA["3D"].copy()
     win = itool(data, execute=False)
     qtbot.addWidget(win)
@@ -800,7 +816,6 @@ def test_copy_matplotlib_code_uses_generated_output(qtbot, monkeypatch) -> None:
     win.slicer_area.set_value(axis=2, value=1.0, cursor=0)
     win.slicer_area.set_value(axis=2, value=3.0, cursor=1)
 
-    expected = main_image._plot_code_multicursor()
     copied: dict[str, str] = {}
 
     def _copy(arg: str) -> None:
@@ -809,8 +824,13 @@ def test_copy_matplotlib_code_uses_generated_output(qtbot, monkeypatch) -> None:
     monkeypatch.setattr(erlab.interactive.utils, "copy_to_clipboard", _copy)
 
     main_image.copy_matplotlib_code()
-    assert copied["text"] == expected
-    assert "beta=[1.0, 3.0]" in expected
+    namespace = _exec_generated_code(
+        copied["text"],
+        {"data": data.copy(deep=True), "plt": plt, "eplt": erlab.plotting},
+    )
+    assert "fig" in namespace
+    assert len(np.asarray(namespace["axs"]).ravel()) == 2
+    plt.close(namespace["fig"])
 
     win.close()
 
@@ -955,6 +975,137 @@ def test_associated_coord_profile_nd_cursor_and_bins(qtbot) -> None:
     assert slicer.associated_coord_profile("plane", 0, (0, 1)) is None
     assert slicer.associated_coord_profile("missing", 0, (0,)) is None
     assert slicer.cursor_color_coord(0, ("y", "x"), "plane") is None
+    win.close()
+
+
+def test_point_value_context_menu_selects_associated_coord(qtbot) -> None:
+    temp = np.arange(25, dtype=float).reshape(5, 5) + 100.0
+    data = xr.DataArray(
+        np.zeros((5, 5), dtype=float),
+        dims=["x", "y"],
+        coords={
+            "x": np.arange(5, dtype=float),
+            "y": np.arange(5, dtype=float),
+            "temp": (("x", "y"), temp),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    control = win.docks[0].widget().findChild(ItoolCrosshairControls)
+    assert control is not None
+    control.update_content()
+
+    win.slicer_area.array_slicer.twin_coord_names = {"temp"}
+    menu = control._build_point_value_context_menu()
+    action_data = [
+        action.data() for action in menu.actions() if not action.isSeparator()
+    ]
+
+    assert control._readout_source_indicator.isHidden()
+    header_action = _menu_action_by_data(menu, ("display_header", None))
+    assert header_action.isSeparator()
+    assert action_data == [
+        ("copy", None),
+        ("select_all", None),
+        ("data", None),
+        ("coord", "temp"),
+    ]
+    assert _menu_action_by_data(menu, ("data", None)).isChecked()
+    temp_action = _menu_action_by_data(menu, ("coord", "temp"))
+    assert not temp_action.icon().isNull()
+
+    temp_action.trigger()
+    assert control._readout_source == "temp"
+    assert not control._readout_source_indicator.isHidden()
+    assert control.spin_dat.value() == temp[2, 2]
+
+    win.slicer_area.set_index(0, 4)
+    assert control.spin_dat.value() == temp[4, 2]
+
+    control._set_computed_point_value(-1.0)
+    assert control.spin_dat.value() == temp[4, 2]
+
+    win.slicer_area.array_slicer.twin_coord_names = set()
+    assert control._readout_source is None
+    assert control._readout_source_indicator.isHidden()
+    assert control.spin_dat.value() == 0.0
+    win.close()
+
+
+def test_profile_menu_opens_associated_coord_targets(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    x = np.arange(3, dtype=float)
+    y = np.arange(4, dtype=float)
+    plane = x[:, None] * 10.0 + y[None, :]
+    data = xr.DataArray(
+        np.zeros((3, 4, 2), dtype=float),
+        dims=["x", "y", "z"],
+        coords={
+            "x": x,
+            "y": y,
+            "z": np.arange(2, dtype=float),
+            "plane": (("x", "y"), plane),
+            "temp": ("x", x + 100.0),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    profile = win.slicer_area.profiles[0]
+    win.slicer_area.array_slicer.twin_coord_names = {"plane", "temp"}
+
+    captured: list[
+        tuple[
+            xr.DataArray,
+            erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
+            bool,
+        ]
+    ] = []
+
+    def _capture_open(data, source_spec, *, use_parent_colormap):
+        captured.append((data, source_spec, use_parent_colormap))
+
+    monkeypatch.setattr(profile, "_open_data_in_new_window", _capture_open)
+
+    profile._refresh_associated_coord_menu()
+    assert profile._associated_coord_menu is not None
+    assert profile._associated_coord_menu.menuAction().isVisible()
+    plot_actions = profile.vb.menu.actions()
+    menu_index = plot_actions.index(profile._associated_coord_menu.menuAction())
+    assert plot_actions[menu_index - 1].isSeparator()
+    assert plot_actions[menu_index - 1].isVisible()
+    assert plot_actions[menu_index + 1].isSeparator()
+    assert plot_actions[menu_index + 1].isVisible()
+
+    temp_action = _menu_action_by_data(
+        profile._associated_coord_menu, ("associated_coord_open", "temp")
+    )
+    assert temp_action.menu() is None
+    temp_action.trigger()
+    temp_data, temp_spec, use_parent_colormap = captured[-1]
+    xr.testing.assert_identical(temp_data, data.coords["temp"])
+    assert temp_spec.kind == "public_data"
+    assert temp_spec.operations[-1].op == "select_coord"
+    assert use_parent_colormap is False
+
+    coord_menu = _menu_action_by_data(
+        profile._associated_coord_menu, ("associated_coord", "plane")
+    ).menu()
+    assert coord_menu is not None
+
+    _menu_action_by_data(coord_menu, ("associated_coord_full", "plane")).trigger()
+    full_data, full_spec, use_parent_colormap = captured[-1]
+    xr.testing.assert_identical(full_data, data.coords["plane"])
+    assert full_spec.kind == "public_data"
+    assert full_spec.operations[-1].op == "select_coord"
+    assert use_parent_colormap is False
+
+    _menu_action_by_data(coord_menu, ("associated_coord_profile", "plane")).trigger()
+    profile_data, profile_spec, use_parent_colormap = captured[-1]
+    xr.testing.assert_identical(profile_data, data.isel(y=1, z=0).coords["plane"])
+    assert profile_spec.kind == "selection"
+    assert profile_spec.operations[-1].op == "select_coord"
+    assert use_parent_colormap is False
     win.close()
 
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -623,6 +623,29 @@ def test_tool_provenance_validation_helpers_and_error_branches() -> None:
         prov.script(start_label="Start", active_name="derived")._display_operations()
 
 
+def test_select_coord_operation_round_trips_and_applies() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data().assign_coords(temp=("x", [100.0, 200.0, 300.0]))
+    operation = prov.SelectCoordOperation(coord_name="temp")
+
+    xr.testing.assert_identical(
+        operation.apply(data, parent_data=data), data.coords["temp"]
+    )
+
+    entry = operation.derivation_entry()
+    assert entry.copyable is True
+    assert entry.code is not None
+    namespace = _exec_generated_code(entry.code, {"derived": data.copy(deep=True)})
+    xr.testing.assert_identical(namespace["derived"], data.coords["temp"])
+
+    parsed = prov.parse_tool_provenance_operation(operation.model_dump(mode="json"))
+    assert parsed == operation
+
+    spec = prov.public_data(operation)
+    assert prov.require_live_source_spec(spec) == spec
+    xr.testing.assert_identical(spec.apply(data), data.coords["temp"])
+
+
 def test_tool_provenance_remaining_operation_and_display_branches(monkeypatch) -> None:
     prov = erlab.interactive.imagetool.provenance
     data = _base_data()

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -346,6 +346,44 @@ def test_point_value_unbinned_returns_current_scalar(qtbot) -> None:
     assert slicer.point_value(0, binned=False) == values[2, 3]
 
 
+def test_associated_coord_point_value_handles_bins_and_missing(qtbot) -> None:
+    x = np.arange(3, dtype=float)
+    y = np.arange(4, dtype=float)
+    z = np.arange(5, dtype=float)
+    plane = x[:, None] * 10.0 + y[None, :] ** 2
+    plane[1, 1] = np.nan
+    xz = x[:, None] * 1000.0 + z[None, :]
+    data = xr.DataArray(
+        np.zeros((3, 4, 5), dtype=np.float32),
+        dims=("x", "y", "z"),
+        coords={
+            "x": x,
+            "y": y,
+            "z": z,
+            "temp": ("x", x + 300.0),
+            "plane": (("x", "y"), plane),
+            "xz": (("x", "z"), xz),
+            "label": ("x", ["a", "b", "c"]),
+        },
+    )
+
+    slicer = ArraySlicer(data, parent=QtCore.QObject())
+    slicer.set_indices(0, [1, 1, 3], update=False)
+
+    assert float(np.asarray(slicer.associated_coord_point_value("temp", 0))) == 301.0
+    assert np.isnan(float(np.asarray(slicer.associated_coord_point_value("plane", 0))))
+    assert float(np.asarray(slicer.associated_coord_point_value("xz", 0))) == 1003.0
+    assert slicer.associated_coord_point_value("missing", 0) is None
+
+    slicer.set_bin(0, 1, 3, update=False)
+
+    np.testing.assert_allclose(
+        slicer.associated_coord_point_value("plane", 0),
+        np.nanmean([10.0, np.nan, 14.0]),
+    )
+    assert float(np.asarray(slicer.associated_coord_point_value("xz", 0))) == 1003.0
+
+
 def test_value_of_index_uniform_path_on_nonuniform_axis(qtbot) -> None:
     data = xr.DataArray(
         np.zeros((4, 3), dtype=np.float32),


### PR DESCRIPTION
ImageTool now lets users inspect plotted associated coordinates values corresponding to the currently active cursor position directly from the cursor value readout. The readout source can now be selected from the value field’s right-click context menu.

Also, the right-click context menu of profile plots now includes actions to open associated coordinates in a new ImageTool window.