### PR TITLE
fix(imagetool): handle dropped workspace load failures

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -6065,7 +6065,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _handle_dropped_files(self, file_paths: list[pathlib.Path]) -> None:
         """Handle files dropped into the window."""
         if file_paths:  # pragma: no branch
-            extensions: set[str] = {file_path.suffix for file_path in file_paths}
+            extensions: set[str] = {
+                file_path.suffix.lower() for file_path in file_paths
+            }
             if len(extensions) != 1:
                 QtWidgets.QMessageBox.critical(
                     self,
@@ -6160,6 +6162,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
         if try_workspace:
             for p in list(queued):
+                explicit_workspace = p.suffix.lower() == ".itws"
                 try:
                     dt = _manager_xarray.open_workspace_datatree(p, chunks=None)
                 except Exception as exc:
@@ -6171,8 +6174,16 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         )
                         _show_workspace_file_lock_error(self, p)
                         queued.remove(p)
+                    elif explicit_workspace:
+                        self._show_operation_error(
+                            "Error while loading workspace",
+                            "An error occurred while loading the workspace file.",
+                        )
+                        queued.remove(p)
                     else:
-                        logger.debug("Failed to open %s as datatree workspace", p)
+                        logger.debug(
+                            "Failed to open %s as datatree workspace", p, exc_info=True
+                        )
                 else:
                     if self._is_datatree_workspace(dt):
                         dt.close()
@@ -6224,13 +6235,8 @@ class ImageToolManager(QtWidgets.QMainWindow):
                                 )
                                 _show_workspace_file_lock_error(self, p)
                             else:
-                                logger.exception(
+                                self._show_operation_error(
                                     "Error while loading workspace",
-                                    extra={"suppress_ui_alert": True},
-                                )
-                                erlab.interactive.utils.MessageDialog.critical(
-                                    self,
-                                    "Error",
                                     "An error occurred while loading the workspace "
                                     "file.",
                                 )
@@ -6239,6 +6245,20 @@ class ImageToolManager(QtWidgets.QMainWindow):
                             loaded.append(p)
                     else:
                         dt.close()
+                        if explicit_workspace:
+                            logger.error(
+                                "File with .itws extension is not an ImageTool "
+                                "workspace: %s",
+                                p,
+                                extra={"suppress_ui_alert": True},
+                            )
+                            erlab.interactive.utils.MessageDialog.critical(
+                                self,
+                                "Error",
+                                "An error occurred while loading the workspace file.",
+                                f"{p.name} is not a valid ImageTool workspace file.",
+                            )
+                            queued.remove(p)
 
         if len(queued) == 0:
             return

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -15962,6 +15962,133 @@ def test_open_multiple_files_dropped_itws_error_does_not_fall_through_to_loaders
     assert "cannot read workspace" in critical_calls[0][1]["detailed_text"]
 
 
+def test_open_multiple_files_h5_workspace_probe_failure_falls_back_to_loaders(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    file_loader_calls: list[list[pathlib.Path]] = []
+    add_calls: list[tuple[list[pathlib.Path], Callable]] = []
+    fname = tmp_path / "data.h5"
+    fname.write_bytes(b"not a workspace")
+
+    def _raise_open_datatree(*args, **kwargs):
+        raise RuntimeError("not a workspace")
+
+    def _fake_file_loaders(paths):
+        file_loader_calls.append(list(paths))
+        return {"Fake HDF5 (*.h5)": (lambda *_args, **_kwargs: None, {})}
+
+    def _fake_add_from_multiple_files(
+        loaded, queued, failed, func, kwargs, retry_callback
+    ) -> None:
+        add_calls.append((queued, func))
+
+    monkeypatch.setattr(manager_xarray, "open_workspace_datatree", _raise_open_datatree)
+    monkeypatch.setattr(erlab.interactive.utils, "file_loaders", _fake_file_loaders)
+
+    with manager_context() as manager:
+        monkeypatch.setattr(
+            manager, "_add_from_multiple_files", _fake_add_from_multiple_files
+        )
+        manager.open_multiple_files([fname], try_workspace=True)
+
+    assert file_loader_calls == [[fname]]
+    assert add_calls[0][0] == [fname]
+
+
+def test_open_multiple_files_h5_non_workspace_falls_back_to_loaders(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    file_loader_calls: list[list[pathlib.Path]] = []
+    closed = {"value": False}
+    fname = tmp_path / "data.h5"
+    fname.write_bytes(b"hdf5 but not a workspace")
+
+    class _FakeDataTree:
+        attrs: typing.ClassVar[dict[str, typing.Any]] = {}
+
+        def close(self) -> None:
+            closed["value"] = True
+
+    def _fake_file_loaders(paths):
+        file_loader_calls.append(list(paths))
+        return {"Fake HDF5 (*.h5)": (lambda *_args, **_kwargs: None, {})}
+
+    monkeypatch.setattr(
+        manager_xarray,
+        "open_workspace_datatree",
+        lambda *args, **kwargs: _FakeDataTree(),
+    )
+    monkeypatch.setattr(erlab.interactive.utils, "file_loaders", _fake_file_loaders)
+
+    with manager_context() as manager:
+        monkeypatch.setattr(
+            manager,
+            "_add_from_multiple_files",
+            lambda *args, **kwargs: None,
+        )
+        manager.open_multiple_files([fname], try_workspace=True)
+
+    assert closed["value"]
+    assert file_loader_calls == [[fname]]
+
+
+def test_open_multiple_files_dropped_itws_non_workspace_does_not_fall_through(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    critical_calls: list[tuple[typing.Any, ...]] = []
+    closed = {"value": False}
+    fname = tmp_path / "not-workspace.itws"
+    fname.write_text("hdf5 but not a workspace", encoding="utf-8")
+
+    class _FakeDataTree:
+        attrs: typing.ClassVar[dict[str, typing.Any]] = {}
+
+        def close(self) -> None:
+            closed["value"] = True
+
+    def _file_loaders_should_not_run(*args, **kwargs):
+        raise AssertionError("non-workspace .itws should not fall through to loaders")
+
+    def _fake_critical(*args, **kwargs):
+        critical_calls.append((args, kwargs))
+        return int(QtWidgets.QDialog.DialogCode.Accepted)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        staticmethod(_fake_critical),
+    )
+    monkeypatch.setattr(
+        manager_xarray,
+        "open_workspace_datatree",
+        lambda *args, **kwargs: _FakeDataTree(),
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils, "file_loaders", _file_loaders_should_not_run
+    )
+
+    with manager_context() as manager:
+        manager.open_multiple_files([fname], try_workspace=True)
+
+    assert closed["value"]
+    assert len(critical_calls) == 1
+    assert critical_calls[0][0][2] == (
+        "An error occurred while loading the workspace file."
+    )
+
+
 def test_open_retry_preserves_non_native_dialog(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -15898,6 +15898,70 @@ def test_open_multiple_files_locked_workspace_does_not_fall_through_to_loaders(
     assert lock_calls == [fname]
 
 
+@pytest.mark.parametrize("suffix", [".ITWS", ".ItWs"])
+def test_handle_dropped_files_treats_itws_suffix_case_insensitively(
+    monkeypatch,
+    tmp_path,
+    suffix: str,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    calls: list[tuple[list[pathlib.Path], bool]] = []
+    fname = tmp_path / f"workspace{suffix}"
+    fname.write_bytes(b"")
+
+    def _record_open(paths, try_workspace: bool = False) -> None:
+        calls.append((paths, try_workspace))
+
+    with manager_context() as manager:
+        monkeypatch.setattr(manager, "open_multiple_files", _record_open)
+        manager._handle_dropped_files([fname])
+
+    assert calls == [([fname], True)]
+
+
+def test_open_multiple_files_dropped_itws_error_does_not_fall_through_to_loaders(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    critical_calls: list[tuple[typing.Any, ...]] = []
+    fname = tmp_path / "broken.itws"
+    fname.write_text("not a workspace", encoding="utf-8")
+
+    def _fake_critical(*args, **kwargs):
+        critical_calls.append((args, kwargs))
+        return int(QtWidgets.QDialog.DialogCode.Accepted)
+
+    def _raise_open_datatree(*args, **kwargs):
+        raise RuntimeError("cannot read workspace")
+
+    def _file_loaders_should_not_run(*args, **kwargs):
+        raise AssertionError("broken .itws should not fall through to loaders")
+
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        staticmethod(_fake_critical),
+    )
+    monkeypatch.setattr(manager_xarray, "open_workspace_datatree", _raise_open_datatree)
+    monkeypatch.setattr(
+        erlab.interactive.utils, "file_loaders", _file_loaders_should_not_run
+    )
+
+    with manager_context() as manager:
+        manager.open_multiple_files([fname], try_workspace=True)
+
+    assert len(critical_calls) == 1
+    assert critical_calls[0][0][2] == (
+        "An error occurred while loading the workspace file."
+    )
+    assert "cannot read workspace" in critical_calls[0][1]["detailed_text"]
+
+
 def test_open_retry_preserves_non_native_dialog(
     qtbot,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Treat dropped `.itws` files as explicit ImageTool workspaces, including mixed-case suffixes.
- Stop falling through to generic data loaders when an explicit `.itws` workspace probe fails.
- Keep `.h5` probe-and-fallback behavior unchanged.

## Root cause
The drag/drop path routed workspace handling from the raw suffix, and `open_multiple_files()` forgot that `.itws` was an explicit workspace after the first workspace probe failed. Broken or unreadable `.itws` files could then reach normal plugin matching and show a misleading unsupported-extension error.

## Tests
- `uv run ruff format src/erlab/interactive/imagetool/manager/_mainwindow.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run ruff check --fix src/erlab/interactive/imagetool/manager/_mainwindow.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run ruff check src/erlab/interactive/imagetool/manager/_mainwindow.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run --group pyqt6 pytest tests/interactive/imagetool/test_imagetool_manager.py -k "dropped or open_multiple_files"`

Note: `uv run pytest tests/interactive/imagetool/test_imagetool_manager.py -k "dropped or open_multiple_files"` failed before collection because that fresh env had no Qt binding; reran with `--group pyqt6`.
