### PR TITLE
feat(io): add data loader `pal4a1` for PAL beamline 4A1

### DIFF
--- a/src/erlab/io/igor.py
+++ b/src/erlab/io/igor.py
@@ -43,6 +43,7 @@ _WAVE_SHAPE_PATTERN = re.compile(
     r"WAVES.*/N=\(([\d,]+)\)\s+[\"\']?([^\'\"\v:;]+)[\"\']?"
 )  # 2D/3D/4D wave with shape
 _SETSCALE_PATTERN = re.compile(r"SetScale\s*((?:/I)|(?:/P))?(.*)")
+_NOTE_PATTERN = re.compile(r"Note\s+[^,]+,\s*(.*)")
 
 
 class IgorBackendEntrypoint(BackendEntrypoint):
@@ -560,8 +561,51 @@ def set_scale(
 
     if units_str:
         darr = darr.rename({dim_name: units_str})
+    elif dim_name != dim:
+        darr = darr.rename({dim_name: dim})
 
     return darr
+
+
+def _parse_note_line(note_line: str) -> str | None:
+    m = _NOTE_PATTERN.match(note_line.strip())
+    if m is None:
+        return None
+
+    note = m.group(1).strip()
+    try:
+        parts = shlex.split(note)
+    except ValueError:
+        return note.strip("\"'")
+
+    if len(parts) == 0:
+        return ""
+    return parts[0]
+
+
+def _parse_key_value_line(
+    line: str, *, skip_time_colons: bool = False
+) -> tuple[str, str] | None:
+    if "=" in line:
+        delim = "="
+    elif ":" in line:
+        delim_idx = line.index(":")
+        if (
+            skip_time_colons
+            and delim_idx > 0
+            and delim_idx + 1 < len(line)
+            and line[delim_idx - 1].isdigit()
+            and line[delim_idx + 1].isdigit()
+        ):
+            return None
+        delim = ":"
+    else:
+        return None
+
+    key, val = line.split(delim, 1)
+    if not val.strip() and delim == ":":
+        return None
+    return key.strip(), val.strip()
 
 
 def load_text(
@@ -587,8 +631,14 @@ def load_text(
     -------
     DataArray
         The loaded data.
+
+    .. versionchanged:: 3.22.0
+
+       Empty-unit ``SetScale`` axes are named with Igor axis letters, and ``X Note``
+       key-value metadata is parsed into attributes.
     """
     comments: dict[str, str] = {}
+    note_lines: list[str] = []
     setscale_lines: list[str] = []
 
     shape: tuple[int, ...] | None = None
@@ -612,22 +662,24 @@ def load_text(
                 # Parse key-value pairs from comment lines
                 comment_line: str = line.removeprefix("X //").strip()
 
-                if "=" in comment_line:
-                    delim = "="
-                elif ":" in comment_line:
-                    delim = ":"
-                else:
+                parsed_comment = _parse_key_value_line(comment_line)
+                if parsed_comment is None:
                     continue
 
-                key, val = comment_line.split(delim, 1)
-                if not val.strip() and delim == ":":
-                    # Header line with no value, skipping
-                    continue
-
+                key, val = parsed_comment
                 comments[key.strip()] = val.strip()
                 continue
             if line.startswith("X SetScale"):
                 setscale_lines.extend(line.removeprefix("X ").strip().split(";"))
+                continue
+            if line.startswith("X Note"):
+                note = _parse_note_line(line.removeprefix("X "))
+                if note is None:
+                    continue
+                note_lines.append(note)
+                parsed_note = _parse_key_value_line(note, skip_time_colons=True)
+                if parsed_note is not None:
+                    comments[parsed_note[0]] = parsed_note[1]
                 continue
             if line.startswith("WAVES"):
                 if wave_name is not None:
@@ -643,6 +695,9 @@ def load_text(
         raise ValueError(
             "No valid wave definition found in the file. Check the file format."
         )
+
+    if note_lines:
+        comments["IGORWaveNote"] = "\n".join(note_lines)
 
     if shape is None:
         # 1D wave

--- a/src/erlab/io/plugins/__init__.py
+++ b/src/erlab/io/plugins/__init__.py
@@ -24,6 +24,7 @@ loader.
    maestro
    mbs
    merlin
+   pal4a1
    snu1
    ssrl52
 

--- a/src/erlab/io/plugins/pal4a1.py
+++ b/src/erlab/io/plugins/pal4a1.py
@@ -1,0 +1,71 @@
+"""Data loader for beamline 4A1 at PAL."""
+
+__all__ = ["PAL4A1Loader"]
+
+import os
+import re
+import typing
+
+import xarray as xr
+
+import erlab
+from erlab.io.dataloader import LoaderBase
+
+_NUMERIC_UNIT_PATTERN = re.compile(
+    r"^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]?\d+)?)"
+    r"\s*(?:[A-Za-z%][A-Za-z0-9_./%()[\]-]*|\[[^\]]+\])?\s*$"
+)
+
+
+def _parse_pal_scalar(value: typing.Any) -> typing.Any:
+    if not isinstance(value, str):
+        return value
+
+    value = value.strip()
+    if "..." in value:
+        return value
+
+    m = _NUMERIC_UNIT_PATTERN.match(value)
+    if m is None:
+        return value
+
+    number = m.group(1)
+    if re.search(r"[.eE]", number):
+        return float(number)
+    return int(number)
+
+
+class PAL4A1Loader(LoaderBase):
+    name = "pal4a1"
+    description = "PAL Beamline 4A1"
+    extensions: typing.ClassVar[set[str]] = {".itx"}
+
+    name_map: typing.ClassVar[dict] = {
+        "eV": "x",
+        "alpha": ["y", "Phi"],
+        "beta": ["z", "Theta"],
+        "hv": "Photon Energy",
+        "x": "X position",
+        "y": "Y position",
+        "z": "Z position",
+    }
+    coordinate_attrs = ("alpha", "beta", "hv", "x", "y", "z")
+    additional_attrs: typing.ClassVar[dict] = {"configuration": 1}
+
+    skip_validate: bool = True
+    always_single: bool = True
+
+    @property
+    def file_dialog_methods(self):
+        return {"PAL 4A1 Raw Data (*.itx)": (self.load, {})}
+
+    def load_single(
+        self, file_path: str | os.PathLike, without_values: bool = False
+    ) -> xr.DataArray:
+        return erlab.io.igor.load_text(file_path, without_values=without_values)
+
+    def post_process(self, data: xr.DataArray) -> xr.DataArray:
+        data = data.assign_attrs(
+            {key: _parse_pal_scalar(value) for key, value in data.attrs.items()}
+        )
+        return super().post_process(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,10 +44,10 @@ from erlab.interactive.utils import _WaitDialog
 from erlab.io.dataloader import LoaderBase
 from erlab.io.exampledata import generate_data_angles, generate_gold_edge
 
-DATA_COMMIT_HASH = "e16f40ad67345a07435afbbc1928568db0f4c71c"
+DATA_COMMIT_HASH = "7b9b49fdc7f3eedcbe655f6b69855b2d09c6bcad"
 """The commit hash of the commit to retrieve from `kmnhan/erlabpy-data`."""
 
-DATA_KNOWN_HASH = "1236511ac3b6b6f85a07246f6df52db2580404a56679ac63cabe4dc246b2b405"
+DATA_KNOWN_HASH = "63c33dc1af7d3b39e39d5a0ccd6577e52ad9d68822991148303ca2a01e98451c"
 """The SHA-256 checksum of the `.tar.gz` file."""
 
 log = logging.getLogger(__name__)

--- a/tests/io/plugins/test_pal4a1.py
+++ b/tests/io/plugins/test_pal4a1.py
@@ -1,0 +1,95 @@
+import pathlib
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import erlab
+
+
+@pytest.fixture(scope="module")
+def data_dir(test_data_dir):
+    erlab.io.set_loader("pal4a1")
+    erlab.io.set_data_dir(test_data_dir / "pal4a1")
+    return test_data_dir / "pal4a1"
+
+
+@pytest.fixture(scope="module")
+def expected_dir(data_dir):
+    return data_dir / "expected"
+
+
+@pytest.mark.parametrize(
+    "filename", ["core_level.itx", "fine_cut.itx", "rough_map.itx"]
+)
+def test_load(filename, expected_dir) -> None:
+    xr.testing.assert_identical(
+        erlab.io.load(filename),
+        xr.load_dataarray(expected_dir / f"{pathlib.Path(filename).stem}.h5"),
+    )
+
+
+def test_core_level_coordinates(data_dir) -> None:
+    data = erlab.io.load("core_level.itx")
+
+    assert data.dims == ("eV",)
+    np.testing.assert_allclose(data["eV"], [10.0, 10.02, 10.04, 10.06])
+    assert float(data["alpha"]) == pytest.approx(-3.0)
+    assert float(data["beta"]) == pytest.approx(1.0)
+    assert float(data["hv"]) == pytest.approx(80.5)
+    assert float(data["x"]) == pytest.approx(1.8701)
+    assert float(data["y"]) == pytest.approx(5.9799)
+    assert float(data["z"]) == pytest.approx(18.92)
+    assert data.attrs["configuration"] == 1
+    assert data.attrs["Pass Energy"] == 10
+    assert data.attrs["I0"] == "25.913 nA ... 25.763 nA"
+
+
+def test_fine_cut_coordinates(data_dir) -> None:
+    data = erlab.io.load("fine_cut.itx")
+
+    assert data.dims == ("eV", "alpha")
+    np.testing.assert_allclose(data["eV"], [62.0, 62.005, 62.01, 62.015])
+    np.testing.assert_allclose(data["alpha"], [-16.6, -16.5534286, -16.5068572])
+    assert float(data["beta"]) == pytest.approx(1.0)
+    assert float(data["hv"]) == pytest.approx(80.5)
+    assert float(data["x"]) == pytest.approx(1.8701)
+    assert float(data["y"]) == pytest.approx(5.9799)
+    assert float(data["z"]) == pytest.approx(18.92)
+    assert data.attrs["configuration"] == 1
+    assert data.attrs["Pass Energy"] == 50
+
+
+def test_rough_map_coordinates(data_dir) -> None:
+    data = erlab.io.load("rough_map.itx")
+
+    assert data.dims == ("eV", "alpha", "beta")
+    np.testing.assert_allclose(data["eV"], [63.0, 63.1])
+    np.testing.assert_allclose(data["alpha"], [-13.8, -13.7534286, -13.7068572])
+    np.testing.assert_allclose(data["beta"], [-19.0, -18.0])
+    assert float(data["hv"]) == pytest.approx(80.5)
+    assert float(data["x"]) == pytest.approx(1.8701)
+    assert float(data["y"]) == pytest.approx(5.9799)
+    assert float(data["z"]) == pytest.approx(18.94)
+    assert data.attrs["configuration"] == 1
+    assert data.attrs["Pass Energy"] == 50
+
+
+def test_without_values(data_dir) -> None:
+    data = erlab.io.load("rough_map.itx", load_kwargs={"without_values": True})
+
+    assert data.dims == ("eV", "alpha", "beta")
+    assert data.shape == (2, 3, 2)
+    np.testing.assert_array_equal(data.values, np.zeros(data.shape))
+    np.testing.assert_allclose(data["eV"], [63.0, 63.1])
+    np.testing.assert_allclose(data["beta"], [-19.0, -18.0])
+    assert float(data["hv"]) == pytest.approx(80.5)
+    assert data.attrs["configuration"] == 1
+
+
+def test_integer_loading_raises(data_dir) -> None:
+    with pytest.raises(
+        NotImplementedError,
+        match="does not support loading data by scan index",
+    ):
+        erlab.io.load(1)

--- a/tests/io/test_igor.py
+++ b/tests/io/test_igor.py
@@ -20,7 +20,7 @@ def test_backend_dataarray(datadir) -> None:
 
 
 def test_backend_dataarray_itx(datadir) -> None:
-    wave = xr.load_dataarray(datadir / "wave0.itx").rename(dim_0="W").astype(np.float32)
+    wave = xr.load_dataarray(datadir / "wave0.itx").rename(x="W").astype(np.float32)
     xarray.testing.assert_equal(wave, WAVE0)
 
 
@@ -76,12 +76,12 @@ def test_parse_wave_shape() -> None:
 
 
 def test_load_text_basic(datadir) -> None:
-    wave = load_text(datadir / "wave0.itx", dtype=np.float32).rename(dim_0="W")
+    wave = load_text(datadir / "wave0.itx", dtype=np.float32).rename(x="W")
     xarray.testing.assert_equal(wave, WAVE0)
 
     wave = load_text(
         datadir / "wave0.itx", dtype=np.float32, without_values=True
-    ).rename(dim_0="W")
+    ).rename(x="W")
     xarray.testing.assert_equal(wave, xr.zeros_like(WAVE0))
 
 
@@ -92,11 +92,59 @@ def test_load_text_invalid_file(datadir) -> None:
 
 def test_load_text_multiple_waves(datadir) -> None:
     with pytest.warns(UserWarning, match="Multiple wave definitions found"):
-        wave = load_text(datadir / "multiple_waves.itx", dtype=np.float32).rename(
-            dim_0="W"
-        )
+        wave = load_text(datadir / "multiple_waves.itx", dtype=np.float32).rename(x="W")
 
     xarray.testing.assert_equal(wave, WAVE0)
+
+
+def test_load_text_empty_unit_setscale_and_notes(tmp_path) -> None:
+    path = tmp_path / "note_wave.itx"
+    path.write_text(
+        """IGOR
+WAVES/D/N=(2,3,2) testwave
+BEGIN
+1 2 3
+4 5 6
+7 8 9
+10 11 12
+END
+X SetScale/P x 10,0.5,"", testwave
+X SetScale/P y -1,1,"", testwave
+X SetScale/P z 4,2,"", testwave
+X Note testwave, "Photon Energy = 80.5 eV"
+X Note testwave, "Acquired from 2025-10-30 14:30:28 To 2025-10-30 14:41:39"
+X Note testwave, "Category: sample"
+X Note testwave, "Compact:sample"
+""",
+        encoding="utf-8",
+    )
+
+    wave = load_text(path)
+
+    assert wave.dims == ("x", "y", "z")
+    assert wave.shape == (2, 3, 2)
+    np.testing.assert_allclose(wave["x"], [10.0, 10.5])
+    np.testing.assert_allclose(wave["y"], [-1.0, 0.0, 1.0])
+    np.testing.assert_allclose(wave["z"], [4.0, 6.0])
+    assert wave.attrs["Photon Energy"] == "80.5 eV"
+    assert wave.attrs["Category"] == "sample"
+    assert wave.attrs["Compact"] == "sample"
+    assert not any(key.startswith("Acquired from") for key in wave.attrs)
+    assert wave.attrs["IGORWaveNote"] == (
+        "Photon Energy = 80.5 eV\n"
+        "Acquired from 2025-10-30 14:30:28 To 2025-10-30 14:41:39\n"
+        "Category: sample\n"
+        "Compact:sample"
+    )
+
+    wave_without_values = load_text(path, without_values=True)
+
+    assert wave_without_values.dims == wave.dims
+    assert wave_without_values.shape == wave.shape
+    for dim in wave.dims:
+        np.testing.assert_allclose(wave_without_values[dim], wave[dim])
+    assert wave_without_values.attrs == wave.attrs
+    np.testing.assert_array_equal(wave_without_values.values, np.zeros(wave.shape))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Updates the Igor text parser to preserve empty-unit `SetScale` axes as x/y/z/t and parse `X Note` metadata into attrs to support loading data files from PAL beamline 4A1 at Pohang.