### PR TITLE
feat(imagetool): share axis inversion by dimension

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -184,6 +184,12 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
   On image plots, the context menu can launch {ref}`goldtool <guide-goldtool>`, {ref}`restool <guide-restool>`, {ref}`dtool <guide-dtool>`, and {ref}`ftool <guide-ftool>`. On line plots, the context menu offers {ref}`ftool <guide-ftool>`.
 
+  :::{versionchanged} 3.23.0
+  Axis inversion is shared by dimension across plots. Use the plot context menu or
+  {guilabel}`View → Invert Axis` to flip every visible plot showing that
+  dimension; the setting is saved with the ImageTool state and follows undo and redo.
+  :::
+
   Tools opened from ImageTool remember the slice or selection that opened them. If that
   ImageTool is updated with compatible data, the tool shows a {guilabel}`Stale` badge
   instead of silently keeping old input. Click the badge inside the tool window to

--- a/src/erlab/interactive/imagetool/_history.py
+++ b/src/erlab/interactive/imagetool/_history.py
@@ -359,8 +359,6 @@ def _plot_state_changes(
 
         view_keys = {
             "vb_aspect_locked",
-            "vb_x_inverted",
-            "vb_y_inverted",
             "vb_autorange",
         }
         view_changed = view_changed or any(
@@ -550,6 +548,14 @@ def _describe_state_change_rows(
         summaries.append("View limits changed")
         details.append(_detail_note("Manual view limits changed"))
         _consume(changes, "manual_limits", prefixes=("manual_limits",))
+
+    if any(
+        path == "axis_inversions" or path.startswith("axis_inversions.")
+        for path in changes
+    ):
+        summaries.append("Axis inversion changed")
+        details.append(_detail_note("Axis inversion changed"))
+        _consume(changes, "axis_inversions", prefixes=("axis_inversions",))
 
     if "plotitem_states" in changes:
         plot_summaries, plot_details = _plot_state_changes(

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -720,6 +720,7 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                 "actions": {
                     "viewAllAct": self.slicer_area.view_all_act,
                     "transposeAct": self.slicer_area.transpose_act,
+                    "invertAxisMenu": {"title": "Invert Axis", "actions": {}},
                     "toggleControlsAct": self.image_tool.toggle_controls_act,
                     "sep0": {"separator": True},
                     "associatedAct": self.slicer_area.associated_coords_act,
@@ -839,6 +840,11 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
         # Disable/Enable menus based on context
         self.menu_dict["fileMenu"].aboutToShow.connect(self._file_menu_visibility)
         self.menu_dict["viewMenu"].aboutToShow.connect(self._view_menu_visibility)
+        self.menu_dict["invertAxisMenu"].setObjectName("itool_invert_axis_menu")
+        self.menu_dict["invertAxisMenu"].aboutToShow.connect(
+            self._populate_invert_axis_menu
+        )
+        self._populate_invert_axis_menu()
 
     @QtCore.Slot()
     def _file_menu_visibility(self) -> None:
@@ -860,6 +866,25 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
         self.action_dict["resetAct"].setEnabled(
             self.slicer_area._applied_func is not None
         )
+        self._populate_invert_axis_menu()
+
+    @QtCore.Slot()
+    def _populate_invert_axis_menu(self) -> None:
+        menu = self.menu_dict["invertAxisMenu"]
+        menu.clear()
+        for i, dim in enumerate(self.slicer_area.data.dims):
+            dim_name = str(dim)
+            action = QtGui.QAction(dim_name, menu)
+            action.setObjectName(f"itool_invert_axis_{i}_action")
+            action.setData(dim_name)
+            action.setCheckable(True)
+            action.setChecked(bool(self.slicer_area.axis_inversions.get(dim_name)))
+            action.toggled.connect(
+                lambda checked, *, name=dim_name: self.slicer_area.set_axis_inverted(
+                    name, checked
+                )
+            )
+            menu.addAction(action)
 
     def execute_dialog(self, dialog_cls: type[QtWidgets.QDialog]) -> None:
         dialog = dialog_cls(self.slicer_area)

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -487,6 +487,8 @@ class ItoolPlotItem(pg.PlotItem):
         self._twin_visible: bool = False
 
         self._roi_list: list[ItoolPolyLineROI] = []
+        self._applying_shared_axis_inversions = False
+        self._last_axis_inversions = self._viewbox_axis_inversions()
 
     def setup_actions(self) -> None:
         self._associated_coord_menu: QtWidgets.QMenu | None = None
@@ -639,6 +641,7 @@ class ItoolPlotItem(pg.PlotItem):
         self.slicer_area.sigBinChanged.connect(self.refresh_items_data)
         self.getViewBox().sigRangeChangedManually.connect(self.range_changed_manually)
         self.getViewBox().sigStateChanged.connect(self.refresh_manual_range)
+        self.getViewBox().sigStateChanged.connect(self._handle_axis_inversion_change)
         if self.is_image:
             self.slicer_area.sigIndexChanged.connect(
                 self._follow_guidelines_on_index_change
@@ -663,6 +666,7 @@ class ItoolPlotItem(pg.PlotItem):
             self.range_changed_manually
         )
         self.getViewBox().sigStateChanged.disconnect(self.refresh_manual_range)
+        self.getViewBox().sigStateChanged.disconnect(self._handle_axis_inversion_change)
         if self.is_image:
             self.slicer_area.sigIndexChanged.disconnect(
                 self._follow_guidelines_on_index_change
@@ -925,8 +929,6 @@ class ItoolPlotItem(pg.PlotItem):
         vb_state = self.getViewBox().getState()
         state: PlotItemState = {
             "vb_aspect_locked": vb_state["aspectLocked"],
-            "vb_x_inverted": vb_state["xInverted"],
-            "vb_y_inverted": vb_state["yInverted"],
             "vb_autorange": tuple(vb_state["autoRange"]),
             "roi_states": [roi.saveState() for roi in self._roi_list],
         }
@@ -948,13 +950,11 @@ class ItoolPlotItem(pg.PlotItem):
         vb = self.getViewBox()
         state_dict: dict[str, typing.Any] = {
             "aspectLocked": state["vb_aspect_locked"],
-            "xInverted": state["vb_x_inverted"],
-            "yInverted": state["vb_y_inverted"],
         }
         autorange = state.get("vb_autorange", None)
         if autorange:
             state_dict["autoRange"] = list(autorange)
-        vb.state.update()
+        vb.state.update(state_dict)
 
         with self.slicer_area.history_suppressed():
             self._restore_guideline_state(state.get("guideline_state", None))
@@ -2273,6 +2273,40 @@ class ItoolPlotItem(pg.PlotItem):
     def update_manual_range(self) -> None:
         """Update view range from values stored in the parent slicer area."""
         self.set_range_from(self.slicer_area.manual_limits)
+
+    def _viewbox_axis_inversions(self) -> tuple[bool, bool]:
+        vb_state = self.getViewBox().state
+        return bool(vb_state["xInverted"]), bool(vb_state["yInverted"])
+
+    def update_axis_inversions(self) -> None:
+        vb = self.getViewBox()
+        self._applying_shared_axis_inversions = True
+        try:
+            for i, dim in enumerate(self.axis_dims_uniform):
+                if dim is None:
+                    continue
+                inverted = bool(self.slicer_area.axis_inversions.get(dim, False))
+                if i == 0:
+                    vb.invertX(inverted)
+                else:
+                    vb.invertY(inverted)
+        finally:
+            self._applying_shared_axis_inversions = False
+            self._last_axis_inversions = self._viewbox_axis_inversions()
+
+    @QtCore.Slot()
+    def _handle_axis_inversion_change(self) -> None:
+        current = self._viewbox_axis_inversions()
+        previous = self._last_axis_inversions
+        self._last_axis_inversions = current
+        if self._applying_shared_axis_inversions or current == previous:
+            return
+
+        for dim, old, new in zip(
+            self.axis_dims_uniform, previous, current, strict=True
+        ):
+            if dim is not None and old != new:
+                self.slicer_area.set_axis_inverted(dim, new)
 
     def set_range_from(self, limits: dict[str, list[float]], **kwargs) -> None:
         for i, (dim, key) in enumerate(

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -38,7 +38,7 @@ from erlab.interactive.imagetool._viewer_dialogs import (
 
 if typing.TYPE_CHECKING:
     import datetime
-    from collections.abc import Callable, Collection, Hashable, Iterable
+    from collections.abc import Callable, Collection, Hashable, Iterable, Mapping
 
     import qtawesome
 
@@ -81,8 +81,8 @@ class PlotItemState(typing.TypedDict):
     """A dictionary containing the state of a `PlotItem` instance."""
 
     vb_aspect_locked: bool | float
-    vb_x_inverted: bool
-    vb_y_inverted: bool
+    vb_x_inverted: typing.NotRequired[bool]
+    vb_y_inverted: typing.NotRequired[bool]
     vb_autorange: typing.NotRequired[tuple[bool, bool]]
     roi_states: typing.NotRequired[list[dict[str, typing.Any]]]
     guideline_state: typing.NotRequired[GuidelineState]
@@ -95,6 +95,7 @@ class ImageSlicerState(typing.TypedDict):
     slice: ArraySlicerState
     current_cursor: int
     manual_limits: dict[str, list[float]]
+    axis_inversions: typing.NotRequired[dict[str, bool]]
     cursor_colors: list[str]
     controls_visible: typing.NotRequired[bool]
     file_path: typing.NotRequired[str | None]
@@ -1195,6 +1196,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self.manual_limits: dict[str, list[float]] = {}
         # Dictionary of current axes limits for each data dimension to ensure all plots
         # show the same range for a given dimension. The keys are the dimension names.
+        self.axis_inversions: dict[str, bool] = {}
+        # Dictionary of inverted view state for each plotted data dimension.
 
         pkw = {"image_cls": image_cls, "plotdata_cls": plotdata_cls}
         self._plots: tuple[ItoolGraphicsLayoutWidget, ...] = (
@@ -1364,6 +1367,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             "slice": self.array_slicer.state,
             "current_cursor": int(self.current_cursor),
             "manual_limits": copy.deepcopy(self.manual_limits),
+            "axis_inversions": copy.deepcopy(self.axis_inversions),
             "splitter_sizes": self.splitter_sizes,
             "file_path": str(self._file_path) if self._file_path is not None else None,
             "load_func": load_func,
@@ -1408,6 +1412,15 @@ class ImageSlicerArea(QtWidgets.QWidget):
             if ax.is_image:
                 ax.sync_guidelines_to_active_cursor()
         logger.debug("Restored array slicer state")
+
+        axis_inversions = state.get("axis_inversions", None)
+        if axis_inversions is None:
+            axis_inversions = self._axis_inversions_from_plotitem_states(
+                plotitem_states
+            )
+        self.axis_inversions = self._normalized_axis_inversions(axis_inversions)
+        self.apply_axis_inversions()
+        logger.debug("Restored axis inversions")
 
         file_path = state.get("file_path", None)
         if file_path is not None:
@@ -2308,6 +2321,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             for ax in self.axes:
                 ax.refresh_labels()
                 ax.update_manual_range()  # Handle axis limits (in case of transpose)
+                ax.update_axis_inversions()
 
     @QtCore.Slot(tuple)
     @link_slicer
@@ -2490,6 +2504,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.array_slicer.add_cursor(update=False)
 
         self.connect_signals()
+        self.axis_inversions = self._normalized_axis_inversions(self.axis_inversions)
 
         if ndim_changed:
             self.adjust_layout()
@@ -2786,6 +2801,51 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self.manual_limits = copy.deepcopy(manual_limits)
         for ax in self.axes:
             ax.update_manual_range()
+
+    def _normalized_axis_inversions(
+        self, axis_inversions: Mapping[str, bool] | None
+    ) -> dict[str, bool]:
+        if axis_inversions is None:
+            return {}
+        valid_dims = {str(dim) for dim in self.data.dims}
+        return {
+            str(dim): True
+            for dim, inverted in axis_inversions.items()
+            if bool(inverted) and str(dim) in valid_dims
+        }
+
+    def _axis_inversions_from_plotitem_states(
+        self, plotitem_states: list[PlotItemState] | None
+    ) -> dict[str, bool]:
+        if plotitem_states is None:
+            return {}
+        axis_inversions: dict[str, bool] = {}
+        for ax, plotitem_state in zip(self.axes, plotitem_states, strict=False):
+            for dim, key in zip(
+                ax.axis_dims_uniform, ("vb_x_inverted", "vb_y_inverted"), strict=True
+            ):
+                if dim is not None and bool(plotitem_state.get(key, False)):
+                    axis_inversions[dim] = True
+        return axis_inversions
+
+    def apply_axis_inversions(self) -> None:
+        for ax in self.axes:
+            ax.update_axis_inversions()
+
+    @link_slicer
+    @record_history
+    def set_axis_inverted(self, dim: str, inverted: bool) -> None:
+        valid_dims = {str(dim_name) for dim_name in self.data.dims}
+        if dim not in valid_dims:
+            return
+        if bool(self.axis_inversions.get(dim, False)) == inverted:
+            return
+
+        if inverted:
+            self.axis_inversions[dim] = True
+        else:
+            self.axis_inversions.pop(dim, None)
+        self.apply_axis_inversions()
 
     def propagate_limit_change(self, axes: ItoolPlotItem) -> None:
         """Propagate manual limits changes to all linked slicers.

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -39,14 +39,13 @@ def _base_state() -> dict:
             "cursor_color_params": None,
         },
         "manual_limits": {},
+        "axis_inversions": {},
         "file_path": None,
         "load_func": None,
         "controls_visible": True,
         "plotitem_states": [
             {
                 "vb_aspect_locked": False,
-                "vb_x_inverted": False,
-                "vb_y_inverted": False,
                 "vb_autorange": (True, True),
                 "roi_states": [],
             }
@@ -396,6 +395,17 @@ def test_describe_state_change_reports_manual_view_limits():
 
     assert label == "View limits changed"
     assert details == ("Manual view limits changed",)
+
+
+def test_describe_state_change_reports_axis_inversions():
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    curr["axis_inversions"] = {"x": True}
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert label == "Axis inversion changed"
+    assert details == ("Axis inversion changed",)
 
 
 def test_describe_state_change_reports_added_keys_and_generic_fallback():

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2038,6 +2038,7 @@ def test_itool_general(qtbot, move_and_compare_values, use_dask) -> None:
         },
         "current_cursor": 1,
         "manual_limits": {},
+        "axis_inversions": {},
         "splitter_sizes": list(old_state["splitter_sizes"]),
         "file_path": None,
         "load_func": None,
@@ -2048,22 +2049,16 @@ def test_itool_general(qtbot, move_and_compare_values, use_dask) -> None:
                 "roi_states": [],
                 "vb_aspect_locked": False,
                 "vb_autorange": (True, True),
-                "vb_x_inverted": False,
-                "vb_y_inverted": False,
             },
             {
                 "roi_states": [],
                 "vb_aspect_locked": False,
                 "vb_autorange": (True, True),
-                "vb_x_inverted": False,
-                "vb_y_inverted": False,
             },
             {
                 "roi_states": [],
                 "vb_aspect_locked": False,
                 "vb_autorange": (True, True),
-                "vb_x_inverted": False,
-                "vb_y_inverted": False,
             },
         ],
     }
@@ -2889,6 +2884,98 @@ def _cursor_line_values(image, cursor: int) -> tuple[float, ...]:
     return tuple(line.value() for line in image.cursor_lines[cursor].values())
 
 
+def _plot_axis_inverted(plot_item, axis: int) -> bool:
+    key = "xInverted" if axis == 0 else "yInverted"
+    return bool(plot_item.getViewBox().state[key])
+
+
+def _assert_dimension_inverted(area: ImageSlicerArea, dim: str, inverted: bool) -> None:
+    matched = False
+    for plot_item in area.axes:
+        for axis, axis_dim in enumerate(plot_item.axis_dims_uniform):
+            if axis_dim == dim:
+                matched = True
+                assert _plot_axis_inverted(plot_item, axis) is inverted
+    assert matched
+
+
+def test_axis_inversion_viewbox_shared_undo_redo_and_roundtrip(qtbot) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+
+    area.main_image.getViewBox().invertX(True)
+
+    assert area.axis_inversions == {"x": True}
+    _assert_dimension_inverted(area, "x", True)
+    _assert_dimension_inverted(area, "y", False)
+    assert area.undoable
+
+    area.undo()
+    assert area.axis_inversions == {}
+    _assert_dimension_inverted(area, "x", False)
+
+    area.redo()
+    assert area.axis_inversions == {"x": True}
+    _assert_dimension_inverted(area, "x", True)
+
+    restored = ImageTool.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert restored.slicer_area.axis_inversions == {"x": True}
+    _assert_dimension_inverted(restored.slicer_area, "x", True)
+
+    restored.close()
+    win.close()
+
+
+def test_axis_inversion_view_menu_toggles_shared_state(qtbot) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    menu = win.mnb.menu_dict["invertAxisMenu"]
+    win.mnb._populate_invert_axis_menu()
+    actions = {action.data(): action for action in menu.actions()}
+
+    y_action = actions["y"]
+    assert y_action.objectName() == "itool_invert_axis_1_action"
+    assert y_action.isCheckable()
+
+    y_action.trigger()
+    assert win.slicer_area.axis_inversions == {"y": True}
+    _assert_dimension_inverted(win.slicer_area, "y", True)
+
+    y_action.trigger()
+    assert win.slicer_area.axis_inversions == {}
+    _assert_dimension_inverted(win.slicer_area, "y", False)
+
+    win.close()
+
+
+def test_axis_inversion_legacy_plotitem_state_migrates(qtbot) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=["x", "y"])
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    ds = win.to_dataset()
+    state = json.loads(ds.attrs["itool_state"])
+    state.pop("axis_inversions")
+    state["plotitem_states"][0]["vb_x_inverted"] = True
+    state["plotitem_states"][2]["vb_y_inverted"] = True
+    ds.attrs["itool_state"] = json.dumps(state)
+
+    restored = ImageTool.from_dataset(ds)
+    qtbot.addWidget(restored)
+
+    assert restored.slicer_area.axis_inversions == {"x": True, "y": True}
+    _assert_dimension_inverted(restored.slicer_area, "x", True)
+    _assert_dimension_inverted(restored.slicer_area, "y", True)
+
+    restored.close()
+    win.close()
+
+
 def test_linked_command_option_image_drag_refreshes_linked_cursors(qtbot) -> None:
     win0, win1 = _linked_pair(qtbot)
     win0.slicer_area.add_cursor()
@@ -2980,6 +3067,32 @@ def test_linked_cursor_undo_redo_propagates(qtbot) -> None:
     win0.slicer_area.redo()
     assert win0.array_slicer.get_indices(0) == [4, 2]
     assert win1.array_slicer.get_indices(0) == [4, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_axis_inversion_undo_redo_propagates(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+
+    win0.slicer_area.set_axis_inverted("x", True)
+    assert win0.slicer_area.axis_inversions == {"x": True}
+    assert win1.slicer_area.axis_inversions == {"x": True}
+    _assert_dimension_inverted(win0.slicer_area, "x", True)
+    _assert_dimension_inverted(win1.slicer_area, "x", True)
+
+    win0.slicer_area.undo()
+    assert win0.slicer_area.axis_inversions == {}
+    assert win1.slicer_area.axis_inversions == {}
+    _assert_dimension_inverted(win0.slicer_area, "x", False)
+    _assert_dimension_inverted(win1.slicer_area, "x", False)
+
+    win0.slicer_area.redo()
+    assert win0.slicer_area.axis_inversions == {"x": True}
+    assert win1.slicer_area.axis_inversions == {"x": True}
+    _assert_dimension_inverted(win0.slicer_area, "x", True)
+    _assert_dimension_inverted(win1.slicer_area, "x", True)
 
     win0.slicer_area.unlink()
     win0.close()


### PR DESCRIPTION
## Summary
- Store ImageTool axis inversion as shared state keyed by data dimension.
- Apply plot context-menu and `View > Invert Axis` toggles to every plot showing the same dimension.
- Persist inversion through ImageTool save/load and migrate legacy per-plot inversion state.
- Add undo/redo coverage, linked ImageTool propagation, and a short user-guide note.

## User impact
Axis inversion now behaves like shared manual limits: flipping a dimension in one plot keeps every plot for that dimension consistent, survives saved state and manager workspace round-trips, and can be undone or redone.

## Validation
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_history.py tests/interactive/imagetool/test_imagetool.py`