### PR TITLE
Add ImageTool leading edge transform

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -253,6 +253,10 @@ script or notebook for reproducibility.
 - {guilabel}`Edit → Interpolate…` opens the {guilabel}`Interpolate` dialog. Choose one
   dimension, enter the target coordinate values, and interpolate with
   {meth}`xarray.DataArray.interp` using `linear` or `nearest`.
+- {guilabel}`Edit → Leading Edge…` opens the {guilabel}`Leading Edge` dialog. Choose the
+  dimension to extract the leading edge from, set the fraction of the curve maximum, and
+  choose whether the edge is searched toward larger or smaller coordinate values with
+  {func}`erlab.analysis.interpolate.leading_edge`.
 - {guilabel}`Edit → Coarsen` opens the {guilabel}`Coarsen` dialog. Select window sizes
   for one or more dimensions, choose the `boundary`, `side`, and coordinate reduction
   function for {meth}`xarray.DataArray.coarsen`, then apply a reducer such as `mean`,

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -694,6 +694,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                         "text": "Interpolate…",
                         "triggered": self._interpolate,
                     },
+                    "leadingEdgeAct": {
+                        "text": "Leading Edge…",
+                        "triggered": self._leading_edge,
+                    },
                     "divideByCoordinateAct": {
                         "text": "Divide by Coordinate…",
                         "triggered": self._divide_by_coord,
@@ -919,6 +923,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     @QtCore.Slot()
     def _interpolate(self) -> None:
         self.execute_dialog(erlab.interactive.imagetool.dialogs.InterpolationDialog)
+
+    @QtCore.Slot()
+    def _leading_edge(self) -> None:
+        self.execute_dialog(erlab.interactive.imagetool.dialogs.LeadingEdgeDialog)
 
     @QtCore.Slot()
     def _divide_by_coord(self) -> None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -1330,6 +1330,127 @@ class InterpolationDialog(DataTransformDialog):
         return operation.code(placeholder)
 
 
+class LeadingEdgeDialog(DataTransformDialog):
+    title = "Leading Edge"
+    enable_copy = True
+    apply_on_nonuniform_data = True
+
+    def setup_widgets(self) -> None:
+        self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+            self.slicer_area.data
+        )
+
+        self.dim_combo = QtWidgets.QComboBox()
+        for dim in self._source_data.dims:
+            self.dim_combo.addItem(str(dim), userData=dim)
+        ev_index = self.dim_combo.findData("eV", QtCore.Qt.ItemDataRole.UserRole)
+        if ev_index >= 0:
+            self.dim_combo.setCurrentIndex(ev_index)
+        self.layout_.addRow("Dimension", self.dim_combo)
+
+        self.fraction_spin = QtWidgets.QDoubleSpinBox()
+        self.fraction_spin.setDecimals(6)
+        self.fraction_spin.setRange(0.000001, 1.0)
+        self.fraction_spin.setSingleStep(0.05)
+        self.fraction_spin.setValue(0.5)
+        self.layout_.addRow("Fraction", self.fraction_spin)
+
+        self.direction_combo = QtWidgets.QComboBox()
+        self.direction_combo.addItem("Positive", userData="positive")
+        self.direction_combo.addItem("Negative", userData="negative")
+        self.layout_.addRow("Direction", self.direction_combo)
+
+    @property
+    def _selected_dim(self) -> Hashable | None:
+        if self.dim_combo.currentIndex() < 0:
+            return None
+        return typing.cast(
+            "Hashable",
+            self.dim_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
+        )
+
+    @property
+    def _direction(self) -> typing.Literal["positive", "negative"]:
+        return typing.cast(
+            "typing.Literal['positive', 'negative']",
+            self.direction_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
+        )
+
+    @property
+    def suffix(self) -> str:
+        dim = self._selected_dim
+        suffix = "" if dim is None else str(dim)
+        suffix = re.sub(r"[^0-9A-Za-z_]+", "_", suffix).strip("_")
+        if not suffix:
+            suffix = "coord"
+        elif suffix[0].isdigit():
+            suffix = f"coord_{suffix}"
+        return f"_leading_edge_{suffix}"
+
+    @suffix.setter
+    def suffix(self, value: str) -> None:
+        # To satisfy mypy
+        pass
+
+    def _source_coord_error(self, dim: Hashable) -> str | None:
+        coord = np.asarray(self._source_data[dim].values)
+        if coord.ndim != 1:
+            return "The selected dimension coordinate must be one-dimensional."
+        if not np.issubdtype(coord.dtype, np.number) or np.issubdtype(
+            coord.dtype, np.complexfloating
+        ):
+            return "The selected dimension coordinate must contain real numbers."
+        numeric = coord.astype(np.float64, copy=False)
+        if not np.all(np.isfinite(numeric)):
+            return "The selected dimension coordinate must be finite."
+        if np.unique(numeric).size != numeric.size:
+            return "The selected dimension coordinate values must be unique."
+        return None
+
+    def source_transform_operation(
+        self,
+    ) -> erlab.interactive.imagetool.provenance.LeadingEdgeOperation:
+        dim = self._selected_dim
+        if dim is None:
+            raise ValueError("No dimension selected")
+        return erlab.interactive.imagetool.provenance.LeadingEdgeOperation(
+            fraction=float(self.fraction_spin.value()),
+            dim=dim,
+            direction=self._direction,
+        )
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        dim = self._selected_dim
+        if dim is None:
+            QtWidgets.QMessageBox.warning(
+                self, "No Dimension Selected", "Choose a dimension to process."
+            )
+            return
+
+        source_error = self._source_coord_error(dim)
+        if source_error is not None:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Invalid Source Coordinate",
+                source_error,
+            )
+            return
+
+        super().accept()
+
+    def make_code(self) -> str:
+        dim = self._selected_dim
+        if dim is None or self._source_coord_error(dim) is not None:
+            return ""
+        try:
+            operation = self.source_transform_operation()
+        except Exception:
+            return ""
+        placeholder = self.slicer_area.watched_data_name or "data"
+        return operation.code(placeholder)
+
+
 class CoarsenDialog(DataTransformDialog):
     title = "Coarsen"
     enable_copy = True

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -80,6 +80,7 @@ __all__ = [
     "ImageToolSelectionSourceBinding",
     "InterpolationOperation",
     "IselOperation",
+    "LeadingEdgeOperation",
     "MaskWithPolygonOperation",
     "QSelAggregationOperation",
     "QSelOperation",
@@ -2160,6 +2161,40 @@ class InterpolationOperation(ToolProvenanceOperation):
         }
         return DerivationEntry(
             f"Interpolate({_format_derivation_value(label_kwargs)})",
+            self.code("derived", assign="derived"),
+            True,
+        )
+
+
+class LeadingEdgeOperation(ToolProvenanceOperation):
+    op: typing.Literal["leading_edge"] = "leading_edge"
+    fraction: float = pydantic.Field(default=0.5, gt=0.0, le=1.0)
+    dim: ProvenanceHashable = "eV"
+    direction: typing.Literal["positive", "negative"] = "positive"
+
+    @property
+    def kwargs(self) -> dict[str, typing.Any]:
+        return {
+            "fraction": self.fraction,
+            "dim": self.dim,
+            "direction": self.direction,
+        }
+
+    def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
+        return erlab.analysis.interpolate.leading_edge(data, **self.kwargs)
+
+    def code(self, data_name: str, *, assign: str | None = None) -> str:
+        return erlab.interactive.utils.generate_code(
+            erlab.analysis.interpolate.leading_edge,
+            [f"|{data_name}|"],
+            self.kwargs,
+            module="era.interpolate",
+            assign=assign,
+        )
+
+    def derivation_entry(self) -> DerivationEntry:
+        return DerivationEntry(
+            f"Leading Edge({_format_derivation_value(self.kwargs)})",
             self.code("derived", assign="derived"),
             True,
         )

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -42,6 +42,7 @@ from erlab.interactive.imagetool.dialogs import (
     EdgeCorrectionDialog,
     GaussianFilterDialog,
     InterpolationDialog,
+    LeadingEdgeDialog,
     NormalizeDialog,
     RenameDimsCoordsDialog,
     ROIMaskDialog,
@@ -5570,6 +5571,178 @@ def test_itool_interpolate_nonuniform_public_dims(qtbot, accept_dialog) -> None:
     assert isinstance(derived, xr.DataArray)
     xarray.testing.assert_identical(derived.rename(None), expected.rename(None))
 
+    win.close()
+
+
+def test_itool_leading_edge(qtbot, accept_dialog) -> None:
+    ev = np.linspace(0.0, 4.0, 5)
+    data = xr.DataArray(
+        np.vstack([4.0 - ev, 8.0 - 2.0 * ev, 2.0 - 0.5 * ev]),
+        dims=["x", "eV"],
+        coords={"x": np.arange(3), "eV": ev},
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    assert "leadingEdgeAct" in win.mnb.action_dict
+
+    def _set_dialog_params(dialog: LeadingEdgeDialog) -> None:
+        assert dialog.dim_combo.currentData(QtCore.Qt.ItemDataRole.UserRole) == "eV"
+        dialog.fraction_spin.setValue(0.5)
+        dialog.direction_combo.setCurrentIndex(
+            dialog.direction_combo.findData("positive", QtCore.Qt.ItemDataRole.UserRole)
+        )
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._leading_edge, pre_call=_set_dialog_params)
+
+    expected = erlab.analysis.interpolate.leading_edge(data)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None), expected.rename(None)
+    )
+    assert win.slicer_area._data.name == "scan_leading_edge_eV"
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, pyperclip.paste()), expected
+    )
+
+    assert win.provenance_spec is not None
+    display_code = win.provenance_spec.display_code()
+    assert display_code is not None
+    namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
+    derived = namespace["derived"]
+    assert isinstance(derived, xr.DataArray)
+    xarray.testing.assert_identical(derived.rename(None), expected.rename(None))
+
+    win.close()
+
+
+def test_leading_edge_dialog_rejects_no_dimension(qtbot, monkeypatch) -> None:
+    ev = np.linspace(0.0, 4.0, 5)
+    data = xr.DataArray(
+        np.vstack([4.0 - ev, 8.0 - 2.0 * ev]),
+        dims=["x", "eV"],
+        coords={"x": np.arange(2), "eV": ev},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = LeadingEdgeDialog(win.slicer_area)
+    dialog.launch_mode_combo.setCurrentText("Replace Current")
+    dialog.dim_combo.setCurrentIndex(-1)
+
+    warning_calls: list[tuple[object, ...]] = []
+
+    def _record_warning(*args, **kwargs):
+        warning_calls.append(args)
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+    assert dialog.suffix == "_leading_edge_coord"
+    dialog.suffix = "ignored"
+    assert dialog.make_code() == ""
+    with pytest.raises(ValueError, match="No dimension selected"):
+        dialog.source_transform_operation()
+    dialog.accept()
+
+    assert len(warning_calls) == 1
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
+
+    dialog.close()
+    win.close()
+
+
+def test_leading_edge_dialog_defaults_and_suffix(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(6, dtype=float).reshape((2, 3)),
+        dims=["1 axis", "energy"],
+        coords={"1 axis": np.arange(2), "energy": np.arange(3)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = LeadingEdgeDialog(win.slicer_area)
+
+    assert dialog.dim_combo.currentData(QtCore.Qt.ItemDataRole.UserRole) == "1 axis"
+    assert dialog.suffix == "_leading_edge_coord_1_axis"
+
+    dialog.close()
+    win.close()
+
+
+@pytest.mark.parametrize(
+    "coord",
+    [
+        np.zeros((2, 2)),
+        np.array(["a", "b"]),
+        np.array([0.0, np.nan]),
+        np.array([0.0, 0.0]),
+    ],
+)
+def test_leading_edge_dialog_source_coord_validation(qtbot, coord) -> None:
+    data = xr.DataArray(
+        np.arange(6, dtype=float).reshape((2, 3)),
+        dims=["x", "eV"],
+        coords={"x": np.arange(2), "eV": np.arange(3)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = LeadingEdgeDialog(win.slicer_area)
+    dialog._source_data = {"eV": types.SimpleNamespace(values=coord)}
+
+    assert dialog._source_coord_error("eV") is not None
+
+    dialog.close()
+    win.close()
+
+
+def test_leading_edge_dialog_rejects_invalid_source_coord(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(10, dtype=float).reshape((2, 5)),
+        dims=["x", "eV"],
+        coords={"x": np.arange(2), "eV": np.array([0.0, 1.0, 1.0, 2.0, 3.0])},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = LeadingEdgeDialog(win.slicer_area)
+    dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    warning_calls: list[tuple[object, ...]] = []
+
+    def _record_warning(*args, **kwargs):
+        warning_calls.append(args)
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+    assert dialog.make_code() == ""
+    dialog.accept()
+
+    assert len(warning_calls) == 1
+    xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
+
+    dialog.close()
+    win.close()
+
+
+def test_leading_edge_dialog_make_code_suppresses_operation_errors(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(
+        np.arange(10, dtype=float).reshape((2, 5)),
+        dims=["x", "eV"],
+        coords={"x": np.arange(2), "eV": np.arange(5)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = LeadingEdgeDialog(win.slicer_area)
+
+    def _raise_operation_error():
+        raise RuntimeError
+
+    monkeypatch.setattr(dialog, "source_transform_operation", _raise_operation_error)
+    assert dialog.make_code() == ""
+
+    dialog.close()
     win.close()
 
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -451,6 +451,47 @@ def test_tool_provenance_interpolation_operation_round_trip_and_code() -> None:
     xr.testing.assert_identical(namespace["derived"], expected)
 
 
+def test_tool_provenance_leading_edge_operation_round_trip_and_code() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    ev = np.linspace(0.0, 4.0, 5)
+    data = xr.DataArray(
+        np.vstack([4.0 - ev, 8.0 - 2.0 * ev, 2.0 - 0.5 * ev]),
+        dims=("x", "eV"),
+        coords={"x": np.arange(3), "eV": ev},
+        name="data",
+    )
+    operation = prov.LeadingEdgeOperation(
+        fraction=0.5,
+        dim="eV",
+        direction="positive",
+    )
+    expected = erlab.analysis.interpolate.leading_edge(data)
+
+    xr.testing.assert_identical(operation.apply(data, parent_data=data), expected)
+    parsed = prov.parse_tool_provenance_operation(operation.model_dump(mode="json"))
+    assert parsed == operation
+    xr.testing.assert_identical(parsed.apply(data, parent_data=data), expected)
+
+    payload = prov.full_data(operation).model_dump(mode="json")
+    json.dumps(payload)
+    reparsed_spec = prov.parse_tool_provenance_spec(payload)
+    assert reparsed_spec is not None
+    xr.testing.assert_identical(reparsed_spec.apply(data), expected)
+
+    entry = operation.derivation_entry()
+    assert entry.copyable is True
+    assert entry.code is not None
+    assert "leading_edge" in entry.code
+    namespace = _exec_generated_code(entry.code, {"derived": data.copy(deep=True)})
+    xr.testing.assert_identical(namespace["derived"], expected)
+
+    code = prov.full_data(operation).to_replay_spec().display_code(parent_data=data)
+    assert code is not None
+    assert any(call.endswith(".leading_edge") for call in _generated_call_names(code))
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    xr.testing.assert_identical(namespace["derived"], expected)
+
+
 @pytest.mark.parametrize(
     ("values", "expected_call"),
     [


### PR DESCRIPTION
## Summary
- Add an ImageTool `Edit -> Leading Edge...` transform dialog for `erlab.analysis.interpolate.leading_edge`
- Add replayable `LeadingEdgeOperation` provenance and copied-code support
- Document the new ImageTool edit action without adding a version directive

## Validation
- `uv sync --all-extras --dev --group pyqt6`
- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_provenance.py::test_tool_provenance_leading_edge_operation_round_trip_and_code tests/interactive/imagetool/test_imagetool.py::test_itool_leading_edge tests/interactive/imagetool/test_imagetool.py::test_leading_edge_dialog_rejects_no_dimension`
- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_provenance.py`
- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_imagetool.py`
- `uv run ruff check src/erlab/interactive/imagetool/provenance.py src/erlab/interactive/imagetool/dialogs.py src/erlab/interactive/imagetool/_mainwindow.py tests/interactive/imagetool/test_provenance.py tests/interactive/imagetool/test_imagetool.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/provenance.py src/erlab/interactive/imagetool/dialogs.py src/erlab/interactive/imagetool/_mainwindow.py tests/interactive/imagetool/test_provenance.py tests/interactive/imagetool/test_imagetool.py`
- `uv run ruff format --check --preview docs/source/user-guide/interactive/imagetool.md`
- `git diff --check`