### PR TITLE
[codex] Guard unsafe ImageTool display values

### DIFF
--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -302,6 +302,18 @@ class ColorOptions(BaseModel):
     """Top-level grouping of color-related options."""
 
     cmap: ColorMapOptions = Field(default_factory=ColorMapOptions, title="Colormap")
+    max_rendered_abs_value: float = Field(
+        default=1e30,
+        title="Max display value",
+        description=(
+            "Largest finite absolute data value ImageTool will send to Qt rendering. "
+            "Larger finite values and infinities are treated as missing for display "
+            "only; source data is not modified."
+        ),
+        ge=1.0,
+        le=1e308,
+        json_schema_extra={"ui_step": 1e30},
+    )
     cursors: list[str] = Field(
         default=[
             "#cccccc",

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -507,10 +507,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
         arr = np.asarray(value)
         if arr.size == 0:
             return None
-        if arr.size != 1:
-            with np.errstate(all="ignore"):
-                return float(np.nanmean(arr))
-        return float(arr.reshape(()))
+        return erlab.interactive.imagetool.slicer._display_safe_float(arr)
 
     def _set_spin_dat_value(self, value: object) -> None:
         readout_value = self._readout_value_to_float(value)

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -2084,6 +2084,7 @@ class CropDialog(_BaseCropDialog):
 class NormalizeDialog(DataFilterDialog):
     title = "Normalize"
     enable_copy = False
+    denominator_rtol: float = 1e-12
 
     def setup_widgets(self) -> None:
         dim_group = QtWidgets.QGroupBox("Dimensions")
@@ -2113,6 +2114,19 @@ class NormalizeDialog(DataFilterDialog):
         self.layout_.addRow(dim_group)
         self.layout_.addRow(option_group)
 
+    def _safe_denominator(
+        self, denominator: xr.DataArray, scale: xr.DataArray
+    ) -> xr.DataArray:
+        threshold = np.maximum(
+            scale * self.denominator_rtol,
+            np.finfo(np.float64).tiny,
+        )
+        return denominator.where(
+            np.isfinite(denominator)
+            & np.isfinite(scale)
+            & (np.abs(denominator) > threshold)
+        )
+
     def process_data(self, data: xr.DataArray) -> xr.DataArray:
         norm_dims = tuple(k for k, v in self.dim_checks.items() if v.isChecked())
         if len(norm_dims) == 0:
@@ -2121,9 +2135,13 @@ class NormalizeDialog(DataFilterDialog):
         calc_area: bool = self.opts[0].isChecked() or self.opts[3].isChecked()
         calc_minimum: bool = not self.opts[0].isChecked()
         calc_maximum: bool = self.opts[1].isChecked()
+        if calc_area:
+            finite_abs_scale = (
+                abs(data).where(np.isfinite(data)).max(norm_dims, skipna=True)
+            )
 
         if calc_area:
-            area = data.mean(norm_dims)
+            area = self._safe_denominator(data.mean(norm_dims), finite_abs_scale)
 
         if calc_minimum:
             minimum = data.min(norm_dims)
@@ -2135,7 +2153,10 @@ class NormalizeDialog(DataFilterDialog):
             return data / area
 
         if self.opts[1].isChecked():
-            return (data - minimum) / (maximum - minimum)
+            finite_abs_scale = np.maximum(np.abs(minimum), np.abs(maximum))
+            return (data - minimum) / self._safe_denominator(
+                maximum - minimum, finite_abs_scale
+            )
 
         if self.opts[2].isChecked():
             return data - minimum

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -256,10 +256,15 @@ class ItoolPlotDataItem(ItoolDisplayObject, pg.PlotDataItem):
         return self.array_slicer.slice_with_coord(self.cursor_index, self.display_axis)
 
     def update_data(self, coord, vals) -> None:
+        mask_display = not self.array_slicer.display_values_known_safe
+        if mask_display:
+            vals = erlab.interactive.imagetool.slicer._display_safe_values(vals)
         if self.normalize:
-            avg = np.nanmean(vals)
+            avg = np.nan if np.isnan(np.asarray(vals)).all() else np.nanmean(vals)
             if not np.isnan(avg):  # pragma: no branch
-                vals = vals / avg
+                with np.errstate(all="ignore"):
+                    vals = vals / avg
+            vals = erlab.interactive.imagetool.slicer._display_safe_values(vals)
 
         coord, vals = _pad_1d_plot(coord, vals)
 
@@ -293,6 +298,8 @@ class ItoolImageItem(ItoolDisplayObject, erlab.interactive.colors.BetterImageIte
         return self.array_slicer.slice_with_coord(self.cursor_index, self.display_axis)
 
     def update_data(self, rect, img) -> None:
+        if not self.array_slicer.display_values_known_safe:
+            img = erlab.interactive.imagetool.slicer._display_safe_values(img)
         self.setImage(
             image=img, rect=rect, autoLevels=not self.slicer_area.levels_locked
         )
@@ -2204,8 +2211,10 @@ class ItoolPlotItem(pg.PlotItem):
         """
         if self.is_image:  # pragma: no branch
             self.slicer_area.lock_levels(True)
-            self.slicer_area.levels = erlab.utils.array.minmax_darr(
-                self._current_data_cropped
+            self.slicer_area.levels = (
+                erlab.interactive.imagetool.slicer._display_safe_minmax(
+                    self._current_data_cropped
+                )
             )
 
     @QtCore.Slot()

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import functools
 import typing
+import warnings
 
 import numpy as np
 import numpy.typing as npt
@@ -129,6 +130,97 @@ def _get_inc(coord):
     except IndexError:
         # Coord size is 1, assume increment of 1
         return 1
+
+
+def _display_value_abs_limit() -> float:
+    return float(
+        erlab.interactive.options.qsettings.value("colors/max_rendered_abs_value", 1e30)
+    )
+
+
+def _limits_require_display_mask(mn: float, mx: float, limit: float) -> bool:
+    return np.isinf(mn) or np.isinf(mx) or mn < -limit or mx > limit
+
+
+def _display_safe_values(values, limit: float | None = None):
+    """Return values safe for Qt rendering without modifying the source array."""
+    arr = np.asarray(values)
+    if (
+        arr.size == 0
+        or not np.issubdtype(arr.dtype, np.number)
+        or np.issubdtype(arr.dtype, np.complexfloating)
+    ):
+        return values
+
+    if limit is None:
+        limit = _display_value_abs_limit()
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
+        mn, mx = float(np.nanmin(arr)), float(np.nanmax(arr))
+    if not _limits_require_display_mask(mn, mx, limit):
+        return values
+
+    with np.errstate(all="ignore"):
+        return np.where(np.isfinite(arr) & (np.abs(arr) <= limit), arr, np.nan)
+
+
+def _display_safe_float(value) -> float:
+    """Return a scalar display value after applying ImageTool display masking."""
+    arr = np.asarray(value)
+    if arr.size == 0:
+        return np.nan
+    if arr.size == 1:
+        out = float(arr.reshape(()))
+        if np.isfinite(out) and abs(out) <= _display_value_abs_limit():
+            return out
+        return np.nan
+
+    arr = np.asarray(_display_safe_values(arr))
+    if np.isnan(arr).all():
+        return np.nan
+    return float(np.nanmean(arr))
+
+
+def _display_safe_minmax(
+    data: xr.DataArray, raw_limits: tuple[float, float] | None = None
+) -> tuple[float, float]:
+    """Return display-safe finite limits for an ImageTool DataArray."""
+    limit = _display_value_abs_limit()
+    mn, mx = raw_limits if raw_limits is not None else _minmax_darr_quiet(data)
+    if _limits_require_display_mask(mn, mx, limit):
+        if data.chunks is None:
+            return _display_safe_minmax_eager(data.values, limit)
+        with np.errstate(all="ignore"):
+            mn, mx = _minmax_darr_quiet(
+                data.where(np.isfinite(data) & (np.abs(data) <= limit))
+            )
+    if np.isfinite(mn) and np.isfinite(mx):
+        return mn, mx
+    return 0.0, 1.0
+
+
+def _display_safe_minmax_eager(values, limit: float) -> tuple[float, float]:
+    mn, mx = np.inf, -np.inf
+    chunks = (values,) if values.ndim <= 2 else values
+    for chunk in chunks:
+        chunk = _display_safe_values(chunk, limit)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
+            chunk_mn = float(np.nanmin(chunk))
+            chunk_mx = float(np.nanmax(chunk))
+        if np.isfinite(chunk_mn):
+            mn = min(mn, chunk_mn)
+        if np.isfinite(chunk_mx):
+            mx = max(mx, chunk_mx)
+    if np.isfinite(mn) and np.isfinite(mx):
+        return mn, mx
+    return 0.0, 1.0
+
+
+def _minmax_darr_quiet(data: xr.DataArray) -> tuple[float, float]:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
+        return erlab.utils.array.minmax_darr(data)
 
 
 def qsel_args_from_indexers(
@@ -553,9 +645,22 @@ class ArraySlicer(QtCore.QObject):
         return self.limits[0]
 
     @functools.cached_property
+    def _raw_limits(self) -> tuple[float, float]:
+        return _minmax_darr_quiet(self._obj)
+
+    @property
+    def display_values_known_safe(self) -> bool:
+        if self._obj.chunks is not None:
+            return False
+        raw_limits = self.__dict__.get("_raw_limits")
+        return raw_limits is not None and not _limits_require_display_mask(
+            raw_limits[0], raw_limits[1], _display_value_abs_limit()
+        )
+
+    @functools.cached_property
     def limits(self) -> tuple[float, float]:
-        """Return the global minimum and maximum of the data."""
-        return erlab.utils.array.minmax_darr(self._obj, skipna=True)
+        """Return the display-safe global minimum and maximum of the data."""
+        return _display_safe_minmax(self._obj, self._raw_limits)
 
     @property
     def n_cursors(self) -> int:
@@ -747,6 +852,7 @@ class ArraySlicer(QtCore.QObject):
         This method clears the cached properties that depend on the data values, such as
         the global minima and maxima.
         """
+        self._reset_property_cache("_raw_limits")
         self._reset_property_cache("limits")
 
     def clear_cache(self) -> None:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1839,7 +1839,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 obj.update_data(coord_or_rect, next(arrays_it))
             ax.vb.blockSignals(False)
 
-        self.sigPointValueChanged.emit(float(next(arrays_it)))
+        self.sigPointValueChanged.emit(
+            erlab.interactive.imagetool.slicer._display_safe_float(next(arrays_it))
+        )
 
     def link(self, proxy: SlicerLinkProxy) -> None:
         proxy.add(self)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -6203,6 +6203,155 @@ def test_itool_normalize(qtbot, accept_dialog, option) -> None:
     win.close()
 
 
+@pytest.mark.parametrize(
+    ("option", "expected_valid"),
+    [
+        (0, [1.0, 1.0]),
+        (3, [0.0, 0.0]),
+    ],
+)
+def test_itool_normalize_masks_unsafe_area_denominators(
+    qtbot, option, expected_valid
+) -> None:
+    data = xr.DataArray(
+        np.array(
+            [
+                [1.0, 1.0, np.inf, np.nan, 1e15],
+                [-1.0, -1.0 + 1e-14, np.inf, np.nan, 1e15],
+            ]
+        ),
+        dims=["x", "y"],
+        coords={"x": np.arange(2), "y": np.arange(5)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = NormalizeDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    dialog.dim_checks["x"].setChecked(True)
+    dialog.opts[option].setChecked(True)
+
+    result = dialog.process_data(data)
+
+    assert np.isnan(result.isel(y=slice(0, 4)).values).all()
+    np.testing.assert_allclose(result.isel(y=4).values, expected_valid)
+
+    dialog.close()
+    win.close()
+
+
+def test_itool_normalize_masks_unsafe_range_denominators(qtbot) -> None:
+    data = xr.DataArray(
+        np.array(
+            [
+                [2.0, 1.0, np.inf, np.nan, 0.0],
+                [2.0, 1.0 + 1e-14, np.inf, np.nan, 1e15],
+            ]
+        ),
+        dims=["x", "y"],
+        coords={"x": np.arange(2), "y": np.arange(5)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = NormalizeDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    dialog.dim_checks["x"].setChecked(True)
+    dialog.opts[1].setChecked(True)
+
+    result = dialog.process_data(data)
+
+    assert np.isnan(result.isel(y=slice(0, 4)).values).all()
+    np.testing.assert_allclose(result.isel(y=4).values, [0.0, 1.0])
+
+    dialog.close()
+    win.close()
+
+
+def test_itool_masks_unsafe_values_for_display_only(qtbot) -> None:
+    data = xr.DataArray(
+        np.array([[0.0, 1e15], [np.inf, 1e300]]),
+        dims=["x", "y"],
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    displayed = win.slicer_area._imageitems[0].image
+
+    assert displayed is not None
+    assert np.nanmax(displayed) == 1e15
+    assert np.isnan(displayed).sum() == 2
+    assert np.isinf(win.slicer_area.data.values[1, 0])
+    assert win.slicer_area.data.values[1, 1] == 1e300
+
+    control = win.docks[0].widget().findChild(ItoolCrosshairControls)
+    assert control is not None
+    assert np.isnan(control._readout_value_to_float(np.array([np.inf, 1e300])))
+
+    win.slicer_area.lock_levels(True)
+    np.testing.assert_allclose(win.slicer_area.levels, (0.0, 1e15))
+
+    win.close()
+
+
+def test_itool_normalize_to_view_ignores_unsafe_display_values(qtbot) -> None:
+    values = np.arange(25, dtype=float).reshape((5, 5))
+    values[2, 1] = 1e300
+    values[2, 2] = np.inf
+    values[3, 1] = 1e15
+    data = xr.DataArray(
+        values,
+        dims=["x", "y"],
+        coords={"x": np.arange(5), "y": np.arange(5)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    with qtbot.wait_exposed(win):
+        win.show()
+        win.activateWindow()
+
+    set_vb_range(
+        win.slicer_area.main_image.getViewBox(), x_range=(1, 4), y_range=(0, 3)
+    )
+    win.slicer_area.main_image.normalize_to_current_view()
+
+    np.testing.assert_allclose(win.slicer_area.levels, (5.0, 1e15))
+    assert win.slicer_area.data.values[2, 1] == 1e300
+    assert np.isinf(win.slicer_area.data.values[2, 2])
+
+    win.close()
+
+
+def test_itool_skips_display_mask_when_global_limits_are_safe(qtbot, monkeypatch):
+    data = xr.DataArray(
+        np.arange(27, dtype=float).reshape((3, 3, 3)),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(3), "y": np.arange(3), "z": np.arange(3)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.lock_levels(True)
+    assert win.slicer_area.array_slicer.display_values_known_safe
+
+    calls = []
+
+    def record_display_mask(values, limit=None):
+        calls.append(values)
+        return values
+
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.slicer,
+        "_display_safe_values",
+        record_display_mask,
+    )
+
+    win.slicer_area.refresh_all(only_plots=True)
+
+    assert calls == []
+
+    win.close()
+
+
 def test_itool_divide_by_coord(qtbot, accept_dialog) -> None:
     data = xr.DataArray(
         np.arange(12, dtype=float).reshape((3, 4)) + 1.0,

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -3,7 +3,13 @@ import pytest
 import xarray as xr
 from qtpy import QtCore
 
-from erlab.interactive.imagetool.slicer import ArraySlicer, qsel_args_from_indexers
+from erlab.interactive.imagetool.slicer import (
+    ArraySlicer,
+    _display_safe_float,
+    _display_safe_minmax,
+    _display_safe_values,
+    qsel_args_from_indexers,
+)
 
 
 def test_nonuniform_axes_ignores_user_idx_dim(qtbot) -> None:
@@ -92,6 +98,51 @@ def test_validate_array_copy_values_detaches_values_buffer(qtbot) -> None:
     validated.values[0, 0] = -1.0
 
     assert float(data.values[0, 0]) == 0.0
+
+
+def test_array_slicer_limits_ignore_values_unsafe_for_display(qtbot) -> None:
+    data = xr.DataArray(
+        np.array([[0.0, np.inf], [1e15, 1e300]]),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+
+    slicer = ArraySlicer(data, parent=QtCore.QObject())
+
+    assert slicer.limits == (0.0, 1e15)
+    assert np.isinf(slicer._obj.values[0, 1])
+    assert slicer._obj.values[1, 1] == 1e300
+
+
+def test_display_safe_values_returns_original_safe_array() -> None:
+    values = np.array([[0.0, 1e15], [2.0, np.nan]])
+
+    assert _display_safe_values(values) is values
+
+
+def test_display_safe_helpers_handle_degenerate_values() -> None:
+    empty = np.array([], dtype=float)
+    strings = np.array(["a", "b"])
+    complex_values = np.array([1.0 + 1.0j])
+
+    assert _display_safe_values(empty) is empty
+    assert _display_safe_values(strings) is strings
+    assert _display_safe_values(complex_values) is complex_values
+    assert np.isnan(_display_safe_float(empty))
+    assert _display_safe_float(np.array([1.0, np.nan, 3.0])) == 2.0
+    assert _display_safe_minmax(
+        xr.DataArray(np.array([[np.nan]])), raw_limits=(np.nan, np.nan)
+    ) == (0.0, 1.0)
+    assert _display_safe_minmax(xr.DataArray(np.array([[np.inf, 1e300]]))) == (0.0, 1.0)
+
+
+def test_display_safe_minmax_masks_dask_values() -> None:
+    data = xr.DataArray(
+        np.array([[0.0, np.inf], [1e15, 1e300]]),
+        dims=("x", "y"),
+    ).chunk({"x": 1})
+
+    assert _display_safe_minmax(data, raw_limits=(0.0, np.inf)) == (0.0, 1e15)
 
 
 def test_refresh_array_layout_cache_ignores_invalid_generated_idx_coord(qtbot) -> None:


### PR DESCRIPTION
## Summary

- Treat infinities and finite values beyond the ImageTool display cap as missing only on rendering/readout/level paths.
- Add a `Max display value` visualization option defaulting to `1e30`, while preserving valid large values such as `1e15`.
- Guard normalize denominators so non-finite or effectively-zero denominators produce `NaN` instead of huge normalized values.
- Keep source data, child-tool data, save/load payloads, and copied output unchanged.

## Validation

- `uv run ruff check src/erlab/interactive/_options/schema.py src/erlab/interactive/imagetool/controls.py src/erlab/interactive/imagetool/dialogs.py src/erlab/interactive/imagetool/plot_items.py src/erlab/interactive/imagetool/slicer.py src/erlab/interactive/imagetool/viewer.py tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/test_slicer.py`
- `uv run ruff format --check src/erlab/interactive/_options/schema.py src/erlab/interactive/imagetool/controls.py src/erlab/interactive/imagetool/dialogs.py src/erlab/interactive/imagetool/plot_items.py src/erlab/interactive/imagetool/slicer.py src/erlab/interactive/imagetool/viewer.py tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/test_slicer.py`
- `uv run pytest tests/interactive/imagetool/test_slicer.py::test_array_slicer_limits_ignore_values_unsafe_for_display tests/interactive/imagetool/test_slicer.py::test_display_safe_values_returns_original_safe_array tests/interactive/imagetool/test_imagetool.py::test_itool_normalize_masks_unsafe_area_denominators tests/interactive/imagetool/test_imagetool.py::test_itool_normalize_masks_unsafe_range_denominators tests/interactive/imagetool/test_imagetool.py::test_itool_masks_unsafe_values_for_display_only tests/interactive/imagetool/test_imagetool.py::test_itool_normalize_to_view_ignores_unsafe_display_values`