### PR TITLE
fix(io.plugins.hers): correct coordinate handling for ALS BL10 data

### DIFF
--- a/src/erlab/io/fitsutils.py
+++ b/src/erlab/io/fitsutils.py
@@ -95,7 +95,7 @@ def parse_bintable_column(header, col, nrows):
             val = parse_tfloat(trval)
             delt = parse_tfloat(tdelt)
             for i, d in enumerate(dims[:-1]):
-                start = val[i] - (pix[i]) * delt[i]
+                start = val[i] - (pix[i] - 1.0) * delt[i]
                 coords[d] = np.arange(shape[i]) * delt[i] + start
 
     else:
@@ -103,6 +103,37 @@ def parse_bintable_column(header, col, nrows):
         dims = [header.get(f"TTYPE{col}", f"col_{col}")]
         shape = (nrows,)
     return coords, dims, shape, tunit
+
+
+_SINGLE_MOTOR_SCAN_TYPES = frozenset(
+    {
+        "One Motor",
+        "Beamline",
+        "DAC",
+        "Manual",
+        "Beta_Compensated",
+        "SES",
+        "Line Scan Fine",
+    }
+)
+
+
+def _nominal_single_motor_coord(ds: xr.Dataset, length: int) -> npt.NDArray[np.float64]:
+    n0 = int(ds.attrs.get("N_0_0", length))
+    st0 = float(ds.attrs.get("ST_0_0", 0.0))
+    en0 = float(ds.attrs.get("EN_0_0", st0))
+
+    if n0 <= 1:
+        return np.full(length, st0, dtype=np.float64)
+
+    return st0 + (en0 - st0) / (n0 - 1) * np.arange(length, dtype=np.float64)
+
+
+def _unindexed_scan_dim(ds: xr.Dataset) -> Hashable:
+    for d in next(iter(ds.data_vars.values())).dims:  # pragma: no branch
+        if d not in ds.coords:
+            return d
+    raise ValueError("Could not determine unindexed scan dimension in FITS dataset.")
 
 
 def fits_to_xarray(filename: str | os.PathLike) -> xr.DataTree:
@@ -185,6 +216,11 @@ def process_fits_dataset(ds: xr.Dataset) -> xr.Dataset:
 
     Assumes a format used by beamlines 10.0.1 and 7.0.1 at ALS, and possibly others.
     Roughly corresponds to ``RedimAndScaleData`` in ``LoadFits7.ipf``.
+
+    .. versionchanged:: 3.22.0
+
+       Single-motor scan axes use nominal scan metadata instead of motor readback
+       values, matching the Igor Pro FITS loader behavior.
     """
     # Make all auxiliary coordinates dependent on time
     coords_to_update: list[Hashable] = [
@@ -213,37 +249,29 @@ def process_fits_dataset(ds: xr.Dataset) -> xr.Dataset:
         match scan_type:
             case "None":
                 return ds
-            case (
-                "One Motor"
-                | "Beamline"
-                | "DAC"
-                | "Manual"
-                | "Beta_Compensated"
-                | "SES"
-                | "Line Scan Fine"
-            ):
-                # Get dim name without coordinates
-                for d in next(iter(ds.data_vars.values())).dims:  # pragma: no branch
-                    if d not in ds.coords:
-                        d_name = d
-                        break
+            case _ if scan_type in _SINGLE_MOTOR_SCAN_TYPES:
+                motor_axis = str(ds.attrs.get("NM_0_0", "")).strip()
+                if not motor_axis:
+                    return ds
 
-                # Assign coordinate to scan axis
-                ds = ds.rename({d_name: "time"})
+                ds = ds.rename({_unindexed_scan_dim(ds): "time"})
+                scan_length = ds.sizes["time"]
+                scan_coord = _nominal_single_motor_coord(ds, scan_length)
 
-                motor_axis = ds.attrs.get("NM_0_0", "")
+                new_coords: dict[str, xr.DataArray] = {
+                    motor_axis: xr.DataArray(scan_coord, dims=("time",))
+                }
+                if motor_axis in ds.coords:
+                    readback = ds.coords[motor_axis]
+                    if readback.ndim == 1 and readback.size == scan_length:
+                        new_coords[f"{motor_axis}_readback"] = xr.DataArray(
+                            readback.data,
+                            dims=("time",),
+                            attrs=readback.attrs,
+                        )
+                    ds = ds.drop_vars(motor_axis)
 
-                if motor_axis not in ds.coords:
-                    # If motor axis is not in coords, create it
-                    # This is not accessed in most cases but is added for safety
-                    n0 = int(ds.attrs.get("N_0_0", 0))
-                    st0 = float(ds.attrs.get("ST_0_0", 0))
-                    en0 = float(ds.attrs.get("EN_0_0", 0))
-
-                    ds = ds.assign_coords(
-                        {motor_axis: ("time", np.linspace(st0, en0, n0))}
-                    )
-
+                ds = ds.assign_coords(new_coords)
                 ds = ds.swap_dims({"time": motor_axis})
 
             case _:

--- a/src/erlab/io/fitsutils.py
+++ b/src/erlab/io/fitsutils.py
@@ -263,12 +263,11 @@ def process_fits_dataset(ds: xr.Dataset) -> xr.Dataset:
                 }
                 if motor_axis in ds.coords:
                     readback = ds.coords[motor_axis]
-                    if readback.ndim == 1 and readback.size == scan_length:
-                        new_coords[f"{motor_axis}_readback"] = xr.DataArray(
-                            readback.data,
-                            dims=("time",),
-                            attrs=readback.attrs,
-                        )
+                    new_coords[f"{motor_axis}_readback"] = xr.DataArray(
+                        readback.data,
+                        dims=("time",),
+                        attrs=readback.attrs,
+                    )
                     ds = ds.drop_vars(motor_axis)
 
                 ds = ds.assign_coords(new_coords)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,10 +44,10 @@ from erlab.interactive.utils import _WaitDialog
 from erlab.io.dataloader import LoaderBase
 from erlab.io.exampledata import generate_data_angles, generate_gold_edge
 
-DATA_COMMIT_HASH = "7b9b49fdc7f3eedcbe655f6b69855b2d09c6bcad"
+DATA_COMMIT_HASH = "6ab6fcb52c4f7cc110b20856170ab00fb9b31999"
 """The commit hash of the commit to retrieve from `kmnhan/erlabpy-data`."""
 
-DATA_KNOWN_HASH = "63c33dc1af7d3b39e39d5a0ccd6577e52ad9d68822991148303ca2a01e98451c"
+DATA_KNOWN_HASH = "c917dc5d0cf2f17d343291cfb1df47892bb0ccabed6840bdf528153cb1c170d5"
 """The SHA-256 checksum of the `.tar.gz` file."""
 
 log = logging.getLogger(__name__)

--- a/tests/io/plugins/test_hers.py
+++ b/tests/io/plugins/test_hers.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 import xarray as xr
 
@@ -45,3 +46,11 @@ def test_load(expected_dir, args, expected) -> None:
     if ip_session:
         ip_session.clear_instance()
     del start_ipython.already_called
+
+
+def test_single_motor_scan_uses_nominal_axis(data_dir) -> None:
+    loaded = erlab.io.load("20211216_00011.fits")
+
+    np.testing.assert_allclose(loaded.beta, [-6.0, -5.5, -5.0])
+    np.testing.assert_allclose(loaded.Alpha_readback, [-6.0, -5.49, -5.02])
+    assert loaded.Alpha_readback.dims == ("beta",)

--- a/tests/io/test_fitsutils.py
+++ b/tests/io/test_fitsutils.py
@@ -1,0 +1,26 @@
+import numpy as np
+from astropy.io import fits
+
+from erlab.io.fitsutils import fits_to_xarray
+
+
+def test_bintable_image_trpix_is_one_based(tmp_path) -> None:
+    column = fits.Column(
+        name="image",
+        format="6D",
+        dim="(2,3)",
+        array=[np.arange(6, dtype=np.float64)],
+    )
+    hdu = fits.BinTableHDU.from_columns([column], name="data")
+    hdu.header["TDESC1"] = "(x,y)"
+    hdu.header["TRPIX1"] = "(1,1)"
+    hdu.header["TRVAL1"] = "(10,20)"
+    hdu.header["TDELT1"] = "(2,3)"
+
+    path = tmp_path / "image.fits"
+    fits.HDUList([fits.PrimaryHDU(), hdu]).writeto(path)
+
+    data = next(iter(fits_to_xarray(path).children.values())).dataset["image"]
+
+    np.testing.assert_allclose(data.coords["x"], [10.0, 12.0])
+    np.testing.assert_allclose(data.coords["y"], [20.0, 23.0, 26.0])

--- a/tests/io/test_fitsutils.py
+++ b/tests/io/test_fitsutils.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
+import xarray as xr
 from astropy.io import fits
 
-from erlab.io.fitsutils import fits_to_xarray
+from erlab.io.fitsutils import fits_to_xarray, process_fits_dataset
 
 
 def test_bintable_image_trpix_is_one_based(tmp_path) -> None:
@@ -24,3 +26,106 @@ def test_bintable_image_trpix_is_one_based(tmp_path) -> None:
 
     np.testing.assert_allclose(data.coords["x"], [10.0, 12.0])
     np.testing.assert_allclose(data.coords["y"], [20.0, 23.0, 26.0])
+
+
+def test_bintable_image_without_axis_scale_has_no_image_coords(tmp_path) -> None:
+    column = fits.Column(
+        name="image",
+        format="6D",
+        dim="(2,3)",
+        array=[np.arange(6, dtype=np.float64)],
+    )
+    hdu = fits.BinTableHDU.from_columns([column], name="data")
+    hdu.header["TDESC1"] = "(x,y)"
+
+    path = tmp_path / "image.fits"
+    fits.HDUList([fits.PrimaryHDU(), hdu]).writeto(path)
+
+    data = next(iter(fits_to_xarray(path).children.values())).dataset["image"]
+
+    assert data.dims == ("x", "y", "dim_0")
+    assert "x" not in data.coords
+    assert "y" not in data.coords
+
+
+def test_process_fits_dataset_without_scan_type_is_unchanged() -> None:
+    data = xr.Dataset({"signal": xr.DataArray(np.arange(3.0), dims=("scan",))})
+
+    xr.testing.assert_identical(process_fits_dataset(data), data)
+
+
+def test_process_fits_dataset_without_motor_name_is_unchanged() -> None:
+    data = xr.Dataset(
+        {"signal": xr.DataArray(np.arange(3.0), dims=("scan",))},
+        attrs={"LWLVNM": "Beamline", "NM_0_0": " "},
+    )
+
+    xr.testing.assert_identical(process_fits_dataset(data), data)
+
+
+def test_process_fits_dataset_single_motor_without_readback() -> None:
+    data = xr.Dataset(
+        {
+            "signal": xr.DataArray(
+                np.zeros((2, 3)),
+                dims=("energy", "scan"),
+                coords={"energy": [0.0, 1.0]},
+            )
+        },
+        attrs={
+            "LWLVNM": "Beamline",
+            "NM_0_0": "Alpha",
+            "ST_0_0": 0.0,
+            "EN_0_0": 4.0,
+            "N_0_0": 5,
+        },
+    )
+
+    processed = process_fits_dataset(data)
+
+    assert processed.signal.dims == ("energy", "Alpha")
+    np.testing.assert_allclose(processed.Alpha, [0.0, 1.0, 2.0])
+    assert "Alpha_readback" not in processed.coords
+
+
+def test_process_fits_dataset_single_point_scan_uses_start_value() -> None:
+    data = xr.Dataset(
+        {"signal": xr.DataArray(np.arange(1.0), dims=("scan",))},
+        attrs={
+            "LWLVNM": "Beamline",
+            "NM_0_0": "Alpha",
+            "ST_0_0": 2.0,
+            "EN_0_0": 9.0,
+            "N_0_0": 1,
+        },
+    )
+
+    processed = process_fits_dataset(data)
+
+    np.testing.assert_allclose(processed.Alpha, [2.0])
+
+
+def test_process_fits_dataset_requires_unindexed_scan_dimension() -> None:
+    data = xr.Dataset(
+        {
+            "signal": xr.DataArray(
+                np.arange(3.0),
+                dims=("Alpha",),
+                coords={"Alpha": [0.0, 1.0, 2.0]},
+            )
+        },
+        attrs={"LWLVNM": "Beamline", "NM_0_0": "Alpha"},
+    )
+
+    with pytest.raises(ValueError, match="unindexed scan dimension"):
+        process_fits_dataset(data)
+
+
+def test_process_fits_dataset_rejects_unsupported_scan_type() -> None:
+    data = xr.Dataset(
+        {"signal": xr.DataArray(np.arange(3.0), dims=("scan",))},
+        attrs={"LWLVNM": "Two Motor"},
+    )
+
+    with pytest.raises(ValueError, match="Only single motor scans"):
+        process_fits_dataset(data)


### PR DESCRIPTION
FITS data from ALS BL10 now use the nominal scan axis from the FITS header for single-motor scans, matching Igor Pro’s loader behavior. This fixes cases where analyzer rotation (`Alpha`, translated to `beta` in `erlab` conventions) loaded with slightly nonuniform measured readback values. The measured values are still retained as `<motor>_readback` coordinates for diagnostics.

FITS binary table image axes also now interpret `TRPIX` as a one-based reference pixel, so `TRPIX=1` starts exactly at `TRVAL`, matching FITS/Igor semantics. This was previously misinterpreted as zero-based, causing a one-pixel shift in the loaded data.