### PR TITLE
fix(interactive): preserve exact float entries in coordinate controls

### DIFF
--- a/src/erlab/interactive/imagetool/_dialog_widgets.py
+++ b/src/erlab/interactive/imagetool/_dialog_widgets.py
@@ -79,11 +79,15 @@ class CoordinateGridWidget(QtWidgets.QWidget):
     def init_ui(self, *, connect_reset_button: bool) -> None:
         layout = QtWidgets.QFormLayout(self)
 
-        self.spin0 = erlab.interactive.utils.BetterSpinBox(compact=False, trim="0")
+        self.spin0 = erlab.interactive.utils.BetterSpinBox(
+            compact=False, exact_float=True, trim="0"
+        )
         self.spin0.valueChanged.connect(self.update_table)
         layout.addRow("Start", self.spin0)
 
-        self.spin1 = erlab.interactive.utils.BetterSpinBox(compact=False, trim="0")
+        self.spin1 = erlab.interactive.utils.BetterSpinBox(
+            compact=False, exact_float=True, trim="0"
+        )
         self.spin1.valueChanged.connect(self.update_table)
 
         self.mode_combo = QtWidgets.QComboBox()
@@ -307,13 +311,13 @@ class CoordinateEditorWidget(QtWidgets.QWidget):
         affine_layout = QtWidgets.QFormLayout(affine_widget)
 
         self.scale_spin = erlab.interactive.utils.BetterSpinBox(
-            compact=False, trim="0", value=1.0
+            compact=False, exact_float=True, trim="0", value=1.0
         )
         self.scale_spin.valueChanged.connect(self.update_affine_preview)
         affine_layout.addRow("Scale", self.scale_spin)
 
         self.offset_spin = erlab.interactive.utils.BetterSpinBox(
-            compact=False, trim="0"
+            compact=False, exact_float=True, trim="0"
         )
         self.offset_spin.valueChanged.connect(self.update_affine_preview)
         affine_layout.addRow("Offset", self.offset_spin)

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -816,6 +816,7 @@ class _SelectionRow:
         self.value_start_spin = erlab.interactive.utils.BetterSpinBox(
             compact=False,
             decimals=6,
+            exact_float=True,
             significant=True,
             minimum=float(np.nanmin(coord)),
             maximum=float(np.nanmax(coord)),
@@ -824,6 +825,7 @@ class _SelectionRow:
         self.value_stop_spin = erlab.interactive.utils.BetterSpinBox(
             compact=False,
             decimals=6,
+            exact_float=True,
             significant=True,
             minimum=float(np.nanmin(coord)),
             maximum=float(np.nanmax(coord)),
@@ -852,6 +854,7 @@ class _SelectionRow:
         self.width_spin = erlab.interactive.utils.BetterSpinBox(
             compact=False,
             decimals=6,
+            exact_float=True,
             significant=True,
             minimum=0.0,
             value=0.0 if bin_value is None else float(bin_value),
@@ -2283,8 +2286,12 @@ class GaussianFilterDialog(DataFilterDialog):
 
         for row, dim in enumerate(self._source_data.dims, start=1):
             check = QtWidgets.QCheckBox(str(dim))
-            sigma_spin = erlab.interactive.utils.BetterSpinBox(compact=False)
-            fwhm_spin = erlab.interactive.utils.BetterSpinBox(compact=False)
+            sigma_spin = erlab.interactive.utils.BetterSpinBox(
+                compact=False, exact_float=True
+            )
+            fwhm_spin = erlab.interactive.utils.BetterSpinBox(
+                compact=False, exact_float=True
+            )
 
             sigma_spin.setMinimum(0.0)
             fwhm_spin.setMinimum(0.0)
@@ -2385,6 +2392,18 @@ class GaussianFilterDialog(DataFilterDialog):
     def _spin_value(self, spin: erlab.interactive.utils.BetterSpinBox) -> float:
         return float(self._spin_literal(spin))
 
+    def _set_synced_exact_value(
+        self, spin: erlab.interactive.utils.BetterSpinBox, value: float
+    ) -> None:
+        with QtCore.QSignalBlocker(spin):
+            spin.setValue(value)
+            line = spin.lineEdit()
+            if line is None:
+                return
+            line.setText(str(float(value)))
+            spin.editingFinishedEvent()
+            line.setModified(False)
+
     def _commit_numeric_inputs(self) -> None:
         for spin in (*self.sigma_spins.values(), *self.fwhm_spins.values()):
             line = spin.lineEdit()
@@ -2402,8 +2421,7 @@ class GaussianFilterDialog(DataFilterDialog):
     @QtCore.Slot()
     def _sync_from_fwhm(self, dim: Hashable) -> None:
         value = self._spin_value(self.fwhm_spins[dim]) / _GAUSSIAN_FWHM_FACTOR
-        with QtCore.QSignalBlocker(self.sigma_spins[dim]):
-            self.sigma_spins[dim].setValue(value)
+        self._set_synced_exact_value(self.sigma_spins[dim], value)
 
     def _sigma_values(self) -> tuple[dict[Hashable, float], dict[Hashable, str]]:
         self._commit_numeric_inputs()

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -1510,6 +1510,11 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
         When `integer` or `scientific` is `True`, this argument is ignored.
     scientific
         Whether to print in scientific notation.
+    exact_float
+        If `True`, floating-point text entered by the user is kept as the accepted
+        display text and parsed directly with :class:`float` instead of being
+        reformatted to ``decimals`` on commit. Programmatic value changes still use
+        the normal formatting rules.
     value
         Initial value of the spinbox.
 
@@ -1528,6 +1533,7 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
         decimals: int = 3,
         significant: bool = False,
         scientific: bool = False,
+        exact_float: bool = False,
         value: float = 0.0,
         prefix: str = "",
         trim: typing.Literal["k", ".", "0", "-"] = "k",
@@ -1537,11 +1543,13 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
         self._is_compact = compact
         self._is_discrete = discrete
         self._is_scientific = scientific
+        self._exact_float = exact_float
         self._decimal_significant = significant
         self._decimals = decimals
 
         self._value = value
         self._lastvalue: float | None = None
+        self._exact_text: str | None = None
         self._min = -np.inf
         self._max = np.inf
         self._step = 1 if self._only_int else 0.01
@@ -1640,6 +1648,8 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
         return self._value
 
     def text(self) -> str:
+        if self._exact_float and self._exact_text is not None:
+            return self._exact_text
         return self.textFromValue(self.value())
 
     def textFromValue(self, value) -> str:
@@ -1718,6 +1728,7 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
             val = round(val)
 
         self._lastvalue, self._value = self._value, val
+        self._exact_text = None
 
         self.valueChanged.emit(self.value())
         line = self.lineEdit()
@@ -1727,6 +1738,8 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
 
     def fixup(self, _):
         # Called when the spinbox loses focus with an invalid or intermediate string
+        if self._exact_float:
+            return self.textFromValue(self.value())
         return self.textFromValue(self._lastvalue)
 
     def validate(self, strn, pos):
@@ -1749,7 +1762,27 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
     def editingFinishedEvent(self) -> None:
         line = self.lineEdit()
         if line is not None:
-            self.setValue(self.valueFromText(line.text()))
+            text = line.text()
+            try:
+                value = self.valueFromText(text)
+            except ValueError:
+                if self._exact_float:
+                    self.setValue(self.value())
+                    return
+                raise
+            if (
+                self._exact_float
+                and not self._only_int
+                and value >= self.minimum()
+                and value <= self.maximum()
+            ):
+                self._lastvalue, self._value = self._value, value
+                self._exact_text = text
+                self.valueChanged.emit(self.value())
+                line.setText(text)
+                self.textChanged.emit(self.text())
+            else:
+                self.setValue(value)
 
     def keyPressEvent(self, evt) -> None:
         line = self.lineEdit()

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5035,6 +5035,39 @@ def test_selection_dialog_qsel_width_executes_code(qtbot) -> None:
     win.close()
 
 
+def test_selection_dialog_qsel_exact_value_and_width(qtbot) -> None:
+    data = _selection_4d_data()
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = SelectionDialog(win.slicer_area)
+    _clear_selection_dialog(dialog)
+
+    value_literal = "2.000000000000001"
+    width_literal = "2.000000000000001"
+    row = dialog.rows[2]
+    row.use_check.setChecked(True)
+    _set_combo_data(row.method_combo, "qsel")
+    _set_combo_data(row.kind_combo, "point")
+    _set_spinbox_text(row.value_start_spin, value_literal)
+    row.width_check.setChecked(True)
+    _set_spinbox_text(row.width_spin, width_literal)
+
+    assert row.value_start_spin.text() == value_literal
+    assert row.width_spin.text() == width_literal
+    _, _, qsel_kwargs = dialog._selection_kwargs()
+    assert qsel_kwargs["beta"] == float(value_literal)
+    assert qsel_kwargs["beta_width"] == float(width_literal)
+
+    expected = data.qsel(beta=float(value_literal), beta_width=float(width_literal))
+    xarray.testing.assert_identical(dialog.process_data(dialog.public_data), expected)
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+
+    dialog.close()
+    win.close()
+
+
 def test_selection_dialog_uses_public_nonuniform_dimensions(qtbot) -> None:
     data = xr.DataArray(
         np.arange(3 * 4 * 5).reshape((3, 4, 5)).astype(float),
@@ -5314,6 +5347,40 @@ def test_itool_interpolate_nearest(qtbot, accept_dialog) -> None:
     xarray.testing.assert_identical(
         win.slicer_area._data.rename(None),
         data.interp({"x": target}, method="nearest").rename(None),
+    )
+
+    win.close()
+
+
+def test_itool_interpolate_exact_generated_coordinates(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(6).reshape((3, 2)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(3, dtype=float), "y": [10.0, 20.0]},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    start_literal = "0.123456789012345"
+    step_literal = "0.123456789012345"
+    target = np.linspace(
+        float(start_literal),
+        float(start_literal) + 2 * float(step_literal),
+        3,
+    )
+
+    def _set_dialog_params(dialog: InterpolationDialog) -> None:
+        dialog.coord_widget.mode_combo.setCurrentText("Delta")
+        _set_spinbox_text(dialog.coord_widget.spin0, start_literal)
+        _set_spinbox_text(dialog.coord_widget.spin1, step_literal)
+        assert dialog.coord_widget.spin0.text() == start_literal
+        assert dialog.coord_widget.spin1.text() == step_literal
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._interpolate, pre_call=_set_dialog_params)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None),
+        data.interp({"x": target}, method="linear").rename(None),
     )
 
     win.close()
@@ -5954,12 +6021,17 @@ def test_itool_assign_coords_affine(qtbot, accept_dialog) -> None:
     def _set_dialog_params(dialog: AssignCoordsDialog) -> None:
         dialog._coord_combo.setCurrentText("y")
         dialog.coord_widget.edit_mode_tabs.setCurrentIndex(1)
-        dialog.coord_widget.scale_spin.setValue(2.0)
-        dialog.coord_widget.offset_spin.setValue(0.5)
+        _set_spinbox_text(dialog.coord_widget.scale_spin, "2.000000000000001")
+        _set_spinbox_text(dialog.coord_widget.offset_spin, "0.5000000000000001")
         dialog.launch_mode_combo.setCurrentText("Replace Current")
 
     accept_dialog(win.mnb._assign_coords, pre_call=_set_dialog_params, timeout=10.0)
-    np.testing.assert_allclose(win.slicer_area._data.y.values, 2.0 * np.arange(4) + 0.5)
+    np.testing.assert_allclose(
+        win.slicer_area._data.y.values,
+        float("2.000000000000001") * np.arange(4) + float("0.5000000000000001"),
+        rtol=0,
+        atol=0,
+    )
 
 
 def _combo_index_for_data(combo: QtWidgets.QComboBox, data: object) -> int:
@@ -6869,7 +6941,7 @@ def test_itool_divide_by_coord_nonuniform_generated_code(qtbot, accept_dialog) -
     win.close()
 
 
-def test_itool_gaussian_filter_sigma_path(qtbot, accept_dialog) -> None:
+def test_itool_gaussian_filter_sigma_path(qtbot, accept_dialog, monkeypatch) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)).astype(float),
         dims=["x", "y"],
@@ -6877,6 +6949,11 @@ def test_itool_gaussian_filter_sigma_path(qtbot, accept_dialog) -> None:
     )
     win = itool(data, execute=False)
     qtbot.addWidget(win)
+    monkeypatch.setattr(
+        type(win.slicer_area),
+        "watched_data_name",
+        property(lambda _self: "data"),
+    )
 
     def _set_normalize_params(dialog: NormalizeDialog) -> None:
         dialog.dim_checks["x"].setChecked(True)
@@ -6884,13 +6961,26 @@ def test_itool_gaussian_filter_sigma_path(qtbot, accept_dialog) -> None:
     accept_dialog(win.mnb._normalize, pre_call=_set_normalize_params)
     xarray.testing.assert_identical(win.slicer_area.data, normalize(data, ("x",), 0))
 
-    sigma_literal = "0.015"
+    sigma_literal = "0.0151234567890123"
 
     def _set_gaussian_params(dialog: GaussianFilterDialog) -> None:
         dialog.dim_checks["x"].setChecked(True)
         _set_spinbox_text(dialog.sigma_spins["x"], sigma_literal)
         assert dialog.sigma_spins["x"].text() == sigma_literal
-        assert dialog.fwhm_spins["x"].text() == "0.035"
+        code = dialog.make_code()
+        assert f'sigma={{"x": {sigma_literal}}}' in code
+        namespace = _exec_generated_code(
+            f"result = {code}",
+            {"data": data.copy(deep=True)},
+        )
+        result = namespace["result"]
+        assert isinstance(result, xr.DataArray)
+        xarray.testing.assert_identical(
+            result,
+            erlab.analysis.image.gaussian_filter(
+                data, sigma={"x": float(sigma_literal)}
+            ),
+        )
         dialog._preview()
 
     accept_dialog(win.mnb._gaussian_filter, pre_call=_set_gaussian_params)
@@ -6913,7 +7003,7 @@ def test_itool_gaussian_filter_sigma_path(qtbot, accept_dialog) -> None:
     win.close()
 
 
-def test_itool_gaussian_filter_fwhm_path_and_code(qtbot) -> None:
+def test_itool_gaussian_filter_fwhm_path_and_code(qtbot, monkeypatch) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)).astype(float),
         dims=["x", "y"],
@@ -6921,23 +7011,39 @@ def test_itool_gaussian_filter_fwhm_path_and_code(qtbot) -> None:
     )
     win = itool(data, execute=False)
     qtbot.addWidget(win)
+    monkeypatch.setattr(
+        type(win.slicer_area),
+        "watched_data_name",
+        property(lambda _self: "data"),
+    )
 
     dialog = GaussianFilterDialog(win.slicer_area)
     qtbot.addWidget(dialog)
 
+    fwhm_literal = "0.0351234567890123"
+    expected_sigma = float(fwhm_literal) / (2 * np.sqrt(2 * np.log(2)))
     dialog.dim_checks["x"].setChecked(True)
-    _set_spinbox_text(dialog.fwhm_spins["x"], "0.035")
+    _set_spinbox_text(dialog.fwhm_spins["x"], fwhm_literal)
 
     sigma_literal = dialog.sigma_spins["x"].text()
-    assert sigma_literal == "0.015"
-    assert dialog.fwhm_spins["x"].text() == "0.035"
+    assert sigma_literal == str(expected_sigma)
+    assert dialog.fwhm_spins["x"].text() == fwhm_literal
 
     code = dialog.make_code()
-    assert 'sigma={"x": 0.015}' in code
+    namespace = _exec_generated_code(
+        f"result = {code}",
+        {"data": data.copy(deep=True)},
+    )
+    result = namespace["result"]
+    assert isinstance(result, xr.DataArray)
+    xarray.testing.assert_identical(
+        result,
+        erlab.analysis.image.gaussian_filter(data, sigma={"x": expected_sigma}),
+    )
 
     xarray.testing.assert_identical(
         dialog.process_data(data),
-        erlab.analysis.image.gaussian_filter(data, sigma={"x": float(sigma_literal)}),
+        erlab.analysis.image.gaussian_filter(data, sigma={"x": expected_sigma}),
     )
 
     dialog.close()

--- a/tests/interactive/imagetool/test_imagetool_coordinate_widget.py
+++ b/tests/interactive/imagetool/test_imagetool_coordinate_widget.py
@@ -7,6 +7,13 @@ from erlab.interactive.imagetool._dialog_widgets import (
 )
 
 
+def _set_spinbox_text(spin, text: str) -> None:
+    line = spin.lineEdit()
+    assert line is not None
+    line.setText(text)
+    spin.editingFinishedEvent()
+
+
 def _affine_preview_values(widget: CoordinateEditorWidget) -> np.ndarray:
     return np.array(
         [
@@ -50,6 +57,45 @@ def test_coordinate_widget_update_table(qtbot):
     for i in range(3):
         item = widget.table.item(i, 0)
         assert float(item.text()) == pytest.approx(vals[i])
+
+
+def test_coordinate_widget_grid_exact_start_end(qtbot):
+    arr = np.linspace(0, 1, 3)
+    widget = CoordinateEditorWidget(arr)
+    qtbot.addWidget(widget)
+
+    start_literal = "0.123456789012345"
+    stop_literal = "0.987654321098765"
+    _set_spinbox_text(widget.spin0, start_literal)
+    _set_spinbox_text(widget.spin1, stop_literal)
+
+    expected = np.linspace(float(start_literal), float(stop_literal), arr.size)
+    assert widget.spin0.text() == start_literal
+    assert widget.spin1.text() == stop_literal
+    np.testing.assert_allclose(widget._current_values_end, expected, rtol=0, atol=0)
+    np.testing.assert_allclose(widget.new_coord, expected, rtol=0, atol=0)
+
+
+def test_coordinate_widget_grid_exact_delta(qtbot):
+    arr = np.linspace(0, 1, 4)
+    widget = CoordinateEditorWidget(arr)
+    qtbot.addWidget(widget)
+
+    start_literal = "1.23456789012345"
+    step_literal = "0.0000001234567890123"
+    widget.mode_combo.setCurrentText("Delta")
+    _set_spinbox_text(widget.spin0, start_literal)
+    _set_spinbox_text(widget.spin1, step_literal)
+
+    expected = np.linspace(
+        float(start_literal),
+        float(start_literal) + float(step_literal) * (arr.size - 1),
+        arr.size,
+    )
+    assert widget.spin0.text() == start_literal
+    assert widget.spin1.text() == step_literal
+    np.testing.assert_allclose(widget._current_values_delta, expected, rtol=0, atol=0)
+    np.testing.assert_allclose(widget.new_coord, expected, rtol=0, atol=0)
 
 
 def test_coordinate_widget_reset(qtbot):
@@ -106,6 +152,30 @@ def test_coordinate_widget_affine_scale_offset(qtbot):
     widget.offset_spin.setValue(-0.5)
     assert np.allclose(widget.affine_coord, [1.5, 3.5, 7.5])
     assert np.allclose(_affine_preview_values(widget), [1.5, 3.5, 7.5])
+
+
+def test_coordinate_widget_affine_exact_scale_offset(qtbot):
+    arr = np.array([1.0, 2.0, 4.0])
+    widget = CoordinateEditorWidget(arr)
+    qtbot.addWidget(widget)
+    widget.edit_mode_tabs.setCurrentIndex(1)
+
+    scale_literal = "1.23456789012345"
+    offset_literal = "-0.000000000000123"
+    _set_spinbox_text(widget.scale_spin, scale_literal)
+    _set_spinbox_text(widget.offset_spin, offset_literal)
+
+    expected = float(scale_literal) * arr + float(offset_literal)
+    assert widget.scale_spin.text() == scale_literal
+    assert widget.offset_spin.text() == offset_literal
+    np.testing.assert_allclose(widget.affine_coord, expected, rtol=0, atol=0)
+    np.testing.assert_allclose(_affine_preview_values(widget), expected, rtol=0, atol=0)
+
+    widget.reset()
+    assert widget.affine_scale == 1.0
+    assert widget.affine_offset == 0.0
+    assert widget.scale_spin.text() == "1.0"
+    assert widget.offset_spin.text() == "0.0"
 
 
 def test_coordinate_widget_affine_offset_only(qtbot):

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -120,6 +120,104 @@ def test_icon_action_button_click(qtbot, action) -> None:
     assert action.isChecked()
 
 
+def _commit_spin_text(spin: erlab.interactive.utils.BetterSpinBox, text: str) -> None:
+    line = spin.lineEdit()
+    assert line is not None
+    line.setText(text)
+    spin.editingFinishedEvent()
+
+
+def test_better_spinbox_exact_float_preserves_user_literal(qtbot) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(decimals=3, exact_float=True, trim="0")
+    qtbot.addWidget(spin)
+
+    literal = "1.23456789012345"
+    _commit_spin_text(spin, literal)
+
+    assert spin.value() == float(literal)
+    assert spin.text() == literal
+    assert spin.lineEdit().text() == literal
+
+
+def test_better_spinbox_exact_float_programmatic_paths_format(qtbot) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(decimals=3, exact_float=True, trim="0")
+    qtbot.addWidget(spin)
+
+    _commit_spin_text(spin, "1.23456789012345")
+    spin.setValue(2.34567)
+    assert spin.text() == np.format_float_positional(
+        2.34567, precision=3, unique=False, fractional=True, trim="0"
+    )
+
+    _commit_spin_text(spin, "1.23456789012345")
+    spin.stepBy(1)
+    assert spin.text() == np.format_float_positional(
+        float("1.23456789012345") + spin.singleStep(),
+        precision=3,
+        unique=False,
+        fractional=True,
+        trim="0",
+    )
+
+
+def test_better_spinbox_exact_float_invalid_input_uses_formatted_value(qtbot) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(decimals=3, exact_float=True, trim="0")
+    qtbot.addWidget(spin)
+
+    literal = "1.23456789012345"
+    _commit_spin_text(spin, literal)
+    _commit_spin_text(spin, "not-a-number")
+
+    assert spin.value() == float(literal)
+    assert spin.text() == np.format_float_positional(
+        float(literal), precision=3, unique=False, fractional=True, trim="0"
+    )
+
+
+def test_better_spinbox_exact_float_fixup_uses_formatted_value(qtbot) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(decimals=3, exact_float=True, trim="0")
+    qtbot.addWidget(spin)
+
+    literal = "1.23456789012345"
+    _commit_spin_text(spin, literal)
+
+    assert spin.fixup("") == np.format_float_positional(
+        float(literal), precision=3, unique=False, fractional=True, trim="0"
+    )
+
+    regular_spin = erlab.interactive.utils.BetterSpinBox(decimals=3, trim="0")
+    qtbot.addWidget(regular_spin)
+    assert regular_spin.fixup("") == regular_spin.text()
+
+
+def test_better_spinbox_exact_float_out_of_range_formats_correction(qtbot) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(
+        decimals=3,
+        exact_float=True,
+        maximum=1.0,
+        trim="0",
+    )
+    qtbot.addWidget(spin)
+
+    _commit_spin_text(spin, "1.23456789012345")
+
+    assert spin.value() == 1.0
+    assert spin.text() == np.format_float_positional(
+        1.0, precision=3, unique=False, fractional=True, trim="0"
+    )
+
+
+def test_better_spinbox_non_exact_invalid_input_raises(qtbot) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(decimals=3, trim="0")
+    qtbot.addWidget(spin)
+    line = spin.lineEdit()
+    assert line is not None
+
+    line.setText("not-a-number")
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        spin.editingFinishedEvent()
+
+
 def test_icon_action_button_toggle(qtbot, action) -> None:
     button = IconActionButton(action, on="mdi6.plus", off="mdi6.minus")
     qtbot.addWidget(button)


### PR DESCRIPTION
## Summary

- Add an opt-in exact-literal mode to `BetterSpinBox` so committed user-entered floats are parsed from the original text and remain visible.
- Enable exact-literal entry for coordinate grid/affine controls, selection value/width controls, and Gaussian sigma/FWHM controls where typed numbers become data, provenance, or copied/generated code.
- Add focused tests for spinbox exact-literal behavior, coordinate editing/interpolation, selection qsel arguments, Gaussian generated-code paths, and Codecov-covered correction branches.

## Root Cause

Several coordinate-like dialogs used `BetterSpinBox` display precision as part of commit handling, so typed floats could be rounded before being used as coordinates or code/provenance values.

## Validation

- `uv run ruff format --check src/erlab/interactive/utils.py src/erlab/interactive/imagetool/_dialog_widgets.py src/erlab/interactive/imagetool/dialogs.py tests/interactive/test_utils.py tests/interactive/imagetool/test_imagetool_coordinate_widget.py tests/interactive/imagetool/test_imagetool.py`
- `uv run ruff check src/erlab/interactive/utils.py src/erlab/interactive/imagetool/_dialog_widgets.py src/erlab/interactive/imagetool/dialogs.py tests/interactive/test_utils.py tests/interactive/imagetool/test_imagetool_coordinate_widget.py tests/interactive/imagetool/test_imagetool.py`
- `uv run pytest tests/interactive/test_utils.py::test_better_spinbox_exact_float_preserves_user_literal tests/interactive/test_utils.py::test_better_spinbox_exact_float_programmatic_paths_format tests/interactive/test_utils.py::test_better_spinbox_exact_float_invalid_input_uses_formatted_value tests/interactive/test_utils.py::test_better_spinbox_exact_float_fixup_uses_formatted_value tests/interactive/test_utils.py::test_better_spinbox_exact_float_out_of_range_formats_correction tests/interactive/test_utils.py::test_better_spinbox_non_exact_invalid_input_raises tests/interactive/imagetool/test_imagetool_coordinate_widget.py::test_coordinate_widget_grid_exact_start_end tests/interactive/imagetool/test_imagetool_coordinate_widget.py::test_coordinate_widget_grid_exact_delta tests/interactive/imagetool/test_imagetool_coordinate_widget.py::test_coordinate_widget_affine_exact_scale_offset tests/interactive/imagetool/test_imagetool.py::test_selection_dialog_qsel_exact_value_and_width tests/interactive/imagetool/test_imagetool.py::test_itool_interpolate_exact_generated_coordinates tests/interactive/imagetool/test_imagetool.py::test_itool_assign_coords_affine tests/interactive/imagetool/test_imagetool.py::test_itool_gaussian_filter_sigma_path tests/interactive/imagetool/test_imagetool.py::test_itool_gaussian_filter_fwhm_path_and_code`
- Local coverage JSON check confirmed no missing changed lines or missing changed branches in `src/erlab/interactive/utils.py` after the added tests.