### PR TITLE
Enhance ImageTool workflows and manager persistence

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -9,7 +9,8 @@ Inspired by *Image Tool* for Igor Pro, developed by the Advanced Light Source at
 - Responsive slicing of multidimensional (up to 4D) {class}`DataArray <xarray.DataArray>` objects, including Dask-backed data.
 - Unlimited number of cursors with independent binning and code export for each line cut.
 - Rich colormap controls with power law scaling, symmetric scaling about a center, and live color range adjustment.
-- Built-in menus for rotation, symmetrization, averaging, interpolation, cropping, coordinate reassignment, Fermi edge correction, and other common operations.
+- Built-in menus for selection, rotation, symmetrization, averaging, interpolation,
+  cropping, coordinate reassignment, Fermi edge correction, and other common operations.
 - Tight integration with tools such as {ref}`ktool <guide-ktool>`, {ref}`dtool <guide-dtool>`, and other tools listed in {ref}`interactive-misc-tools`, all accessible from ImageTool’s menus and context menus.
 - Seamless integration with {ref}`ImageTool manager <imagetool-manager>` when you need
   to organize top-level ImageTool rows, tools opened from those ImageTools, ImageTool
@@ -234,6 +235,9 @@ generated snippet is placed on your clipboard, ready to paste into a script or n
 for reproducibility.
 
 - {guilabel}`Edit → Rotate` opens the {guilabel}`Rotate` dialog. Enter the angle, center, interpolation order, and whether to reshape the image. If a rotation guideline is active, the dialog pre-fills the angle and center from the guideline.
+- {guilabel}`Edit → Select Data…` opens the {guilabel}`Select Data` dialog. Use it to
+  build {meth}`~xarray.DataArray.qsel`, {meth}`~xarray.DataArray.sel`, and
+  {meth}`~xarray.DataArray.isel` selections from a table of dimensions. Each row can select a scalar point or a contiguous range.
 - {guilabel}`Edit → Average` opens the {guilabel}`Average Over Dimensions` dialog. Select any set of dimensions to average via {meth}`xarray.DataArray.qsel.average`.
 - {guilabel}`Edit → Interpolate…` opens the {guilabel}`Interpolate` dialog. Choose one dimension, enter the target coordinate values, and interpolate with {meth}`xarray.DataArray.interp` using `linear` or `nearest`.
 - {guilabel}`Edit → Coarsen` opens the {guilabel}`Coarsen` dialog. Select window sizes for one or more dimensions, choose the `boundary`, `side`, and coordinate reduction function for {meth}`xarray.DataArray.coarsen`, then apply a reducer such as `mean`, `sum`, or `median`.

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -197,7 +197,7 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
   Holding {kbd}`Alt` while opening the menu switches many actions to cropped mode, which crops the data to what is currently visible in the plot before performing the action. This is useful for conducting analysis on a specific region.
   :::
 
-- Use {guilabel}`Edit → Rotation Guidelines` to add guidelines for azimuthal offsets or symmetry operations.
+- Use {guilabel}`View → Rotation Guidelines` to add guidelines for azimuthal offsets or symmetry operations.
 
   The guideline center moves together with the cursor. The center and the angle of the guidelines feed directly into the {guilabel}`Rotate` dialog and {guilabel}`ktool` for fast alignment.
 

--- a/docs/source/user-guide/workflow-bridge.md
+++ b/docs/source/user-guide/workflow-bridge.md
@@ -36,6 +36,10 @@ code for reproducibility and batch processing.
   - {ref}`Manager opening and replacement paths <imagetool-manager-open>`
   - `data.qshow(manager=True)` and `eri.itool(data, manager=True)`, see
     {ref}`working-with-notebooks` for notebook-manager synchronization options.
+- - Select a point or range from multidimensional data
+  - {guilabel}`Edit → Select Data…` or the right-click context menu of each plot
+  - {meth}`xarray.DataArray.qsel`, {meth}`xarray.DataArray.sel`, and
+    {meth}`xarray.DataArray.isel`
 - - Average over dimensions
   - {ref}`Averaging dialog <imagetool-editing>`
   - {meth}`xarray.DataArray.qsel.average`

--- a/skills/arpes-analysis/references/docs-links.md
+++ b/skills/arpes-analysis/references/docs-links.md
@@ -1,6 +1,6 @@
 # ERLabPy docs links (stable)
 
-Last verified: 2026-03-13.
+Last verified: 2026-05-22.
 
 ## Base links
 
@@ -72,6 +72,8 @@ Last verified: 2026-03-13.
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/misc-tools.html#interactive-misc-magics
 - Interactive configuration:
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/options.html
+- Interactive tool authoring:
+  https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/tool-authoring.html
 
 ## API landing pages
 
@@ -104,9 +106,9 @@ Last verified: 2026-03-13.
 - `xarray.DataArray.kspace.convert_coords`:
   https://erlabpy.readthedocs.io/en/stable/accessors/xarray.DataArray.kspace.convert_coords.html
 - `xarray.DataArray.xlm.modelfit`:
-  https://xarray-lmfit.readthedocs.io/en/stable/accessors/xarray.DataArray.xlm.modelfit.html
+  https://xarray-lmfit.readthedocs.io/stable/accessors/xarray.DataArray.xlm.modelfit.html
 - `xarray.Dataset.xlm.modelfit`:
-  https://xarray-lmfit.readthedocs.io/en/stable/accessors/xarray.Dataset.xlm.modelfit.html
+  https://xarray-lmfit.readthedocs.io/stable/accessors/xarray.Dataset.xlm.modelfit.html
 
 ## URL patterns
 

--- a/src/erlab/interactive/imagetool/_history.py
+++ b/src/erlab/interactive/imagetool/_history.py
@@ -13,15 +13,37 @@ if typing.TYPE_CHECKING:
     import erlab
 
 
+_MISSING = object()
+
+_DetailRow = tuple[str, str, str]
+
+_DETAIL_LABELS = {
+    "color.cmap": "Colormap",
+    "color.gamma": "Gamma",
+    "color.high_contrast": "High contrast",
+    "color.levels": "Levels",
+    "color.levels_locked": "Lock levels",
+    "color.reverse": "Reverse colormap",
+    "color.zero_centered": "Zero centered",
+    "slice.snap_to_data": "Snap to pixels",
+    "slice.twin_coord_names": "Associated coordinates",
+    "slice.cursor_color_params": "Cursor color mapping",
+    "cursor_colors": "Cursor colors",
+    "controls_visible": "Controls visible",
+}
+
+
 def _normalize_value(value: typing.Any) -> typing.Any:
+    if isinstance(value, np.ndarray):
+        return [_normalize_value(v) for v in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
     if isinstance(value, numbers.Number):
         return value
     if isinstance(value, (str, bytes)):
         return value
     if isinstance(value, pathlib.Path):
         return str(value)
-    if isinstance(value, np.generic):
-        return value.item()
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return [_normalize_value(v) for v in value]
     if isinstance(value, Mapping):
@@ -42,6 +64,160 @@ def _flatten_state(
     return flat
 
 
+def _format_value(value: typing.Any) -> str:
+    value = _normalize_value(value)
+    if value is _MISSING:
+        text = "Not set"
+    elif value is None:
+        text = "None"
+    elif isinstance(value, bool):
+        text = "On" if value else "Off"
+    elif isinstance(value, str):
+        text = value or "Empty"
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        text = "[" + ", ".join(_format_value(v) for v in value) + "]"
+    elif isinstance(value, Mapping):
+        text = (
+            "{" + ", ".join(f"{k}: {_format_value(v)}" for k, v in value.items()) + "}"
+        )
+    else:
+        text = repr(value)
+    if len(text) > 96:
+        text = f"{text[:93]}..."
+    return text
+
+
+def _change_detail(label: str, old: typing.Any, new: typing.Any) -> _DetailRow:
+    return (label, _format_value(old), _format_value(new))
+
+
+def _detail_note(text: str) -> _DetailRow:
+    return (text, "", "")
+
+
+def _detail_rows_to_lines(details: Sequence[_DetailRow]) -> tuple[str, ...]:
+    lines: list[str] = []
+    for label, before, after in details:
+        if before or after:
+            lines.append(f"{label} changed from {before} to {after}")
+        else:
+            lines.append(label)
+    return tuple(lines)
+
+
+def _changed_paths(
+    prev_flat: Mapping[str, typing.Any], curr_flat: Mapping[str, typing.Any]
+) -> set[str]:
+    paths = set(prev_flat) | set(curr_flat)
+    return {
+        path
+        for path in paths
+        if not (path == "splitter_sizes" or path.startswith("splitter_sizes."))
+        and prev_flat.get(path, _MISSING) != curr_flat.get(path, _MISSING)
+    }
+
+
+def _consume(changes: set[str], *paths: str, prefixes: Sequence[str] = ()) -> None:
+    for path in paths:
+        changes.discard(path)
+    for path in tuple(changes):
+        if any(path == prefix or path.startswith(f"{prefix}.") for prefix in prefixes):
+            changes.discard(path)
+
+
+def _append_unique(items: list[str], item: str) -> None:
+    if item not in items:
+        items.append(item)
+
+
+def _state_value(state: Mapping[str, typing.Any], key: str) -> typing.Any:
+    return state.get(key, _MISSING)
+
+
+def _safe_len(value: typing.Any) -> int:
+    return len(value) if isinstance(value, Sequence) else 0
+
+
+def _cursor_detail_rows(
+    prev_indices: typing.Any,
+    curr_indices: typing.Any,
+    prev_values: typing.Any,
+    curr_values: typing.Any,
+) -> tuple[_DetailRow, ...]:
+    details: list[_DetailRow] = []
+    if not isinstance(prev_indices, Sequence) or not isinstance(curr_indices, Sequence):
+        return ()
+
+    for i, (old_index, new_index) in enumerate(
+        zip(prev_indices, curr_indices, strict=False), start=1
+    ):
+        old_value = prev_values[i - 1] if i <= _safe_len(prev_values) else _MISSING
+        new_value = curr_values[i - 1] if i <= _safe_len(curr_values) else _MISSING
+        if old_index == new_index and old_value == new_value:
+            continue
+
+        if old_index != new_index:
+            details.append(_change_detail(f"Cursor {i} index", old_index, new_index))
+        if old_value != new_value:
+            details.append(_change_detail(f"Cursor {i} value", old_value, new_value))
+    return tuple(details)
+
+
+def _plot_state_changes(
+    prev_plot_states: typing.Any, curr_plot_states: typing.Any
+) -> tuple[list[str], list[_DetailRow]]:
+    summaries: list[str] = []
+    details: list[_DetailRow] = []
+
+    if not isinstance(prev_plot_states, Sequence) or not isinstance(
+        curr_plot_states, Sequence
+    ):
+        return ["Plot view changed"], [_detail_note("Plot state changed")]
+
+    old_roi_count = 0
+    new_roi_count = 0
+    roi_changed = False
+    guideline_changed = False
+    view_changed = len(prev_plot_states) != len(curr_plot_states)
+
+    for old, new in zip(prev_plot_states, curr_plot_states, strict=False):
+        if not isinstance(old, Mapping) or not isinstance(new, Mapping):
+            view_changed = True
+            continue
+
+        old_rois = old.get("roi_states", [])
+        new_rois = new.get("roi_states", [])
+        old_roi_count += _safe_len(old_rois)
+        new_roi_count += _safe_len(new_rois)
+        roi_changed = roi_changed or old_rois != new_rois
+
+        old_guideline = old.get("guideline_state", None)
+        new_guideline = new.get("guideline_state", None)
+        guideline_changed = guideline_changed or old_guideline != new_guideline
+
+        view_keys = {
+            "vb_aspect_locked",
+            "vb_x_inverted",
+            "vb_y_inverted",
+            "vb_autorange",
+        }
+        view_changed = view_changed or any(
+            old.get(key, _MISSING) != new.get(key, _MISSING) for key in view_keys
+        )
+
+    if roi_changed:
+        summaries.append("ROI changed")
+        details.append(_change_detail("ROI count", old_roi_count, new_roi_count))
+    if guideline_changed:
+        summaries.append("Guidelines changed")
+        details.append(_detail_note("Guideline state changed"))
+    if view_changed:
+        summaries.append("Plot view changed")
+        details.append(_detail_note("Plot view state changed"))
+
+    return summaries, details
+
+
 def parse_change(key: str, old, new) -> str:
     match key:
         case "cursor_colors":
@@ -49,18 +225,34 @@ def parse_change(key: str, old, new) -> str:
         case "slice.indices" | "slice.values":
             return "Cursor moved"
         case "slice.bins":
-            return "Number of bins changed"
+            return "Bins changed"
         case "slice.dims":
             return "Transposed"
+        case "slice.snap_to_data":
+            if new is _MISSING or old is _MISSING:
+                return "Snap to pixels changed"
+            return "Snap to pixels enabled" if new else "Snap to pixels disabled"
+        case "slice.twin_coord_names":
+            return "Associated coordinates changed"
+        case "slice.cursor_color_params":
+            return "Cursor color mapping changed"
         case "controls_visible":
+            if new is _MISSING or old is _MISSING:
+                return "Controls visibility changed"
             return "Controls shown" if new else "Controls hidden"
         case "color.reverse":
-            return "Colormap reversed"
+            if new is _MISSING or old is _MISSING:
+                return "Colormap reversal changed"
+            return "Colormap reversed" if new else "Colormap unreversed"
         case "color.cmap":
+            if new is _MISSING:
+                return "Colormap changed"
             return f"Changed colormap to {new}"
         case "color.gamma" | "color.high_contrast" | "color.zero_centered":
             return "Colormap options changed"
         case "color.levels_locked":
+            if new is _MISSING or old is _MISSING:
+                return "Colormap levels lock changed"
             return "Colormap levels locked" if new else "Colormap levels unlocked"
         case "color.levels":
             return "Colormap levels changed"
@@ -68,42 +260,501 @@ def parse_change(key: str, old, new) -> str:
             return f"{key} changed"
 
 
+def _describe_state_change_rows(
+    prev: Mapping[str, typing.Any], curr: Mapping[str, typing.Any]
+) -> tuple[str, tuple[_DetailRow, ...]] | None:
+    prev_flat, curr_flat = _flatten_state(prev), _flatten_state(curr)
+    changes = _changed_paths(prev_flat, curr_flat)
+    if not changes:
+        return None
+
+    summaries: list[str] = []
+    details: list[_DetailRow] = []
+
+    prev_indices = prev_flat.get("slice.indices", [])
+    curr_indices = curr_flat.get("slice.indices", [])
+    prev_values = prev_flat.get("slice.values", [])
+    curr_values = curr_flat.get("slice.values", [])
+    old_ncursors = _safe_len(prev_indices)
+    new_ncursors = _safe_len(curr_indices)
+
+    transposed = (
+        "slice.dims" in changes
+        and isinstance(prev_flat.get("slice.dims"), Sequence)
+        and isinstance(curr_flat.get("slice.dims"), Sequence)
+        and set(prev_flat["slice.dims"]) == set(curr_flat["slice.dims"])
+    )
+
+    if transposed:
+        summaries.append("Transposed")
+        details.append(
+            _change_detail(
+                "Dimensions",
+                _state_value(prev_flat, "slice.dims"),
+                _state_value(curr_flat, "slice.dims"),
+            )
+        )
+        _consume(changes, "slice.dims", "slice.indices", "slice.values")
+
+    if old_ncursors > new_ncursors:
+        summaries.append("Cursor removed")
+        details.append(_change_detail("Cursors", old_ncursors, new_ncursors))
+        _consume(
+            changes,
+            "current_cursor",
+            "cursor_colors",
+            "slice.indices",
+            "slice.values",
+            "slice.bins",
+        )
+    elif old_ncursors < new_ncursors:
+        summaries.append("Cursor added")
+        details.append(_change_detail("Cursors", old_ncursors, new_ncursors))
+        _consume(
+            changes,
+            "current_cursor",
+            "cursor_colors",
+            "slice.indices",
+            "slice.values",
+            "slice.bins",
+        )
+    elif "current_cursor" in changes:
+        summaries.append("Cursor changed")
+        details.append(
+            _change_detail(
+                "Active cursor",
+                _state_value(prev_flat, "current_cursor"),
+                _state_value(curr_flat, "current_cursor"),
+            )
+        )
+        _consume(changes, "current_cursor")
+
+    if not transposed and {"slice.indices", "slice.values"} & changes:
+        indices_changed = prev_indices != curr_indices
+        values_changed = prev_values != curr_values
+        if indices_changed:
+            _append_unique(summaries, "Cursor moved")
+        elif values_changed:
+            _append_unique(summaries, "Cursor moved within pixel")
+        details.extend(
+            _cursor_detail_rows(prev_indices, curr_indices, prev_values, curr_values)
+        )
+        _consume(changes, "slice.indices", "slice.values")
+
+    if "slice.bins" in changes:
+        summaries.append("Bins changed")
+        details.append(
+            _change_detail(
+                "Bins",
+                _state_value(prev_flat, "slice.bins"),
+                _state_value(curr_flat, "slice.bins"),
+            )
+        )
+        _consume(changes, "slice.bins")
+
+    for key in (
+        "slice.snap_to_data",
+        "slice.twin_coord_names",
+        "slice.cursor_color_params",
+        "cursor_colors",
+        "controls_visible",
+    ):
+        if key in changes:
+            old_value = _state_value(prev_flat, key)
+            new_value = _state_value(curr_flat, key)
+            summaries.append(parse_change(key, old_value, new_value))
+            details.append(_change_detail(_DETAIL_LABELS[key], old_value, new_value))
+            _consume(changes, key)
+
+    for key in (
+        "color.cmap",
+        "color.reverse",
+        "color.gamma",
+        "color.high_contrast",
+        "color.zero_centered",
+        "color.levels_locked",
+        "color.levels",
+    ):
+        if key in changes:
+            old_value = _state_value(prev_flat, key)
+            new_value = _state_value(curr_flat, key)
+            summaries.append(parse_change(key, old_value, new_value))
+            details.append(_change_detail(_DETAIL_LABELS[key], old_value, new_value))
+            _consume(changes, key)
+
+    if any(
+        path == "manual_limits" or path.startswith("manual_limits.") for path in changes
+    ):
+        summaries.append("View limits changed")
+        details.append(_detail_note("Manual view limits changed"))
+        _consume(changes, "manual_limits", prefixes=("manual_limits",))
+
+    if "plotitem_states" in changes:
+        plot_summaries, plot_details = _plot_state_changes(
+            prev_flat.get("plotitem_states", []), curr_flat.get("plotitem_states", [])
+        )
+        summaries.extend(plot_summaries)
+        details.extend(plot_details)
+        _consume(changes, "plotitem_states")
+
+    if {"file_path", "load_func"} & changes:
+        summaries.append("Source changed")
+        details.extend(
+            _change_detail(
+                key, _state_value(prev_flat, key), _state_value(curr_flat, key)
+            )
+            for key in ("file_path", "load_func")
+            if key in changes
+        )
+        _consume(changes, "file_path", "load_func")
+
+    if changes:
+        if not summaries:
+            summaries.append("State changed")
+        details.append(_detail_note(f"Changed paths: {', '.join(sorted(changes))}"))
+
+    if not summaries:
+        return None
+    return ", ".join(dict.fromkeys(summaries)), tuple(dict.fromkeys(details))
+
+
+def describe_state_change(
+    prev: Mapping[str, typing.Any], curr: Mapping[str, typing.Any]
+) -> tuple[str, tuple[str, ...]] | None:
+    change = _describe_state_change_rows(prev, curr)
+    if change is None:
+        return None
+    summary, details = change
+    return summary, _detail_rows_to_lines(details)
+
+
 def describe_state_diff(
     prev: Mapping[str, typing.Any], curr: Mapping[str, typing.Any]
 ) -> str | None:
-    prev_flat, curr_flat = _flatten_state(prev), _flatten_state(curr)
-    keys: set[str] = set.intersection(set(prev_flat.keys()), set(curr_flat.keys()))
+    change = describe_state_change(prev, curr)
+    if change is None:
+        return None
+    return change[0]
 
-    old_ncursors = len(prev_flat["slice.indices"])
-    new_ncursors = len(curr_flat["slice.indices"])
-    if old_ncursors > new_ncursors:
-        return "Cursor removed"
 
-    changes: set[str] = {key for key in keys if prev_flat[key] != curr_flat[key]}
+def _history_entries(
+    slicer_area: erlab.interactive.imagetool.viewer.ImageSlicerArea,
+) -> list[tuple[int, int, str, tuple[_DetailRow, ...], bool]]:
+    states, current_index = slicer_area.history_states()
+    entries: list[tuple[int, int, str, tuple[_DetailRow, ...], bool]] = []
+    for i in range(len(states) - 1, 0, -1):
+        prev_state, this_state = states[i - 1], states[i]
+        change = _describe_state_change_rows(prev_state, this_state)
+        if change is None:
+            if i != current_index:
+                continue
+            summary, details = "Current state", ()
+        else:
+            summary, details = change
+        is_current = i == current_index
+        entries.append((i, i - current_index, summary, details, is_current))
+    if current_index == 0 and len(states) > 1:
+        entries.append((0, 0, "Current state", (), True))
+    return entries
 
-    if "current_cursor" in changes:
-        if old_ncursors == new_ncursors:
-            return "Cursor changed"
-        return "Cursor added"
 
-    # Ignore value changes if indices didn't change
-    changes.discard("slice.values")
+class HistoryDialog(QtWidgets.QDialog):
+    def __init__(
+        self,
+        slicer_area: erlab.interactive.imagetool.viewer.ImageSlicerArea,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._slicer_area = weakref.ref(slicer_area)
+        self.setObjectName("itool_history_dialog")
+        self.setWindowTitle("History")
+        self.setModal(False)
+        self.resize(460, 210)
+        self.setSizeGripEnabled(False)
+        self._fitting_height = False
 
-    if "slice.dims" in changes and set(prev_flat["slice.dims"]) == set(
-        curr_flat["slice.dims"]
-    ):
-        # Transposed
-        changes.discard("slice.indices")
-
-    return (
-        ", ".join(
-            sorted(
-                {parse_change(key, prev_flat[key], curr_flat[key]) for key in changes}
-            )
+        self._history_list = QtWidgets.QListWidget()
+        self._history_list.setObjectName("itool_history_list")
+        self._history_list.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
         )
-        if changes
-        else None
-    )
+        self._history_list.installEventFilter(self)
+        self._history_list.setMinimumHeight(140)
+
+        self._details = QtWidgets.QWidget()
+        self._details.setObjectName("itool_history_details")
+        self._details.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+        self._details_layout = QtWidgets.QGridLayout(self._details)
+        self._details_layout.setContentsMargins(0, 0, 0, 0)
+        self._details_layout.setHorizontalSpacing(16)
+        self._details_layout.setVerticalSpacing(6)
+        self._details_layout.setColumnMinimumWidth(0, 96)
+        self._details_layout.setColumnMinimumWidth(1, 80)
+        self._details_layout.setColumnMinimumWidth(2, 80)
+        self._details_layout.setColumnStretch(1, 1)
+        self._details_layout.setColumnStretch(2, 1)
+
+        self._details_panel = QtWidgets.QGroupBox("Details")
+        self._details_panel.setObjectName("itool_history_details_group")
+        self._details_panel.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+        details_layout = QtWidgets.QVBoxLayout(self._details_panel)
+        details_layout.addWidget(self._details)
+
+        self._button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Close
+        )
+        self._button_box.setObjectName("itool_history_button_box")
+        self._go_to_btn = QtWidgets.QPushButton("Restore State")
+        self._go_to_btn.setObjectName("itool_history_go_to_button")
+        self._button_box.addButton(
+            self._go_to_btn, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole
+        )
+        self._close_btn = self._button_box.button(
+            QtWidgets.QDialogButtonBox.StandardButton.Close
+        )
+        if self._close_btn is not None:
+            self._close_btn.setObjectName("itool_history_close_button")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self._history_list)
+        layout.addWidget(self._details_panel)
+        layout.addWidget(self._button_box)
+
+        self._history_list.currentItemChanged.connect(self._selection_changed)
+        self._history_list.itemDoubleClicked.connect(self._go_to_item)
+        self._go_to_btn.clicked.connect(self._go_to_selected)
+        self._button_box.rejected.connect(self.close)
+        self.slicer_area.sigHistoryChanged.connect(self.refresh)
+
+        self.refresh()
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        if not self._fitting_height:
+            QtCore.QTimer.singleShot(0, self._fit_height_to_content)
+
+    @property
+    def slicer_area(self) -> erlab.interactive.imagetool.viewer.ImageSlicerArea:
+        slicer_area = self._slicer_area()
+        if slicer_area:
+            return slicer_area
+        raise LookupError("Parent was destroyed")
+
+    def eventFilter(
+        self, obj: QtCore.QObject | None, event: QtCore.QEvent | None
+    ) -> bool:
+        if (
+            obj is self._history_list
+            and event is not None
+            and event.type() == QtCore.QEvent.Type.KeyPress
+        ):
+            key_event = typing.cast("typing.Any", event)
+            if key_event.key() in (
+                QtCore.Qt.Key.Key_Return,
+                QtCore.Qt.Key.Key_Enter,
+            ):
+                self._go_to_selected()
+                return True
+        return super().eventFilter(obj, event)
+
+    @QtCore.Slot()
+    def refresh(self) -> None:
+        self._history_list.clear()
+        entries = _history_entries(self.slicer_area)
+        if not entries:
+            self._set_detail_rows((_detail_note("No history recorded yet."),))
+            self._go_to_btn.setEnabled(False)
+            item = QtWidgets.QListWidgetItem("No history recorded yet")
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, None)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole + 1, ())
+            self._history_list.addItem(item)
+            self._history_list.setCurrentItem(item)
+            self._update_history_list_height()
+            return
+
+        current_item: QtWidgets.QListWidgetItem | None = None
+        for _, relative_index, summary, details, is_current in entries:
+            item = QtWidgets.QListWidgetItem(
+                f"Current: {summary}" if is_current else summary
+            )
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, relative_index)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole + 1, details)
+            if is_current:
+                font = item.font()
+                font.setBold(True)
+                item.setFont(font)
+            self._history_list.addItem(item)
+            if is_current:
+                current_item = item
+
+        self._history_list.setCurrentItem(current_item or self._history_list.item(0))
+        self._update_history_list_height()
+        self._selection_changed()
+
+    @QtCore.Slot()
+    def _selection_changed(self, *_args) -> None:
+        item = self._history_list.currentItem()
+        if item is None:
+            self._clear_detail_rows()
+            self._go_to_btn.setEnabled(False)
+            return
+
+        details = item.data(QtCore.Qt.ItemDataRole.UserRole + 1)
+        if details:
+            self._set_detail_rows(details)
+        elif item.data(QtCore.Qt.ItemDataRole.UserRole) is None:
+            self._set_detail_rows((_detail_note("No history recorded yet."),))
+        else:
+            self._set_detail_rows((_detail_note("No additional details."),))
+        self._go_to_btn.setEnabled(self._selected_relative_index() not in (None, 0))
+
+    def _set_detail_rows(self, details: Sequence[_DetailRow]) -> None:
+        self._clear_detail_rows()
+        row = 0
+        if any(before or after for _, before, after in details):
+            self._details_layout.addWidget(self._detail_heading("Before"), row, 1)
+            self._details_layout.addWidget(self._detail_heading("After"), row, 2)
+            row += 1
+        for label, before, after in details:
+            self._add_detail_row(row, label, before, after)
+            row += 1
+        self._fit_height_to_content()
+        QtCore.QTimer.singleShot(0, self._fit_height_to_content)
+
+    def _update_history_list_height(self) -> None:
+        row_count = max(1, min(self._history_list.count(), 8))
+        row_height = self._history_list.sizeHintForRow(0)
+        if row_height <= 0:
+            row_height = self.fontMetrics().height() + 6
+        height = row_count * row_height + 2 * self._history_list.frameWidth() + 4
+        self._history_list.setFixedHeight(height)
+
+    def _fit_height_to_content(self) -> None:
+        main_layout = self.layout()
+        if main_layout is None:
+            return
+        self._fitting_height = True
+        try:
+            detail_width = max(1, self._details.width())
+            detail_height = self._details_layout.sizeHint().height()
+            if self._details_layout.hasHeightForWidth():
+                detail_height = max(
+                    detail_height,
+                    self._details_layout.heightForWidth(detail_width),
+                )
+            self._details.setFixedHeight(detail_height)
+            details_panel_layout = self._details_panel.layout()
+            if details_panel_layout is not None:
+                details_panel_layout.activate()
+            details_margins = (
+                details_panel_layout.contentsMargins()
+                if details_panel_layout is not None
+                else QtCore.QMargins()
+            )
+            detail_top = max(
+                self._details.y(),
+                self.fontMetrics().height() + details_margins.top() + 4,
+            )
+            panel_height = detail_height + detail_top + details_margins.bottom()
+            self._details_panel.setFixedHeight(panel_height)
+            self._details_layout.activate()
+            main_layout.activate()
+            main_margins = main_layout.contentsMargins()
+            main_spacing = max(0, main_layout.spacing())
+            height = (
+                main_margins.top()
+                + self._history_list.height()
+                + main_spacing
+                + panel_height
+                + main_spacing
+                + self._button_box.sizeHint().height()
+                + main_margins.bottom()
+            )
+            self.setFixedHeight(height)
+            self.resize(self.width(), height)
+        finally:
+            self._fitting_height = False
+
+    def _clear_detail_rows(self) -> None:
+        while self._details_layout.count():
+            item = self._details_layout.takeAt(0)
+            if item is None:
+                continue
+            if widget := item.widget():
+                widget.setParent(None)
+                widget.deleteLater()
+
+    def _add_detail_row(self, row: int, label: str, before: str, after: str) -> None:
+        label_widget = self._detail_label(label)
+        label_widget.setObjectName("itool_history_detail_row")
+        label_widget.setProperty("detail", label)
+        label_widget.setProperty("before", before)
+        label_widget.setProperty("after", after)
+        if before or after:
+            self._details_layout.addWidget(label_widget, row, 0)
+            self._details_layout.addWidget(self._value_label(before), row, 1)
+            self._details_layout.addWidget(self._value_label(after), row, 2)
+        else:
+            self._details_layout.addWidget(label_widget, row, 0, 1, 3)
+
+    def _detail_heading(self, text: str) -> QtWidgets.QLabel:
+        label = QtWidgets.QLabel(text)
+        label.setObjectName("itool_history_detail_heading")
+        font = label.font()
+        font.setBold(True)
+        label.setFont(font)
+        label.setAlignment(
+            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
+        )
+        return label
+
+    def _detail_label(self, text: str) -> QtWidgets.QLabel:
+        label_widget = QtWidgets.QLabel(text)
+        label_widget.setObjectName("itool_history_detail_label")
+        label_widget.setWordWrap(True)
+        label_widget.setAlignment(
+            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
+        )
+        label_widget.setTextInteractionFlags(
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        return label_widget
+
+    def _value_label(self, text: str) -> QtWidgets.QLabel:
+        label = QtWidgets.QLabel(text)
+        label.setObjectName("itool_history_detail_value")
+        label.setWordWrap(True)
+        label.setAlignment(
+            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
+        )
+        label.setTextInteractionFlags(
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        return label
+
+    def _selected_relative_index(self) -> int | None:
+        item = self._history_list.currentItem()
+        if item is None:
+            return None
+        value = item.data(QtCore.Qt.ItemDataRole.UserRole)
+        return value if isinstance(value, int) else None
+
+    def _go_to_item(self, item: QtWidgets.QListWidgetItem) -> None:
+        self._history_list.setCurrentItem(item)
+        self._go_to_selected()
+
+    @QtCore.Slot()
+    def _go_to_selected(self) -> None:
+        relative_index = self._selected_relative_index()
+        if relative_index is None or relative_index == 0:
+            return
+        self.slicer_area.go_to_history_index(relative_index)
 
 
 class HistoryMenu(QtWidgets.QMenu):
@@ -118,6 +769,7 @@ class HistoryMenu(QtWidgets.QMenu):
         self._slicer_area = weakref.ref(slicer_area)
         self.aboutToShow.connect(self.update_actions)
         self._actions: list[QtWidgets.QAction] = []
+        self._dialog: HistoryDialog | None = None
         self.slicer_area.sigHistoryChanged.connect(self._history_changed)
 
     @property
@@ -133,11 +785,30 @@ class HistoryMenu(QtWidgets.QMenu):
         if self.isVisible():
             self.update_actions()
 
+    @QtCore.Slot()
+    def show_history(self) -> None:
+        if self._dialog is None:
+            slicer_area = self.slicer_area
+            self._dialog = HistoryDialog(slicer_area, slicer_area.window())
+        self._dialog.refresh()
+        self._dialog.show()
+        self._dialog.raise_()
+        self._dialog.activateWindow()
+
     def update_actions(self) -> None:
         self.clear()
         self._actions.clear()
-        states, current_index = self.slicer_area.history_states()
-        if len(states) < 2:
+
+        show_action = QtWidgets.QAction("Show History", self)
+        show_action.setObjectName("itool_history_show_action")
+        show_action.setData({"kind": "show_history"})
+        show_action.triggered.connect(self.show_history)
+        self.addAction(show_action)
+        self.addSeparator()
+        self._actions.append(show_action)
+
+        entries = _history_entries(self.slicer_area)
+        if not entries:
             action = QtWidgets.QAction("No history recorded yet")
             action.setObjectName("itool_history_empty_action")
             action.setData({"kind": "empty"})
@@ -146,17 +817,13 @@ class HistoryMenu(QtWidgets.QMenu):
             self._actions.append(action)
             return
 
-        for i in range(len(states) - 1, 0, -1):
-            prev_state, this_state = states[i - 1], states[i]
-            summary = describe_state_diff(prev_state, this_state) or "No changes"
-            marker = "•" if i == current_index else " "
+        for state_index, relative_index, summary, _, is_current in entries:
+            marker = "•" if is_current else " "
             action = QtWidgets.QAction(f"{marker} {summary}")
-            action.setObjectName(f"itool_history_action_{i}")
-            action.setData(i - current_index)
+            action.setObjectName(f"itool_history_action_{state_index}")
+            action.setData(relative_index)
             action.triggered.connect(
-                lambda *, idx=i - current_index: self.slicer_area.go_to_history_index(
-                    idx
-                )
+                lambda *, idx=relative_index: self.slicer_area.go_to_history_index(idx)
             )
             self.addAction(action)
             self._actions.append(action)

--- a/src/erlab/interactive/imagetool/_history.py
+++ b/src/erlab/interactive/imagetool/_history.py
@@ -52,6 +52,8 @@ def parse_change(key: str, old, new) -> str:
             return "Number of bins changed"
         case "slice.dims":
             return "Transposed"
+        case "controls_visible":
+            return "Controls shown" if new else "Controls hidden"
         case "color.reverse":
             return "Colormap reversed"
         case "color.cmap":

--- a/src/erlab/interactive/imagetool/_history.py
+++ b/src/erlab/interactive/imagetool/_history.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import copy
+import dataclasses
+import datetime
 import numbers
 import pathlib
 import typing
 import weakref
-from collections.abc import Mapping, Sequence
+from collections.abc import Hashable, Mapping, MutableMapping, Sequence
 
 import numpy as np
 from qtpy import QtCore, QtWidgets
@@ -16,6 +19,22 @@ if typing.TYPE_CHECKING:
 _MISSING = object()
 
 _DetailRow = tuple[str, str, str]
+_StatePath = tuple[Hashable, ...]
+_HistoryEntryRow = tuple[
+    int, int, str, tuple[_DetailRow, ...], bool, datetime.datetime | None
+]
+
+
+@dataclasses.dataclass(slots=True, eq=False)
+class HistoryEntry:
+    before_state: dict[str, typing.Any]
+    after_state: dict[str, typing.Any]
+    changed_paths: frozenset[_StatePath]
+    transaction_id: str | None
+    created_at: datetime.datetime = dataclasses.field(
+        default_factory=lambda: datetime.datetime.now().astimezone()
+    )
+
 
 _DETAIL_LABELS = {
     "color.cmap": "Colormap",
@@ -105,6 +124,12 @@ def _detail_rows_to_lines(details: Sequence[_DetailRow]) -> tuple[str, ...]:
     return tuple(lines)
 
 
+def _format_history_datetime(timestamp: datetime.datetime | None) -> str:
+    if timestamp is None:
+        return ""
+    return timestamp.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+
+
 def _changed_paths(
     prev_flat: Mapping[str, typing.Any], curr_flat: Mapping[str, typing.Any]
 ) -> set[str]:
@@ -115,6 +140,143 @@ def _changed_paths(
         if not (path == "splitter_sizes" or path.startswith("splitter_sizes."))
         and prev_flat.get(path, _MISSING) != curr_flat.get(path, _MISSING)
     }
+
+
+def changed_paths(
+    prev: Mapping[str, typing.Any], curr: Mapping[str, typing.Any]
+) -> frozenset[_StatePath]:
+    paths: set[_StatePath] = set()
+
+    def visit(old: typing.Any, new: typing.Any, prefix: _StatePath = ()) -> None:
+        if prefix and prefix[0] == "splitter_sizes":
+            return
+
+        if isinstance(old, Mapping) and isinstance(new, Mapping):
+            for key in set(old) | set(new):
+                visit(
+                    old.get(key, _MISSING),
+                    new.get(key, _MISSING),
+                    (*prefix, key),
+                )
+            return
+        if isinstance(old, list) and isinstance(new, list) and len(old) == len(new):
+            for i, (old_item, new_item) in enumerate(zip(old, new, strict=True)):
+                visit(old_item, new_item, (*prefix, i))
+            return
+        old = _normalize_value(old)
+        new = _normalize_value(new)
+        if prefix and old != new:
+            paths.add(prefix)
+
+    visit(prev, curr)
+    return frozenset(paths)
+
+
+def _path_value(
+    state: Mapping[str, typing.Any], path: _StatePath, *, normalize: bool = True
+) -> typing.Any:
+    value: typing.Any = state
+    for part in path:
+        if isinstance(value, Mapping):
+            if part not in value:
+                return _MISSING
+            value = value[part]
+            continue
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            if not isinstance(part, int) or isinstance(part, bool):
+                return _MISSING
+            index = part
+            if index < 0 or index >= len(value):
+                return _MISSING
+            value = value[index]
+            continue
+        return _MISSING
+    if normalize:
+        return _normalize_value(value)
+    return value
+
+
+def _set_path(
+    state: dict[str, typing.Any], path: _StatePath, value: typing.Any
+) -> None:
+    if not path:
+        return
+
+    target: typing.Any = state
+    for i, part in enumerate(path[:-1]):
+        next_part = path[i + 1]
+        if isinstance(target, MutableMapping):
+            child = target.get(part, _MISSING)
+            if not isinstance(child, (dict, list)):
+                if value is _MISSING:
+                    return
+                child = (
+                    []
+                    if isinstance(next_part, int) and not isinstance(next_part, bool)
+                    else {}
+                )
+                target[part] = child
+            target = child
+            continue
+        if isinstance(target, list):
+            if not isinstance(part, int) or isinstance(part, bool):
+                return
+            index = part
+            if index < 0 or index >= len(target):
+                return
+            child = target[index]
+            if not isinstance(child, (dict, list)):
+                if value is _MISSING:
+                    return
+                child = (
+                    []
+                    if isinstance(next_part, int) and not isinstance(next_part, bool)
+                    else {}
+                )
+                target[index] = child
+            target = child
+            continue
+        return
+
+    last = path[-1]
+    if isinstance(target, MutableMapping):
+        if value is _MISSING:
+            target.pop(last, None)
+        else:
+            target[last] = copy.deepcopy(value)
+    elif isinstance(target, list):
+        if not isinstance(last, int) or isinstance(last, bool):
+            return
+        index = last
+        if index < 0 or index >= len(target):
+            return
+        if value is _MISSING:
+            target.pop(index)
+        else:
+            target[index] = copy.deepcopy(value)
+
+
+def entry_matches_current(
+    entry: HistoryEntry, current: Mapping[str, typing.Any], *, undo: bool
+) -> bool:
+    expected = entry.after_state if undo else entry.before_state
+    return all(
+        _normalize_value(_path_value(current, path)) == _path_value(expected, path)
+        for path in entry.changed_paths
+    )
+
+
+def patch_state(
+    base: Mapping[str, typing.Any],
+    source: Mapping[str, typing.Any],
+    paths: frozenset[_StatePath],
+) -> dict[str, typing.Any]:
+    patched = copy.deepcopy(dict(base))
+    for path in paths:
+        _set_path(patched, path, _path_value(source, path, normalize=False))
+    return patched
 
 
 def _consume(changes: set[str], *paths: str, prefixes: Sequence[str] = ()) -> None:
@@ -439,9 +601,32 @@ def describe_state_diff(
 
 def _history_entries(
     slicer_area: erlab.interactive.imagetool.viewer.ImageSlicerArea,
-) -> list[tuple[int, int, str, tuple[_DetailRow, ...], bool]]:
+) -> list[_HistoryEntryRow]:
+    history_entry_changes = getattr(slicer_area, "history_entry_changes", None)
+    if callable(history_entry_changes):
+        entry_rows: list[_HistoryEntryRow] = []
+        for (
+            i,
+            relative_index,
+            prev_state,
+            this_state,
+            is_current,
+            created_at,
+        ) in reversed(history_entry_changes(finalize_pending=False)):
+            change = _describe_state_change_rows(prev_state, this_state)
+            if change is None:
+                if not is_current:
+                    continue
+                summary, details = "Current state", ()
+            else:
+                summary, details = change
+            entry_rows.append(
+                (i, relative_index, summary, details, is_current, created_at)
+            )
+        return entry_rows
+
     states, current_index = slicer_area.history_states()
-    entries: list[tuple[int, int, str, tuple[_DetailRow, ...], bool]] = []
+    entries: list[_HistoryEntryRow] = []
     for i in range(len(states) - 1, 0, -1):
         prev_state, this_state = states[i - 1], states[i]
         change = _describe_state_change_rows(prev_state, this_state)
@@ -452,9 +637,9 @@ def _history_entries(
         else:
             summary, details = change
         is_current = i == current_index
-        entries.append((i, i - current_index, summary, details, is_current))
+        entries.append((i, i - current_index, summary, details, is_current, None))
     if current_index == 0 and len(states) > 1:
-        entries.append((0, 0, "Current state", (), True))
+        entries.append((0, 0, "Current state", (), True, None))
     return entries
 
 
@@ -579,12 +764,17 @@ class HistoryDialog(QtWidgets.QDialog):
             return
 
         current_item: QtWidgets.QListWidgetItem | None = None
-        for _, relative_index, summary, details, is_current in entries:
-            item = QtWidgets.QListWidgetItem(
-                f"Current: {summary}" if is_current else summary
-            )
+        for _, relative_index, summary, details, is_current, created_at in entries:
+            timestamp = _format_history_datetime(created_at)
+            text = f"Current: {summary}" if is_current else summary
+            if timestamp:
+                text = f"{text}\n{timestamp}"
+            item = QtWidgets.QListWidgetItem(text)
             item.setData(QtCore.Qt.ItemDataRole.UserRole, relative_index)
             item.setData(QtCore.Qt.ItemDataRole.UserRole + 1, details)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole + 2, timestamp)
+            if timestamp:
+                item.setToolTip(timestamp)
             if is_current:
                 font = item.font()
                 font.setBold(True)
@@ -817,7 +1007,7 @@ class HistoryMenu(QtWidgets.QMenu):
             self._actions.append(action)
             return
 
-        for state_index, relative_index, summary, _, is_current in entries:
+        for state_index, relative_index, summary, _, is_current, _ in entries:
             marker = "•" if is_current else " "
             action = QtWidgets.QAction(f"{marker} {summary}")
             action.setObjectName(f"itool_history_action_{state_index}")

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -660,18 +660,7 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                         "triggered": self._swap_dims,
                         "sep_after": True,
                     },
-                    "Rotate": {"triggered": self._rotate},
-                    "Rotation Guidelines": {
-                        "actions": {
-                            **{
-                                f"guide{i}": act
-                                for i, act in enumerate(guideline_actions)
-                            },
-                            "sep": {"separator": True},
-                            "followGuidelinesAct": guideline_follow_action,
-                        },
-                        "sep_after": True,
-                    },
+                    "Rotate": {"triggered": self._rotate, "sep_after": True},
                     "Crop": {"triggered": self._crop},
                     "Crop to View": {
                         "triggered": self._crop_to_view,
@@ -726,6 +715,16 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                     "cursorMoveMenu": {"title": "Cursor Control", "actions": {}},
                     "cursorColorAct": self.slicer_area.cursor_color_act,
                     "cursorColorCoordAct": self.slicer_area.cursor_colors_by_coord_act,
+                    "Rotation Guidelines": {
+                        "actions": {
+                            **{
+                                f"guide{i}": act
+                                for i, act in enumerate(guideline_actions)
+                            },
+                            "sep": {"separator": True},
+                            "followGuidelinesAct": guideline_follow_action,
+                        },
+                    },
                     "sep2": {"separator": True},
                     "colorInvertAct": self.slicer_area.reverse_act,
                     "highContrastAct": self.slicer_area.high_contrast_act,

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -677,6 +677,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                         "triggered": self._crop_to_view,
                         "tooltip": "Crop to the current axes view range",
                     },
+                    "selectDataAct": {
+                        "text": "Select Data…",
+                        "triggered": self._select_data,
+                    },
                     "Average": {"triggered": self._average},
                     "interpolateAct": {
                         "text": "Interpolate…",
@@ -896,6 +900,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     @QtCore.Slot()
     def _crop_to_view(self) -> None:
         self.execute_dialog(erlab.interactive.imagetool.dialogs.CropToViewDialog)
+
+    @QtCore.Slot()
+    def _select_data(self) -> None:
+        self.execute_dialog(erlab.interactive.imagetool.dialogs.SelectionDialog)
 
     @QtCore.Slot()
     def _gaussian_filter(self) -> None:

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -58,13 +58,14 @@ class BaseImageTool(QtWidgets.QMainWindow):
         self, data=None, parent: QtWidgets.QWidget | None = None, **kwargs
     ) -> None:
         super().__init__(parent=parent)
+        state = kwargs.pop("state", None)
+        transpose = bool(kwargs.pop("transpose", False))
         self._provenance_spec: (
             erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None
         ) = None
         self._slicer_area = erlab.interactive.imagetool.viewer.ImageSlicerArea(
             self, data, **kwargs
         )
-        self._sync_file_load_provenance()
         self.setCentralWidget(self.slicer_area)
 
         self.docks: tuple[QtWidgets.QDockWidget, ...] = tuple(
@@ -99,6 +100,12 @@ class BaseImageTool(QtWidgets.QMainWindow):
             self.addDockWidget(QtCore.Qt.DockWidgetArea.TopDockWidgetArea, d)
         self.resize(720, 720)
 
+        if state is not None:
+            self.slicer_area.state = state
+        if transpose:
+            self.slicer_area.transpose_main_image()
+        self._sync_file_load_provenance()
+
         # Allow writing history after initialization
         self.slicer_area._write_history = True
 
@@ -117,6 +124,37 @@ class BaseImageTool(QtWidgets.QMainWindow):
         <erlab.interactive.imagetool.slicer.ArraySlicer>`.
         """  # noqa: D205
         return self.slicer_area.array_slicer
+
+    @property
+    def controls_visible(self) -> bool:
+        """Whether the ImageTool control docks are shown."""
+        return all(not dock.isHidden() for dock in self.docks)
+
+    @controls_visible.setter
+    def controls_visible(self, visible: bool) -> None:
+        self._set_controls_visible(visible)
+
+    def _set_controls_visible(self, visible: bool) -> None:
+        visible = bool(visible)
+        for dock in self.docks:
+            dock.setVisible(visible)
+
+        menu_bar = self.menuBar()
+        action = getattr(menu_bar, "action_dict", {}).get("toggleControlsAct")
+        if isinstance(action, QtGui.QAction):
+            with QtCore.QSignalBlocker(action):
+                action.setChecked(visible)
+
+    @QtCore.Slot(bool)
+    def _set_controls_visible_recorded(self, visible: bool) -> None:
+        visible = bool(visible)
+        if visible == self.controls_visible:
+            self._set_controls_visible(visible)
+            return
+
+        self.slicer_area.record_history_mutation(
+            None, lambda: self._set_controls_visible(visible)
+        )
 
     @property
     def provenance_spec(
@@ -415,6 +453,11 @@ class ImageTool(BaseImageTool):
         self.remove_act.triggered.connect(self.slicer_area.remove_from_manager)
         self.remove_act.setVisible(self.slicer_area._in_manager)
 
+        self.toggle_controls_act = QtWidgets.QAction("Show Controls", self)
+        self.toggle_controls_act.setCheckable(True)
+        self.toggle_controls_act.setChecked(self.controls_visible)
+        self.toggle_controls_act.triggered.connect(self._set_controls_visible_recorded)
+
         self._dask_menu.addSeparator()
         self._dask_menu.addAction(self.slicer_area.compute_act)
         self._dask_menu.addAction(self.slicer_area.chunk_auto_act)
@@ -668,6 +711,7 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                 "actions": {
                     "viewAllAct": self.slicer_area.view_all_act,
                     "transposeAct": self.slicer_area.transpose_act,
+                    "toggleControlsAct": self.image_tool.toggle_controls_act,
                     "sep0": {"separator": True},
                     "associatedAct": self.slicer_area.associated_coords_act,
                     "sep1": {"separator": True},

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -537,7 +537,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
         self._set_readout_source_indicator(self._readout_source)
 
         if self._readout_source is None:
-            if not self.slicer_area.data_chunked:
+            if self.array_slicer._obj.chunks is None:
                 self._set_spin_dat_value(
                     self.array_slicer.point_value(self.current_cursor, binned=True)
                 )
@@ -660,8 +660,8 @@ class ItoolCrosshairControls(ItoolControlsBase):
             self.spin_idx[i].blockSignals(False)
             self.spin_val[i].blockSignals(False)
 
-        # For chunked data, updating the point value is expensive, we let slicer_area
-        # emit sigPointValueChanged after computation is done
+        # For chunked displayed data, updating the point value is expensive, so
+        # slicer_area emits sigPointValueChanged after the batched computation is done.
         self.update_point_value_readout()
 
     @QtCore.Slot(int)

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -82,6 +82,7 @@ class ItoolControlsBase(QtWidgets.QWidget):
         self, slicer_area: ImageSlicerArea | ItoolControlsBase, *args, **kwargs
     ) -> None:
         self.sub_controls: list[ItoolControlsBase] = []
+        self._history_group_spins: list[erlab.interactive.utils.BetterSpinBox] = []
         super().__init__(*args, **kwargs)
         self._parent_control = weakref.ref(slicer_area)
         self.initialize_layout()
@@ -127,6 +128,7 @@ class ItoolControlsBase(QtWidgets.QWidget):
                 ctrl.initialize_widgets()
 
     def connect_signals(self) -> None:
+        self._connect_history_grouping()
         for ctrl in self.sub_controls:
             if isinstance(ctrl, ItoolControlsBase):  # pragma: no branch
                 ctrl.connect_signals()
@@ -135,9 +137,27 @@ class ItoolControlsBase(QtWidgets.QWidget):
         # Multiple inheritance disconnection is broken
         # https://bugreports.qt.io/browse/PYSIDE-229
         # Will not work correctly until this is fixed
+        self._disconnect_history_grouping()
         for ctrl in self.sub_controls:
             if isinstance(ctrl, ItoolControlsBase):
                 ctrl.disconnect_signals()
+
+    def _connect_history_grouping(self) -> None:
+        sub_controls = tuple(self.sub_controls)
+        for spin in self.findChildren(erlab.interactive.utils.BetterSpinBox):
+            if any(ctrl.isAncestorOf(spin) for ctrl in sub_controls):
+                continue
+            if spin not in self._history_group_spins:
+                spin.editingStarted.connect(self.slicer_area.begin_history_group)
+                self._history_group_spins.append(spin)
+
+    def _disconnect_history_grouping(self) -> None:
+        with contextlib.suppress(LookupError):
+            slicer_area = self.slicer_area
+            for spin in self._history_group_spins:
+                with contextlib.suppress(TypeError, RuntimeError):
+                    spin.editingStarted.disconnect(slicer_area.begin_history_group)
+        self._history_group_spins.clear()
 
     def update_content(self) -> None:
         for ctrl in self.sub_controls:
@@ -741,14 +761,9 @@ class ItoolColormapControls(ItoolControlsBase):
         self.gamma_widget = erlab.interactive.colors.ColorMapGammaWidget(
             spin_cls=erlab.interactive.utils.BetterSpinBox
         )
-        self.gamma_widget.valueChanged.connect(
-            lambda g: self.slicer_area.set_colormap(gamma=g)
-        )
+        self.gamma_widget.valueChanged.connect(self._set_gamma)
         self.gamma_widget.slider.sliderPressed.connect(
-            self.slicer_area.sigWriteHistory.emit
-        )
-        self.gamma_widget.spin.editingStarted.connect(
-            self.slicer_area.sigWriteHistory.emit
+            self.slicer_area.begin_history_group
         )
         self.gamma_widget.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
@@ -760,6 +775,10 @@ class ItoolColormapControls(ItoolControlsBase):
         layout.addWidget(self.cb_colormap)
         layout.addWidget(self.gamma_widget)
         layout.addWidget(self.misc_controls)
+
+    def _set_gamma(self, gamma: float) -> None:
+        self.slicer_area.sigWriteHistory.emit()
+        self.slicer_area.set_colormap(gamma=gamma)
 
     def update_content(self) -> None:
         if not erlab.interactive.utils.qt_is_valid(

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -777,7 +777,6 @@ class ItoolColormapControls(ItoolControlsBase):
         layout.addWidget(self.misc_controls)
 
     def _set_gamma(self, gamma: float) -> None:
-        self.slicer_area.sigWriteHistory.emit()
         self.slicer_area.set_colormap(gamma=gamma)
 
     def update_content(self) -> None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -745,6 +745,397 @@ class AverageDialog(DataTransformDialog):
         return f"{placeholder}.qsel.average({arg})"
 
 
+class _SelectionRow:
+    def __init__(
+        self,
+        dialog: SelectionDialog,
+        axis: int,
+        dim: Hashable,
+        row: int,
+        *,
+        active: bool,
+    ) -> None:
+        self.dialog = dialog
+        self.axis = axis
+        self.dim = dim
+
+        data = dialog.public_data
+        coord = np.asarray(data[dim].values, dtype=float)
+        self._coord_ascending = coord[0] <= coord[-1]
+        current_index = dialog.array_slicer.get_index(
+            dialog.slicer_area.current_cursor, axis
+        )
+        current_value = float(
+            dialog.array_slicer.get_value(
+                dialog.slicer_area.current_cursor, axis, uniform=False
+            )
+        )
+        stop_index = min(current_index + 1, data.sizes[dim] - 1)
+        stop_value = float(coord[stop_index])
+        bin_value = dialog.array_slicer.get_bin_values(
+            dialog.slicer_area.current_cursor
+        )[axis]
+        is_binned = dialog.array_slicer.get_binned(dialog.slicer_area.current_cursor)[
+            axis
+        ]
+
+        self.use_check = QtWidgets.QCheckBox()
+        self.use_check.setObjectName(f"selection_use_{axis}")
+        self.use_check.setChecked(active)
+
+        self.dim_label = QtWidgets.QLabel(str(dim))
+        self.cursor_label = QtWidgets.QLabel(f"{current_value:.6g}")
+
+        self.method_combo = QtWidgets.QComboBox()
+        self.method_combo.setObjectName(f"selection_method_{axis}")
+        for method in ("qsel", "sel", "isel"):
+            self.method_combo.addItem(method, method)
+
+        self.kind_combo = QtWidgets.QComboBox()
+        self.kind_combo.setObjectName(f"selection_kind_{axis}")
+        self.kind_combo.addItem("Point", "point")
+        self.kind_combo.addItem("Range", "range")
+
+        self.index_start_spin = erlab.interactive.utils.BetterSpinBox(
+            integer=True,
+            compact=False,
+            minimum=0,
+            maximum=data.sizes[dim] - 1,
+            value=current_index,
+        )
+        self.index_stop_spin = erlab.interactive.utils.BetterSpinBox(
+            integer=True,
+            compact=False,
+            minimum=0,
+            maximum=data.sizes[dim],
+            value=min(current_index + 1, data.sizes[dim]),
+        )
+
+        self.value_start_spin = erlab.interactive.utils.BetterSpinBox(
+            compact=False,
+            decimals=6,
+            significant=True,
+            minimum=float(np.nanmin(coord)),
+            maximum=float(np.nanmax(coord)),
+            value=current_value,
+        )
+        self.value_stop_spin = erlab.interactive.utils.BetterSpinBox(
+            compact=False,
+            decimals=6,
+            significant=True,
+            minimum=float(np.nanmin(coord)),
+            maximum=float(np.nanmax(coord)),
+            value=stop_value,
+        )
+
+        self.start_stack = QtWidgets.QStackedWidget()
+        self.start_stack.addWidget(self.value_start_spin)
+        self.start_stack.addWidget(self.index_start_spin)
+
+        self.stop_stack = QtWidgets.QStackedWidget()
+        self.stop_stack.addWidget(self.value_stop_spin)
+        self.stop_stack.addWidget(self.index_stop_spin)
+
+        self.width_widget = QtWidgets.QWidget()
+        width_layout = QtWidgets.QHBoxLayout(self.width_widget)
+        width_layout.setContentsMargins(0, 0, 0, 0)
+        width_layout.setSpacing(3)
+        self.width_check = QtWidgets.QCheckBox()
+        self.width_check.setObjectName(f"selection_width_enabled_{axis}")
+        self.width_spin = erlab.interactive.utils.BetterSpinBox(
+            compact=False,
+            decimals=6,
+            significant=True,
+            minimum=0.0,
+            value=0.0 if bin_value is None else float(bin_value),
+        )
+        self.width_spin.setObjectName(f"selection_width_{axis}")
+        self.width_check.setChecked(is_binned and bin_value is not None)
+        width_layout.addWidget(self.width_check)
+        width_layout.addWidget(self.width_spin)
+
+        widgets: tuple[QtWidgets.QWidget, ...] = (
+            self.use_check,
+            self.dim_label,
+            self.cursor_label,
+            self.method_combo,
+            self.kind_combo,
+            self.start_stack,
+            self.stop_stack,
+            self.width_widget,
+        )
+        for column, widget in enumerate(widgets):
+            dialog.grid_layout.addWidget(widget, row, column)
+
+        for widget in (
+            self.use_check,
+            self.method_combo,
+            self.kind_combo,
+            self.index_start_spin,
+            self.index_stop_spin,
+            self.value_start_spin,
+            self.value_stop_spin,
+            self.width_check,
+            self.width_spin,
+        ):
+            if isinstance(widget, QtWidgets.QComboBox):
+                widget.currentIndexChanged.connect(dialog.update_preview)
+            elif isinstance(widget, QtWidgets.QAbstractButton):
+                widget.toggled.connect(dialog.update_preview)
+            else:
+                widget.valueChanged.connect(dialog.update_preview)
+
+        self.method_combo.currentIndexChanged.connect(self.sync_widgets)
+        self.kind_combo.currentIndexChanged.connect(self.sync_widgets)
+        self.width_check.toggled.connect(self.sync_widgets)
+        self.sync_widgets()
+
+    @property
+    def method(self) -> typing.Literal["qsel", "sel", "isel"]:
+        return typing.cast(
+            "typing.Literal['qsel', 'sel', 'isel']",
+            self.method_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
+        )
+
+    @property
+    def kind(self) -> typing.Literal["point", "range"]:
+        return typing.cast(
+            "typing.Literal['point', 'range']",
+            self.kind_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
+        )
+
+    def sync_widgets(self) -> None:
+        is_index = self.method == "isel"
+        is_range = self.kind == "range"
+        is_qsel = self.method == "qsel"
+
+        self.start_stack.setCurrentIndex(1 if is_index else 0)
+        self.stop_stack.setCurrentIndex(1 if is_index else 0)
+        self.stop_stack.setEnabled(is_range)
+        self.width_widget.setEnabled(is_qsel and not is_range)
+        self.width_spin.setEnabled(
+            is_qsel and not is_range and self.width_check.isChecked()
+        )
+
+    def indexer(self) -> tuple[Hashable, typing.Any]:
+        if self.method == "isel":
+            start = int(self.index_start_spin.value())
+            if self.kind == "point":
+                return self.dim, start
+            stop = int(self.index_stop_spin.value())
+            return self.dim, slice(min(start, stop), max(start, stop))
+
+        start = float(self.value_start_spin.value())
+        if self.kind == "point":
+            return self.dim, start
+
+        stop = float(self.value_stop_spin.value())
+        if self._coord_ascending:
+            return self.dim, slice(min(start, stop), max(start, stop))
+        return self.dim, slice(max(start, stop), min(start, stop))
+
+    def qsel_width_indexer(self) -> tuple[str, float] | None:
+        if (
+            self.method != "qsel"
+            or self.kind != "point"
+            or not self.width_check.isChecked()
+        ):
+            return None
+        width = float(self.width_spin.value())
+        if not np.isfinite(width) or width <= 0.0:
+            return None
+        return f"{self.dim}_width", width
+
+
+class SelectionDialog(DataTransformDialog):
+    title = "Select Data"
+    suffix = "_sel"
+    enable_copy = True
+    apply_on_nonuniform_data = True
+
+    def setup_widgets(self) -> None:
+        self.public_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+            self.slicer_area.data
+        )
+
+        self.grid_layout = QtWidgets.QGridLayout()
+        self.grid_layout.setContentsMargins(0, 0, 0, 0)
+        self.grid_layout.setSpacing(3)
+
+        for column, label in enumerate(
+            (
+                "Use",
+                "Dimension",
+                "Cursor",
+                "Method",
+                "Selection",
+                "Start",
+                "Stop",
+                "Width",
+            )
+        ):
+            header = QtWidgets.QLabel(label)
+            header.setObjectName(f"selection_header_{column}")
+            self.grid_layout.addWidget(header, 0, column)
+
+        self.rows: list[_SelectionRow] = []
+        default_axis = self.public_data.ndim - 1 if self.public_data.ndim == 4 else None
+        for axis, dim in enumerate(self.public_data.dims):
+            self.rows.append(
+                _SelectionRow(
+                    self,
+                    axis,
+                    dim,
+                    axis + 1,
+                    active=axis == default_axis,
+                )
+            )
+
+        self.preview_label = QtWidgets.QLabel()
+        self.preview_label.setObjectName("selection_result_preview")
+        self.code_preview = QtWidgets.QPlainTextEdit()
+        self.code_preview.setObjectName("selection_code_preview")
+        self.code_preview.setReadOnly(True)
+        self.code_preview.setMaximumBlockCount(4)
+        self.code_preview.setMaximumHeight(
+            4 * QtGui.QFontMetrics(self.code_preview.font()).height()
+        )
+
+        self.layout_.addRow(self.grid_layout)
+        self.layout_.addRow("Result", self.preview_label)
+        self.layout_.addRow("Code", self.code_preview)
+        self.update_preview()
+
+    def _selection_kwargs(
+        self,
+    ) -> tuple[
+        dict[Hashable, typing.Any],
+        dict[Hashable, typing.Any],
+        dict[Hashable, typing.Any],
+    ]:
+        isel_kwargs: dict[Hashable, typing.Any] = {}
+        sel_kwargs: dict[Hashable, typing.Any] = {}
+        qsel_kwargs: dict[Hashable, typing.Any] = {}
+
+        target: dict[str, dict[Hashable, typing.Any]] = {
+            "isel": isel_kwargs,
+            "sel": sel_kwargs,
+            "qsel": qsel_kwargs,
+        }
+        for row in self.rows:
+            if not row.use_check.isChecked():
+                continue
+            dim, indexer = row.indexer()
+            target[row.method][dim] = indexer
+            width_indexer = row.qsel_width_indexer()
+            if width_indexer is not None:
+                width_dim, width = width_indexer
+                qsel_kwargs[width_dim] = width
+
+        return isel_kwargs, sel_kwargs, qsel_kwargs
+
+    def source_operations(
+        self,
+    ) -> list[erlab.interactive.imagetool.provenance.ToolProvenanceOperation]:
+        isel_kwargs, sel_kwargs, qsel_kwargs = self._selection_kwargs()
+        operations: list[
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation
+        ] = []
+        if isel_kwargs:
+            operations.append(
+                erlab.interactive.imagetool.provenance.IselOperation(kwargs=isel_kwargs)
+            )
+        if sel_kwargs:
+            operations.append(
+                erlab.interactive.imagetool.provenance.SelOperation(kwargs=sel_kwargs)
+            )
+        if qsel_kwargs:
+            operations.append(
+                erlab.interactive.imagetool.provenance.QSelOperation(kwargs=qsel_kwargs)
+            )
+        return operations
+
+    def process_data(self, data: xr.DataArray) -> xr.DataArray:
+        isel_kwargs, sel_kwargs, qsel_kwargs = self._selection_kwargs()
+        if isel_kwargs:
+            data = data.isel(isel_kwargs)
+        if sel_kwargs:
+            data = data.sel(sel_kwargs)
+        if qsel_kwargs:
+            data = data.qsel(qsel_kwargs)
+        return data
+
+    def make_code(self) -> str:
+        placeholder = self.slicer_area.watched_data_name or ""
+        code = placeholder
+        for method, kwargs in zip(
+            ("isel", "sel", "qsel"),
+            self._selection_kwargs(),
+            strict=True,
+        ):
+            if kwargs:
+                code += f".{method}({erlab.interactive.utils.format_kwargs(kwargs)})"
+        return code
+
+    @QtCore.Slot()
+    @QtCore.Slot(int)
+    @QtCore.Slot(bool)
+    @QtCore.Slot(object)
+    def update_preview(self, *args) -> None:
+        try:
+            selected = self.process_data(self.public_data)
+        except Exception as exc:
+            self.preview_label.setText(f"Invalid selection: {exc}")
+            self.code_preview.setPlainText(self.make_code())
+            ok_button = self.buttonBox.button(
+                QtWidgets.QDialogButtonBox.StandardButton.Ok
+            )
+            if ok_button is not None:
+                ok_button.setEnabled(False)
+            return
+
+        shape = " × ".join(str(size) for size in selected.shape)
+        dims = ", ".join(str(dim) for dim in selected.dims)
+        self.preview_label.setText(f"{selected.ndim}D ({shape}) [{dims}]")
+        self.code_preview.setPlainText(self.make_code())
+        ok_button = self.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        if ok_button is not None:
+            ok_button.setEnabled(
+                bool(self.source_operations())
+                and 2 <= selected.ndim <= 4
+                and selected.size > 0
+            )
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        if not self.source_operations():
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Selection",
+                "Select at least one dimension before applying.",
+            )
+            return
+
+        try:
+            selected = self.process_data(self.public_data)
+        except Exception:
+            erlab.interactive.utils.MessageDialog.critical(
+                self, "Error", "An error occurred while selecting data."
+            )
+            return
+
+        if not (2 <= selected.ndim <= 4) or selected.size == 0:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Invalid Selection",
+                "Selected data must have 2 to 4 dimensions and contain at least "
+                "one value.",
+            )
+            return
+
+        super().accept()
+
+
 class InterpolationDialog(DataTransformDialog):
     title = "Interpolate"
     enable_copy = True
@@ -1526,9 +1917,9 @@ class _BaseCropDialog(DataTransformDialog):
 
         out: str = self.slicer_area.watched_data_name or ""
         if sel_kwargs:
-            out += f".sel({erlab.interactive.utils.format_call_kwargs(sel_kwargs)})"
+            out += f".sel({erlab.interactive.utils.format_kwargs(sel_kwargs)})"
         if isel_kwargs:
-            out += f".isel({erlab.interactive.utils.format_call_kwargs(isel_kwargs)})"
+            out += f".isel({erlab.interactive.utils.format_kwargs(isel_kwargs)})"
 
         return out
 

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -4842,7 +4842,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 )
                 slicer_area.set_data(data, auto_compute=False)
                 slicer_area.state = state
-                node.name = name
+                node._set_name(name, manual=False)
 
     def offload_to_workspace(
         self, targets: Iterable[int | str], *, native: bool = True

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1142,12 +1142,14 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self.reindex_action.setToolTip("Reset indices of all windows")
 
         self.link_action = QtWidgets.QAction("Link", self)
-        self.link_action.triggered.connect(self.link_selected)
+        self.link_action.triggered.connect(lambda _checked=False: self.link_selected())
         self.link_action.setShortcut(QtGui.QKeySequence("Ctrl+L"))
         self.link_action.setToolTip("Link selected windows")
 
         self.unlink_action = QtWidgets.QAction("Unlink", self)
-        self.unlink_action.triggered.connect(self.unlink_selected)
+        self.unlink_action.triggered.connect(
+            lambda _checked=False: self.unlink_selected()
+        )
         self.unlink_action.setShortcut(QtGui.QKeySequence("Ctrl+Shift+L"))
         self.unlink_action.setToolTip("Unlink selected windows")
 

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3495,8 +3495,15 @@ class ImageToolManager(QtWidgets.QMainWindow):
     @QtCore.Slot(bool)
     def unlink_selected(self, deselect: bool = True) -> None:
         """Unlink selected ImageTool windows."""
+        dirty_uids: list[str] = []
         for index in self._selected_imagetool_targets():
-            self.get_imagetool(index).slicer_area.unlink()
+            node = self._node_for_target(index)
+            slicer_area = self.get_imagetool(index).slicer_area
+            if slicer_area.is_linked:
+                dirty_uids.append(node.uid)
+            slicer_area.unlink()
+        for uid in dirty_uids:
+            self._mark_node_state_dirty(uid)
         self._sigReloadLinkers.emit()
         if deselect:
             self.tree_view.deselect_all()
@@ -3624,11 +3631,15 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
     def link_imagetools(self, *indices: int | str, link_colors: bool = True) -> None:
         """Link the ImageTool windows corresponding to the given indices."""
+        if len(indices) <= 1:
+            return
         linker = erlab.interactive.imagetool.viewer.SlicerLinkProxy(
             *[self.get_imagetool(t).slicer_area for t in indices],
             link_colors=link_colors,
         )
         self._linkers.append(linker)
+        for index in indices:
+            self._mark_node_state_dirty(self._node_for_target(index).uid)
         self._sigReloadLinkers.emit()
 
     def name_of_imagetool(self, index: int) -> str:
@@ -3764,6 +3775,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         *,
         parent_target: int | str | None,
         node_path: str | None,
+        loaded_targets_by_uid: dict[str, int | str] | None = None,
     ) -> int | str:
         uid = ds.attrs.get("manager_node_uid")
         provenance_spec = ds.attrs.get("manager_node_provenance_spec")
@@ -3821,12 +3833,16 @@ class ImageToolManager(QtWidgets.QMainWindow):
             tool_kwargs["auto_compute"] = False
         tool = ImageTool.from_dataset(ds, **tool_kwargs)
         if parent_target is not None:
-            return self.add_imagetool_child(
+            target = self.add_imagetool_child(
                 tool,
                 parent_target,
                 show=ds.attrs.get("itool_visible", True),
                 **kwargs,
             )
+            self._record_workspace_loaded_imagetool_target(
+                ds, target, loaded_targets_by_uid
+            )
+            return target
 
         kwargs.pop("output_id", None)
         kwargs["source_input_ndim"] = typing.cast(
@@ -3856,12 +3872,16 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 preferred_index = int(node_path)
             if preferred_index is not None and preferred_index < 0:
                 preferred_index = None
-        return self.add_imagetool(
+        target = self.add_imagetool(
             tool,
             show=ds.attrs.get("itool_visible", True),
             index=preferred_index,
             **kwargs,
         )
+        self._record_workspace_loaded_imagetool_target(
+            ds, target, loaded_targets_by_uid
+        )
+        return target
 
     def _load_workspace_tool_dataset(
         self, ds: xr.Dataset, *, parent_target: int | str | None
@@ -3875,6 +3895,88 @@ class ImageToolManager(QtWidgets.QMainWindow):
             uid=ds.attrs.get("manager_node_uid"),
         )
 
+    @staticmethod
+    def _workspace_saved_uid_from_dataset(ds: xr.Dataset) -> str | None:
+        uid = ds.attrs.get("manager_node_uid")
+        if isinstance(uid, bytes):
+            with contextlib.suppress(UnicodeDecodeError):
+                uid = uid.decode()
+        if isinstance(uid, str) and uid:
+            return uid
+        return None
+
+    def _record_workspace_loaded_imagetool_target(
+        self,
+        ds: xr.Dataset,
+        target: int | str,
+        loaded_targets_by_uid: dict[str, int | str] | None,
+    ) -> None:
+        if loaded_targets_by_uid is None:
+            return
+        saved_uid = self._workspace_saved_uid_from_dataset(ds)
+        if saved_uid is not None:
+            loaded_targets_by_uid[saved_uid] = target
+
+    def _restore_workspace_link_groups(
+        self,
+        manifest: Mapping[str, typing.Any] | None,
+        loaded_targets_by_uid: Mapping[str, int | str],
+    ) -> None:
+        if manifest is None:
+            return
+        nodes = manifest.get("nodes", ())
+        if not isinstance(nodes, list):
+            return
+
+        group_targets: dict[int, list[int | str]] = {}
+        group_colors: dict[int, bool] = {}
+        invalid_groups: set[int] = set()
+        for entry in nodes:
+            if not isinstance(entry, dict) or "link_group" not in entry:
+                continue
+            uid = entry.get("uid")
+            link_group = entry.get("link_group")
+            link_colors = entry.get("link_colors")
+            if (
+                not isinstance(uid, str)
+                or type(link_group) is not int
+                or not isinstance(link_colors, bool)
+            ):
+                continue
+            target = loaded_targets_by_uid.get(uid)
+            if target is None:
+                continue
+            try:
+                node = self._node_for_target(target)
+            except KeyError:
+                continue
+            if not node.is_imagetool or node.imagetool is None:
+                continue
+            current_group_colors = group_colors.get(link_group)
+            if current_group_colors is None:
+                group_colors[link_group] = link_colors
+            elif current_group_colors != link_colors:
+                invalid_groups.add(link_group)
+                continue
+            targets = group_targets.setdefault(link_group, [])
+            if target not in targets:
+                targets.append(target)
+
+        for link_group in sorted(group_targets):
+            if link_group in invalid_groups:
+                continue
+            targets = [
+                target
+                for target in group_targets[link_group]
+                if not self.get_imagetool(target).slicer_area.is_linked
+            ]
+            if len(targets) <= 1:
+                continue
+            self.link_imagetools(
+                *targets,
+                link_colors=group_colors.get(link_group, True),
+            )
+
     def _load_workspace_node(
         self,
         node_tree: xr.DataTree,
@@ -3884,6 +3986,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         manifest: dict[str, typing.Any] | None = None,
         node_path: str | None = None,
         workspace_file_path: str | os.PathLike[str] | None = None,
+        loaded_targets_by_uid: dict[str, int | str] | None = None,
     ) -> int | str:
         if "imagetool" in node_tree:
             ds = None
@@ -3918,7 +4021,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     .load()
                 )
             target = self._load_workspace_imagetool_dataset(
-                ds, parent_target=parent_target, node_path=node_path
+                ds,
+                parent_target=parent_target,
+                node_path=node_path,
+                loaded_targets_by_uid=loaded_targets_by_uid,
             )
         elif "tool" in node_tree:
             ds = (
@@ -3971,6 +4077,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         if node_path is None
                         else f"{node_path}/childtools/{child_key}"
                     ),
+                    loaded_targets_by_uid=loaded_targets_by_uid,
                 )
         return target
 
@@ -3982,6 +4089,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         root_item: QtWidgets.QTreeWidgetItem | None = None,
         manifest: dict[str, typing.Any] | None = None,
         workspace_file_path: str | os.PathLike[str] | None = None,
+        loaded_targets_by_uid: dict[str, int | str] | None = None,
     ) -> None:
         for key in root_keys:
             if key not in tree:
@@ -3995,6 +4103,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     manifest=manifest,
                     workspace_file_path=workspace_file_path,
                     node_path=key,
+                    loaded_targets_by_uid=loaded_targets_by_uid,
                 )
 
     def _from_h5py_workspace_file(
@@ -4035,6 +4144,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if not root_paths:
             raise ValueError("Workspace manifest has no root ImageTool nodes")
 
+        loaded_targets_by_uid: dict[str, int | str] = {}
         child_paths: dict[str, list[str]] = {path: [] for path in entries_by_path}
         for path in entries_by_path:
             if "/childtools/" not in path:
@@ -4091,6 +4201,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     ds,
                     parent_target=parent_target,
                     node_path=path,
+                    loaded_targets_by_uid=loaded_targets_by_uid,
                 )
             else:
                 target = self._load_workspace_tool_dataset(
@@ -4126,6 +4237,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     self.remove_all_tools()
                 for root_path in root_paths:
                     _load_path(root_path)
+                self._restore_workspace_link_groups(manifest, loaded_targets_by_uid)
                 if not mark_dirty:
                     self._drain_workspace_deferred_events()
             except Exception:
@@ -4210,6 +4322,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             )
             backup_tree: xr.DataTree | None = None
             backup_snapshot: dict[str, typing.Any] | None = None
+            loaded_targets_by_uid: dict[str, int | str] = {}
             with (
                 maybe_guard,
                 erlab.interactive.utils.wait_dialog(self, "Loading workspace..."),
@@ -4230,7 +4343,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         root_item=root_item,
                         manifest=manifest,
                         workspace_file_path=workspace_file_path,
+                        loaded_targets_by_uid=loaded_targets_by_uid,
                     )
+                    self._restore_workspace_link_groups(manifest, loaded_targets_by_uid)
                     if not mark_dirty:
                         self._drain_workspace_deferred_events()
                 except Exception:
@@ -4309,8 +4424,31 @@ class ImageToolManager(QtWidgets.QMainWindow):
         ]
         return (*displayed, *remaining)
 
+    def _workspace_link_metadata_by_uid(self) -> dict[str, tuple[int, bool]]:
+        metadata: dict[str, tuple[int, bool]] = {}
+        group_index = 0
+        for linker in self._linkers:
+            linked_nodes: list[_ImageToolWrapper | _ManagedWindowNode] = []
+            for slicer_area in linker.children:
+                node = self.node_from_slicer_area(slicer_area)
+                if (
+                    node is None
+                    or not node.is_imagetool
+                    or node.imagetool is None
+                    or node.slicer_area._linking_proxy is not linker
+                ):
+                    continue
+                linked_nodes.append(node)
+            if len(linked_nodes) <= 1:
+                continue
+            for node in linked_nodes:
+                metadata[node.uid] = (group_index, bool(linker.link_colors))
+            group_index += 1
+        return metadata
+
     def _workspace_node_manifest_entries(self) -> list[dict[str, typing.Any]]:
         entries: list[dict[str, typing.Any]] = []
+        link_metadata = self._workspace_link_metadata_by_uid()
 
         def _append(uid: str) -> None:
             node = self._all_nodes[uid]
@@ -4329,6 +4467,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     entry["data_backing"] = "file_lazy"
                 else:
                     entry["data_backing"] = "memory"
+                link_info = link_metadata.get(uid)
+                if link_info is not None:
+                    entry["link_group"], entry["link_colors"] = link_info
             entries.append(entry)
             for child_uid in node._childtool_indices:
                 if child_uid in self._all_nodes:

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -1654,7 +1654,9 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
             return
 
         wrapper.slicer_area.unlink()
-        self._model.manager._sigReloadLinkers.emit()
+        manager = self._model.manager
+        manager._mark_node_state_dirty(wrapper.uid)
+        manager._sigReloadLinkers.emit()
         self.refresh(wrapper.index)
 
     def _show_watched_badge_menu(

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -667,6 +667,128 @@ def _read_workspace_root_attrs_h5py(
         return _h5py_attrs_to_dict(h5_file.attrs)
 
 
+def _workspace_h5py_dataset_storage_supported(dataset: typing.Any) -> bool:
+    import h5py
+
+    return dataset.dtype.kind in "biufcS" or (
+        dataset.dtype.kind == "O" and h5py.check_string_dtype(dataset.dtype) is not None
+    )
+
+
+def _workspace_h5py_coord_dims_fit(
+    coord: xr.DataArray, data_array: xr.DataArray
+) -> bool:
+    return all(
+        dim in data_array.sizes and coord.sizes[dim] == data_array.sizes[dim]
+        for dim in coord.dims
+    )
+
+
+def _workspace_h5py_variable_payload(
+    variable: xr.Variable, name: typing.Hashable
+) -> tuple[typing.Any, dict[typing.Hashable, typing.Any], typing.Any] | None:
+    import h5py
+    import numpy as np
+    import xarray as xr
+
+    try:
+        if variable.dtype.kind == "M":
+            variable = xr.coders.CFDatetimeCoder().encode(variable, name=str(name))
+        elif variable.dtype.kind == "m":
+            variable = xr.coders.CFTimedeltaCoder().encode(variable, name=str(name))
+    except Exception:
+        return None
+
+    data = np.asarray(variable.data)
+    dtype = None
+    if data.dtype.kind == "U":
+        data = data.astype(object)
+        dtype = h5py.string_dtype(encoding="utf-8")
+    elif data.dtype.kind not in "biufcS":
+        return None
+    return data, dict(variable.attrs), dtype
+
+
+def _workspace_h5py_dataarray_can_write(data_array: xr.DataArray) -> bool:
+    if data_array.chunks is not None:
+        return False
+    return (
+        _workspace_h5py_variable_payload(data_array.variable, data_array.name)
+        is not None
+    )
+
+
+def _workspace_h5py_read_values(dataset: typing.Any) -> typing.Any:
+    import h5py
+    import numpy as np
+
+    string_info = h5py.check_string_dtype(dataset.dtype)
+    if dataset.dtype.kind == "O" and string_info is not None:
+        values = np.asarray(dataset.asstr()[()])
+        if values.dtype.kind == "O":
+            values = values.astype(str)
+        return values
+    return np.asarray(dataset[()])
+
+
+def _workspace_h5py_decode_coord_variable(
+    variable: xr.Variable, name: str
+) -> xr.Variable | None:
+    import xarray as xr
+
+    attrs = variable.attrs
+    dtype_attr = attrs.get("dtype")
+    units_attr = attrs.get("units")
+    calendar_attr = attrs.get("calendar")
+    try:
+        if isinstance(dtype_attr, str) and dtype_attr.startswith("timedelta64["):
+            return xr.coders.CFTimedeltaCoder().decode(variable, name=name)
+        if (
+            isinstance(units_attr, str)
+            and isinstance(calendar_attr, str)
+            and " since " in units_attr
+        ):
+            return xr.coders.CFDatetimeCoder().decode(variable, name=name)
+    except Exception:
+        return None
+    return variable
+
+
+def _workspace_h5py_dataset_variable(
+    dataset: typing.Any,
+    dims: tuple[str, ...],
+    *,
+    name: str,
+    exclude_attrs: Iterable[typing.Hashable],
+) -> xr.Variable | None:
+    import xarray as xr
+
+    if not _workspace_h5py_dataset_storage_supported(dataset):
+        return None
+    variable = xr.Variable(
+        dims,
+        _workspace_h5py_read_values(dataset),
+        _h5py_attrs_to_dict(dataset.attrs, exclude=exclude_attrs),
+    )
+    return _workspace_h5py_decode_coord_variable(variable, name)
+
+
+def _workspace_h5py_create_dataset(
+    group: typing.Any, name: str, variable: xr.Variable
+) -> typing.Any | None:
+    payload = _workspace_h5py_variable_payload(variable, name)
+    if payload is None:
+        return None
+    data, attrs, dtype = payload
+    kwargs: dict[str, typing.Any] = {}
+    if dtype is not None:
+        kwargs["dtype"] = dtype
+    dataset = group.create_dataset(name, data=data, **kwargs)
+    for key, value in attrs.items():
+        dataset.attrs[key] = value
+    return dataset
+
+
 def _read_workspace_dataset_group_h5py(
     fname: str | os.PathLike[str],
     group_path: str,
@@ -694,7 +816,9 @@ def _read_workspace_dataset_group_h5py(
         group = h5_file[group_path]
         datasets: dict[str, h5py.Dataset] = {}
         for name, obj in group.items():
-            if not isinstance(obj, h5py.Dataset) or obj.dtype.kind not in "biufc":
+            if not isinstance(
+                obj, h5py.Dataset
+            ) or not _workspace_h5py_dataset_storage_supported(obj):
                 continue
             marker = obj.attrs.get("CLASS")
             if isinstance(marker, bytes):
@@ -721,13 +845,15 @@ def _read_workspace_dataset_group_h5py(
                     not isinstance(scale, h5py.Dataset)
                     or scale.ndim != 1
                     or scale.shape[0] != dataset.shape[axis]
-                    or scale.dtype.kind not in "biufc"
+                    or not _workspace_h5py_dataset_storage_supported(scale)
                 ):
                     return None
                 dims.append(dim_name)
             return tuple(dims)
 
         data_dataset = datasets[data_name]
+        if data_dataset.dtype.kind not in "biufc":
+            return None
         dims: list[str] = []
         coords: dict[str, typing.Any] = {}
         for axis, dim in enumerate(data_dataset.dims):
@@ -740,15 +866,19 @@ def _read_workspace_dataset_group_h5py(
                 not isinstance(scale, h5py.Dataset)
                 or scale.ndim != 1
                 or scale.shape[0] != data_dataset.shape[axis]
-                or scale.dtype.kind not in "biufc"
+                or not _workspace_h5py_dataset_storage_supported(scale)
             ):
                 return None
             dims.append(dim_name)
-            coords[dim_name] = (
-                dim_name,
-                np.asarray(scale[()]),
-                _h5py_attrs_to_dict(scale.attrs, exclude=internal_attrs),
+            coord_variable = _workspace_h5py_dataset_variable(
+                scale,
+                (dim_name,),
+                name=dim_name,
+                exclude_attrs=internal_attrs,
             )
+            if coord_variable is None:
+                return None
+            coords[dim_name] = coord_variable
 
         scalar_coord_names = data_dataset.attrs.get("coordinates", "")
         if isinstance(scalar_coord_names, bytes):
@@ -758,7 +888,7 @@ def _read_workspace_dataset_group_h5py(
             for name, dataset in datasets.items()
             if name != data_name
             and _serialization.coord_name_needs_private_storage(name)
-            and dataset.dtype.kind in "biufc"
+            and _workspace_h5py_dataset_storage_supported(dataset)
         )
         if isinstance(scalar_coord_names, str):
             for coord_name in scalar_coord_names.split():
@@ -769,13 +899,21 @@ def _read_workspace_dataset_group_h5py(
                         continue
                     return None
                 coord_dataset = group[coord_name]
-                if coord_dataset.ndim != 0 or coord_dataset.dtype.kind not in "biufc":
-                    return None
-                coords[coord_name] = (
-                    (),
-                    np.asarray(coord_dataset[()]),
-                    _h5py_attrs_to_dict(coord_dataset.attrs, exclude=internal_attrs),
+                if coord_dataset.ndim == 0:
+                    coord_dims = ()
+                else:
+                    coord_dims = _dataset_dims(coord_dataset)
+                    if coord_dims is None or not all(dim in dims for dim in coord_dims):
+                        return None
+                coord_variable = _workspace_h5py_dataset_variable(
+                    coord_dataset,
+                    coord_dims,
+                    name=coord_name,
+                    exclude_attrs=internal_attrs,
                 )
+                if coord_variable is None:
+                    return None
+                coords[coord_name] = coord_variable
 
         data_attrs = _h5py_attrs_to_dict(data_dataset.attrs, exclude=internal_attrs)
         data_vars: dict[typing.Hashable, typing.Any] = {
@@ -797,15 +935,19 @@ def _read_workspace_dataset_group_h5py(
             coord_dims = tuple(record["dims"])
             if (
                 coord_dataset.ndim != len(coord_dims)
-                or coord_dataset.dtype.kind not in "biufc"
+                or not _workspace_h5py_dataset_storage_supported(coord_dataset)
                 or not all(dim in dims for dim in coord_dims)
             ):
                 return None
-            data_vars[variable_name] = (
+            coord_variable = _workspace_h5py_dataset_variable(
+                coord_dataset,
                 coord_dims,
-                np.asarray(coord_dataset[()]),
-                _h5py_attrs_to_dict(coord_dataset.attrs, exclude=internal_attrs),
+                name=variable_name,
+                exclude_attrs=internal_attrs,
             )
+            if coord_variable is None:
+                return None
+            data_vars[variable_name] = coord_variable
 
         for variable_name in legacy_spaced_coord_names:
             if variable_name in data_vars:
@@ -814,11 +956,15 @@ def _read_workspace_dataset_group_h5py(
             coord_dims = _dataset_dims(coord_dataset)
             if coord_dims is None or not all(dim in dims for dim in coord_dims):
                 continue
-            data_vars[variable_name] = (
+            coord_variable = _workspace_h5py_dataset_variable(
+                coord_dataset,
                 coord_dims,
-                np.asarray(coord_dataset[()]),
-                _h5py_attrs_to_dict(coord_dataset.attrs, exclude=internal_attrs),
+                name=variable_name,
+                exclude_attrs=internal_attrs,
             )
+            if coord_variable is None:
+                continue
+            data_vars[variable_name] = coord_variable
 
         return _serialization.restore_private_coords(
             xr.Dataset(
@@ -856,18 +1002,26 @@ def _workspace_dataset_can_write_h5py(ds: xr.Dataset) -> bool:
         private_data = ds[private_name]
         if (
             private_data.chunks is not None
-            or private_data.dtype.kind not in "biufc"
-            or not all(dim in data_array.dims for dim in private_data.dims)
+            or not _workspace_h5py_coord_dims_fit(private_data, data_array)
+            or not _workspace_h5py_dataarray_can_write(private_data)
         ):
             return False
     for dim in data_array.dims:
         coord = ds.coords.get(dim)
-        if coord is None or coord.dims != (dim,) or coord.dtype.kind not in "biufc":
+        if (
+            coord is None
+            or coord.dims != (dim,)
+            or not _workspace_h5py_dataarray_can_write(coord)
+        ):
             return False
     for name, coord in ds.coords.items():
         if name in data_array.dims:
             continue
-        if coord.ndim != 0 or coord.dtype.kind not in "biufc":
+        if (
+            _serialization.coord_name_needs_private_storage(name)
+            or not _workspace_h5py_coord_dims_fit(coord, data_array)
+            or not _workspace_h5py_dataarray_can_write(coord)
+        ):
             return False
     return True
 
@@ -905,13 +1059,17 @@ def _write_workspace_dataset_group_h5py(
             dim_scales_by_name = {}
             for dim_id, dim in enumerate(data_array.dims):
                 coord = ds.coords[dim]
-                coord_dataset = group.create_dataset(
-                    str(dim), data=np.asarray(coord.data)
+                coord_dataset = _workspace_h5py_create_dataset(
+                    group, str(dim), coord.variable
                 )
+                if coord_dataset is None:
+                    del parent[group_name]
+                    return False
                 coord_dataset.make_scale(str(dim))
                 coord_dataset.attrs["_Netcdf4Dimid"] = np.int32(dim_id)
-                for key, value in coord.attrs.items():
-                    coord_dataset.attrs[key] = value
+                coord_dataset.attrs["_Netcdf4Coordinates"] = np.asarray(
+                    [dim_id], dtype=np.int32
+                )
                 dim_scales.append(coord_dataset)
                 dim_scales_by_name[dim] = coord_dataset
 
@@ -941,11 +1099,22 @@ def _write_workspace_dataset_group_h5py(
             for name, coord in ds.coords.items():
                 if name in data_array.dims:
                     continue
-                coord_dataset = group.create_dataset(
-                    str(name), data=np.asarray(coord.data)
+                coord_dataset = _workspace_h5py_create_dataset(
+                    group, str(name), coord.variable
                 )
-                for key, value in coord.attrs.items():
-                    coord_dataset.attrs[key] = value
+                if coord_dataset is None:
+                    del parent[group_name]
+                    return False
+                coordinate_ids = []
+                for coord_dim_index, coord_dim in enumerate(coord.dims):
+                    scale = dim_scales_by_name[coord_dim]
+                    coord_dataset.dims[coord_dim_index].attach_scale(scale)
+                    coordinate_ids.append(data_array.dims.index(coord_dim))
+                if coordinate_ids:
+                    coord_dataset.attrs["_Netcdf4Coordinates"] = np.asarray(
+                        coordinate_ids, dtype=np.int32
+                    )
+                    coord_dataset.attrs["_Netcdf4Dimid"] = np.int32(coordinate_ids[0])
                 scalar_coord_names.append(str(name))
             if scalar_coord_names:
                 existing_coordinates = data_dataset.attrs.get("coordinates")
@@ -958,20 +1127,24 @@ def _write_workspace_dataset_group_h5py(
 
             for private_name in private_data_names:
                 private_data = ds[private_name]
-                private_dataset = group.create_dataset(
-                    str(private_name), data=np.asarray(private_data.data)
+                private_dataset = _workspace_h5py_create_dataset(
+                    group, str(private_name), private_data.variable
                 )
-                coordinate_ids: list[int] = []
+                if private_dataset is None:
+                    del parent[group_name]
+                    return False
+                private_coordinate_ids: list[int] = []
                 for private_dim_index, private_dim in enumerate(private_data.dims):
                     scale = dim_scales_by_name[private_dim]
                     private_dataset.dims[private_dim_index].attach_scale(scale)
-                    coordinate_ids.append(data_array.dims.index(private_dim))
-                if coordinate_ids:
+                    private_coordinate_ids.append(data_array.dims.index(private_dim))
+                if private_coordinate_ids:
                     private_dataset.attrs["_Netcdf4Coordinates"] = np.asarray(
-                        coordinate_ids, dtype=np.int32
+                        private_coordinate_ids, dtype=np.int32
                     )
-                for key, value in private_data.attrs.items():
-                    private_dataset.attrs[key] = value
+                    private_dataset.attrs["_Netcdf4Dimid"] = np.int32(
+                        private_coordinate_ids[0]
+                    )
         except Exception:
             del parent[group_name]
             return False

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -737,13 +737,13 @@ class _ManagedWindowNode(QtCore.QObject):
                 erlab.interactive.utils.single_shot(
                     self.slicer_area, 0, self.slicer_area._update_if_delayed
                 )
-            mark_dirty = (
-                self.manager._workspace_loading_depth == 0
-                and self.manager._workspace_saving_depth == 0
-                and not self.manager._suppress_workspace_visibility_dirty
-            )
 
             def _mark_visibility_changed() -> None:
+                mark_dirty = (
+                    self.manager._workspace_loading_depth == 0
+                    and self.manager._workspace_saving_depth == 0
+                    and not self.manager._suppress_workspace_visibility_dirty
+                )
                 self.visibility_changed(mark_dirty=mark_dirty)
 
             erlab.interactive.utils.single_shot(
@@ -818,6 +818,8 @@ class _ManagedWindowNode(QtCore.QObject):
 
     @QtCore.Slot()
     def _handle_imagetool_state_changed(self) -> None:
+        if self.manager._suppress_workspace_visibility_dirty:
+            return
         self.manager._mark_node_state_dirty(self.uid)
 
     @QtCore.Slot()

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -139,6 +139,10 @@ class _ManagedWindowNode(QtCore.QObject):
             "imagetool" if isinstance(window, ImageTool) else "tool"
         )
         self._name = window.windowTitle()
+        self._name_manually_overridden = (
+            isinstance(window, ImageTool)
+            and self._name.replace("[*]", "") != window.slicer_area.display_name
+        )
 
         self._source_spec: (
             erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None
@@ -316,12 +320,17 @@ class _ManagedWindowNode(QtCore.QObject):
 
     @name.setter
     def name(self, name: str) -> None:
+        self._set_name(name, manual=True)
+
+    def _set_name(self, name: str, *, manual: bool) -> None:
+        if manual:
+            self._name_manually_overridden = True
         if self.tool_window is not None:
             self.tool_window._tool_display_name = name
             self.manager.tree_view.refresh(self.uid)
             self.manager._mark_node_state_dirty(self.uid)
             return
-        if name == self._name and self.imagetool is not None:
+        if name == self._name and self.imagetool is not None and not manual:
             return
         self._name = name
         if self.imagetool is not None:
@@ -760,7 +769,10 @@ class _ManagedWindowNode(QtCore.QObject):
             if title is None:
                 title = self.imagetool.windowTitle()
             title = title.replace("[*]", "")
-            self.name = title
+            if self._name_manually_overridden:
+                self.imagetool.setWindowTitle(self.label_text)
+                return
+            self._set_name(title, manual=False)
 
     @QtCore.Slot()
     def visibility_changed(self, *, mark_dirty: bool = True) -> None:

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -1060,13 +1060,11 @@ class ItoolPlotItem(pg.PlotItem):
                 qsel_kw = self.array_slicer.qsel_args(cursor, self.display_axis)
                 qsel_kw = qsel_kw | sel_indexers
 
-                sel_code = erlab.interactive.utils.format_call_kwargs(qsel_kw)
+                sel_code = erlab.interactive.utils.format_kwargs(qsel_kw)
                 sel_code = f".qsel({sel_code})"
 
                 if isel_indexers:
-                    isel_code = erlab.interactive.utils.format_call_kwargs(
-                        isel_indexers
-                    )
+                    isel_code = erlab.interactive.utils.format_kwargs(isel_indexers)
                     sel_code = sel_code + f".isel({isel_code})"
 
                 return sel_code
@@ -1079,11 +1077,11 @@ class ItoolPlotItem(pg.PlotItem):
 
             if isel_kw or isel_indexers:
                 isel_kw.update(isel_indexers)
-                sel_code = erlab.interactive.utils.format_call_kwargs(isel_kw)
+                sel_code = erlab.interactive.utils.format_kwargs(isel_kw)
                 sel_code = f".isel({sel_code})"
 
             if sel_indexers:
-                crop_code = erlab.interactive.utils.format_call_kwargs(sel_indexers)
+                crop_code = erlab.interactive.utils.format_kwargs(sel_indexers)
                 sel_code = sel_code + f".sel({crop_code})"
 
         return sel_code
@@ -1582,13 +1580,9 @@ class ItoolPlotItem(pg.PlotItem):
 
         selected = data_name
         if isel_kwargs:
-            selected += (
-                f".isel({erlab.interactive.utils.format_call_kwargs(isel_kwargs)})"
-            )
+            selected += f".isel({erlab.interactive.utils.format_kwargs(isel_kwargs)})"
         if qsel_kwargs:
-            selected += (
-                f".qsel({erlab.interactive.utils.format_call_kwargs(qsel_kwargs)})"
-            )
+            selected += f".qsel({erlab.interactive.utils.format_kwargs(qsel_kwargs)})"
         if avg_nonuniform_dims:
             avg_arg = (
                 erlab.interactive.utils._parse_single_arg(avg_nonuniform_dims[0])
@@ -1718,7 +1712,7 @@ class ItoolPlotItem(pg.PlotItem):
             )
             selected = (
                 f"{data_name}.qsel("
-                f"{erlab.interactive.utils.format_call_kwargs(qsel_kwargs_nonnull)})"
+                f"{erlab.interactive.utils.format_kwargs(qsel_kwargs_nonnull)})"
             )
             if variable_dim is None:
                 plot_lines.append(selected + ".plot(ax=ax)")
@@ -1855,7 +1849,7 @@ class ItoolPlotItem(pg.PlotItem):
             if variable_dim is None:
                 selected_maps = [
                     f"{data_name}.qsel("
-                    f"{erlab.interactive.utils.format_call_kwargs(qsel_kwargs_nonnull)})"
+                    f"{erlab.interactive.utils.format_kwargs(qsel_kwargs_nonnull)})"
                 ]
             else:
                 selected_maps = []
@@ -1866,7 +1860,7 @@ class ItoolPlotItem(pg.PlotItem):
                     }
                     selected_maps.append(
                         f"{data_name}.qsel("
-                        f"{erlab.interactive.utils.format_call_kwargs(selected_map)})"
+                        f"{erlab.interactive.utils.format_kwargs(selected_map)})"
                     )
             return self._plot_code_image(
                 data_name,

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -748,16 +748,23 @@ class ItoolPlotItem(pg.PlotItem):
             return
 
         menu.clear()
-        coord_profiles = self._displayed_associated_coord_profiles()
-        has_coord_profiles = bool(coord_profiles)
-        typing.cast("QtGui.QAction", menu.menuAction()).setVisible(has_coord_profiles)
+        coord_names: tuple[Hashable, ...] = ()
+        if len(self.display_axis) == 1:
+            display_dim = self.array_slicer._obj.dims[self.display_axis[0]]
+            coord_names = tuple(
+                name
+                for name in _plotted_associated_coord_names(self.array_slicer)
+                if display_dim in self.array_slicer.associated_coord_dims[name]
+            )
+        has_coords = bool(coord_names)
+        typing.cast("QtGui.QAction", menu.menuAction()).setVisible(has_coords)
         for separator in (
             self._associated_coord_menu_separator_above,
             self._associated_coord_menu_separator_below,
         ):
             if separator is not None:
-                separator.setVisible(has_coord_profiles)
-        for coord_name, _profile in coord_profiles:
+                separator.setVisible(has_coords)
+        for coord_name in coord_names:
             if len(self.array_slicer.associated_coord_dims[coord_name]) == 1:
                 coord_action = typing.cast(
                     "QtGui.QAction", menu.addAction(str(coord_name))
@@ -2519,7 +2526,7 @@ class ItoolPlotItem(pg.PlotItem):
     def refresh_items_data(
         self, cursor: int | tuple[int, ...], axes: tuple[int, ...] | None = None
     ) -> None:
-        if self.slicer_area.data_chunked:
+        if self.array_slicer._obj.chunks is not None:
             # When data is chunked, refreshing is handled by _handle_refresh_dask
             return
 

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -1219,8 +1219,14 @@ class ItoolPlotItem(pg.PlotItem):
     def _connect_guideline_history(self) -> None:
         for item in self._guidelines_items[:-1]:
             typing.cast("typing.Any", item)._sigAngleDragStarted.connect(
+                self.slicer_area.begin_history_group
+            )
+            typing.cast("typing.Any", item)._sigAngleDragStarted.connect(
                 self.slicer_area.sigWriteHistory.emit
             )
+        typing.cast(
+            "typing.Any", self._guidelines_items[-1]
+        ).sigPositionDragStarted.connect(self.slicer_area.begin_history_group)
         typing.cast(
             "typing.Any", self._guidelines_items[-1]
         ).sigPositionDragStarted.connect(self.slicer_area.sigWriteHistory.emit)
@@ -2381,7 +2387,10 @@ class ItoolPlotItem(pg.PlotItem):
                 lambda v, *, line=c, axis=ax: self.line_drag(line, v.temp_value, axis)
             )
             c.sigClicked.connect(lambda *, line=c: self.line_click(line))
-            c._sigDragStarted.connect(lambda: self.slicer_area.sigWriteHistory.emit())
+            c._sigDragStarted.connect(lambda *_: self.slicer_area.begin_history_group())
+            c._sigDragStarted.connect(
+                lambda *_: self.slicer_area.sigWriteHistory.emit()
+            )
 
         if update:
             self.refresh_cursor(new_cursor)
@@ -2756,7 +2765,10 @@ class ItoolColorBarItem(erlab.interactive.colors.BetterColorBarItem):
         self._span.setRegion(self.limits)
         self._span.blockSignals(False)
         self._span.sigRegionChangeStarted.connect(
-            lambda: self.slicer_area.sigWriteHistory.emit()
+            lambda *_: self.slicer_area.begin_history_group()
+        )
+        self._span.sigRegionChangeStarted.connect(
+            lambda *_: self.slicer_area.sigWriteHistory.emit()
         )
         self._span.sigRegionChanged.connect(self.level_change)
         self._span.sigRegionChangeFinished.connect(self.level_change_fin)

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -2283,12 +2283,13 @@ class ItoolPlotItem(pg.PlotItem):
             data_pos_coords = (data_pos.x(), data_pos.y())
 
         if QtCore.Qt.KeyboardModifier.AltModifier in modifiers:
+            cursors = tuple(range(self.slicer_area.n_cursors))
             for c in range(self.slicer_area.n_cursors):
                 for i, ax in enumerate(self.display_axis):
                     self.slicer_area.set_value(
                         ax, data_pos_coords[i], update=False, uniform=True, cursor=c
                     )
-            self.slicer_area.refresh_all(self.display_axis)
+            self.slicer_area.refresh(cursors, self.display_axis)
         else:
             for i, ax in enumerate(self.display_axis):
                 self.slicer_area.set_value(
@@ -2426,8 +2427,8 @@ class ItoolPlotItem(pg.PlotItem):
         if cursor != self.slicer_area.current_cursor:
             self.slicer_area.set_current_cursor(cursor, update=True)
         if (
-            self.slicer_area.qapp.keyboardModifiers()
-            != QtCore.Qt.KeyboardModifier.AltModifier
+            QtCore.Qt.KeyboardModifier.AltModifier
+            not in self.slicer_area.qapp.keyboardModifiers()
         ):
             self.slicer_area.set_value(
                 axis, value, update=True, uniform=True, cursor=cursor
@@ -2438,7 +2439,7 @@ class ItoolPlotItem(pg.PlotItem):
                 self.slicer_area.set_value(
                     axis, value, update=False, uniform=True, cursor=c
                 )
-            self.slicer_area.sigIndexChanged.emit(cursors, (axis,))
+            self.slicer_area.refresh(cursors, (axis,))
 
     def remove_cursor(self, index: int) -> None:
         item = self.slicer_data_items.pop(index)

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -303,7 +303,7 @@ def _coerce_float_sequence(value: typing.Any) -> list[float]:
 def _format_selection_step(method: str, kwargs: Mapping[Hashable, typing.Any]) -> str:
     if not kwargs:
         return f"derived = derived.{method}()"
-    args = erlab.interactive.utils.format_call_kwargs(dict(kwargs))
+    args = erlab.interactive.utils.format_kwargs(dict(kwargs))
     return f"derived = derived.{method}({args})"
 
 

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -528,7 +528,7 @@ class ArraySlicer(QtCore.QObject):
         for i, (bins, indices, values) in enumerate(
             zip(state["bins"], state["indices"], state["values"], strict=True)
         ):
-            self.center_cursor(i)
+            self.center_cursor(i, update=False)
             self.set_indices(i, indices, update=False)
             self.set_values(i, values, update=False)
             self.set_bins(i, bins, update=False)

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -1093,13 +1093,13 @@ class ArraySlicer(QtCore.QObject):
             qsel_kw = self.qsel_args(cursor, disp)
         except ValueError:
             return self.isel_code(cursor, disp)
-        kwargs_str = erlab.interactive.utils.format_call_kwargs(qsel_kw)
+        kwargs_str = erlab.interactive.utils.format_kwargs(qsel_kw)
         if kwargs_str:
             return f".qsel({kwargs_str})"
         return ""
 
     def isel_code(self, cursor: int, disp: Sequence[int]) -> str:
-        kwargs_str = erlab.interactive.utils.format_call_kwargs(
+        kwargs_str = erlab.interactive.utils.format_kwargs(
             self.isel_args(cursor, disp, int_if_one=True)
         )
         if kwargs_str:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -529,6 +529,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     """
 
+    _HISTORY_GROUP_IDLE_TIMEOUT_MS = 300
+
     @property
     def provenance_spec(
         self,
@@ -670,6 +672,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._next_states: collections.deque[ImageSlicerState] = collections.deque(
             maxlen=1000
         )
+        self._history_group_active = False
+        self._history_group_recorded = False
+        self._history_group_timer = QtCore.QTimer(self)
+        self._history_group_timer.setSingleShot(True)
+        self._history_group_timer.timeout.connect(self.end_history_group)
 
         # Flag to prevent writing history when restoring state, must be set to True
         # after initialization is complete
@@ -1172,11 +1179,30 @@ class ImageSlicerArea(QtWidgets.QWidget):
         finally:
             self._write_history = original
 
-    @QtCore.Slot()
-    def write_state(self) -> None:
-        if not self._write_history:
-            return
+    @contextlib.contextmanager
+    def history_group(self, timeout_ms: int = _HISTORY_GROUP_IDLE_TIMEOUT_MS):
+        self.begin_history_group(timeout_ms)
+        try:
+            yield
+        finally:
+            self.end_history_group()
 
+    @QtCore.Slot()
+    def begin_history_group(
+        self, timeout_ms: int = _HISTORY_GROUP_IDLE_TIMEOUT_MS
+    ) -> None:
+        if not self._history_group_active:
+            self._history_group_recorded = False
+        self._history_group_active = True
+        self._history_group_timer.start(timeout_ms)
+
+    @QtCore.Slot()
+    def end_history_group(self) -> None:
+        self._history_group_timer.stop()
+        self._history_group_active = False
+        self._history_group_recorded = False
+
+    def _append_current_state_to_history(self) -> None:
         last_state = self._prev_states[-1] if self.undoable else None
         curr_state = self.state.copy()
 
@@ -1192,9 +1218,24 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.sigHistoryChanged.emit()
 
     @QtCore.Slot()
+    def write_state(self) -> None:
+        if not self._write_history:
+            return
+
+        if self._history_group_active:
+            if not self._history_group_recorded:
+                self._append_current_state_to_history()
+                self._history_group_recorded = True
+            self._history_group_timer.start()
+            return
+
+        self._append_current_state_to_history()
+
+    @QtCore.Slot()
     @suppress_history
     def flush_history(self) -> None:
         """Clear the undo and redo history."""
+        self.end_history_group()
         self._prev_states.clear()
         self._next_states.clear()
         self.sigHistoryChanged.emit()
@@ -1204,6 +1245,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
     @suppress_history
     def undo(self) -> None:
         """Undo the most recent action."""
+        self.end_history_group()
         if self.undoable:  # pragma: no branch
             self._next_states.append(self.state)
             self.state = self._prev_states.pop()
@@ -1214,6 +1256,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
     @suppress_history
     def redo(self) -> None:
         """Redo the most recently undone action."""
+        self.end_history_group()
         if self.redoable:  # pragma: no branch
             self._prev_states.append(self.state)
             self.state = self._next_states.pop()
@@ -1240,6 +1283,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             Index in the history to go to. 0 corresponds to the current state. Positive
             indices point to the future, while negative indices point to the past.
         """
+        self.end_history_group()
         if index == 0:
             return
         if index < 0:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -29,12 +29,14 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+from erlab.interactive.imagetool import _history
 from erlab.interactive.imagetool._viewer_dialogs import (
     _AssociatedCoordsDialog,
     _CursorColorCoordDialog,
 )
 
 if typing.TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Collection, Hashable, Iterable
 
     import qtawesome
@@ -260,11 +262,17 @@ def record_history(method: Callable | None = None):
         @functools.wraps(method)
         def wrapped(self, *args, **kwargs):
             area = self.slicer_area if hasattr(self, "slicer_area") else self
-            area.sigWriteHistory.emit()
-            with area.history_suppressed():
-                # Prevent making additional records within the method
-                return method(self, *args, **kwargs)
+            transaction_id = kwargs.pop("__slicer_transaction_id", None)
+            keep_pending = kwargs.pop(
+                "__slicer_keep_pending", area._history_group_active
+            )
+            return area.record_history_mutation(
+                transaction_id,
+                lambda: method(self, *args, **kwargs),
+                keep_pending=keep_pending,
+            )
 
+        typing.cast("typing.Any", wrapped)._itool_records_history = True
         return wrapped
 
     if method is not None:
@@ -306,15 +314,41 @@ def link_slicer(
         def wrapped(*args, **kwargs):
             # skip sync if already synced
             skip_sync = kwargs.pop("__slicer_skip_sync", False)
+            transaction_id = kwargs.pop("__slicer_transaction_id", None)
+            keep_pending = kwargs.pop("__slicer_keep_pending", None)
+            obj = args[0]
+            records_history = getattr(func, "_itool_records_history", False)
+            if keep_pending is None:
+                keep_pending = obj._history_group_active
+            sync_enabled = (
+                obj.is_linked
+                and not skip_sync
+                and obj._link_sync_suppressed == 0
+                and obj._linking_proxy is not None
+                and (not color or obj._linking_proxy.link_colors)
+            )
+            if records_history and transaction_id is None and sync_enabled:
+                transaction_id = obj.next_linked_history_transaction_id()
 
-            out = func(*args, **kwargs)
-            if args[0].is_linked and not skip_sync:
+            call_kwargs = dict(kwargs)
+            if records_history:
+                call_kwargs["__slicer_transaction_id"] = transaction_id
+                call_kwargs["__slicer_keep_pending"] = keep_pending
+            out = func(*args, **call_kwargs)
+            if sync_enabled:
                 all_args = inspect.Signature.from_callable(func).bind(*args, **kwargs)
                 all_args.apply_defaults()
                 obj = all_args.arguments.pop("self")
                 if obj._linking_proxy is not None:  # pragma: no branch
                     obj._linking_proxy.sync(
-                        obj, func.__name__, all_args.arguments, indices, steps, color
+                        obj,
+                        func.__name__,
+                        all_args.arguments,
+                        indices,
+                        steps,
+                        color,
+                        transaction_id,
+                        keep_pending,
                     )
             return out
 
@@ -377,6 +411,8 @@ class SlicerLinkProxy:
         indices: bool,
         steps: bool,
         color: bool,
+        transaction_id: str | None,
+        keep_pending: bool,
     ) -> None:
         r"""Propagate changes across multiple :class:`ImageSlicerArea`\ s.
 
@@ -399,7 +435,15 @@ class SlicerLinkProxy:
             return
         for target in self.children.difference({source}):
             getattr(target, funcname)(
-                **self.convert_args(source, target, arguments, indices, steps)
+                **self.convert_args(
+                    source,
+                    target,
+                    dict(arguments),
+                    indices,
+                    steps,
+                    transaction_id,
+                    keep_pending,
+                )
             )
 
     def convert_args(
@@ -409,6 +453,8 @@ class SlicerLinkProxy:
         args: dict[str, typing.Any],
         indices: bool,
         steps: bool,
+        transaction_id: str | None,
+        keep_pending: bool,
     ):
         if indices:
             index: int | None = args.get("value")
@@ -425,6 +471,8 @@ class SlicerLinkProxy:
                 args["value"] = self.convert_index(source, target, axis, index, steps)
 
         args["__slicer_skip_sync"] = True  # passed onto the decorator
+        args["__slicer_transaction_id"] = transaction_id
+        args["__slicer_keep_pending"] = keep_pending
         return args
 
     @staticmethod
@@ -666,14 +714,16 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._obj_shares_data_values: bool = False
 
         # Queues to handle undo and redo
-        self._prev_states: collections.deque[ImageSlicerState] = collections.deque(
+        self._prev_states: collections.deque[_history.HistoryEntry] = collections.deque(
             maxlen=1000
         )
-        self._next_states: collections.deque[ImageSlicerState] = collections.deque(
+        self._next_states: collections.deque[_history.HistoryEntry] = collections.deque(
             maxlen=1000
         )
+        self._pending_history_entry: _history.HistoryEntry | None = None
+        self._pending_history_committed = False
+        self._link_sync_suppressed = 0
         self._history_group_active = False
-        self._history_group_recorded = False
         self._history_group_timer = QtCore.QTimer(self)
         self._history_group_timer.setSingleShot(True)
         self._history_group_timer.timeout.connect(self.end_history_group)
@@ -911,6 +961,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     @state.setter
     def state(self, state: ImageSlicerState) -> None:
+        with self.history_suppressed(), self.link_sync_suppressed():
+            self._restore_state(state)
+
+    def _restore_state(self, state: ImageSlicerState) -> None:
         logger.debug("Restoring state...")
         parent = self.parent()
         if hasattr(parent, "_set_controls_visible"):
@@ -1180,6 +1234,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._write_history = original
 
     @contextlib.contextmanager
+    def link_sync_suppressed(self):
+        self._link_sync_suppressed += 1
+        try:
+            yield
+        finally:
+            self._link_sync_suppressed -= 1
+
+    @contextlib.contextmanager
     def history_group(self, timeout_ms: int = _HISTORY_GROUP_IDLE_TIMEOUT_MS):
         self.begin_history_group(timeout_ms)
         try:
@@ -1191,31 +1253,130 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def begin_history_group(
         self, timeout_ms: int = _HISTORY_GROUP_IDLE_TIMEOUT_MS
     ) -> None:
-        if not self._history_group_active:
-            self._history_group_recorded = False
         self._history_group_active = True
         self._history_group_timer.start(timeout_ms)
 
     @QtCore.Slot()
     def end_history_group(self) -> None:
+        self.finalize_history_entry()
         self._history_group_timer.stop()
         self._history_group_active = False
-        self._history_group_recorded = False
 
-    def _append_current_state_to_history(self) -> None:
-        last_state = self._prev_states[-1] if self.undoable else None
-        curr_state = self.state.copy()
+    def _history_state_snapshot(self) -> ImageSlicerState:
+        state = copy.deepcopy(self.state)
+        state.pop("splitter_sizes", None)
+        return state
 
-        # Don't store splitter sizes in history
-        if last_state is not None:
-            last_state.pop("splitter_sizes", None)
-        curr_state.pop("splitter_sizes", None)
+    def next_linked_history_transaction_id(self) -> str:
+        if (
+            self._history_group_active
+            and self._pending_history_entry is not None
+            and self._pending_history_entry.transaction_id is not None
+        ):
+            return self._pending_history_entry.transaction_id
+        return uuid.uuid4().hex
 
-        if last_state is None or last_state != curr_state:
-            # Only store state if it has changed
-            self._prev_states.append(curr_state)
-            self._next_states.clear()
+    def begin_history_entry(self, transaction_id: str | None) -> None:
+        if not self._write_history:
+            return
+        if self._pending_history_entry is not None:
+            if self._pending_history_entry.transaction_id == transaction_id:
+                return
+            self.finalize_history_entry()
+
+        before_state = self._history_state_snapshot()
+        entry = _history.HistoryEntry(
+            before_state=typing.cast("dict[str, typing.Any]", before_state),
+            after_state=typing.cast(
+                "dict[str, typing.Any]", copy.deepcopy(before_state)
+            ),
+            changed_paths=frozenset(),
+            transaction_id=transaction_id,
+        )
+        self._pending_history_entry = entry
+        self._pending_history_committed = False
+
+    def finalize_history_entry(self, *, keep_pending: bool = False) -> None:
+        entry = self._pending_history_entry
+        if entry is None:
+            return
+
+        after_state = self._history_state_snapshot()
+        entry.after_state = typing.cast("dict[str, typing.Any]", after_state)
+        entry.changed_paths = _history.changed_paths(entry.before_state, after_state)
+        if not entry.changed_paths and not keep_pending:
+            if self._pending_history_committed:
+                self._prev_states.remove(entry)
+            self._pending_history_entry = None
+            self._pending_history_committed = False
             self.sigHistoryChanged.emit()
+            return
+
+        if entry.changed_paths and not self._pending_history_committed:
+            self._prev_states.append(entry)
+            self._next_states.clear()
+            self._pending_history_committed = True
+
+        if not keep_pending:
+            self._pending_history_entry = None
+            self._pending_history_committed = False
+        self.sigHistoryChanged.emit()
+
+    def record_history_mutation(
+        self,
+        transaction_id: str | None,
+        mutation: Callable[[], typing.Any],
+        *,
+        keep_pending: bool = False,
+    ) -> typing.Any:
+        recording = self._write_history
+        self.begin_history_entry(transaction_id)
+        try:
+            with self.history_suppressed():
+                return mutation()
+        finally:
+            if recording:
+                self.finalize_history_entry(keep_pending=keep_pending)
+
+    def _apply_history_entry(self, entry: _history.HistoryEntry, *, undo: bool) -> None:
+        source = entry.before_state if undo else entry.after_state
+        patched = _history.patch_state(self.state, source, entry.changed_paths)
+        with self.history_suppressed(), self.link_sync_suppressed():
+            self.state = typing.cast("ImageSlicerState", patched)
+
+    def _apply_matching_linked_history_entry(
+        self, transaction_id: str, *, undo: bool
+    ) -> None:
+        self.end_history_group()
+        stack = self._prev_states if undo else self._next_states
+        entry = next(
+            (
+                candidate
+                for candidate in reversed(stack)
+                if candidate.transaction_id == transaction_id
+            ),
+            None,
+        )
+        if entry is None or not _history.entry_matches_current(
+            entry, self._history_state_snapshot(), undo=undo
+        ):
+            return
+
+        stack.remove(entry)
+        self._apply_history_entry(entry, undo=undo)
+        if undo:
+            self._next_states.append(entry)
+        else:
+            self._prev_states.append(entry)
+        self.sigHistoryChanged.emit()
+
+    def _propagate_history_entry(
+        self, entry: _history.HistoryEntry, *, undo: bool
+    ) -> None:
+        if entry.transaction_id is None or self._linking_proxy is None:
+            return
+        for target in tuple(self.linked_slicers):
+            target._apply_matching_linked_history_entry(entry.transaction_id, undo=undo)
 
     @QtCore.Slot()
     def write_state(self) -> None:
@@ -1223,13 +1384,12 @@ class ImageSlicerArea(QtWidgets.QWidget):
             return
 
         if self._history_group_active:
-            if not self._history_group_recorded:
-                self._append_current_state_to_history()
-                self._history_group_recorded = True
+            self.begin_history_entry(None)
             self._history_group_timer.start()
             return
 
-        self._append_current_state_to_history()
+        self.begin_history_entry(None)
+        QtCore.QTimer.singleShot(0, self.finalize_history_entry)
 
     @QtCore.Slot()
     @suppress_history
@@ -1241,38 +1401,102 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self.sigHistoryChanged.emit()
 
     @QtCore.Slot()
-    @link_slicer
     @suppress_history
     def undo(self) -> None:
         """Undo the most recent action."""
         self.end_history_group()
         if self.undoable:  # pragma: no branch
-            self._next_states.append(self.state)
-            self.state = self._prev_states.pop()
+            entry = self._prev_states.pop()
+            self._apply_history_entry(entry, undo=True)
+            self._next_states.append(entry)
+            self._propagate_history_entry(entry, undo=True)
             self.sigHistoryChanged.emit()
 
     @QtCore.Slot()
-    @link_slicer
     @suppress_history
     def redo(self) -> None:
         """Redo the most recently undone action."""
         self.end_history_group()
         if self.redoable:  # pragma: no branch
-            self._prev_states.append(self.state)
-            self.state = self._next_states.pop()
+            entry = self._next_states.pop()
+            self._apply_history_entry(entry, undo=False)
+            self._prev_states.append(entry)
+            self._propagate_history_entry(entry, undo=False)
             self.sigHistoryChanged.emit()
 
-    def history_states(self) -> tuple[list[ImageSlicerState], int]:
-        states = list(self._prev_states)
-        current_state = self.state.copy()
+    def history_states(
+        self, *, finalize_pending: bool = True
+    ) -> tuple[list[ImageSlicerState], int]:
+        if finalize_pending:
+            self.finalize_history_entry()
+        states = [
+            typing.cast("ImageSlicerState", entry.before_state)
+            for entry in self._prev_states
+        ]
+        current_state = self._history_state_snapshot()
         if not states or states[-1] != current_state:
             states.append(current_state)
         current_index = len(states) - 1
 
         if self._next_states:
-            states.extend(reversed(self._next_states))
+            states.extend(
+                typing.cast("ImageSlicerState", entry.after_state)
+                for entry in reversed(self._next_states)
+            )
 
         return states, current_index
+
+    def history_entry_changes(
+        self, *, finalize_pending: bool = True
+    ) -> list[
+        tuple[
+            int,
+            int,
+            ImageSlicerState,
+            ImageSlicerState,
+            bool,
+            datetime.datetime | None,
+        ]
+    ]:
+        if finalize_pending:
+            self.finalize_history_entry()
+        entries: list[
+            tuple[
+                int,
+                int,
+                ImageSlicerState,
+                ImageSlicerState,
+                bool,
+                datetime.datetime | None,
+            ]
+        ] = []
+        current_index = len(self._prev_states)
+        if current_index == 0 and self._next_states:
+            current_state = self._history_state_snapshot()
+            entries.append((0, 0, current_state, current_state, True, None))
+        for i, entry in enumerate(self._prev_states, start=1):
+            entries.append(
+                (
+                    i,
+                    i - current_index,
+                    typing.cast("ImageSlicerState", entry.before_state),
+                    typing.cast("ImageSlicerState", entry.after_state),
+                    i == current_index,
+                    entry.created_at,
+                )
+            )
+        for i, entry in enumerate(reversed(self._next_states), start=1):
+            entries.append(
+                (
+                    current_index + i,
+                    i,
+                    typing.cast("ImageSlicerState", entry.before_state),
+                    typing.cast("ImageSlicerState", entry.after_state),
+                    False,
+                    entry.created_at,
+                )
+            )
+        return entries
 
     def go_to_history_index(self, index: int) -> None:
         """Go to a specific index in the history.
@@ -2382,7 +2606,6 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.sigCurrentCursorChanged.emit(self.current_cursor)
 
     @QtCore.Slot()
-    @record_history
     def remove_current_cursor(self) -> None:
         self.remove_cursor(self.current_cursor)
 
@@ -2420,6 +2643,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self.sigCursorColorsChanged.emit()
 
     @link_slicer(color=True)
+    @record_history
     def set_colormap(
         self,
         cmap: str | pg.ColorMap | None = None,
@@ -2431,43 +2655,53 @@ class ImageSlicerArea(QtWidgets.QWidget):
         levels: tuple[float, float] | None = None,
         update: bool = True,
     ) -> None:
-        if gamma is None and levels_locked is None and levels is None:
-            # These will be handled in their respective methods or calling widgets
-            self.sigWriteHistory.emit()
-            prop = copy.deepcopy(self._colormap_properties)
-            new_reverse = self.reverse_act.isChecked()
-            new_high_contrast = self.high_contrast_act.isChecked()
-            new_zero_centered = self.zero_centered_act.isChecked()
-            if any(
-                (
-                    prop["reverse"] != new_reverse,
-                    prop["high_contrast"] != new_high_contrast,
-                    prop["zero_centered"] != new_zero_centered,
-                )
-            ):
-                self._colormap_properties["reverse"] = new_reverse
-                self._colormap_properties["high_contrast"] = new_high_contrast
-                self._colormap_properties["zero_centered"] = new_zero_centered
-
+        action_values = gamma is None and levels_locked is None and levels is None
         if cmap is not None:
             self._colormap_properties["cmap"] = cmap
         if gamma is not None:
             self._colormap_properties["gamma"] = float(gamma)
-        if reverse is not None:
-            # Don't block signals here to trigger updates to linked buttons.
-            # Will be called twice, but unnoticable
-            self.reverse_act.setChecked(reverse)
-        if high_contrast is not None:
-            self.high_contrast_act.setChecked(high_contrast)
-        if zero_centered is not None:
-            self.zero_centered_act.setChecked(zero_centered)
+
+        reverse_value = (
+            self.reverse_act.isChecked()
+            if reverse is None and action_values
+            else reverse
+        )
+        high_contrast_value = (
+            self.high_contrast_act.isChecked()
+            if high_contrast is None and action_values
+            else high_contrast
+        )
+        zero_centered_value = (
+            self.zero_centered_act.isChecked()
+            if zero_centered is None and action_values
+            else zero_centered
+        )
+
+        reverse_blocker = QtCore.QSignalBlocker(self.reverse_act)
+        high_contrast_blocker = QtCore.QSignalBlocker(self.high_contrast_act)
+        zero_centered_blocker = QtCore.QSignalBlocker(self.zero_centered_act)
+        try:
+            if reverse_value is not None:
+                self._colormap_properties["reverse"] = bool(reverse_value)
+                self.reverse_act.setChecked(bool(reverse_value))
+            if high_contrast_value is not None:
+                self._colormap_properties["high_contrast"] = bool(high_contrast_value)
+                self.high_contrast_act.setChecked(bool(high_contrast_value))
+            if zero_centered_value is not None:
+                self._colormap_properties["zero_centered"] = bool(zero_centered_value)
+                self.zero_centered_act.setChecked(bool(zero_centered_value))
+        finally:
+            del reverse_blocker
+            del high_contrast_blocker
+            del zero_centered_blocker
+
         if levels_locked is not None:
             self.levels_locked = levels_locked
         if levels is not None:
             self.levels = levels
 
         properties = self.colormap_properties
-        cmap = erlab.interactive.colors._pg_colormap_powernorm_lut(
+        pg_colormap = erlab.interactive.colors._pg_colormap_powernorm_lut(
             properties["cmap"],
             properties["gamma"],
             properties["reverse"],
@@ -2475,12 +2709,17 @@ class ImageSlicerArea(QtWidgets.QWidget):
             zero_centered=properties["zero_centered"],
         )
         for im in self._imageitems:
-            im.set_pg_colormap(cmap, update=update)
+            im.set_pg_colormap(pg_colormap, update=update)
         self.sigViewOptionChanged.emit()
 
     @QtCore.Slot()
     def refresh_colormap(self) -> None:
-        self.set_colormap(update=True)
+        self.set_colormap(
+            reverse=self.reverse_act.isChecked(),
+            high_contrast=self.high_contrast_act.isChecked(),
+            zero_centered=self.zero_centered_act.isChecked(),
+            update=True,
+        )
         logger.debug("Colormap refreshed")
 
     @QtCore.Slot(bool)

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -93,6 +93,7 @@ class ImageSlicerState(typing.TypedDict):
     current_cursor: int
     manual_limits: dict[str, list[float]]
     cursor_colors: list[str]
+    controls_visible: typing.NotRequired[bool]
     file_path: typing.NotRequired[str | None]
     load_func: typing.NotRequired[tuple[str, dict[str, typing.Any], int] | None]
     splitter_sizes: typing.NotRequired[list[list[int]]]
@@ -875,6 +876,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
         return typing.cast("ColorMapState", prop)
 
     @property
+    def controls_visible(self) -> bool:
+        parent = self.parent()
+        if hasattr(parent, "controls_visible"):
+            return bool(typing.cast("typing.Any", parent).controls_visible)
+        return True
+
+    @property
     def state(self) -> ImageSlicerState:
         load_func = self._load_func
         if load_func is not None:
@@ -890,12 +898,19 @@ class ImageSlicerArea(QtWidgets.QWidget):
             "file_path": str(self._file_path) if self._file_path is not None else None,
             "load_func": load_func,
             "cursor_colors": [c.name() for c in self.cursor_colors],
+            "controls_visible": self.controls_visible,
             "plotitem_states": [p._serializable_state for p in self.axes],
         }
 
     @state.setter
     def state(self, state: ImageSlicerState) -> None:
         logger.debug("Restoring state...")
+        parent = self.parent()
+        if hasattr(parent, "_set_controls_visible"):
+            typing.cast("typing.Any", parent)._set_controls_visible(
+                bool(state.get("controls_visible", True))
+            )
+
         if "splitter_sizes" in state:
             self.splitter_sizes = state["splitter_sizes"]
 

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1883,9 +1883,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def refresh_current(self, axes: tuple[int, ...] | None = None) -> None:
         self.sigIndexChanged.emit(self.current_cursor, axes)
 
-    @QtCore.Slot(int, list)
+    @QtCore.Slot(object, object)
     @link_slicer
-    def refresh(self, cursor: int, axes: tuple[int, ...] | None = None) -> None:
+    def refresh(
+        self, cursor: int | tuple[int, ...], axes: tuple[int, ...] | None = None
+    ) -> None:
         self.sigIndexChanged.emit(cursor, axes)
 
     @QtCore.Slot()

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1794,7 +1794,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             Tuple of axis indices to refresh. If `None`, all axes are refreshed.
 
         """
-        if not self.data_chunked:
+        if self.array_slicer._obj.chunks is None:
             return
 
         import dask
@@ -2315,10 +2315,36 @@ class ImageSlicerArea(QtWidgets.QWidget):
         # source array remains unchanged and can be restored cheaply.
         self._applied_func = func
 
-        if self._applied_func is None:
+        if func is None:
             self._restore_obj_from_source(update=update)
-        else:
-            self.update_values(self._applied_func(self._data), update=update)
+            return
+
+        filtered = func(self._data)
+        if filtered.chunks is None:
+            self.update_values(filtered, update=update)
+            return
+
+        if self.data.ndim != filtered.ndim:
+            raise ValueError("DataArray dimensions do not match")
+        if set(self.data.dims) != set(filtered.dims):
+            raise ValueError("DataArray dimensions do not match")
+
+        if self.data.dims != filtered.dims:
+            filtered = filtered.transpose(*self.data.dims)
+        if self.data.shape != filtered.shape:
+            raise ValueError("DataArray shape does not match")
+
+        self.array_slicer.set_array(
+            filtered,
+            reset=False,
+            copy_values=False,
+            preserve_dims=tuple(filtered.dims),
+        )
+        self._obj_shares_data_values = False
+        if update:
+            self.array_slicer.clear_val_cache()
+            self.refresh_all(only_plots=True)
+            self.lock_levels(self.levels_locked)
 
     def set_manual_limits(self, manual_limits: dict[str, list[float]]) -> None:
         """Set manual limits for the axes.

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -29,6 +29,7 @@ def _base_state() -> dict:
             "bins": [1, 1],
             "dims": ["x", "y"],
         },
+        "controls_visible": True,
     }
 
 
@@ -55,6 +56,8 @@ class _DummySlicerArea(QtCore.QObject):
         ("slice.indices", None, "Cursor moved"),
         ("slice.bins", None, "Number of bins changed"),
         ("slice.dims", None, "Transposed"),
+        ("controls_visible", True, "Controls shown"),
+        ("controls_visible", False, "Controls hidden"),
         ("color.reverse", True, "Colormap reversed"),
         ("color.cmap", "magma", "Changed colormap to magma"),
         ("color.gamma", 2.0, "Colormap options changed"),

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -6,9 +6,15 @@ import unittest.mock
 import numpy as np
 import pytest
 import xarray as xr
-from qtpy import QtCore
+from qtpy import QtCore, QtWidgets
 
+import erlab.interactive.utils
 from erlab.interactive.imagetool import ImageTool, _history
+from erlab.interactive.imagetool.controls import (
+    ItoolBinningControls,
+    ItoolColormapControls,
+    ItoolCrosshairControls,
+)
 
 
 def _base_state() -> dict:
@@ -26,10 +32,25 @@ def _base_state() -> dict:
         "slice": {
             "indices": [[np.int64(0), np.int64(0)]],
             "values": [[np.float64(0.0), np.float64(1.0)]],
-            "bins": [1, 1],
+            "bins": [[1, 1]],
             "dims": ["x", "y"],
+            "snap_to_data": False,
+            "twin_coord_names": (),
+            "cursor_color_params": None,
         },
+        "manual_limits": {},
+        "file_path": None,
+        "load_func": None,
         "controls_visible": True,
+        "plotitem_states": [
+            {
+                "vb_aspect_locked": False,
+                "vb_x_inverted": False,
+                "vb_y_inverted": False,
+                "vb_autorange": (True, True),
+                "roi_states": [],
+            }
+        ],
     }
 
 
@@ -48,14 +69,20 @@ class _DummySlicerArea(QtCore.QObject):
     def go_to_history_index(self, idx: int) -> None:
         self.go_to_history_calls.append(idx)
 
+    def window(self) -> QtWidgets.QWidget | None:
+        return None
+
 
 @pytest.mark.parametrize(
     ("key", "new", "expected"),
     [
         ("cursor_colors", None, "Cursor colors changed"),
         ("slice.indices", None, "Cursor moved"),
-        ("slice.bins", None, "Number of bins changed"),
+        ("slice.bins", None, "Bins changed"),
         ("slice.dims", None, "Transposed"),
+        ("slice.snap_to_data", True, "Snap to pixels enabled"),
+        ("slice.twin_coord_names", None, "Associated coordinates changed"),
+        ("slice.cursor_color_params", None, "Cursor color mapping changed"),
         ("controls_visible", True, "Controls shown"),
         ("controls_visible", False, "Controls hidden"),
         ("color.reverse", True, "Colormap reversed"),
@@ -73,12 +100,183 @@ def test_parse_change(key, new, expected):
     assert _history.parse_change(key, None, new) == expected
 
 
-def test_describe_state_diff_ignores_value_only_changes():
+@pytest.mark.parametrize(
+    ("key", "old", "new", "expected"),
+    [
+        ("slice.snap_to_data", _history._MISSING, True, "Snap to pixels changed"),
+        (
+            "controls_visible",
+            True,
+            _history._MISSING,
+            "Controls visibility changed",
+        ),
+        ("color.reverse", _history._MISSING, False, "Colormap reversal changed"),
+        ("color.cmap", "viridis", _history._MISSING, "Colormap changed"),
+        (
+            "color.levels_locked",
+            _history._MISSING,
+            True,
+            "Colormap levels lock changed",
+        ),
+    ],
+)
+def test_parse_change_reports_missing_values_generically(key, old, new, expected):
+    assert _history.parse_change(key, old, new) == expected
+
+
+def test_history_value_formatting_handles_edge_values() -> None:
+    long_text = "x" * 120
+
+    assert _history._format_value(_history._MISSING) == "Not set"
+    assert _history._format_value(None) == "None"
+    assert (
+        _history._format_value({"flag": True, "empty": ""})
+        == "{flag: On, empty: Empty}"
+    )
+    assert _history._format_value(long_text) == f"{long_text[:93]}..."
+
+
+def test_changed_paths_ignores_splitter_sizes() -> None:
+    before = {"splitter_sizes": [1, 2], "value": 1}
+    after = {"splitter_sizes": [3, 4], "value": 2}
+
+    assert _history.changed_paths(before, after) == frozenset({("value",)})
+
+
+@pytest.mark.parametrize(
+    ("state", "path"),
+    [
+        ({}, ("missing",)),
+        ({"items": [1]}, ("items", "bad")),
+        ({"items": [1]}, ("items", -1)),
+        ({"items": [1]}, ("items", 2)),
+        ({"value": 1}, ("value", "child")),
+    ],
+)
+def test_path_value_returns_missing_for_invalid_paths(state, path) -> None:
+    assert _history._path_value(state, path) is _history._MISSING
+
+
+def test_path_value_normalizes_returned_value() -> None:
+    value = _history._path_value({"values": np.array([1, 2])}, ("values",))
+
+    assert value == [1, 2]
+
+
+def test_patch_state_ignores_empty_path() -> None:
+    state = {"value": 1}
+
+    assert _history.patch_state(state, {"value": 2}, frozenset({()})) == state
+
+
+def test_patch_state_creates_and_removes_nested_mapping_values() -> None:
+    current: dict[str, object] = {}
+    patched = _history.patch_state(
+        current,
+        {"outer": {"inner": 1}},
+        frozenset({("outer", "inner")}),
+    )
+    assert patched == {"outer": {"inner": 1}}
+
+    patched = _history.patch_state(
+        {"outer": {"inner": 1, "kept": 2}},
+        {"outer": {}},
+        frozenset({("outer", "inner")}),
+    )
+    assert patched == {"outer": {"kept": 2}}
+
+
+def test_patch_state_handles_invalid_and_missing_sequence_paths() -> None:
+    state = {"items": [{"old": 1}]}
+    before = {"items": [{"new": 2}]}
+
+    assert _history.patch_state(state, before, frozenset({("items", "bad")})) == state
+    assert (
+        _history.patch_state(state, {}, frozenset({("items", 0, "missing")})) == state
+    )
+    assert _history.patch_state(state, before, frozenset({("items", -1)})) == state
+    assert (
+        _history.patch_state(state, before, frozenset({("items", 2, "new")})) == state
+    )
+    assert (
+        _history.patch_state(state, before, frozenset({("items", 0, "old", 0)}))
+        == state
+    )
+    assert _history.patch_state(state, before, frozenset({("items", 0, "new")})) == {
+        "items": [{"old": 1, "new": 2}]
+    }
+    assert _history.patch_state(
+        {"items": [0]},
+        {"items": [[1]]},
+        frozenset({("items", 0, 0)}),
+    ) == {"items": [[]]}
+    assert _history.patch_state(
+        {"items": [{"old": 1, "new": 2}]},
+        {"items": [{"old": 1}]},
+        frozenset({("items", 0, "new")}),
+    ) == {"items": [{"old": 1}]}
+    assert _history.patch_state(
+        {"items": [0]},
+        {"items": []},
+        frozenset({("items", 0)}),
+    ) == {"items": []}
+
+
+def test_set_path_handles_invalid_intermediate_targets() -> None:
+    state: dict[str, object] = {"items": [1], "value": 1}
+
+    _history._set_path(state, ("items", "bad", "value"), 2)
+    _history._set_path(state, ("items", 0, "missing"), _history._MISSING)
+    _history._set_path(state, ("value", "child"), 2)
+
+    assert state == {"items": [1], "value": {"child": 2}}
+
+
+def test_entry_matches_current_checks_before_or_after_state() -> None:
+    entry = _history.HistoryEntry(
+        {"value": np.array([1, 2])},
+        {"value": np.array([1, 3])},
+        frozenset({("value",)}),
+        None,
+    )
+
+    assert _history.entry_matches_current(entry, {"value": [1, 3]}, undo=True)
+    assert _history.entry_matches_current(entry, {"value": [1, 2]}, undo=False)
+    assert not _history.entry_matches_current(entry, {"value": [9]}, undo=True)
+
+
+def test_cursor_detail_rows_handle_invalid_and_changed_values() -> None:
+    assert _history._cursor_detail_rows(1, [[0]], [], []) == ()
+    assert _history._cursor_detail_rows([[0]], 1, [], []) == ()
+    assert _history._cursor_detail_rows([[0]], [[0]], [[1.0]], [[1.0]]) == ()
+    assert _history._cursor_detail_rows([[0]], [[1]], [], [[2.0]]) == (
+        ("Cursor 1 index", "[0]", "[1]"),
+        ("Cursor 1 value", "Not set", "[2.0]"),
+    )
+
+
+def test_plot_state_changes_handles_non_sequence_and_non_mapping_states() -> None:
+    assert _history._plot_state_changes(1, []) == (
+        ["Plot view changed"],
+        [("Plot state changed", "", "")],
+    )
+    summaries, details = _history._plot_state_changes([{}], [1])
+
+    assert summaries == ["Plot view changed"]
+    assert details == [("Plot view state changed", "", "")]
+
+
+def test_describe_state_change_reports_same_pixel_cursor_move():
     prev = _base_state()
     curr = copy.deepcopy(prev)
-    curr["slice"]["values"] = [[5.0, 6.0]]
+    curr["slice"]["values"] = [[0.5, 1.0]]
 
-    assert _history.describe_state_diff(prev, curr) is None
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert label == "Cursor moved within pixel"
+    assert details == ("Cursor 1 value changed from [0.0, 1.0] to [0.5, 1.0]",)
+    assert all("->" not in detail for detail in details)
+    assert _history.describe_state_diff(prev, curr) == label
 
 
 @pytest.mark.parametrize(
@@ -122,7 +320,7 @@ def test_describe_state_diff_cursor_changes(
     assert _history.describe_state_diff(prev, curr) == expected
 
 
-def test_describe_state_diff_reports_colormap_and_dims():
+def test_describe_state_change_reports_colormap_and_dims_without_cursor_noise():
     prev = _base_state()
     curr = copy.deepcopy(prev)
     curr["color"]["reverse"] = True
@@ -130,7 +328,137 @@ def test_describe_state_diff_reports_colormap_and_dims():
     curr["slice"]["indices"] = [[np.int64(1), np.int64(0)]]
     curr["slice"]["values"] = [[2.0, 3.0]]
 
-    assert _history.describe_state_diff(prev, curr) == "Colormap reversed, Transposed"
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert "Transposed" in label
+    assert "Colormap reversed" in label
+    assert "Cursor moved" not in label
+    assert details[0] == "Dimensions changed from [x, y] to [y, x]"
+
+
+def test_describe_state_change_reports_snap_toggle():
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    curr["slice"]["snap_to_data"] = True
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert label == "Snap to pixels enabled"
+    assert details == ("Snap to pixels changed from Off to On",)
+
+
+def test_describe_state_change_reports_active_cursor_and_bins() -> None:
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    prev["slice"]["indices"] = [[0, 0], [1, 1]]
+    prev["slice"]["values"] = [[0.0, 1.0], [1.0, 2.0]]
+    prev["slice"]["bins"] = [[1, 1], [1, 1]]
+    curr["slice"]["indices"] = [[0, 0], [1, 1]]
+    curr["slice"]["values"] = [[0.0, 1.0], [1.0, 2.0]]
+    curr["slice"]["bins"] = [[1, 1], [2, 1]]
+    curr["current_cursor"] = 1
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert "Cursor changed" in label
+    assert "Bins changed" in label
+    assert "Active cursor changed from 0 to 1" in details
+    assert "Bins changed from [[1, 1], [1, 1]] to [[1, 1], [2, 1]]" in details
+
+
+def test_describe_state_change_reports_roi_guideline_and_plot_changes():
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    curr["plotitem_states"][0]["roi_states"] = [{"points": [(0.0, 0.0), (1.0, 1.0)]}]
+    curr["plotitem_states"][0]["guideline_state"] = {
+        "count": 1,
+        "angle": 45.0,
+        "offset": (0.0, 0.0),
+        "follow_cursor": False,
+    }
+    curr["plotitem_states"][0]["vb_autorange"] = (False, False)
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert "ROI changed" in label
+    assert "Guidelines changed" in label
+    assert "Plot view changed" in label
+    assert "ROI count changed from 0 to 1" in details
+    assert "Guideline state changed" in details
+
+
+def test_describe_state_change_reports_manual_view_limits():
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    curr["manual_limits"] = {"x": [0.0, 1.0]}
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert label == "View limits changed"
+    assert details == ("Manual view limits changed",)
+
+
+def test_describe_state_change_reports_added_keys_and_generic_fallback():
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    curr["new_state"] = {"flag": True}
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert label == "State changed"
+    assert details == ("Changed paths: new_state.flag",)
+
+
+def test_describe_state_change_reports_source_change_and_noop() -> None:
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    curr["file_path"] = "/data/source.h5"
+    curr["load_func"] = ("loader:func", "arg")
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert label == "Source changed"
+    assert "file_path changed from None to /data/source.h5" in details
+    assert "load_func changed from None to [loader:func, arg]" in details
+    assert _history.describe_state_change(prev, copy.deepcopy(prev)) is None
+    assert _history.describe_state_diff(prev, copy.deepcopy(prev)) is None
+
+
+def test_history_entries_skip_noop_noncurrent_entries() -> None:
+    states = [
+        {"color": {"cmap": "viridis"}},
+        {"color": {"cmap": "viridis"}},
+        {"color": {"cmap": "magma"}},
+    ]
+    area = _DummySlicerArea(states, 2)
+
+    assert _history._history_entries(area) == [
+        (
+            2,
+            0,
+            "Changed colormap to magma",
+            (("Colormap", "viridis", "magma"),),
+            True,
+            None,
+        )
+    ]
+
+
+def test_history_entries_keep_noop_current_entries() -> None:
+    states = [{"value": 1}, {"value": 1}]
+    area = _DummySlicerArea(states, 1)
+
+    assert _history._history_entries(area) == [(1, 0, "Current state", (), True, None)]
+
+
+def test_history_entries_keep_noop_current_callable_entries() -> None:
+    class AreaWithEntryChanges(_DummySlicerArea):
+        def history_entry_changes(self, *, finalize_pending: bool = True):
+            return [(1, 0, {"value": 1}, {"value": 1}, True, None)]
+
+    area = AreaWithEntryChanges([{"value": 1}], 0)
+
+    assert _history._history_entries(area) == [(1, 0, "Current state", (), True, None)]
 
 
 def test_history_states_include_current_and_future(qtbot):
@@ -183,6 +511,216 @@ def test_go_to_history_index_triggers_expected_actions(qtbot):
     win.close()
 
 
+def test_history_group_coalesces_cursor_spinbox_steps(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    control = win.docks[0].widget().findChild(ItoolCrosshairControls)
+    assert control is not None
+    control.update_content()
+    area = win.slicer_area
+    start_index = area.current_indices[0]
+
+    control.spin_idx[0].stepBy(1)
+    control.spin_idx[0].stepBy(1)
+
+    assert area.current_indices[0] == start_index + 2
+    assert len(area._prev_states) == 1
+    area.undo()
+    assert area.current_indices[0] == start_index
+    win.close()
+
+
+def test_controls_history_grouping_skips_nested_controls_and_disconnects(qtbot) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    control = win.docks[1].widget().findChild(ItoolColormapControls)
+    assert control is not None
+    nested_spin = erlab.interactive.utils.BetterSpinBox(control.misc_controls)
+    qtbot.addWidget(nested_spin)
+    orphan_spin = erlab.interactive.utils.BetterSpinBox()
+    qtbot.addWidget(orphan_spin)
+    control._history_group_spins.append(orphan_spin)
+
+    control._connect_history_grouping()
+    control.disconnect_signals()
+
+    assert nested_spin not in control._history_group_spins
+    assert control._history_group_spins == []
+    win.close()
+
+
+def test_history_group_context_manager_finalizes_entry(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    start_index = area.current_indices[0]
+
+    with area.history_group():
+        area.set_index(0, start_index + 1)
+
+    assert not area._history_group_active
+    assert len(area._prev_states) == 1
+    win.close()
+
+
+def test_history_finalize_removes_committed_noop_entry_and_suppressed_write(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.begin_history_entry(None)
+    entry = area._pending_history_entry
+    assert entry is not None
+    area._prev_states.append(entry)
+    area._pending_history_committed = True
+    area.finalize_history_entry()
+
+    with area.history_suppressed():
+        area.write_state()
+
+    assert entry not in area._prev_states
+    assert area._pending_history_entry is None
+    win.close()
+
+
+def test_history_entry_changes_finalizes_pending_entry(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.begin_history_entry(None)
+    entries = area.history_entry_changes()
+
+    assert entries == []
+    assert area._pending_history_entry is None
+    win.close()
+
+
+def test_history_group_coalesces_binning_spinbox_steps(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    control = win.docks[2].widget().findChild(ItoolBinningControls)
+    assert control is not None
+    control.update_content()
+    area = win.slicer_area
+
+    control.spins[0].stepBy(1)
+    control.spins[0].stepBy(1)
+
+    assert area.array_slicer.get_bins(area.current_cursor)[0] == 5
+    assert len(area._prev_states) == 1
+    area.undo()
+    assert area.array_slicer.get_bins(area.current_cursor)[0] == 1
+    win.close()
+
+
+def test_history_group_records_gamma_slider_as_one_entry(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    control = win.docks[1].widget().findChild(ItoolColormapControls)
+    assert control is not None
+    area = win.slicer_area
+    initial_gamma = area.colormap_properties["gamma"]
+
+    control.gamma_widget.slider.sliderPressed.emit()
+    control.gamma_widget.setValue(1.2)
+    control.gamma_widget.setValue(1.4)
+
+    assert area.colormap_properties["gamma"] == pytest.approx(1.4)
+    assert len(area._prev_states) == 1
+    area.undo()
+    assert area.colormap_properties["gamma"] == pytest.approx(initial_gamma)
+    win.close()
+
+
+def test_history_group_coalesces_gamma_spinbox_steps(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    control = win.docks[1].widget().findChild(ItoolColormapControls)
+    assert control is not None
+    area = win.slicer_area
+    initial_gamma = area.colormap_properties["gamma"]
+
+    control.gamma_widget.spin.stepBy(1)
+    control.gamma_widget.spin.stepBy(1)
+
+    assert area.colormap_properties["gamma"] != pytest.approx(initial_gamma)
+    assert len(area._prev_states) == 1
+    area.undo()
+    assert area.colormap_properties["gamma"] == pytest.approx(initial_gamma)
+    win.close()
+
+
+def test_history_group_idle_timeout_starts_new_entry(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.begin_history_group()
+    area.set_index(0, 3)
+    qtbot.wait(area._HISTORY_GROUP_IDLE_TIMEOUT_MS + 50)
+    area.begin_history_group()
+    area.set_index(0, 4)
+
+    assert len(area._prev_states) == 2
+    win.close()
+
+
+def test_history_group_undo_redo_cancels_active_group(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    start_index = area.current_indices[0]
+
+    area.begin_history_group()
+    area.set_index(0, start_index + 1)
+    assert area._history_group_active
+
+    area.undo()
+    assert not area._history_group_active
+    assert area.current_indices[0] == start_index
+
+    area.redo()
+    assert not area._history_group_active
+    assert area.current_indices[0] == start_index + 1
+    win.close()
+
+
+def test_quick_discrete_actions_remain_separate_history_entries(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.swap_axes(0, 1)
+    area.swap_axes(0, 1)
+
+    assert len(area._prev_states) == 2
+    win.close()
+
+
+def test_history_entries_include_current_oldest_state():
+    states = [
+        {"color": {"cmap": "viridis"}},
+        {"color": {"cmap": "magma"}},
+    ]
+    area = _DummySlicerArea(states, 0)
+
+    entries = _history._history_entries(area)
+
+    assert entries[-1] == (0, 0, "Current state", (), True)
+
+
 def test_history_menu_handles_empty_history(qtbot):
     area = _DummySlicerArea([{"state": 1}], 0)
     menu = _history.HistoryMenu(area)
@@ -191,24 +729,22 @@ def test_history_menu_handles_empty_history(qtbot):
     menu.update_actions()
 
     actions = menu.actions()
-    assert len(actions) == 1
-    assert actions[0].objectName() == "itool_history_empty_action"
-    assert actions[0].data() == {"kind": "empty"}
-    assert not actions[0].isEnabled()
+    assert len(actions) == 3
+    assert actions[0].objectName() == "itool_history_show_action"
+    assert actions[0].data() == {"kind": "show_history"}
+    assert actions[1].isSeparator()
+    assert actions[2].objectName() == "itool_history_empty_action"
+    assert actions[2].data() == {"kind": "empty"}
+    assert not actions[2].isEnabled()
 
 
-def test_history_menu_populates_actions_and_triggers(monkeypatch, qtbot):
+def test_history_menu_populates_actions_and_triggers(qtbot):
     states = [
         {"color": {"cmap": "viridis"}},
         {"color": {"cmap": "magma"}},
         {"color": {"cmap": "plasma"}},
     ]
     area = _DummySlicerArea(states, 1)
-    monkeypatch.setattr(
-        _history,
-        "describe_state_diff",
-        lambda prev, curr: f"{prev['color']['cmap']}->{curr['color']['cmap']}",
-    )
 
     menu = _history.HistoryMenu(area)
     qtbot.addWidget(menu)
@@ -216,12 +752,164 @@ def test_history_menu_populates_actions_and_triggers(monkeypatch, qtbot):
     menu.update_actions()
 
     actions = menu.actions()
-    assert [action.objectName() for action in actions] == [
+    assert actions[0].objectName() == "itool_history_show_action"
+    assert actions[1].isSeparator()
+    history_actions = actions[2:]
+    assert [action.objectName() for action in history_actions] == [
         "itool_history_action_2",
         "itool_history_action_1",
     ]
-    assert [action.data() for action in actions] == [1, 0]
+    assert [action.data() for action in history_actions] == [1, 0]
+    assert all("Colormap changed" not in action.toolTip() for action in history_actions)
+    assert [action.statusTip() for action in history_actions] == ["", ""]
 
     actions[0].trigger()
-    actions[1].trigger()
+    assert isinstance(menu._dialog, _history.HistoryDialog)
+    qtbot.addWidget(menu._dialog)
+
+    history_actions[0].trigger()
+    history_actions[1].trigger()
     assert area.go_to_history_calls == [1, 0]
+
+
+def _dialog_widgets(dialog):
+    history_list = dialog.findChild(QtWidgets.QListWidget, "itool_history_list")
+    details = dialog.findChild(QtWidgets.QWidget, "itool_history_details")
+    go_to_btn = dialog.findChild(QtWidgets.QPushButton, "itool_history_go_to_button")
+    assert history_list is not None
+    assert details is not None
+    assert dialog.findChild(QtWidgets.QScrollArea, "itool_history_details") is None
+    assert go_to_btn is not None
+    return history_list, details, go_to_btn
+
+
+def _states_for_dialog_tests():
+    past = _base_state()
+    past["color"]["cmap"] = "magma"
+    current = _base_state()
+    future = copy.deepcopy(current)
+    future["slice"]["values"] = [[0.5, 1.0]]
+    return [past, current, future]
+
+
+def _detail_rows(details: QtWidgets.QWidget) -> list[tuple[str, str, str]]:
+    return [
+        (
+            row.property("detail"),
+            row.property("before"),
+            row.property("after"),
+        )
+        for row in details.findChildren(QtWidgets.QWidget, "itool_history_detail_row")
+    ]
+
+
+def test_history_dialog_populates_current_entry_and_details(qtbot):
+    area = _DummySlicerArea(_states_for_dialog_tests(), 1)
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+
+    history_list, details, go_to_btn = _dialog_widgets(dialog)
+
+    assert history_list.count() == 2
+    assert history_list.currentItem().data(QtCore.Qt.ItemDataRole.UserRole) == 0
+    assert history_list.currentItem().text().startswith("Current: ")
+    assert ("Colormap", "magma", "viridis") in _detail_rows(details)
+    assert all("->" not in "".join(row) for row in _detail_rows(details))
+    assert not go_to_btn.isEnabled()
+
+
+def test_history_dialog_selection_updates_visible_details(qtbot):
+    area = _DummySlicerArea(_states_for_dialog_tests(), 1)
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+    history_list, details, go_to_btn = _dialog_widgets(dialog)
+
+    history_list.setCurrentItem(history_list.item(0))
+
+    assert history_list.currentItem().data(QtCore.Qt.ItemDataRole.UserRole) == 1
+    assert ("Cursor 1 value", "[0.0, 1.0]", "[0.5, 1.0]") in _detail_rows(details)
+    assert go_to_btn.isEnabled()
+
+
+def test_history_dialog_resizes_long_cursor_details(qtbot):
+    past = _base_state()
+    past["slice"]["indices"] = [[123456789, 987654321]]
+    past["slice"]["values"] = [[12345.678901234567, -98765.43210987654]]
+    current = copy.deepcopy(past)
+    current["slice"]["indices"] = [[123456790, 987654111]]
+    current["slice"]["values"] = [[12345.678901239999, -98765.43210900001]]
+    future = copy.deepcopy(current)
+    future["slice"]["values"] = [[12345.678901240123, -98765.43210900077]]
+    area = _DummySlicerArea([past, current, future], 1)
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+    dialog.resize(460, dialog.height())
+
+    history_list, details, go_to_btn = _dialog_widgets(dialog)
+    history_list.setCurrentItem(history_list.item(0))
+
+    assert go_to_btn.isEnabled()
+    assert any(row[0] == "Cursor 1 value" for row in _detail_rows(details))
+
+
+def test_history_dialog_go_to_selected_entry(qtbot):
+    area = _DummySlicerArea(_states_for_dialog_tests(), 1)
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+    history_list, _, go_to_btn = _dialog_widgets(dialog)
+
+    history_list.setCurrentItem(history_list.item(0))
+    qtbot.mouseClick(go_to_btn, QtCore.Qt.MouseButton.LeftButton)
+
+    assert area.go_to_history_calls == [1]
+
+
+def test_history_dialog_handles_empty_selection_and_row_height_fallback(qtbot):
+    area = _DummySlicerArea(_states_for_dialog_tests(), 1)
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+    history_list, _, _ = _dialog_widgets(dialog)
+
+    history_list.sizeHintForRow = lambda _: 0
+    dialog._update_history_list_height()
+    history_list.clearSelection()
+    history_list.setCurrentItem(None)
+
+    dialog._go_to_selected()
+
+    assert dialog._selected_relative_index() is None
+    assert area.go_to_history_calls == []
+
+
+def test_history_dialog_activates_entry_from_double_click_and_return(qtbot):
+    area = _DummySlicerArea(_states_for_dialog_tests(), 1)
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+    dialog.show()
+    history_list, _, _ = _dialog_widgets(dialog)
+    history_list.setCurrentItem(history_list.item(0))
+
+    history_list.itemDoubleClicked.emit(history_list.currentItem())
+    assert area.go_to_history_calls == [1]
+
+    area.go_to_history_calls.clear()
+    history_list.setFocus()
+    qtbot.keyClick(history_list, QtCore.Qt.Key.Key_Return)
+    assert area.go_to_history_calls == [1]
+
+
+def test_history_dialog_refreshes_to_current_entry(qtbot):
+    area = _DummySlicerArea(_states_for_dialog_tests(), 1)
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+    history_list, details, go_to_btn = _dialog_widgets(dialog)
+
+    history_list.setCurrentItem(history_list.item(0))
+    assert go_to_btn.isEnabled()
+
+    area._current_index = 2
+    area.sigHistoryChanged.emit()
+
+    assert history_list.currentItem().data(QtCore.Qt.ItemDataRole.UserRole) == 0
+    assert not go_to_btn.isEnabled()
+    assert ("Cursor 1 value", "[0.0, 1.0]", "[0.5, 1.0]") in _detail_rows(details)

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -467,21 +467,17 @@ def test_history_states_include_current_and_future(qtbot):
     qtbot.addWidget(win)
     area = win.slicer_area
 
-    base_state = area.state
-    past_state = copy.deepcopy(base_state)
-    past_state["color"]["reverse"] = True
-    future_state = copy.deepcopy(base_state)
-    future_state["current_cursor"] = base_state["current_cursor"] + 1
-
-    area._prev_states.clear()
-    area._next_states.clear()
-    area._prev_states.append(past_state)
-    area._next_states.append(future_state)
+    base_state = area._history_state_snapshot()
+    area.set_index(0, 1)
+    current_state = area._history_state_snapshot()
+    area.set_index(1, 1)
+    future_state = area._history_state_snapshot()
+    area.undo()
 
     states, current_index = area.history_states()
 
-    assert states[0] == past_state
-    assert states[1] == base_state
+    assert states[0] == base_state
+    assert states[1] == current_state
     assert states[2] == future_state
     assert current_index == 1
     win.close()
@@ -551,6 +547,133 @@ def test_controls_history_grouping_skips_nested_controls_and_disconnects(qtbot) 
     win.close()
 
 
+def test_history_entries_record_timestamps(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.set_index(0, 1)
+
+    entry = area._prev_states[-1]
+    assert entry.created_at.tzinfo is not None
+    assert entry.created_at.utcoffset() is not None
+    win.close()
+
+
+def test_noop_history_write_does_not_evict_full_undo_stack(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    base_state = area._history_state_snapshot()
+
+    area._prev_states.clear()
+    for i in range(area._prev_states.maxlen or 0):
+        before_state = copy.deepcopy(base_state)
+        after_state = copy.deepcopy(base_state)
+        before_state["current_cursor"] = i
+        after_state["current_cursor"] = i + 1
+        area._prev_states.append(
+            _history.HistoryEntry(
+                before_state,
+                after_state,
+                frozenset({("current_cursor",)}),
+                None,
+            )
+        )
+    oldest_entry = area._prev_states[0]
+
+    area.sigWriteHistory.emit()
+    area.finalize_history_entry()
+
+    assert len(area._prev_states) == area._prev_states.maxlen
+    assert area._prev_states[0] is oldest_entry
+    win.close()
+
+
+def test_noop_history_write_does_not_clear_redo_stack(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    base_state = area._history_state_snapshot()
+    future_state = copy.deepcopy(base_state)
+    future_state["current_cursor"] = base_state["current_cursor"] + 1
+    future_entry = _history.HistoryEntry(
+        base_state,
+        future_state,
+        frozenset({("current_cursor",)}),
+        None,
+    )
+    area._next_states.append(future_entry)
+
+    area.sigWriteHistory.emit()
+    area.finalize_history_entry()
+
+    assert list(area._next_states) == [future_entry]
+    win.close()
+
+
+def test_history_patch_preserves_unrelated_sequence_items():
+    before = {
+        "slice": {
+            "indices": [[2, 2], [2, 2]],
+            "values": [[2.0, 2.0], [2.0, 2.0]],
+        }
+    }
+    after = {
+        "slice": {
+            "indices": [[4, 2], [2, 2]],
+            "values": [[4.0, 2.0], [2.0, 2.0]],
+        }
+    }
+    current = {
+        "slice": {
+            "indices": [[4, 2], [2, 4]],
+            "values": [[4.0, 2.0], [2.0, 4.0]],
+        }
+    }
+
+    paths = _history.changed_paths(before, after)
+
+    assert paths == frozenset({("slice", "indices", 0, 0), ("slice", "values", 0, 0)})
+    assert _history.patch_state(current, before, paths) == {
+        "slice": {
+            "indices": [[2, 2], [2, 4]],
+            "values": [[2.0, 2.0], [2.0, 4.0]],
+        }
+    }
+
+
+def test_history_patch_uses_whole_path_for_sequence_shape_changes():
+    before = {"slice": {"indices": [[2, 2]]}}
+    after = {"slice": {"indices": [[2, 2], [4, 4]]}}
+    paths = _history.changed_paths(before, after)
+
+    assert paths == frozenset({("slice", "indices")})
+    assert _history.patch_state(after, before, paths) == before
+
+
+def test_history_patch_preserves_mapping_keys_containing_dots():
+    before = {"manual_limits": {"a.b": [0.0, 1.0]}}
+    after = {"manual_limits": {"a.b": [0.0, 2.0]}}
+    paths = _history.changed_paths(before, after)
+
+    assert paths == frozenset({("manual_limits", "a.b", 1)})
+    assert _history.patch_state(after, before, paths) == before
+
+
+def test_history_patch_uses_whole_path_for_arrays():
+    before = {"values": np.array([1, 2])}
+    after = {"values": np.array([1, 3])}
+    paths = _history.changed_paths(before, after)
+
+    assert paths == frozenset({("values",)})
+    patched = _history.patch_state(after, before, paths)
+    assert np.array_equal(patched["values"], before["values"])
+
+
 def test_history_group_context_manager_finalizes_entry(qtbot):
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
     win = ImageTool(data)
@@ -598,6 +721,39 @@ def test_history_entry_changes_finalizes_pending_entry(qtbot):
 
     assert entries == []
     assert area._pending_history_entry is None
+    win.close()
+
+
+def test_manual_limit_undo_preserves_dotted_dimension_name(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["a.b", "c"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.set_manual_limits({"a.b": [0.0, 1.0]})
+    area.sigWriteHistory.emit()
+    area.set_manual_limits({"a.b": [0.0, 2.0]})
+    area.finalize_history_entry()
+    area.undo()
+
+    assert area.manual_limits == {"a.b": [0.0, 1.0]}
+    win.close()
+
+
+def test_history_dialog_open_does_not_consume_new_entry(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    start_index = area.current_indices[0]
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+
+    area.set_index(0, start_index + 1)
+    area.undo()
+
+    assert area.current_indices[0] == start_index
+    dialog.close()
     win.close()
 
 
@@ -659,6 +815,30 @@ def test_history_group_coalesces_gamma_spinbox_steps(qtbot):
     win.close()
 
 
+def test_compound_colormap_change_records_one_entry(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    initial_gamma = area.colormap_properties["gamma"]
+
+    area.set_colormap(gamma=1.2, reverse=True)
+
+    assert area.colormap_properties["gamma"] == pytest.approx(1.2)
+    assert area.colormap_properties["reverse"] is True
+    assert area.reverse_act.isChecked()
+    assert len(area._prev_states) == 1
+    assert area._prev_states[-1].changed_paths == frozenset(
+        {("color", "gamma"), ("color", "reverse")}
+    )
+
+    area.undo()
+    assert area.colormap_properties["gamma"] == pytest.approx(initial_gamma)
+    assert area.colormap_properties["reverse"] is False
+    assert not area.reverse_act.isChecked()
+    win.close()
+
+
 def test_history_group_idle_timeout_starts_new_entry(qtbot):
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
     win = ImageTool(data)
@@ -696,6 +876,68 @@ def test_history_group_undo_redo_cancels_active_group(qtbot):
     win.close()
 
 
+def test_history_group_reuses_pending_linked_transaction_id(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.begin_history_group()
+    transaction_id = area.next_linked_history_transaction_id()
+    area.record_history_mutation(
+        transaction_id,
+        lambda: area.set_manual_limits({"x": [0.0, 1.0]}),
+        keep_pending=True,
+    )
+    assert area.next_linked_history_transaction_id() == transaction_id
+
+    area.record_history_mutation(
+        transaction_id,
+        lambda: area.set_manual_limits({"x": [0.0, 2.0]}),
+        keep_pending=True,
+    )
+    area.end_history_group()
+
+    assert [entry.transaction_id for entry in area._prev_states] == [transaction_id]
+    assert area._prev_states[-1].after_state["manual_limits"] == {"x": [0.0, 2.0]}
+    win.close()
+
+
+def test_history_group_linked_transaction_id_resets_after_local_split(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.begin_history_group()
+    first_transaction_id = area.next_linked_history_transaction_id()
+    area.record_history_mutation(
+        first_transaction_id,
+        lambda: area.set_manual_limits({"x": [0.0, 1.0]}),
+        keep_pending=True,
+    )
+    area.record_history_mutation(
+        None,
+        lambda: area.set_manual_limits({"x": [0.0, 1.0], "y": [0.0, 1.0]}),
+        keep_pending=True,
+    )
+    second_transaction_id = area.next_linked_history_transaction_id()
+    area.record_history_mutation(
+        second_transaction_id,
+        lambda: area.set_manual_limits({"x": [0.0, 2.0], "y": [0.0, 1.0]}),
+        keep_pending=True,
+    )
+    area.end_history_group()
+
+    assert second_transaction_id != first_transaction_id
+    assert [entry.transaction_id for entry in area._prev_states] == [
+        first_transaction_id,
+        None,
+        second_transaction_id,
+    ]
+    win.close()
+
+
 def test_quick_discrete_actions_remain_separate_history_entries(qtbot):
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
     win = ImageTool(data)
@@ -718,7 +960,22 @@ def test_history_entries_include_current_oldest_state():
 
     entries = _history._history_entries(area)
 
-    assert entries[-1] == (0, 0, "Current state", (), True)
+    assert entries[-1] == (0, 0, "Current state", (), True, None)
+
+
+def test_history_entries_include_current_after_undoing_to_oldest_state(qtbot):
+    data = xr.DataArray(np.arange(4).reshape((2, 2)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.set_index(0, 1)
+    area.undo()
+
+    entries = _history._history_entries(area)
+
+    assert entries[-1] == (0, 0, "Current state", (), True, None)
+    win.close()
 
 
 def test_history_menu_handles_empty_history(qtbot):
@@ -816,6 +1073,26 @@ def test_history_dialog_populates_current_entry_and_details(qtbot):
     assert ("Colormap", "magma", "viridis") in _detail_rows(details)
     assert all("->" not in "".join(row) for row in _detail_rows(details))
     assert not go_to_btn.isEnabled()
+
+
+def test_history_dialog_shows_entry_timestamp(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    area.set_index(0, 1)
+
+    dialog = _history.HistoryDialog(area)
+    qtbot.addWidget(dialog)
+    history_list, _, _ = _dialog_widgets(dialog)
+
+    timestamp = _history._format_history_datetime(area._prev_states[-1].created_at)
+    item = history_list.item(0)
+    assert item.data(QtCore.Qt.ItemDataRole.UserRole + 2) == timestamp
+    assert item.toolTip() == timestamp
+    assert timestamp in item.text()
+    dialog.close()
+    win.close()
 
 
 def test_history_dialog_selection_updates_visible_details(qtbot):

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2295,6 +2295,95 @@ def _linked_pair(qtbot):
     return typing.cast("list[ImageTool]", wins)
 
 
+class _SceneDragEvent:
+    def __init__(self, scene_pos: QtCore.QPointF) -> None:
+        self._scene_pos = scene_pos
+
+    def scenePos(self) -> QtCore.QPointF:
+        return self._scene_pos
+
+
+def _cursor_line_values(image, cursor: int) -> tuple[float, ...]:
+    return tuple(line.value() for line in image.cursor_lines[cursor].values())
+
+
+def test_linked_command_option_image_drag_refreshes_linked_cursors(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    win0.slicer_area.add_cursor()
+    assert win0.slicer_area.n_cursors == 2
+    assert win1.slicer_area.n_cursors == 2
+
+    with qtbot.waitExposed(win0):
+        win0.show()
+    with qtbot.waitExposed(win1):
+        win1.show()
+
+    source_image = win0.slicer_area.main_image
+    target_image = win1.slicer_area.main_image
+    assert _cursor_line_values(target_image, 0) == (2.0, 2.0)
+    assert _cursor_line_values(target_image, 1) == (2.0, 2.0)
+
+    scene_pos = source_image.getViewBox().mapViewToScene(QtCore.QPointF(3.0, 1.0))
+    source_image.process_drag(
+        (
+            _SceneDragEvent(scene_pos),
+            QtCore.Qt.KeyboardModifier.ControlModifier
+            | QtCore.Qt.KeyboardModifier.AltModifier,
+        )
+    )
+
+    for cursor in range(2):
+        qtbot.waitUntil(
+            lambda cursor=cursor: np.allclose(
+                _cursor_line_values(target_image, cursor), (3.0, 1.0)
+            )
+        )
+        assert win0.array_slicer.get_indices(cursor) == [3, 1]
+        assert win1.array_slicer.get_indices(cursor) == [3, 1]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_option_cursor_line_drag_refreshes_linked_cursors(
+    qtbot, monkeypatch
+) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    win0.slicer_area.add_cursor()
+
+    with qtbot.waitExposed(win0):
+        win0.show()
+    with qtbot.waitExposed(win1):
+        win1.show()
+
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "keyboardModifiers",
+        staticmethod(lambda: QtCore.Qt.KeyboardModifier.AltModifier),
+    )
+
+    source_image = win0.slicer_area.main_image
+    target_image = win1.slicer_area.main_image
+    axis = source_image.display_axis[0]
+    line = source_image.cursor_lines[0][axis]
+
+    source_image.line_drag(line, 4.0, axis)
+
+    for cursor in range(2):
+        qtbot.waitUntil(
+            lambda cursor=cursor: np.allclose(
+                _cursor_line_values(target_image, cursor), (4.0, 2.0)
+            )
+        )
+        assert win0.array_slicer.get_indices(cursor) == [4, 2]
+        assert win1.array_slicer.get_indices(cursor) == [4, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
 def test_linked_cursor_undo_redo_propagates(qtbot) -> None:
     win0, win1 = _linked_pair(qtbot)
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -42,6 +42,7 @@ from erlab.interactive.imagetool.dialogs import (
     ROIMaskDialog,
     ROIPathDialog,
     RotationDialog,
+    SelectionDialog,
     SwapDimsDialog,
     SymmetrizeDialog,
     SymmetrizeNfoldDialog,
@@ -134,6 +135,18 @@ def _menu_action_by_data(menu: QtWidgets.QMenu, data: object) -> QtGui.QAction:
     matches = [action for action in menu.actions() if action.data() == data]
     assert len(matches) == 1
     return matches[0]
+
+
+def _set_combo_data(combo: QtWidgets.QComboBox, data: object) -> None:
+    index = combo.findData(data, QtCore.Qt.ItemDataRole.UserRole)
+    assert index != -1
+    combo.setCurrentIndex(index)
+
+
+def _clear_selection_dialog(dialog: SelectionDialog) -> None:
+    for row in dialog.rows:
+        row.use_check.setChecked(False)
+        row.width_check.setChecked(False)
 
 
 def _assert_guideline_state(
@@ -712,7 +725,7 @@ def test_selection_expr_for_cursor_preserves_nonstring_qsel_dim(qtbot) -> None:
     qtbot.addWidget(win)
 
     expr = win.slicer_area.main_image._selection_expr_for_cursor("data", 0, (0,))
-    assert expr == 'data.qsel(**{"k-space": 0.0})'
+    assert expr == 'data.qsel({"k-space": 0.0})'
 
     win.close()
 
@@ -760,7 +773,7 @@ def test_plot_code_multicursor_image_with_non_identifier_dim_name(qtbot) -> None
     main_image = win.slicer_area.images[0]
 
     code = main_image._plot_code_multicursor()
-    assert 'selected = data.qsel(**{"k-space": 2.0})' in code
+    assert 'selected = data.qsel({"k-space": 2.0})' in code
 
     win.close()
 
@@ -3611,6 +3624,267 @@ def test_average_dialog_make_code_preserves_nonstring_dim(qtbot) -> None:
         _exec_data_fragment(data, dialog.make_code()),
         data.qsel.average("k-space"),
     )
+
+    dialog.close()
+    win.close()
+
+
+def _selection_4d_data() -> xr.DataArray:
+    return xr.DataArray(
+        np.arange(3 * 4 * 5 * 6).reshape((3, 4, 5, 6)).astype(float),
+        dims=["alpha", "eV", "beta", "hv"],
+        coords={
+            "alpha": np.arange(3, dtype=float),
+            "eV": np.arange(4, dtype=float),
+            "beta": np.arange(5, dtype=float),
+            "hv": np.linspace(20.0, 70.0, 6),
+        },
+        name="scan",
+    )
+
+
+def test_selection_dialog_seeds_4d_cursor_slice(qtbot) -> None:
+    data = _selection_4d_data()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.set_index(3, 4)
+
+    dialog = SelectionDialog(win.slicer_area)
+
+    assert [row.use_check.isChecked() for row in dialog.rows] == [
+        False,
+        False,
+        False,
+        True,
+    ]
+    expected = data.qsel(hv=60.0)
+    xarray.testing.assert_identical(dialog.process_data(dialog.public_data), expected)
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+    assert dialog.buttonBox.button(
+        QtWidgets.QDialogButtonBox.StandardButton.Ok
+    ).isEnabled()
+
+    dialog.close()
+    win.close()
+
+
+def test_selection_dialog_accept_replaces_current_data(qtbot) -> None:
+    data = _selection_4d_data()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.set_index(3, 2)
+
+    dialog = SelectionDialog(win.slicer_area)
+    dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    dialog.accept()
+
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None), data.qsel(hv=40.0).rename(None)
+    )
+    assert win.provenance_spec is not None
+    assert [op.op for op in win.provenance_spec.operations] == ["qsel", "rename"]
+
+    win.close()
+
+
+def test_selection_dialog_isel_range_executes_code(qtbot) -> None:
+    data = _selection_4d_data()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = SelectionDialog(win.slicer_area)
+    _clear_selection_dialog(dialog)
+
+    row = dialog.rows[0]
+    row.use_check.setChecked(True)
+    _set_combo_data(row.method_combo, "isel")
+    _set_combo_data(row.kind_combo, "range")
+    row.index_start_spin.setValue(1)
+    row.index_stop_spin.setValue(3)
+
+    expected = data.isel(alpha=slice(1, 3))
+    xarray.testing.assert_identical(dialog.process_data(dialog.public_data), expected)
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+
+    dialog.close()
+    win.close()
+
+
+def test_selection_dialog_formats_non_identifier_dim_as_mapping(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(3 * 4 * 5).reshape((3, 4, 5)).astype(float),
+        dims=["Fake Motor", "eV", "beta"],
+        coords={
+            "Fake Motor": np.arange(3, dtype=float),
+            "eV": np.arange(4, dtype=float),
+            "beta": np.arange(5, dtype=float),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = SelectionDialog(win.slicer_area)
+    _clear_selection_dialog(dialog)
+
+    row = dialog.rows[0]
+    row.use_check.setChecked(True)
+    _set_combo_data(row.method_combo, "isel")
+    row.index_start_spin.setValue(1)
+
+    expected = data.isel({"Fake Motor": 1})
+    assert dialog.make_code() == '.isel({"Fake Motor": 1})'
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+
+    dialog.close()
+    win.close()
+
+
+def test_selection_dialog_sel_range_executes_code(qtbot) -> None:
+    data = _selection_4d_data()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = SelectionDialog(win.slicer_area)
+    _clear_selection_dialog(dialog)
+
+    row = dialog.rows[1]
+    row.use_check.setChecked(True)
+    _set_combo_data(row.method_combo, "sel")
+    _set_combo_data(row.kind_combo, "range")
+    row.value_start_spin.setValue(1.0)
+    row.value_stop_spin.setValue(3.0)
+
+    expected = data.sel(eV=slice(1.0, 3.0))
+    xarray.testing.assert_identical(dialog.process_data(dialog.public_data), expected)
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+
+    dialog.close()
+    win.close()
+
+
+def test_selection_dialog_qsel_range_ignores_cursor_width(qtbot) -> None:
+    data = _selection_4d_data()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.array_slicer.set_bin(0, axis=2, value=3, update=True)
+    dialog = SelectionDialog(win.slicer_area)
+    for dialog_row in dialog.rows:
+        dialog_row.use_check.setChecked(False)
+
+    row = dialog.rows[2]
+    row.use_check.setChecked(True)
+    _set_combo_data(row.method_combo, "qsel")
+    _set_combo_data(row.kind_combo, "range")
+    row.value_start_spin.setValue(1.0)
+    row.value_stop_spin.setValue(3.0)
+
+    expected = data.qsel(beta=slice(1.0, 3.0))
+    assert row.width_check.isChecked()
+    assert not row.width_widget.isEnabled()
+    assert row.qsel_width_indexer() is None
+    xarray.testing.assert_identical(dialog.process_data(dialog.public_data), expected)
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+    assert dialog.buttonBox.button(
+        QtWidgets.QDialogButtonBox.StandardButton.Ok
+    ).isEnabled()
+
+    dialog.close()
+    win.close()
+
+
+def test_selection_dialog_qsel_width_executes_code(qtbot) -> None:
+    data = _selection_4d_data()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = SelectionDialog(win.slicer_area)
+    _clear_selection_dialog(dialog)
+
+    row = dialog.rows[2]
+    row.use_check.setChecked(True)
+    _set_combo_data(row.method_combo, "qsel")
+    _set_combo_data(row.kind_combo, "point")
+    row.value_start_spin.setValue(2.0)
+    row.width_check.setChecked(True)
+    row.width_spin.setValue(2.0)
+
+    expected = data.qsel(beta=2.0, beta_width=2.0)
+    xarray.testing.assert_identical(dialog.process_data(dialog.public_data), expected)
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+
+    dialog.close()
+    win.close()
+
+
+def test_selection_dialog_uses_public_nonuniform_dimensions(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(3 * 4 * 5).reshape((3, 4, 5)).astype(float),
+        dims=["alpha", "eV", "beta"],
+        coords={
+            "alpha": np.array([0.1, 0.4, 0.8]),
+            "eV": np.arange(4, dtype=float),
+            "beta": np.arange(5, dtype=float),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = SelectionDialog(win.slicer_area)
+    _clear_selection_dialog(dialog)
+
+    assert win.slicer_area.data.dims == ("alpha_idx", "eV", "beta")
+    row = dialog.rows[0]
+    row.use_check.setChecked(True)
+    _set_combo_data(row.method_combo, "qsel")
+    row.value_start_spin.setValue(0.4)
+
+    expected = data.qsel(alpha=0.4)
+    selected = dialog.process_data(dialog.public_data)
+    assert selected.dims == ("eV", "beta")
+    xarray.testing.assert_identical(selected, expected)
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+    spec = dialog.source_spec("scan_sel")
+    assert spec.kind == "public_data"
+    xarray.testing.assert_identical(
+        spec.apply(win.slicer_area.data), expected.rename("scan_sel")
+    )
+
+    dialog.close()
+    win.close()
+
+
+def test_selection_dialog_menu_action_key(qtbot) -> None:
+    win = itool(_TEST_DATA["2D"].copy(), execute=False)
+    qtbot.addWidget(win)
+
+    action = win.mnb.action_dict["selectDataAct"]
+    assert action.isEnabled()
+
+    win.close()
+
+
+def test_selection_dialog_rejects_empty_selection(qtbot) -> None:
+    win = itool(_TEST_DATA["2D"].copy(), execute=False)
+    qtbot.addWidget(win)
+    dialog = SelectionDialog(win.slicer_area)
+    _clear_selection_dialog(dialog)
+
+    assert dialog.source_operations() == []
+    assert not dialog.buttonBox.button(
+        QtWidgets.QDialogButtonBox.StandardButton.Ok
+    ).isEnabled()
 
     dialog.close()
     win.close()

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import logging
 import pathlib
 import tempfile
@@ -1830,6 +1831,7 @@ def test_itool_general(qtbot, move_and_compare_values, use_dask) -> None:
         "file_path": None,
         "load_func": None,
         "cursor_colors": ["#cccccc", "#ffff00"],
+        "controls_visible": True,
         "plotitem_states": [
             {
                 "roi_states": [],
@@ -2593,6 +2595,66 @@ def test_itool_guideline_state_dataset_roundtrip(qtbot) -> None:
         offset=(2.0, 2.0),
         follow_cursor=True,
     )
+
+    restored.close()
+    win.close()
+
+
+def test_itool_controls_visibility_menu_history_and_dataset_roundtrip(qtbot) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    action = win.mnb.action_dict["toggleControlsAct"]
+    assert action.isCheckable()
+    assert action.isChecked()
+    assert win.controls_visible
+    assert win.slicer_area.state["controls_visible"] is True
+
+    action.trigger()
+    assert not action.isChecked()
+    assert not win.controls_visible
+    assert win.slicer_area.state["controls_visible"] is False
+    assert win.slicer_area.undoable
+
+    win.slicer_area.undo()
+    assert action.isChecked()
+    assert win.controls_visible
+    assert win.slicer_area.state["controls_visible"] is True
+
+    win.slicer_area.redo()
+    assert not action.isChecked()
+    assert not win.controls_visible
+    assert win.slicer_area.state["controls_visible"] is False
+
+    restored = ImageTool.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+
+    assert not restored.controls_visible
+    assert not restored.mnb.action_dict["toggleControlsAct"].isChecked()
+    assert restored.slicer_area.state["controls_visible"] is False
+
+    restored.close()
+    win.close()
+
+
+def test_itool_controls_visibility_legacy_state_defaults_visible(qtbot) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.controls_visible = False
+
+    ds = win.to_dataset()
+    state = json.loads(ds.attrs["itool_state"])
+    state.pop("controls_visible")
+    ds.attrs["itool_state"] = json.dumps(state)
+
+    restored = ImageTool.from_dataset(ds)
+    qtbot.addWidget(restored)
+
+    assert restored.controls_visible
+    assert restored.mnb.action_dict["toggleControlsAct"].isChecked()
+    assert restored.slicer_area.state["controls_visible"] is True
 
     restored.close()
     win.close()

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1139,6 +1139,42 @@ def test_profile_menu_opens_associated_coord_targets(
     win.close()
 
 
+def test_profile_associated_coord_menu_does_not_compute_dask_coord(qtbot) -> None:
+    da = pytest.importorskip("dask.array")
+    from dask.callbacks import Callback
+
+    x = np.arange(3, dtype=float)
+    y = np.arange(4, dtype=float)
+    plane = da.from_array(x[:, None] * 10.0 + y[None, :], chunks=(1, 4))
+    data = xr.DataArray(
+        np.zeros((3, 4, 2), dtype=float),
+        dims=["x", "y", "z"],
+        coords={
+            "x": x,
+            "y": y,
+            "z": np.arange(2, dtype=float),
+            "plane": (("x", "y"), plane),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    profile = win.slicer_area.profiles[0]
+    win.slicer_area.array_slicer.twin_coord_names = {"plane"}
+
+    computed_keys: list[object] = []
+    with Callback(pretask=lambda key, _dsk, _state: computed_keys.append(key)):
+        profile._refresh_associated_coord_menu()
+
+    assert computed_keys == []
+    assert profile._associated_coord_menu is not None
+    assert profile._associated_coord_menu.menuAction().isVisible()
+    associated_coord_action = _menu_action_by_data(
+        profile._associated_coord_menu, ("associated_coord", "plane")
+    )
+    assert associated_coord_action.menu() is not None
+    win.close()
+
+
 def test_associated_coord_dialog_empty_warning(qtbot, monkeypatch) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)),
@@ -2817,6 +2853,111 @@ def test_apply_func_preserves_source_data(qtbot) -> None:
 
     win.slicer_area.apply_func(None)
     xarray.testing.assert_identical(win.slicer_area.data, data)
+    win.close()
+
+
+def test_apply_func_preserves_dask_backed_preview(qtbot) -> None:
+    da = pytest.importorskip("dask.array")
+    from dask.callbacks import Callback
+
+    values = np.arange(25, dtype=np.float32).reshape((5, 5))
+    data = xr.DataArray(
+        da.from_array(values, chunks=(2, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5), "y": np.arange(5)},
+    )
+
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+
+    computed_keys: list[object] = []
+    with Callback(pretask=lambda key, _dsk, _state: computed_keys.append(key)):
+        win.slicer_area.apply_func(lambda darr: darr + 1, update=False)
+
+    assert computed_keys == []
+    assert win.slicer_area.data_chunked
+    assert win.slicer_area.data.chunks is not None
+    assert win.slicer_area._obj_shares_data_values is False
+    xarray.testing.assert_identical(
+        win.slicer_area.data.compute(), (data + 1).compute()
+    )
+
+    win.slicer_area.apply_func(None, update=False)
+    assert win.slicer_area.data_chunked
+    assert win.slicer_area.data.chunks == data.chunks
+    assert win.slicer_area._obj_shares_data_values is True
+    win.close()
+
+
+def test_apply_func_accepts_transposed_dask_preview_and_updates(qtbot) -> None:
+    da = pytest.importorskip("dask.array")
+
+    values = np.arange(20, dtype=np.float32).reshape((4, 5))
+    data = xr.DataArray(
+        da.from_array(values, chunks=(2, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(4), "y": np.arange(5)},
+    )
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+
+    win.slicer_area.apply_func(lambda darr: (darr + 1).transpose("y", "x"))
+
+    assert win.slicer_area.data.dims == data.dims
+    assert win.slicer_area.data.chunks is not None
+    xarray.testing.assert_identical(
+        win.slicer_area.data.compute(), (data + 1).compute()
+    )
+    win.close()
+
+
+def test_apply_func_rejects_mismatched_dask_preview(qtbot) -> None:
+    da = pytest.importorskip("dask.array")
+
+    values = np.arange(20, dtype=np.float32).reshape((4, 5))
+    data = xr.DataArray(
+        da.from_array(values, chunks=(2, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(4), "y": np.arange(5)},
+    )
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+
+    with pytest.raises(ValueError, match="dimensions do not match"):
+        win.slicer_area.apply_func(lambda darr: darr.expand_dims("z"), update=False)
+    with pytest.raises(ValueError, match="dimensions do not match"):
+        win.slicer_area.apply_func(lambda darr: darr.rename({"x": "z"}), update=False)
+    with pytest.raises(ValueError, match="shape does not match"):
+        win.slicer_area.apply_func(
+            lambda darr: darr.isel(x=slice(1, None)), update=False
+        )
+    win.close()
+
+
+def test_eager_preview_from_dask_source_updates_readout(qtbot) -> None:
+    da = pytest.importorskip("dask.array")
+
+    source_values = np.arange(20, dtype=np.float32).reshape((4, 5))
+    preview_values = source_values + 100.0
+    data = xr.DataArray(
+        da.from_array(source_values, chunks=(2, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(4), "y": np.arange(5)},
+    )
+    preview = xr.DataArray(preview_values, dims=data.dims, coords=data.coords)
+
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+    control = win.docks[0].widget().findChild(ItoolCrosshairControls)
+    assert control is not None
+
+    win.slicer_area.apply_func(lambda _darr: preview)
+    assert win.slicer_area.data_chunked
+    assert win.slicer_area.data.chunks is None
+
+    control.update_content()
+    win.slicer_area.set_index(0, 3)
+    assert control.spin_dat.value() == preview_values[3, 2]
     win.close()
 
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2285,6 +2285,393 @@ def test_itool_ds(qtbot) -> None:
         win.close()
 
 
+def _linked_pair(qtbot):
+    data = xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=["x", "y"])
+    wins = itool([data, data], execute=False, link=True)
+    assert isinstance(wins, list)
+    assert len(wins) == 2
+    for win in wins:
+        qtbot.addWidget(win)
+    return typing.cast("list[ImageTool]", wins)
+
+
+def test_linked_cursor_undo_redo_propagates(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.set_index(0, 4)
+    assert win0.array_slicer.get_indices(0) == [4, 2]
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+
+    win0.slicer_area.redo()
+    assert win0.array_slicer.get_indices(0) == [4, 2]
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_cursor_entry_closes_before_unrecorded_linked_state(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    for win in (win0, win1):
+        win.slicer_area.set_manual_limits({"x": [1.0, 3.0]})
+        win.slicer_area.flush_history()
+
+    win0.slicer_area.set_index(0, 4)
+    assert win0.slicer_area._pending_history_entry is None
+    assert win1.slicer_area._pending_history_entry is None
+
+    win0.slicer_area.view_all()
+    assert win0.slicer_area.manual_limits == {}
+    assert win1.slicer_area.manual_limits == {}
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+    assert win0.slicer_area.manual_limits == {}
+    assert win1.slicer_area.manual_limits == {}
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_grouped_cursor_undo_propagates(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    control = win0.docks[0].widget().findChild(ItoolCrosshairControls)
+    assert control is not None
+    control.update_content()
+
+    control.spin_idx[0].stepBy(1)
+    control.spin_idx[0].stepBy(1)
+    assert win0.array_slicer.get_indices(0) == [4, 2]
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_remove_current_cursor_undo_propagates(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    win0.slicer_area.add_cursor()
+    win0.slicer_area.flush_history()
+    win1.slicer_area.flush_history()
+
+    win0.slicer_area.remove_current_cursor()
+    assert win0.slicer_area.n_cursors == 1
+    assert win1.slicer_area.n_cursors == 1
+    assert (
+        win0.slicer_area._prev_states[-1].transaction_id
+        == win1.slicer_area._prev_states[-1].transaction_id
+    )
+
+    win0.slicer_area.undo()
+    assert win0.slicer_area.n_cursors == 2
+    assert win1.slicer_area.n_cursors == 2
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_gamma_undo_redo_propagates(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.set_colormap(gamma=1.4)
+    assert win0.slicer_area.colormap_properties["gamma"] == pytest.approx(1.4)
+    assert win1.slicer_area.colormap_properties["gamma"] == pytest.approx(1.4)
+
+    win0.slicer_area.undo()
+    assert win0.slicer_area.colormap_properties["gamma"] == pytest.approx(0.5)
+    assert win1.slicer_area.colormap_properties["gamma"] == pytest.approx(0.5)
+
+    win0.slicer_area.redo()
+    assert win0.slicer_area.colormap_properties["gamma"] == pytest.approx(1.4)
+    assert win1.slicer_area.colormap_properties["gamma"] == pytest.approx(1.4)
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_grouped_gamma_undo_propagates(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    control = win0.docks[1].widget().findChild(ItoolColormapControls)
+    assert control is not None
+
+    control.gamma_widget.slider.sliderPressed.emit()
+    control.gamma_widget.setValue(1.2)
+    control.gamma_widget.setValue(1.4)
+    assert win0.slicer_area.colormap_properties["gamma"] == pytest.approx(1.4)
+    assert win1.slicer_area.colormap_properties["gamma"] == pytest.approx(1.4)
+
+    win0.slicer_area.undo()
+    assert win0.slicer_area.colormap_properties["gamma"] == pytest.approx(0.5)
+    assert win1.slicer_area.colormap_properties["gamma"] == pytest.approx(0.5)
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_compound_colormap_undo_propagates(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.set_colormap(gamma=1.2, reverse=True)
+    for win in (win0, win1):
+        assert win.slicer_area.colormap_properties["gamma"] == pytest.approx(1.2)
+        assert win.slicer_area.colormap_properties["reverse"] is True
+        assert win.slicer_area.reverse_act.isChecked()
+        assert len(win.slicer_area._prev_states) == 1
+        assert win.slicer_area._prev_states[-1].changed_paths == frozenset(
+            {("color", "gamma"), ("color", "reverse")}
+        )
+
+    assert (
+        win0.slicer_area._prev_states[-1].transaction_id
+        == win1.slicer_area._prev_states[-1].transaction_id
+    )
+
+    win0.slicer_area.undo()
+    for win in (win0, win1):
+        assert win.slicer_area.colormap_properties["gamma"] == pytest.approx(0.5)
+        assert win.slicer_area.colormap_properties["reverse"] is False
+        assert not win.slicer_area.reverse_act.isChecked()
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_colormap_action_undo_propagates(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.reverse_act.trigger()
+    assert win0.slicer_area.colormap_properties["reverse"] is True
+    assert win1.slicer_area.colormap_properties["reverse"] is True
+    assert win1.slicer_area.reverse_act.isChecked()
+
+    win0.slicer_area.undo()
+    assert win0.slicer_area.colormap_properties["reverse"] is False
+    assert win1.slicer_area.colormap_properties["reverse"] is False
+    assert not win0.slicer_area.reverse_act.isChecked()
+    assert not win1.slicer_area.reverse_act.isChecked()
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_controls_visibility_undo_redo_stays_local(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.mnb.action_dict["toggleControlsAct"].trigger()
+    assert not win0.controls_visible
+    assert win1.controls_visible
+
+    win0.slicer_area.undo()
+    assert win0.controls_visible
+    assert win1.controls_visible
+    assert not win1.slicer_area.redoable
+
+    win0.slicer_area.redo()
+    assert not win0.controls_visible
+    assert win1.controls_visible
+    assert not win1.slicer_area.redoable
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_undo_handles_local_entry_before_linked_entry(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.set_index(0, 4)
+    win0.mnb.action_dict["toggleControlsAct"].trigger()
+
+    win0.slicer_area.undo()
+    assert win0.controls_visible
+    assert win1.controls_visible
+    assert win0.array_slicer.get_indices(0) == [4, 2]
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_history_group_splits_linked_then_local_action(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.begin_history_group()
+    win0.slicer_area.set_index(0, 4)
+    win0.mnb.action_dict["toggleControlsAct"].trigger()
+    win0.slicer_area.end_history_group()
+
+    assert [entry.transaction_id for entry in win0.slicer_area._prev_states] == [
+        win1.slicer_area._prev_states[-1].transaction_id,
+        None,
+    ]
+
+    win0.slicer_area.undo()
+    assert win0.controls_visible
+    assert win0.array_slicer.get_indices(0) == [4, 2]
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_history_group_splits_local_then_linked_action(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.begin_history_group()
+    win0.mnb.action_dict["toggleControlsAct"].trigger()
+    win0.slicer_area.set_index(0, 4)
+    win0.slicer_area.end_history_group()
+
+    assert [entry.transaction_id for entry in win0.slicer_area._prev_states] == [
+        None,
+        win1.slicer_area._prev_states[-1].transaction_id,
+    ]
+
+    win0.slicer_area.undo()
+    assert not win0.controls_visible
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+
+    win0.slicer_area.undo()
+    assert win0.controls_visible
+    assert win1.controls_visible
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_history_group_resets_transaction_after_local_split(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.begin_history_group()
+    win0.slicer_area.set_index(0, 4)
+    win0.mnb.action_dict["toggleControlsAct"].trigger()
+    win0.slicer_area.set_index(1, 4)
+    win0.slicer_area.end_history_group()
+
+    source_transaction_ids = [
+        entry.transaction_id for entry in win0.slicer_area._prev_states
+    ]
+    assert source_transaction_ids[0] is not None
+    assert source_transaction_ids[1] is None
+    assert source_transaction_ids[2] is not None
+    assert source_transaction_ids[2] != source_transaction_ids[0]
+    assert [entry.transaction_id for entry in win1.slicer_area._prev_states] == [
+        source_transaction_ids[0],
+        source_transaction_ids[2],
+    ]
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [4, 2]
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+    assert not win0.controls_visible
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [4, 2]
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+    assert win0.controls_visible
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_undo_preserves_non_conflicting_peer_local_change(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.set_index(0, 4)
+    win1.mnb.action_dict["toggleControlsAct"].trigger()
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+    assert win1.controls_visible is False
+
+    win0.slicer_area.redo()
+    assert win0.array_slicer.get_indices(0) == [4, 2]
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+    assert win1.controls_visible is False
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_undo_preserves_non_conflicting_peer_cursor_change(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    win0.slicer_area.add_cursor()
+    win0.slicer_area.flush_history()
+    win1.slicer_area.flush_history()
+
+    win0.slicer_area.set_index(0, 4, cursor=0)
+    with win1.slicer_area.link_sync_suppressed():
+        win1.slicer_area.set_index(1, 4, cursor=1)
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(1) == [2, 4]
+
+    win1.slicer_area.undo()
+    assert win1.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(1) == [2, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_undo_skips_peer_with_conflicting_local_change(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.set_index(0, 4)
+    with win1.slicer_area.link_sync_suppressed():
+        win1.slicer_area.set_index(0, 3)
+
+    win0.slicer_area.undo()
+    assert win0.array_slicer.get_indices(0) == [2, 2]
+    assert win1.array_slicer.get_indices(0) == [3, 2]
+
+    win1.slicer_area.undo()
+    assert win1.array_slicer.get_indices(0) == [4, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
 def test_itool_multidimensional(qtbot, move_and_compare_values) -> None:
     win = ImageTool(xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"]))
     qtbot.addWidget(win)

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -12372,6 +12372,44 @@ def test_manager_workspace_load_visible_windows_stays_clean_after_events(
         assert not manager.is_workspace_modified
 
 
+def test_manager_workspace_roundtrip_preserves_controls_visibility(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        manager._mark_workspace_clean()
+        assert not manager.is_workspace_modified
+
+        root.mnb.action_dict["toggleControlsAct"].trigger()
+        assert not root.controls_visible
+        qtbot.wait_until(lambda: manager.is_workspace_modified, timeout=5000)
+
+        fname = tmp_path / "controls.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        assert not manager.is_workspace_modified
+
+        assert manager._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        restored = manager.get_imagetool(0)
+        assert not restored.controls_visible
+        assert not restored.mnb.action_dict["toggleControlsAct"].isChecked()
+        assert restored.slicer_area.state["controls_visible"] is False
+        assert not manager.is_workspace_modified
+
+
 def test_manager_workspace_delta_save_persists_geometry_changes(
     qtbot,
     tmp_path,

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -6920,6 +6920,95 @@ def test_manager_workspace_io(
             qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
 
+def test_manager_workspace_preserves_link_groups(
+    qtbot,
+    tmp_path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool([test_data, test_data, test_data], link=False, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        fname = tmp_path / "linked.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        assert not manager.is_workspace_modified
+
+        manager.link_imagetools(0, 1, link_colors=False)
+        assert manager.is_workspace_modified
+        manager._save_workspace_document(fname, force_full=True)
+
+        manifest = manager_workspace._workspace_manifest_from_attrs(
+            manager_workspace._read_workspace_root_attrs_h5py(fname)
+        )
+        linked_entries = [entry for entry in manifest["nodes"] if "link_group" in entry]
+        assert {entry["path"] for entry in linked_entries} == {"0", "1"}
+        assert {entry["link_group"] for entry in linked_entries} == {0}
+        assert {entry["link_colors"] for entry in linked_entries} == {False}
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        proxy0 = manager.get_imagetool(0).slicer_area._linking_proxy
+        proxy1 = manager.get_imagetool(1).slicer_area._linking_proxy
+        assert proxy0 is not None
+        assert proxy0 is proxy1
+        assert proxy0.link_colors is False
+        assert not manager.get_imagetool(2).slicer_area.is_linked
+        assert not manager.is_workspace_modified
+
+
+def test_manager_workspace_unlink_removes_saved_link_group(
+    qtbot,
+    tmp_path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool([test_data, test_data], link=False, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        fname = tmp_path / "unlinked.itws"
+        manager.link_imagetools(0, 1)
+        manager._save_workspace_document(fname, force_full=True)
+
+        select_tools(manager, [0, 1])
+        manager.unlink_selected()
+        assert manager.is_workspace_modified
+        manager._save_workspace_document(fname, force_full=True)
+
+        manifest = manager_workspace._workspace_manifest_from_attrs(
+            manager_workspace._read_workspace_root_attrs_h5py(fname)
+        )
+        assert all("link_group" not in entry for entry in manifest["nodes"])
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert not manager.get_imagetool(0).slicer_area.is_linked
+        assert not manager.get_imagetool(1).slicer_area.is_linked
+        assert not manager.is_workspace_modified
+
+
 def test_manager_workspace_save_selection_cancel_does_not_write(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -1447,6 +1447,244 @@ def test_manager_childtool_source_updates(
         assert_nonempty_tooltip(tooltip_text)
 
 
+def test_manager_reload_selected_preserves_manual_root_name(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = test_data.astype(float).rename("scan")
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            source,
+            manager=True,
+            file_path=file_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        model = typing.cast("_ImageToolWrapperItemModel", manager.tree_view.model())
+        root_index = model._row_index(0)
+        assert model.setData(
+            root_index,
+            "manual root name",
+            QtCore.Qt.ItemDataRole.EditRole,
+        )
+        assert manager.name_of_imagetool(0) == "manual root name"
+
+        updated = (source + 100.0).rename("reloaded_scan")
+        updated.to_netcdf(file_path, engine="h5netcdf")
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [0])
+        manager._update_actions()
+        assert manager.reload_action.isVisible()
+
+        root_tool = manager.get_imagetool(0)
+        with qtbot.wait_signal(root_tool.slicer_area.sigDataChanged, timeout=5000):
+            manager.reload_selected()
+
+        assert manager.name_of_imagetool(0) == "manual root name"
+        xr.testing.assert_identical(fetch(0), updated)
+
+
+def test_manager_reload_selected_preserves_manual_child_imagetool_name(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    source = xr.DataArray(
+        np.arange(24, dtype=float).reshape((6, 4)),
+        dims=["x", "y"],
+        coords={"x": np.arange(6), "y": np.arange(4)},
+        name="scan",
+    )
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            source,
+            manager=True,
+            file_path=file_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child_tool = itool(source.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=False,
+        )
+
+        model = typing.cast("_ImageToolWrapperItemModel", manager.tree_view.model())
+        child_index = model._row_index(child_uid)
+        assert model.setData(
+            child_index,
+            "manual child name",
+            QtCore.Qt.ItemDataRole.EditRole,
+        )
+        child_node = manager._child_node(child_uid)
+        assert child_node.name == "manual child name"
+
+        updated = (source + 50.0).rename("reloaded_scan")
+        updated.to_netcdf(file_path, engine="h5netcdf")
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        manager._update_actions()
+        assert manager.reload_action.isVisible()
+
+        with qtbot.wait_signal(child_tool.slicer_area.sigDataChanged, timeout=5000):
+            manager.reload_selected()
+
+        assert child_node.source_state == "fresh"
+        assert child_node.name == "manual child name"
+        xr.testing.assert_identical(fetch(child_uid), updated)
+
+
+def test_manager_workspace_reload_preserves_manual_root_name(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = test_data.astype(float).rename("scan")
+    source_path = tmp_path / "scan.h5"
+    source.to_netcdf(source_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            source,
+            manager=True,
+            file_path=source_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        manager.rename_imagetool(0, "saved manual root")
+        workspace_path = tmp_path / "manual-root-name.itws"
+        manager._save_workspace_document(workspace_path, force_full=True)
+
+        assert manager._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        assert manager.name_of_imagetool(0) == "saved manual root"
+
+        updated = (source + 200.0).rename("updated_scan")
+        updated.to_netcdf(source_path, engine="h5netcdf")
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [0])
+        with qtbot.wait_signal(
+            manager.get_imagetool(0).slicer_area.sigDataChanged, timeout=5000
+        ):
+            manager.reload_selected()
+
+        assert manager.name_of_imagetool(0) == "saved manual root"
+        xr.testing.assert_identical(fetch(0), updated)
+
+
+def test_manager_workspace_reload_preserves_manual_child_imagetool_name(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    source = xr.DataArray(
+        np.arange(24, dtype=float).reshape((6, 4)),
+        dims=["x", "y"],
+        coords={"x": np.arange(6), "y": np.arange(4)},
+        name="scan",
+    )
+    source_path = tmp_path / "scan.h5"
+    source.to_netcdf(source_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            source,
+            manager=True,
+            file_path=source_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child_tool = itool(source.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=False,
+        )
+        manager._child_node(child_uid).name = "saved manual child"
+
+        workspace_path = tmp_path / "manual-child-name.itws"
+        manager._save_workspace_document(workspace_path, force_full=True)
+
+        assert manager._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        loaded_child_uid = manager._imagetool_wrappers[0]._childtool_indices[0]
+        loaded_child_node = manager._child_node(loaded_child_uid)
+        loaded_child_tool = manager.get_imagetool(loaded_child_uid)
+        assert loaded_child_node.name == "saved manual child"
+
+        updated = (source + 125.0).rename("updated_scan")
+        updated.to_netcdf(source_path, engine="h5netcdf")
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, loaded_child_uid)
+        with qtbot.wait_signal(
+            loaded_child_tool.slicer_area.sigDataChanged, timeout=5000
+        ):
+            manager.reload_selected()
+
+        assert loaded_child_node.source_state == "fresh"
+        assert loaded_child_node.name == "saved manual child"
+        xr.testing.assert_identical(fetch(loaded_child_uid), updated)
+
+
 @pytest.mark.parametrize("auto_update", [False, True], ids=["manual", "auto"])
 def test_manager_reload_selected_child_tool_refreshes_from_file_parent(
     qtbot,

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -59,6 +59,7 @@ from erlab.interactive.imagetool._load_source import (
     _scan_number_load_call_args,
 )
 from erlab.interactive.imagetool._magic import _normalize_manager_target_args
+from erlab.interactive.imagetool.dialogs import SelectionDialog
 from erlab.interactive.imagetool.manager import (
     ImageToolManager,
     fetch,
@@ -4026,6 +4027,59 @@ def test_manager_meshtool_output_itools_use_distinct_output_ids(
         assert mesh_node.provenance_spec is not None
         xr.testing.assert_identical(fetch(corr_uid), child._corrected)
         xr.testing.assert_identical(fetch(mesh_uid), child._mesh)
+
+
+def test_manager_selection_dialog_opens_child_with_source_spec(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(3 * 4 * 5 * 6).reshape((3, 4, 5, 6)).astype(float),
+        dims=["alpha", "eV", "beta", "hv"],
+        coords={
+            "alpha": np.arange(3, dtype=float),
+            "eV": np.arange(4, dtype=float),
+            "beta": np.arange(5, dtype=float),
+            "hv": np.linspace(20.0, 70.0, 6),
+        },
+        name="scan",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.set_index(3, 2)
+        dialog = SelectionDialog(parent_tool.slicer_area)
+        assert (
+            dialog.launch_mode_combo.currentData(QtCore.Qt.ItemDataRole.UserRole)
+            == "nest"
+        )
+
+        dialog.accept()
+
+        parent = manager._imagetool_wrappers[0]
+        qtbot.wait_until(lambda: len(parent._childtool_indices) == 1, timeout=5000)
+        child_uid = parent._childtool_indices[0]
+        child_node = manager._child_node(child_uid)
+        child_tool = child_node.imagetool
+        expected = data.qsel(hv=40.0).rename("scan_sel")
+
+        assert child_tool is not None
+        assert child_node.source_spec is not None
+        assert [op.op for op in child_node.source_spec.operations] == ["qsel", "rename"]
+        xarray.testing.assert_identical(
+            child_node.source_spec.apply(parent_tool.slicer_area.data), expected
+        )
+        xarray.testing.assert_identical(
+            child_tool.slicer_area._data.rename(None), expected.rename(None)
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -59,6 +59,7 @@ from erlab.interactive.imagetool._load_source import (
     _scan_number_load_call_args,
 )
 from erlab.interactive.imagetool._magic import _normalize_manager_target_args
+from erlab.interactive.imagetool.controls import ItoolColormapControls
 from erlab.interactive.imagetool.dialogs import SelectionDialog
 from erlab.interactive.imagetool.manager import (
     ImageToolManager,
@@ -7154,6 +7155,45 @@ def test_manager_sync(
             win0.slicer_area.main_image.getViewBox().state["mouseEnabled"][:]
         )
         assert win1.slicer_area.main_image.getViewBox().viewRange() == [[2, 3], [1, 2]]
+
+
+def test_manager_link_action_links_colors(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool([test_data, test_data], link=False, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        select_tools(manager, [0, 1])
+        qtbot.wait_until(lambda: manager.link_action.isEnabled())
+        manager.link_action.trigger()
+
+        proxy = manager.get_imagetool(0).slicer_area._linking_proxy
+        assert proxy is not None
+        assert proxy.link_colors is True
+
+        control = (
+            manager.get_imagetool(0).docks[1].widget().findChild(ItoolColormapControls)
+        )
+        assert control is not None
+        control._set_gamma(1.5)
+        assert manager.get_imagetool(1).slicer_area.colormap_properties[
+            "gamma"
+        ] == pytest.approx(1.5)
+
+        manager.get_imagetool(0).slicer_area.undo()
+        assert manager.get_imagetool(0).slicer_area.colormap_properties[
+            "gamma"
+        ] == pytest.approx(0.5)
+        assert manager.get_imagetool(1).slicer_area.colormap_properties[
+            "gamma"
+        ] == pytest.approx(0.5)
 
 
 def test_manager_workspace_io(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -7538,6 +7538,33 @@ def test_workspace_h5py_attrs_and_root_validation(tmp_path) -> None:
         manager_workspace._read_workspace_root_attrs_h5py(fname)
 
 
+def _assert_workspace_h5py_roundtrip(
+    tmp_path: pathlib.Path, label: str, data: xr.DataArray
+) -> tuple[xr.Dataset, xr.Dataset, pathlib.Path]:
+    data_name = manager_mainwindow._ITOOL_DATA_NAME
+    fname = tmp_path / f"{label}.itws"
+    ds = data.rename(data_name).to_dataset()
+
+    assert manager_workspace._workspace_dataset_can_write_h5py(ds)
+    assert manager_workspace._write_workspace_dataset_group_h5py(
+        fname, "0/imagetool", ds
+    )
+    loaded = manager_workspace._read_workspace_dataset_group_h5py(
+        fname,
+        "0/imagetool",
+        preferred_data_name=data_name,
+    )
+    assert loaded is not None
+
+    opened = manager_xarray.open_workspace_dataset(fname, "0/imagetool", chunks=None)
+    try:
+        opened_loaded = opened.load()
+    finally:
+        opened.close()
+    xr.testing.assert_equal(loaded, opened_loaded)
+    return loaded, opened_loaded, fname
+
+
 def test_workspace_h5py_fast_path_roundtrips_scalar_coords(tmp_path) -> None:
     import h5py
 
@@ -7577,6 +7604,132 @@ def test_workspace_h5py_fast_path_roundtrips_scalar_coords(tmp_path) -> None:
     assert coordinates == "temperature"
 
 
+def test_workspace_h5py_fast_path_roundtrips_associated_coords_and_xarray(
+    tmp_path,
+) -> None:
+    import h5py
+
+    data_name = manager_mainwindow._ITOOL_DATA_NAME
+    base = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(2.0), "y": np.arange(3.0)},
+    )
+
+    divided = base.assign_coords(mesh_current=("x", [1.0, 2.0]))
+    divided = divided / divided.coords["mesh_current"]
+    loaded, _opened, _fname = _assert_workspace_h5py_roundtrip(
+        tmp_path, "divide-by-coord", divided
+    )
+    assert loaded.coords["mesh_current"].dims == ("x",)
+    np.testing.assert_allclose(loaded.coords["mesh_current"], [1.0, 2.0])
+
+    loaded, _opened, _fname = _assert_workspace_h5py_roundtrip(
+        tmp_path,
+        "two-dimensional-associated-coord",
+        base.assign_coords(
+            detector_norm=(("x", "y"), np.arange(6.0).reshape(2, 3) + 1.0)
+        ),
+    )
+    assert loaded.coords["detector_norm"].dims == ("x", "y")
+
+    loaded, _opened, _fname = _assert_workspace_h5py_roundtrip(
+        tmp_path,
+        "unicode-scalar-coord",
+        base.assign_coords(label="sample"),
+    )
+    assert loaded.coords["label"].item() == "sample"
+
+    loaded, _opened, _fname = _assert_workspace_h5py_roundtrip(
+        tmp_path,
+        "unicode-associated-coord",
+        base.assign_coords(label=("x", np.array(["left", "right"]))),
+    )
+    assert loaded.coords["label"].dtype.kind == "U"
+
+    loaded, _opened, _fname = _assert_workspace_h5py_roundtrip(
+        tmp_path,
+        "bytes-associated-coord",
+        base.assign_coords(raw=("x", np.array([b"a", b"bb"], dtype="S2"))),
+    )
+    assert loaded.coords["raw"].dtype.kind == "S"
+
+    loaded, _opened, _fname = _assert_workspace_h5py_roundtrip(
+        tmp_path,
+        "datetime-associated-coord",
+        xr.DataArray(
+            np.arange(2.0),
+            dims=("time",),
+            coords={
+                "time": np.array(["2024-01-01", "2024-01-02"], dtype="datetime64[D]"),
+                "event_time": (
+                    "time",
+                    np.array(["2024-02-01", "2024-02-02"], dtype="datetime64[D]"),
+                ),
+            },
+        ),
+    )
+    assert loaded.coords["time"].dtype.kind == "M"
+    assert loaded.coords["event_time"].dtype.kind == "M"
+
+    loaded, _opened, _fname = _assert_workspace_h5py_roundtrip(
+        tmp_path,
+        "timedelta-associated-coord",
+        xr.DataArray(
+            np.arange(2.0),
+            dims=("delay",),
+            coords={
+                "delay": np.array([0, 5], dtype="timedelta64[ms]"),
+                "exposure": (
+                    "delay",
+                    np.array([1, 2], dtype="timedelta64[s]"),
+                ),
+            },
+        ),
+    )
+    assert loaded.coords["delay"].dtype == np.dtype("timedelta64[ms]")
+    assert loaded.coords["exposure"].dtype == np.dtype("timedelta64[s]")
+
+    with h5py.File(_fname, "r") as h5_file:
+        coordinates = h5_file["0/imagetool"][data_name].attrs["coordinates"]
+    if isinstance(coordinates, bytes):
+        coordinates = coordinates.decode()
+    assert coordinates == "exposure"
+
+
+def test_workspace_h5py_fast_path_keeps_numeric_since_units(tmp_path) -> None:
+    data_name = manager_mainwindow._ITOOL_DATA_NAME
+    fname = tmp_path / "numeric-since-units.itws"
+    data = xr.DataArray(
+        [1.0, 2.0],
+        dims=("x",),
+        coords={
+            "x": [0.0, 1.0],
+            "elapsed": xr.DataArray(
+                [0.0, 1.0],
+                dims=("x",),
+                attrs={"units": "seconds since start"},
+            ),
+        },
+        name=data_name,
+    )
+    ds = data.to_dataset()
+
+    assert manager_workspace._workspace_dataset_can_write_h5py(ds)
+    assert manager_workspace._write_workspace_dataset_group_h5py(
+        fname, "0/imagetool", ds
+    )
+    loaded = manager_workspace._read_workspace_dataset_group_h5py(
+        fname,
+        "0/imagetool",
+        preferred_data_name=data_name,
+    )
+
+    assert loaded is not None
+    xr.testing.assert_equal(loaded[data_name], data)
+    assert loaded.coords["elapsed"].attrs["units"] == "seconds since start"
+
+
 def test_workspace_h5py_fast_path_rejects_invalid_payloads(
     monkeypatch, tmp_path
 ) -> None:
@@ -7610,9 +7763,30 @@ def test_workspace_h5py_fast_path_rejects_invalid_payloads(
         [{"coord_name": "Fake Motor", "variable_name": "private", "dims": ["z"]}]
     )
     assert not manager_workspace._workspace_dataset_can_write_h5py(bad_private_dims)
+
     assert not manager_workspace._workspace_dataset_can_write_h5py(
-        xr.Dataset({data_name: ("x", [1.0])}, coords={"x": ["bad"]})
+        xr.Dataset(
+            {data_name: ("x", [1.0])},
+            coords={"x": np.array([object()], dtype=object)},
+        )
     )
+
+    bad_associated_dims = xr.Dataset(
+        {data_name: ("x", [1.0])},
+        coords={"x": [0.0], "z": [0.0], "bad": ("z", [1.0])},
+    )
+    assert not manager_workspace._workspace_dataset_can_write_h5py(bad_associated_dims)
+
+    import dask.array as da
+
+    chunked_coord = xr.Dataset(
+        {data_name: ("x", [1.0, 2.0])},
+        coords={
+            "x": [0.0, 1.0],
+            "chunked": ("x", da.from_array(np.array([1.0, 2.0]), chunks=(1,))),
+        },
+    )
+    assert not manager_workspace._workspace_dataset_can_write_h5py(chunked_coord)
 
     monkeypatch.setattr(
         manager_workspace, "_workspace_dataset_can_write_h5py", lambda _ds: True
@@ -7676,6 +7850,45 @@ def test_workspace_h5py_reader_rejects_malformed_groups(tmp_path) -> None:
         private_data.attrs[private_attr] = json.dumps(
             [{"coord_name": "Fake Motor", "variable_name": "private", "dims": ["z"]}]
         )
+        bad_associated_no_scale = h5_file.create_group("bad-associated-no-scale")
+        x = bad_associated_no_scale.create_dataset("x", data=np.arange(2.0))
+        x.make_scale("x")
+        data = bad_associated_no_scale.create_dataset(data_name, data=np.arange(2.0))
+        data.dims[0].attach_scale(x)
+        data.attrs["coordinates"] = "associated"
+        bad_associated_no_scale.create_dataset("associated", data=np.arange(2.0))
+        bad_associated_length = h5_file.create_group("bad-associated-length")
+        x = bad_associated_length.create_dataset("x", data=np.arange(2.0))
+        x.make_scale("x")
+        data = bad_associated_length.create_dataset(data_name, data=np.arange(2.0))
+        data.dims[0].attach_scale(x)
+        data.attrs["coordinates"] = "associated"
+        associated = bad_associated_length.create_dataset(
+            "associated", data=np.arange(3.0)
+        )
+        associated.dims[0].attach_scale(x)
+        bad_associated_foreign_dim = h5_file.create_group("bad-associated-foreign-dim")
+        x = bad_associated_foreign_dim.create_dataset("x", data=np.arange(2.0))
+        x.make_scale("x")
+        z = bad_associated_foreign_dim.create_dataset("z", data=np.arange(2.0))
+        z.make_scale("z")
+        data = bad_associated_foreign_dim.create_dataset(data_name, data=np.arange(2.0))
+        data.dims[0].attach_scale(x)
+        data.attrs["coordinates"] = "associated"
+        associated = bad_associated_foreign_dim.create_dataset(
+            "associated", data=np.arange(2.0)
+        )
+        associated.dims[0].attach_scale(z)
+        bad_time = h5_file.create_group("bad-time-metadata")
+        x = bad_time.create_dataset("x", data=np.arange(2.0))
+        x.make_scale("x")
+        data = bad_time.create_dataset(data_name, data=np.arange(2.0))
+        data.dims[0].attach_scale(x)
+        data.attrs["coordinates"] = "time"
+        time = bad_time.create_dataset("time", data=np.arange(2, dtype=np.int64))
+        time.dims[0].attach_scale(x)
+        time.attrs["units"] = "days since not-a-date"
+        time.attrs["calendar"] = "proleptic_gregorian"
 
     assert (
         manager_workspace._read_workspace_dataset_group_h5py(fname, "missing") is None
@@ -7704,6 +7917,30 @@ def test_workspace_h5py_reader_rejects_malformed_groups(tmp_path) -> None:
     assert (
         manager_workspace._read_workspace_dataset_group_h5py(
             fname, "bad-private", preferred_data_name=data_name
+        )
+        is None
+    )
+    assert (
+        manager_workspace._read_workspace_dataset_group_h5py(
+            fname, "bad-associated-no-scale", preferred_data_name=data_name
+        )
+        is None
+    )
+    assert (
+        manager_workspace._read_workspace_dataset_group_h5py(
+            fname, "bad-associated-length", preferred_data_name=data_name
+        )
+        is None
+    )
+    assert (
+        manager_workspace._read_workspace_dataset_group_h5py(
+            fname, "bad-associated-foreign-dim", preferred_data_name=data_name
+        )
+        is None
+    )
+    assert (
+        manager_workspace._read_workspace_dataset_group_h5py(
+            fname, "bad-time-metadata", preferred_data_name=data_name
         )
         is None
     )

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -759,12 +759,11 @@ def test_tool_provenance_preserves_hashable_dims_and_mapping_keys() -> None:
         prov.QSelOperation(kwargs={"k-space": 1.0, "k-space_width": 1.0})
     )
     assert qsel_spec.derivation_code() == (
-        "derived = data\n"
-        'derived = derived.qsel(**{"k-space": 1.0, "k-space_width": 1.0})'
+        'derived = data\nderived = derived.qsel({"k-space": 1.0, "k-space_width": 1.0})'
     )
     xr.testing.assert_identical(
         qsel_spec.apply(string_key_data),
-        string_key_data.qsel(**{"k-space": 1.0, "k-space_width": 1.0}),
+        string_key_data.qsel({"k-space": 1.0, "k-space_width": 1.0}),
     )
 
     isel_spec = prov.full_data(prov.IselOperation(kwargs={1: slice(1, 3)}))

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -315,6 +315,46 @@ def test_state_restore_rebuilds_layout_caches_before_cursor_restore(qtbot) -> No
     np.testing.assert_allclose(slicer.get_values(0), saved_state["values"][0])
 
 
+def test_state_restore_suppresses_partial_cursor_restore_signal(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(107 * 36 * 35, dtype=np.float32).reshape(107, 36, 35),
+        dims=("eV", "y", "x"),
+        coords={
+            "eV": np.arange(107, dtype=np.float32),
+            "y": np.arange(36, dtype=np.float32),
+            "x": np.arange(35, dtype=np.float32),
+        },
+    )
+
+    parent = QtCore.QObject()
+    slicer = ArraySlicer(data, parent=parent)
+    slicer.add_cursor(update=False)
+    saved_state = {
+        "dims": ("x", "y", "eV"),
+        "bins": [[1, 1, 1], [1, 1, 1]],
+        "indices": [[26, 29, 36], [9, 9, 36]],
+        "values": [[26.0, 29.0, 36.0], [9.0, 9.0, 36.0]],
+        "snap_to_data": False,
+        "twin_coord_names": (),
+        "cursor_color_params": None,
+    }
+    emissions = []
+
+    slicer.sigIndexChanged.connect(lambda *args: emissions.append(args))
+
+    slicer.state = saved_state
+
+    assert emissions == []
+    assert slicer._obj.dims == saved_state["dims"]
+    assert slicer._obj.shape == (35, 36, 107)
+    assert slicer.get_indices(0) == saved_state["indices"][0]
+    assert slicer.get_indices(1) == saved_state["indices"][1]
+    assert (
+        slicer.point_value(1, binned=True)
+        == data.transpose("x", "y", "eV").data[9, 9, 36]
+    )
+
+
 def test_bin_along_axis_unbinned_matches_integer_index_selection(qtbot) -> None:
     values = np.arange(4 * 5 * 6, dtype=np.float32).reshape(4, 5, 6)
     data = xr.DataArray(


### PR DESCRIPTION
## Summary

This PR contains the full `dev-enh-itool` ImageTool stack:

- expand ImageTool workspace handling, including h5py-backed datetime/timedelta/string data support plus persisted manager links and manual row names
- add user-facing ImageTool workflow controls, including a controls-visibility toggle and a `Select Data…` dialog for validated xarray selections and copied selection code
- improve ImageTool history behavior with more descriptive/coalesced entries, and fix inconsistent history entry creation
- refine related ImageTool UI behavior, including moving rotation guidelines to the `View` menu and fixing linked multi-cursor dragging
- reduce redundant dask computations during ImageTool preview/readout/menu paths while keeping explicit compute and workspace contracts unchanged
- update the related ImageTool docs and ARPES docs-link references

## Validation

Latest local validation run for the dask/readout/menu changes:

- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_imagetool.py::test_apply_func_preserves_source_data tests/interactive/imagetool/test_imagetool.py::test_apply_func_preserves_dask_backed_preview tests/interactive/imagetool/test_imagetool.py::test_eager_preview_from_dask_source_updates_readout tests/interactive/imagetool/test_imagetool.py::test_profile_menu_opens_associated_coord_targets tests/interactive/imagetool/test_imagetool.py::test_profile_associated_coord_menu_does_not_compute_dask_coord`
- `uv run ruff format --check src/erlab/interactive/imagetool/viewer.py src/erlab/interactive/imagetool/plot_items.py src/erlab/interactive/imagetool/controls.py tests/interactive/imagetool/test_imagetool.py`
- `uv run ruff check src/erlab/interactive/imagetool/viewer.py src/erlab/interactive/imagetool/plot_items.py src/erlab/interactive/imagetool/controls.py tests/interactive/imagetool/test_imagetool.py`
- `uv run mypy src/erlab/interactive/imagetool/viewer.py src/erlab/interactive/imagetool/plot_items.py src/erlab/interactive/imagetool/controls.py`