### PR TITLE
[codex] Simplify Select Data row controls

### DIFF
--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -779,15 +779,17 @@ class _SelectionRow:
             axis
         ]
 
-        self.use_check = QtWidgets.QCheckBox()
+        self.use_check = QtWidgets.QCheckBox(str(dim))
         self.use_check.setObjectName(f"selection_use_{axis}")
         self.use_check.setChecked(active)
 
-        self.dim_label = QtWidgets.QLabel(str(dim))
-        self.cursor_label = QtWidgets.QLabel(f"{current_value:.6g}")
-
         self.method_combo = QtWidgets.QComboBox()
         self.method_combo.setObjectName(f"selection_method_{axis}")
+        self.method_combo.setToolTip(
+            "Choose how this dimension is selected: qsel selects the nearest "
+            "coordinate value, sel uses coordinate labels, and isel uses "
+            "integer indices."
+        )
         for method in ("qsel", "sel", "isel"):
             self.method_combo.addItem(method, method)
 
@@ -837,11 +839,16 @@ class _SelectionRow:
         self.stop_stack.addWidget(self.index_stop_spin)
 
         self.width_widget = QtWidgets.QWidget()
+        self.width_widget.setToolTip(
+            "For point qsel selections, include nearby coordinate values within "
+            "this width. Ignored for range selections and for sel/isel."
+        )
         width_layout = QtWidgets.QHBoxLayout(self.width_widget)
         width_layout.setContentsMargins(0, 0, 0, 0)
         width_layout.setSpacing(3)
         self.width_check = QtWidgets.QCheckBox()
         self.width_check.setObjectName(f"selection_width_enabled_{axis}")
+        self.width_check.setToolTip(self.width_widget.toolTip())
         self.width_spin = erlab.interactive.utils.BetterSpinBox(
             compact=False,
             decimals=6,
@@ -850,14 +857,13 @@ class _SelectionRow:
             value=0.0 if bin_value is None else float(bin_value),
         )
         self.width_spin.setObjectName(f"selection_width_{axis}")
+        self.width_spin.setToolTip(self.width_widget.toolTip())
         self.width_check.setChecked(is_binned and bin_value is not None)
         width_layout.addWidget(self.width_check)
         width_layout.addWidget(self.width_spin)
 
         widgets: tuple[QtWidgets.QWidget, ...] = (
             self.use_check,
-            self.dim_label,
-            self.cursor_label,
             self.method_combo,
             self.kind_combo,
             self.start_stack,
@@ -965,8 +971,6 @@ class SelectionDialog(DataTransformDialog):
         for column, label in enumerate(
             (
                 "Use",
-                "Dimension",
-                "Cursor",
                 "Method",
                 "Selection",
                 "Start",

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -4350,6 +4350,51 @@ def test_selection_dialog_seeds_4d_cursor_slice(qtbot) -> None:
     win.close()
 
 
+def test_selection_dialog_dimension_checkbox_label_toggles_row(qtbot) -> None:
+    data = _selection_4d_data()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    dialog = SelectionDialog(win.slicer_area)
+    _clear_selection_dialog(dialog)
+    row = dialog.rows[0]
+    ok_button = dialog.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+
+    assert not row.use_check.isChecked()
+    assert dialog.source_operations() == []
+    assert not ok_button.isEnabled()
+
+    dialog.show()
+    qtbot.waitExposed(dialog)
+    option = QtWidgets.QStyleOptionButton()
+    row.use_check.initStyleOption(option)
+    indicator_rect = row.use_check.style().subElementRect(
+        QtWidgets.QStyle.SubElement.SE_CheckBoxIndicator,
+        option,
+        row.use_check,
+    )
+    contents_rect = row.use_check.style().subElementRect(
+        QtWidgets.QStyle.SubElement.SE_CheckBoxContents,
+        option,
+        row.use_check,
+    )
+    click_pos = contents_rect.center()
+    assert contents_rect.isValid()
+    assert not indicator_rect.contains(click_pos)
+
+    qtbot.mouseClick(
+        row.use_check,
+        QtCore.Qt.MouseButton.LeftButton,
+        pos=click_pos,
+    )
+
+    assert row.use_check.isChecked()
+    assert dialog.source_operations()
+    assert ok_button.isEnabled()
+
+    win.close()
+
+
 def test_selection_dialog_accept_replaces_current_data(qtbot) -> None:
     data = _selection_4d_data()
     win = itool(data, execute=False)


### PR DESCRIPTION
## Summary
- make Select Data dimension labels part of the row Use checkbox so clicking the label toggles the row
- remove the low-value Cursor column from the Select Data dialog
- add focused behavior coverage for clicking the checkbox content area
- add concise Method and Width tooltips

## Validation
- `uv run ruff format src/erlab/interactive/imagetool/dialogs.py tests/interactive/imagetool/test_imagetool.py && uv run ruff check --fix src/erlab/interactive/imagetool/dialogs.py tests/interactive/imagetool/test_imagetool.py`
- `uv run pytest tests/interactive/imagetool/test_imagetool.py::test_selection_dialog_dimension_checkbox_label_toggles_row`
- `uv run pytest tests/interactive/imagetool/test_imagetool.py::test_selection_dialog_seeds_4d_cursor_slice tests/interactive/imagetool/test_imagetool.py::test_selection_dialog_rejects_empty_selection`
- `git diff --check`