### PR TITLE
[codex] fix(manager): group watched badges by source

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2572,6 +2572,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         watched_var: tuple[str, str] | None = None,
         watched_workspace_link_id: str | None = None,
         watched_source_label: str | None = None,
+        watched_source_uid: str | None = None,
         watched_connected: bool = True,
         source_input_ndim: int | None = None,
         source_input_dtype: np.dtype[typing.Any] | str | None = None,
@@ -2620,6 +2621,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             watched_var=watched_var,
             watched_workspace_link_id=watched_workspace_link_id,
             watched_source_label=watched_source_label,
+            watched_source_uid=watched_source_uid,
             watched_connected=watched_connected,
             source_input_ndim=source_input_ndim,
             source_input_dtype=source_input_dtype,
@@ -3688,6 +3690,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
             source_label = watched_metadata.get("source_label")
             if source_label is not None:
                 ds.attrs["manager_node_watched_source_label"] = str(source_label)
+            source_uid = watched_metadata.get("source_uid")
+            if source_uid is not None:
+                ds.attrs["manager_node_watched_source_uid"] = str(source_uid)
             ds.attrs["manager_node_watched_connected"] = bool(
                 watched_metadata.get("connected", False)
             )
@@ -3864,6 +3869,11 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 None
                 if ds.attrs.get("manager_node_watched_source_label") is None
                 else str(ds.attrs["manager_node_watched_source_label"])
+            )
+            kwargs["watched_source_uid"] = (
+                None
+                if ds.attrs.get("manager_node_watched_source_uid") is None
+                else str(ds.attrs["manager_node_watched_source_uid"])
             )
             # Loaded watched rows stay watched, but are disconnected until
             # a notebook explicitly reconnects them.
@@ -5723,6 +5733,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         watched_source_label=typing.cast(
                             "str | None", watched_metadata.get("source_label")
                         ),
+                        watched_source_uid=typing.cast(
+                            "str | None", watched_metadata.get("source_uid")
+                        ),
                         watched_connected=bool(
                             watched_metadata.get("connected", watched_var is not None)
                         ),
@@ -5789,14 +5802,26 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 return k
         return None
 
-    def color_for_watched_var_kernel(self, kernel_uid: str) -> QtGui.QColor:
-        """Return a different color for different source kernels."""
-        all_kernel_uids = tuple(
-            typing.cast("str", v._watched_uid).removeprefix(f"{v._watched_varname} ")
-            for v in self._imagetool_wrappers.values()
-            if v.watched
+    def _watched_source_color_key(self, wrapper: _ImageToolWrapper) -> str:
+        if wrapper._watched_source_uid:
+            return f"source-uid:{wrapper._watched_source_uid}"
+        if wrapper._watched_source_label:
+            return f"source-label:{wrapper._watched_source_label}"
+        watched_uid = typing.cast("str", wrapper._watched_uid)
+        watched_varname = typing.cast("str", wrapper._watched_varname)
+        return f"legacy:{watched_uid.removeprefix(f'{watched_varname} ')}"
+
+    def color_for_watched_var_source(self, wrapper: _ImageToolWrapper) -> QtGui.QColor:
+        """Return a different color for different watched-variable sources."""
+        source_key = self._watched_source_color_key(wrapper)
+        all_source_keys = tuple(
+            dict.fromkeys(
+                self._watched_source_color_key(v)
+                for v in self._imagetool_wrappers.values()
+                if v.watched
+            )
         )
-        idx = all_kernel_uids.index(kernel_uid)
+        idx = all_source_keys.index(source_key)
         return _WATCHED_VAR_COLORS[idx % len(_WATCHED_VAR_COLORS)]
 
     @QtCore.Slot(str)
@@ -5861,6 +5886,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     "str | None",
                     watched_metadata.get("source_label")
                     or wrapper._watched_source_label,
+                ),
+                source_uid=typing.cast(
+                    "str | None",
+                    watched_metadata.get("source_uid") or wrapper._watched_source_uid,
                 ),
                 connected=True,
             )

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -405,10 +405,8 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         if watched_rect:
             palette = option.palette
             watched_varname = str(tool_wrapper._watched_varname)
-            watched_uid = str(tool_wrapper._watched_uid)
-            kernel_uid = watched_uid.removeprefix(f"{watched_varname} ")
             if tool_wrapper._watched_connected:
-                color = self.manager.color_for_watched_var_kernel(kernel_uid)
+                color = self.manager.color_for_watched_var_source(tool_wrapper)
             else:
                 color = option.palette.color(QtGui.QPalette.ColorRole.Mid)
 

--- a/src/erlab/interactive/imagetool/manager/_watcher/_core.py
+++ b/src/erlab/interactive/imagetool/manager/_watcher/_core.py
@@ -228,6 +228,7 @@ class _Watcher:
             metadata = {
                 "workspace_link_id": workspace_link_id,
                 "source_label": selected.get("source_label"),
+                "source_uid": self._uid,
                 "connected": True,
             }
             return uid, metadata
@@ -235,6 +236,7 @@ class _Watcher:
         return _stable_watch_uid(workspace_link_id, varname, source_label_text), {
             "workspace_link_id": workspace_link_id,
             "source_label": source_label_text,
+            "source_uid": self._uid,
             "connected": True,
         }
 
@@ -264,6 +266,7 @@ class _Watcher:
                     "dict[str, typing.Any]",
                     self.watched_vars[varname].get("watched_metadata", {}),
                 )
+                watched_metadata["source_uid"] = self._uid
                 show = True
             else:
                 uid, watched_metadata = self._watch_binding(
@@ -353,6 +356,7 @@ class _Watcher:
             watched_metadata = typing.cast(
                 "dict[str, typing.Any]", state.get("watched_metadata", {})
             )
+            watched_metadata["source_uid"] = self._uid
         erlab.interactive.imagetool.manager._watch_data(
             varname,
             uid,

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -998,6 +998,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         watched_var: tuple[str, str] | None = None,
         watched_workspace_link_id: str | None = None,
         watched_source_label: str | None = None,
+        watched_source_uid: str | None = None,
         watched_connected: bool = True,
         source_input_ndim: int | None = None,
         source_input_dtype: np.dtype[typing.Any] | str | None = None,
@@ -1014,6 +1015,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         self._watched_uid: str | None = None
         self._watched_workspace_link_id: str | None = None
         self._watched_source_label: str | None = None
+        self._watched_source_uid: str | None = None
         self._watched_connected: bool = False
         self._source_input_ndim = source_input_ndim
         self._source_input_dtype: np.dtype[typing.Any] | None = (
@@ -1024,6 +1026,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
                 *watched_var,
                 workspace_link_id=watched_workspace_link_id,
                 source_label=watched_source_label,
+                source_uid=watched_source_uid,
                 connected=watched_connected,
             )
 
@@ -1053,6 +1056,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         *,
         workspace_link_id: str | None = None,
         source_label: str | None = None,
+        source_uid: str | None = None,
         connected: bool = True,
     ) -> None:
         """Bind this root ImageTool to a watched variable."""
@@ -1060,6 +1064,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         self._watched_uid = uid
         self._watched_workspace_link_id = workspace_link_id
         self._watched_source_label = source_label
+        self._watched_source_uid = source_uid
         self._watched_connected = connected
 
     def watched_metadata(self) -> dict[str, typing.Any]:
@@ -1071,6 +1076,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
             "uid": self._watched_uid,
             "workspace_link_id": self._watched_workspace_link_id,
             "source_label": self._watched_source_label,
+            "source_uid": self._watched_source_uid,
             "connected": self._watched_connected,
         }
 
@@ -1149,6 +1155,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
             self._watched_uid = None
             self._watched_workspace_link_id = None
             self._watched_source_label = None
+            self._watched_source_uid = None
             self._watched_connected = False
             self.manager.tree_view.refresh(self.index)
             self.manager._mark_node_state_dirty(self.uid)

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -6095,6 +6095,7 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
             watched_metadata={
                 "workspace_link_id": manager._workspace_link_id,
                 "source_label": "notebook-a",
+                "source_uid": "kernel-a",
                 "connected": True,
             },
         )
@@ -6110,6 +6111,7 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
         assert attrs["manager_node_watched_uid"] == "watch:stable-data"
         assert attrs["manager_node_watched_workspace_link_id"] == workspace_link_id
         assert attrs["manager_node_watched_source_label"] == "notebook-a"
+        assert attrs["manager_node_watched_source_uid"] == "kernel-a"
 
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
@@ -6124,6 +6126,7 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
         assert wrapper._watched_uid == "watch:stable-data"
         assert wrapper._watched_workspace_link_id == workspace_link_id
         assert wrapper._watched_source_label == "notebook-a"
+        assert wrapper._watched_source_uid == "kernel-a"
         assert wrapper._watched_connected is False
 
         with qtbot.wait_signal(manager._sigReplyData) as blocker:
@@ -6131,6 +6134,7 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
         assert blocker.args[0]["workspace_link_id"] == "different-workspace-link"
         assert blocker.args[0]["watched"][0]["workspace_link_id"] == workspace_link_id
         assert blocker.args[0]["watched"][0]["source_label"] == "notebook-a"
+        assert blocker.args[0]["watched"][0]["source_uid"] == "kernel-a"
 
         manager._from_datatree(tree, replace=True, select=False)
         assert manager._workspace_link_id == workspace_link_id
@@ -6158,6 +6162,114 @@ def test_manager_workspace_watched_attrs_skip_missing_workspace_link(
         assert attrs["manager_node_watched_varname"] == "data"
         assert attrs["manager_node_watched_uid"] == "watch:stable-data"
         assert "manager_node_watched_workspace_link_id" not in attrs
+
+
+def test_manager_watched_badge_color_groups_by_source_uid(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        for varname, uid, source_uid in (
+            ("left", "watch:left", "kernel-a"),
+            ("right", "watch:right", "kernel-a"),
+            ("other", "watch:other", "kernel-b"),
+        ):
+            manager.add_imagetool(
+                erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+                watched_var=(varname, uid),
+                watched_source_uid=source_uid,
+            )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        left = manager._imagetool_wrappers[0]
+        right = manager._imagetool_wrappers[1]
+        other = manager._imagetool_wrappers[2]
+
+        assert (
+            manager.color_for_watched_var_source(left)
+            == manager_mainwindow._WATCHED_VAR_COLORS[0]
+        )
+        assert (
+            manager.color_for_watched_var_source(right)
+            == manager_mainwindow._WATCHED_VAR_COLORS[0]
+        )
+        assert (
+            manager.color_for_watched_var_source(other)
+            == manager_mainwindow._WATCHED_VAR_COLORS[1]
+        )
+
+
+def test_manager_watched_badge_color_falls_back_to_source_label(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            watched_var=("left", "watch:left"),
+            watched_source_label="notebook-a",
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            watched_var=("right", "watch:right"),
+            watched_source_label="notebook-a",
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            watched_var=("other", "watch:other"),
+            watched_source_label="notebook-b",
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        left = manager._imagetool_wrappers[0]
+        right = manager._imagetool_wrappers[1]
+        other = manager._imagetool_wrappers[2]
+        assert manager.color_for_watched_var_source(
+            left
+        ) == manager.color_for_watched_var_source(right)
+        assert manager.color_for_watched_var_source(
+            other
+        ) != manager.color_for_watched_var_source(left)
+
+
+def test_manager_watched_badge_color_uses_legacy_uid_suffix(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            watched_var=("left", "left legacy-kernel"),
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            watched_var=("right", "right legacy-kernel"),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        left = manager._imagetool_wrappers[0]
+        right = manager._imagetool_wrappers[1]
+        assert manager.color_for_watched_var_source(
+            left
+        ) == manager.color_for_watched_var_source(right)
 
 
 def test_manager_watched_root_provenance_uses_variable_name(

--- a/tests/interactive/imagetool/test_watcher.py
+++ b/tests/interactive/imagetool/test_watcher.py
@@ -63,6 +63,7 @@ def patch_manager(monkeypatch):
             "uid": uid,
             "workspace_link_id": metadata.get("workspace_link_id"),
             "source_label": metadata.get("source_label"),
+            "source_uid": metadata.get("source_uid"),
             "connected": True,
         }
         state["watch_info"]["watched"] = [
@@ -180,6 +181,30 @@ def test_watch_uid_reconnects_with_workspace_link_id(
     assert uid1.startswith("watch:")
     assert patch_manager["last_watch_calls"][-1][1] == uid1
     watcher2.shutdown()
+
+
+def test_watch_source_uid_groups_same_watcher_variables(
+    fake_shell, patch_manager, monkeypatch
+):
+    fake_shell.user_ns["left"] = xr.DataArray(np.array([1, 2, 3]), dims=("x",))
+    fake_shell.user_ns["right"] = xr.DataArray(np.array([4, 5, 6]), dims=("x",))
+
+    watcher = _Watcher(fake_shell)
+    monkeypatch.setattr(watcher, "start_thread", lambda: None)
+
+    watcher.watch("left")
+    watcher.watch("right")
+
+    left_state = watcher.watched_vars["left"]
+    right_state = watcher.watched_vars["right"]
+    assert left_state["uid"] != right_state["uid"]
+    assert (
+        left_state["watched_metadata"]["source_uid"]
+        == right_state["watched_metadata"]["source_uid"]
+        == watcher._uid
+    )
+
+    watcher.shutdown()
 
 
 def test_watch_binding_helpers_handle_invalid_and_labeled_entries(monkeypatch):


### PR DESCRIPTION
## Summary

- Add an explicit watched-variable `source_uid` alongside the stable watched-row UID.
- Persist and restore that source identity through manager workspace metadata and watch info.
- Key connected watched-variable badge colors by source identity, with `source_label` and legacy UID suffix fallbacks.

## Root Cause

The watched-row UID now correctly uses stable per-variable workspace identity, but badge colors were still derived from that UID by stripping the variable name. That made variables from the same notebook resolve to different color keys.

## Validation

- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_watcher.py tests/interactive/imagetool/test_imagetool_manager.py -k "watch or watched"`
- `uv run ruff check src/erlab/interactive/imagetool/manager tests/interactive/imagetool/test_watcher.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/manager/_mainwindow.py src/erlab/interactive/imagetool/manager/_modelview.py src/erlab/interactive/imagetool/manager/_watcher/_core.py src/erlab/interactive/imagetool/manager/_wrapper.py tests/interactive/imagetool/test_watcher.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run mypy src/erlab/interactive/imagetool/manager`
- `git diff --check`