### PR TITLE
[codex] Select variables from xarray containers in ImageTool

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -20,8 +20,7 @@ Inspired by *Image Tool* for Igor Pro, developed by the Advanced Light Source at
 
 ## Launching ImageTool
 
-ImageTool expects *image-like* data—usually a {class}`DataArray <xarray.DataArray>`—with 2–4 dimensions. ImageTool tries to handle incompatible input dimensions by adding a new dimension for 1D data and squeezing out dimensions of size 1 for 5D+ data. Non-uniform coordinates gain parallel `_idx` indices so you can still slice by position. Supported inputs include numpy arrays, {class}`Dataset <xarray.Dataset>`, or entire {class}`DataTree <xarray.DataTree>` objects; Dataset and DataTree inputs open one ImageTool window per valid variable.
-
+ImageTool expects *image-like* data—usually a {class}`DataArray <xarray.DataArray>`—with 2–4 dimensions. ImageTool tries to handle incompatible input dimensions by adding a new dimension for 1D data and squeezing out dimensions of size 1 for 5D+ data. Non-uniform coordinates gain parallel `_idx` indices so you can still slice by position. Supported inputs include numpy arrays, {class}`Dataset <xarray.Dataset>`, or entire {class}`DataTree <xarray.DataTree>` objects.
 (imagetool-entry-points)=
 
 ### Entry points
@@ -40,7 +39,7 @@ ImageTool expects *image-like* data—usually a {class}`DataArray <xarray.DataAr
   eri.itool(data, cmap="cividis")
   ```
 
-  Passing a list or dataset to {func}`itool <erlab.interactive.imagetool.itool>` spawns multiple windows; set `link=True` to synchronize their cursor positions and bins.
+  Passing a list to {func}`itool <erlab.interactive.imagetool.itool>` spawns multiple windows; set `link=True` to synchronize their cursor positions and bins. Passing a Dataset or DataTree with multiple valid variables first asks which variables to open.
 
 - Launch ImageTool from IPython or a notebook using the `%itool` line magic. Load the extension first:
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -230,11 +230,11 @@ Once the manager is running, you can open ImageTools in several ways:
 
 - Drag and drop supported ARPES data into the manager window.
 
-  In the dialog that appears, you can choose the plugin to use for loading the data.
-  For plugin loaders, expand {guilabel}`Loader Extensions` to set literal
+  In the dialog that appears, you can choose the plugin to use for loading the data. For
+  plugin loaders, expand {guilabel}`Loader Extensions` to set literal
   {func}`erlab.io.extend_loader` options. The {guilabel}`name_map` and
-  {guilabel}`coordinate_attrs` rows also have buttons that inspect the first
-  selected file and help build the literal values interactively.
+  {guilabel}`coordinate_attrs` rows also have buttons that inspect the first selected
+  file and help build the literal values interactively.
 
   :::{hint}
   For scans that are recorded across multiple files, drag and dropping any file in the scan will automatically load and concatenate the entire scan. If you want to load only the file you dropped, choose the plugin suffixed with {guilabel}`Single File` in the dialog.

--- a/src/erlab/interactive/imagetool/_itool.py
+++ b/src/erlab/interactive/imagetool/_itool.py
@@ -7,7 +7,11 @@ import numpy.typing as npt
 import xarray as xr
 
 import erlab
-from erlab.interactive.imagetool.viewer import SlicerLinkProxy, _parse_input
+from erlab.interactive.imagetool.viewer import (
+    SlicerLinkProxy,
+    _parse_input,
+    _select_input_dataarrays,
+)
 
 
 def itool(
@@ -52,13 +56,16 @@ def itool(
 
         - A `xarray.Dataset`
 
-          Every DataArray in the Dataset will be displayed across multiple ImageTool
-          windows. Data variables that have less than 2 dimensions or more than 4
-          dimensions are ignored. Dimensions with length 1 are automatically squeezed.
+          If the Dataset contains multiple displayable DataArrays, ImageTool asks which
+          variables to open. Data variables that have less than 2 dimensions or more
+          than 4 dimensions are ignored. Dimensions with length 1 are automatically
+          squeezed.
 
         - A `xarray.DataTree`
 
-          Every leaf node will be parsed as a `xarray.Dataset`.
+          Every leaf node will be parsed as a `xarray.Dataset`. If the DataTree
+          contains multiple displayable DataArrays, ImageTool asks which variables to
+          open, grouped by DataTree node path.
     link
         Whether to enable linking between multiple ImageTool windows when `data` is a
         sequence or a `xarray.Dataset`, by default `False`.
@@ -162,14 +169,24 @@ def itool(
         )
         use_manager = False
 
+    parsed = _parse_input(data)
+    if len(parsed) > 1 and isinstance(data, xr.Dataset | xr.DataTree):
+        with erlab.interactive.utils.setup_qapp(False):
+            selected_data = _select_input_dataarrays(data)
+        if selected_data is None:
+            return None
+        parsed = [darr for darr, _source_index in selected_data]
+
+    data_parsed = parsed
+
     if use_manager:
         if replace is not None:
             erlab.interactive.imagetool.manager.replace_data(
-                index=replace, data=data, target=manager_target
+                index=replace, data=data_parsed, target=manager_target
             )
         else:
             erlab.interactive.imagetool.manager.show_in_manager(
-                data,
+                data_parsed,
                 link=link,
                 link_colors=link_colors,
                 target=manager_target,
@@ -177,7 +194,6 @@ def itool(
             )
         return None
 
-    data_parsed = _parse_input(data)
     with erlab.interactive.utils.setup_qapp(execute) as execute:
         itool_list = [
             erlab.interactive.imagetool.ImageTool(d, **kwargs) for d in data_parsed

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -21,6 +21,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 from erlab.interactive.imagetool import _serialization
 from erlab.interactive.imagetool._load_source import _load_provenance_from_file_details
+from erlab.interactive.imagetool.viewer import _select_input_dataarrays
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
@@ -510,10 +511,24 @@ class ImageTool(BaseImageTool):
 
             try:
                 with erlab.interactive.utils.wait_dialog(self, "Loading..."):
-                    self.slicer_area.replace_source_data(
-                        fn(fname, **kargs),
+                    loaded_data = fn(fname, **kargs)
+                selected_data = _select_input_dataarrays(loaded_data, self)
+                if selected_data is None:
+                    return
+                first_data, first_source_index = selected_data[0]
+                self.slicer_area.replace_source_data(
+                    first_data,
+                    file_path=fname,
+                    load_func=(fn, kargs, first_source_index),
+                )
+                for data_array, source_index in selected_data[1:]:
+                    tool = ImageTool(
+                        data_array,
                         file_path=fname,
-                        load_func=(fn, kargs, 0),
+                        load_func=(fn, kargs, source_index),
+                    )
+                    self.slicer_area.add_tool_window(
+                        tool, update_title=False, transfer_to_manager=False
                     )
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(

--- a/src/erlab/interactive/imagetool/manager/_io.py
+++ b/src/erlab/interactive/imagetool/manager/_io.py
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:
 
 
 class _DataLoaderSignals(QtCore.QObject):
-    sigLoaded = QtCore.Signal(pathlib.Path, list)
+    sigLoaded = QtCore.Signal(pathlib.Path, object)
     sigFailed = QtCore.Signal(pathlib.Path, str)
 
 
@@ -64,18 +64,14 @@ class _DataLoader(QtCore.QRunnable):
 
     def run(self) -> None:
         try:
-            data_list: list[xr.DataArray] = (
-                erlab.interactive.imagetool.viewer._parse_input(
-                    self._func(self._file_path, **self._kwargs)
-                )
-            )
+            data = self._func(self._file_path, **self._kwargs)
         except Exception:
             logger.debug(
                 "Error loading data from %s", self._file_path
             )  # Use debug level to avoid duplicate popup
             self.signals.sigFailed.emit(self._file_path, traceback.format_exc())
         else:
-            self.signals.sigLoaded.emit(self._file_path, data_list)
+            self.signals.sigLoaded.emit(self._file_path, data)
 
 
 class _MultiFileHandler(QtCore.QObject):
@@ -96,6 +92,8 @@ class _MultiFileHandler(QtCore.QObject):
     ----------
     loaded
         List of successfully loaded files.
+    canceled
+        List of files that were loaded but not opened.
     failed
         List of files that failed to load.
 
@@ -126,6 +124,7 @@ class _MultiFileHandler(QtCore.QObject):
         self._kwargs = kwargs
 
         self.loaded: list[pathlib.Path] = []
+        self.canceled: list[pathlib.Path] = []
         self.failed: list[pathlib.Path] = []
 
         self._abort: bool = False
@@ -157,7 +156,7 @@ class _MultiFileHandler(QtCore.QObject):
     def _load_next(self) -> None:
         """Load the next file in the queue."""
         if len(self._queue) == 0 or self._abort:
-            self.sigFinished.emit(self.loaded, self.queued, self.failed)
+            self.sigFinished.emit(self.loaded, self.canceled + self.queued, self.failed)
             return
 
         file_path = self._queue.popleft()
@@ -169,19 +168,35 @@ class _MultiFileHandler(QtCore.QObject):
         loader.signals.sigFailed.connect(self._on_failed)
         self._threadpool.start(loader)
 
-    @QtCore.Slot(pathlib.Path, list)
-    def _on_loaded(
-        self, file_path: pathlib.Path, data_list: list[xr.DataArray]
-    ) -> None:
+    @QtCore.Slot(pathlib.Path, object)
+    def _on_loaded(self, file_path: pathlib.Path, data: object) -> None:
         self.manager._status_bar.showMessage("")
-        self.loaded.append(file_path)
         self.manager._recent_directory = str(file_path.parent)
+        try:
+            selected_data = erlab.interactive.imagetool.viewer._select_input_dataarrays(
+                typing.cast(
+                    "xr.DataArray | xr.Dataset | xr.DataTree | list[xr.DataArray]",
+                    data,
+                ),
+                self.manager,
+            )
+        except Exception:
+            self._on_failed(file_path, traceback.format_exc())
+            return
+        if selected_data is None:
+            self.canceled.append(file_path)
+            erlab.interactive.utils.single_shot(self, 0, self._load_next)
+            return
+
+        self.loaded.append(file_path)
         erlab.interactive.utils.single_shot(
-            self, 0, lambda: self._deliver_and_queue(file_path, data_list)
+            self, 0, lambda: self._deliver_and_queue(file_path, selected_data)
         )
 
     def _deliver_and_queue(
-        self, file_path: pathlib.Path, data_list: list[xr.DataArray]
+        self,
+        file_path: pathlib.Path,
+        selected_data: tuple[tuple[xr.DataArray, int], ...],
     ) -> None:
         func: Callable | str = self._func
         func_instance = getattr(func, "__self__", None)
@@ -189,8 +204,14 @@ class _MultiFileHandler(QtCore.QObject):
             func = func_instance.name
 
         self.manager._data_recv(
-            data_list,
-            kwargs={"file_path": file_path, "load_func": (func, self._kwargs.copy())},
+            [data_array for data_array, _source_index in selected_data],
+            kwargs={
+                "file_path": file_path,
+                "load_func": (func, self._kwargs.copy()),
+                "load_indices": tuple(
+                    source_index for _data_array, source_index in selected_data
+                ),
+            },
             show=(self.n_total == 1),
         )
         erlab.interactive.utils.single_shot(self, 0, self._load_next)
@@ -214,7 +235,9 @@ class _MultiFileHandler(QtCore.QObject):
             case QtWidgets.QDialog.DialogCode.Accepted:
                 self._load_next()
             case _:
-                self.sigFinished.emit(self.loaded, self.queued, self.failed)
+                self.sigFinished.emit(
+                    self.loaded, self.canceled + self.queued, self.failed
+                )
 
     def abort(self) -> None:
         """Abort the loading process.

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -55,7 +55,14 @@ from erlab.interactive.imagetool.manager._wrapper import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
+    from collections.abc import (
+        Callable,
+        Hashable,
+        Iterable,
+        Iterator,
+        Mapping,
+        Sequence,
+    )
 
     from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
     from erlab.interactive.imagetool._load_source import _LoadSourceDetails
@@ -5740,6 +5747,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         kwargs["_in_manager"] = True
 
         load_func = kwargs.pop("load_func", None)
+        load_indices = kwargs.pop("load_indices", None)
         if show is None:
             show = len(data) == 1
         watched_metadata = dict(watched_metadata or {})
@@ -5748,7 +5756,12 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
         for i, d in enumerate(data):
             # Set index-specific load function if provided
-            this_load_func = (*load_func[:2], i) if load_func else None
+            load_index = (
+                typing.cast("Sequence[int]", load_indices)[i]
+                if load_indices is not None
+                else i
+            )
+            this_load_func = (*load_func[:2], load_index) if load_func else None
             try:
                 indices.append(
                     self.add_imagetool(

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -124,6 +124,400 @@ def _parse_dataset(ds: xr.Dataset) -> tuple[xr.DataArray, ...]:
     return tuple(d for d in ds.data_vars.values() if _supported_shape(d))
 
 
+class _SelectDataArraysDialog(QtWidgets.QDialog):
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget | None,
+        data: xr.Dataset | xr.DataTree,
+    ) -> None:
+        super().__init__(parent)
+        self._data_arrays: list[xr.DataArray] = []
+        self._source_paths: list[str] = []
+        variable_names: list[str] = []
+
+        if isinstance(data, xr.Dataset):
+            for variable_name, darr in data.data_vars.items():
+                if _supported_shape(darr):
+                    self._data_arrays.append(darr)
+                    self._source_paths.append("/")
+                    variable_names.append(str(variable_name))
+        else:
+            for leaf in data.leaves:
+                source_path = str(leaf.path)
+                for variable_name, darr in leaf.dataset.data_vars.items():
+                    if _supported_shape(darr):
+                        self._data_arrays.append(darr)
+                        self._source_paths.append(source_path)
+                        variable_names.append(str(variable_name))
+
+        self.setWindowTitle("Select Data Variables")
+        self.resize(820, 420)
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        show_path_tree = any(source_path != "/" for source_path in self._source_paths)
+        name_column = 2 if show_path_tree else 1
+        ndim_column = 3 if show_path_tree else 2
+        shape_column = 4 if show_path_tree else 3
+        size_column = 5 if show_path_tree else 4
+
+        self._tree_widget = QtWidgets.QTreeWidget(self)
+        if show_path_tree:
+            self._tree_widget.setColumnCount(6)
+            self._tree_widget.setHeaderLabels(
+                ["", "Path", "Name", "ndim", "Shape", "Size"]
+            )
+        else:
+            self._tree_widget.setColumnCount(5)
+            self._tree_widget.setHeaderLabels(["", "Name", "ndim", "Shape", "Size"])
+        self._tree_widget.setRootIsDecorated(False)
+        self._tree_widget.setIndentation(0)
+        self._tree_widget.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self._tree_widget.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        header = self._tree_widget.header()
+        if header is not None:
+            header.setStretchLastSection(False)
+        self._tree_widget.setAlternatingRowColors(True)
+        self._tree_widget.setUniformRowHeights(True)
+
+        self._path_tree: QtWidgets.QTreeWidget | None = None
+        if show_path_tree:
+            splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal, self)
+            self._path_tree = QtWidgets.QTreeWidget(splitter)
+            self._path_tree.setColumnCount(1)
+            self._path_tree.setHeaderHidden(True)
+            self._path_tree.setSelectionMode(
+                QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+            )
+            self._path_tree.setUniformRowHeights(True)
+            self._path_tree.setMinimumWidth(160)
+            splitter.addWidget(self._path_tree)
+            splitter.addWidget(self._tree_widget)
+            splitter.setStretchFactor(0, 0)
+            splitter.setStretchFactor(1, 1)
+            splitter.setSizes([180, 640])
+            layout.addWidget(splitter)
+        else:
+            layout.addWidget(self._tree_widget)
+
+        for source_index, (darr, source_path, variable_name) in enumerate(
+            zip(self._data_arrays, self._source_paths, variable_names, strict=True)
+        ):
+            row_text = [""] * self._tree_widget.columnCount()
+            if show_path_tree:
+                row_text[1] = source_path.strip("/")
+            row_text[name_column] = variable_name
+            row_text[ndim_column] = str(darr.ndim)
+            row_text[size_column] = erlab.utils.formatting.format_nbytes(darr.nbytes)
+            item = QtWidgets.QTreeWidgetItem(row_text)
+            item.setData(0, QtCore.Qt.ItemDataRole.UserRole, source_index)
+            item.setFlags(
+                item.flags()
+                | QtCore.Qt.ItemFlag.ItemIsEnabled
+                | QtCore.Qt.ItemFlag.ItemIsSelectable
+            )
+            item.setTextAlignment(
+                ndim_column,
+                QtCore.Qt.AlignmentFlag.AlignRight
+                | QtCore.Qt.AlignmentFlag.AlignVCenter,
+            )
+            item.setTextAlignment(
+                size_column,
+                QtCore.Qt.AlignmentFlag.AlignRight
+                | QtCore.Qt.AlignmentFlag.AlignVCenter,
+            )
+            item.setToolTip(0, source_path)
+            for column in range(1, self._tree_widget.columnCount()):
+                item.setToolTip(column, repr(darr))
+            self._tree_widget.addTopLevelItem(item)
+
+            checkbox_container = QtWidgets.QWidget(self._tree_widget)
+            checkbox_layout = QtWidgets.QHBoxLayout(checkbox_container)
+            checkbox_layout.setContentsMargins(0, 0, 0, 0)
+            checkbox_layout.setSpacing(0)
+            checkbox_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+            checkbox = QtWidgets.QCheckBox(checkbox_container)
+            checkbox.setChecked(True)
+            checkbox.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+            checkbox.setToolTip("Load this variable")
+            checkbox.toggled.connect(self._update_ok_enabled)
+            checkbox.clicked.connect(
+                lambda _checked=False, item=item: self._tree_widget.setCurrentItem(item)
+            )
+            checkbox_layout.addWidget(checkbox)
+            item.setSizeHint(0, checkbox_container.sizeHint())
+            self._tree_widget.setItemWidget(item, 0, checkbox_container)
+
+            label = QtWidgets.QLabel(
+                erlab.interactive.utils._apply_qt_accent_color(
+                    erlab.utils.formatting.format_darr_shape_html(
+                        darr.rename(None),
+                        show_size=False,
+                    )
+                ),
+                self,
+            )
+            label.setTextFormat(QtCore.Qt.TextFormat.RichText)
+            label.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.NoTextInteraction
+            )
+            label.setToolTip(repr(darr))
+            label.setContentsMargins(4, 0, 4, 0)
+            item.setSizeHint(shape_column, label.sizeHint())
+            self._tree_widget.setItemWidget(item, shape_column, label)
+
+        if self._path_tree is not None:
+            self._populate_path_tree()
+        for column in range(self._tree_widget.columnCount()):
+            self._tree_widget.resizeColumnToContents(column)
+        header = self._tree_widget.header()
+        if header is not None:
+            header.setSectionResizeMode(
+                shape_column, QtWidgets.QHeaderView.ResizeMode.Stretch
+            )
+
+        self._details = QtWidgets.QTextBrowser(self)
+        self._details.setOpenExternalLinks(False)
+        self._details.setMinimumHeight(150)
+        self._details.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Expanding,
+        )
+        self._tree_widget.currentItemChanged.connect(self._update_details)
+        layout.addWidget(self._details)
+
+        button_row = QtWidgets.QHBoxLayout()
+        self._clear_path_filter_button: QtWidgets.QPushButton | None = None
+        if self._path_tree is not None:
+            self._clear_path_filter_button = QtWidgets.QPushButton(
+                "Clear Path Filter", self
+            )
+            self._clear_path_filter_button.setEnabled(False)
+            self._clear_path_filter_button.clicked.connect(self._clear_path_filter)
+            button_row.addWidget(self._clear_path_filter_button)
+        select_all_button = QtWidgets.QPushButton("Select All", self)
+        deselect_all_button = QtWidgets.QPushButton("Deselect All", self)
+        select_all_button.clicked.connect(self._check_all)
+        deselect_all_button.clicked.connect(self._uncheck_all)
+        button_row.addWidget(select_all_button)
+        button_row.addWidget(deselect_all_button)
+        button_row.addStretch()
+
+        self._button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            parent=self,
+        )
+        self._button_box.accepted.connect(self.accept)
+        self._button_box.rejected.connect(self.reject)
+        button_row.addWidget(self._button_box)
+        layout.addLayout(button_row)
+
+        self._tree_widget.itemChanged.connect(self._update_ok_enabled)
+        if self._path_tree is not None:
+            self._path_tree.currentItemChanged.connect(self._filter_for_path)
+            self._tree_widget.setCurrentItem(next(self._items(), None))
+        else:
+            self._tree_widget.setCurrentItem(next(self._items(), None))
+        self._update_ok_enabled()
+
+    def _populate_path_tree(self) -> None:
+        if self._path_tree is None:  # pragma: no cover - guarded by caller
+            return
+
+        data_paths = {
+            source_path for source_path in self._source_paths if source_path != "/"
+        }
+        path_children: dict[str, set[str]] = {}
+        for source_path in data_paths:
+            parent_path = ""
+            for part in source_path.strip("/").split("/"):
+                path_children.setdefault(parent_path, set()).add(part)
+                parent_path = f"{parent_path}/{part}"
+
+        path_items: dict[str, QtWidgets.QTreeWidgetItem] = {}
+
+        def compressed_child_path(parent_path: str, part: str) -> tuple[str, str]:
+            label_parts = [part]
+            child_path = f"{parent_path}/{part}" if parent_path else f"/{part}"
+            while (
+                child_path not in data_paths
+                and len(path_children.get(child_path, ())) == 1
+            ):
+                next_part = sorted(path_children[child_path])[0]
+                label_parts.append(next_part)
+                child_path = f"{child_path}/{next_part}"
+            return child_path, "/".join(label_parts)
+
+        for source_path in sorted(data_paths):
+            parent_item: QtWidgets.QTreeWidgetItem | None = None
+            current_path = ""
+            while current_path != source_path:
+                remaining_path = source_path.removeprefix(current_path).strip("/")
+                part = remaining_path.split("/", maxsplit=1)[0]
+                current_path, label = compressed_child_path(current_path, part)
+                item = path_items.get(current_path)
+                if item is None:
+                    item = QtWidgets.QTreeWidgetItem([label])
+                    item.setData(0, QtCore.Qt.ItemDataRole.UserRole, current_path)
+                    item.setToolTip(0, current_path)
+                    path_items[current_path] = item
+                    if parent_item is None:
+                        self._path_tree.addTopLevelItem(item)
+                    else:
+                        parent_item.addChild(item)
+                parent_item = item
+
+        self._path_tree.expandAll()
+
+    def _item_checkbox(self, item: QtWidgets.QTreeWidgetItem) -> QtWidgets.QCheckBox:
+        widget = self._tree_widget.itemWidget(item, 0)
+        checkbox = widget.findChild(QtWidgets.QCheckBox) if widget is not None else None
+        if checkbox is None:  # pragma: no cover - only possible if the widget is lost
+            raise RuntimeError("Missing variable selection checkbox")
+        return checkbox
+
+    def _items(self) -> collections.abc.Iterator[QtWidgets.QTreeWidgetItem]:
+        stack = [
+            self._tree_widget.topLevelItem(row)
+            for row in reversed(range(self._tree_widget.topLevelItemCount()))
+        ]
+        while stack:
+            item = stack.pop()
+            if item is None:  # pragma: no cover - only possible if Qt drops an item
+                continue
+            stack.extend(item.child(row) for row in reversed(range(item.childCount())))
+            if item.data(0, QtCore.Qt.ItemDataRole.UserRole) is not None:
+                yield item
+
+    @QtCore.Slot()
+    def _check_all(self) -> None:
+        for item in self._items():
+            if not item.isHidden():
+                self._item_checkbox(item).setChecked(True)
+
+    @QtCore.Slot()
+    def _uncheck_all(self) -> None:
+        for item in self._items():
+            if not item.isHidden():
+                self._item_checkbox(item).setChecked(False)
+
+    @QtCore.Slot()
+    def _clear_path_filter(self) -> None:
+        if self._path_tree is None:  # pragma: no cover - guarded by caller
+            return
+        self._path_tree.clearSelection()
+        self._path_tree.setCurrentIndex(QtCore.QModelIndex())
+        self._filter_for_path(None)
+
+    def selected_dataarrays(self) -> tuple[tuple[xr.DataArray, int], ...]:
+        selected: list[tuple[xr.DataArray, int]] = []
+        for item in self._items():
+            if self._item_checkbox(item).isChecked():
+                index = typing.cast(
+                    "int", item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+                )
+                selected.append((self._data_arrays[index], index))
+        return tuple(selected)
+
+    def _update_ok_enabled(self, *_args: object) -> None:
+        button = self._button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        if button is not None:  # pragma: no branch
+            button.setEnabled(bool(self.selected_dataarrays()))
+
+    def _filter_for_path(
+        self,
+        current: QtWidgets.QTreeWidgetItem | None,
+        _previous: QtWidgets.QTreeWidgetItem | None = None,
+    ) -> None:
+        selected_path = ""
+        if current is not None:
+            selected_path = typing.cast(
+                "str", current.data(0, QtCore.Qt.ItemDataRole.UserRole)
+            )
+
+        if self._clear_path_filter_button is not None:
+            self._clear_path_filter_button.setEnabled(selected_path != "")
+
+        first_visible: QtWidgets.QTreeWidgetItem | None = None
+        for item in self._items():
+            source_path = self._source_paths[
+                typing.cast("int", item.data(0, QtCore.Qt.ItemDataRole.UserRole))
+            ]
+            visible = (
+                selected_path == ""
+                or source_path == selected_path
+                or source_path.startswith(f"{selected_path}/")
+            )
+            item.setHidden(not visible)
+            if visible and first_visible is None:
+                first_visible = item
+
+        current_item = self._tree_widget.currentItem()
+        if first_visible is None:
+            self._tree_widget.setCurrentItem(None)
+            self._details.clear()
+        elif current_item is None or current_item.isHidden():
+            self._tree_widget.setCurrentItem(first_visible)
+        else:
+            self._update_details(current_item)
+
+    def _update_details(
+        self,
+        current: QtWidgets.QTreeWidgetItem | None,
+        _previous: QtWidgets.QTreeWidgetItem | None = None,
+    ) -> None:
+        if current is None:
+            self._details.clear()
+            return
+
+        candidate_index = current.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        if candidate_index is None:
+            self._details.clear()
+            return
+
+        data_array = self._data_arrays[typing.cast("int", candidate_index)]
+        self._details.setHtml(
+            erlab.interactive.utils._apply_qt_accent_color(
+                erlab.utils.formatting.format_darr_html(
+                    data_array,
+                    show_size=False,
+                    show_summary=False,
+                )
+            )
+        )
+
+    def accept(self) -> None:
+        if not self.selected_dataarrays():
+            self.reject()
+            return
+        super().accept()
+
+
+def _select_input_dataarrays(
+    data: Collection[xr.DataArray | npt.NDArray]
+    | xr.DataArray
+    | npt.NDArray
+    | xr.Dataset
+    | xr.DataTree,
+    parent: QtWidgets.QWidget | None = None,
+) -> tuple[tuple[xr.DataArray, int], ...] | None:
+    data_arrays = tuple(enumerate(_parse_input(data)))
+    if len(data_arrays) > 1 and isinstance(data, xr.Dataset | xr.DataTree):
+        dialog = _SelectDataArraysDialog(parent, data)
+        if not dialog.exec():
+            return None
+        selected = dialog.selected_dataarrays()
+        if not selected:
+            return None
+        return selected
+    return tuple((darr, source_index) for source_index, darr in data_arrays)
+
+
 def _make_cursor_colors(
     clr: QtGui.QColor,
 ) -> tuple[QtGui.QColor, QtGui.QColor, QtGui.QColor, QtGui.QColor, QtGui.QColor]:

--- a/src/erlab/utils/formatting.py
+++ b/src/erlab/utils/formatting.py
@@ -432,6 +432,7 @@ def format_darr_html(
     darr: xr.DataArray,
     *,
     show_size: bool = True,
+    show_summary: bool = True,
     additional_info: Iterable[str] | None = None,
 ) -> str:
     """Make a simple HTML representation of a DataArray.
@@ -442,6 +443,9 @@ def format_darr_html(
         The DataArray to represent.
     show_size
         Whether to include the size of the DataArray in the representation.
+    show_summary
+        Whether to include the DataArray name, dimensions, and optional size before the
+        coordinates and attributes.
     additional_info
         Additional information to include in the representation. Each item in the list
         is added as a separate paragraph.
@@ -454,7 +458,9 @@ def format_darr_html(
     if additional_info is None:
         additional_info = []
 
-    out = format_darr_shape_html(darr, show_size=show_size)
+    out = ""
+    if show_summary:
+        out += format_darr_shape_html(darr, show_size=show_size)
 
     for info in additional_info:
         out += rf"<p>{info}</p>"

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1,3 +1,4 @@
+import collections.abc
 import copy
 import json
 import logging
@@ -19,6 +20,9 @@ from numpy.testing import assert_almost_equal
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool._itool as itool_mod
+import erlab.interactive.imagetool._mainwindow as imagetool_mainwindow
+import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive.derivative import DerivativeTool, dtool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
 from erlab.interactive.imagetool import ImageTool, itool
@@ -54,6 +58,7 @@ from erlab.interactive.imagetool.viewer import (
     _AssociatedCoordsDialog,
     _CursorColorCoordDialog,
     _parse_input,
+    _SelectDataArraysDialog,
 )
 
 logger = logging.getLogger(__name__)
@@ -1616,6 +1621,126 @@ def test_itool_load(qtbot, monkeypatch, move_and_compare_values, accept_dialog) 
     win.close()
 
 
+def test_itool_file_open_uses_selected_variable_source_index(
+    qtbot,
+    monkeypatch,
+    accept_dialog,
+    tmp_path: pathlib.Path,
+) -> None:
+    first = xr.DataArray(np.zeros((2, 3)), dims=("x", "y"), name="first")
+    second = xr.DataArray(
+        np.ones((4, 5)),
+        dims=("u", "v"),
+        coords={"u": np.arange(4), "v": np.arange(5)},
+        name="second",
+    )
+    file_path = tmp_path / "multi.h5"
+    file_path.touch()
+
+    def _load_multi(_path: str) -> xr.Dataset:
+        return xr.Dataset({"first": first, "second": second})
+
+    def _select_second(data, parent=None):
+        assert parent is not None
+        return ((data["second"], 1),)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "file_loaders",
+        lambda *_args: {"Test xarray (*.h5)": (_load_multi, {})},
+    )
+    monkeypatch.setattr(
+        imagetool_mainwindow, "_select_input_dataarrays", _select_second
+    )
+
+    win = itool(np.zeros((2, 2)), execute=False)
+    qtbot.addWidget(win)
+
+    def _go_to_file(dialog: QtWidgets.QFileDialog) -> None:
+        dialog.setDirectory(str(tmp_path))
+        dialog.selectFile(str(file_path))
+        dialog.selectNameFilter("Test xarray (*.h5)")
+        focused = dialog.focusWidget()
+        if isinstance(focused, QtWidgets.QLineEdit):
+            focused.setText(file_path.name)
+
+    accept_dialog(lambda: win._open_file(native=False), pre_call=_go_to_file)
+
+    assert isinstance(win, ImageTool)
+    xr.testing.assert_identical(win.slicer_area.data, second)
+    assert win.slicer_area._load_func is not None
+    assert win.slicer_area._load_func[2] == 1
+
+    win.close()
+
+
+@pytest.mark.parametrize("selection", ["all", "cancel"])
+def test_itool_file_open_selection_branches(
+    qtbot,
+    monkeypatch,
+    accept_dialog,
+    tmp_path: pathlib.Path,
+    selection: str,
+) -> None:
+    first = xr.DataArray(
+        np.zeros((2, 3)),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(3)},
+        name="first",
+    )
+    second = xr.DataArray(
+        np.ones((4, 5)),
+        dims=("u", "v"),
+        coords={"u": np.arange(4), "v": np.arange(5)},
+        name="second",
+    )
+    file_path = tmp_path / "multi.h5"
+    file_path.touch()
+
+    def _load_multi(_path: str) -> xr.Dataset:
+        return xr.Dataset({"first": first, "second": second})
+
+    def _select_data(data, parent=None):
+        assert parent is not None
+        if selection == "cancel":
+            return None
+        return ((data["first"], 0), (data["second"], 1))
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "file_loaders",
+        lambda *_args: {"Test xarray (*.h5)": (_load_multi, {})},
+    )
+    monkeypatch.setattr(imagetool_mainwindow, "_select_input_dataarrays", _select_data)
+
+    win = itool(np.full((2, 2), -1.0), execute=False)
+    qtbot.addWidget(win)
+
+    def _go_to_file(dialog: QtWidgets.QFileDialog) -> None:
+        dialog.setDirectory(str(tmp_path))
+        dialog.selectFile(str(file_path))
+        dialog.selectNameFilter("Test xarray (*.h5)")
+        focused = dialog.focusWidget()
+        if isinstance(focused, QtWidgets.QLineEdit):
+            focused.setText(file_path.name)
+
+    accept_dialog(lambda: win._open_file(native=False), pre_call=_go_to_file)
+
+    if selection == "cancel":
+        np.testing.assert_array_equal(win.slicer_area.data.values, -1.0)
+    else:
+        xr.testing.assert_identical(win.slicer_area.data, first)
+        qtbot.wait_until(
+            lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000
+        )
+        child = next(iter(win.slicer_area._associated_tools.values()))
+        assert isinstance(child, ImageTool)
+        xr.testing.assert_identical(child.slicer_area.data, second)
+        child.close()
+
+    win.close()
+
+
 def test_itool_provenance_reload_rejects_incomplete_or_invalid_replay(
     qtbot,
     tmp_path: pathlib.Path,
@@ -2257,6 +2382,328 @@ def test_parse_input() -> None:
         )
 
 
+def test_select_dataarrays_dialog_preserves_tree_source_indices(qtbot) -> None:
+    first = xr.DataArray(
+        np.zeros((2, 3), dtype=np.float32),
+        dims=("alpha", "eV"),
+        attrs={"long_name": "first map", "units": "counts"},
+    )
+    second = xr.DataArray(
+        np.ones((4, 5), dtype=np.float64),
+        dims=("alpha", "eV"),
+        attrs={"description": "second branch"},
+    )
+    tree = xr.DataTree.from_dict(
+        {
+            "branch_a": xr.Dataset({"signal": first}),
+            "branch_b": xr.Dataset({"signal": second, "scalar": xr.DataArray(1)}),
+        }
+    )
+
+    dialog = _SelectDataArraysDialog(None, tree)
+    qtbot.addWidget(dialog)
+    selected_data = dialog.selected_dataarrays()
+
+    assert [source_index for _data_array, source_index in selected_data] == [0, 1]
+    assert dialog._tree_widget.topLevelItem(0).text(1) == "branch_a"
+    assert dialog._tree_widget.topLevelItem(0).text(2) == "signal"
+    assert dialog._tree_widget.topLevelItem(1).text(1) == "branch_b"
+    assert dialog._tree_widget.topLevelItem(1).text(2) == "signal"
+    xr.testing.assert_identical(selected_data[0][0], tree["branch_a"].dataset["signal"])
+    xr.testing.assert_identical(selected_data[1][0], tree["branch_b"].dataset["signal"])
+
+
+def test_select_dataarrays_dialog_formats_selected_dataarray(
+    qtbot, monkeypatch
+) -> None:
+    ds = xr.Dataset(
+        {
+            "first": xr.DataArray(
+                np.zeros((2, 3)),
+                dims=("x", "y"),
+                attrs={"long_name": "first image"},
+            ),
+            "second": xr.DataArray(
+                np.ones((4, 5)),
+                dims=("u", "v"),
+                coords={"u": np.arange(4), "v": np.arange(5)},
+                attrs={"units": "arb."},
+            ),
+        }
+    )
+    formatted: list[tuple[xr.DataArray, bool, bool, tuple[str, ...]]] = []
+
+    def format_darr_html(
+        darr: xr.DataArray,
+        *,
+        show_size: bool = True,
+        show_summary: bool = True,
+        additional_info: collections.abc.Iterable[str] | None = None,
+    ) -> str:
+        formatted.append((darr, show_size, show_summary, tuple(additional_info or ())))
+        return f"<p>{darr.name}</p>"
+
+    monkeypatch.setattr(erlab.utils.formatting, "format_darr_html", format_darr_html)
+
+    dialog = _SelectDataArraysDialog(None, ds)
+    qtbot.addWidget(dialog)
+
+    first_item = dialog._tree_widget.topLevelItem(0)
+    second_item = dialog._tree_widget.topLevelItem(1)
+    assert first_item is not None
+    assert second_item is not None
+    assert not dialog._tree_widget.rootIsDecorated()
+    assert dialog._tree_widget.indentation() == 0
+    assert dialog._path_tree is None
+    assert isinstance(dialog._item_checkbox(second_item), QtWidgets.QCheckBox)
+    assert dialog._item_checkbox(second_item).isChecked()
+    assert second_item.text(1) == "second"
+    assert second_item.text(2) == "2"
+    second_label = dialog._tree_widget.itemWidget(second_item, 3)
+    assert isinstance(second_label, QtWidgets.QLabel)
+    assert "second" not in second_label.text()
+    assert "<b>u</b>: 4" in second_label.text()
+    assert "<b>v</b>: 5" in second_label.text()
+    assert "Size " not in second_label.text()
+    assert second_item.text(4) == "160 Bytes"
+
+    dialog._item_checkbox(first_item).setChecked(False)
+    dialog._tree_widget.setCurrentItem(second_item)
+
+    selected_data = dialog.selected_dataarrays()
+    assert [source_index for _data_array, source_index in selected_data] == [1]
+    xr.testing.assert_identical(selected_data[0][0], ds["second"])
+    xr.testing.assert_identical(formatted[-1][0], ds["second"])
+    assert formatted[-1][1] is False
+    assert formatted[-1][2] is False
+    assert formatted[-1][3] == ()
+
+    accepted_dialog = _SelectDataArraysDialog(None, ds)
+    qtbot.addWidget(accepted_dialog)
+    accepted_dialog.accept()
+    assert accepted_dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+
+    dialog._update_details(None)
+    assert not dialog._details.toPlainText()
+    dialog._update_details(QtWidgets.QTreeWidgetItem(["orphan"]))
+    assert not dialog._details.toPlainText()
+
+    dialog._item_checkbox(second_item).setChecked(False)
+    dialog.accept()
+
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Rejected
+
+    tree_dialog = _SelectDataArraysDialog(
+        None,
+        xr.DataTree.from_dict({"branch": ds}),
+    )
+    qtbot.addWidget(tree_dialog)
+
+    assert tree_dialog._path_tree is not None
+    tree_item = tree_dialog._path_tree.topLevelItem(0)
+    assert tree_item is not None
+    assert tree_item.data(0, QtCore.Qt.ItemDataRole.UserRole) == "/branch"
+    assert tree_item.childCount() == 0
+    assert tree_dialog._tree_widget.topLevelItemCount() == 2
+    first_tree_child = tree_dialog._tree_widget.topLevelItem(0)
+    assert first_tree_child is not None
+    assert first_tree_child.text(1) == "branch"
+    assert first_tree_child.text(2) == "first"
+    tree_label = tree_dialog._tree_widget.itemWidget(first_tree_child, 4)
+    assert isinstance(tree_label, QtWidgets.QLabel)
+    tree_dialog._tree_widget.setCurrentItem(first_tree_child)
+    assert formatted[-1][3] == ()
+
+
+def test_select_dataarrays_dialog_nests_datatree_paths(qtbot) -> None:
+    tree = xr.DataTree.from_dict(
+        {
+            "/branch_a/sweep_0": xr.Dataset(
+                {
+                    "signal": xr.DataArray(
+                        np.zeros((2, 3)),
+                        dims=("alpha", "eV"),
+                    )
+                }
+            ),
+            "/branch_a/sweep_1": xr.Dataset(
+                {
+                    "signal": xr.DataArray(
+                        np.ones((4, 5)),
+                        dims=("alpha", "eV"),
+                    )
+                }
+            ),
+        }
+    )
+
+    dialog = _SelectDataArraysDialog(None, tree)
+    qtbot.addWidget(dialog)
+
+    assert dialog._path_tree is not None
+    branch_item = dialog._path_tree.topLevelItem(0)
+    assert branch_item is not None
+    assert all(not item.isHidden() for item in dialog._items())
+    assert dialog._clear_path_filter_button is not None
+    assert not dialog._clear_path_filter_button.isEnabled()
+    assert branch_item.text(0) == "branch_a"
+    assert branch_item.childCount() == 2
+    assert branch_item.data(0, QtCore.Qt.ItemDataRole.UserRole) == "/branch_a"
+
+    sweep_item = branch_item.child(1)
+    assert sweep_item is not None
+    assert sweep_item.text(0) == "sweep_1"
+    assert sweep_item.childCount() == 0
+    assert sweep_item.data(0, QtCore.Qt.ItemDataRole.UserRole) == "/branch_a/sweep_1"
+
+    dialog._path_tree.setCurrentItem(sweep_item)
+    signal_item = next(item for item in dialog._items() if not item.isHidden())
+    assert signal_item is not None
+    assert signal_item.text(1) == "branch_a/sweep_1"
+    assert signal_item.text(2) == "signal"
+    assert dialog._item_checkbox(signal_item).isChecked()
+    assert dialog._clear_path_filter_button.isEnabled()
+
+    dialog._uncheck_all()
+    assert not dialog._item_checkbox(signal_item).isChecked()
+    dialog._check_all()
+    assert dialog._item_checkbox(signal_item).isChecked()
+
+    dialog._item_checkbox(signal_item).setChecked(False)
+
+    assert [
+        source_index for _data_array, source_index in dialog.selected_dataarrays()
+    ] == [0]
+
+    empty_item = QtWidgets.QTreeWidgetItem(["missing"])
+    empty_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, "/missing")
+    dialog._filter_for_path(empty_item)
+    assert all(item.isHidden() for item in dialog._items())
+    assert not dialog._details.toPlainText()
+
+    dialog._clear_path_filter()
+    assert all(not item.isHidden() for item in dialog._items())
+    assert not dialog._clear_path_filter_button.isEnabled()
+
+
+def test_select_dataarrays_dialog_collapses_single_child_datatree_paths(qtbot) -> None:
+    tree = xr.DataTree.from_dict(
+        {
+            "/cut_a": xr.Dataset(
+                {"spectrum": xr.DataArray(np.zeros((2, 3)), dims=("alpha", "eV"))}
+            ),
+            "/nested/cut_b": xr.Dataset(
+                {"spectrum": xr.DataArray(np.ones((4, 5)), dims=("beta", "eV"))}
+            ),
+        }
+    )
+
+    dialog = _SelectDataArraysDialog(None, tree)
+    qtbot.addWidget(dialog)
+
+    assert dialog._path_tree is not None
+    path_items = [
+        dialog._path_tree.topLevelItem(row)
+        for row in range(dialog._path_tree.topLevelItemCount())
+    ]
+    nested_item = next(item for item in path_items if item.text(0) == "nested/cut_b")
+
+    assert nested_item.childCount() == 0
+    assert nested_item.toolTip(0) == "/nested/cut_b"
+    dialog._path_tree.setCurrentItem(nested_item)
+    visible_items = [item for item in dialog._items() if not item.isHidden()]
+    assert len(visible_items) == 1
+    assert visible_items[0].text(1) == "nested/cut_b"
+    assert visible_items[0].text(2) == "spectrum"
+    assert visible_items[0].toolTip(0) == "/nested/cut_b"
+
+
+@pytest.mark.parametrize(
+    ("dialog_result", "selected", "expected"),
+    [
+        (False, ((xr.DataArray(np.ones((2, 2)), dims=("x", "y")), 0),), None),
+        (True, (), None),
+        (
+            True,
+            ((xr.DataArray(np.ones((3, 4)), dims=("u", "v")), 1),),
+            (1,),
+        ),
+    ],
+)
+def test_select_input_dataarrays_dialog_branches(
+    monkeypatch,
+    dialog_result: bool,
+    selected: tuple[tuple[xr.DataArray, int], ...],
+    expected: tuple[int, ...] | None,
+) -> None:
+    ds = xr.Dataset(
+        {
+            "first": xr.DataArray(np.zeros((2, 3)), dims=("x", "y")),
+            "second": xr.DataArray(np.ones((4, 5)), dims=("u", "v")),
+        }
+    )
+
+    class _Dialog:
+        def __init__(self, parent, data) -> None:
+            assert parent is None
+            assert data is ds
+
+        def exec(self) -> bool:
+            return dialog_result
+
+        def selected_dataarrays(self) -> tuple[tuple[xr.DataArray, int], ...]:
+            return selected
+
+    monkeypatch.setattr(imagetool_viewer, "_SelectDataArraysDialog", _Dialog)
+
+    result = imagetool_viewer._select_input_dataarrays(ds)
+
+    if expected is None:
+        assert result is None
+    else:
+        assert result is not None
+        assert [source_index for _data_array, source_index in result] == list(expected)
+
+
+def test_itool_dataset_selection_returns_selected_variable(qtbot, monkeypatch) -> None:
+    ds = xr.Dataset(
+        {
+            "first": xr.DataArray(np.zeros((2, 3)), dims=("x", "y")),
+            "second": xr.DataArray(
+                np.ones((4, 5)),
+                dims=("u", "v"),
+                coords={"u": np.arange(4), "v": np.arange(5)},
+            ),
+        }
+    )
+    monkeypatch.setattr(
+        itool_mod, "_select_input_dataarrays", lambda _data: ((ds["second"], 1),)
+    )
+
+    win = itool(ds, execute=False)
+    qtbot.addWidget(win)
+
+    assert isinstance(win, ImageTool)
+    xr.testing.assert_identical(win.slicer_area.data, ds["second"])
+    win.close()
+
+
+def test_itool_dataset_selection_cancel(monkeypatch) -> None:
+    ds = xr.Dataset(
+        {
+            "first": xr.DataArray(np.zeros((2, 3)), dims=("x", "y")),
+            "second": xr.DataArray(
+                np.ones((4, 5)),
+                dims=("u", "v"),
+                coords={"u": np.arange(4), "v": np.arange(5)},
+            ),
+        }
+    )
+    monkeypatch.setattr(itool_mod, "_select_input_dataarrays", lambda _data: None)
+
+    assert itool(ds, execute=False) is None
+
+
 def test_itool_promotes_1d_input(qtbot) -> None:
     data = xr.DataArray(np.arange(5), dims=["x"], coords={"x": np.arange(5)})
     win = itool(data, execute=False)
@@ -2339,13 +2786,18 @@ def test_itool_squeezes_high_dim_input(qtbot) -> None:
     win.close()
 
 
-def test_itool_ds(qtbot) -> None:
+def test_itool_ds(qtbot, monkeypatch) -> None:
     data = xr.Dataset(
         {
             "data1d": xr.DataArray(np.arange(5), dims=["x"]),
             "a": xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"]),
             "b": xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"]),
         }
+    )
+    monkeypatch.setattr(
+        itool_mod,
+        "_select_input_dataarrays",
+        lambda _data: tuple((darr, i) for i, darr in enumerate(_parse_input(_data))),
     )
     wins = itool(data, execute=False, link=True)
     assert isinstance(wins, list)

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -37,11 +37,13 @@ import erlab.interactive.imagetool.manager as manager_module
 import erlab.interactive.imagetool.manager._console as manager_console
 import erlab.interactive.imagetool.manager._desktop as manager_desktop
 import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
+import erlab.interactive.imagetool.manager._io as manager_io
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._registry as manager_registry
 import erlab.interactive.imagetool.manager._server as manager_server
 import erlab.interactive.imagetool.manager._workspace as manager_workspace
 import erlab.interactive.imagetool.manager._xarray as manager_xarray
+import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive._mesh import MeshTool
@@ -14175,6 +14177,170 @@ def test_manager_open_files(
         xarray.testing.assert_identical(
             manager.get_imagetool(1).slicer_area.data, test_data
         )
+
+
+def test_manager_file_open_uses_selected_variable_source_index(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    file_path = tmp_path / "multi.h5"
+    file_path.touch()
+    initial_second = xr.DataArray(
+        np.ones((4, 5)),
+        dims=("u", "v"),
+        coords={"u": np.arange(4), "v": np.arange(5)},
+        name="second",
+    )
+    updated_second = xr.DataArray(
+        np.full((4, 5), 2.0),
+        dims=("u", "v"),
+        coords={"u": np.arange(4), "v": np.arange(5)},
+        name="second",
+    )
+    datasets = {
+        "current": xr.Dataset(
+            {
+                "first": xr.DataArray(np.zeros((2, 3)), dims=("x", "y")),
+                "second": initial_second,
+            }
+        )
+    }
+
+    def _load_multi(_path: pathlib.Path) -> xr.Dataset:
+        return datasets["current"]
+
+    def _select_second(data, parent=None):
+        assert parent is not None
+        return ((data["second"], 1),)
+
+    monkeypatch.setattr(
+        imagetool_viewer,
+        "_select_input_dataarrays",
+        _select_second,
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        manager._add_from_multiple_files(
+            [],
+            [file_path],
+            [],
+            _load_multi,
+            {},
+            lambda _failed: None,
+        )
+
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        tool = manager.get_imagetool(0)
+
+        xr.testing.assert_identical(tool.slicer_area.data, initial_second)
+        assert tool.slicer_area._load_func is not None
+        assert tool.slicer_area._load_func[2] == 1
+
+        datasets["current"] = xr.Dataset(
+            {
+                "first": xr.DataArray(np.zeros((2, 3)), dims=("x", "y")),
+                "second": updated_second,
+            }
+        )
+        with qtbot.wait_signal(tool.slicer_area.sigDataChanged):
+            tool.slicer_area.reload()
+
+        xr.testing.assert_identical(tool.slicer_area.data, updated_second)
+
+
+@pytest.mark.parametrize("case", ["cancel", "selection_error", "failed_reject"])
+def test_manager_multifile_handler_selection_failure_branches(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    case: str,
+) -> None:
+    file_path = tmp_path / "multi.h5"
+    queued_path = tmp_path / "queued.h5"
+    data = xr.Dataset({"signal": xr.DataArray(np.ones((2, 3)), dims=("x", "y"))})
+
+    class _StatusBar:
+        def __init__(self) -> None:
+            self.messages: list[str] = []
+
+        def showMessage(self, message: str) -> None:
+            self.messages.append(message)
+
+    class _Manager(QtCore.QObject):
+        def __init__(self) -> None:
+            super().__init__()
+            self._status_bar = _StatusBar()
+            self._recent_directory: str | None = None
+            self.received: list[
+                tuple[tuple[typing.Any, ...], dict[str, typing.Any]]
+            ] = []
+
+        def _data_recv(self, *args, **kwargs) -> None:
+            self.received.append((args, kwargs))
+
+    class _MessageDialog:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def setDetailedText(self, text: str) -> None:
+            self.detail = text
+
+        def adjustSize(self) -> None:
+            self.adjusted = True
+
+        def exec(self) -> QtWidgets.QDialog.DialogCode:
+            if case == "failed_reject":
+                return QtWidgets.QDialog.DialogCode.Rejected
+            return QtWidgets.QDialog.DialogCode.Accepted
+
+    manager = _Manager()
+    handler = manager_io._MultiFileHandler(
+        typing.cast("ImageToolManager", manager),
+        [queued_path] if case == "failed_reject" else [],
+        lambda _path: data,
+        {},
+    )
+    finished: list[
+        tuple[list[pathlib.Path], list[pathlib.Path], list[pathlib.Path]]
+    ] = []
+    handler.sigFinished.connect(
+        lambda loaded, aborted, failed: finished.append((loaded, aborted, failed))
+    )
+    monkeypatch.setattr(erlab.interactive.utils, "MessageDialog", _MessageDialog)
+    monkeypatch.setattr(
+        erlab.interactive.utils, "single_shot", lambda _obj, _ms, func: func()
+    )
+
+    if case == "cancel":
+        monkeypatch.setattr(
+            imagetool_viewer, "_select_input_dataarrays", lambda _data, _parent: None
+        )
+        handler._on_loaded(file_path, data)
+
+        assert handler.canceled == [file_path]
+        assert finished == [([], [file_path], [])]
+    elif case == "selection_error":
+
+        def _raise_selection_error(_data, _parent):
+            raise ValueError("bad selection")
+
+        monkeypatch.setattr(
+            imagetool_viewer, "_select_input_dataarrays", _raise_selection_error
+        )
+        handler._on_loaded(file_path, data)
+
+        assert handler.failed == [file_path]
+        assert finished == [([], [], [file_path])]
+    else:
+        handler._on_failed(file_path, "Traceback\nboom")
+
+        assert handler.failed == [file_path]
+        assert finished == [([], [queued_path], [file_path])]
 
 
 @pytest.mark.parametrize("case", ["loader_cancel", "non_loader"])


### PR DESCRIPTION
## Summary
- Add an interactive variable-selection dialog for multi-variable xarray `Dataset` and `DataTree` inputs before opening ImageTool windows.
- Show xarray-style metadata in the dialog, with flat Dataset rows and a DataTree path navigator that keeps all loadable DataArrays visible by default.
- Preserve file-backed reload provenance by carrying each selected variable's original parsed source index through standalone and manager file opens.
- Document the new multi-variable open behavior for ImageTool and the manager.

## Validation
- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/test_imagetool.py::test_select_dataarrays_dialog_formats_selected_dataarray tests/interactive/imagetool/test_imagetool.py::test_select_dataarrays_dialog_nests_datatree_paths tests/interactive/imagetool/test_imagetool.py::test_select_dataarrays_dialog_collapses_single_child_datatree_paths`
- `uv run ruff check src/erlab/interactive/imagetool/viewer.py tests/interactive/imagetool/test_imagetool.py`
- `git diff --check`
- `ITOOL_MANAGER_REGISTRY=/tmp/erlab-manager-registry-codex-eb71-pr.json QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/test_imagetool_manager.py` (`632 passed, 83 warnings`)
- `uv run --group docs make -C docs html SPHINXOPTS="-W --keep-going"`