### PR TITLE
fix(interactive): preserve exact float spinbox display

### DIFF
--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -1513,8 +1513,8 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
     exact_float
         If `True`, floating-point text entered by the user is kept as the accepted
         display text and parsed directly with :class:`float` instead of being
-        reformatted to ``decimals`` on commit. Programmatic value changes still use
-        the normal formatting rules.
+        reformatted to ``decimals`` on commit. Programmatic value changes use the
+        shortest round-tripping float representation.
     value
         Initial value of the spinbox.
 
@@ -1655,12 +1655,25 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
     def textFromValue(self, value) -> str:
         if (not self._only_int) or (not np.isfinite(value)):
             if self._is_scientific:
+                if self._exact_float and not self._only_int:
+                    return self.prefix() + np.format_float_scientific(
+                        value,
+                        unique=True,
+                        trim=self._trim,
+                        exp_digits=1,
+                    )
                 return self.prefix() + np.format_float_scientific(
                     value,
                     precision=self.decimals(),
                     unique=False,
                     trim=self._trim,
                     exp_digits=1,
+                )
+            if self._exact_float and not self._only_int:
+                return self.prefix() + np.format_float_positional(
+                    value,
+                    unique=True,
+                    trim=self._trim,
                 )
             return self.prefix() + np.format_float_positional(
                 value,

--- a/tests/interactive/imagetool/test_imagetool_coordinate_widget.py
+++ b/tests/interactive/imagetool/test_imagetool_coordinate_widget.py
@@ -45,6 +45,23 @@ def test_coordinate_widget_mode_switch(qtbot):
     assert widget.spin1.value() == 5.0
 
 
+def test_coordinate_widget_delta_mode_preserves_round_trip_display(qtbot):
+    arr = np.linspace(-18.290462493896484, 19.133707046508789, 800)
+    widget = CoordinateEditorWidget(arr)
+    qtbot.addWidget(widget)
+
+    widget.mode_combo.setCurrentText("Delta")
+    delta_text = "0.04683876037597656"
+
+    assert widget.spin1.text() == delta_text
+    assert widget.spin1.value() == float(arr[1] - arr[0])
+
+    _set_spinbox_text(widget.spin1, widget.spin1.text())
+
+    assert widget.spin1.value() == float(arr[1] - arr[0])
+    np.testing.assert_allclose(widget._current_values_delta, arr, rtol=0, atol=0)
+
+
 def test_coordinate_widget_update_table(qtbot):
     arr = np.linspace(2, 4, 3)
     widget = CoordinateEditorWidget(arr)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -145,18 +145,53 @@ def test_better_spinbox_exact_float_programmatic_paths_format(qtbot) -> None:
 
     _commit_spin_text(spin, "1.23456789012345")
     spin.setValue(2.34567)
-    assert spin.text() == np.format_float_positional(
-        2.34567, precision=3, unique=False, fractional=True, trim="0"
-    )
+    assert spin.text() == np.format_float_positional(2.34567, unique=True, trim="0")
 
     _commit_spin_text(spin, "1.23456789012345")
     spin.stepBy(1)
     assert spin.text() == np.format_float_positional(
         float("1.23456789012345") + spin.singleStep(),
-        precision=3,
-        unique=False,
-        fractional=True,
+        unique=True,
         trim="0",
+    )
+
+
+def test_better_spinbox_exact_float_programmatic_paths_round_trip(qtbot) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(decimals=3, exact_float=True, trim="0")
+    qtbot.addWidget(spin)
+
+    value = 0.04683876037597656
+    spin.setValue(value)
+
+    assert spin.text() == "0.04683876037597656"
+    assert float(spin.text()) == value
+
+
+def test_better_spinbox_exact_float_scientific_programmatic_paths_format(
+    qtbot,
+) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(
+        decimals=3, exact_float=True, scientific=True, trim="0"
+    )
+    qtbot.addWidget(spin)
+
+    value = 0.04683876037597656
+    spin.setValue(value)
+
+    assert spin.text() == np.format_float_scientific(
+        value, unique=True, trim="0", exp_digits=1
+    )
+    assert float(spin.text()) == value
+
+
+def test_better_spinbox_non_exact_programmatic_paths_format(qtbot) -> None:
+    spin = erlab.interactive.utils.BetterSpinBox(decimals=3, trim="0")
+    qtbot.addWidget(spin)
+
+    spin.setValue(2.34567)
+
+    assert spin.text() == np.format_float_positional(
+        2.34567, precision=3, unique=False, fractional=True, trim="0"
     )
 
 
@@ -170,7 +205,7 @@ def test_better_spinbox_exact_float_invalid_input_uses_formatted_value(qtbot) ->
 
     assert spin.value() == float(literal)
     assert spin.text() == np.format_float_positional(
-        float(literal), precision=3, unique=False, fractional=True, trim="0"
+        float(literal), unique=True, trim="0"
     )
 
 
@@ -182,7 +217,7 @@ def test_better_spinbox_exact_float_fixup_uses_formatted_value(qtbot) -> None:
     _commit_spin_text(spin, literal)
 
     assert spin.fixup("") == np.format_float_positional(
-        float(literal), precision=3, unique=False, fractional=True, trim="0"
+        float(literal), unique=True, trim="0"
     )
 
     regular_spin = erlab.interactive.utils.BetterSpinBox(decimals=3, trim="0")
@@ -202,9 +237,7 @@ def test_better_spinbox_exact_float_out_of_range_formats_correction(qtbot) -> No
     _commit_spin_text(spin, "1.23456789012345")
 
     assert spin.value() == 1.0
-    assert spin.text() == np.format_float_positional(
-        1.0, precision=3, unique=False, fractional=True, trim="0"
-    )
+    assert spin.text() == np.format_float_positional(1.0, unique=True, trim="0")
 
 
 def test_better_spinbox_non_exact_invalid_input_raises(qtbot) -> None:


### PR DESCRIPTION
## Summary

- Use NumPy unique round-trip formatting for all `BetterSpinBox(exact_float=True)` programmatic float displays.
- Preserve user-entered exact float literals while avoiding fixed-decimal rounding on mode switches and fallback formatting.
- Add regression coverage for the coordinate editor delta display precision case.

## Root Cause

`exact_float=True` preserved user-entered literals, but programmatic updates still used fixed `decimals` formatting. For coordinate deltas such as `0.04683876037597656`, that rounded the visible spinbox text to `0.046838760375977`.

## Validation

- `uv run pytest tests/interactive/test_utils.py tests/interactive/imagetool/test_imagetool_coordinate_widget.py`
- `uv run ruff format --check src/erlab/interactive/utils.py tests/interactive/test_utils.py tests/interactive/imagetool/test_imagetool_coordinate_widget.py`
- `uv run ruff check src/erlab/interactive/utils.py tests/interactive/test_utils.py tests/interactive/imagetool/test_imagetool_coordinate_widget.py`