### PR TITLE
feat(manager): reconnect watched variables from saved workspaces

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -55,6 +55,11 @@ or by dragging the `.itws` file back into the manager to recreate your windows
 exactly as they were. Share the file with collaborators and they will see the
 identical layout.
 
+If the workspace contains watched notebook variables, the watched rows reopen with
+their variable-name badges. The rows stay disconnected until a notebook defines the
+matching variables and reconnects them, as described in
+{ref}`imagetool-manager-reconnect-watches`.
+
 (imagetool-manager-nested-results)=
 
 ## Nested windows
@@ -275,7 +280,7 @@ The following lists common actions included in the {guilabel}`File`, {guilabel}`
 - {guilabel}`Reload Data` – Re-fetches data from disk using the original loader function. Handy when data is updated during acquisition.
 
 Icons next to each entry indicate special states: linked windows share a colored badge,
-chunked Dask arrays show the dask icon, watched variables display their notebook name,
+chunked Dask arrays show the dask icon, watched variables display their variable name,
 and rows opened from another row can show the {guilabel}`Stale`,
 {guilabel}`Unavailable`, or {guilabel}`Auto` badges described in
 {ref}`imagetool-manager-refresh`.
@@ -377,6 +382,7 @@ Controlling watches:
 ```python
 %watch data1 data2 data3   # add multiple variables
 %watch                     # list watched names
+%watch --restore           # reconnect saved watched rows by variable name
 %watch -d data1 data2      # stop watching specific variables
 %watch -x data1            # stop watching and close the window
 %watch -z                  # stop watching everything
@@ -385,11 +391,54 @@ Controlling watches:
 
 You can also right-click a tool in the manager and choose {guilabel}`Stop Watching`.
 
-If a variable is deleted or replaced with a non-`DataArray`, the manager automatically breaks the link and keeps the window as a regular ImageTool.
+If a variable is deleted or replaced with a non-`DataArray`, the manager automatically
+breaks the link and keeps the window as a regular ImageTool.
 
-:::{note}
-When a notebook kernel shuts down, watched windows remain open in the manager but no longer synchronize. Use {guilabel}`Stop Watching` or run `%watch -z` before closing the kernel to avoid confusion. Variables watched from different notebooks are color-coded for clarity.
-:::
+(imagetool-manager-reconnect-watches)=
+
+#### Reconnecting watched rows
+
+A watched row stores the variable name shown on its badge. If a notebook kernel stops,
+or if you close and reopen the manager workspace, the row stays in the manager but
+cannot synchronize until a notebook reconnects it. Disconnected watched rows keep
+their variable-name badge and show a disconnected tooltip in the manager.
+
+To reconnect one variable after restarting a notebook kernel:
+
+1. Run the notebook cells that create the `DataArray`.
+2. Run `%watch my_data` again.
+
+The manager reuses the existing watched row for `my_data` instead of creating a
+duplicate. This also forces a refresh if the automatic change detector missed an
+update.
+
+To reconnect every watched row in the open manager workspace:
+
+```python
+%watch --restore
+```
+
+`%watch --restore` looks at the watched variable names saved in the open workspace and
+reconnects the rows whose names exist in the current notebook namespace as
+`xarray.DataArray` objects. Rows for variables that are missing, or variables that
+currently hold a different kind of object, stay disconnected.
+
+To share a linked notebook and workspace with someone else:
+
+1. Save the manager workspace as a `.itws` file.
+2. Send both the `.ipynb` notebook and the `.itws` workspace.
+3. On the other computer, open the `.itws` file in ImageTool Manager.
+4. Run the notebook cells that create the watched variables.
+5. Run `%watch --restore`.
+
+The notebook and workspace do not need to live in the same folder. The rows reconnect
+by the variable names saved in the workspace, so the receiving notebook must define
+matching `DataArray` variables such as `my_data`.
+
+If several disconnected watched rows use the same variable name, `%watch my_data` and
+`%watch --restore` skip that name instead of guessing. Remove the extra watched links
+with {guilabel}`Stop Watching`, or use an editor integration that can reconnect a
+specific manager row.
 
 #### Outside IPython (e.g., marimo notebooks)
 
@@ -406,6 +455,9 @@ watch("my_data", stop=True)
 
 # Stop watching everything
 watch(stop_all=True)
+
+# Reconnect saved watched rows in the open manager workspace
+watch(restore=True)
 ```
 
 In non-IPython environments, watcher updates fall back to polling, which periodically checks for changes in the watched variables. You can adjust the frequency with `poll_interval_s` if needed:
@@ -452,6 +504,11 @@ Later, in any notebook, retrieve the stored variable with `%store -r my_data` an
 ### Editor integration
 
 If you are using VS Code (or other editor that supports VS Code extensions), the dedicated `erlab` extension ( [marketplace](https://marketplace.visualstudio.com/items?itemName=khan.erlab) | [open-vsx](https://open-vsx.org/extension/khan/erlab) ) adds convenient features for working with the manager directly from notebooks. Search for `erlab` in the extensions panel of your editor to install it.
+
+Editor commands named {guilabel}`Reconnect Watched Variables` use the same restore
+workflow as `%watch --restore`: the notebook must define the watched
+{class}`xarray.DataArray` variables, and the open manager workspace supplies the saved
+watched row names.
 
 (imagetool-manager-automation)=
 

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -57,7 +57,8 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
 - Search `ImageTool`, `ImageTool Manager`, `%watch`, `fetch`,
   `show_in_manager`, `load_in_manager`, `managers`, `set_default_manager`,
   `manager_selection_info`, `workspace_path`, `Save Workspace`,
-  `Open Workspace`, `Import From Workspace`, `Result Placement`, `stale`,
+  `Open Workspace`, `Import From Workspace`, `%watch --restore`,
+  `Reconnect Watched Variables`, `.itws`, `Result Placement`, `stale`,
   `automatic updates`, `Auto`, `Refit after update`, `code for repeating steps`,
   `ImageTool windows opened from tools`, or
   `workflow-bridge` for notebook and interactive-workflow questions.
@@ -92,9 +93,12 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
 - Prefer the manager workflow when the user needs a tree that shows top-level ImageTool
   rows, tools opened from those ImageTools, and ImageTool windows made by those tools;
   rows that update after data changes; code that repeats GUI steps; multiple windows;
-  notebook synchronization; or reusable workspaces.
+  notebook synchronization; reusable workspaces; or shared `.ipynb` and `.itws`
+  files.
 - Mention `%watch` or `erlab.interactive.imagetool.manager.watch()` when
   notebook synchronization is relevant.
+- Mention `%watch --restore` when a saved manager workspace contains disconnected
+  watched rows that should reconnect to variables in an open notebook.
 
 ## Troubleshooting
 

--- a/src/erlab/interactive/imagetool/manager/__init__.py
+++ b/src/erlab/interactive/imagetool/manager/__init__.py
@@ -52,6 +52,7 @@ __all__ = [
     "shutdown",
     "use_manager",
     "watch",
+    "watch_info",
     "watched_variables",
 ]
 
@@ -93,6 +94,7 @@ from erlab.interactive.imagetool.manager._server import (
     set_default_manager,
     show_in_manager,
     use_manager,
+    watch_info,
 )
 from erlab.interactive.imagetool.manager._watcher import (
     maybe_push,

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -643,6 +643,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         )
 
         self._workspace_path: pathlib.Path | None = None
+        self._workspace_link_id: str = uuid.uuid4().hex
         self._workspace_loading_depth: int = 0
         self._workspace_saving_depth: int = 0
         self._workspace_structure_modified: bool = False
@@ -1156,7 +1157,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
     @contextlib.contextmanager
     def _workspace_document_access_context(
         self, fname: str | os.PathLike[str]
-    ) -> typing.Iterator[_WorkspaceDocumentAccess]:
+    ) -> Iterator[_WorkspaceDocumentAccess]:
         access = self._workspace_document_access(fname)
         try:
             yield access
@@ -1392,6 +1393,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _workspace_state_snapshot(self) -> dict[str, typing.Any]:
         return {
             "path": self._workspace_path,
+            "link_id": self._workspace_link_id,
             "needs_full_save": self._workspace_needs_full_save,
             "node_uid_counter": self._node_uid_counter,
             "structure_modified": self._workspace_structure_modified,
@@ -1410,6 +1412,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self, snapshot: dict[str, typing.Any]
     ) -> None:
         self._workspace_path = snapshot["path"]
+        self._workspace_link_id = snapshot["link_id"]
         self._workspace_needs_full_save = snapshot["needs_full_save"]
         self._node_uid_counter = snapshot["node_uid_counter"]
         self._workspace_structure_modified = snapshot["structure_modified"]
@@ -2009,6 +2012,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
         show: bool = True,
         activate: bool = False,
         watched_var: tuple[str, str] | None = None,
+        watched_workspace_link_id: str | None = None,
+        watched_source_label: str | None = None,
+        watched_connected: bool = True,
         source_input_ndim: int | None = None,
         source_input_dtype: np.dtype[typing.Any] | str | None = None,
         uid: str | None = None,
@@ -2054,6 +2060,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
             self._next_node_uid(uid),
             tool,
             watched_var=watched_var,
+            watched_workspace_link_id=watched_workspace_link_id,
+            watched_source_label=watched_source_label,
+            watched_connected=watched_connected,
             source_input_ndim=source_input_ndim,
             source_input_dtype=source_input_dtype,
             provenance_spec=provenance_spec,
@@ -3103,6 +3112,25 @@ class ImageToolManager(QtWidgets.QMainWindow):
             )
         if isinstance(node, _ImageToolWrapper) and node.source_input_ndim is not None:
             ds.attrs["manager_node_source_input_ndim"] = int(node.source_input_ndim)
+        if isinstance(node, _ImageToolWrapper) and node.watched:
+            watched_metadata = node.watched_metadata()
+            ds.attrs["manager_node_watched_varname"] = typing.cast(
+                "str", watched_metadata["varname"]
+            )
+            ds.attrs["manager_node_watched_uid"] = typing.cast(
+                "str", watched_metadata["uid"]
+            )
+            workspace_link_id = watched_metadata.get("workspace_link_id")
+            if workspace_link_id is not None:
+                ds.attrs["manager_node_watched_workspace_link_id"] = str(
+                    workspace_link_id
+                )
+            source_label = watched_metadata.get("source_label")
+            if source_label is not None:
+                ds.attrs["manager_node_watched_source_label"] = str(source_label)
+            ds.attrs["manager_node_watched_connected"] = bool(
+                watched_metadata.get("connected", False)
+            )
         output_id = node.output_id
         if kind == "imagetool" and output_id is not None:
             ds.attrs["manager_node_output_id"] = output_id
@@ -3255,6 +3283,24 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     "int | None",
                     ds.attrs.get("manager_node_source_input_ndim"),
                 )
+                watched_varname = ds.attrs.get("manager_node_watched_varname")
+                watched_uid = ds.attrs.get("manager_node_watched_uid")
+                if watched_varname is not None and watched_uid is not None:
+                    kwargs["watched_var"] = (str(watched_varname), str(watched_uid))
+                    kwargs["watched_workspace_link_id"] = (
+                        None
+                        if ds.attrs.get("manager_node_watched_workspace_link_id")
+                        is None
+                        else str(ds.attrs["manager_node_watched_workspace_link_id"])
+                    )
+                    kwargs["watched_source_label"] = (
+                        None
+                        if ds.attrs.get("manager_node_watched_source_label") is None
+                        else str(ds.attrs["manager_node_watched_source_label"])
+                    )
+                    # Loaded watched rows stay watched, but are disconnected until
+                    # a notebook explicitly reconnects them.
+                    kwargs["watched_connected"] = False
                 preferred_index: int | None = None
                 if node_path is not None and "/" not in node_path:
                     with contextlib.suppress(ValueError):
@@ -3393,6 +3439,15 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         "file may be from a newer version of erlab"
                     )
             manifest = metadata.manifest
+            if replace:
+                manifest_workspace_link_id = (
+                    None if manifest is None else manifest.get("workspace_link_id")
+                )
+                self._workspace_link_id = (
+                    str(manifest_workspace_link_id)
+                    if manifest_workspace_link_id
+                    else uuid.uuid4().hex
+                )
 
             root_keys = _manager_workspace._workspace_root_keys(tree, manifest)
 
@@ -3557,6 +3612,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             nodes=self._workspace_node_manifest_entries(),
             delta_save_count=delta_save_count,
             erlab_version=str(erlab.__version__),
+            workspace_link_id=self._workspace_link_id,
         )
 
     def _write_full_workspace_file(self, fname: str | os.PathLike[str]) -> None:
@@ -4399,6 +4455,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         kwargs: dict[str, typing.Any],
         *,
         watched_var: tuple[str, str] | None = None,
+        watched_metadata: Mapping[str, typing.Any] | None = None,
         show: bool | None = None,
     ) -> list[bool]:
         """Slot function to receive data from the server.
@@ -4453,6 +4510,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
         load_func = kwargs.pop("load_func", None)
         if show is None:
             show = len(data) == 1
+        watched_metadata = dict(watched_metadata or {})
+        if watched_var is not None:
+            watched_metadata.setdefault("workspace_link_id", self._workspace_link_id)
 
         for i, d in enumerate(data):
             # Set index-specific load function if provided
@@ -4464,6 +4524,16 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         show=show,
                         activate=show,
                         watched_var=watched_var,
+                        watched_workspace_link_id=typing.cast(
+                            "str | None",
+                            watched_metadata.get("workspace_link_id"),
+                        ),
+                        watched_source_label=typing.cast(
+                            "str | None", watched_metadata.get("source_label")
+                        ),
+                        watched_connected=bool(
+                            watched_metadata.get("connected", watched_var is not None)
+                        ),
                         source_input_ndim=d.ndim,
                         source_input_dtype=d.dtype,
                     )
@@ -4562,17 +4632,48 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if uid in self._all_nodes:
             self._node_for_target(uid).show()
 
-    @QtCore.Slot(str, str, object)
-    def _data_watched_update(self, varname: str, uid: str, darr: xr.DataArray) -> None:
+    @QtCore.Slot(str, str, object, object)
+    def _data_watched_update(
+        self,
+        varname: str,
+        uid: str,
+        darr: xr.DataArray,
+        watched_metadata: Mapping[str, typing.Any] | None = None,
+    ) -> None:
         """Update ImageTool window corresponding to the given watched variable."""
+        watched_metadata = dict(watched_metadata or {})
         idx = self._find_watched_idx(uid)
         if idx is None:
             # If the tool does not exist, create a new one
-            self._data_recv([darr], {}, watched_var=(varname, uid))
+            self._data_recv(
+                [darr],
+                {},
+                watched_var=(varname, uid),
+                watched_metadata={
+                    **dict(watched_metadata),
+                    "connected": True,
+                },
+            )
         else:
             # Update data in the existing tool
-            self._imagetool_wrappers[idx].set_source_input_ndim(darr.ndim)
-            self._imagetool_wrappers[idx].set_source_input_dtype(darr.dtype)
+            wrapper = self._imagetool_wrappers[idx]
+            wrapper.set_watched_binding(
+                varname,
+                uid,
+                workspace_link_id=typing.cast(
+                    "str | None",
+                    watched_metadata.get("workspace_link_id")
+                    or wrapper._watched_workspace_link_id,
+                ),
+                source_label=typing.cast(
+                    "str | None",
+                    watched_metadata.get("source_label")
+                    or wrapper._watched_source_label,
+                ),
+                connected=True,
+            )
+            wrapper.set_source_input_ndim(darr.ndim)
+            wrapper.set_source_input_dtype(darr.dtype)
             self.get_imagetool(idx).slicer_area.replace_source_data(darr)
 
     @QtCore.Slot(str)
@@ -4605,6 +4706,22 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _send_imagetool_data(self, index_or_uid: int | str) -> None:
         """Send data of the ImageTool window corresponding to the given index."""
         self._sigReplyData.emit(self._get_imagetool_data(index_or_uid))
+
+    def _watch_info(self) -> dict[str, typing.Any]:
+        """Return watched-variable metadata used by notebook reconnect workflows."""
+        return {
+            "workspace_link_id": self._workspace_link_id,
+            "watched": [
+                wrapper.watched_metadata()
+                for wrapper in self._imagetool_wrappers.values()
+                if wrapper.watched
+            ],
+        }
+
+    @QtCore.Slot()
+    def _send_watch_info(self) -> None:
+        """Send watched-variable metadata to the manager server."""
+        self._sigReplyData.emit(self._watch_info())
 
     def ensure_console_initialized(self) -> None:
         """Ensure that the console window is initialized."""
@@ -5211,6 +5328,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         server.sigLoadRequested.connect(self._data_load)
         server.sigReplaceRequested.connect(self._data_replace)
         server.sigDataRequested.connect(self._send_imagetool_data)
+        server.sigWatchInfoRequested.connect(self._send_watch_info)
         self._sigReplyData.connect(server.set_return_value)
         server.sigRemoveIndex.connect(self.remove_imagetool)
         server.sigShowIndex.connect(self.show_imagetool)

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -402,7 +402,10 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             watched_varname = str(tool_wrapper._watched_varname)
             watched_uid = str(tool_wrapper._watched_uid)
             kernel_uid = watched_uid.removeprefix(f"{watched_varname} ")
-            color = self.manager.color_for_watched_var_kernel(kernel_uid)
+            if tool_wrapper._watched_connected:
+                color = self.manager.color_for_watched_var_kernel(kernel_uid)
+            else:
+                color = option.palette.color(QtGui.QPalette.ColorRole.Mid)
 
             _fill_rounded_rect(
                 painter,
@@ -701,10 +704,17 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                     )
             if watched_rect is not None and watched_rect.contains(pos):
                 varname = str(node._watched_varname)
+                if node._watched_connected:
+                    tooltip = f"Watching variable {varname!r}. Click for watch actions."
+                else:
+                    tooltip = (
+                        f"Watched variable {varname!r} is disconnected. "
+                        f"Run %watch {varname} or %watch --restore after defining it."
+                    )
                 return _RowBadge(
                     "watched",
                     watched_rect,
-                    f"Watching variable {varname!r}. Click for watch actions.",
+                    tooltip,
                 )
             return None
 
@@ -1616,7 +1626,15 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
         refresh_action = typing.cast(
             "QtGui.QAction", menu.addAction("Refresh From Variable")
         )
-        refresh_action.setToolTip("Refresh this ImageTool from the watched variable")
+        if wrapper._watched_connected:
+            refresh_action.setToolTip(
+                "Refresh this ImageTool from the watched variable"
+            )
+        else:
+            refresh_action.setEnabled(False)
+            refresh_action.setToolTip(
+                "Reconnect this watched variable from the notebook"
+            )
         refresh_action.triggered.connect(wrapper._trigger_watched_update)
         stop_action = typing.cast("QtGui.QAction", menu.addAction("Stop Watching..."))
         stop_action.setToolTip("Detach this ImageTool from the watched variable")

--- a/src/erlab/interactive/imagetool/manager/_server.py
+++ b/src/erlab/interactive/imagetool/manager/_server.py
@@ -22,6 +22,7 @@ __all__ = [
     "set_default_manager",
     "show_in_manager",
     "use_manager",
+    "watch_info",
 ]
 
 
@@ -170,6 +171,7 @@ class WatchPacket(_BasePacket):
     packet_type: typing.Literal["watch"]
     watched_info: tuple[str, str]
     watched_data: xr.DataArray
+    watched_metadata: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
 
 
 class CommandPacket(_BasePacket):
@@ -184,6 +186,7 @@ class CommandPacket(_BasePacket):
         "remove-uid",
         "show-uid",
         "unwatch-uid",
+        "watch-info",
     ]
     command_arg: str | int | None = None
 
@@ -212,6 +215,7 @@ class Response(pydantic.BaseModel):
 
     status: typing.Literal["ok", "error", "unpickle-failed"]
     data: xr.DataArray | None = None
+    watch_info: dict[str, typing.Any] | None = None
     pickler_kind: typing.Literal["pickle", "cloudpickle"] = "pickle"
 
     model_config = {
@@ -518,9 +522,10 @@ class _ManagerServer(QtCore.QThread):
     sigReceived = QtCore.Signal(list, dict)
     sigLoadRequested = QtCore.Signal(list, str, dict)
     sigReplaceRequested = QtCore.Signal(list, list)
-    sigWatchedVarChanged = QtCore.Signal(str, str, object)
+    sigWatchedVarChanged = QtCore.Signal(str, str, object, object)
 
     sigDataRequested = QtCore.Signal(object)
+    sigWatchInfoRequested = QtCore.Signal()
     sigRemoveIndex = QtCore.Signal(int)
     sigShowIndex = QtCore.Signal(int)
     sigRemoveUID = QtCore.Signal(str)
@@ -560,6 +565,16 @@ class _ManagerServer(QtCore.QThread):
             self._cv.wakeAll()
         if self.isRunning() and not self.wait(timeout_ms):
             logger.warning("Manager server did not stop within timeout")
+
+    def _wait_for_return_value(self) -> typing.Any:
+        with QtCore.QMutexLocker(self._mutex):
+            while self._ret_val is _UNSET:
+                if self.stopped.is_set():
+                    break
+                self._cv.wait(self._mutex, 100)
+            value = self._ret_val
+            self._ret_val = _UNSET
+            return value
 
     def run(self) -> None:
         self.stopped.clear()
@@ -606,9 +621,11 @@ class _ManagerServer(QtCore.QThread):
 
                 logger.debug("Received payload with type %s", payload.packet_type)
                 if not (
-                    payload.packet_type == "command" and payload.command == "get-data"
+                    payload.packet_type == "command"
+                    and payload.command in {"get-data", "watch-info"}
                 ):
-                    # For non-get-data commands, send an immediate OK response
+                    # For commands without return payloads, send an immediate OK
+                    # response before dispatching work to the GUI thread.
                     logger.debug("Sending response...")
                     _send_multipart(sock, {"status": "ok"})
                     logger.debug("Response sent")
@@ -624,7 +641,9 @@ class _ManagerServer(QtCore.QThread):
                         )
                     case "watch":
                         self.sigWatchedVarChanged.emit(
-                            *payload.watched_info, payload.watched_data
+                            *payload.watched_info,
+                            payload.watched_data,
+                            payload.watched_metadata,
                         )
                     case "replace":
                         self.sigReplaceRequested.emit(
@@ -636,19 +655,13 @@ class _ManagerServer(QtCore.QThread):
                             case "get-data":
                                 self.sigDataRequested.emit(payload.command_arg)
                                 logger.debug("Getting data...")
-                                with QtCore.QMutexLocker(self._mutex):
-                                    while self._ret_val is _UNSET:
-                                        if self.stopped.is_set():
-                                            break
-                                        self._cv.wait(self._mutex, 100)
-                                    if self._ret_val is _UNSET:
-                                        logger.debug(
-                                            "Server stopping while waiting for data"
-                                        )
-                                        _send_multipart(sock, {"status": "error"})
-                                        break
-                                    data = self._ret_val
-                                    self._ret_val = _UNSET
+                                data = self._wait_for_return_value()
+                                if data is _UNSET:
+                                    logger.debug(
+                                        "Server stopping while waiting for data"
+                                    )
+                                    _send_multipart(sock, {"status": "error"})
+                                    break
 
                                 logger.debug("Data obtained, sending response...")
                                 _send_multipart(
@@ -657,6 +670,29 @@ class _ManagerServer(QtCore.QThread):
                                     use_cloudpickle=bool(
                                         payload.pickler_kind == "cloudpickle"
                                     ),
+                                )
+                                logger.debug("Response sent")
+
+                                continue
+                            case "watch-info":
+                                self.sigWatchInfoRequested.emit()
+                                logger.debug("Getting watched-variable info...")
+                                info = self._wait_for_return_value()
+                                if info is _UNSET:
+                                    logger.debug(
+                                        "Server stopping while waiting for "
+                                        "watched-variable info"
+                                    )
+                                    _send_multipart(sock, {"status": "error"})
+                                    break
+
+                                logger.debug(
+                                    "Watched-variable info obtained, sending "
+                                    "response..."
+                                )
+                                _send_multipart(
+                                    sock,
+                                    {"status": "ok", "watch_info": info},
                                 )
                                 logger.debug("Response sent")
 
@@ -800,6 +836,10 @@ class ImageToolManagerHandle:
         return erlab.interactive.imagetool.manager.watch(
             *varnames, target=self.index, **kwargs
         )
+
+    def watch_info(self) -> dict[str, typing.Any]:
+        """Return watched-variable metadata for this manager."""
+        return erlab.interactive.imagetool.manager.watch_info(target=self.index)
 
     def use(self) -> int:
         """Set this manager as the default for the current Python process."""
@@ -1126,6 +1166,7 @@ def _watch_data(
     show: bool = False,
     *,
     target: int | None = None,
+    watched_metadata: dict[str, typing.Any] | None = None,
 ) -> None:
     """Add or update a watched variable in the ImageToolManager.
 
@@ -1146,10 +1187,16 @@ def _watch_data(
         used. If no default is set, the only live manager is used. If multiple
         managers are live, an ambiguity error is raised.
     """
+    if watched_metadata is None:
+        watched_metadata = {}
+
     record = resolve_manager_record(target)
     _query_zmq(
         WatchPacket(
-            packet_type="watch", watched_info=(varname, uid), watched_data=data
+            packet_type="watch",
+            watched_info=(varname, uid),
+            watched_data=data,
+            watched_metadata=watched_metadata,
         ),
         record=record,
     )
@@ -1187,6 +1234,30 @@ def _unwatch_data(
         CommandPacket(packet_type="command", command="unwatch-uid", command_arg=uid),
         record=record,
     )
+
+
+def _watch_info(*, target: int | None = None) -> dict[str, typing.Any]:
+    """Return watched-variable metadata for the target manager."""
+    direct_manager = _direct_manager_for_target(target)
+    if direct_manager is not None:
+        return direct_manager._watch_info()
+    record = resolve_manager_record(target)
+    response = _query_zmq(
+        CommandPacket(packet_type="command", command="watch-info"),
+        record=record,
+    )
+    return response.watch_info or {}
+
+
+def watch_info(*, target: int | None = None) -> dict[str, typing.Any]:
+    """Return watched-variable metadata for the target manager.
+
+    This is primarily intended for editor integrations and the watcher restore
+    workflow.
+
+    .. versionadded:: 3.22.0
+    """
+    return _watch_info(target=target)
 
 
 def watch_data(varname: str, uid: str, data: xr.DataArray, show: bool = False) -> None:

--- a/src/erlab/interactive/imagetool/manager/_watcher/_core.py
+++ b/src/erlab/interactive/imagetool/manager/_watcher/_core.py
@@ -59,7 +59,8 @@ class _NamespaceShell:
 
 _STATE_LOCK: threading.RLock = threading.RLock()
 _WATCHERS: dict[int, _Watcher] = {}
-_POST_RUN_CELL_CALLBACKS: dict[int, tuple[typing.Any, typing.Callable[..., None]]] = {}
+_POST_RUN_CELL_CALLBACKS: dict[int, tuple[typing.Any, Callable[..., None]]] = {}
+_WORKSPACE_WATCH_NAMESPACE = uuid.UUID("1b949069-0469-4c5c-a2e2-2d49b393fcf2")
 
 
 class _MessageObject:
@@ -93,6 +94,86 @@ def _stopped_watching_message(varname: str, reason: str) -> None:
     )
 
 
+def _stable_watch_uid(
+    workspace_link_id: str, varname: str, source_label: str | None = None
+) -> str:
+    source = "" if source_label is None else source_label
+    key = f"{workspace_link_id}\0{source}\0{varname}"
+    return f"watch:{uuid.uuid5(_WORKSPACE_WATCH_NAMESPACE, key)}"
+
+
+class _AmbiguousWatchBindingError(ValueError):
+    """Raised when a watched variable name matches multiple saved rows."""
+
+
+def _ambiguous_watch_message(varname: str) -> str:
+    return (
+        f"Multiple watched ImageTool rows match variable {varname!r}. "
+        "Use Stop Watching on the extra manager rows, or reconnect from an "
+        "editor command that can target a specific watched row."
+    )
+
+
+def _watch_entries(
+    watch_info: dict[str, typing.Any],
+) -> tuple[dict[str, typing.Any], ...]:
+    raw_watched = watch_info.get("watched", ())
+    if not isinstance(raw_watched, (list, tuple)):
+        return ()
+    return tuple(
+        entry
+        for entry in raw_watched
+        if isinstance(entry, dict) and isinstance(entry.get("varname"), str)
+    )
+
+
+def _matching_watch_entries(
+    entries: tuple[dict[str, typing.Any], ...],
+    *,
+    varname: str,
+    workspace_link_id: str | None = None,
+) -> list[dict[str, typing.Any]]:
+    matches: list[dict[str, typing.Any]] = []
+    for entry in entries:
+        if entry.get("varname") != varname:
+            continue
+        entry_workspace_link_id = entry.get("workspace_link_id")
+        if (
+            workspace_link_id is not None
+            and entry_workspace_link_id is not None
+            and str(entry_workspace_link_id) != workspace_link_id
+        ):
+            continue
+        matches.append(entry)
+    return matches
+
+
+def _select_watch_entry(
+    candidates: list[dict[str, typing.Any]],
+    *,
+    varname: str,
+    source_label: str | None,
+) -> dict[str, typing.Any] | None:
+    if source_label is not None:
+        candidates = [
+            entry
+            for entry in candidates
+            if (entry.get("source_label") or None) == source_label
+        ]
+    else:
+        unlabeled = [
+            entry for entry in candidates if entry.get("source_label") in {None, ""}
+        ]
+        if len(unlabeled) == 1:
+            return unlabeled[0]
+        if len(unlabeled) > 1:
+            raise _AmbiguousWatchBindingError(_ambiguous_watch_message(varname))
+
+    if len(candidates) > 1:
+        raise _AmbiguousWatchBindingError(_ambiguous_watch_message(varname))
+    return candidates[0] if candidates else None
+
+
 class _Watcher:
     def __init__(self, shell: _ShellProtocol) -> None:
         self._shell: _ShellProtocol = shell
@@ -114,7 +195,56 @@ class _Watcher:
         self._poll_interval_s: float = 0.25
         self._poll_thread: threading.Thread | None = None
 
-    def watch(self, varname: str, *, target: int | None = None) -> None:
+    def _watch_info(self, target: int | None) -> dict[str, typing.Any]:
+        with contextlib.suppress(Exception):
+            return erlab.interactive.imagetool.manager.watch_info(target=target)
+        return {
+            "workspace_link_id": self._uid,
+            "watched": (),
+        }
+
+    def _watch_binding(
+        self,
+        varname: str,
+        *,
+        target: int | None,
+        source_label: str | None,
+    ) -> tuple[str, dict[str, typing.Any]]:
+        info = self._watch_info(target)
+        workspace_link_id = str(info.get("workspace_link_id") or self._uid)
+        source_label_text = None if source_label is None else str(source_label)
+        selected = _select_watch_entry(
+            _matching_watch_entries(
+                _watch_entries(info),
+                varname=varname,
+                workspace_link_id=workspace_link_id,
+            ),
+            varname=varname,
+            source_label=source_label_text,
+        )
+
+        if selected is not None and selected.get("uid") is not None:
+            uid = str(selected["uid"])
+            metadata = {
+                "workspace_link_id": workspace_link_id,
+                "source_label": selected.get("source_label"),
+                "connected": True,
+            }
+            return uid, metadata
+
+        return _stable_watch_uid(workspace_link_id, varname, source_label_text), {
+            "workspace_link_id": workspace_link_id,
+            "source_label": source_label_text,
+            "connected": True,
+        }
+
+    def watch(
+        self,
+        varname: str,
+        *,
+        target: int | None = None,
+        source_label: str | None = None,
+    ) -> None:
         """Watch a DataArray variable and show in ImageTool manager."""
         ns = self._shell.user_ns
         if varname not in ns:
@@ -130,9 +260,15 @@ class _Watcher:
             if varname in self.watched_vars:
                 # Already linked, trigger refresh and show
                 uid = self.watched_vars[varname]["uid"]
+                watched_metadata = typing.cast(
+                    "dict[str, typing.Any]",
+                    self.watched_vars[varname].get("watched_metadata", {}),
+                )
                 show = True
             else:
-                uid = f"{varname} {self._uid}"
+                uid, watched_metadata = self._watch_binding(
+                    varname, target=manager_record.index, source_label=source_label
+                )
 
         fingerprint = erlab.utils.hashing.fingerprint_dataarray(obj)
         with self._lock:
@@ -143,6 +279,7 @@ class _Watcher:
                 "target": manager_record.index,
                 "watch_host": manager_record.host,
                 "watch_port": manager_record.watch_port,
+                "watched_metadata": watched_metadata,
             }
             self._last_send = time.time()
 
@@ -213,8 +350,16 @@ class _Watcher:
                 return
             uid = state["uid"]
             target = state.get("target")
+            watched_metadata = typing.cast(
+                "dict[str, typing.Any]", state.get("watched_metadata", {})
+            )
         erlab.interactive.imagetool.manager._watch_data(
-            varname, uid, darr, show=show, target=target
+            varname,
+            uid,
+            darr,
+            show=show,
+            target=target,
+            watched_metadata=watched_metadata,
         )
 
     def start_thread(self) -> None:
@@ -291,13 +436,13 @@ class _Watcher:
                 logger.debug("Watcher received message: %s", info)
                 varname, uid, event = info["varname"], info["uid"], info["event"]
 
-                if not uid.endswith(self._uid):
-                    continue  # Not for this watcher instance
-
                 with self._lock:
-                    if varname not in self.watched_vars:
+                    state = self.watched_vars.get(varname)
+                    if state is None:
                         continue  # Not watching
-                    watched_target = self.watched_vars[varname].get("target")
+                    if state.get("uid") != uid:
+                        continue  # Not for this watcher binding
+                    watched_target = state.get("target")
                     if (
                         target is not None
                         and watched_target is not None
@@ -553,6 +698,37 @@ def watched_variables(
         return tuple(watcher.watched_vars.keys())
 
 
+def _restore_varnames(
+    watch_info: dict[str, typing.Any],
+    namespace: NamespaceType,
+    requested: tuple[str, ...],
+    *,
+    source_label: str | None,
+) -> tuple[str, ...]:
+    entries = _watch_entries(watch_info)
+    names = requested or tuple(
+        dict.fromkeys(str(entry["varname"]) for entry in entries)
+    )
+    restore_names: list[str] = []
+    for name in names:
+        try:
+            selected = _select_watch_entry(
+                _matching_watch_entries(entries, varname=name),
+                varname=name,
+                source_label=source_label,
+            )
+        except _AmbiguousWatchBindingError:
+            _display_message(
+                f"Skipped '{name}' because multiple watched rows match it.",
+                f"Skipped <code>{name}</code> because multiple watched rows match it.",
+            )
+            continue
+        if selected is not None and isinstance(namespace.get(name), xr.DataArray):
+            restore_names.append(name)
+
+    return tuple(dict.fromkeys(restore_names))
+
+
 @_inject_target_param_docs
 def watch(
     *varnames: str,
@@ -561,7 +737,9 @@ def watch(
     stop: bool = False,
     remove: bool = False,
     stop_all: bool = False,
+    restore: bool = False,
     target: int | None = None,
+    source_label: str | None = None,
     poll_interval_s: float = 0.25,
 ) -> tuple[str, ...]:
     """Watch namespace variables and synchronize them with ImageTool manager.
@@ -603,14 +781,25 @@ def watch(
         If ``True``, remove watched variables from manager while stopping.
     stop_all
         If ``True``, stop watching all variables in the namespace.
+    restore
+        If ``True``, reconnect watched variables stored in the selected ImageTool
+        manager workspace when variables with matching names exist in the namespace.
     target
         Optional 0-based ImageTool manager index to watch into. If omitted, the
         current process default is used. If no default is set, the only live manager is
         used. If multiple managers are live, an ambiguity error is raised.
+    source_label
+        Optional integration-supplied notebook/source label used to disambiguate
+        saved watched rows. Regular notebook users do not need to set this.
     poll_interval_s
         Polling interval in seconds for fallback polling when post-run hooks are
         unavailable (for example, non-IPython environments). Must be greater than 0.
         This value is ignored when a post-run callback is successfully registered.
+
+    .. versionchanged:: 3.22.0
+
+       Added ``restore`` and stable workspace-linked watched variables so saved
+       manager workspaces can reconnect to notebook variables by name.
 
     Returns
     -------
@@ -619,7 +808,7 @@ def watch(
     """
     shell, namespace = _resolve_or_infer_target(shell=shell, namespace=namespace)
 
-    if not varnames and not stop_all and not stop and not remove:
+    if not varnames and not stop_all and not stop and not remove and not restore:
         return watched_variables(shell=shell, namespace=namespace)
 
     watcher, key = _get_or_create_watcher(shell=shell, namespace=namespace)
@@ -630,9 +819,23 @@ def watch(
     elif stop or remove:
         for varname in varnames:
             watcher.stop_watching(varname, remove=remove)
+    elif restore:
+        restore_names = _restore_varnames(
+            watcher._watch_info(target),
+            shell_obj.user_ns,
+            tuple(varnames),
+            source_label=source_label,
+        )
+        for varname in restore_names:
+            watcher.watch(varname, target=target, source_label=source_label)
+
+        if restore_names and not _register_post_run_cell_callback(
+            shell_obj, watcher, key
+        ):
+            watcher.start_polling(poll_interval_s)
     else:
         for varname in varnames:
-            watcher.watch(varname, target=target)
+            watcher.watch(varname, target=target, source_label=source_label)
 
         if not _register_post_run_cell_callback(shell_obj, watcher, key):
             watcher.start_polling(poll_interval_s)

--- a/src/erlab/interactive/imagetool/manager/_watcher/_ipython.py
+++ b/src/erlab/interactive/imagetool/manager/_watcher/_ipython.py
@@ -12,6 +12,7 @@ from erlab.interactive.imagetool.manager._server import (
     set_default_manager,
 )
 from erlab.interactive.imagetool.manager._watcher._core import (
+    _AmbiguousWatchBindingError,
     _display_message,
     _get_or_create_watcher,
     _register_post_run_cell_callback,
@@ -74,6 +75,11 @@ class WatcherMagics(Magics):
     @argument("-x", action="store_true", help="Remove from manager.")
     @argument("-z", action="store_true", help="Stop watching all variables.")
     @argument(
+        "--restore",
+        action="store_true",
+        help="Reconnect watched variables from the open manager workspace.",
+    )
+    @argument(
         "--manager",
         "-m",
         type=int,
@@ -102,11 +108,14 @@ class WatcherMagics(Magics):
 
         * ``%watch -z``       - Stop watching all variables
 
+        * ``%watch --restore`` - Reconnect watched rows from the open manager
+                                 workspace
+
         """
         args = parse_argstring(self.watch, line)
         shell = self._typed_shell
 
-        if not args.darr and not args.z:
+        if not args.darr and not args.z and not args.restore:
             watched = watched_variables(shell=shell)
             if len(watched) == 0:
                 _display_message("No variables are being watched.")
@@ -120,18 +129,44 @@ class WatcherMagics(Magics):
 
             return
 
+        if args.restore:
+            before = set(watched_variables(shell=shell))
+            try:
+                watch(*args.darr, shell=shell, restore=True, target=args.manager)
+            except _AmbiguousWatchBindingError as exc:
+                _display_message(str(exc))
+                return
+            restored = tuple(
+                name
+                for name in watched_variables(shell=shell)
+                if name not in before or not args.darr or name in args.darr
+            )
+            if restored:
+                _display_message(
+                    f"Reconnected watched variables: {', '.join(restored)}",
+                    "🔄 Reconnected watched variables "
+                    + " ".join([f"<code>{varname}</code>" for varname in restored]),
+                )
+            else:
+                _display_message("No watched variables were reconnected.")
+            return
+
         if args.z:
             watch(shell=shell, stop_all=True, remove=args.x)
             _display_message("Stopped watching all variables.")
             return
 
-        watch(
-            *args.darr,
-            shell=shell,
-            stop=args.d or args.x,
-            remove=args.x,
-            target=args.manager,
-        )
+        try:
+            watch(
+                *args.darr,
+                shell=shell,
+                stop=args.d or args.x,
+                remove=args.x,
+                target=args.manager,
+            )
+        except _AmbiguousWatchBindingError as exc:
+            _display_message(str(exc))
+            return
 
         if args.d or args.x:
             _display_message(

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -330,6 +330,7 @@ def _workspace_root_attrs_payload(
     nodes: Iterable[Mapping[str, typing.Any]],
     delta_save_count: int,
     erlab_version: str,
+    workspace_link_id: str | None = None,
 ) -> dict[str, typing.Any]:
     manifest: dict[str, typing.Any] = {
         "schema_version": _WORKSPACE_SCHEMA_VERSION,
@@ -337,6 +338,8 @@ def _workspace_root_attrs_payload(
         "root_order": list(root_order),
         "nodes": list(nodes),
     }
+    if workspace_link_id is not None:
+        manifest["workspace_link_id"] = workspace_link_id
     if delta_save_count > 0:
         manifest["transaction_protocol"] = _WORKSPACE_TRANSACTION_PROTOCOL
         manifest["delta_save_count"] = int(delta_save_count)

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -1062,6 +1062,9 @@ class _ImageToolWrapper(_ManagedWindowNode):
         uid: str,
         tool: ImageTool,
         watched_var: tuple[str, str] | None = None,
+        watched_workspace_link_id: str | None = None,
+        watched_source_label: str | None = None,
+        watched_connected: bool = True,
         source_input_ndim: int | None = None,
         source_input_dtype: np.dtype[typing.Any] | str | None = None,
         *,
@@ -1075,12 +1078,20 @@ class _ImageToolWrapper(_ManagedWindowNode):
         self._index = index
         self._watched_varname: str | None = None
         self._watched_uid: str | None = None
+        self._watched_workspace_link_id: str | None = None
+        self._watched_source_label: str | None = None
+        self._watched_connected: bool = False
         self._source_input_ndim = source_input_ndim
         self._source_input_dtype: np.dtype[typing.Any] | None = (
             np.dtype(source_input_dtype) if source_input_dtype is not None else None
         )
         if watched_var is not None:
-            self._watched_varname, self._watched_uid = watched_var
+            self.set_watched_binding(
+                *watched_var,
+                workspace_link_id=watched_workspace_link_id,
+                source_label=watched_source_label,
+                connected=watched_connected,
+            )
 
         super().__init__(
             manager,
@@ -1100,6 +1111,34 @@ class _ImageToolWrapper(_ManagedWindowNode):
     @property
     def watched(self) -> bool:
         return self._watched_varname is not None and self._watched_uid is not None
+
+    def set_watched_binding(
+        self,
+        varname: str,
+        uid: str,
+        *,
+        workspace_link_id: str | None = None,
+        source_label: str | None = None,
+        connected: bool = True,
+    ) -> None:
+        """Bind this root ImageTool to a watched variable."""
+        self._watched_varname = varname
+        self._watched_uid = uid
+        self._watched_workspace_link_id = workspace_link_id
+        self._watched_source_label = source_label
+        self._watched_connected = connected
+
+    def watched_metadata(self) -> dict[str, typing.Any]:
+        """Return JSON-serializable watched binding metadata."""
+        if not self.watched:
+            return {}
+        return {
+            "varname": self._watched_varname,
+            "uid": self._watched_uid,
+            "workspace_link_id": self._watched_workspace_link_id,
+            "source_label": self._watched_source_label,
+            "connected": self._watched_connected,
+        }
 
     def set_source_input_ndim(self, ndim: int | None) -> None:
         """Track the latest dimensionality of the root source before UI promotion."""
@@ -1174,6 +1213,9 @@ class _ImageToolWrapper(_ManagedWindowNode):
             )
             self._watched_varname = None
             self._watched_uid = None
+            self._watched_workspace_link_id = None
+            self._watched_source_label = None
+            self._watched_connected = False
             self.manager.tree_view.refresh(self.index)
             self.manager._mark_node_state_dirty(self.uid)
 

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -5538,7 +5538,7 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
             watched_var=("data", "watch:stable-data"),
             watched_metadata={
                 "workspace_link_id": manager._workspace_link_id,
-                "source_label": None,
+                "source_label": "notebook-a",
                 "connected": True,
             },
         )
@@ -5553,6 +5553,7 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
         assert attrs["manager_node_watched_varname"] == "data"
         assert attrs["manager_node_watched_uid"] == "watch:stable-data"
         assert attrs["manager_node_watched_workspace_link_id"] == workspace_link_id
+        assert attrs["manager_node_watched_source_label"] == "notebook-a"
 
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
@@ -5566,10 +5567,41 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
         assert wrapper._watched_varname == "data"
         assert wrapper._watched_uid == "watch:stable-data"
         assert wrapper._watched_workspace_link_id == workspace_link_id
+        assert wrapper._watched_source_label == "notebook-a"
         assert wrapper._watched_connected is False
+
+        with qtbot.wait_signal(manager._sigReplyData) as blocker:
+            manager._send_watch_info()
+        assert blocker.args[0]["workspace_link_id"] == "different-workspace-link"
+        assert blocker.args[0]["watched"][0]["workspace_link_id"] == workspace_link_id
+        assert blocker.args[0]["watched"][0]["source_label"] == "notebook-a"
 
         manager._from_datatree(tree, replace=True, select=False)
         assert manager._workspace_link_id == workspace_link_id
+
+
+def test_manager_workspace_watched_attrs_skip_missing_workspace_link(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            watched_var=("data", "watch:stable-data"),
+            watched_workspace_link_id=None,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        attrs = manager._to_datatree()["0/imagetool"].attrs
+        assert attrs["manager_node_watched_varname"] == "data"
+        assert attrs["manager_node_watched_uid"] == "watch:stable-data"
+        assert "manager_node_watched_workspace_link_id" not in attrs
 
 
 def test_manager_watched_root_provenance_uses_variable_name(
@@ -11457,7 +11489,7 @@ def test_manager_hover_tooltip(
         assert manager.get_imagetool(2).slicer_area.is_linked
 
         wrapper = manager._imagetool_wrappers[0]
-        wrapper.set_watched_binding("sample", "sample kernel", connected=True)
+        wrapper.set_watched_binding("sample", "sample kernel", connected=False)
         option = QtWidgets.QStyleOptionViewItem()
         delegate.initStyleOption(option, index)
         option.rect = view.visualRect(index)
@@ -11476,6 +11508,13 @@ def test_manager_hover_tooltip(
         click_tree_view_pos(view, watched_rect.center())
         assert view._badge_menu is not None
         refresh_action, stop_action = view._badge_menu.actions()
+        assert not refresh_action.isEnabled()
+
+        wrapper.set_watched_binding("sample", "sample kernel", connected=True)
+        click_tree_view_pos(view, watched_rect.center())
+        assert view._badge_menu is not None
+        refresh_action, stop_action = view._badge_menu.actions()
+        assert refresh_action.isEnabled()
         with qtbot.wait_signal(manager._sigWatchedDataEdited) as blocker:
             refresh_action.trigger()
         assert blocker.args == ["sample", "sample kernel", "updated"]
@@ -11496,6 +11535,7 @@ def test_manager_hover_tooltip(
             stop_action.trigger()
         assert blocker.args == ["sample", "sample kernel", "removed"]
         assert not wrapper.watched
+        assert wrapper.watched_metadata() == {}
 
         # Hover outside icons
         text = None
@@ -12890,6 +12930,163 @@ def test_manager_server_bind_failures_close_socket(monkeypatch) -> None:
     assert manager_socket.closed
 
 
+def test_manager_server_wait_for_return_value_stops_cleanly() -> None:
+    manager = manager_server._ManagerServer()
+    manager.stopped.set()
+
+    assert manager._wait_for_return_value() is manager_server._UNSET
+
+
+def test_manager_server_run_returns_watch_info(monkeypatch) -> None:
+    sent: list[dict[str, typing.Any]] = []
+
+    class _DummySocket:
+        def __init__(self) -> None:
+            self.closed = False
+            self.bound: list[str] = []
+
+        def setsockopt(self, *args) -> None:
+            return None
+
+        def bind(self, address: str) -> None:
+            self.bound.append(address)
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _DummyContext:
+        def __init__(self, socket: _DummySocket) -> None:
+            self._socket = socket
+
+        def socket(self, *_args) -> _DummySocket:
+            return self._socket
+
+    socket = _DummySocket()
+    manager = manager_server._ManagerServer(port=45555)
+    watch_info = {"workspace_link_id": "workspace-1", "watched": []}
+
+    monkeypatch.setattr(
+        zmq.Context, "instance", staticmethod(lambda: _DummyContext(socket))
+    )
+    monkeypatch.setattr(
+        manager_server,
+        "_recv_multipart",
+        lambda _socket: {"packet_type": "command", "command": "watch-info"},
+    )
+    monkeypatch.setattr(
+        manager_server,
+        "_send_multipart",
+        lambda _socket, payload, **_kwargs: sent.append(payload),
+    )
+    manager.sigWatchInfoRequested.connect(
+        lambda: (manager.set_return_value(watch_info), manager.stopped.set())
+    )
+
+    manager.run()
+
+    assert sent == [{"status": "ok", "watch_info": watch_info}]
+    assert socket.bound == ["tcp://*:45555"]
+    assert socket.closed
+
+
+def test_manager_server_run_errors_when_data_request_stops(monkeypatch) -> None:
+    sent: list[dict[str, typing.Any]] = []
+
+    class _DummySocket:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def setsockopt(self, *args) -> None:
+            return None
+
+        def bind(self, _address: str) -> None:
+            return None
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _DummyContext:
+        def __init__(self, socket: _DummySocket) -> None:
+            self._socket = socket
+
+        def socket(self, *_args) -> _DummySocket:
+            return self._socket
+
+    socket = _DummySocket()
+    manager = manager_server._ManagerServer(port=45555)
+
+    monkeypatch.setattr(
+        zmq.Context, "instance", staticmethod(lambda: _DummyContext(socket))
+    )
+    monkeypatch.setattr(
+        manager_server,
+        "_recv_multipart",
+        lambda _socket: {
+            "packet_type": "command",
+            "command": "get-data",
+            "command_arg": 0,
+        },
+    )
+    monkeypatch.setattr(
+        manager_server,
+        "_send_multipart",
+        lambda _socket, payload, **_kwargs: sent.append(payload),
+    )
+    manager.sigDataRequested.connect(lambda _arg: manager.stopped.set())
+
+    manager.run()
+
+    assert sent == [{"status": "error"}]
+    assert socket.closed
+
+
+def test_manager_server_run_errors_when_watch_info_request_stops(monkeypatch) -> None:
+    sent: list[dict[str, typing.Any]] = []
+
+    class _DummySocket:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def setsockopt(self, *args) -> None:
+            return None
+
+        def bind(self, _address: str) -> None:
+            return None
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _DummyContext:
+        def __init__(self, socket: _DummySocket) -> None:
+            self._socket = socket
+
+        def socket(self, *_args) -> _DummySocket:
+            return self._socket
+
+    socket = _DummySocket()
+    manager = manager_server._ManagerServer(port=45555)
+
+    monkeypatch.setattr(
+        zmq.Context, "instance", staticmethod(lambda: _DummyContext(socket))
+    )
+    monkeypatch.setattr(
+        manager_server,
+        "_recv_multipart",
+        lambda _socket: {"packet_type": "command", "command": "watch-info"},
+    )
+    monkeypatch.setattr(
+        manager_server,
+        "_send_multipart",
+        lambda _socket, payload, **_kwargs: sent.append(payload),
+    )
+    manager.sigWatchInfoRequested.connect(lambda: manager.stopped.set())
+
+    manager.run()
+
+    assert sent == [{"status": "error"}]
+    assert socket.closed
+
+
 def test_manager_server_client_helpers_target_socket_branches(
     monkeypatch, tmp_path, test_data
 ) -> None:
@@ -12910,13 +13107,17 @@ def test_manager_server_client_helpers_target_socket_branches(
     monkeypatch.setattr(
         manager_server, "resolve_manager_record", lambda target=None: record
     )
-    monkeypatch.setattr(
-        manager_server,
-        "_query_zmq",
-        lambda payload, **kwargs: (
-            calls.append((payload, kwargs)) or Response(status="ok", data=test_data)
-        ),
-    )
+
+    def _query_zmq(payload, **kwargs):
+        calls.append((payload, kwargs))
+        if (
+            isinstance(payload, manager_server.CommandPacket)
+            and payload.command == "watch-info"
+        ):
+            return Response(status="ok", watch_info={"watched": []})
+        return Response(status="ok", data=test_data)
+
+    monkeypatch.setattr(manager_server, "_query_zmq", _query_zmq)
 
     path = tmp_path / "data.dat"
     path.write_text("data", encoding="utf-8")
@@ -12927,6 +13128,7 @@ def test_manager_server_client_helpers_target_socket_branches(
     assert manager_server._unwatch_data("uid", target=2).status == "ok"
     assert manager_server._unwatch_data("uid", remove=True, target=2).status == "ok"
     xr.testing.assert_identical(manager_server.fetch("uid", target=2), test_data)
+    assert manager_server.watch_info(target=2) == {"watched": []}
     with pytest.warns(DeprecationWarning, match="watch_data"):
         manager_server.watch_data("data", "uid", test_data)
     with pytest.warns(DeprecationWarning, match="unwatch_data"):
@@ -12947,10 +13149,31 @@ def test_manager_server_client_helpers_target_socket_branches(
         "command",
         "command",
         "command",
+        "command",
         "watch",
         "command",
     ]
     assert all(kwargs["record"] == record for _payload, kwargs in calls)
+
+
+def test_manager_handle_watch_info_delegates_to_target(monkeypatch) -> None:
+    handle = manager_server.ImageToolManagerHandle(
+        index=7,
+        pid=123,
+        host="localhost",
+        port=45555,
+        watch_port=45556,
+        started="2026-05-08T10:00:00",
+        version="3.22.0",
+    )
+
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager,
+        "watch_info",
+        lambda *, target=None: {"target": target},
+    )
+
+    assert handle.watch_info() == {"target": 7}
 
 
 def test_manager_progressbar_alert(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -18,7 +18,7 @@ import time
 import types
 import typing
 import webbrowser
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 
 import numpy as np
 import pydantic
@@ -5521,6 +5521,57 @@ def test_manager_data_watched_update_replaces_existing_tool_source_data(
         xr.testing.assert_identical(tool.slicer_area.data, updated)
 
 
+def test_manager_workspace_roundtrip_preserves_watched_binding(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager._data_recv(
+            [test_data],
+            {},
+            watched_var=("data", "watch:stable-data"),
+            watched_metadata={
+                "workspace_link_id": manager._workspace_link_id,
+                "source_label": None,
+                "connected": True,
+            },
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        workspace_link_id = manager._workspace_link_id
+        tree = manager._to_datatree()
+        tree.attrs.update(manager._workspace_root_attrs_payload(delta_save_count=0))
+        manifest = json.loads(tree.attrs["imagetool_workspace_manifest"])
+        assert manifest["workspace_link_id"] == workspace_link_id
+        attrs = tree["0/imagetool"].attrs
+        assert attrs["manager_node_watched_varname"] == "data"
+        assert attrs["manager_node_watched_uid"] == "watch:stable-data"
+        assert attrs["manager_node_watched_workspace_link_id"] == workspace_link_id
+
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+        manager._workspace_link_id = "different-workspace-link"
+
+        manager._load_workspace_node(typing.cast("xr.DataTree", tree["0"]))
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        wrapper = manager._imagetool_wrappers[0]
+        assert wrapper.watched
+        assert wrapper._watched_varname == "data"
+        assert wrapper._watched_uid == "watch:stable-data"
+        assert wrapper._watched_workspace_link_id == workspace_link_id
+        assert wrapper._watched_connected is False
+
+        manager._from_datatree(tree, replace=True, select=False)
+        assert manager._workspace_link_id == workspace_link_id
+
+
 def test_manager_watched_root_provenance_uses_variable_name(
     qtbot,
     monkeypatch,
@@ -8701,7 +8752,7 @@ def test_manager_workspace_state_save_updates_attrs_without_full_rewrite(
             _fname: str | os.PathLike[str],
             rewrite_groups: Iterable[manager_workspace._WorkspaceRewriteGroup],
             attr_updates: Iterable[manager_workspace._WorkspaceAttrUpdate],
-            root_attrs: typing.Mapping[str, typing.Any],
+            root_attrs: Mapping[str, typing.Any],
         ) -> None:
             rewrite_groups = tuple(rewrite_groups)
             updates = tuple(attr_updates)
@@ -9476,7 +9527,7 @@ def test_manager_workspace_lazy_data_delta_pending_failure_preserves_old_group(
 
         def _write_partial_pending_then_raise(
             fname: str | os.PathLike[str],
-            _constructor: typing.Mapping[str, xr.Dataset],
+            _constructor: Mapping[str, xr.Dataset],
             _group_path: str,
             pending_path: str,
         ) -> None:

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -11457,8 +11457,7 @@ def test_manager_hover_tooltip(
         assert manager.get_imagetool(2).slicer_area.is_linked
 
         wrapper = manager._imagetool_wrappers[0]
-        wrapper._watched_varname = "sample"
-        wrapper._watched_uid = "sample kernel"
+        wrapper.set_watched_binding("sample", "sample kernel", connected=True)
         option = QtWidgets.QStyleOptionViewItem()
         delegate.initStyleOption(option, index)
         option.rect = view.visualRect(index)

--- a/tests/interactive/imagetool/test_watcher.py
+++ b/tests/interactive/imagetool/test_watcher.py
@@ -48,11 +48,27 @@ def patch_manager(monkeypatch):
         "last_watch_calls": [],
         "last_unwatch_calls": [],
         "fetch_map": {},
+        "watch_info": {
+            "workspace_link_id": "workspace-link-0",
+            "watched": [],
+        },
     }
 
-    def watch_data(varname, uid, darr, show=False, target=None):
+    def watch_data(varname, uid, darr, show=False, target=None, watched_metadata=None):
         state["watched"][uid] = darr
         state["last_watch_calls"].append((varname, uid, darr, show))
+        metadata = {} if watched_metadata is None else watched_metadata
+        entry = {
+            "varname": varname,
+            "uid": uid,
+            "workspace_link_id": metadata.get("workspace_link_id"),
+            "source_label": metadata.get("source_label"),
+            "connected": True,
+        }
+        state["watch_info"]["watched"] = [
+            item for item in state["watch_info"]["watched"] if item.get("uid") != uid
+        ]
+        state["watch_info"]["watched"].append(entry)
 
     def unwatch_data(uid, remove=False, target=None):
         state["watched"].pop(uid, None)
@@ -61,6 +77,9 @@ def patch_manager(monkeypatch):
     def fetch(uid, target=None):
         return state["fetch_map"].get(uid)
 
+    def watch_info(target=None):
+        return state["watch_info"]
+
     # Patch manager attributes on the already-imported module namespace
     manager = erlab.interactive.imagetool.manager
     monkeypatch.setattr(manager, "_watch_data", watch_data, raising=False)
@@ -68,6 +87,7 @@ def patch_manager(monkeypatch):
     monkeypatch.setattr(manager, "watch_data", watch_data, raising=False)
     monkeypatch.setattr(manager, "unwatch_data", unwatch_data, raising=False)
     monkeypatch.setattr(manager, "fetch", fetch, raising=False)
+    monkeypatch.setattr(manager, "watch_info", watch_info, raising=False)
     monkeypatch.setattr(manager, "HOST_IP", "127.0.0.1", raising=False)
     monkeypatch.setattr(
         watcher_core,
@@ -137,6 +157,95 @@ def test_watch_and_maybe_push_and_delete(fake_shell, patch_manager, monkeypatch)
     # Try pushing non-watched var -> no action
     watcher._push_to_gui("nonwatched", xr.DataArray())
 
+    watcher.shutdown()
+
+
+def test_watch_uid_reconnects_with_workspace_link_id(
+    fake_shell, patch_manager, monkeypatch
+):
+    fake_shell.user_ns["data"] = xr.DataArray(np.array([1, 2, 3]), dims=("x",))
+
+    watcher1 = _Watcher(fake_shell)
+    monkeypatch.setattr(watcher1, "start_thread", lambda: None)
+    watcher1.watch("data")
+    uid1 = watcher1.watched_vars["data"]["uid"]
+    watcher1.shutdown()
+
+    watcher2 = _Watcher(fake_shell)
+    monkeypatch.setattr(watcher2, "start_thread", lambda: None)
+    watcher2.watch("data")
+    uid2 = watcher2.watched_vars["data"]["uid"]
+
+    assert uid2 == uid1
+    assert uid1.startswith("watch:")
+    assert patch_manager["last_watch_calls"][-1][1] == uid1
+    watcher2.shutdown()
+
+
+def test_watch_restore_reconnects_workspace_rows(patch_manager, monkeypatch):
+    namespace = {
+        "data": xr.DataArray(np.array([1, 2, 3]), dims=("x",)),
+        "other": "not data",
+    }
+    uid = watcher_core._stable_watch_uid("workspace-link-0", "data")
+    patch_manager["watch_info"]["watched"] = [
+        {
+            "varname": "data",
+            "uid": uid,
+            "workspace_link_id": "workspace-link-0",
+            "source_label": None,
+            "connected": False,
+        },
+        {
+            "varname": "missing",
+            "uid": watcher_core._stable_watch_uid("workspace-link-0", "missing"),
+            "workspace_link_id": "workspace-link-0",
+            "source_label": None,
+            "connected": False,
+        },
+    ]
+    monkeypatch.setattr(_Watcher, "start_thread", lambda self: None)
+    monkeypatch.setattr(_Watcher, "start_polling", lambda self, interval_s=0.25: None)
+
+    watched = watcher_mod.watch(restore=True, namespace=namespace)
+
+    assert watched == ("data",)
+    assert patch_manager["last_watch_calls"][-1][1] == uid
+
+    watcher_mod.shutdown(namespace=namespace)
+
+
+def test_watch_warns_when_workspace_watch_match_is_ambiguous(
+    fake_shell, patch_manager, monkeypatch
+):
+    fake_shell.user_ns["data"] = xr.DataArray(np.array([1, 2, 3]), dims=("x",))
+    patch_manager["watch_info"]["watched"] = [
+        {
+            "varname": "data",
+            "uid": "watch:first",
+            "workspace_link_id": "workspace-link-0",
+            "source_label": "notebook-a",
+            "connected": False,
+        },
+        {
+            "varname": "data",
+            "uid": "watch:second",
+            "workspace_link_id": "workspace-link-0",
+            "source_label": "notebook-b",
+            "connected": False,
+        },
+    ]
+
+    watcher = _Watcher(fake_shell)
+    monkeypatch.setattr(watcher, "start_thread", lambda: None)
+
+    with pytest.raises(
+        watcher_core._AmbiguousWatchBindingError,
+        match="Multiple watched ImageTool rows match variable 'data'",
+    ):
+        watcher.watch("data")
+
+    assert patch_manager["last_watch_calls"] == []
     watcher.shutdown()
 
 
@@ -304,6 +413,7 @@ def test_manager_reexports_watch_helpers():
     assert manager.watched_variables is watcher_mod.watched_variables
     assert manager.maybe_push is watcher_mod.maybe_push
     assert manager.shutdown is watcher_mod.shutdown
+    assert callable(manager.watch_info)
 
 
 def test_watch_shutdown_stops_threads_even_if_unwatch_fails(patch_manager, monkeypatch):
@@ -375,6 +485,31 @@ def test_watch_magic_delegates_to_watch_api(
     assert calls[-1][0] == ()
     assert calls[-1][1]["stop_all"] is True
     assert calls[-1][1]["remove"] is True
+
+    ip_shell.run_line_magic("watch", "--restore")
+    assert calls[-1][0] == ()
+    assert calls[-1][1]["restore"] is True
+    assert calls[-1][1]["target"] is None
+
+
+def test_watch_magic_reports_ambiguous_workspace_link(
+    ip_shell: IPython.InteractiveShell, monkeypatch
+):
+    messages = []
+
+    def fake_watch(*varnames, **kwargs):
+        raise watcher_core._AmbiguousWatchBindingError("ambiguous watched row")
+
+    monkeypatch.setattr(watcher_ipy, "watch", fake_watch)
+    monkeypatch.setattr(
+        watcher_ipy,
+        "_display_message",
+        lambda message, html=None: messages.append(message),
+    )
+
+    ip_shell.run_line_magic("watch", "data")
+
+    assert messages == ["ambiguous watched row"]
 
 
 def test_watch_magic_lists_currently_watched_variables(

--- a/tests/interactive/imagetool/test_watcher.py
+++ b/tests/interactive/imagetool/test_watcher.py
@@ -182,6 +182,75 @@ def test_watch_uid_reconnects_with_workspace_link_id(
     watcher2.shutdown()
 
 
+def test_watch_binding_helpers_handle_invalid_and_labeled_entries(monkeypatch):
+    messages = []
+    entries = watcher_core._watch_entries(
+        {
+            "watched": [
+                {"varname": "data", "uid": "watch:data", "workspace_link_id": "a"},
+                {"varname": "data", "uid": "watch:old", "workspace_link_id": "b"},
+                {"varname": "other", "uid": "watch:other", "workspace_link_id": "a"},
+                {"varname": None, "uid": "watch:invalid"},
+            ]
+        }
+    )
+
+    assert watcher_core._watch_entries({"watched": object()}) == ()
+    assert watcher_core._matching_watch_entries(
+        entries, varname="data", workspace_link_id="a"
+    ) == [{"varname": "data", "uid": "watch:data", "workspace_link_id": "a"}]
+    assert watcher_core._select_watch_entry(
+        [
+            {"varname": "data", "uid": "watch:a", "source_label": "notebook-a"},
+            {"varname": "data", "uid": "watch:b", "source_label": "notebook-b"},
+        ],
+        varname="data",
+        source_label="notebook-b",
+    ) == {"varname": "data", "uid": "watch:b", "source_label": "notebook-b"}
+    with pytest.raises(watcher_core._AmbiguousWatchBindingError):
+        watcher_core._select_watch_entry(
+            [
+                {"varname": "data", "uid": "watch:a", "source_label": None},
+                {"varname": "data", "uid": "watch:b", "source_label": ""},
+            ],
+            varname="data",
+            source_label=None,
+        )
+
+    monkeypatch.setattr(
+        watcher_core,
+        "_display_message",
+        lambda message, html=None: messages.append((message, html)),
+    )
+    restored = watcher_core._restore_varnames(
+        {
+            "watched": [
+                {"varname": "data", "uid": "watch:a", "source_label": None},
+                {"varname": "data", "uid": "watch:b", "source_label": ""},
+            ]
+        },
+        {"data": xr.DataArray(np.array([1]), dims=("x",))},
+        (),
+        source_label=None,
+    )
+    assert restored == ()
+    assert len(messages) == 1
+
+
+def test_watch_info_falls_back_to_local_uid(fake_shell, monkeypatch):
+    watcher = _Watcher(fake_shell)
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager,
+        "watch_info",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("manager down")),
+    )
+
+    info = watcher._watch_info(target=None)
+
+    assert info == {"workspace_link_id": watcher._uid, "watched": ()}
+    watcher.shutdown()
+
+
 def test_watch_restore_reconnects_workspace_rows(patch_manager, monkeypatch):
     namespace = {
         "data": xr.DataArray(np.array([1, 2, 3]), dims=("x",)),
@@ -212,6 +281,25 @@ def test_watch_restore_reconnects_workspace_rows(patch_manager, monkeypatch):
     assert watched == ("data",)
     assert patch_manager["last_watch_calls"][-1][1] == uid
 
+    watcher_mod.shutdown(namespace=namespace)
+
+
+def test_watch_restore_no_matches_skips_polling(patch_manager, monkeypatch):
+    namespace = {"other": "not data"}
+    poll_calls = []
+
+    monkeypatch.setattr(_Watcher, "start_thread", lambda self: None)
+    monkeypatch.setattr(
+        _Watcher,
+        "start_polling",
+        lambda self, interval_s=0.25: poll_calls.append(interval_s),
+    )
+
+    watched = watcher_mod.watch(restore=True, namespace=namespace)
+
+    assert watched == ()
+    assert patch_manager["last_watch_calls"] == []
+    assert poll_calls == []
     watcher_mod.shutdown(namespace=namespace)
 
 
@@ -246,6 +334,53 @@ def test_watch_warns_when_workspace_watch_match_is_ambiguous(
         watcher.watch("data")
 
     assert patch_manager["last_watch_calls"] == []
+    watcher.shutdown()
+
+
+def test_recv_loop_ignores_mismatched_watch_uid(fake_shell, patch_manager, monkeypatch):
+    fake_shell.user_ns["a"] = xr.DataArray(np.array([0.0, 1.0]), dims=("x",))
+    watcher = _Watcher(fake_shell)
+    monkeypatch.setattr(watcher, "start_thread", lambda: None)
+    watcher.watch("a")
+    uid = watcher.watched_vars["a"]["uid"]
+
+    updated_da = xr.DataArray(np.array([10.0, 20.0]), dims=("x",))
+    patch_manager["fetch_map"][uid] = updated_da
+
+    class FakeSocket:
+        def __init__(self):
+            self._messages = [
+                {"varname": "a", "uid": "watch:other", "event": "updated"},
+                {"varname": "a", "uid": uid, "event": "updated"},
+            ]
+
+        def setsockopt(self, *args, **kwargs):
+            pass
+
+        def connect(self, *args, **kwargs):
+            pass
+
+        def recv_json(self):
+            if self._messages:
+                return self._messages.pop(0)
+            raise RuntimeError("stop")
+
+        def close(self):
+            pass
+
+    class FakeContext:
+        def socket(self, *_):
+            return FakeSocket()
+
+    monkeypatch.setattr(
+        watcher_core.zmq.Context, "instance", classmethod(lambda cls: FakeContext())
+    )
+
+    t = threading.Thread(target=watcher._recv_loop, daemon=True)
+    t.start()
+    t.join(timeout=2.0)
+
+    xr.testing.assert_identical(fake_shell.user_ns["a"], updated_da)
     watcher.shutdown()
 
 
@@ -490,6 +625,49 @@ def test_watch_magic_delegates_to_watch_api(
     assert calls[-1][0] == ()
     assert calls[-1][1]["restore"] is True
     assert calls[-1][1]["target"] is None
+
+
+def test_watch_magic_restore_reports_reconnected_variables(
+    ip_shell: IPython.InteractiveShell, monkeypatch
+):
+    messages = []
+    watched_states = iter([(), ("data",)])
+
+    monkeypatch.setattr(watcher_ipy, "watch", lambda *args, **kwargs: ())
+    monkeypatch.setattr(
+        watcher_ipy,
+        "watched_variables",
+        lambda **kwargs: next(watched_states),
+    )
+    monkeypatch.setattr(
+        watcher_ipy,
+        "_display_message",
+        lambda message, html=None: messages.append((message, html)),
+    )
+
+    ip_shell.run_line_magic("watch", "--restore data")
+
+    assert len(messages) == 1
+
+
+def test_watch_magic_restore_reports_ambiguous_workspace_link(
+    ip_shell: IPython.InteractiveShell, monkeypatch
+):
+    messages = []
+
+    def fake_watch(*varnames, **kwargs):
+        raise watcher_core._AmbiguousWatchBindingError("ambiguous watched row")
+
+    monkeypatch.setattr(watcher_ipy, "watch", fake_watch)
+    monkeypatch.setattr(
+        watcher_ipy,
+        "_display_message",
+        lambda message, html=None: messages.append(message),
+    )
+
+    ip_shell.run_line_magic("watch", "--restore data")
+
+    assert messages == ["ambiguous watched row"]
 
 
 def test_watch_magic_reports_ambiguous_workspace_link(


### PR DESCRIPTION
Makes watched variables in ImageTool Manager now reconnect by their name after notebook or workspace restarts.

Users can watch a variable with the usual `%watch data` command, restart the notebook kernel, rerun the notebook, and run `%watch data_name` again to reconnect the existing watched row instead of creating a duplicate. Saved ImageTool workspaces also remember watched variables, so reopening an `.itws` file shows the watched rows and lets the notebook reconnect them.

A new `%watch --restore` command reconnects all watched variables from the open manager workspace when matching variables exist in the notebook. This makes sharing notebooks and workspaces together straightforward: send the `.itws` file along with the `.ipynb` file, open both, execute run the notebook cells, then run `%watch --restore`.

Watched rows that cannot currently connect to a notebook variable are shown as disconnected until they are restored.