### PR TITLE
[codex] Fix ImageTool manager child refresh after coordinate edits

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -59,6 +59,7 @@ if typing.TYPE_CHECKING:
 
     from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
     from erlab.interactive.imagetool._load_source import _LoadSourceDetails
+    from erlab.interactive.imagetool.provenance import ImageToolSelectionSourceBinding
     from erlab.interactive.ptable import PeriodicTableWindow
 
 logger = logging.getLogger(__name__)
@@ -2580,6 +2581,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         | None = None,
         source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         | None = None,
+        source_binding: ImageToolSelectionSourceBinding | None = None,
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         index: int | None = None,
@@ -2625,6 +2627,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             source_input_dtype=source_input_dtype,
             provenance_spec=provenance_spec,
             source_spec=source_spec,
+            source_binding=source_binding,
             source_auto_update=source_auto_update,
             source_state=source_state,
         )
@@ -3698,8 +3701,14 @@ class ImageToolManager(QtWidgets.QMainWindow):
             ds.attrs["manager_node_live_source_spec"] = json.dumps(
                 node.source_spec.model_dump(mode="json")
             )
+        if kind == "imagetool" and node.source_binding is not None:
+            ds.attrs["manager_node_live_source_binding"] = json.dumps(
+                node.source_binding.model_dump(mode="json")
+            )
         if kind == "imagetool" and (
-            node.source_spec is not None or output_id is not None
+            node.source_spec is not None
+            or node.source_binding is not None
+            or output_id is not None
         ):
             ds.attrs["manager_node_source_state"] = node.source_state
             ds.attrs["manager_node_source_auto_update"] = bool(node.source_auto_update)
@@ -3782,6 +3791,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         uid = ds.attrs.get("manager_node_uid")
         provenance_spec = ds.attrs.get("manager_node_provenance_spec")
         live_source_spec = ds.attrs.get("manager_node_live_source_spec")
+        live_source_binding = ds.attrs.get("manager_node_live_source_binding")
         parse_provenance_spec = (
             erlab.interactive.imagetool.provenance.parse_tool_provenance_spec
         )
@@ -3817,10 +3827,30 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     uid,
                     exc_info=True,
                 )
+        parsed_source_binding = None
+        if live_source_binding is not None:
+            try:
+                provenance = erlab.interactive.imagetool.provenance
+                binding_payload = typing.cast(
+                    "Mapping[str, typing.Any]",
+                    json.loads(live_source_binding),
+                )
+                parsed_source_binding = (
+                    provenance.ImageToolSelectionSourceBinding.model_validate(
+                        binding_payload
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "Ignoring invalid saved manager source binding for node %s",
+                    uid,
+                    exc_info=True,
+                )
         kwargs: dict[str, typing.Any] = {
             "uid": uid,
             "provenance_spec": parsed_provenance_spec,
             "source_spec": parsed_source_spec,
+            "source_binding": parsed_source_binding,
             "output_id": ds.attrs.get("manager_node_output_id"),
             "source_auto_update": bool(
                 ds.attrs.get("manager_node_source_auto_update", False)
@@ -6345,11 +6375,14 @@ class ImageToolManager(QtWidgets.QMainWindow):
         | None = None,
         source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         | None = None,
+        source_binding: ImageToolSelectionSourceBinding | None = None,
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         output_id: str | None = None,
     ) -> str:
         parent_node = self._node_for_target(parent)
+        if source_spec is None and source_binding is not None:
+            source_spec = source_binding.materialize(parent_node.current_source_data())
         if provenance_spec is None and source_spec is not None:
             provenance_spec = (
                 erlab.interactive.imagetool.provenance.compose_display_provenance(
@@ -6367,6 +6400,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             tool,
             provenance_spec=provenance_spec,
             source_spec=source_spec,
+            source_binding=source_binding,
             source_auto_update=source_auto_update,
             source_state=source_state,
             output_id=output_id,

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -30,6 +30,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Iterator
 
     from erlab.interactive.imagetool.manager import ImageToolManager
+    from erlab.interactive.imagetool.provenance import ImageToolSelectionSourceBinding
     from erlab.interactive.imagetool.viewer import ImageSlicerArea
 
 
@@ -119,6 +120,7 @@ class _ManagedWindowNode(QtCore.QObject):
         | None = None,
         source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         | None = None,
+        source_binding: ImageToolSelectionSourceBinding | None = None,
         source_auto_update: bool = False,
         source_state: _source_state_type = "fresh",
         output_id: str | None = None,
@@ -147,6 +149,7 @@ class _ManagedWindowNode(QtCore.QObject):
         self._source_spec: (
             erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None
         ) = None
+        self._source_binding: ImageToolSelectionSourceBinding | None = None
         self._provenance_spec: (
             erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None
         ) = None
@@ -159,6 +162,15 @@ class _ManagedWindowNode(QtCore.QObject):
         if source_spec is not None:
             self.set_source_binding(
                 source_spec,
+                source_binding=source_binding,
+                provenance_spec=provenance_spec,
+                auto_update=source_auto_update,
+                state=source_state,
+            )
+        elif source_binding is not None:
+            self.set_source_binding(
+                None,
+                source_binding=source_binding,
                 provenance_spec=provenance_spec,
                 auto_update=source_auto_update,
                 state=source_state,
@@ -479,6 +491,14 @@ class _ManagedWindowNode(QtCore.QObject):
         return self._source_spec
 
     @property
+    def source_binding(
+        self,
+    ) -> ImageToolSelectionSourceBinding | None:
+        if self.tool_window is not None:
+            return self.tool_window.source_binding
+        return self._source_binding
+
+    @property
     def provenance_spec(
         self,
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
@@ -504,7 +524,11 @@ class _ManagedWindowNode(QtCore.QObject):
     def has_source_binding(self) -> bool:
         if self.tool_window is not None:
             return self.tool_window.has_source_binding
-        return self._source_spec is not None or self._output_id is not None
+        return (
+            self._source_spec is not None
+            or self._source_binding is not None
+            or self._output_id is not None
+        )
 
     @property
     def output_id(self) -> str | None:
@@ -555,17 +579,47 @@ class _ManagedWindowNode(QtCore.QObject):
         self,
         source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None,
         *,
+        source_binding: ImageToolSelectionSourceBinding | None = None,
         provenance_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         | None = None,
         auto_update: bool = False,
         state: _source_state_type = "fresh",
     ) -> None:
+        """Bind this node to data selected from its parent ImageTool.
+
+        Parameters
+        ----------
+        source_spec
+            Current source spec used for derivation display and older saved
+            workspaces. If ``source_binding`` is not provided, refresh applies this
+            spec as stored.
+        source_binding
+            Selection state from an ImageTool plot. When provided, refresh first builds
+            a new ``source_spec`` from the current parent data.
+        provenance_spec
+            Displayed provenance to show immediately. If omitted and the source is
+            fresh, provenance is rebuilt from the parent and current source spec.
+        auto_update
+            Whether compatible parent changes should refresh this node automatically.
+        state
+            Current refresh state for manager status UI.
+        """
         if source_spec is not None and not isinstance(
             source_spec, erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         ):
             raise TypeError(
                 "source_spec must be a ToolProvenanceSpec or None. Use "
                 "parse_tool_provenance_spec() when deserializing saved payloads."
+            )
+        if source_binding is not None and not isinstance(
+            source_binding,
+            erlab.interactive.imagetool.provenance.ImageToolSelectionSourceBinding,
+        ):
+            raise TypeError("source_binding must be an ImageToolSelectionSourceBinding")
+        self._source_binding = source_binding
+        if source_spec is None and self._source_binding is not None and self.parent_uid:
+            source_spec = self._source_binding.materialize(
+                self.manager._parent_node(self).current_source_data()
             )
         self._source_spec = (
             erlab.interactive.imagetool.provenance.require_live_source_spec(source_spec)
@@ -581,16 +635,18 @@ class _ManagedWindowNode(QtCore.QObject):
         self._output_id = None
         if provenance_spec is not None:
             self.set_displayed_provenance(provenance_spec)
-        elif self._source_spec is not None and state == "fresh" and self.parent_uid:
+        elif self.has_source_binding and state == "fresh" and self.parent_uid:
             parent = self.manager._parent_node(self)
+            parent_data = parent.current_source_data()
+            source_spec = self._materialized_source_spec(parent_data)
             self.set_displayed_provenance(
                 erlab.interactive.imagetool.provenance.compose_display_provenance(
                     parent.provenance_spec,
-                    self._source_spec,
-                    parent_data=parent.current_source_data(),
+                    source_spec,
+                    parent_data=parent_data,
                 )
             )
-        self._set_source_state(state if self._source_spec is not None else "fresh")
+        self._set_source_state(state if self.has_source_binding else "fresh")
         self.manager._mark_node_state_dirty(self.uid)
 
     def set_output_binding(
@@ -616,6 +672,7 @@ class _ManagedWindowNode(QtCore.QObject):
                 "parse_tool_provenance_spec() when deserializing saved payloads."
             )
         self._source_spec = None
+        self._source_binding = None
         self._source_auto_update = bool(auto_update)
         self._output_id = output_id
         if provenance_spec is not None:
@@ -636,11 +693,23 @@ class _ManagedWindowNode(QtCore.QObject):
                 "parse_tool_provenance_spec() when deserializing saved payloads."
             )
         self._source_spec = None
+        self._source_binding = None
         self._source_auto_update = False
         self._output_id = None
         self.set_displayed_provenance(provenance_spec)
         self._set_source_state("fresh")
         self.manager._mark_node_state_dirty(self.uid)
+
+    def _materialized_source_spec(
+        self, parent_data: xr.DataArray
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec:
+        """Return the source spec to apply to ``parent_data``."""
+        if self._source_binding is not None:
+            self._source_spec = self._source_binding.materialize(parent_data)
+            return self._source_spec
+        if self._source_spec is None:
+            raise RuntimeError("Node is not bound to an ImageTool source.")
+        return self._source_spec
 
     def _resolved_output_payload(
         self,
@@ -871,14 +940,15 @@ class _ManagedWindowNode(QtCore.QObject):
                     return False
                 resolved, provenance_spec = payload
             else:
-                if self._source_spec is None:
+                if not self.has_source_binding:
                     return False
                 parent_data = self.parent_source_data()
-                resolved = self._source_spec.apply(parent_data)
+                source_spec = self._materialized_source_spec(parent_data)
+                resolved = source_spec.apply(parent_data)
                 provenance_spec = (
                     erlab.interactive.imagetool.provenance.compose_display_provenance(
                         self.manager._parent_node(self).provenance_spec,
-                        self._source_spec,
+                        source_spec,
                         parent_data=parent_data,
                     )
                 )
@@ -921,13 +991,14 @@ class _ManagedWindowNode(QtCore.QObject):
                     return False
                 resolved, provenance_spec = payload
             else:
-                if self._source_spec is None:
+                if not self.has_source_binding:
                     return False
-                resolved = self._source_spec.apply(parent_data)
+                source_spec = self._materialized_source_spec(parent_data)
+                resolved = source_spec.apply(parent_data)
                 provenance_spec = (
                     erlab.interactive.imagetool.provenance.compose_display_provenance(
                         self.manager._parent_node(self).provenance_spec,
-                        self._source_spec,
+                        source_spec,
                         parent_data=parent_data,
                     )
                 )
@@ -1006,6 +1077,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         | None = None,
         source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         | None = None,
+        source_binding: ImageToolSelectionSourceBinding | None = None,
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
     ) -> None:
@@ -1034,6 +1106,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
             tool,
             provenance_spec=provenance_spec,
             source_spec=source_spec,
+            source_binding=source_binding,
             source_auto_update=source_auto_update,
             source_state=source_state,
         )

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -37,6 +37,7 @@ if typing.TYPE_CHECKING:
     import qtawesome
 
     from erlab.interactive.imagetool import ImageTool
+    from erlab.interactive.imagetool.provenance import ImageToolSelectionSourceBinding
     from erlab.interactive.imagetool.viewer import ImageSlicerArea
 else:
     import lazy_loader as _lazy
@@ -1116,66 +1117,103 @@ class ItoolPlotItem(pg.PlotItem):
     def make_tool_source_spec(
         self, *, transpose: bool = False, squeeze: bool = False
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec:
+        """Return a source spec for the current plot selection.
+
+        The spec contains ``qsel``, ``isel``, and ``sel`` operations for the current
+        parent data. Copied code, derivation display, and older saved workspaces use
+        this form directly. Manager child refreshes should store
+        :meth:`make_tool_source_binding` and call ``materialize`` before applying the
+        source.
+
+        Parameters
+        ----------
+        transpose
+            Whether to append a transpose step for the opened tool.
+        squeeze
+            Whether to append a squeeze step for singleton dimensions.
+
+        Returns
+        -------
+        ToolProvenanceSpec
+            Source spec for the current parent data.
+        """
+        return self.make_tool_source_binding(
+            transpose=transpose, squeeze=squeeze
+        ).materialize(self.slicer_area._tool_source_parent_data())
+
+    def make_tool_source_binding(
+        self, *, transpose: bool = False, squeeze: bool = False
+    ) -> ImageToolSelectionSourceBinding:
+        """Return ImageTool selection state for future manager refreshes.
+
+        Parameters
+        ----------
+        transpose
+            Whether refreshed data should be transposed for the opened tool.
+        squeeze
+            Whether refreshed data should squeeze singleton dimensions.
+
+        Returns
+        -------
+        ImageToolSelectionSourceBinding
+            Selection state that stores cursor, bin, crop, transpose, and squeeze
+            choices from this plot.
+        """
         cursor = self.slicer_area.current_cursor
         alt_pressed: bool = (
             QtCore.Qt.KeyboardModifier.AltModifier
             in QtWidgets.QApplication.queryKeyboardModifiers()
         )
         selection_code = self.selection_code_for_cursor(cursor)
-        operations: list[
-            erlab.interactive.imagetool.provenance.ToolProvenanceOperation
-        ] = []
-        if selection_code.startswith(".qsel"):
-            qsel_kwargs = self.array_slicer.qsel_args(cursor, self.display_axis)
-            if qsel_kwargs:
-                operations.append(
-                    erlab.interactive.imagetool.provenance.QSelOperation(
-                        kwargs=qsel_kwargs
-                    )
-                )
-        else:
-            isel_kwargs = self.array_slicer.isel_args(
-                cursor, self.display_axis, int_if_one=True
-            )
-            if isel_kwargs:
-                operations.append(
-                    erlab.interactive.imagetool.provenance.IselOperation(
-                        kwargs=isel_kwargs
-                    )
-                )
-
-        if alt_pressed:
-            crop_indexers = dict(self._crop_indexers)
-            isel_indexers: dict[Hashable, slice] = {}
-            for key in list(crop_indexers.keys()):
-                if isinstance(key, str) and key.endswith("_idx"):
-                    isel_indexers[key.removesuffix("_idx")] = crop_indexers.pop(key)
-
-            if crop_indexers:
-                operations.append(
-                    erlab.interactive.imagetool.provenance.SelOperation(
-                        kwargs=crop_indexers
-                    )
-                )
-            if isel_indexers:
-                operations.append(
-                    erlab.interactive.imagetool.provenance.IselOperation(
-                        kwargs=isel_indexers
-                    )
-                )
-
-        operations.append(
-            erlab.interactive.imagetool.provenance.SortCoordOrderOperation()
+        selection_indexers = self.array_slicer.isel_args(
+            cursor, self.display_axis, int_if_one=True
         )
-        if transpose:
-            operations.append(
-                erlab.interactive.imagetool.provenance.TransposeOperation(
-                    dims=tuple(reversed(self.current_data.dims))
-                )
-            )
-        if squeeze and any(size == 1 for size in self.current_data.shape):
-            operations.append(erlab.interactive.imagetool.provenance.SqueezeOperation())
-        return erlab.interactive.imagetool.provenance.selection(*operations)
+        selection_mode: typing.Literal["qsel", "isel"] = (
+            "qsel" if selection_code.startswith(".qsel") else "isel"
+        )
+        selection_binned_dims: list[Hashable] = []
+        if selection_code.startswith(".qsel"):
+            binned = self.array_slicer.get_binned(cursor)
+            for dim in selection_indexers:
+                axis_idx = self.array_slicer._dim_indices.get(dim)
+                if axis_idx is None:
+                    axis_idx = self.array_slicer._obj.dims.index(dim)
+                if binned[axis_idx]:
+                    selection_binned_dims.append(dim)
+
+        crop_sel_indexers: dict[Hashable, slice] = {}
+        crop_isel_indexers: dict[Hashable, slice] = {}
+        if alt_pressed:
+            for key, selector in self._crop_indexers.items():
+                axis_idx = self.array_slicer._dim_indices.get(key)
+                if axis_idx is None:
+                    axis_idx = self.array_slicer._obj.dims.index(key)
+                if selector.start is None or selector.stop is None:
+                    index_selector = selector
+                else:
+                    start = self.array_slicer.index_of_value(
+                        axis_idx, selector.start, uniform=True
+                    )
+                    stop = self.array_slicer.index_of_value(
+                        axis_idx, selector.stop, uniform=True
+                    )
+                    lower, upper = sorted((start, stop))
+                    index_selector = slice(lower, upper + 1, selector.step)
+                if isinstance(key, str) and key.endswith("_idx"):
+                    crop_isel_indexers[key.removesuffix("_idx")] = index_selector
+                else:
+                    crop_sel_indexers[key] = index_selector
+
+        transpose_dims = tuple(reversed(self.current_data.dims)) if transpose else None
+        return erlab.interactive.imagetool.provenance.ImageToolSelectionSourceBinding(
+            selection_mode=selection_mode,
+            selection_indexers=selection_indexers,
+            selection_binned_dims=tuple(selection_binned_dims),
+            crop_sel_indexers=crop_sel_indexers,
+            crop_isel_indexers=crop_isel_indexers,
+            transpose_dims=transpose_dims,
+            squeeze=squeeze and any(size == 1 for size in self.current_data.shape),
+        )
 
     @property
     def is_guidelines_visible(self) -> bool:
@@ -1984,6 +2022,7 @@ class ItoolPlotItem(pg.PlotItem):
         data: xr.DataArray,
         source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
         *,
+        source_binding: ImageToolSelectionSourceBinding | None = None,
         use_parent_colormap: bool,
     ) -> None:
         itool_kw: dict[str, typing.Any] = {"data": data, "execute": False}
@@ -2022,7 +2061,12 @@ class ItoolPlotItem(pg.PlotItem):
                     erlab.interactive.itool(manager=False, **itool_kw),
                 )
                 if tool is not None:  # pragma: no branch
-                    manager.add_imagetool_child(tool, target, source_spec=source_spec)
+                    manager.add_imagetool_child(
+                        tool,
+                        target,
+                        source_spec=source_spec,
+                        source_binding=source_binding,
+                    )
                 return
 
         tool_window = erlab.interactive.itool(**itool_kw)
@@ -2041,9 +2085,11 @@ class ItoolPlotItem(pg.PlotItem):
     def open_in_new_window(self) -> None:
         """Open the current data in a new window."""
         data = self.current_data
+        source_binding = self.make_tool_source_binding()
         self._open_data_in_new_window(
             data,
-            self.make_tool_source_spec(),
+            source_binding.materialize(self.slicer_area._tool_source_parent_data()),
+            source_binding=source_binding,
             use_parent_colormap=True,
         )
 
@@ -2063,6 +2109,7 @@ class ItoolPlotItem(pg.PlotItem):
         self._open_data_in_new_window(
             data,
             source_spec,
+            source_binding=None,
             use_parent_colormap=False,
         )
 
@@ -2075,7 +2122,13 @@ class ItoolPlotItem(pg.PlotItem):
                     data, data_name=self.get_selection_code(), execute=False
                 )
                 if isinstance(tool, erlab.interactive.utils.ToolWindow):
-                    tool.set_source_binding(self.make_tool_source_spec())
+                    source_binding = self.make_tool_source_binding()
+                    tool.set_source_binding(
+                        source_binding.materialize(
+                            self.slicer_area._tool_source_parent_data()
+                        ),
+                        source_binding=source_binding,
+                    )
                 self.slicer_area.add_tool_window(tool)
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(
@@ -2098,7 +2151,13 @@ class ItoolPlotItem(pg.PlotItem):
                 data, data_name=self.get_selection_code(), execute=False
             )
             if isinstance(tool, erlab.interactive.utils.ToolWindow):
-                tool.set_source_binding(self.make_tool_source_spec())
+                source_binding = self.make_tool_source_binding()
+                tool.set_source_binding(
+                    source_binding.materialize(
+                        self.slicer_area._tool_source_parent_data()
+                    ),
+                    source_binding=source_binding,
+                )
             self.slicer_area.add_tool_window(tool)
 
     @QtCore.Slot()
@@ -2110,7 +2169,13 @@ class ItoolPlotItem(pg.PlotItem):
                 execute=False,
             )
             if isinstance(tool, erlab.interactive.utils.ToolWindow):
-                tool.set_source_binding(self.make_tool_source_spec(transpose=True))
+                source_binding = self.make_tool_source_binding(transpose=True)
+                tool.set_source_binding(
+                    source_binding.materialize(
+                        self.slicer_area._tool_source_parent_data()
+                    ),
+                    source_binding=source_binding,
+                )
             self.slicer_area.add_tool_window(tool)
 
     @QtCore.Slot()
@@ -2121,7 +2186,11 @@ class ItoolPlotItem(pg.PlotItem):
             execute=False,
         )
         if isinstance(tool, erlab.interactive.utils.ToolWindow):
-            tool.set_source_binding(self.make_tool_source_spec(squeeze=True))
+            source_binding = self.make_tool_source_binding(squeeze=True)
+            tool.set_source_binding(
+                source_binding.materialize(self.slicer_area._tool_source_parent_data()),
+                source_binding=source_binding,
+            )
         self.slicer_area.add_tool_window(tool)
 
     @QtCore.Slot()

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -19,6 +19,11 @@ ImageTool window. A :class:`ToolProvenanceSpec` answers two questions:
    - Each operation is represented by an immutable :class:`ToolProvenanceOperation`
      subclass whose serialized fields are safe to persist in JSON.
 
+Manager children opened from an ImageTool cursor or bin selection do not keep the
+first generated ``qsel`` arguments as their refresh state. They store the selected
+parent indices in :class:`ImageToolSelectionSourceBinding` and rebuild ``qsel`` or
+``isel`` operations from the current parent data each time they refresh.
+
 Adding a new provenance-carrying operation follows the same pattern every time:
 
 1. Define a new :class:`ToolProvenanceOperation` subclass with a unique ``op``
@@ -45,8 +50,8 @@ Adding a new provenance-carrying operation follows the same pattern every time:
 6. Give the class a unique ``op`` discriminator literal. Subclasses register themselves
    automatically so serialized payloads can dispatch to the right model.
 
-7. Export the concrete operation class from this module so runtime call sites can
-   instantiate it directly.
+7. Export the operation class from this module so runtime call sites can instantiate
+   it directly.
 
 8. Add tests that cover round-trip validation, :meth:`apply`, and derivation text/code,
    plus any save/load path that persists the new operation.
@@ -54,7 +59,7 @@ Adding a new provenance-carrying operation follows the same pattern every time:
 Parsing of serialized payloads happens only through :func:`parse_tool_provenance_spec`
 and :func:`parse_tool_provenance_operation`. Runtime authoring code should create specs
 with :func:`full_data`, :func:`public_data`, or :func:`selection`, then instantiate
-concrete operation models from this module directly.
+operation models from this module directly.
 """
 
 from __future__ import annotations
@@ -72,6 +77,7 @@ __all__ = [
     "DivideByCoordOperation",
     "FileLoadSource",
     "FileReplayCall",
+    "ImageToolSelectionSourceBinding",
     "InterpolationOperation",
     "IselOperation",
     "MaskWithPolygonOperation",
@@ -475,12 +481,18 @@ _OPERATION_TYPES: dict[str, type[ToolProvenanceOperation]] = {}
 
 
 class ToolProvenanceOperation(pydantic.BaseModel):
-    """Base class for immutable provenance operations.
+    """Base class for operations stored in :class:`ToolProvenanceSpec`.
 
     New operations should keep runtime fields in their decoded Python form, prefer the
     annotated provenance field aliases in this module for lossless JSON serialization,
     implement :meth:`apply` to replay the transformation, and implement
     :meth:`derivation_entry` to describe the step in manager UI.
+
+    Operation instances store the exact arguments used by replay, copied code, and
+    derivation display. For ImageTool cursor or bin children that refresh after parent
+    coordinate edits, store the selected indices in
+    :class:`ImageToolSelectionSourceBinding` and rebuild ``qsel`` operations before
+    applying the spec.
     """
 
     live_applicable: typing.ClassVar[bool] = True
@@ -566,14 +578,23 @@ class ToolProvenanceOperation(pydantic.BaseModel):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         """Apply this operation to the current derived array.
 
-        ``data`` is the array produced by the preceding replay step. ``parent_data`` is
-        the original parent source array for the enclosing provenance spec and is
-        available for operations that need parent coordinates, ordering, or other
-        contextual metadata while replaying.
+        Parameters
+        ----------
+        data
+            Array produced by the preceding replay step.
+        parent_data
+            Parent ImageTool data for the enclosing provenance spec. Operations may
+            inspect it for coordinates, dimension order, or metadata.
 
-        This method is used only for live-source provenance paths. Operations that are
-        intended purely for generated replay code should raise an error here and set
-        ``live_applicable = False``.
+        Returns
+        -------
+        xarray.DataArray
+            Array after this operation has been applied.
+
+        Notes
+        -----
+        Operations that only emit generated code should set ``live_applicable = False``
+        and raise from this method.
         """
         raise NotImplementedError
 
@@ -859,8 +880,13 @@ class ToolProvenanceSpec(pydantic.BaseModel):
     """Immutable provenance recipe for rebuilding tool data from a parent ImageTool.
 
     Author new specs with :func:`full_data`, :func:`public_data`, or
-    :func:`selection` plus concrete operation instances from this module. Deserialize
-    saved payloads with :func:`parse_tool_provenance_spec`.
+    :func:`selection` plus operation instances from this module. Deserialize saved
+    payloads with :func:`parse_tool_provenance_spec`.
+
+    A spec records the exact operation arguments used for replay, copied code, and
+    derivation display. Manager children opened from ImageTool cursor or bin selections
+    should keep :class:`ImageToolSelectionSourceBinding` as their refresh state; that
+    binding builds a spec before refresh so edited parent coordinates are used.
     """
 
     schema_version: typing.Literal[2] = 2
@@ -1533,6 +1559,115 @@ def require_live_source_spec(
             "whose operations support `apply()`."
         )
     return spec
+
+
+class ImageToolSelectionSourceBinding(pydantic.BaseModel):
+    """ImageTool selection state stored for manager child refreshes.
+
+    Stores the parent dimension indices selected in an ImageTool plot. When a child
+    refreshes after parent coordinates change, :meth:`materialize` rebuilds ``qsel`` or
+    ``isel`` operations from the current parent data so the child follows the same
+    cursor or bin position instead of old coordinate labels.
+
+    Parameters
+    ----------
+    selection_mode
+        Use ``"qsel"`` when selected hidden dimensions should be represented by current
+        coordinate values, or ``"isel"`` when they must stay index-based.
+    selection_indexers
+        Parent dimension names mapped to integer indices or index slices from the
+        cursor or bin selection.
+    selection_binned_dims
+        Dimensions in ``selection_indexers`` whose slices should become ``qsel`` center
+        and width arguments.
+    crop_sel_indexers
+        Index slice selections from visible axes that should be represented by current
+        coordinate values during refresh.
+    crop_isel_indexers
+        Index slice selections from visible non-uniform axes.
+    transpose_dims
+        Dimension order to apply after selection, if the opened tool expects a
+        transposed input.
+    squeeze
+        Whether to squeeze singleton dimensions after selection.
+    """
+
+    schema_version: typing.Literal[1] = 1
+    kind: typing.Literal["imagetool_selection"] = "imagetool_selection"
+    selection_mode: typing.Literal["qsel", "isel"] = "qsel"
+    selection_indexers: ProvenanceMapping = pydantic.Field(default_factory=dict)
+    selection_binned_dims: ProvenanceHashableTuple = ()
+    crop_sel_indexers: ProvenanceMapping = pydantic.Field(default_factory=dict)
+    crop_isel_indexers: ProvenanceMapping = pydantic.Field(default_factory=dict)
+    transpose_dims: NullableProvenanceHashableTuple = None
+    squeeze: bool = False
+
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        extra="forbid",
+    )
+
+    def materialize(self, parent_data: xr.DataArray) -> ToolProvenanceSpec:
+        """Build a source spec for the current parent data.
+
+        Parameters
+        ----------
+        parent_data
+            Current data from the parent ImageTool.
+
+        Returns
+        -------
+        ToolProvenanceSpec
+            Source spec whose ``qsel``, ``isel``, and ``sel`` operations match this
+            binding on ``parent_data``.
+        """
+        operations: list[ToolProvenanceOperation] = []
+        selection_data = ToolProvenanceSpec._starting_data_for_kind(
+            "selection", parent_data
+        )
+        selection_indexers = dict(self.selection_indexers)
+        if selection_indexers:
+            if self.selection_mode == "qsel":
+                operation = QSelOperation(
+                    kwargs=erlab.interactive.imagetool.slicer.qsel_args_from_indexers(
+                        selection_data,
+                        selection_indexers,
+                        self.selection_binned_dims,
+                    )
+                )
+            else:
+                operation = IselOperation(kwargs=selection_indexers)
+            operations.append(operation)
+
+        crop_sel_indexers = dict(self.crop_sel_indexers)
+        if crop_sel_indexers:
+            crop_sel_kwargs: dict[Hashable, typing.Any] = {}
+            for dim, selector in crop_sel_indexers.items():
+                if dim not in selection_data.dims:
+                    raise ValueError(f"Dimension `{dim}` not found in data")
+                coord = selection_data[dim][selector].values
+                if isinstance(selector, slice):
+                    if coord.size == 0:
+                        raise ValueError(f"Selection for dimension `{dim}` is empty")
+                    crop_sel_kwargs[dim] = slice(
+                        erlab.utils.misc._convert_to_native(coord[0]),
+                        erlab.utils.misc._convert_to_native(coord[-1]),
+                    )
+                else:
+                    crop_sel_kwargs[dim] = erlab.utils.misc._convert_to_native(coord)
+            operations.append(SelOperation(kwargs=crop_sel_kwargs))
+
+        crop_isel_indexers = dict(self.crop_isel_indexers)
+        if crop_isel_indexers:
+            operations.append(IselOperation(kwargs=crop_isel_indexers))
+
+        operations.append(SortCoordOrderOperation())
+        if self.transpose_dims is not None:
+            operations.append(TransposeOperation(dims=self.transpose_dims))
+        if self.squeeze:
+            operations.append(SqueezeOperation())
+        return ToolProvenanceSpec(kind="selection").append_operations(*operations)
 
 
 def full_data(

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -13,7 +13,7 @@ from qtpy import QtCore, QtWidgets
 import erlab
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable, Sequence
+    from collections.abc import Hashable, Mapping, Sequence
 
     import dask.array
     import xarray as xr
@@ -129,6 +129,67 @@ def _get_inc(coord):
     except IndexError:
         # Coord size is 1, assume increment of 1
         return 1
+
+
+def qsel_args_from_indexers(
+    data: xr.DataArray,
+    indexers: Mapping[Hashable, slice | int],
+    binned_dims: Sequence[Hashable],
+) -> dict[Hashable, float]:
+    """Build ``qsel`` keyword arguments from index selections.
+
+    Parameters
+    ----------
+    data
+        Data whose current coordinates should be used for the returned ``qsel`` values.
+    indexers
+        Dimension names mapped to integer indices or index slices.
+    binned_dims
+        Dimensions whose index slices should become ``qsel`` center and width
+        arguments.
+
+    Returns
+    -------
+    dict
+        Keyword arguments suitable for :meth:`xarray.DataArray.qsel`.
+
+    Raises
+    ------
+    ValueError
+        If a requested dimension is missing or a binned selection cannot be expressed
+        by the current coordinate values.
+    """
+    out: dict[Hashable, float] = {}
+    binned_dim_set = set(binned_dims)
+
+    for dim, selector in indexers.items():
+        if dim not in data.dims:
+            raise ValueError(f"Dimension `{dim}` not found in data")
+        coord_values = data[dim].values
+        inc = _get_inc(coord_values)
+        order = 3 if inc == 0 else erlab.utils.array.effective_decimals(inc)
+
+        if dim in binned_dim_set:
+            coord = data[dim][selector].values
+            center = float(np.round(coord.mean(), order))
+            width = float(np.round(coord[-1] - coord[0] + inc, order))
+
+            out[dim] = center
+            if not np.allclose(
+                data[dim]
+                .sel({dim: slice(center - width / 2, center + width / 2)})
+                .values,
+                coord,
+            ):
+                raise ValueError(
+                    "Bin does not contain the same values as the original data."
+                )
+
+            out[str(dim) + "_width"] = width
+        else:
+            out[dim] = float(np.round(coord_values[selector], order))
+
+    return out
 
 
 class ArraySlicer(QtCore.QObject):
@@ -1050,39 +1111,18 @@ class ArraySlicer(QtCore.QObject):
         return out
 
     def qsel_args(self, cursor: int, disp: Sequence[int]) -> dict:
-        out: dict[Hashable, float] = {}
         binned = self.get_binned(cursor)
+        indexers = self.isel_args(cursor, disp, int_if_one=True)
+        binned_dims: list[Hashable] = []
 
-        for dim, selector in self.isel_args(cursor, disp, int_if_one=True).items():
+        for dim in indexers:
             axis_idx = self._dim_indices.get(dim)
             if axis_idx is None:
                 axis_idx = self._obj.dims.index(dim)
-            inc = self.incs[axis_idx]
-            # Estimate minimum number of decimal places required to represent selection
-            order = self.get_significant(axis_idx)
-
             if binned[axis_idx]:
-                coord = self._obj[dim][selector].values
-                center = float(np.round(coord.mean(), order))
-                width = float(np.round(coord[-1] - coord[0] + inc, order))
+                binned_dims.append(dim)
 
-                out[dim] = center
-                if not np.allclose(
-                    self._obj[dim]
-                    .sel({dim: slice(center - width / 2, center + width / 2)})
-                    .values,
-                    coord,
-                ):
-                    raise ValueError(
-                        "Bin does not contain the same values as the original data."
-                    )
-
-                out[str(dim) + "_width"] = width
-
-            else:
-                out[dim] = float(np.round(self._obj[dim].values[selector], order))
-
-        return out
+        return qsel_args_from_indexers(self._obj, indexers, binned_dims)
 
     def qsel_code(self, cursor: int, disp: Sequence[int]) -> str:
         if self._hidden_axes_have_nonuniform(disp):

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -48,6 +48,8 @@ if typing.TYPE_CHECKING:
     import pyperclip
     import qtawesome
     from pyqtgraph.GraphicsScene.mouseEvents import MouseDragEvent
+
+    from erlab.interactive.imagetool.provenance import ImageToolSelectionSourceBinding
 else:
     import lazy_loader as _lazy
 
@@ -746,6 +748,7 @@ def copy_to_clipboard(content: str | list[str]) -> str:
 
 
 _TOOL_SOURCE_SPEC_ATTR = "tool_source_spec"
+_TOOL_SOURCE_BINDING_ATTR = "tool_source_binding"
 _TOOL_SOURCE_STATE_ATTR = "tool_source_state"
 _TOOL_SOURCE_AUTO_UPDATE_ATTR = "tool_source_auto_update"
 _TOOL_INPUT_PROVENANCE_SPEC_ATTR = "tool_input_provenance_spec"
@@ -2919,6 +2922,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._source_spec: (
             erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None
         ) = None
+        self._source_binding: ImageToolSelectionSourceBinding | None = None
         self._input_provenance_spec: (
             erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None
         ) = None
@@ -3181,9 +3185,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         parent_provenance = None
         if self._input_provenance_parent_fetcher is not None:
             parent_provenance = self._parent_input_provenance()
+        source_spec = self._source_spec
+        if parent_data is not None and self._source_binding is not None:
+            source_spec = self._materialized_source_spec(parent_data)
         return erlab.interactive.imagetool.provenance.compose_display_provenance(
             parent_provenance,
-            self._source_spec,
+            source_spec,
             parent_data=parent_data,
         )
 
@@ -3684,6 +3691,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         return self._source_spec
 
     @property
+    def source_binding(
+        self,
+    ) -> ImageToolSelectionSourceBinding | None:
+        """Return the ImageTool selection state used for source refreshes, if any."""
+        return self._source_binding
+
+    @property
     def source_state(self) -> typing.Literal["fresh", "stale", "unavailable"]:
         """Return whether the bound ImageTool source is fresh, stale, or unavailable."""
         return self._source_state
@@ -3696,12 +3710,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     @property
     def has_source_binding(self) -> bool:
         """Return `True` when this tool is bound to ImageTool source data."""
-        return self._source_spec is not None
+        return self._source_spec is not None or self._source_binding is not None
 
     @property
     def source_status_text(self) -> str:
         """Return the status label shown for source bindings that need attention."""
-        if self._source_spec is None:
+        if not self.has_source_binding:
             return ""
         if self._source_state == "stale":
             return "Update Available"
@@ -3715,10 +3729,26 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self,
         source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None,
         *,
+        source_binding: ImageToolSelectionSourceBinding | None = None,
         auto_update: bool = False,
         state: typing.Literal["fresh", "stale", "unavailable"] = "fresh",
     ) -> None:
-        """Bind this tool to an ImageTool source specification and status state."""
+        """Bind this tool to data selected from a parent ImageTool.
+
+        Parameters
+        ----------
+        source_spec
+            Current source spec used for derivation display and older saved
+            workspaces. If ``source_binding`` is not provided, refresh applies this
+            spec as stored.
+        source_binding
+            Selection state from an ImageTool plot. When provided, refresh first builds
+            a new ``source_spec`` from the current parent data.
+        auto_update
+            Whether compatible parent changes should update this tool automatically.
+        state
+            Current refresh state for manager and tool status UI.
+        """
         if source_spec is not None and not isinstance(
             source_spec, erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         ):
@@ -3729,10 +3759,16 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._source_spec = (
             erlab.interactive.imagetool.provenance.require_live_source_spec(source_spec)
         )
+        if source_binding is not None and not isinstance(
+            source_binding,
+            erlab.interactive.imagetool.provenance.ImageToolSelectionSourceBinding,
+        ):
+            raise TypeError("source_binding must be an ImageToolSelectionSourceBinding")
+        self._source_binding = source_binding
         self._source_auto_update = bool(auto_update)
-        if self._source_spec is not None and state == "fresh":
+        if self.has_source_binding and state == "fresh":
             self._sync_input_provenance_snapshot()
-        self._set_source_state(state if self._source_spec is not None else "fresh")
+        self._set_source_state(state if self.has_source_binding else "fresh")
 
     def set_source_parent_fetcher(
         self, fetcher: Callable[[], xr.DataArray] | None
@@ -3773,7 +3809,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def _refresh_source_status_widget(self) -> None:
         """Refresh the inline banner that reports update availability."""
-        if self._source_spec is None or (
+        if not self.has_source_binding or (
             self._source_state == "fresh" and not self._source_auto_update
         ):
             self._source_status_bar.hide()
@@ -3811,11 +3847,20 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         )
         self._source_status_bar.show()
 
-    def _resolve_source_data(self, parent_data: xr.DataArray) -> xr.DataArray:
-        """Resolve the current source specification against replacement parent data."""
+    def _materialized_source_spec(
+        self, parent_data: xr.DataArray
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec:
+        """Return the source spec to apply to ``parent_data``."""
+        if self._source_binding is not None:
+            self._source_spec = self._source_binding.materialize(parent_data)
+            return self._source_spec
         if self._source_spec is None:
             raise RuntimeError("Tool is not bound to an ImageTool source.")
-        return self._source_spec.apply(parent_data)
+        return self._source_spec
+
+    def _resolve_source_data(self, parent_data: xr.DataArray) -> xr.DataArray:
+        """Apply the current source spec or selection state to ``parent_data``."""
+        return self._materialized_source_spec(parent_data).apply(parent_data)
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
         """Validate or normalize source data before `update_data` consumes it.
@@ -3917,7 +3962,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def handle_parent_source_replaced(self, parent_data: xr.DataArray) -> None:
         """React to replacement of the parent ImageTool data source."""
-        if self._source_spec is None:
+        if not self.has_source_binding:
             return
         try:
             resolved = self._resolve_source_data(parent_data)
@@ -3959,7 +4004,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if self._managed_source_update_dialog is not None:
             return self._managed_source_update_dialog(parent=parent)
 
-        if self._source_spec is None:
+        if not self.has_source_binding:
             return int(QtWidgets.QDialog.DialogCode.Rejected)
 
         dialog = _ToolSourceUpdateDialog(
@@ -4020,6 +4065,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             attrs[_TOOL_SOURCE_SPEC_ATTR] = json.dumps(
                 self._source_spec.model_dump(mode="json")
             )
+        if self._source_binding is not None:
+            attrs[_TOOL_SOURCE_BINDING_ATTR] = json.dumps(
+                self._source_binding.model_dump(mode="json")
+            )
+        if self.has_source_binding:
             attrs[_TOOL_SOURCE_STATE_ATTR] = self._source_state
             attrs[_TOOL_SOURCE_AUTO_UPDATE_ATTR] = bool(self._source_auto_update)
         input_provenance = self._effective_input_provenance_spec()
@@ -4099,6 +4149,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             ds.attrs["tool_state"]
         )
         tool._tool_display_name = ds.attrs.get("tool_display_name", "")
+        source_spec = None
         if _TOOL_SOURCE_SPEC_ATTR in ds.attrs:
             try:
                 source_spec = (
@@ -4120,17 +4171,34 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     cls_obj.__qualname__,
                     exc_info=True,
                 )
-            else:
-                tool.set_source_binding(
-                    source_spec,
-                    auto_update=bool(
-                        ds.attrs.get(_TOOL_SOURCE_AUTO_UPDATE_ATTR, False)
-                    ),
-                    state=typing.cast(
-                        "typing.Literal['fresh', 'stale', 'unavailable']",
-                        ds.attrs.get(_TOOL_SOURCE_STATE_ATTR, "fresh"),
-                    ),
+        source_binding = None
+        if _TOOL_SOURCE_BINDING_ATTR in ds.attrs:
+            try:
+                provenance = erlab.interactive.imagetool.provenance
+                source_binding = (
+                    provenance.ImageToolSelectionSourceBinding.model_validate(
+                        typing.cast(
+                            "Mapping[str, typing.Any]",
+                            json.loads(ds.attrs[_TOOL_SOURCE_BINDING_ATTR]),
+                        )
+                    )
                 )
+            except Exception:
+                logger.warning(
+                    "Ignoring invalid saved tool source binding for %s",
+                    cls_obj.__qualname__,
+                    exc_info=True,
+                )
+        if source_spec is not None or source_binding is not None:
+            tool.set_source_binding(
+                source_spec,
+                source_binding=source_binding,
+                auto_update=bool(ds.attrs.get(_TOOL_SOURCE_AUTO_UPDATE_ATTR, False)),
+                state=typing.cast(
+                    "typing.Literal['fresh', 'stale', 'unavailable']",
+                    ds.attrs.get(_TOOL_SOURCE_STATE_ATTR, "fresh"),
+                ),
+            )
         if _TOOL_INPUT_PROVENANCE_SPEC_ATTR in ds.attrs:
             try:
                 tool.set_input_provenance_spec(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1088,12 +1088,14 @@ def test_profile_menu_opens_associated_coord_targets(
         tuple[
             xr.DataArray,
             erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
+            erlab.interactive.imagetool.provenance.ImageToolSelectionSourceBinding
+            | None,
             bool,
         ]
     ] = []
 
-    def _capture_open(data, source_spec, *, use_parent_colormap):
-        captured.append((data, source_spec, use_parent_colormap))
+    def _capture_open(data, source_spec, *, source_binding=None, use_parent_colormap):
+        captured.append((data, source_spec, source_binding, use_parent_colormap))
 
     monkeypatch.setattr(profile, "_open_data_in_new_window", _capture_open)
 
@@ -1112,10 +1114,11 @@ def test_profile_menu_opens_associated_coord_targets(
     )
     assert temp_action.menu() is None
     temp_action.trigger()
-    temp_data, temp_spec, use_parent_colormap = captured[-1]
+    temp_data, temp_spec, temp_binding, use_parent_colormap = captured[-1]
     xr.testing.assert_identical(temp_data, data.coords["temp"])
     assert temp_spec.kind == "public_data"
     assert temp_spec.operations[-1].op == "select_coord"
+    assert temp_binding is None
     assert use_parent_colormap is False
 
     coord_menu = _menu_action_by_data(
@@ -1124,17 +1127,19 @@ def test_profile_menu_opens_associated_coord_targets(
     assert coord_menu is not None
 
     _menu_action_by_data(coord_menu, ("associated_coord_full", "plane")).trigger()
-    full_data, full_spec, use_parent_colormap = captured[-1]
+    full_data, full_spec, full_binding, use_parent_colormap = captured[-1]
     xr.testing.assert_identical(full_data, data.coords["plane"])
     assert full_spec.kind == "public_data"
     assert full_spec.operations[-1].op == "select_coord"
+    assert full_binding is None
     assert use_parent_colormap is False
 
     _menu_action_by_data(coord_menu, ("associated_coord_profile", "plane")).trigger()
-    profile_data, profile_spec, use_parent_colormap = captured[-1]
+    profile_data, profile_spec, profile_binding, use_parent_colormap = captured[-1]
     xr.testing.assert_identical(profile_data, data.isel(y=1, z=0).coords["plane"])
     assert profile_spec.kind == "selection"
     assert profile_spec.operations[-1].op == "select_coord"
+    assert profile_binding is None
     assert use_parent_colormap is False
     win.close()
 
@@ -2152,7 +2157,7 @@ def test_itool_make_tool_source_spec_includes_alt_crop_indexers(
     monkeypatch.setattr(
         type(image),
         "_crop_indexers",
-        property(lambda self: {"alpha": slice(1, 4), "eV_idx": slice(0, 2)}),
+        property(lambda self: {"alpha": slice(1, 4)}),
     )
 
     monkeypatch.setattr(
@@ -2161,12 +2166,69 @@ def test_itool_make_tool_source_spec_includes_alt_crop_indexers(
         staticmethod(lambda: QtCore.Qt.KeyboardModifier.AltModifier),
     )
 
+    binding = image.make_tool_source_binding()
     spec = image.make_tool_source_spec()
     sel_kwargs = next(op.decoded_kwargs for op in spec.operations if op.op == "sel")
-    isel_kwargs = [op.decoded_kwargs for op in spec.operations if op.op == "isel"][-1]
 
+    assert binding.crop_sel_indexers == {"alpha": slice(1, 5)}
     assert sel_kwargs == {"alpha": slice(1, 4)}
-    assert isel_kwargs == {"eV": slice(0, 2)}
+
+    win.close()
+
+
+def test_itool_make_tool_source_binding_uses_index_crop_for_nonuniform_dim(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(
+        np.zeros((4, 5), dtype=float),
+        dims=("x", "y"),
+        coords={"x": [0.0, 0.5, 2.0, 3.0], "y": np.arange(5.0)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    image = win.slicer_area.images[0]
+    monkeypatch.setattr(
+        type(image),
+        "_crop_indexers",
+        property(lambda self: {"x_idx": slice(None, None)}),
+    )
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "queryKeyboardModifiers",
+        staticmethod(lambda: QtCore.Qt.KeyboardModifier.AltModifier),
+    )
+
+    binding = image.make_tool_source_binding()
+
+    assert binding.crop_isel_indexers == {"x": slice(None, None)}
+
+    win.close()
+
+
+def test_itool_make_tool_source_binding_falls_back_to_dim_lookup(
+    qtbot, monkeypatch
+) -> None:
+    win = itool(_TEST_DATA["3D"].copy(), execute=False)
+    qtbot.addWidget(win)
+
+    image = win.slicer_area.images[0]
+    image.array_slicer._dim_indices = {}
+    monkeypatch.setattr(
+        type(image),
+        "_crop_indexers",
+        property(lambda self: {"alpha": slice(1, 4)}),
+    )
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "queryKeyboardModifiers",
+        staticmethod(lambda: QtCore.Qt.KeyboardModifier.AltModifier),
+    )
+
+    binding = image.make_tool_source_binding()
+
+    assert binding.selection_indexers["beta"] == 2
+    assert binding.crop_sel_indexers == {"alpha": slice(1, 5)}
 
     win.close()
 
@@ -3529,6 +3591,7 @@ def test_itool_open_in_ftool_sets_squeezed_source_binding(qtbot, monkeypatch) ->
     image.open_in_ftool()
 
     assert child.source_spec == image.make_tool_source_spec(squeeze=True)
+    assert child.source_binding == image.make_tool_source_binding(squeeze=True)
     assert child.source_state == "fresh"
 
     win.close()

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -2068,6 +2068,106 @@ def test_manager_full_data_childtool_updates_follow_transposed_view(
         xarray.testing.assert_identical(child.tool_data, parent_tool.slicer_area.data)
 
 
+def test_manager_selection_child_binding_survives_coordinate_shift_and_workspace_reload(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(4 * 5 * 3, dtype=float).reshape((4, 5, 3)),
+        dims=("x", "y", "z"),
+        coords={"x": np.arange(4), "y": np.arange(5), "z": np.arange(3)},
+        name="scan",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(data, link=False, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.set_value(axis=2, value=1.0, cursor=0)
+        parent_tool.array_slicer.set_bin(0, axis=2, value=3, update=True)
+        parent_tool.slicer_area.images[0].open_in_new_window()
+
+        root = manager._imagetool_wrappers[0]
+        qtbot.wait_until(lambda: len(root._childtool_indices) == 1, timeout=5000)
+        child_uid = root._childtool_indices[0]
+        child_node = manager._child_node(child_uid)
+        assert child_node.source_binding is not None
+
+        tree = manager._to_datatree()
+        child_attrs = tree[f"0/childtools/{child_uid}/imagetool"].attrs
+        assert "manager_node_live_source_binding" in child_attrs
+        assert "manager_node_live_source_spec" in child_attrs
+
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+        for node in tree.values():
+            manager._load_workspace_node(typing.cast("xr.DataTree", node))
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        loaded_child = manager._child_node(child_uid)
+        assert loaded_child.source_binding is not None
+
+        shifted = data.assign_coords(z=[10.0, 11.0, 12.0])
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, shifted)
+
+        qtbot.wait_until(lambda: loaded_child.source_state == "stale", timeout=5000)
+        assert loaded_child._update_from_parent_source() is True
+        child_data = manager.get_imagetool(child_uid).slicer_area._data.rename(None)
+        assert not np.isnan(child_data.values).all()
+        xarray.testing.assert_identical(
+            child_data,
+            shifted.qsel(z=11.0, z_width=3.0).rename(None),
+        )
+
+
+def test_manager_add_imagetool_child_materializes_source_binding_without_spec(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("x", "y"),
+        coords={"x": np.arange(3.0), "y": np.arange(4.0)},
+        name="scan",
+    )
+    source_binding = prov.ImageToolSelectionSourceBinding(
+        selection_mode="isel",
+        selection_indexers={"y": slice(1, 3)},
+    )
+    source_spec = source_binding.materialize(data)
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(data, link=False, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child = itool(source_spec.apply(data), manager=False, execute=False)
+        assert isinstance(child, erlab.interactive.imagetool.ImageTool)
+        qtbot.addWidget(child)
+        child_uid = manager.add_imagetool_child(
+            child,
+            0,
+            show=False,
+            source_binding=source_binding,
+        )
+        child_node = manager._child_node(child_uid)
+
+        assert child_node.source_binding == source_binding
+        assert child_node.source_spec == source_spec
+
+
 def test_manager_goldtool_output_itool_nests_under_tool(
     qtbot,
     monkeypatch,
@@ -8486,6 +8586,7 @@ def test_manager_load_workspace_dataset_ignores_invalid_saved_metadata(
     ds.attrs["manager_node_uid"] = "loaded"
     ds.attrs["manager_node_provenance_spec"] = "{not-json"
     ds.attrs["manager_node_live_source_spec"] = "{not-json"
+    ds.attrs["manager_node_live_source_binding"] = "{not-json"
 
     with manager_context() as manager:
         target = manager._load_workspace_imagetool_dataset(

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -920,6 +920,102 @@ def test_tool_provenance_display_entries_keep_ambiguous_script_steps() -> None:
     )
 
 
+def test_imagetool_selection_source_binding_materializes_current_coordinates() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    original = _base_data()
+    shifted = original.assign_coords(y=[20.0, 21.0, 22.0, 23.0])
+
+    binned = prov.ImageToolSelectionSourceBinding(
+        selection_indexers={"y": slice(1, 4)},
+        selection_binned_dims=("y",),
+    )
+    old_spec = binned.materialize(original)
+    new_spec = binned.materialize(shifted)
+
+    assert old_spec.operations[0].decoded_kwargs == {"y": 12.0, "y_width": 3.0}
+    assert new_spec.operations[0].decoded_kwargs == {"y": 22.0, "y_width": 3.0}
+    xr.testing.assert_identical(
+        new_spec.apply(shifted), shifted.qsel(y=22.0, y_width=3.0)
+    )
+
+    unbinned = prov.ImageToolSelectionSourceBinding(selection_indexers={"y": 2})
+    unbinned_spec = unbinned.materialize(shifted)
+    assert unbinned_spec.operations[0].decoded_kwargs == {"y": 22.0}
+    xr.testing.assert_identical(unbinned_spec.apply(shifted), shifted.qsel(y=22.0))
+
+    cropped = prov.ImageToolSelectionSourceBinding(crop_sel_indexers={"y": slice(1, 3)})
+    cropped_spec = cropped.materialize(shifted)
+    assert cropped_spec.operations[0].decoded_kwargs == {"y": slice(21.0, 22.0)}
+    xr.testing.assert_identical(
+        cropped_spec.apply(shifted),
+        shifted.sel(y=slice(21.0, 22.0)),
+    )
+
+
+def test_imagetool_selection_source_binding_round_trips_and_reuses_operations() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data()
+    binding = prov.ImageToolSelectionSourceBinding(
+        selection_mode="isel",
+        selection_indexers={"z": 1},
+        crop_sel_indexers={"x": slice(0, 3)},
+        crop_isel_indexers={"y": slice(1, 3)},
+        transpose_dims=("y", "x"),
+        squeeze=True,
+    )
+
+    reparsed = prov.ImageToolSelectionSourceBinding.model_validate(
+        binding.model_dump(mode="json")
+    )
+    assert reparsed == binding
+
+    spec = reparsed.materialize(data)
+    assert [op.op for op in spec.operations] == [
+        "isel",
+        "sel",
+        "isel",
+        "sort_coord_order",
+        "transpose",
+        "squeeze",
+    ]
+    xr.testing.assert_identical(
+        spec.apply(data),
+        erlab.utils.array.sort_coord_order(
+            data.isel(z=1).sel(x=slice(0.0, 2.0)).isel(y=slice(1, 3)),
+            data.coords.keys(),
+        )
+        .transpose("y", "x")
+        .squeeze(),
+    )
+
+
+def test_imagetool_selection_source_binding_validates_crop_indexers() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+    )
+
+    with pytest.raises(ValueError, match="Dimension `missing` not found"):
+        prov.ImageToolSelectionSourceBinding(
+            crop_sel_indexers={"missing": slice(0, 1)}
+        ).materialize(data)
+
+    with pytest.raises(ValueError, match="Selection for dimension `x` is empty"):
+        prov.ImageToolSelectionSourceBinding(
+            crop_sel_indexers={"x": slice(1, 1)}
+        ).materialize(data)
+
+    binding = prov.ImageToolSelectionSourceBinding(
+        crop_sel_indexers={"x": typing.cast("typing.Any", 1)}
+    )
+    spec = binding.materialize(data)
+    sel_kwargs = next(op.decoded_kwargs for op in spec.operations if op.op == "sel")
+
+    assert sel_kwargs == {"x": 1.0}
+
+
 def test_tool_provenance_rejects_unsupported_hashables() -> None:
     class _UnsupportedHashable:
         def __hash__(self) -> int:

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pytest
 import xarray as xr
 from qtpy import QtCore
 
-from erlab.interactive.imagetool.slicer import ArraySlicer
+from erlab.interactive.imagetool.slicer import ArraySlicer, qsel_args_from_indexers
 
 
 def test_nonuniform_axes_ignores_user_idx_dim(qtbot) -> None:
@@ -470,6 +471,20 @@ def test_qsel_args_falls_back_to_dims_index_lookup(qtbot) -> None:
     slicer._dim_indices = {}
 
     assert slicer.qsel_args(0, (0, 1)) == {"z": 2.0}
+
+
+def test_qsel_args_from_indexers_validates_live_bin_coordinates() -> None:
+    data = xr.DataArray(
+        np.zeros(5, dtype=np.float32),
+        dims=("x",),
+        coords={"x": np.array([0.0, 1.0, 1.0, 3.0, 2.0])},
+    )
+
+    with pytest.raises(ValueError, match="Dimension `missing` not found"):
+        qsel_args_from_indexers(data, {"missing": 0}, ())
+
+    with pytest.raises(ValueError, match="Bin does not contain"):
+        qsel_args_from_indexers(data, {"x": slice(2, 5)}, ("x",))
 
 
 def test_isel_code_uses_call_kwargs_formatting(qtbot) -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1398,6 +1398,34 @@ def test_tool_window_dataset_roundtrips_source_and_input_provenance(qtbot) -> No
     assert restored.input_provenance_spec == input_spec.to_replay_spec()
 
 
+def test_tool_window_dataset_roundtrips_source_binding(qtbot) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4)})
+    tool = _PersistentTool(data.isel(x=slice(1, 3)))
+    qtbot.addWidget(tool)
+
+    source_binding = prov.ImageToolSelectionSourceBinding(
+        selection_mode="isel",
+        selection_indexers={"x": slice(1, 3)},
+    )
+    source_spec = source_binding.materialize(data)
+    tool.set_source_binding(
+        source_spec,
+        source_binding=source_binding,
+        auto_update=True,
+        state="stale",
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(tool.to_dataset())
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, _PersistentTool)
+    assert restored.source_spec == source_spec
+    assert restored.source_binding == source_binding
+    assert restored.source_auto_update is True
+    assert restored.source_state == "stale"
+
+
 def test_tool_window_dataset_ignores_invalid_saved_provenance(
     qtbot,
     caplog,
@@ -1407,6 +1435,7 @@ def test_tool_window_dataset_ignores_invalid_saved_provenance(
     qtbot.addWidget(tool)
     ds = tool.to_dataset()
     ds.attrs["tool_source_spec"] = "{not-json"
+    ds.attrs["tool_source_binding"] = "{not-json"
     ds.attrs["tool_input_provenance_spec"] = "{not-json"
 
     with caplog.at_level("WARNING", logger="erlab.interactive.utils"):
@@ -1417,7 +1446,26 @@ def test_tool_window_dataset_ignores_invalid_saved_provenance(
     assert restored.source_spec is None
     assert restored.input_provenance_spec is None
     assert "Ignoring invalid saved tool source provenance" in caplog.text
+    assert "Ignoring invalid saved tool source binding" in caplog.text
     assert "Ignoring invalid saved tool input provenance" in caplog.text
+
+
+def test_tool_window_source_binding_empty_and_type_error_branches(qtbot) -> None:
+    tool = _PersistentTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
+    qtbot.addWidget(tool)
+
+    assert tool.source_status_text == ""
+    assert tool.show_source_update_dialog() == int(
+        QtWidgets.QDialog.DialogCode.Rejected
+    )
+    with pytest.raises(TypeError, match="source_binding must be"):
+        tool.set_source_binding(
+            None,
+            source_binding=typing.cast(
+                "erlab.interactive.imagetool.provenance.ImageToolSelectionSourceBinding",
+                object(),
+            ),
+        )
 
 
 def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) -> None:
@@ -1484,6 +1532,14 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
 
     with pytest.raises(TypeError, match="source_spec must be"):
         node.set_source_binding(typing.cast("object", {"kind": "full_data"}))
+    with pytest.raises(TypeError, match="source_binding must be"):
+        node.set_source_binding(
+            None,
+            source_binding=typing.cast(
+                "erlab.interactive.imagetool.provenance.ImageToolSelectionSourceBinding",
+                object(),
+            ),
+        )
     with pytest.raises(ValueError, match="output_id must not be None"):
         node.set_output_binding(typing.cast("str", None))
     with pytest.raises(TypeError, match="output_id must be a string"):
@@ -1504,9 +1560,16 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
     assert manager.tree_view.refreshed[-1] == "child"
     assert manager.updated[-1] == "child"
 
+    source_binding = prov.ImageToolSelectionSourceBinding()
     source_spec = prov.full_data()
-    tool.set_source_binding(source_spec, auto_update=True, state="stale")
+    tool.set_source_binding(
+        source_spec,
+        source_binding=source_binding,
+        auto_update=True,
+        state="stale",
+    )
     assert node.source_spec == source_spec
+    assert node.source_binding == source_binding
     assert node.source_state == "stale"
     assert node.source_auto_update is True
     assert node.has_source_binding is True
@@ -1669,6 +1732,24 @@ def test_managed_tool_window_node_detached_update_branches(
         "parent",
         tool,
     )
+    with pytest.raises(RuntimeError, match="not bound"):
+        node._materialized_source_spec(parent_data)
+
+    source_binding = prov.ImageToolSelectionSourceBinding(
+        selection_mode="isel",
+        selection_indexers={"x": slice(0, 2)},
+    )
+    bound_tool = _PersistentTool(parent_data.isel(x=slice(0, 2)))
+    qtbot.addWidget(bound_tool)
+    bound_node = _ManagedWindowNode(
+        typing.cast("erlab.interactive.imagetool.manager.ImageToolManager", manager),
+        "bound",
+        "parent",
+        bound_tool,
+        source_binding=source_binding,
+    )
+    assert bound_node._source_binding == source_binding
+    assert bound_node._source_spec == source_binding.materialize(parent_data)
 
     with pytest.raises(TypeError, match="provenance_spec must be"):
         node.set_source_binding(


### PR DESCRIPTION
## Summary
- Add an ImageTool selection source binding that stores cursor, bin, and crop selections as parent index spans.
- Materialize fresh `ToolProvenanceSpec` operations from the current parent data during refresh, so edited coordinates no longer leave manager children bound to stale generated `qsel(...)` values.
- Thread the binding through manager child creation, `ToolWindow` source refresh, and workspace save/load while keeping the existing materialized source spec for copied code, provenance display, and legacy workspace compatibility.
- Reuse existing provenance operations (`QSelOperation`, `IselOperation`, `SelOperation`, `SortCoordOrderOperation`, `TransposeOperation`, `SqueezeOperation`) instead of adding a parallel replay path.

## Testing
- `uv run ruff check src/erlab/interactive/imagetool/manager/_mainwindow.py src/erlab/interactive/imagetool/manager/_wrapper.py src/erlab/interactive/imagetool/plot_items.py src/erlab/interactive/imagetool/provenance.py src/erlab/interactive/imagetool/slicer.py src/erlab/interactive/utils.py tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/test_imagetool_manager.py tests/interactive/imagetool/test_provenance.py`
- `uv run pytest tests/interactive/imagetool/test_provenance.py::test_imagetool_selection_source_binding_materializes_current_coordinates tests/interactive/imagetool/test_provenance.py::test_imagetool_selection_source_binding_round_trips_and_reuses_operations`
- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_imagetool.py::test_itool_make_tool_source_spec_includes_alt_crop_indexers tests/interactive/imagetool/test_imagetool.py::test_itool_open_in_ftool_sets_squeezed_source_binding tests/interactive/imagetool/test_imagetool_manager.py::test_manager_selection_child_binding_survives_coordinate_shift_and_workspace_reload`
- `git diff --check`