### PR TITLE
[codex] support ktool angle-energy cuts

### DIFF
--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -23,7 +23,9 @@ Here are some of the miscellaneous interactive tools provided:
 
 ## ktool
 
-Interactive conversion from angles to momentum space.
+Interactive conversion from angles to momentum space. `ktool` supports constant-energy
+`alpha`/`beta` maps, angle-energy `alpha`/`eV` cuts with a fixed `beta` coordinate,
+and 3D angle volumes.
 
 There are four ways to start `ktool`.
 
@@ -73,7 +75,9 @@ The GUI is divided into two tabs.
 
 :::
 
-The first tab is for setting momentum conversion parameters. The image is updated in real time as you change the parameters.
+The first tab is for setting momentum conversion parameters. The image is updated in
+real time as you change the parameters. For angle-energy cuts, the preview keeps the
+full energy axis and displays the converted `k`/`eV` cut.
 
 Clicking {guilabel}`Copy code` will copy the code for conversion to the clipboard.
 
@@ -97,7 +101,10 @@ outside the manager, it opens as a normal standalone ImageTool window.
 
 :::
 
-The second tab provides visualization options. You can overlay Brillouin zones and high symmetry points on the result, adjust colors, and optionally preview n-fold symmetrized constant energy contours for maps.
+The second tab provides visualization options. You can overlay Brillouin zones and
+high symmetry points on momentum-momentum or momentum-`kz` previews, adjust colors,
+and optionally preview n-fold symmetrized constant energy contours for maps.
+Brillouin-zone and symmetry previews are disabled for angle-energy cuts.
 
 :::{note}
 

--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -901,8 +901,14 @@ class MomentumAccessor(ERLabDataArrayAccessor):
     def _interactive_compatible(self) -> bool:
         """Check if the data is compatible with the interactive tool."""
         if self._obj.ndim == 2:
-            # alpha-beta 2D scan
-            return set(self._obj.dims) == {"alpha", "beta"}
+            # alpha-beta 2D scan or alpha-energy cut with a fixed beta coordinate
+            if set(self._obj.dims) == {"alpha", "beta"}:
+                return True
+            return (
+                set(self._obj.dims) == {"alpha", "eV"}
+                and "beta" in self._obj.coords
+                and self._obj["beta"].size == 1
+            )
 
         if self._obj.ndim == 3:
             # any 3D scan that has alpha & eV
@@ -1383,8 +1389,14 @@ class MomentumAccessor(ERLabDataArrayAccessor):
 
         - 2D data with `alpha` and `beta` dimensions (constant energy surfaces)
 
+        - 2D data with `alpha` and `eV` dimensions, and a fixed `beta` coordinate
+          (angle-energy cuts)
+
         - 3D data with dimensions including `alpha` and `eV` (including maps and
           hv-dependent cuts)
+
+        .. versionchanged:: 3.22.0
+            Added support for 2D angle-energy cuts with `alpha` and `eV` dimensions.
 
         """
         if not self._interactive_compatible:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -2557,10 +2557,15 @@ class ImageSlicerArea(QtWidgets.QWidget):
             str(dim): float(value)
             for dim, value in zip(self.data.dims, self.current_values, strict=True)
         }
-        if "alpha" in dim_values and "beta" in dim_values:
+        beta_value = dim_values.get("beta")
+        if beta_value is None and "beta" in self.data.coords:
+            beta_coord = self.data["beta"]
+            if beta_coord.size == 1:
+                beta_value = float(beta_coord.values)
+        if "alpha" in dim_values and beta_value is not None:
             initial_normal_emission: tuple[float, float] | None = (
                 dim_values["alpha"],
-                dim_values["beta"],
+                beta_value,
             )
             initial_delta: float | None = None
             guideline_dims = tuple(

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -701,7 +701,11 @@ class KspaceTool(KspaceToolGUI):
         )
         self._energy_controls_connected: bool = False
 
-        if self.data.kspace._has_eV and self.data.eV.size > 1:
+        if (
+            self.data.kspace._has_eV
+            and self.data.eV.size > 1
+            and not self._shows_full_energy_cut()
+        ):
             self._update_energy_controls()
             self.width_spin.setRange(1, len(self.data.eV))
             self._ensure_energy_control_connections()
@@ -850,7 +854,7 @@ class KspaceTool(KspaceToolGUI):
         self.copy_btn.clicked.connect(self.copy_code)
         self.update()
 
-        if avec is not None:
+        if avec is not None and self.bz_group.isEnabled():
             self.bz_group.setChecked(True)
 
     def _ensure_energy_control_connections(self) -> None:
@@ -872,7 +876,11 @@ class KspaceTool(KspaceToolGUI):
             f"({self.data.kspace.configuration.name})"
         )
 
-        if self.data.kspace._has_eV and self.data.eV.size > 1:
+        if (
+            self.data.kspace._has_eV
+            and self.data.eV.size > 1
+            and not self._shows_full_energy_cut()
+        ):
             self.energy_group.setDisabled(False)
             self._update_energy_controls()
             self.width_spin.setRange(1, len(self.data.eV))
@@ -894,6 +902,10 @@ class KspaceTool(KspaceToolGUI):
         current_configuration = int(self.data.kspace.configuration)
         current_has_hv = self.data.kspace._has_hv
 
+        if not data.kspace._interactive_compatible:
+            raise ValueError(
+                "Updated data is not compatible with the interactive tool."
+            )
         if tuple(data.kspace._valid_offset_keys) != current_offset_keys:
             raise ValueError("Updated data has incompatible offset coordinates.")
         if tuple(data.kspace.momentum_axes) != current_momentum_axes:
@@ -1165,10 +1177,15 @@ class KspaceTool(KspaceToolGUI):
         self._sync_normal_emission_spins()
         self.queue_update()
 
+    def _shows_full_energy_cut(self) -> bool:
+        return self.data.ndim == 2 and set(self.data.dims) == {"alpha", "eV"}
+
     def _angle_data(self) -> xr.DataArray:
         if self.data.kspace._has_eV:
             binding_energy = self._binding_energy()
             data_binding = self.data.copy(deep=False).assign_coords(eV=binding_energy)
+            if self._shows_full_energy_cut():
+                return data_binding
 
             center, width = self.center_spin.value(), self.width_spin.value()
             arr = binding_energy
@@ -1216,11 +1233,26 @@ class KspaceTool(KspaceToolGUI):
     def _preview_supports_symmetry(preview_data: xr.DataArray) -> bool:
         return preview_data.ndim == 2 and set(preview_data.dims) == {"kx", "ky"}
 
+    def _preview_supports_bz(self, preview_data: xr.DataArray) -> bool:
+        if preview_data.ndim != 2:
+            return False
+        if self.data.kspace._has_hv:
+            return "kz" in preview_data.dims and (
+                "kx" in preview_data.dims or "ky" in preview_data.dims
+            )
+        return set(preview_data.dims) == {"kx", "ky"}
+
     def _set_preview_symmetry_available(self, available: bool) -> None:
         if not available:
             with QtCore.QSignalBlocker(self.preview_symmetry_group):
                 self.preview_symmetry_group.setChecked(False)
         self.preview_symmetry_group.setEnabled(available)
+
+    def _set_bz_available(self, available: bool) -> None:
+        if not available:
+            with QtCore.QSignalBlocker(self.bz_group):
+                self.bz_group.setChecked(False)
+        self.bz_group.setEnabled(available)
 
     def _symmetrized_preview(self, preview_data: xr.DataArray) -> xr.DataArray:
         preview_data = preview_data.transpose("ky", "kx")
@@ -1259,10 +1291,12 @@ class KspaceTool(KspaceToolGUI):
         self._set_preview_symmetry_available(preview_symmetry_available)
         if preview_symmetry_available and self.preview_symmetry_group.isChecked():
             k_preview = self._symmetrized_preview(k_preview)
+        bz_available = self._preview_supports_bz(k_preview)
+        self._set_bz_available(bz_available)
         self.images[0].setDataArray(ang.T)
         self.images[1].setDataArray(k_preview)
         self._notify_data_changed()
-        if self.bz_group.isChecked():
+        if bz_available and self.bz_group.isChecked():
             self.update_bz()
 
     @staticmethod
@@ -1354,7 +1388,7 @@ class KspaceTool(KspaceToolGUI):
         )
         bvec = erlab.lattice.to_reciprocal(avec_primitive)
         converted_slice: xr.DataArray | None = self.images[1].data_array
-        if converted_slice is None:
+        if converted_slice is None or not self._preview_supports_bz(converted_slice):
             return [], np.zeros((0, 2)), np.zeros((0, 2))
 
         cache_token = self._bz_cache_token(converted_slice)
@@ -1443,8 +1477,9 @@ def ktool(
     ----------
     data
         Data to convert. Currently supports constant energy slices (2D data with alpha
-        and beta dimensions) and all 3D data that has eV and alpha dimensions, including
-        maps and photon energy dependent data.
+        and beta dimensions), 2D angle-energy cuts with alpha and eV dimensions and a
+        fixed beta coordinate, and all 3D data that has eV and alpha dimensions,
+        including maps and photon energy dependent data.
     avec : array-like, optional
         Real-space lattice vectors as a 2x2 or 3x3 numpy array. If provided, the
         Brillouin zone boundary overlay will be calculated based on these vectors. If
@@ -1468,6 +1503,9 @@ def ktool(
         seed the normal emission controls and derived angle offsets.
     initial_delta
         Optional delta value to apply alongside ``initial_normal_emission``.
+
+    .. versionchanged:: 3.22.0
+        Added support for 2D angle-energy cuts with ``alpha`` and ``eV`` dimensions.
 
     """
     if data_name is None:

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2551,6 +2551,59 @@ def test_itool_open_in_ktool_uses_active_cursor_seed(qtbot, monkeypatch) -> None
     win.close()
 
 
+def test_itool_open_in_ktool_uses_scalar_beta_for_angle_energy_cut(
+    qtbot, monkeypatch
+) -> None:
+    win = itool(_TEST_DATA["3D"].isel(beta=3).copy(), execute=False)
+    qtbot.addWidget(win)
+
+    captured: dict[str, object] = {}
+    tool = QtWidgets.QWidget()
+
+    def fake_ktool(data, **kwargs):
+        captured["data"] = data
+        captured["kwargs"] = kwargs
+        return tool
+
+    monkeypatch.setattr(erlab.interactive, "ktool", fake_ktool)
+
+    assert win.slicer_area.ktool_act.isEnabled()
+    win.slicer_area.set_value(0, 2.0)
+    win.slicer_area.open_in_ktool()
+
+    assert captured["data"] is win.slicer_area.data
+    assert captured["kwargs"]["initial_normal_emission"] == (2.0, 3.0)
+    assert captured["kwargs"]["initial_delta"] is None
+
+    win.close()
+
+
+def test_itool_open_in_ktool_ignores_nonscalar_beta_coord(qtbot, monkeypatch) -> None:
+    data = _TEST_DATA["3D"].isel(beta=0).drop_vars("beta").copy()
+    data = data.assign_coords(beta=("alpha", np.arange(data.sizes["alpha"])))
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    captured: dict[str, object] = {}
+    tool = QtWidgets.QWidget()
+
+    def fake_ktool(data, **kwargs):
+        captured["data"] = data
+        captured["kwargs"] = kwargs
+        return tool
+
+    monkeypatch.setattr(erlab.interactive, "ktool", fake_ktool)
+
+    win.slicer_area.set_value(0, 2.0)
+    win.slicer_area.open_in_ktool()
+
+    assert captured["data"] is win.slicer_area.data
+    assert captured["kwargs"]["initial_normal_emission"] is None
+    assert captured["kwargs"]["initial_delta"] is None
+
+    win.close()
+
+
 def test_itool_open_in_ktool_sets_full_data_source_binding(qtbot, monkeypatch) -> None:
     win = itool(_TEST_DATA["3D"].copy(), execute=False)
     qtbot.addWidget(win)

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -106,10 +106,23 @@ def _solve_normal_emission_angles(
 
 def test_ktool_compatible(anglemap) -> None:
     cut = anglemap.qsel(beta=-8.3)
+    const_energy = anglemap.qsel(eV=-0.1)
+    cut_without_beta = cut.drop_vars("beta")
+    cut_with_beta_coord = cut_without_beta.assign_coords(
+        beta=("alpha", np.linspace(-1.0, 1.0, cut.sizes["alpha"]))
+    )
     data_4d = anglemap.expand_dims("x", 2)
     data_3d_without_alpha = data_4d.qsel(alpha=-8.3)
 
-    for data in (cut, data_4d, data_3d_without_alpha):
+    assert cut.kspace._interactive_compatible
+    assert const_energy.kspace._interactive_compatible
+
+    for data in (
+        cut_without_beta,
+        cut_with_beta_coord,
+        data_4d,
+        data_3d_without_alpha,
+    ):
         with pytest.raises(
             ValueError, match=r"Data is not compatible with the interactive tool."
         ):
@@ -208,6 +221,62 @@ def test_ktool(qtbot, anglemap, wf, kind, assignment) -> None:
 
         assert win.tool_status == win_restored.tool_status
         assert str(win_restored.info_text) == str(win.info_text)
+
+
+def test_ktool_angle_energy_cut(qtbot, anglemap) -> None:
+    cut = (
+        anglemap.isel(alpha=slice(0, 4), eV=slice(0, 5)).qsel(beta=-8.3).copy(deep=True)
+    )
+    win = cut.kspace.interactive(data_name="cut", execute=False)
+    qtbot.addWidget(win)
+
+    assert isinstance(win, KspaceTool)
+    assert win.energy_group.isEnabled() is False
+    assert win.bz_group.isEnabled() is False
+    assert win.bz_group.isChecked() is False
+    assert win.preview_symmetry_group.isEnabled() is False
+    assert win.preview_symmetry_group.isChecked() is False
+
+    assert win.images[0].data_array is not None
+    assert win.images[0].data_array.dims == ("eV", "alpha")
+    assert win.images[1].data_array is not None
+    assert win.images[1].data_array.dims == ("eV", cut.kspace.slit_axis)
+
+    expected = win._converted_output()
+
+    win.show_converted()
+    win._itool.show()
+    xr.testing.assert_identical(win._itool.slicer_area.data, expected)
+    win._itool.close()
+
+    code = win.copy_code()
+    namespace = {"cut": cut.copy(deep=True)}
+    exec(code, {"__builtins__": {}}, namespace)  # noqa: S102
+    xr.testing.assert_identical(namespace["cut_kconv"], expected)
+
+    updated = cut.copy(deep=True)
+    updated.data = np.asarray(updated.data) + 1.0
+    win.update_data(updated)
+    assert win.energy_group.isEnabled() is False
+    assert win.bz_group.isEnabled() is False
+    assert win.images[1].data_array is not None
+    assert win.images[1].data_array.dims == ("eV", cut.kspace.slit_axis)
+
+
+@pytest.mark.parametrize(
+    ("has_hv", "preview_data", "expected"),
+    [
+        (False, xr.DataArray(np.zeros((2, 3)), dims=("ky", "kx")), True),
+        (False, xr.DataArray(np.zeros((2, 3)), dims=("eV", "kx")), False),
+        (True, xr.DataArray(np.zeros((2, 3)), dims=("kz", "kx")), True),
+        (True, xr.DataArray(np.zeros((2, 3)), dims=("ky", "kx")), False),
+        (False, xr.DataArray(np.zeros((2, 3, 4)), dims=("eV", "ky", "kx")), False),
+    ],
+)
+def test_ktool_preview_supports_bz(has_hv, preview_data, expected) -> None:
+    stub = SimpleNamespace(data=SimpleNamespace(kspace=SimpleNamespace(_has_hv=has_hv)))
+
+    assert KspaceTool._preview_supports_bz(stub, preview_data) is expected
 
 
 @pytest.mark.parametrize(
@@ -896,6 +965,7 @@ def test_get_bz_lines_uses_legacy_hv_path_for_scalar_other_axis(monkeypatch) -> 
         rot_spin=SimpleNamespace(value=lambda: 15.0),
         data=SimpleNamespace(kspace=SimpleNamespace(_has_hv=True)),
     )
+    stub._preview_supports_bz = lambda data: KspaceTool._preview_supports_bz(stub, data)
 
     lines, vertices, midpoints = KspaceTool.get_bz_lines(stub)
 
@@ -939,15 +1009,18 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
 def test_ktool_update_data_with_single_energy_disables_energy_group(
     qtbot, anglemap
 ) -> None:
+    initial = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5)).copy(
+        deep=True
+    )
     data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(1, 2)).copy(
         deep=True
     )
-    win = ktool(data, execute=False)
+    win = ktool(initial, execute=False)
     qtbot.addWidget(win)
 
+    win.update_data(data)
     fixed_energy = float(data.eV.values[0])
     assert win.energy_group.isEnabled() is False
-    assert win.center_spin.value() == pytest.approx(fixed_energy, abs=1e-3)
     assert win.center_spin.minimum() == pytest.approx(fixed_energy - 0.1, abs=1e-3)
     assert win.center_spin.maximum() == pytest.approx(fixed_energy + 0.1, abs=1e-3)
 
@@ -985,6 +1058,19 @@ def test_ktool_update_data_reconnects_energy_controls_after_single_energy(
     qtbot.wait_until(lambda: len(update_calls) > 0, timeout=5000)
 
 
+def test_ktool_update_data_rejects_noninteractive_replacement_for_cut(
+    qtbot, anglemap
+) -> None:
+    data = (
+        anglemap.isel(alpha=slice(0, 3), eV=slice(0, 5)).qsel(beta=-8.3).copy(deep=True)
+    )
+    win = ktool(data, execute=False)
+    qtbot.addWidget(win)
+
+    with pytest.raises(ValueError, match="not compatible with the interactive tool"):
+        win.update_data(data.isel(eV=0))
+
+
 @pytest.mark.parametrize(
     ("field", "value", "match"),
     [
@@ -1008,6 +1094,7 @@ def test_ktool_validate_update_data_rejects_incompatible_metadata(
     qtbot.addWidget(win)
 
     fake_kspace = SimpleNamespace(
+        _interactive_compatible=True,
         _valid_offset_keys=tuple(win.data.kspace._valid_offset_keys),
         momentum_axes=tuple(win.data.kspace.momentum_axes),
         configuration=int(win.data.kspace.configuration),


### PR DESCRIPTION
## Summary
- allow `ktool` / `DataArray.kspace.interactive()` to accept 2D `alpha`/`eV` cuts with fixed `beta`
- preview full angle-energy cuts as converted `k`/`eV` images while disabling non-applicable energy binning, BZ, and symmetry controls
- seed ImageTool-launched cut conversions from cursor `alpha` plus scalar `beta`
- document the new supported shape and add regression coverage

## Validation
- `uv run ruff format src/erlab/accessors/kspace.py src/erlab/interactive/kspace.py src/erlab/interactive/imagetool/viewer.py tests/interactive/test_kspace.py tests/interactive/imagetool/test_imagetool.py`
- `uv run ruff check --fix src/erlab/accessors/kspace.py src/erlab/interactive/kspace.py src/erlab/interactive/imagetool/viewer.py tests/interactive/test_kspace.py tests/interactive/imagetool/test_imagetool.py`
- `uv run pytest tests/interactive/test_kspace.py::test_ktool_update_data_rejects_noninteractive_replacement_for_cut tests/interactive/test_kspace.py::test_ktool_validate_update_data_rejects_incompatible_metadata tests/interactive/test_kspace.py tests/interactive/imagetool/test_imagetool.py -k ktool`
- `uv run mypy src`