### PR TITLE
feat(qsel): add min/max/sum aggregation

### DIFF
--- a/docs/source/user-guide/indexing.ipynb
+++ b/docs/source/user-guide/indexing.ipynb
@@ -277,7 +277,7 @@
    "source": [
     "### Averaging across dimensions\n",
     "\n",
-    "Taking a mean across multiple dimensions is a common operation, and can be performed easily with {meth}`xarray.DataArray.mean`. However, it is often necessary to preserve the coordinate information of the averaged dimension. In this case, {meth}`xarray.DataArray.qsel.average` can be used.\n",
+    "Taking a mean across multiple dimensions is a common operation, and can be performed easily with {meth}`xarray.DataArray.mean`. However, it is often necessary to preserve the coordinate information of the averaged dimension. In this case, {meth}`xarray.DataArray.qsel.mean` can be used.\n",
     "\n",
     "The following code first selects the data around the Fermi level, and calculates the average of the intensity over the energy axis. The coordinate `eV` is preserved in the resulting DataArray."
    ]
@@ -289,7 +289,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dat.sel(eV=slice(-0.05, 0.05)).qsel.average(\"eV\")"
+    "dat.sel(eV=slice(-0.05, 0.05)).qsel.mean(\"eV\")"
    ]
   },
   {

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -160,7 +160,7 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
   :::{hint}
 
-  To reduce the underlying data instead of displaying binned slices, use the {guilabel}`Edit → Average` dialog or the {guilabel}`Coarsen` dialog for more options.
+  To reduce the underlying data instead of displaying binned slices, use the {guilabel}`Edit → Aggregate…` dialog or the {guilabel}`Coarsen` dialog for more options.
 
   :::
 
@@ -228,27 +228,53 @@ Editing dialogs live under the {guilabel}`Edit` and {guilabel}`View` menus. Most
 transforms are destructive, but they let you keep the data as it was before the edit by
 opening the result separately. When the current ImageTool is open in the manager, use
 {guilabel}`Result Placement` to choose whether the new data opens as a child row of the
-current ImageTool, opens as a separate top-level window, or replaces the current ImageTool; see
-{ref}`imagetool-manager-result-placement`. When {guilabel}`Copy Code` is available, the
-generated snippet is placed on your clipboard, ready to paste into a script or notebook
-for reproducibility.
+current ImageTool, opens as a separate top-level window, or replaces the current
+ImageTool; see {ref}`imagetool-manager-result-placement`. When {guilabel}`Copy Code` is
+available, the generated snippet is placed on your clipboard, ready to paste into a
+script or notebook for reproducibility.
 
-- {guilabel}`Edit → Rotate` opens the {guilabel}`Rotate` dialog. Enter the angle, center, interpolation order, and whether to reshape the image. If a rotation guideline is active, the dialog pre-fills the angle and center from the guideline.
+- {guilabel}`Edit → Rotate` opens the {guilabel}`Rotate` dialog. Enter the angle,
+  center, interpolation order, and whether to reshape the image. If a rotation guideline
+  is active, the dialog pre-fills the angle and center from the guideline.
 - {guilabel}`Edit → Select Data…` opens the {guilabel}`Select Data` dialog. Use it to
-  build {meth}`~xarray.DataArray.qsel`, {meth}`~xarray.DataArray.sel`, and
-  {meth}`~xarray.DataArray.isel` selections from a table of dimensions. Each row can select a scalar point or a contiguous range.
-- {guilabel}`Edit → Average` opens the {guilabel}`Average Over Dimensions` dialog. Select any set of dimensions to average via {meth}`xarray.DataArray.qsel.average`.
-- {guilabel}`Edit → Interpolate…` opens the {guilabel}`Interpolate` dialog. Choose one dimension, enter the target coordinate values, and interpolate with {meth}`xarray.DataArray.interp` using `linear` or `nearest`.
-- {guilabel}`Edit → Coarsen` opens the {guilabel}`Coarsen` dialog. Select window sizes for one or more dimensions, choose the `boundary`, `side`, and coordinate reduction function for {meth}`xarray.DataArray.coarsen`, then apply a reducer such as `mean`, `sum`, or `median`.
-- {guilabel}`Edit → Thin` opens the {guilabel}`Thin Data` dialog which uses {meth}`xarray.DataArray.thin`.
-- {guilabel}`Edit → Symmetrize → Mirror…` opens the {guilabel}`Symmetrize` dialog. Mirror a selected dimension about a specified center with additive or subtractive symmetry, `valid` or `full` overlap, and one-sided or two-sided output.
-- {guilabel}`Edit → Symmetrize → Rotational…` opens the rotational symmetrization dialog. If a rotation guideline is visible, the dialog pre-fills the center and fold count based on the guideline.
-- {guilabel}`Edit → Crop` opens the {guilabel}`Crop Between Cursors` dialog, while {guilabel}`Edit → Crop to View` opens the {guilabel}`Crop to View` dialog.
-- {guilabel}`Edit → Correct With Edge…` opens the {guilabel}`Edge Correction` dialog. If your data exposes an `eV` axis, ImageTool can import a previously fitted edge via {func}`xarray_lmfit.load_fit` and shift the spectrum accordingly.
-- {guilabel}`View → Normalize` opens the {guilabel}`Normalize` dialog, which applies a non-destructive filter that supports area normalization, min-max scaling, and baseline subtraction.
-- {guilabel}`View → Gaussian Filter` opens the {guilabel}`Gaussian Filter` dialog, which applies a non-destructive filter that applies coordinate-aware Gaussian broadening along selected dimensions.
+  build {meth}`xarray.DataArray.qsel`, {meth}`xarray.DataArray.sel`, and
+  {meth}`xarray.DataArray.isel` selections from a table of dimensions. Each row can
+  select a scalar point or a contiguous range.
+- {guilabel}`Edit → Aggregate…` opens the {guilabel}`Aggregate Over Dimensions` dialog.
+  Select any set of dimensions and reduce them with mean, minimum, maximum, or sum via
+  {meth}`xarray.DataArray.qsel.mean`, {meth}`xarray.DataArray.qsel.min`,
+  {meth}`xarray.DataArray.qsel.max`, or {meth}`xarray.DataArray.qsel.sum`.
+- {guilabel}`Edit → Interpolate…` opens the {guilabel}`Interpolate` dialog. Choose one
+  dimension, enter the target coordinate values, and interpolate with
+  {meth}`xarray.DataArray.interp` using `linear` or `nearest`.
+- {guilabel}`Edit → Coarsen` opens the {guilabel}`Coarsen` dialog. Select window sizes
+  for one or more dimensions, choose the `boundary`, `side`, and coordinate reduction
+  function for {meth}`xarray.DataArray.coarsen`, then apply a reducer such as `mean`,
+  `sum`, or `median`.
+- {guilabel}`Edit → Thin` opens the {guilabel}`Thin Data` dialog which uses
+  {meth}`xarray.DataArray.thin`.
+- {guilabel}`Edit → Symmetrize → Mirror…` opens the {guilabel}`Symmetrize` dialog.
+  Mirror a selected dimension about a specified center with additive or subtractive
+  symmetry, `valid` or `full` overlap, and one-sided or two-sided output.
+- {guilabel}`Edit → Symmetrize → Rotational…` opens the rotational symmetrization
+  dialog. If a rotation guideline is visible, the dialog pre-fills the center and fold
+  count based on the guideline.
+- {guilabel}`Edit → Crop` opens the {guilabel}`Crop Between Cursors` dialog, while
+  {guilabel}`Edit → Crop to View` opens the {guilabel}`Crop to View` dialog.
+- {guilabel}`Edit → Correct With Edge…` opens the {guilabel}`Edge Correction` dialog. If
+  your data exposes an `eV` axis, ImageTool can import a previously fitted edge via
+  {func}`xarray_lmfit.load_fit` and shift the spectrum accordingly.
+- {guilabel}`View → Normalize` opens the {guilabel}`Normalize` dialog, which applies a
+  non-destructive filter that supports area normalization, min-max scaling, and baseline
+  subtraction.
+- {guilabel}`View → Gaussian Filter` opens the {guilabel}`Gaussian Filter` dialog, which
+  applies a non-destructive filter that applies coordinate-aware Gaussian broadening
+  along selected dimensions.
 
-Use {guilabel}`Edit → Undo` and {guilabel}`Edit → Redo` to walk changes back, and {guilabel}`View → Reset` to remove any currently applied filter function. ImageTool also keeps track of additional tool windows opened from the context menus, so everything is closed cleanly when the main window exits.
+Use {guilabel}`Edit → Undo` and {guilabel}`Edit → Redo` to walk changes back, and
+{guilabel}`View → Reset` to remove any currently applied filter function. ImageTool also
+keeps track of additional tool windows opened from the context menus, so everything is
+closed cleanly when the main window exits.
 
 (imagetool-roi)=
 

--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -594,9 +594,9 @@ which ImageTool data and selection opened it:
   array should be used again during an update.
 - Use the operation models in ``erlab.interactive.imagetool.provenance`` such as
   ``QSelOperation(...)``, ``IselOperation(...)``, ``SelOperation(...)``,
-  ``AverageOperation(...)``, and ``TransposeOperation(...)`` when a tool needs to
-  write or modify the saved operation list explicitly. Pass those operation instances to
-  ``selection(...)`` or ``full_data(...)``.
+  ``QSelAggregationOperation(...)``, and ``TransposeOperation(...)`` when a tool
+  needs to write or modify the saved operation list explicitly. Pass those operation
+  instances to ``selection(...)`` or ``full_data(...)``.
 - When implementing a custom ``ToolProvenanceOperation.derivation_entry()``, return a
   ``DerivationEntry`` for steps that should appear in the manager derivation list or
   copied code. Return ``None`` only for operations that must still run during an update

--- a/docs/source/user-guide/workflow-bridge.md
+++ b/docs/source/user-guide/workflow-bridge.md
@@ -40,9 +40,10 @@ code for reproducibility and batch processing.
   - {guilabel}`Edit → Select Data…` or the right-click context menu of each plot
   - {meth}`xarray.DataArray.qsel`, {meth}`xarray.DataArray.sel`, and
     {meth}`xarray.DataArray.isel`
-- - Average over dimensions
-  - {ref}`Averaging dialog <imagetool-editing>`
-  - {meth}`xarray.DataArray.qsel.average`
+- - Aggregate over dimensions
+  - {ref}`Aggregation dialog <imagetool-editing>`
+  - {meth}`xarray.DataArray.qsel.mean`, {meth}`~xarray.DataArray.qsel.min`,
+    {meth}`~xarray.DataArray.qsel.max`, and {meth}`~xarray.DataArray.qsel.sum`
 - - Interpolate along a dimension
   - {ref}`Interpolation dialog <imagetool-editing>`
   - {meth}`xarray.DataArray.interp`

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -48,8 +48,9 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
 
 - Search `erlab.io.load`, `loader_context`, `set_loader`, `set_data_dir`,
   `plugins`, or `data explorer` for loading and plugin questions.
-- Search `xarray.DataArray.qsel`, `qsel.average`, `qsel.around`, or
-  `workflow-bridge` for slicing and indexing questions.
+- Search `xarray.DataArray.qsel`, `qsel.mean`, `qsel.min`,
+  `qsel.max`, `qsel.sum`, `qsel.around`, `Aggregate`, or `workflow-bridge` for
+  slicing and indexing questions.
 - Search `kspace.convert`, `kspace.convert_coords`, `ktool`, `work function`,
   `inner potential`, or `offsets` for momentum-conversion questions.
 - Search `xlm.modelfit`, `MultiPeakModel`, `FermiEdgeModel`, `gold`, `ftool`,

--- a/src/erlab/accessors/general.py
+++ b/src/erlab/accessors/general.py
@@ -24,6 +24,9 @@ from erlab.accessors.utils import (
     either_dict_or_kwargs,
 )
 
+QSelReducer: typing.TypeAlias = typing.Literal["mean", "min", "max", "sum"]
+_QSEL_REDUCERS: tuple[QSelReducer, ...] = ("mean", "min", "max", "sum")
+
 if typing.TYPE_CHECKING:
     import lmfit
 
@@ -451,7 +454,7 @@ class InteractiveDatasetAccessor(ERLabDatasetAccessor):
 
 @xr.register_dataarray_accessor("qsel")
 class SelectionAccessor(ERLabDataArrayAccessor):
-    """`xarray.DataArray.qsel` accessor for convenient selection and averaging."""
+    """`xarray.DataArray.qsel` accessor for convenient selection and aggregation."""
 
     @staticmethod
     def _qsel_scalar(
@@ -460,6 +463,7 @@ class SelectionAccessor(ERLabDataArrayAccessor):
         slices: dict[Hashable, slice],
         avg_dims: list[Hashable],
         lost_dims: list[Hashable],
+        func: QSelReducer,
     ) -> xr.DataArray:
         unindexed_dims: list[Hashable] = [
             k for k in slices | scalars if k not in obj.indexes
@@ -517,7 +521,8 @@ class SelectionAccessor(ERLabDataArrayAccessor):
                             dim=set(avg_dims).intersection(out[k].dims), keep_attrs=True
                         )
 
-            out = out.mean(dim=avg_dims, keep_attrs=True)
+            if avg_dims:
+                out = getattr(out, func)(dim=avg_dims, keep_attrs=True)
             out = out.assign_coords(lost_coords)
 
         return out.drop_vars(unindexed_dims, errors="ignore")
@@ -525,9 +530,11 @@ class SelectionAccessor(ERLabDataArrayAccessor):
     def __call__(
         self,
         indexers: Mapping[Hashable, float | slice] | None = None,
+        *,
+        func: QSelReducer = "mean",
         **indexers_kwargs,
     ):
-        """Select and average data along specified dimensions.
+        """Select and aggregate data along specified dimensions.
 
         Parameters
         ----------
@@ -546,8 +553,8 @@ class SelectionAccessor(ERLabDataArrayAccessor):
 
             - As a value and width: ``alpha=5, alpha_width=0.5``
 
-              The data is *averaged* over a slice of width ``alpha_width``, centered at
-              ``alpha``. If ``alpha`` is a collection, the data is averaged over
+              The data is aggregated over a slice of width ``alpha_width``, centered at
+              ``alpha``. If ``alpha`` is a collection, the data is aggregated over
               multiple slices and concatenated along the dimension.
 
             - As a slice: ``alpha=slice(-10, 10)``
@@ -559,11 +566,16 @@ class SelectionAccessor(ERLabDataArrayAccessor):
         **indexers_kwargs
             The keyword arguments form of ``indexers``. One of ``indexers`` or
             ``indexers_kwargs`` must be provided.
+        func : {"mean", "min", "max", "sum"}, optional
+            Function used when qsel aggregates over width-based selections. Must be one
+            of ``"mean"``, ``"min"``, ``"max"``, or ``"sum"``. ``"mean"`` by default.
+            This argument only affects reduced data; reduced numeric coordinates are
+            still represented by their mean.
 
         Returns
         -------
         DataArray
-            The selected and averaged data.
+            The selected and aggregated data.
 
         Note
         ----
@@ -582,6 +594,10 @@ class SelectionAccessor(ERLabDataArrayAccessor):
             da.qsel(x=slice(2.0, 3.0))  # This works
 
         """
+        if func not in _QSEL_REDUCERS:
+            allowed = ", ".join(repr(item) for item in _QSEL_REDUCERS)
+            raise ValueError(f"func must be one of {allowed}; got {func!r}")
+
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "qsel")
 
         coord_order = list(self._obj.coords.keys())
@@ -686,6 +702,7 @@ class SelectionAccessor(ERLabDataArrayAccessor):
                             slices=slices | {dim: s},
                             avg_dims=[*avg_dims, dim],
                             lost_dims=lost_dims + lost_dims_extend,
+                            func=func,
                         )
                         for s in slice_list
                     ],
@@ -697,20 +714,19 @@ class SelectionAccessor(ERLabDataArrayAccessor):
                 )
         else:
             out = self._qsel_scalar(
-                self._obj.copy(), scalars, slices, avg_dims, lost_dims
+                self._obj.copy(), scalars, slices, avg_dims, lost_dims, func
             )
 
         return erlab.utils.array.sort_coord_order(
             out, keys=coord_order, dims_first=True
         )
 
-    def average(self, dim: str | Sequence[Hashable] | None = None) -> xr.DataArray:
-        """Average the data along the specified dimension(s).
+    def mean(self, dim: str | Sequence[Hashable] | None = None) -> xr.DataArray:
+        """Return the mean over dimensions while keeping their coordinates.
 
-        The difference between this method and :meth:`xarray.DataArray.mean` is that
-        this method averages the data along the specified dimension(s) and retains the
-        averaged coordinate. This method also implicitly averages all coordinates that
-        depend on the averaged dimension(s) instead of dropping them.
+        Dimensions removed from the data are retained as scalar coordinates with the
+        mean of their coordinate values. Numeric coordinates that depend on reduced
+        dimensions are averaged as well.
 
         Parameters
         ----------
@@ -723,6 +739,48 @@ class SelectionAccessor(ERLabDataArrayAccessor):
         DataArray
             The data averaged along the specified dimension(s).
         """
+        return self._reduce_dims(dim, "mean")
+
+    def average(self, dim: str | Sequence[Hashable] | None = None) -> xr.DataArray:
+        """Alias for :meth:`qsel.mean <xarray.DataArray.qsel.mean>`.
+
+        New code should use :meth:`qsel.mean <SelectionAccessor.mean>`.
+        """
+        return self.mean(dim)
+
+    def min(self, dim: str | Sequence[Hashable] | None = None) -> xr.DataArray:
+        """Return the minimum over dimensions while keeping their coordinates.
+
+        Data values are reduced with :meth:`xarray.DataArray.min`. Dimensions removed
+        from the data are retained as scalar coordinates with the mean of their
+        coordinate values. Numeric coordinates that depend on reduced dimensions are
+        averaged as well.
+        """
+        return self._reduce_dims(dim, "min")
+
+    def max(self, dim: str | Sequence[Hashable] | None = None) -> xr.DataArray:
+        """Return the maximum over dimensions while keeping their coordinates.
+
+        Data values are reduced with :meth:`xarray.DataArray.max`. Dimensions removed
+        from the data are retained as scalar coordinates with the mean of their
+        coordinate values. Numeric coordinates that depend on reduced dimensions are
+        averaged as well.
+        """
+        return self._reduce_dims(dim, "max")
+
+    def sum(self, dim: str | Sequence[Hashable] | None = None) -> xr.DataArray:
+        """Return the sum over dimensions while keeping their coordinates.
+
+        Data values are reduced with :meth:`xarray.DataArray.sum`. Dimensions removed
+        from the data are retained as scalar coordinates with the mean of their
+        coordinate values. Numeric coordinates that depend on reduced dimensions are
+        averaged as well.
+        """
+        return self._reduce_dims(dim, "sum")
+
+    def _reduce_dims(
+        self, dim: str | Sequence[Hashable] | None, func: QSelReducer
+    ) -> xr.DataArray:
         if dim is None:
             dim = list(self._obj.dims)
         if isinstance(dim, str):
@@ -733,7 +791,7 @@ class SelectionAccessor(ERLabDataArrayAccessor):
             qsel_kwargs[d] = 0.0
             qsel_kwargs[f"{d}_width"] = np.inf
 
-        return self._obj.sortby(list(dim)).qsel(qsel_kwargs)
+        return self._obj.sortby(list(dim)).qsel(qsel_kwargs, func=func)
 
     def around(
         self,
@@ -799,7 +857,7 @@ class SelectionAccessor(ERLabDataArrayAccessor):
             self._obj, radius, boundary=boundary, invert=invert, drop=drop, **sel_kw
         )
         if average:
-            return masked.qsel.average(sel_kw.keys())
+            return masked.qsel.mean(sel_kw.keys())
         return masked
 
 

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -686,7 +686,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                         "text": "Select Data…",
                         "triggered": self._select_data,
                     },
-                    "Average": {"triggered": self._average},
+                    "aggregateAct": {
+                        "text": "Aggregate…",
+                        "triggered": self._aggregate,
+                    },
                     "interpolateAct": {
                         "text": "Interpolate…",
                         "triggered": self._interpolate,
@@ -881,8 +884,12 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
         self.execute_dialog(erlab.interactive.imagetool.dialogs.CropDialog)
 
     @QtCore.Slot()
+    def _aggregate(self) -> None:
+        self.execute_dialog(erlab.interactive.imagetool.dialogs.AggregateDialog)
+
+    @QtCore.Slot()
     def _average(self) -> None:
-        self.execute_dialog(erlab.interactive.imagetool.dialogs.AverageDialog)
+        self._aggregate()
 
     @QtCore.Slot()
     def _interpolate(self) -> None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -686,10 +686,24 @@ class RotationDialog(DataTransformDialog):
         )
 
 
-class AverageDialog(DataTransformDialog):
-    title = "Average Over Dimensions"
-    suffix = "_avg"
+class AggregateDialog(DataTransformDialog):
+    title = "Aggregate Over Dimensions"
     enable_copy = True
+
+    _REDUCERS: typing.ClassVar[dict[str, tuple[str, str]]] = {
+        "mean": ("Mean", "_avg"),
+        "min": ("Minimum", "_min"),
+        "max": ("Maximum", "_max"),
+        "sum": ("Sum", "_sum"),
+    }
+
+    @property
+    def suffix(self) -> str:
+        return self._REDUCERS[self._reducer][1]
+
+    @suffix.setter
+    def suffix(self, value: str) -> None:
+        pass
 
     def setup_widgets(self) -> None:
         dim_group = QtWidgets.QGroupBox("Dimensions")
@@ -704,15 +718,28 @@ class AverageDialog(DataTransformDialog):
 
         self.layout_.addRow(dim_group)
 
+        self.reducer_combo = QtWidgets.QComboBox()
+        for reducer, (label, _) in self._REDUCERS.items():
+            self.reducer_combo.addItem(label, userData=reducer)
+        self.layout_.addRow("Reducer", self.reducer_combo)
+
     @property
     def _target_dims(self) -> tuple[Hashable, ...]:
         return tuple(k for k, v in self.dim_checks.items() if v.isChecked())
 
+    @property
+    def _reducer(self) -> typing.Literal["mean", "min", "max", "sum"]:
+        return typing.cast(
+            "typing.Literal['mean', 'min', 'max', 'sum']",
+            self.reducer_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
+        )
+
     def source_transform_operation(
         self,
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation:
-        return erlab.interactive.imagetool.provenance.AverageOperation(
-            dims=self._target_dims
+        return erlab.interactive.imagetool.provenance.QSelAggregationOperation(
+            dims=self._target_dims,
+            func=self._reducer,
         )
 
     @QtCore.Slot()
@@ -729,7 +756,8 @@ class AverageDialog(DataTransformDialog):
             QtWidgets.QMessageBox.warning(
                 self,
                 "Not Enough Dimensions Left",
-                "Data must have at least 1 dimension after averaging to be displayed.",
+                "Data must have at least 1 dimension after aggregation to be "
+                "displayed.",
             )
             return
 
@@ -742,7 +770,10 @@ class AverageDialog(DataTransformDialog):
             if len(self._target_dims) == 1 and isinstance(self._target_dims[0], str)
             else erlab.interactive.utils._parse_single_arg(self._target_dims)
         )
-        return f"{placeholder}.qsel.average({arg})"
+        return f"{placeholder}.qsel.{self._reducer}({arg})"
+
+
+AverageDialog = AggregateDialog
 
 
 class _SelectionRow:

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -1611,7 +1611,7 @@ class ItoolPlotItem(pg.PlotItem):
         Non-uniform non-display axes are selected with ``isel`` while uniform
         non-display axes are selected with ``qsel`` (including width terms for binned
         selections). Binned non-uniform non-display axes are averaged via
-        ``qsel.average`` after indexing.
+        ``qsel.mean`` after indexing.
 
         Returns
         -------
@@ -1655,7 +1655,7 @@ class ItoolPlotItem(pg.PlotItem):
                     tuple(avg_nonuniform_dims)
                 )
             )
-            selected += f".qsel.average({avg_arg})"
+            selected += f".qsel.mean({avg_arg})"
         return selected
 
     def _plot_code_multicursor(self, *, placeholder_name: str | None = None) -> str:

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -81,6 +81,7 @@ __all__ = [
     "InterpolationOperation",
     "IselOperation",
     "MaskWithPolygonOperation",
+    "QSelAggregationOperation",
     "QSelOperation",
     "RenameDimsCoordsOperation",
     "RenameOperation",
@@ -2057,23 +2058,45 @@ class RotateOperation(ToolProvenanceOperation):
         )
 
 
+def _format_qsel_dims_arg(dims: ProvenanceHashableTuple) -> str:
+    return (
+        erlab.interactive.utils._parse_single_arg(dims[0])
+        if len(dims) == 1 and isinstance(dims[0], str)
+        else erlab.interactive.utils._parse_single_arg(dims)
+    )
+
+
 class AverageOperation(ToolProvenanceOperation):
     op: typing.Literal["average"] = "average"
     dims: ProvenanceHashableTuple
 
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
-        return data.qsel.average(self.dims)
+        return data.qsel.mean(self.dims)
 
     def derivation_entry(self) -> DerivationEntry:
-        arg = (
-            erlab.interactive.utils._parse_single_arg(self.dims[0])
-            if len(self.dims) == 1 and isinstance(self.dims[0], str)
-            else erlab.interactive.utils._parse_single_arg(self.dims)
-        )
+        arg = _format_qsel_dims_arg(self.dims)
         label_kwargs = {"dims": self.dims}
         return DerivationEntry(
             f"Average({_format_derivation_value(label_kwargs)})",
-            f"derived = derived.qsel.average({arg})",
+            f"derived = derived.qsel.mean({arg})",
+            True,
+        )
+
+
+class QSelAggregationOperation(ToolProvenanceOperation):
+    op: typing.Literal["qsel_aggregate"] = "qsel_aggregate"
+    dims: ProvenanceHashableTuple
+    func: typing.Literal["mean", "min", "max", "sum"] = "mean"
+
+    def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
+        return typing.cast("xr.DataArray", getattr(data.qsel, self.func)(self.dims))
+
+    def derivation_entry(self) -> DerivationEntry:
+        arg = _format_qsel_dims_arg(self.dims)
+        label_kwargs = {"dims": self.dims, "func": self.func}
+        return DerivationEntry(
+            f"Aggregate({_format_derivation_value(label_kwargs)})",
+            f"derived = derived.qsel.{self.func}({arg})",
             True,
         )
 

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -1156,7 +1156,7 @@ class ArraySlicer(QtCore.QObject):
             for k, v in zip(self._obj.dims, self.get_binned(cursor), strict=True)
             if (v and (k in isel_kw))
         ]  # Select only relevant binned dimensions
-        sliced = self._obj.isel(isel_kw).qsel.average(binned_dims)
+        sliced = self._obj.isel(isel_kw).qsel.mean(binned_dims)
         if self._nonuniform_axes:
             return restore_nonuniform_dims(sliced)
         return sliced

--- a/tests/accessors/test_general.py
+++ b/tests/accessors/test_general.py
@@ -233,6 +233,74 @@ def test_qsel_associated_dim() -> None:
     xr.testing.assert_identical(dat.qsel(x=2, x_width=3), expected)
 
 
+def test_qsel_reducer_preserves_associated_coords() -> None:
+    dat = xr.DataArray(
+        np.arange(5 * 4 * 3).reshape(5, 4, 3).astype(float),
+        dims=("x", "y", "z"),
+        coords={
+            "x": np.arange(5),
+            "y": np.arange(4),
+            "z": np.arange(3),
+            "w": (["x", "y"], np.arange(5 * 4).reshape(5, 4)),
+        },
+    )
+
+    expected = xr.DataArray(
+        np.array(
+            [
+                [72.0, 75.0, 78.0],
+                [81.0, 84.0, 87.0],
+                [90.0, 93.0, 96.0],
+                [99.0, 102.0, 105.0],
+            ]
+        ),
+        dims=("y", "z"),
+        coords={
+            "y": np.arange(4),
+            "z": np.arange(3),
+            "x": 2.0,
+            "w": (["y"], np.array([8.0, 9.0, 10.0, 11.0])),
+        },
+    )
+
+    xr.testing.assert_identical(dat.qsel(x=2, x_width=3, func="sum"), expected)
+
+
+@pytest.mark.parametrize("func", ["min", "max", "sum"])
+def test_qsel_reducer_matches_descending_coordinates(func) -> None:
+    dat = xr.DataArray(
+        np.arange(25).reshape(5, 5),
+        dims=("x", "y"),
+        coords={"x": np.arange(5), "y": np.arange(5)},
+    )
+
+    result = dat.qsel(x=2.0, x_width=3.0, func=func)
+    result_rev = dat.sortby("x", ascending=False).qsel(x=2.0, x_width=3.0, func=func)
+
+    xr.testing.assert_identical(result, result_rev)
+
+
+def test_qsel_invalid_reducer() -> None:
+    dat = xr.DataArray(
+        np.arange(25).reshape(5, 5),
+        dims=("x", "y"),
+        coords={"x": np.arange(5), "y": np.arange(5)},
+    )
+
+    with pytest.raises(ValueError, match="func must be one of"):
+        dat.qsel(x=2.0, x_width=3.0, func="median")
+
+
+def test_qsel_func_dimension_uses_mapping_form() -> None:
+    dat = xr.DataArray(
+        np.arange(6).reshape(3, 2),
+        dims=("func", "y"),
+        coords={"func": np.arange(3, dtype=float), "y": np.arange(2)},
+    )
+
+    xr.testing.assert_identical(dat.qsel({"func": 1.0}), dat.sel(func=1.0))
+
+
 def test_qsel_value_outside_bounds() -> None:
     dat = xr.DataArray(
         np.arange(25).reshape(5, 5),
@@ -276,7 +344,7 @@ def test_qsel_around() -> None:
     )
 
 
-def test_qsel_average_single_dim() -> None:
+def test_qsel_mean_single_dim() -> None:
     # Create a simple 2D DataArray with dims 'x' and 'y'
 
     x = np.array([10, 20])
@@ -284,11 +352,11 @@ def test_qsel_average_single_dim() -> None:
     data = np.array([[1, 2, 3], [4, 5, 6]])
     da = xr.DataArray(data, dims=("x", "y"), coords={"x": x, "y": y})
 
-    # Average over the 'x' dimension using qsel.average.
+    # Average over the 'x' dimension using qsel.mean.
     # The expected result is the mean along 'x' and retaining the averaged coordinate.
     # Expected mean data: [[(1+4)/2, (2+5)/2, (3+6)/2]] = [[2.5, 3.5, 4.5]]
     expected = data.mean(axis=0)
-    result = da.qsel.average("x")
+    result = da.qsel.mean("x")
 
     # After averaging, 'x' should not be a dimension; it is stored as a coordinate.
     assert "x" not in result.dims
@@ -296,10 +364,54 @@ def test_qsel_average_single_dim() -> None:
     np.testing.assert_allclose(result.data, expected)
     # Check that the coordinate 'x' is the mean of the original x-values.
     np.testing.assert_allclose(result.coords["x"].data, x.mean())
+    xr.testing.assert_identical(da.qsel.average("x"), result)
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_values"),
+    [
+        ("min", np.array([1, 2, 3])),
+        ("max", np.array([4, 5, 6])),
+        ("sum", np.array([5, 7, 9])),
+    ],
+)
+def test_qsel_reducer_helpers_single_dim(method, expected_values) -> None:
+    x = np.array([10, 20])
+    y = np.array([30, 40, 50])
+    data = np.array([[1, 2, 3], [4, 5, 6]])
+    da = xr.DataArray(data, dims=("x", "y"), coords={"x": x, "y": y})
+
+    result = getattr(da.qsel, method)("x")
+
+    assert "x" not in result.dims
+    np.testing.assert_allclose(result.data, expected_values)
+    np.testing.assert_allclose(result.coords["x"].data, x.mean())
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_value"),
+    [
+        ("min", 1),
+        ("max", 8),
+        ("sum", 27),
+    ],
+)
+def test_qsel_reducer_helpers_all_dims(method, expected_value) -> None:
+    x = np.array([0, 10, 20])
+    y = np.array([100, 200])
+    data = np.array([[1, 2], [4, 5], [7, 8]])
+    da = xr.DataArray(data, dims=("x", "y"), coords={"x": x, "y": y})
+
+    result = getattr(da.qsel, method)()
+
+    assert not result.dims
+    np.testing.assert_allclose(result.data, expected_value)
+    np.testing.assert_allclose(result.coords["x"].data, x.mean())
+    np.testing.assert_allclose(result.coords["y"].data, y.mean())
 
 
 @pytest.mark.parametrize("avg_args", [(["x", "y"],), ()])
-def test_qsel_average_multiple_dim(avg_args) -> None:
+def test_qsel_mean_multiple_dim(avg_args) -> None:
     # Create a simple 2D DataArray with dims 'x' and 'y'
 
     x = np.array([0, 10, 20])
@@ -310,7 +422,7 @@ def test_qsel_average_multiple_dim(avg_args) -> None:
     # Average over both 'x' and 'y'
     # Expected result is a scalar value: mean of all data.
     expected = data.mean()
-    result = da.qsel.average(*avg_args)
+    result = da.qsel.mean(*avg_args)
 
     # The resulting DataArray should have no dimensions.
     assert not result.dims
@@ -321,7 +433,7 @@ def test_qsel_average_multiple_dim(avg_args) -> None:
     np.testing.assert_allclose(result.coords["y"].data, y.mean())
 
 
-def test_qsel_average_invalid_dim() -> None:
+def test_qsel_mean_invalid_dim() -> None:
     # Create a simple 1D DataArray
 
     x = np.array([0, 1, 2])
@@ -330,4 +442,4 @@ def test_qsel_average_invalid_dim() -> None:
 
     # Averaging over an invalid dimension should raise a ValueError
     with pytest.raises(KeyError, match="No variable named 'z'"):
-        _ = da.qsel.average("z")
+        _ = da.qsel.mean("z")

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -31,6 +31,7 @@ from erlab.interactive.imagetool.controls import (
     ItoolCrosshairControls,
 )
 from erlab.interactive.imagetool.dialogs import (
+    AggregateDialog,
     AssignAttrsDialog,
     AssignCoordsDialog,
     AverageDialog,
@@ -662,10 +663,10 @@ def test_plot_code_multicursor_image_supports_nonuniform_hidden_axis(
     assert "plot_slices" in code
     assert ".isel(alpha=" in code
     if bin_value == 1:
-        assert ".qsel.average(" not in code
+        assert ".qsel.mean(" not in code
     else:
-        assert ".qsel.average(" in code
-        assert '.qsel.average("alpha")' in code
+        assert ".qsel.mean(" in code
+        assert '.qsel.mean("alpha")' in code
 
     win.close()
 
@@ -728,7 +729,7 @@ def test_selection_expr_for_cursor_multiple_average_dims_with_quotes(qtbot) -> N
     win.array_slicer.set_bin(0, axis=2, value=3, update=True)
 
     expr = image_plot._selection_expr_for_cursor("data", 0, (0, 2))
-    assert ".qsel.average((" in expr
+    assert ".qsel.mean((" in expr
     assert "'a\"b'" in expr
     assert '"c"' in expr
 
@@ -787,10 +788,10 @@ def test_plot_code_multicursor_line_supports_nonuniform_hidden_axis(
     assert ".isel(alpha=" in code
     assert ".qsel(" in code
     if bin_value == 1:
-        assert ".qsel.average(" not in code
+        assert ".qsel.mean(" not in code
     else:
-        assert ".qsel.average(" in code
-        assert '.qsel.average("alpha")' in code
+        assert ".qsel.mean(" in code
+        assert '.qsel.mean("alpha")' in code
 
     win.close()
 
@@ -1614,7 +1615,12 @@ def test_itool_load(qtbot, monkeypatch, move_and_compare_values, accept_dialog) 
         assert win.provenance_spec is not None
         entries = win.provenance_spec.display_entries()
         assert entries[0].label == "Load data from file 'data.h5'"
-        assert any("Average" in entry.label for entry in entries)
+        assert win.provenance_spec.replay_stages is not None
+        assert any(
+            op.op == "qsel_aggregate"
+            for stage in win.provenance_spec.replay_stages
+            for op in stage.operations
+        )
 
         display_code = win.provenance_spec.display_code()
         assert display_code is not None
@@ -1624,7 +1630,7 @@ def test_itool_load(qtbot, monkeypatch, move_and_compare_values, accept_dialog) 
         assert isinstance(derived, xr.DataArray)
         xarray.testing.assert_identical(
             derived.rename(None),
-            data.astype(np.float64).qsel.average("x").rename(None),
+            data.astype(np.float64).qsel.mean("x").rename(None),
         )
 
         assert win.slicer_area._file_path is None
@@ -1647,7 +1653,7 @@ def test_itool_load(qtbot, monkeypatch, move_and_compare_values, accept_dialog) 
         assert win.slicer_area._file_path is None
         xarray.testing.assert_identical(
             win.slicer_area._data.rename(None),
-            updated.astype(np.float64).qsel.average("x").rename(None),
+            updated.astype(np.float64).qsel.mean("x").rename(None),
         )
 
     win.close()
@@ -4679,12 +4685,12 @@ def test_itool_average(qtbot, accept_dialog) -> None:
 
     accept_dialog(win.mnb._average, pre_call=_set_dialog_params)
     xarray.testing.assert_identical(
-        win.slicer_area._data.rename(None), data.qsel.average("x")
+        win.slicer_area._data.rename(None), data.qsel.mean("x")
     )
 
     xarray.testing.assert_identical(
         _exec_data_fragment(data, pyperclip.paste()),
-        data.qsel.average("x"),
+        data.qsel.mean("x"),
     )
     assert win.provenance_spec is not None
     display_code = win.provenance_spec.display_code()
@@ -4695,7 +4701,60 @@ def test_itool_average(qtbot, accept_dialog) -> None:
     )
     derived = display_namespace["derived"]
     assert isinstance(derived, xr.DataArray)
-    xarray.testing.assert_identical(derived, data.qsel.average("x"))
+    xarray.testing.assert_identical(derived, data.qsel.mean("x"))
+    win.close()
+
+
+def test_itool_aggregate_sum(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(60).reshape((3, 4, 5)).astype(float),
+        dims=["x", "y", "z"],
+        coords={
+            "x": np.arange(3),
+            "y": np.arange(4),
+            "z": np.arange(5),
+            "t": ("x", np.arange(3)),
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: AggregateDialog) -> None:
+        dialog.dim_checks["x"].setChecked(True)
+        _set_combo_data(dialog.reducer_combo, "sum")
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._aggregate, pre_call=_set_dialog_params)
+
+    expected = data.qsel.sum("x")
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), expected)
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, pyperclip.paste()), expected
+    )
+
+    assert win.provenance_spec is not None
+    assert [op.op for op in win.provenance_spec.operations] == [
+        "qsel_aggregate",
+        "rename",
+    ]
+    aggregate_op = win.provenance_spec.operations[0]
+    assert isinstance(
+        aggregate_op, erlab.interactive.imagetool.provenance.QSelAggregationOperation
+    )
+    assert aggregate_op.func == "sum"
+
+    display_code = win.provenance_spec.display_code()
+    assert display_code is not None
+    display_namespace = _exec_generated_code(
+        display_code,
+        {"data": data.copy(deep=True)},
+    )
+    derived = display_namespace["derived"]
+    assert isinstance(derived, xr.DataArray)
+    xarray.testing.assert_identical(derived, expected)
+
     win.close()
 
 
@@ -4722,7 +4781,7 @@ def test_average_source_spec_restores_nonuniform_dims_after_refresh(qtbot) -> No
 
     assert spec.kind == "full_data"
     assert [op.op for op in spec.operations] == [
-        "average",
+        "qsel_aggregate",
         "restore_nonuniform_dims",
         "rename",
     ]
@@ -4737,6 +4796,51 @@ def test_average_source_spec_restores_nonuniform_dims_after_refresh(qtbot) -> No
         {"data": win.slicer_area.data.copy(deep=True)},
     )
     derived = display_namespace["derived"]
+    assert isinstance(derived, xr.DataArray)
+    xarray.testing.assert_identical(derived.rename(None), expected.rename(None))
+
+    dialog.close()
+    win.close()
+
+
+def test_aggregate_source_spec_restores_nonuniform_dims_after_refresh(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(20).reshape((5, 4)).astype(float),
+        dims=["x", "y"],
+        coords={"x": [0.0, 0.2, 0.8, 1.4, 2.0], "y": np.arange(4)},
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    assert win.slicer_area.data.dims == ("x_idx", "y")
+    dialog = AggregateDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    dialog.dim_checks["y"].setChecked(True)
+    _set_combo_data(dialog.reducer_combo, "sum")
+
+    spec = dialog.source_spec("scan_sum")
+    expected = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+        dialog.process_data(win.slicer_area.data)
+    ).rename("scan_sum")
+    refreshed = spec.apply(win.slicer_area.data)
+
+    assert spec.kind == "full_data"
+    assert [op.op for op in spec.operations] == [
+        "qsel_aggregate",
+        "restore_nonuniform_dims",
+        "rename",
+    ]
+    assert refreshed.dims == ("x",)
+    xarray.testing.assert_identical(refreshed, expected)
+
+    display_code = spec.display_code(parent_data=win.slicer_area.data)
+    assert display_code is not None
+    namespace = _exec_generated_code(
+        display_code,
+        {"data": win.slicer_area.data.copy(deep=True)},
+    )
+    derived = namespace["derived"]
     assert isinstance(derived, xr.DataArray)
     xarray.testing.assert_identical(derived.rename(None), expected.rename(None))
 
@@ -4764,7 +4868,7 @@ def test_itool_average_marks_incompatible_child_tools_unavailable(
         accept_dialog(win.mnb._average, pre_call=_set_dialog_params)
 
     xarray.testing.assert_identical(
-        win.slicer_area._data.rename(None), data.qsel.average("alpha")
+        win.slicer_area._data.rename(None), data.qsel.mean("alpha")
     )
     qtbot.wait_until(lambda: child.source_state == "unavailable", timeout=5000)
 
@@ -4786,7 +4890,7 @@ def test_average_dialog_make_code_preserves_nonstring_dim(qtbot) -> None:
 
     xarray.testing.assert_identical(
         _exec_data_fragment(data, dialog.make_code()),
-        data.qsel.average("k-space"),
+        data.qsel.mean("k-space"),
     )
 
     dialog.close()
@@ -5196,14 +5300,14 @@ def test_transform_replace_composes_after_script_active_name(qtbot) -> None:
 
     assert win.provenance_spec is not None
     code = win.provenance_spec.derivation_code()
-    assert code == (
-        'result = data + 1\nderived = result\nderived = derived.qsel.average("x")'
+    assert (
+        code == 'result = data + 1\nderived = result\nderived = derived.qsel.mean("x")'
     )
     namespace = _exec_generated_code(code, {"data": source.copy(deep=True)})
     derived = namespace["derived"]
     assert isinstance(derived, xr.DataArray)
     xarray.testing.assert_identical(
-        derived.rename(None), displayed.qsel.average("x").rename(None)
+        derived.rename(None), displayed.qsel.mean("x").rename(None)
     )
 
     dialog.close()
@@ -5235,7 +5339,7 @@ def test_average_dialog_launch_modes_for_standalone(qtbot, monkeypatch) -> None:
     )
     dialog.dim_checks["x"].setChecked(True)
     dialog.accept()
-    xarray.testing.assert_identical(launched[0].rename(None), data.qsel.average("x"))
+    xarray.testing.assert_identical(launched[0].rename(None), data.qsel.mean("x"))
 
     dialog_replace = AverageDialog(win.slicer_area)
     qtbot.addWidget(dialog_replace)
@@ -5243,7 +5347,7 @@ def test_average_dialog_launch_modes_for_standalone(qtbot, monkeypatch) -> None:
     dialog_replace.launch_mode_combo.setCurrentText("Replace Current")
     dialog_replace.accept()
     xarray.testing.assert_identical(
-        win.slicer_area._data.rename(None), data.qsel.average("y")
+        win.slicer_area._data.rename(None), data.qsel.mean("y")
     )
 
     win.close()

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -5110,7 +5110,7 @@ def test_manager_promote_child_imagetool_rehomes_subtree_and_detaches_provenance
 
         manager._update_info()
         derivation = metadata_derivation_texts(manager)
-        assert any("Average" in line for line in derivation)
+        assert any("Aggregate" in line for line in derivation)
 
         updated = data.copy(deep=True)
         updated.data = np.asarray(updated.data) + 10
@@ -5155,11 +5155,11 @@ def test_manager_replace_current_sets_provenance_on_provenance_free_root(
         assert root.source_spec is None
         assert root.provenance_spec is not None
         assert root.provenance_spec.derivation_code() == (
-            'derived = data\nderived = derived.qsel.average("x")'
+            'derived = data\nderived = derived.qsel.mean("x")'
         )
         xr.testing.assert_identical(
             root_tool.slicer_area._data.rename(None),
-            data.qsel.average("x").rename(None),
+            data.qsel.mean("x").rename(None),
         )
 
         manager.tree_view.clearSelection()
@@ -5168,8 +5168,63 @@ def test_manager_replace_current_sets_provenance_on_provenance_free_root(
         derivation = metadata_derivation_texts(manager)
         assert derivation == [
             "Start from current parent ImageTool data",
-            'Average(dims=("x",))',
+            'Aggregate(dims=("x",), func="mean")',
         ]
+
+
+def test_manager_aggregate_child_refreshes_from_parent(
+    qtbot,
+    accept_dialog,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(60).reshape((3, 4, 5)).astype(float),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(3), "y": np.arange(4), "z": np.arange(5)},
+        name="scan",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+
+        def _nest_sum(dialog) -> None:
+            dialog.dim_checks["x"].setChecked(True)
+            dialog.reducer_combo.setCurrentText("Sum")
+            set_transform_launch_mode(dialog, "nest")
+
+        accept_dialog(parent_tool.mnb._aggregate, pre_call=_nest_sum)
+
+        parent = manager._imagetool_wrappers[0]
+        qtbot.wait_until(lambda: len(parent._childtool_indices) == 1, timeout=5000)
+        child_uid = parent._childtool_indices[0]
+        child_node = manager._child_node(child_uid)
+
+        assert child_node.source_spec is not None
+        assert [op.op for op in child_node.source_spec.operations] == [
+            "qsel_aggregate",
+            "rename",
+        ]
+        xr.testing.assert_identical(
+            fetch(child_uid).rename(None), data.qsel.sum("x").rename(None)
+        )
+
+        updated = data + 10
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+
+        qtbot.wait_until(lambda: child_node.source_state == "stale", timeout=5000)
+        assert child_node._update_from_parent_source() is True
+        xr.testing.assert_identical(
+            fetch(child_uid).rename(None), updated.qsel.sum("x").rename(None)
+        )
 
 
 def test_manager_file_backed_replace_current_keeps_file_provenance(
@@ -5215,12 +5270,12 @@ def test_manager_file_backed_replace_current_keeps_file_provenance(
         assert len(root.provenance_spec.replay_stages) == 1
         assert root.provenance_spec.replay_stages[0].source_kind == "full_data"
         assert [op.op for op in root.provenance_spec.replay_stages[0].operations] == [
-            "average",
+            "qsel_aggregate",
             "rename",
         ]
         entries = root.provenance_spec.display_entries()
         assert entries[0].label == "Load data from file 'scan.h5'"
-        assert any("Average" in entry.label for entry in entries)
+        assert any("Aggregate" in entry.label for entry in entries)
 
         manager.tree_view.clearSelection()
         select_tools(manager, [0])
@@ -5251,7 +5306,7 @@ def test_manager_file_backed_replace_current_keeps_file_provenance(
             derived.rename(None),
             xr.load_dataarray(file_path, engine="h5netcdf")
             .astype(np.float64)
-            .qsel.average("alpha")
+            .qsel.mean("alpha")
             .rename(None),
         )
 
@@ -5301,7 +5356,7 @@ def test_manager_detached_file_provenance_metadata_and_reload_roundtrip(
         assert [
             operation["op"]
             for operation in provenance_payload["replay_stages"][0]["operations"]
-        ] == ["average", "rename"]
+        ] == ["qsel_aggregate", "rename"]
         assert (
             provenance_payload["file_load_source"]["replay_call"]["target"]
             == "xarray.load_dataarray"
@@ -5344,7 +5399,7 @@ def test_manager_detached_file_provenance_metadata_and_reload_roundtrip(
         assert detached_tool.slicer_area._file_path is None
         xr.testing.assert_identical(
             fetch(1).rename(None),
-            updated.astype(np.float64).qsel.average("alpha").rename(None),
+            updated.astype(np.float64).qsel.mean("alpha").rename(None),
         )
 
         file_path.unlink()
@@ -5623,7 +5678,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         child_tool = manager.get_imagetool(child_uid)
         xr.testing.assert_identical(
             child_tool.slicer_area._data.rename(None),
-            data.qsel.average("x").rename(None),
+            data.qsel.mean("x").rename(None),
         )
 
         manager.tree_view.clearSelection()
@@ -5633,7 +5688,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert details["Kind"] == "ImageTool"
         assert "Added" in details
         derivation = metadata_derivation_texts(manager)
-        assert any("Average" in line for line in derivation)
+        assert any("Aggregate" in line for line in derivation)
         assert all("rename(" not in line for line in derivation)
 
         copied: list[str] = []
@@ -5655,12 +5710,12 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
                 "erlab.interactive.imagetool.provenance.ToolProvenanceSpec",
                 child_node.source_spec,
             ).operations
-            if op.op == "average"
+            if op.op == "qsel_aggregate"
         ]
-        assert [op.op for op in transforms] == ["average", "average"]
+        assert [op.op for op in transforms] == ["qsel_aggregate", "qsel_aggregate"]
         xr.testing.assert_identical(
             child_tool.slicer_area._data.rename(None),
-            data.qsel.average("x").qsel.average("y").rename(None),
+            data.qsel.mean("x").qsel.mean("y").rename(None),
         )
 
         manager.tree_view.clearSelection()
@@ -5669,9 +5724,9 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         derivation = metadata_derivation_texts(manager)
         assert derivation[0] == "Start from current parent ImageTool data"
         assert len(derivation) == 3
-        assert "Average" in derivation[1]
+        assert "Aggregate" in derivation[1]
         assert "dims=" in derivation[1]
-        assert "Average" in derivation[2]
+        assert "Aggregate" in derivation[2]
         assert "dims=" in derivation[2]
         manager.metadata_derivation_list.setFocus()
         select_metadata_rows(manager, [0])
@@ -5696,7 +5751,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert isinstance(selected_result, xr.DataArray)
         xr.testing.assert_identical(
             selected_result.rename(None),
-            data.qsel.average("x").qsel.average("y").rename(None),
+            data.qsel.mean("x").qsel.mean("y").rename(None),
         )
 
         menu = manager._build_metadata_derivation_menu()
@@ -5710,7 +5765,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert isinstance(selected_result, xr.DataArray)
         xr.testing.assert_identical(
             selected_result.rename(None),
-            data.qsel.average("x").qsel.average("y").rename(None),
+            data.qsel.mean("x").qsel.mean("y").rename(None),
         )
 
         monkeypatch.setattr(
@@ -5730,7 +5785,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert isinstance(full_result, xr.DataArray)
         xr.testing.assert_identical(
             full_result.rename(None),
-            data.qsel.average("x").qsel.average("y").rename(None),
+            data.qsel.mean("x").qsel.mean("y").rename(None),
         )
         assert ".rename(" not in copied[-1]
 
@@ -5754,7 +5809,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert child_node._update_from_parent_source() is True
         xr.testing.assert_identical(
             child_tool.slicer_area._data.rename(None),
-            updated.qsel.average("x").qsel.average("y").rename(None),
+            updated.qsel.mean("x").qsel.mean("y").rename(None),
         )
 
         def _detach_average(dialog) -> None:
@@ -5778,18 +5833,23 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert detached.source_spec is None
         assert detached.provenance_spec is not None
         detached_transforms = [
-            op for op in detached.provenance_spec.operations if op.op == "average"
+            op
+            for op in detached.provenance_spec.operations
+            if op.op == "qsel_aggregate"
         ]
-        assert [op.op for op in detached_transforms] == ["average", "average"]
+        assert [op.op for op in detached_transforms] == [
+            "qsel_aggregate",
+            "qsel_aggregate",
+        ]
         assert detached.provenance_spec.derivation_code() == (
             "derived = data\n"
-            'derived = derived.qsel.average("x")\n'
-            'derived = derived.qsel.average("y")'
+            'derived = derived.qsel.mean("x")\n'
+            'derived = derived.qsel.mean("y")'
         )
         assert detached.provenance_spec.derivation_code() != detached_derivation_before
         xr.testing.assert_identical(
             detached_tool.slicer_area._data.rename(None),
-            updated.qsel.average("x").qsel.average("y").rename(None),
+            updated.qsel.mean("x").qsel.mean("y").rename(None),
         )
         detached_before = detached_tool.slicer_area._data.copy(deep=True)
 
@@ -5799,8 +5859,8 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         detached_derivation = metadata_derivation_texts(manager)
         assert detached_derivation[0] == "Start from current parent ImageTool data"
         assert len(detached_derivation) == 3
-        assert "Average" in detached_derivation[1]
-        assert "Average" in detached_derivation[2]
+        assert "Aggregate" in detached_derivation[1]
+        assert "Aggregate" in detached_derivation[2]
 
         duplicated_detached_index = typing.cast("int", manager.duplicate_imagetool(1))
         duplicated_detached = manager._imagetool_wrappers[duplicated_detached_index]
@@ -6477,9 +6537,7 @@ def test_manager_non_watched_full_code_prompts_for_source_variable(
         namespace = _exec_generated_code(
             copied[-1], {"source_data": test_data.copy(deep=True)}
         )
-        xr.testing.assert_identical(
-            namespace["derived"], test_data.qsel.average("alpha")
-        )
+        xr.testing.assert_identical(namespace["derived"], test_data.qsel.mean("alpha"))
 
 
 def test_manager_non_watched_full_code_prompt_cancel_does_not_copy(
@@ -6575,9 +6633,7 @@ def test_manager_file_backed_full_code_uses_load_code(
             copied[-1]
         )
         namespace = _exec_generated_code(copied[-1], {})
-        xr.testing.assert_identical(
-            namespace["derived"], test_data.qsel.average("alpha")
-        )
+        xr.testing.assert_identical(namespace["derived"], test_data.qsel.mean("alpha"))
 
 
 def test_manager_file_backed_full_code_prefers_scan_number_loader(
@@ -6632,7 +6688,7 @@ def test_manager_file_backed_full_code_prefers_scan_number_loader(
         assert copied
         assert f"erlab.io.load(2, data_dir={str(example_data_dir)!r})" in copied[-1]
         namespace = _exec_generated_code(copied[-1], {})
-        xr.testing.assert_identical(namespace["derived"], data.qsel.average("alpha"))
+        xr.testing.assert_identical(namespace["derived"], data.qsel.mean("alpha"))
 
 
 def test_manager_watched_root_child_tool_copy_code_uses_variable_name(
@@ -13579,7 +13635,7 @@ def test_manager_workspace_roundtrip_recursive_nested_imagetools(
         assert loaded_child._update_from_parent_source() is True
         xr.testing.assert_identical(
             manager.get_imagetool(child_uid).slicer_area._data.rename(None),
-            updated.qsel.average("x").rename(None),
+            updated.qsel.mean("x").rename(None),
         )
 
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -181,9 +181,7 @@ def test_tool_provenance_parse_final_payload_and_migrate_legacy_schema() -> None
         "Start from current parent ImageTool data",
         'Average(dims=("x",))',
     ]
-    assert (
-        spec.derivation_code() == 'derived = data\nderived = derived.qsel.average("x")'
-    )
+    assert spec.derivation_code() == 'derived = data\nderived = derived.qsel.mean("x")'
 
     dumped = spec.model_dump(mode="json")
     assert dumped["schema_version"] == 2
@@ -320,7 +318,16 @@ def test_tool_provenance_apply_selection_and_xarray_operations() -> None:
         erlab.interactive.imagetool.provenance.full_data(
             erlab.interactive.imagetool.provenance.AverageOperation(dims=("y",))
         ).apply(data),
-        data.qsel.average("y"),
+        data.qsel.mean("y"),
+    )
+    xr.testing.assert_identical(
+        erlab.interactive.imagetool.provenance.full_data(
+            erlab.interactive.imagetool.provenance.QSelAggregationOperation(
+                dims=("y",),
+                func="sum",
+            )
+        ).apply(data),
+        data.qsel.sum("y"),
     )
     xr.testing.assert_identical(
         erlab.interactive.imagetool.provenance.full_data(
@@ -743,7 +750,7 @@ def test_tool_provenance_public_data_replays_on_restored_nonuniform_dims() -> No
     assert reparsed_restored is not None
     xr.testing.assert_identical(
         reparsed_restored.apply(uniform),
-        public.qsel.average("y"),
+        public.qsel.mean("y"),
     )
     restored_code = reparsed_restored.display_code(parent_data=uniform)
     assert restored_code is not None
@@ -785,17 +792,44 @@ def test_tool_provenance_preserves_hashable_dims_and_mapping_keys() -> None:
     average_spec = prov.full_data(prov.AverageOperation(dims=("k-space",)))
     assert (
         average_spec.derivation_code()
-        == 'derived = data\nderived = derived.qsel.average("k-space")'
+        == 'derived = data\nderived = derived.qsel.mean("k-space")'
     )
     xr.testing.assert_identical(
-        average_spec.apply(string_key_data), string_key_data.qsel.average("k-space")
+        average_spec.apply(string_key_data), string_key_data.qsel.mean("k-space")
     )
 
     tuple_average_spec = prov.full_data(prov.AverageOperation(dims=(("beta", 0),)))
     assert (
         tuple_average_spec.derivation_code()
-        == 'derived = data\nderived = derived.qsel.average((("beta", 0),))'
+        == 'derived = data\nderived = derived.qsel.mean((("beta", 0),))'
     )
+
+    aggregate_spec = prov.full_data(
+        prov.QSelAggregationOperation(dims=("k-space",), func="sum")
+    )
+    assert (
+        aggregate_spec.derivation_code()
+        == 'derived = data\nderived = derived.qsel.sum("k-space")'
+    )
+    xr.testing.assert_identical(
+        aggregate_spec.apply(string_key_data), string_key_data.qsel.sum("k-space")
+    )
+
+    mean_aggregate_spec = prov.full_data(
+        prov.QSelAggregationOperation(dims=(("beta", 0),), func="mean")
+    )
+    assert mean_aggregate_spec.derivation_code() == (
+        'derived = data\nderived = derived.qsel.mean((("beta", 0),))'
+    )
+
+    dumped = aggregate_spec.model_dump(mode="json")
+    assert dumped["operations"][0] == {
+        "op": "qsel_aggregate",
+        "dims": {prov._TUPLE_MARKER: ["k-space"]},
+        "func": "sum",
+    }
+    reparsed = prov.parse_tool_provenance_spec(dumped)
+    assert reparsed.operations[0] == aggregate_spec.operations[0]
 
     coarsen_spec = prov.full_data(
         prov.CoarsenOperation(
@@ -1481,12 +1515,12 @@ def test_tool_provenance_compose_full_uses_parent_active_name_for_live_local() -
     assert composed is not None
     code = composed.derivation_code()
     assert code == (
-        'result = data + 1\nderived = result\nderived = derived.qsel.average("x")'
+        'result = data + 1\nderived = result\nderived = derived.qsel.mean("x")'
     )
     namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
     derived = namespace["derived"]
     assert isinstance(derived, xr.DataArray)
-    xr.testing.assert_identical(derived, (data + 1).qsel.average("x"))
+    xr.testing.assert_identical(derived, (data + 1).qsel.mean("x"))
 
 
 def test_file_load_source_replay_call_round_trips() -> None:


### PR DESCRIPTION
## Summary

- Add `qsel.mean`, `qsel.min`, `qsel.max`, and `qsel.sum` coordinate-preserving aggregation helpers.
- Keep `qsel.average` as an alias for `qsel.mean`, while generated code now uses the canonical `.qsel.mean(...)` form.
- Add ImageTool aggregate support for mean/min/max/sum with qsel aggregation provenance, while preserving legacy `AverageOperation` payload parsing.
- Update qsel and ImageTool docs without adding versionchanged notes.

## Validation

- `uv run pytest tests/accessors/test_general.py -k qsel`
- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_provenance.py`
- Targeted ImageTool dialog and manager aggregation tests
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`