### PR TITLE
[codex] fix macOS close-save file path crash

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -968,6 +968,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         )
         self._workspace_lock: QtCore.QLockFile | None = None
         self._application_quit_requested: bool = False
+        self._closing_workspace_document: bool = False
         self._update_workspace_window_title()
 
         qapp = QtWidgets.QApplication.instance()
@@ -1672,7 +1673,12 @@ class ImageToolManager(QtWidgets.QMainWindow):
             window_file_path = ""
         else:
             window_file_path = typing.cast("str", self.workspace_path)
-        self.setWindowFilePath(window_file_path)
+        # Work around a macOS Qt/Cocoa crash observed during close-time workspace
+        # saves in QWidget.setWindowFilePath() -> QImage.toCGImage(). The window is
+        # closing, so the document proxy icon update is unnecessary here. Add the
+        # QTBUG ID once a reproducible report exists and remove this guard once fixed.
+        if not (sys.platform == "darwin" and self._closing_workspace_document):
+            self.setWindowFilePath(window_file_path)
         workspace_display_name = (
             "Untitled" if self._workspace_path is None else self._workspace_path.name
         )
@@ -6692,76 +6698,81 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """Handle proper termination of resources before closing the application."""
         logger.debug("Closing ImageTool Manager...")
-        if not self._confirm_save_dirty_workspace(
-            "Closing this manager will discard unsaved workspace changes."
-        ):
-            self._application_quit_requested = False
-            if event:
-                event.ignore()
-            return
-
-        logger.debug("Waiting for file handlers to finish...")
-        if len(self._file_handlers) > 0:  # pragma: no cover
-            with erlab.interactive.utils.wait_dialog(
-                self, "Waiting for file operations to finish..."
+        previous_closing_workspace_document = self._closing_workspace_document
+        self._closing_workspace_document = True
+        try:
+            if not self._confirm_save_dirty_workspace(
+                "Closing this manager will discard unsaved workspace changes."
             ):
-                for handler in list(self._file_handlers):
-                    handler.wait()
+                self._application_quit_requested = False
+                if event:
+                    event.ignore()
+                return
 
-        self._compact_workspace_before_shutdown()
+            logger.debug("Waiting for file handlers to finish...")
+            if len(self._file_handlers) > 0:  # pragma: no cover
+                with erlab.interactive.utils.wait_dialog(
+                    self, "Waiting for file operations to finish..."
+                ):
+                    for handler in list(self._file_handlers):
+                        handler.wait()
 
-        logger.debug("Removing all ImageTool windows...")
-        with self._workspace_load_context():
-            self.remove_all_tools()
+            self._compact_workspace_before_shutdown()
 
-        logger.debug("Closing additional windows...")
-        for widget in dict(self._additional_windows).values():
-            widget.close()
-            widget.deleteLater()
+            logger.debug("Removing all ImageTool windows...")
+            with self._workspace_load_context():
+                self.remove_all_tools()
 
-        logger.debug("Removing event filters...")
-        qapp = QtWidgets.QApplication.instance()
-        if (
-            isinstance(qapp, QtWidgets.QApplication)
-            and self._application_quit_filter is not None
-        ):
-            qapp.removeEventFilter(self._application_quit_filter)
-            self._application_quit_filter = None
-        for widget in (
-            self.text_box,
-            self.metadata_derivation_list,
-        ):
-            widget.removeEventFilter(self._kb_filter)
-        self.tree_view._delegate._cleanup_filter()
+            logger.debug("Closing additional windows...")
+            for widget in dict(self._additional_windows).values():
+                widget.close()
+                widget.deleteLater()
 
-        if hasattr(self, "console"):
-            logger.debug("Shutting down console kernel...")
-            self.console._console_widget.shutdown_kernel()
-            self.console.close()
-            self.console.deleteLater()
+            logger.debug("Removing event filters...")
+            qapp = QtWidgets.QApplication.instance()
+            if (
+                isinstance(qapp, QtWidgets.QApplication)
+                and self._application_quit_filter is not None
+            ):
+                qapp.removeEventFilter(self._application_quit_filter)
+                self._application_quit_filter = None
+            for widget in (
+                self.text_box,
+                self.metadata_derivation_list,
+            ):
+                widget.removeEventFilter(self._kb_filter)
+            self.tree_view._delegate._cleanup_filter()
 
-        if self._standalone_app_windows:
-            logger.debug("Closing standalone apps...")
-            self._close_standalone_apps()
+            if hasattr(self, "console"):
+                logger.debug("Shutting down console kernel...")
+                self.console._console_widget.shutdown_kernel()
+                self.console.close()
+                self.console.deleteLater()
 
-        logger.debug("Releasing workspace lock...")
-        self._release_workspace_lock()
+            if self._standalone_app_windows:
+                logger.debug("Closing standalone apps...")
+                self._close_standalone_apps()
 
-        logger.debug("Stopping servers...")
-        self._registry_heartbeat_timer.stop()
-        self._stop_servers()
-        unregister_manager_record(self._manager_record.internal_id)
+            logger.debug("Releasing workspace lock...")
+            self._release_workspace_lock()
 
-        logger.debug("Closing dask client (if any)...")
-        self._dask_menu.close_client()
+            logger.debug("Stopping servers...")
+            self._registry_heartbeat_timer.stop()
+            self._stop_servers()
+            unregister_manager_record(self._manager_record.internal_id)
 
-        root_logger = logging.getLogger()
-        if self._warning_handler in root_logger.handlers:  # pragma: no branch
-            root_logger.removeHandler(self._warning_handler)
+            logger.debug("Closing dask client (if any)...")
+            self._dask_menu.close_client()
 
-        self._clear_all_alerts()
+            root_logger = logging.getLogger()
+            if self._warning_handler in root_logger.handlers:  # pragma: no branch
+                root_logger.removeHandler(self._warning_handler)
 
-        if sys.excepthook == self._handle_uncaught_exception:
-            sys.excepthook = self._previous_excepthook
+            self._clear_all_alerts()
 
-        super().closeEvent(event)
+            if sys.excepthook == self._handle_uncaught_exception:
+                sys.excepthook = self._previous_excepthook
+
+            super().closeEvent(event)
+        finally:
+            self._closing_workspace_document = previous_closing_workspace_document

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -9467,6 +9467,154 @@ def test_workspace_window_title_placeholder_non_macos(monkeypatch) -> None:
     )
 
 
+def test_manager_workspace_window_title_sets_file_path_normally(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        workspace = tmp_path / "normal.itws"
+        manager._workspace_path = workspace
+        manager._workspace_structure_modified = True
+        file_path_calls: list[str] = []
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                ImageToolManager,
+                "setWindowFilePath",
+                lambda _manager, path: file_path_calls.append(path),
+            )
+            manager._update_workspace_window_title()
+
+        assert file_path_calls == [str(workspace)]
+        assert workspace.name in manager.windowTitle()
+        assert manager.isWindowModified()
+
+
+def test_manager_workspace_window_title_skips_file_path_during_macos_close(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        workspace = tmp_path / "close-save.itws"
+        manager._workspace_path = workspace
+        manager._workspace_structure_modified = True
+        previous_closing = manager._closing_workspace_document
+        manager._closing_workspace_document = True
+
+        def _fail_if_called(_manager, _path: str) -> None:
+            raise AssertionError("setWindowFilePath should be skipped")
+
+        try:
+            with monkeypatch.context() as patch:
+                patch.setattr(manager_mainwindow.sys, "platform", "darwin")
+                patch.setattr(ImageToolManager, "setWindowFilePath", _fail_if_called)
+                manager._update_workspace_window_title()
+        finally:
+            manager._closing_workspace_document = previous_closing
+
+        assert workspace.name in manager.windowTitle()
+        assert manager.isWindowModified()
+
+
+def test_manager_workspace_window_title_sets_file_path_for_non_macos_close(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        workspace = tmp_path / "linux-close.itws"
+        manager._workspace_path = workspace
+        previous_closing = manager._closing_workspace_document
+        manager._closing_workspace_document = True
+        file_path_calls: list[str] = []
+
+        try:
+            with monkeypatch.context() as patch:
+                patch.setattr(manager_mainwindow.sys, "platform", "linux")
+                patch.setattr(
+                    ImageToolManager,
+                    "setWindowFilePath",
+                    lambda _manager, path: file_path_calls.append(path),
+                )
+                manager._update_workspace_window_title()
+        finally:
+            manager._closing_workspace_document = previous_closing
+
+        assert file_path_calls == [str(workspace)]
+
+
+def test_manager_close_cancel_restores_workspace_document_closing_state(
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager._workspace_structure_modified = True
+        manager._application_quit_requested = True
+        manager._closing_workspace_document = False
+        event = QtGui.QCloseEvent()
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager, "_confirm_save_dirty_workspace", lambda _message: False
+            )
+            manager.closeEvent(event)
+
+        assert not event.isAccepted()
+        assert not manager._closing_workspace_document
+        assert not manager._application_quit_requested
+
+
+def test_manager_close_save_path_skips_macos_file_path_update(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager._workspace_path = tmp_path / "close-save.itws"
+        manager._workspace_structure_modified = True
+        save_closing_states: list[bool] = []
+
+        def _fail_during_close_file_path_update(
+            window: ImageToolManager, _path: str
+        ) -> None:
+            if window._closing_workspace_document:
+                raise AssertionError("setWindowFilePath should be skipped")
+
+        def _save(*, native: bool = True) -> bool:
+            save_closing_states.append(manager._closing_workspace_document)
+            manager._mark_workspace_clean()
+            return True
+
+        with monkeypatch.context() as patch:
+            patch.setattr(manager_mainwindow.sys, "platform", "darwin")
+            patch.setattr(
+                ImageToolManager,
+                "setWindowFilePath",
+                _fail_during_close_file_path_update,
+            )
+            patch.setattr(
+                QtWidgets.QMessageBox,
+                "exec",
+                lambda _msg_box: QtWidgets.QMessageBox.StandardButton.Save,
+            )
+            patch.setattr(manager, "save", _save)
+            assert manager.close()
+
+        assert save_closing_states == [True]
+        assert not manager._closing_workspace_document
+
+
 def test_workspace_lock_error_message_without_owner(monkeypatch, tmp_path) -> None:
     fname = tmp_path / "busy-message.itws"
     calls: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary

- Add a narrow ImageTool Manager close-state flag for workspace-document shutdown.
- Skip only `setWindowFilePath()` on macOS while the manager is inside `closeEvent()`.
- Keep visible window title and modified-state updates running, including close-cancel and normal save/save-as paths.
- Add focused manager tests for normal, macOS close-time, non-mac close-time, cancel, and close-save behavior.

## Root Cause

The observed crash points at Qt/Cocoa document proxy metadata update inside `QWidget.setWindowFilePath()` during close-triggered workspace saves. The workspace file is already written before that native metadata update, so this change avoids only the unnecessary close-time proxy icon update on macOS without changing workspace save ordering, locks, recent-file storage, or file format.

## Validation

- `uv run pytest tests/interactive/imagetool/test_imagetool_manager.py -k "workspace_window_title or close"`
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run mypy src`
- `git diff --check`