### PR TITLE
feat(analysis): support leading edge axis selection

### DIFF
--- a/src/erlab/analysis/interpolate.py
+++ b/src/erlab/analysis/interpolate.py
@@ -548,50 +548,76 @@ def slice_along_vector(
     return slice_along_path(data, vertices=vert, **kwargs)
 
 
-def _minimize_func(edc_values: npt.NDArray, energy_coord: npt.NDArray) -> float:
-    spl = scipy.interpolate.make_interp_spline(energy_coord, edc_values)
+def _minimize_func(
+    edc_values: npt.NDArray,
+    coord: npt.NDArray,
+    direction: typing.Literal["positive", "negative"],
+) -> float:
+    order = np.argsort(coord)
+    coord = coord[order]
+    edc_values = edc_values[order]
+
+    spl = scipy.interpolate.make_interp_spline(coord, edc_values)
+    peak_coord = coord[np.argmax(edc_values)]
+    endpoint = coord.max() if direction == "positive" else coord.min()
     rs = scipy.optimize.root_scalar(
         spl,
-        bracket=[energy_coord[np.argmax(edc_values)], energy_coord.max()],
+        bracket=sorted([peak_coord, endpoint]),
     )
     return rs.root
 
 
-def leading_edge(darr: xr.DataArray, fraction: float = 0.5) -> xr.DataArray:
-    """Calculate the leading edge of EDCs in a DataArray with subpixel precision.
+def leading_edge(
+    darr: xr.DataArray,
+    fraction: float = 0.5,
+    *,
+    dim: Hashable = "eV",
+    direction: typing.Literal["positive", "negative"] = "positive",
+) -> xr.DataArray:
+    """Calculate leading edges in a DataArray with subpixel precision.
 
-    The leading edge is defined as the energy where the intensity reaches a given
-    fraction of the maximum intensity in the EDC, by default 50%.
+    The leading edge is defined as the coordinate where the intensity reaches a given
+    fraction of the maximum intensity along `dim`, by default 50%.
 
-    It is calculated by interpolating the EDC with a spline and finding the root of the
-    function defined as the difference between the EDC and the target intensity.
+    It is calculated by interpolating each curve with a spline and finding the root of
+    the function defined as the difference between the curve and the target intensity.
 
     Parameters
     ----------
     darr : xr.DataArray
-        The input DataArray containing EDCs along the 'eV' dimension. It can be of any
-        shape, as long as one dimension is named 'eV'.
+        The input DataArray containing curves along `dim`.
     fraction : float, optional
         The fraction of the maximum intensity to define the leading edge, by default
         0.5.
+    dim : Hashable, optional
+        The dimension along which to solve for the leading edge, by default ``"eV"``.
+    direction : {"positive", "negative"}, optional
+        Direction from the curve maximum in which to solve. ``"positive"`` solves
+        toward larger coordinate values, while ``"negative"`` solves toward smaller
+        coordinate values.
 
     Returns
     -------
     leading_edge : xr.DataArray
-        A DataArray containing the leading edge energies for each EDC in the input
-        DataArray. The shape will be the same as the input DataArray, but without the
-        'eV' dimension.
+        A DataArray containing the leading edge coordinate for each curve in the input
+        DataArray. The shape will be the same as the input DataArray, but without
+        `dim`.
     """
-    half_max = darr.max("eV") * fraction
+    if dim not in darr.dims:
+        raise ValueError(f"Dimension {dim!r} not found in input DataArray")
+    if direction not in {"positive", "negative"}:
+        raise ValueError("direction must be 'positive' or 'negative'")
+
+    half_max = darr.max(dim=[dim]) * fraction
 
     return xr.apply_ufunc(
         _minimize_func,
         darr - half_max,
-        input_core_dims=[["eV"]],
+        input_core_dims=[[dim]],
         dask="parallelized",
         output_dtypes=[float],
         vectorize=True,
-        kwargs={"energy_coord": darr.eV.values},
+        kwargs={"coord": darr[dim].values, "direction": direction},
     )
 
 

--- a/tests/analysis/test_interpolate.py
+++ b/tests/analysis/test_interpolate.py
@@ -274,6 +274,48 @@ def test_leading_edge_vectorized_over_other_dims() -> None:
     np.testing.assert_allclose(out.values, edges, atol=1e-3)
 
 
+def test_leading_edge_along_custom_dim() -> None:
+    kx = np.linspace(-1.0, 1.0, 501)
+    edges = np.array([-0.25, 0.35])
+    width = 0.02
+
+    ee, kk = np.meshgrid(edges, kx, indexing="ij")
+    values = 1.0 / (1.0 + np.exp((kk - ee) / width))
+    darr = xr.DataArray(values, dims=("idx", "kx"), coords={"idx": [0, 1], "kx": kx})
+
+    out = leading_edge(darr, fraction=0.5, dim="kx")
+    assert out.dims == ("idx",)
+    np.testing.assert_allclose(out.values, edges, atol=1e-3)
+
+
+def test_leading_edge_direction() -> None:
+    eV = np.linspace(-1.0, 1.0, 801)
+    width = 0.2
+    values = np.exp(-((eV / width) ** 2))
+    darr = xr.DataArray(values, dims=("eV",), coords={"eV": eV}, name="edc")
+    expected_offset = width * np.sqrt(np.log(2.0))
+
+    out_positive = leading_edge(darr, fraction=0.5, direction="positive")
+    out_negative = leading_edge(darr, fraction=0.5, direction="negative")
+
+    assert float(out_positive) == pytest.approx(expected_offset, abs=1e-3)
+    assert float(out_negative) == pytest.approx(-expected_offset, abs=1e-3)
+
+
+def test_leading_edge_invalid_direction_raises() -> None:
+    darr = xr.DataArray(np.zeros(3), dims=("eV",), coords={"eV": [-1.0, 0.0, 1.0]})
+
+    with pytest.raises(ValueError, match="direction"):
+        leading_edge(darr, direction="left")
+
+
+def test_leading_edge_invalid_dim_raises() -> None:
+    darr = xr.DataArray(np.zeros(3), dims=("eV",), coords={"eV": [-1.0, 0.0, 1.0]})
+
+    with pytest.raises(ValueError, match="Dimension"):
+        leading_edge(darr, dim="kx")
+
+
 def test_leading_edge_dask_parallelized() -> None:
     pytest.importorskip("dask.array")
 


### PR DESCRIPTION
## Summary

- Add `dim` to `leading_edge` so callers can solve along dimensions other than `eV`.
- Add `direction` to choose whether the root is solved toward larger or smaller coordinate values from the curve maximum.
- Cover custom dimensions, positive/negative direction selection, and invalid direction validation.

## Validation

- `uv run ruff format --check src/erlab/analysis/interpolate.py tests/analysis/test_interpolate.py`
- `uv run ruff check src/erlab/analysis/interpolate.py tests/analysis/test_interpolate.py`
- `uv run --group pyqt6 pytest tests/analysis/test_interpolate.py -q`