### PR TITLE
Add provenance-aware multi-input ImageTool workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
           - group: "cov-qt-imagetool"
             timeout-minutes: 30
             use-xdist: false
+          - group: "cov-qt-imagetool-manager"
+            timeout-minutes: 30
+            use-xdist: false
           - group: "cov-qt-tools"
             timeout-minutes: 25
             use-xdist: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,7 +216,7 @@
 
   Previously, ImageTool windows were always top-level items in the manager, while tools launched from ImageTool were nested under their source ImageTool. This made derived ImageTool outputs inconsistent: opening an ImageTool from an existing ImageTool created a sibling window instead of a child, and the manager could not track the relationship between the output and its source.
 
-  Starting with this release, ImageTool windows can be nested below the tool or ImageTool that created them, and the manager tracks parent-child relationships between source data, tools, and derived outputs. Results are organized under their source in the manager tree, and their lineage is tracked back to the original data. When parent data changes, child tools and outputs are marked as stale and can be refreshed manually or automatically. `ftool`, `goldtool`, and `restool` can also be configured to rerun fits when their source data updates.
+  Starting with this release, ImageTool windows can be nested below the tool or ImageTool that created them, and the manager tracks parent-child relationships between source data, tools, and derived outputs. Results are organized under their source in the manager tree, and their provenance is tracked back to the original data. When parent data changes, child tools and outputs are marked as stale and can be refreshed manually or automatically. `ftool`, `goldtool`, and `restool` can also be configured to rerun fits when their source data updates.
 
   ImageTool transform dialogs now include a `Result Placement` selector. In manager-backed windows, the default is `Open Child Window`. Choose `Open Top-Level Window` to keep the previous detached-window behavior, or `Replace Current` to overwrite the active ImageTool.
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -131,9 +131,7 @@ updated.
 
 Some manager results are made from two or more top-level ImageTools instead of from one
 parent row. Examples include {guilabel}`Concatenate` and console expressions such as
-`tools[0] - tools[1]`. These results open as normal top-level ImageTools, not as child
-rows, and they remain valid saved data even if one of the inputs is later renamed,
-reindexed, changed, or removed.
+`tools[0] - tools[1]`.
 
 The manager records the ImageTools that contributed to the result and shows their live
 relationship in the tree and side panel:
@@ -146,17 +144,13 @@ relationship in the tree and side panel:
 These badges describe the relationship to the currently open inputs. They do not mean
 the displayed result is invalid, and they do not change the result data automatically.
 
-Select a derived result and choose {guilabel}`Reload Data` to recompute it from its
-recorded inputs. If the live inputs are open, the manager uses their current data. If an
-input was removed but its recorded file source is still available, the manager reloads
-that input from the file before recomputing the result. When the new result is
-compatible with the current ImageTool view, the manager replaces the data in place so
-cursor positions, bins, dimension order, and display settings are kept. If the reloaded
-data has incompatible coordinates or dimensions, the manager lets you replace and reset
-the view, open the reloaded result as a new ImageTool, or cancel.
+{guilabel}`Reload Data` also works on these results. If the live inputs are open, the
+manager uses their current data. If an input was removed but its recorded file source is
+still available, the manager reloads that input from the file before recomputing the
+result.
 
-For script-derived results, {guilabel}`Reload Data` replays code recorded by the
-manager. Only reload derived results from workspaces you trust.
+For results from console scripts, {guilabel}`Reload Data` replays the recorded code in
+the console if possible. Only reload derived results from workspaces you trust.
 
 (imagetool-manager-replay-code)=
 
@@ -373,8 +367,21 @@ many of the same operations and keep track of the manager history. For example:
   # Create an ImageTool containing the difference of the first two windows
   tools[0] - tools[1]
 
+  # Use complicated expressions
+  tools[0].qsel(alpha=slice(-1, 1)).qsel.average("eV")
+  era.transform.rotate(tools[0], 2.0, axes=("alpha", "eV"), reshape=False)
+
   # Use a child ImageTool in a similar calculation
   tools[0].children[0] - tools[1]
+
+  # xarray module calls also keep manager inputs when they receive tool handles
+  xr.concat([tools[0], tools[1]], dim="scan")
+
+  # Simple helper functions defined in the console can receive tool handles directly
+  def normalize(data):
+      return data / data.max()
+
+  normalize(tools[0])
 
   # Keep the result in the console, then open it later
   diff = tools[0] - tools[1]

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -138,9 +138,9 @@ reindexed, changed, or removed.
 The manager records the ImageTools that contributed to the result and shows their live
 relationship in the tree and side panel:
 
-- {guilabel}`Inputs changed` means every recorded live input is still open, but at
+- {guilabel}`Changed` means every recorded live input is still open, but at
   least one no longer matches the data or provenance that made the result.
-- {guilabel}`Inputs missing` means at least one recorded live input was removed from
+- {guilabel}`Missing` means at least one recorded live input was removed from
   the manager.
 
 These badges describe the relationship to the currently open inputs. They do not mean
@@ -318,7 +318,7 @@ chunked Dask arrays show the dask icon, watched variables display their variable
 rows opened from another row can show the {guilabel}`Stale`,
 {guilabel}`Unavailable`, or {guilabel}`Auto` badges described in
 {ref}`imagetool-manager-refresh`, and top-level results made from several ImageTools
-can show the {guilabel}`Inputs changed` or {guilabel}`Inputs missing` badges described
+can show the {guilabel}`Changed` or {guilabel}`Missing` badges described
 in {ref}`imagetool-manager-derived-data`.
 
 ## Data Explorer and Console

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -367,8 +367,14 @@ many of the same operations and keep track of the manager history. For example:
   # Access the underlying DataArray of the first window
   tools[0].data
 
+  # Inspect and access ImageTool children under the first window
+  tools[0].children
+
   # Create an ImageTool containing the difference of the first two windows
   tools[0] - tools[1]
+
+  # Use a child ImageTool in a similar calculation
+  tools[0].children[0] - tools[1]
 
   # Keep the result in the console, then open it later
   diff = tools[0] - tools[1]

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -63,10 +63,9 @@ status, whether there are unsaved changes, and the number of open ImageTool wind
 Use its buttons to copy the path or reveal the `.itws` file in your system file
 browser.
 
-Use {guilabel}`File → Offload to Workspace` to save the workspace if needed, free
-selected in-memory ImageTool data, and reconnect those rows to dask-backed data read
-from the `.itws` file. Use {guilabel}`Dask → Load Into Memory` in ImageTool to bring
-that data back into memory.
+Use {guilabel}`File → Offload to Workspace` to make the selected data lazy-loaded from
+the workspace file. This frees up memory but will slow down indexing and slicing. Use
+{guilabel}`Dask → Load Into Memory` in ImageTool to bring that data back into memory.
 
 If the workspace contains watched notebook variables, the watched rows reopen with
 their variable-name badges. The rows stay disconnected until a notebook defines the
@@ -126,6 +125,39 @@ and {guilabel}`restool` include {guilabel}`Refit after update`; when it is enabl
 the tool reruns the same fit after compatible data from the ImageTool that opened it is
 updated.
 
+(imagetool-manager-derived-data)=
+
+## Results from several ImageTools
+
+Some manager results are made from two or more top-level ImageTools instead of from one
+parent row. Examples include {guilabel}`Concatenate` and console expressions such as
+`tools[0] - tools[1]`. These results open as normal top-level ImageTools, not as child
+rows, and they remain valid saved data even if one of the inputs is later renamed,
+reindexed, changed, or removed.
+
+The manager records the ImageTools that contributed to the result and shows their live
+relationship in the tree and side panel:
+
+- {guilabel}`Inputs changed` means every recorded live input is still open, but at
+  least one no longer matches the data or provenance that made the result.
+- {guilabel}`Inputs missing` means at least one recorded live input was removed from
+  the manager.
+
+These badges describe the relationship to the currently open inputs. They do not mean
+the displayed result is invalid, and they do not change the result data automatically.
+
+Select a derived result and choose {guilabel}`Reload Data` to recompute it from its
+recorded inputs. If the live inputs are open, the manager uses their current data. If an
+input was removed but its recorded file source is still available, the manager reloads
+that input from the file before recomputing the result. When the new result is
+compatible with the current ImageTool view, the manager replaces the data in place so
+cursor positions, bins, dimension order, and display settings are kept. If the reloaded
+data has incompatible coordinates or dimensions, the manager lets you replace and reset
+the view, open the reloaded result as a new ImageTool, or cancel.
+
+For script-derived results, {guilabel}`Reload Data` replays code recorded by the
+manager. Only reload derived results from workspaces you trust.
+
 (imagetool-manager-replay-code)=
 
 ## Operation history
@@ -133,17 +165,17 @@ updated.
 Selecting a row fills the side panel with details about that item. For an ImageTool
 window created from another row, the panel can show:
 
-- the file or data that started the workflow;
-- the steps used to create the selected ImageTool window;
-- code that can be pasted into a notebook or script to repeat those steps.
+- The file(s) or data required to create the window
+- The steps used to create the selected ImageTool window
+- Code that can be pasted into a notebook or script to repeat those steps
 
-Use the steps list to copy exactly what you need. Select one or more steps and copy the
-selected code, or use {guilabel}`Copy Full Code` to copy the whole workflow from the
-data that started the workflow to the selected ImageTool window. For [watched
-variables](working-with-notebooks), copied code contains the watched variable name.
-File-backed workflows also include a snippet that loads the data in the copied code.
-Otherwise, you will be prompted to enter the name of the variable to use as the source
-when you copy code.
+Right-click on the steps list to copy code that rebuilds the data shown in the selected
+ImageTool window.
+
+For [watched variables](working-with-notebooks), copied code contains the watched
+variable name. File-backed workflows also include a snippet that loads the data in the
+copied code. Otherwise, you will be prompted to enter the name of the variable to use as
+the source when you copy code.
 
 (imagetool-manager-start)=
 
@@ -170,13 +202,6 @@ manager `#0`, and later managers receive 0-based indexes in the order they start
 
 To start a new manager instance, choose {guilabel}`File → New Manager Window` from an
 existing manager window.
-
-Indexes are not reused while a higher-index manager is live or starting. If managers
-`#0`, `#1`, and `#2` are running, then `#1` closes, the next manager starts as `#3`.
-After all managers close or become stale, the next manager starts again as `#0`.
-
-When one manager is running, notebook and script calls can use `manager=True` without
-choosing an index.
 
 When more than one manager is running, either pass the index like `manager=2` or set a
 default for the current Python process or notebook kernel:
@@ -283,13 +308,18 @@ The following lists common actions included in the {guilabel}`File`, {guilabel}`
 - {guilabel}`Link` / {guilabel}`Unlink` – {kbd}`Ctrl+L` links the selected windows so they share cursors and slices; {kbd}`Ctrl+Shift+L` removes the links.
 - {guilabel}`Offload to Workspace` – Reloads the data as dask-backed data from the workspace file, freeing up memory but slowing down indexing. Use {guilabel}`Dask → Load Into Memory` in ImageTool to load it back into memory when needed.
 - {guilabel}`Concatenate` – Combine selected data with {func}`xarray.concat` and open the result in a new ImageTool window.
-- {guilabel}`Reload Data` – Re-fetches data from disk using the original loader function. When a source-bound child row is selected, reloads the reloadable ancestor ImageTool and refreshes the selected child path. Handy when data is updated during acquisition.
+- {guilabel}`Reload Data` – Recomputes selected data from its recorded source. For
+  file-backed ImageTools, this re-fetches data from disk and reapplies any recorded
+  operations. This is useful when conducting experiments, where you can repeat analysis
+  on a continually updated file source with a single click.
 
 Icons next to each entry indicate special states: linked windows share a colored badge,
 chunked Dask arrays show the dask icon, watched variables display their variable name,
-and rows opened from another row can show the {guilabel}`Stale`,
+rows opened from another row can show the {guilabel}`Stale`,
 {guilabel}`Unavailable`, or {guilabel}`Auto` badges described in
-{ref}`imagetool-manager-refresh`.
+{ref}`imagetool-manager-refresh`, and top-level results made from several ImageTools
+can show the {guilabel}`Inputs changed` or {guilabel}`Inputs missing` badges described
+in {ref}`imagetool-manager-derived-data`.
 
 ## Data Explorer and Console
 
@@ -325,19 +355,27 @@ For the standalone tool page, see {ref}`guide-ptable`.
 
 ### Console
 
-Toggle the embedded IPython console with {kbd}`Ctrl+J` or via the {guilabel}`View`
-menu. The console exposes a `tools` list containing wrappers for every ImageTool. For
-example:
+For quick calculations and data exploration without leaving the manager, the embedded
+IPython console is useful.
+
+Toggle the embedded IPython console with {kbd}`Ctrl+J` or via the {guilabel}`View` menu.
+The console exposes a `tools` list containing a provenance-aware handle for every
+ImageTool. These handles are not {class}`xarray.DataArray` objects, but they support
+many of the same operations and keep track of the manager history. For example:
 
   ```python
-  # List names of all windows
-  [tool.name for tool in tools]
-
   # Access the underlying DataArray of the first window
   tools[0].data
 
+  # Create an ImageTool containing the difference of the first two windows
+  tools[0] - tools[1]
+
+  # Keep the result in the console, then open it later
+  diff = tools[0] - tools[1]
+  diff.qshow(manager=True)
+
   # Replace data in the first window
-  tools[0].data = new_data
+  tools[0].data = tools[0].assign_coords(time=tools[1].time)
   ```
 
 Run standard Python, `%magic` commands, or inspect objects with `?` exactly as you would

--- a/docs/source/user-guide/workflow-bridge.md
+++ b/docs/source/user-guide/workflow-bridge.md
@@ -79,6 +79,9 @@ code for reproducibility and batch processing.
 - - Normalize interactively
   - {ref}`ImageTool normalization dialog <imagetool-editing>`
   - Expressions like `data / data.mean(...)`
+- - Combine manager ImageTools
+  - {guilabel}`Concatenate` in the {ref}`ImageTool manager <imagetool-manager-derived-data>`
+  - {func}`xarray.concat`
 - - Slice along an ROI path
   - {ref}`ROI context menu <imagetool-roi>`
   - {func}`erlab.analysis.interpolate.slice_along_path`

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -52,7 +52,21 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
         "tests/test_lattice.py",
     ),
     "cov-io": ("tests/io",),
-    "cov-qt-imagetool": ("tests/interactive/imagetool",),
+    "cov-qt-imagetool": (
+        "tests/interactive/imagetool/test_history.py",
+        "tests/interactive/imagetool/test_imagetool.py",
+        "tests/interactive/imagetool/test_imagetool_coordinate_widget.py",
+        "tests/interactive/imagetool/test_manager_warnings.py",
+        "tests/interactive/imagetool/test_module_split.py",
+        "tests/interactive/imagetool/test_provenance.py",
+        "tests/interactive/imagetool/test_replay_graph.py",
+        "tests/interactive/imagetool/test_server_multipart.py",
+        "tests/interactive/imagetool/test_slicer.py",
+        "tests/interactive/imagetool/test_watcher.py",
+    ),
+    "cov-qt-imagetool-manager": (
+        "tests/interactive/imagetool/test_imagetool_manager.py",
+    ),
     "cov-qt-tools": (
         "tests/interactive/test_bzplot.py",
         "tests/interactive/test_dask.py",

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -63,7 +63,8 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `Reconnect Watched Variables`, `.itws`, `standalone application`,
   `recent documents`, `Jump List`, `Dock menu`, `Result Placement`, `stale`,
   `automatic updates`, `Auto`, `Changed`, `Missing`, `Reload Data`,
-  `Concatenate`, `tools[0] - tools[1]`, `tools.selected`,
+  `Concatenate`, `tools[0] - tools[1]`, `tools[0].children`,
+  `tools.selected`,
   `Refit after update`, `code for repeating steps`,
   `reuses shared load and processing work`, `shared loader setup`,
   `ImageTool windows opened from tools`, or

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -65,6 +65,7 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `automatic updates`, `Auto`, `Changed`, `Missing`, `Reload Data`,
   `Concatenate`, `tools[0] - tools[1]`, `tools.selected`,
   `Refit after update`, `code for repeating steps`,
+  `reuses shared load and processing work`, `shared loader setup`,
   `ImageTool windows opened from tools`, or
   `workflow-bridge` for notebook and interactive-workflow questions.
 - Search `interactive-tool-authoring`, `ToolWindow`, `tool_status`,

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -62,7 +62,9 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `Add Windows From Workspace`, `%watch --restore`,
   `Reconnect Watched Variables`, `.itws`, `standalone application`,
   `recent documents`, `Jump List`, `Dock menu`, `Result Placement`, `stale`,
-  `automatic updates`, `Auto`, `Refit after update`, `code for repeating steps`,
+  `automatic updates`, `Auto`, `Inputs changed`, `Inputs missing`, `Reload Data`,
+  `Concatenate`, `tools[0] - tools[1]`, `tools.selected`,
+  `Refit after update`, `code for repeating steps`,
   `ImageTool windows opened from tools`, or
   `workflow-bridge` for notebook and interactive-workflow questions.
 - Search `interactive-tool-authoring`, `ToolWindow`, `tool_status`,

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -64,7 +64,9 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `recent documents`, `Jump List`, `Dock menu`, `Result Placement`, `stale`,
   `automatic updates`, `Auto`, `Changed`, `Missing`, `Reload Data`,
   `Concatenate`, `tools[0] - tools[1]`, `tools[0].children`,
-  `tools.selected`,
+  `tools.selected`, `tools[0].qsel`, `era.transform.rotate(tools[0])`,
+  `xr.concat([tools[0], tools[1]])`, `my_func(tools[0])`,
+  `structured console provenance`,
   `Refit after update`, `code for repeating steps`,
   `reuses shared load and processing work`, `shared loader setup`,
   `ImageTool windows opened from tools`, or

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -62,7 +62,7 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `Add Windows From Workspace`, `%watch --restore`,
   `Reconnect Watched Variables`, `.itws`, `standalone application`,
   `recent documents`, `Jump List`, `Dock menu`, `Result Placement`, `stale`,
-  `automatic updates`, `Auto`, `Inputs changed`, `Inputs missing`, `Reload Data`,
+  `automatic updates`, `Auto`, `Changed`, `Missing`, `Reload Data`,
   `Concatenate`, `tools[0] - tools[1]`, `tools.selected`,
   `Refit after update`, `code for repeating steps`,
   `ImageTool windows opened from tools`, or

--- a/src/erlab/interactive/imagetool/_load_source.py
+++ b/src/erlab/interactive/imagetool/_load_source.py
@@ -42,7 +42,9 @@ _RESERVED_REPLAY_SOURCE_NAMES = {
 _LoadFunc: typing.TypeAlias = tuple[
     Callable[..., typing.Any] | str,
     dict[str, typing.Any],
-    int,
+    int
+    | dict[str, typing.Any]
+    | erlab.interactive.imagetool.provenance.FileDataSelection,
 ]
 _LoadKind: typing.TypeAlias = typing.Literal["erlab_loader", "callable"]
 
@@ -80,7 +82,7 @@ class _ResolvedLoadFunc:
     setup_lines: tuple[str, ...]
     loader_name: str | None
     kwargs: dict[str, typing.Any]
-    selected_index: int
+    selection: erlab.interactive.imagetool.provenance.FileDataSelection
     cast_float64: bool
 
     @property
@@ -98,7 +100,7 @@ class _ResolvedLoadFunc:
             kind=self.kind,
             target=self.target,
             kwargs=self.kwargs,
-            selected_index=self.selected_index,
+            selection=self.selection,
             cast_float64=self.cast_float64,
         )
 
@@ -107,11 +109,7 @@ class _ResolvedLoadFunc:
         imports = list(self.imports)
         call_args = self._call_args(file_path)
         call_expr = f"{self.loader_expr}({', '.join(call_args)})"
-        if self.selected_index != 0:
-            call_expr = (
-                "erlab.interactive.imagetool.viewer._parse_input("
-                f"{call_expr})[{self.selected_index}]"
-            )
+        call_expr = _file_data_selection_code(call_expr, self.selection)
         if self.cast_float64:
             call_expr = f'{call_expr}.astype("float64")'
 
@@ -152,6 +150,26 @@ def _needs_float64_cast(source_input_dtype: np.dtype[typing.Any] | str | None) -
     return source_input_dtype is not None and np.dtype(source_input_dtype) not in (
         np.dtype(np.float32),
         np.dtype(np.float64),
+    )
+
+
+def _file_data_selection_code(
+    load_expr: str,
+    selection: erlab.interactive.imagetool.provenance.FileDataSelection,
+) -> str:
+    if selection.kind == "dataarray":
+        return load_expr
+    if selection.kind == "dataset_variable":
+        variable_code = erlab.interactive.imagetool.provenance._provenance_value_code(
+            selection.value
+        )
+        return f"{load_expr}[{variable_code}]"
+    if selection.kind == "datatree_path":
+        return f"{load_expr}[{selection.value!r}]"
+
+    return (
+        "erlab.interactive.imagetool.viewer._parse_input("
+        f"{load_expr})[{selection.value}]"
     )
 
 
@@ -275,7 +293,10 @@ def _resolve_load_func(
     if load_func is None:
         return None
 
-    loader, kwargs, selected_index = load_func
+    loader, kwargs, selection = load_func
+    selection = erlab.interactive.imagetool.provenance.FileDataSelection.model_validate(
+        selection
+    )
     cast_float64 = _needs_float64_cast(source_input_dtype)
     if isinstance(loader, str):
         return _ResolvedLoadFunc(
@@ -288,7 +309,7 @@ def _resolve_load_func(
             setup_lines=(f"erlab.io.set_loader({loader!r})",),
             loader_name=loader,
             kwargs=kwargs,
-            selected_index=selected_index,
+            selection=selection,
             cast_float64=cast_float64,
         )
 
@@ -305,7 +326,7 @@ def _resolve_load_func(
             setup_lines=(f"erlab.io.set_loader({loader_name!r})",),
             loader_name=loader_name,
             kwargs=kwargs,
-            selected_index=selected_index,
+            selection=selection,
             cast_float64=cast_float64,
         )
 
@@ -322,7 +343,7 @@ def _resolve_load_func(
         setup_lines=(),
         loader_name=None,
         kwargs=kwargs,
-        selected_index=selected_index,
+        selection=selection,
         cast_float64=cast_float64,
     )
 

--- a/src/erlab/interactive/imagetool/_load_source.py
+++ b/src/erlab/interactive/imagetool/_load_source.py
@@ -108,7 +108,6 @@ class _ResolvedLoadFunc:
         call_args = self._call_args(file_path)
         call_expr = f"{self.loader_expr}({', '.join(call_args)})"
         if self.selected_index != 0:
-            imports.append("import erlab")
             call_expr = (
                 "erlab.interactive.imagetool.viewer._parse_input("
                 f"{call_expr})[{self.selected_index}]"
@@ -116,14 +115,12 @@ class _ResolvedLoadFunc:
         if self.cast_float64:
             call_expr = f'{call_expr}.astype("float64")'
 
-        return "\n".join(
-            [
-                *list(dict.fromkeys(imports)),
-                "",
-                *self.setup_lines,
-                f"{assign} = {call_expr}",
-            ]
-        )
+        lines = list(dict.fromkeys(imports))
+        if lines:
+            lines.append("")
+        lines.extend(self.setup_lines)
+        lines.append(f"{assign} = {call_expr}")
+        return "\n".join(lines)
 
     def _call_args(self, file_path: Path) -> list[str]:
         """Return loader call arguments, using compact scan-number syntax when safe."""
@@ -287,7 +284,7 @@ def _resolve_load_func(
             loader_label="Loader",
             loader_text=loader,
             loader_expr="erlab.io.load",
-            imports=("import erlab",),
+            imports=(),
             setup_lines=(f"erlab.io.set_loader({loader!r})",),
             loader_name=loader,
             kwargs=kwargs,
@@ -304,7 +301,7 @@ def _resolve_load_func(
             loader_label="Loader",
             loader_text=loader_name,
             loader_expr="erlab.io.load",
-            imports=("import erlab",),
+            imports=(),
             setup_lines=(f"erlab.io.set_loader({loader_name!r})",),
             loader_name=loader_name,
             kwargs=kwargs,

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -516,17 +516,17 @@ class ImageTool(BaseImageTool):
                 selected_data = _select_input_dataarrays(loaded_data, self)
                 if selected_data is None:
                     return
-                first_data, first_source_index = selected_data[0]
+                first_data, first_selection = selected_data[0]
                 self.slicer_area.replace_source_data(
                     first_data,
                     file_path=fname,
-                    load_func=(fn, kargs, first_source_index),
+                    load_func=(fn, kargs, first_selection),
                 )
-                for data_array, source_index in selected_data[1:]:
+                for data_array, selection in selected_data[1:]:
                     tool = ImageTool(
                         data_array,
                         file_path=fname,
-                        load_func=(fn, kargs, source_index),
+                        load_func=(fn, kargs, selection),
                     )
                     self.slicer_area.add_tool_window(
                         tool, update_title=False, transfer_to_manager=False

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -1,0 +1,671 @@
+"""Internal replay graph for ImageTool provenance.
+
+The saved provenance schema stays in :mod:`erlab.interactive.imagetool.provenance`.
+This module compiles those specs into an execution/code-generation graph at runtime so
+shared file loads and shared structured operations are emitted or replayed once.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import typing
+from collections.abc import Callable, Mapping, Sequence
+
+import numpy as np
+import xarray as xr
+
+import erlab
+
+
+class ReplayGraphError(Exception):
+    """Raised when provenance cannot be compiled, emitted, or replayed."""
+
+
+class ReplayNode:
+    __slots__ = (
+        "cacheable",
+        "key",
+        "kind",
+        "parents",
+        "payload",
+    )
+
+    def __init__(
+        self,
+        key: str,
+        kind: str,
+        *,
+        parents: Sequence[str] = (),
+        cacheable: bool = True,
+        payload: Mapping[str, typing.Any] | None = None,
+    ) -> None:
+        self.key = key
+        self.kind = kind
+        self.parents = tuple(parents)
+        self.cacheable = cacheable
+        self.payload = dict(payload or {})
+
+
+class ReplayGraph:
+    __slots__ = ("_cacheable_keys", "_reserved_names", "aliases", "nodes", "output_key")
+
+    def __init__(self, *, reserved_names: set[str] | None = None) -> None:
+        self.nodes: list[ReplayNode] = []
+        self._cacheable_keys: dict[str, str] = {}
+        self._reserved_names = set(reserved_names or ())
+        self.aliases: list[tuple[str, str]] = []
+        self.output_key: str | None = None
+
+    @property
+    def reserved_names(self) -> set[str]:
+        return set(self._reserved_names)
+
+    def add_node(
+        self,
+        key: str,
+        kind: str,
+        *,
+        parents: Sequence[str] = (),
+        cacheable: bool = True,
+        payload: Mapping[str, typing.Any] | None = None,
+    ) -> str:
+        if cacheable and key in self._cacheable_keys:
+            return self._cacheable_keys[key]
+
+        node_key = key if cacheable else f"{key}#{len(self.nodes)}"
+        node = ReplayNode(
+            node_key,
+            kind,
+            parents=parents,
+            cacheable=cacheable,
+            payload=payload,
+        )
+        self.nodes.append(node)
+        if cacheable:
+            self._cacheable_keys[key] = node_key
+        return node_key
+
+
+LiveInputResolver = Callable[[typing.Any], tuple[xr.DataArray, typing.Any] | None]
+
+
+def _prov():
+    from erlab.interactive.imagetool import provenance
+
+    return provenance
+
+
+def _canonical_key(kind: str, payload: Mapping[str, typing.Any]) -> str:
+    return json.dumps(
+        {"kind": kind, **dict(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _reserved_names_from_spec(spec: typing.Any) -> set[str]:
+    names: set[str] = set()
+    active_name = getattr(spec, "active_name", None)
+    if isinstance(active_name, str):
+        names.add(active_name)
+    for script_input in getattr(spec, "script_inputs", ()):
+        names.add(script_input.name)
+        nested = script_input.parsed_provenance_spec()
+        if nested is not None:
+            names.update(_reserved_names_from_spec(nested))
+    return names
+
+
+def _script_replay_codes(spec: typing.Any) -> tuple[str, ...]:
+    prov = _prov()
+    if spec.kind != "script":
+        raise ReplayGraphError("Expected script provenance")
+    if spec.active_name is None:
+        raise ReplayGraphError(
+            "Script provenance cannot be replayed without active_name"
+        )
+
+    codes: list[str] = []
+    if spec.seed_code:
+        codes.append(spec.seed_code)
+    for operation in spec.operations:
+        if not isinstance(operation, prov.ScriptCodeOperation):
+            raise ReplayGraphError(
+                "Only script_code operations can be replayed as script provenance"
+            )
+        if not operation.copyable or operation.code is None:
+            raise ReplayGraphError("Script provenance contains non-replayable code")
+        codes.append(operation.code)
+    if not codes:
+        raise ReplayGraphError("Script provenance has no replay code")
+    for code in codes:
+        try:
+            prov._validate_script_replay_code(code)
+        except (TypeError, ValueError) as exc:
+            raise ReplayGraphError(str(exc)) from exc
+    return tuple(codes)
+
+
+def _file_seed_code_parts(seed_code: str, active_name: str) -> tuple[str | None, str]:
+    prov = _prov()
+
+    def module_code(body: Sequence[ast.stmt]) -> str | None:
+        if not body:
+            return None
+        module = ast.Module(body=list(body), type_ignores=[])
+        return ast.unparse(ast.fix_missing_locations(module))
+
+    try:
+        module = ast.parse(seed_code, mode="exec")
+    except SyntaxError as exc:
+        raise ReplayGraphError("File replay code is not valid Python") from exc
+
+    output_stmt_idx = next(
+        (
+            idx
+            for idx, stmt in enumerate(module.body)
+            if prov._statement_store_count(stmt, active_name) > 0
+        ),
+        None,
+    )
+    if output_stmt_idx is None:
+        raise ReplayGraphError("File replay code does not assign its output")
+
+    setup_code = module_code(module.body[:output_stmt_idx])
+    load_code = module_code(module.body[output_stmt_idx:])
+    if load_code is None:
+        raise ReplayGraphError("File replay code does not assign its output")
+    return setup_code, load_code
+
+
+def _compile_spec(
+    graph: ReplayGraph,
+    spec: typing.Any,
+    *,
+    display: bool,
+    external_inputs: Mapping[str, xr.DataArray] | None,
+    live_input_resolver: LiveInputResolver | None,
+) -> str:
+    prov = _prov()
+    parsed = prov.parse_tool_provenance_spec(spec)
+    if parsed is None:
+        raise ReplayGraphError("Expected provenance spec")
+
+    if parsed.kind == "file":
+        if parsed.file_load_source is None:
+            raise ReplayGraphError("File provenance does not define a load source")
+        if parsed.active_name is None or parsed.seed_code is None:
+            raise ReplayGraphError("File provenance does not define replay code")
+
+        setup_code, load_code = _file_seed_code_parts(
+            parsed.seed_code,
+            parsed.active_name,
+        )
+        setup_key = None
+        if setup_code:
+            setup_key = graph.add_node(
+                _canonical_key("setup", {"code": setup_code}),
+                "setup",
+                payload={"code": setup_code},
+            )
+        current_key = graph.add_node(
+            _canonical_key(
+                "file_load",
+                parsed.file_load_source.model_dump(mode="json"),
+            ),
+            "file_load",
+            parents=() if setup_key is None else (setup_key,),
+            payload={
+                "active_name": parsed.active_name,
+                "load_source": parsed.file_load_source,
+                "load_code": load_code,
+            },
+        )
+        for stage in parsed.replay_stages:
+            source_parent_key = current_key
+            current_key = graph.add_node(
+                _canonical_key(
+                    "source_view",
+                    {"parent": source_parent_key, "source_kind": stage.source_kind},
+                ),
+                "source_view",
+                parents=(source_parent_key,),
+                payload={"source_kind": stage.source_kind},
+            )
+            operations = stage.operations
+            if display:
+                operations = prov.ToolProvenanceSpec._streamlined_operations(
+                    stage.source_kind,
+                    operations,
+                )
+            for operation in operations:
+                current_key = graph.add_node(
+                    _canonical_key(
+                        "operation",
+                        {
+                            "context": source_parent_key,
+                            "operation": operation.model_dump(mode="json"),
+                            "parent": current_key,
+                        },
+                    ),
+                    "operation",
+                    parents=(current_key, source_parent_key),
+                    payload={"operation": operation},
+                )
+        return current_key
+
+    if parsed.kind == "script":
+        codes = _script_replay_codes(parsed)
+        bindings: list[tuple[str, str]] = []
+        if parsed.script_inputs:
+            for script_input in parsed.script_inputs:
+                live_data: xr.DataArray | None = None
+                if external_inputs is not None and script_input.name in external_inputs:
+                    live_data = external_inputs[script_input.name]
+                elif (
+                    live_input_resolver is not None
+                    and (resolved := live_input_resolver(script_input)) is not None
+                ):
+                    live_data = resolved[0]
+
+                if live_data is not None:
+                    input_key = graph.add_node(
+                        _canonical_key(
+                            "live_input",
+                            {
+                                "name": script_input.name,
+                                "node_snapshot_token": script_input.node_snapshot_token,
+                                "node_uid": script_input.node_uid,
+                            },
+                        ),
+                        "live_input",
+                        cacheable=False,
+                        payload={"data": live_data},
+                    )
+                else:
+                    input_spec = script_input.parsed_provenance_spec()
+                    if input_spec is None:
+                        raise ReplayGraphError(
+                            f"{script_input.name} from {script_input.label} "
+                            "does not contain recorded source provenance"
+                        )
+                    input_key = _compile_spec(
+                        graph,
+                        input_spec,
+                        display=display,
+                        external_inputs=external_inputs,
+                        live_input_resolver=live_input_resolver,
+                    )
+                bindings.append((script_input.name, input_key))
+        elif external_inputs:
+            for name, data in external_inputs.items():
+                input_key = graph.add_node(
+                    _canonical_key("external_input", {"name": name}),
+                    "live_input",
+                    cacheable=False,
+                    payload={"data": data},
+                )
+                bindings.append((name, input_key))
+
+        return graph.add_node(
+            _canonical_key(
+                "script",
+                {
+                    "active_name": parsed.active_name,
+                    "bindings": tuple(bindings),
+                    "codes": codes,
+                },
+            ),
+            "script",
+            parents=tuple(key for _name, key in bindings),
+            cacheable=False,
+            payload={
+                "active_name": parsed.active_name,
+                "bindings": tuple(bindings),
+                "codes": codes,
+            },
+        )
+
+    raise ReplayGraphError(f"{parsed.kind!r} provenance is not self-contained")
+
+
+def compile_replay_graph(
+    spec: typing.Any,
+    *,
+    display: bool = False,
+    external_inputs: Mapping[str, xr.DataArray] | None = None,
+    live_input_resolver: LiveInputResolver | None = None,
+) -> ReplayGraph:
+    parsed = _prov().parse_tool_provenance_spec(spec)
+    if parsed is None:
+        raise ReplayGraphError("Expected provenance spec")
+    reserved_names = _reserved_names_from_spec(parsed)
+    if external_inputs:
+        reserved_names.update(external_inputs)
+    graph = ReplayGraph(reserved_names=reserved_names)
+    graph.output_key = _compile_spec(
+        graph,
+        parsed,
+        display=display,
+        external_inputs=external_inputs,
+        live_input_resolver=live_input_resolver,
+    )
+    return graph
+
+
+def _node_names(graph: ReplayGraph) -> dict[str, str]:
+    names: dict[str, str] = {}
+    used = graph.reserved_names
+    counter = 0
+
+    def next_temp() -> str:
+        nonlocal counter
+        while True:
+            name = f"_itool_replay_{counter}"
+            counter += 1
+            if name not in used:
+                used.add(name)
+                return name
+
+    for node in graph.nodes:
+        names[node.key] = next_temp()
+    return names
+
+
+def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> str:
+    prov = _prov()
+    names = _node_names(graph)
+    node_by_key = {node.key: node for node in graph.nodes}
+    lines: list[str] = []
+    active_setup_key: str | None = None
+
+    for node in graph.nodes:
+        name = names[node.key]
+        if node.kind == "setup":
+            continue
+        if node.kind == "file_load":
+            active_name = typing.cast("str", node.payload["active_name"])
+            load_code = typing.cast("str", node.payload["load_code"])
+            setup_key = node.parents[0] if node.parents else None
+            if setup_key is not None and active_setup_key != setup_key:
+                setup_node = node_by_key[setup_key]
+                lines.append(typing.cast("str", setup_node.payload["code"]))
+                active_setup_key = setup_key
+            try:
+                code = prov._replace_code_identifiers(load_code, {active_name: name})
+            except SyntaxError as exc:
+                raise ReplayGraphError("File replay code is not valid Python") from exc
+            if not prov._code_stores_name(code, name):
+                raise ReplayGraphError("File replay code does not assign its output")
+            lines.append(code)
+        elif node.kind == "live_input":
+            raise ReplayGraphError("Live inputs cannot be emitted as replay code")
+        elif node.kind == "source_view":
+            parent_name = names[node.parents[0]]
+            if node.payload["source_kind"] == "full_data":
+                lines.append(f"{name} = {parent_name}")
+            else:
+                lines.append(
+                    f"{name} = erlab.interactive.imagetool.slicer."
+                    f"restore_nonuniform_dims({parent_name})"
+                )
+        elif node.kind == "operation":
+            parent_name = names[node.parents[0]]
+            context_name = names[node.parents[1]]
+            operation = node.payload["operation"]
+            entry = operation.derivation_entry()
+            if entry is None:
+                raise ReplayGraphError("Operation does not provide replay code")
+            lines.append(f"{name} = {parent_name}")
+            if entry.code is None:
+                raise ReplayGraphError("Operation does not provide replay code")
+            try:
+                lines.append(
+                    prov._replace_code_identifiers(
+                        entry.code,
+                        {"data": context_name, "derived": name},
+                    )
+                )
+            except SyntaxError as exc:
+                raise ReplayGraphError(
+                    "Operation replay code is not valid Python"
+                ) from exc
+        elif node.kind == "script":
+            for input_name, input_key in typing.cast(
+                "tuple[tuple[str, str], ...]", node.payload["bindings"]
+            ):
+                input_value_name = names[input_key]
+                if input_name != input_value_name:
+                    lines.append(f"{input_name} = {input_value_name}")
+            lines.extend(typing.cast("tuple[str, ...]", node.payload["codes"]))
+            active_name = typing.cast("str", node.payload["active_name"])
+            if active_name != name:
+                lines.append(f"{name} = {active_name}")
+            active_setup_key = None
+        else:
+            raise ReplayGraphError(f"Unknown replay graph node kind {node.kind!r}")
+
+    aliases = graph.aliases
+    if output_name is not None:
+        if graph.output_key is None:
+            raise ReplayGraphError("Replay graph has no output")
+        aliases = [*aliases, (output_name, graph.output_key)]
+    for public_name, key in aliases:
+        planned_name = names[key]
+        if public_name != planned_name:
+            lines.append(f"{public_name} = {planned_name}")
+    return "\n".join(lines)
+
+
+def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) -> str:
+    reserved_names: set[str] = set()
+    for script_input in script_inputs:
+        reserved_names.add(script_input.name)
+        reserved_names.update(
+            _reserved_names_from_spec(script_input.parsed_provenance_spec())
+        )
+    graph = ReplayGraph(reserved_names=reserved_names)
+    for script_input in script_inputs:
+        input_spec = script_input.parsed_provenance_spec()
+        if input_spec is None:
+            raise ReplayGraphError(
+                f"{script_input.name} from {script_input.label} "
+                "does not contain recorded source provenance"
+            )
+        input_key = _compile_spec(
+            graph,
+            input_spec,
+            display=display,
+            external_inputs=None,
+            live_input_resolver=None,
+        )
+        graph.aliases.append((script_input.name, input_key))
+    return emit_replay_code(graph)
+
+
+def execute_replay_graph(
+    graph: ReplayGraph,
+    *,
+    cache: dict[str, xr.DataArray] | None = None,
+) -> xr.DataArray:
+    prov = _prov()
+    replay_cache = {} if cache is None else cache
+    values: dict[str, xr.DataArray] = {}
+
+    for node in graph.nodes:
+        if node.cacheable and node.key in replay_cache:
+            values[node.key] = replay_cache[node.key].copy(deep=False)
+            continue
+
+        if node.kind == "file_load":
+            data = prov._load_file_source_data(node.payload["load_source"])
+        elif node.kind == "setup":
+            continue
+        elif node.kind == "live_input":
+            data = typing.cast("xr.DataArray", node.payload["data"]).copy(deep=False)
+        elif node.kind == "source_view":
+            parent_data = values[node.parents[0]]
+            data = prov.ToolProvenanceSpec._starting_data_for_kind(
+                node.payload["source_kind"],
+                parent_data,
+            )
+        elif node.kind == "operation":
+            data = node.payload["operation"].apply(
+                values[node.parents[0]],
+                parent_data=values[node.parents[1]],
+            )
+        elif node.kind == "script":
+            namespace: dict[str, typing.Any] = {
+                "__builtins__": prov._SCRIPT_REPLAY_ALLOWED_BUILTINS,
+                "erlab": erlab,
+                "np": np,
+                "numpy": np,
+                "xr": xr,
+                "xarray": xr,
+            }
+            for input_name, input_key in typing.cast(
+                "tuple[tuple[str, str], ...]", node.payload["bindings"]
+            ):
+                namespace[input_name] = values[input_key].copy(deep=True)
+            for code in typing.cast("tuple[str, ...]", node.payload["codes"]):
+                compiled = compile(code, "<ImageTool script provenance>", "exec")
+                exec(compiled, namespace, namespace)  # noqa: S102
+            active_name = typing.cast("str", node.payload["active_name"])
+            if active_name not in namespace:
+                raise ReplayGraphError(
+                    f"Script provenance did not create active variable {active_name!r}"
+                )
+            result = namespace[active_name]
+            if not isinstance(result, xr.DataArray):
+                raise ReplayGraphError(
+                    "Script provenance did not produce an xarray.DataArray for "
+                    f"{active_name!r}"
+                )
+            data = result
+        else:
+            raise ReplayGraphError(f"Unknown replay graph node kind {node.kind!r}")
+
+        if node.cacheable:
+            replay_cache[node.key] = data.copy(deep=False)
+        values[node.key] = data
+
+    if graph.output_key is None:
+        raise ReplayGraphError("Replay graph has no output")
+    return values[graph.output_key]
+
+
+def replay_file_provenance(
+    spec: typing.Any,
+    *,
+    cache: dict[str, xr.DataArray] | None = None,
+) -> xr.DataArray:
+    graph = compile_replay_graph(spec)
+    return execute_replay_graph(graph, cache=cache)
+
+
+def script_provenance_replayable(spec: typing.Any) -> bool:
+    parsed = _prov().parse_tool_provenance_spec(spec)
+    if parsed is None:
+        return False
+    try:
+        _script_replay_codes(parsed)
+    except (ReplayGraphError, TypeError, ValueError):
+        return False
+    return True
+
+
+def replay_script_provenance(
+    spec: typing.Any,
+    inputs: Mapping[str, xr.DataArray],
+) -> xr.DataArray:
+    graph = compile_replay_graph(spec, external_inputs=inputs)
+    return execute_replay_graph(graph)
+
+
+def rebuild_script_provenance(
+    spec: typing.Any,
+    *,
+    live_input_resolver: LiveInputResolver | None = None,
+    cache: dict[str, xr.DataArray] | None = None,
+    depth: int = 0,
+) -> tuple[xr.DataArray, typing.Any]:
+    prov = _prov()
+    parsed = prov.parse_tool_provenance_spec(spec)
+    if parsed is None or parsed.kind != "script":
+        raise ReplayGraphError("Selected provenance is not script-derived")
+    if depth > 20:
+        raise ReplayGraphError(
+            "Nested script provenance exceeded the maximum reload depth"
+        )
+    if not script_provenance_replayable(parsed):
+        raise ReplayGraphError(
+            "The recorded operation cannot be replayed automatically"
+        )
+
+    shared_cache = {} if cache is None else cache
+    resolved_inputs: list[tuple[xr.DataArray, typing.Any]] = []
+    for script_input in parsed.script_inputs:
+        resolved = live_input_resolver(script_input) if live_input_resolver else None
+        if resolved is not None:
+            resolved_inputs.append(resolved)
+            continue
+
+        input_spec = script_input.parsed_provenance_spec()
+        if input_spec is None:
+            raise ReplayGraphError(
+                f"{script_input.name} from {script_input.label} is not open and "
+                "does not contain recorded source provenance."
+            )
+
+        if input_spec.kind == "file":
+            data = replay_file_provenance(input_spec, cache=shared_cache)
+            resolved_inputs.append(
+                (
+                    data,
+                    script_input.model_copy(
+                        update={
+                            "node_uid": None,
+                            "node_snapshot_token": None,
+                            "provenance_spec": input_spec.model_dump(mode="json"),
+                        }
+                    ),
+                )
+            )
+            continue
+
+        if input_spec.kind == "script":
+            data, rebuilt_spec = rebuild_script_provenance(
+                input_spec,
+                live_input_resolver=live_input_resolver,
+                cache=shared_cache,
+                depth=depth + 1,
+            )
+            resolved_inputs.append(
+                (
+                    data,
+                    script_input.model_copy(
+                        update={
+                            "node_uid": None,
+                            "node_snapshot_token": None,
+                            "provenance_spec": rebuilt_spec.model_dump(mode="json"),
+                        }
+                    ),
+                )
+            )
+            continue
+
+        raise ReplayGraphError(
+            f"{script_input.name} from {script_input.label} is not open and "
+            "does not contain reloadable script or file provenance."
+        )
+
+    rebuilt_spec = parsed.model_copy(
+        update={
+            "script_inputs": tuple(
+                script_input for _data, script_input in resolved_inputs
+            )
+        }
+    )
+    input_data = {script_input.name: data for data, script_input in resolved_inputs}
+    return replay_script_provenance(rebuilt_spec, input_data), rebuilt_spec

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -8,7 +8,9 @@ shared file loads and shared structured operations are emitted or replayed once.
 from __future__ import annotations
 
 import ast
+import copy
 import json
+import symtable
 import typing
 from collections.abc import Callable, Mapping, Sequence
 
@@ -88,6 +90,11 @@ class ReplayGraph:
 
 
 LiveInputResolver = Callable[[typing.Any], tuple[xr.DataArray, typing.Any] | None]
+_REPLAY_ALIASES = {
+    "era": "erlab.analysis",
+    "eri": "erlab.interactive",
+    "eplt": "erlab.plotting",
+}
 
 
 def _prov():
@@ -117,7 +124,171 @@ def _reserved_names_from_spec(spec: typing.Any) -> set[str]:
     return names
 
 
-def _script_replay_codes(spec: typing.Any) -> tuple[str, ...]:
+def _code_uses_name(code: str, name: str) -> bool:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return False
+    return any(
+        isinstance(node, ast.Name)
+        and node.id == name
+        and isinstance(node.ctx, ast.Load)
+        for node in ast.walk(module)
+    )
+
+
+class _CurrentScopeNames(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.loads: set[str] = set()
+        self.stores: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Load):
+            self.loads.add(node.id)
+        elif isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.stores.add(node.id)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.stores.add(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_argument_expressions(node.args)
+        if node.returns is not None:
+            self.visit(node.returns)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.visit_FunctionDef(typing.cast("ast.FunctionDef", node))
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_argument_expressions(node.args)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.stores.add(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+
+    def _visit_argument_expressions(self, args: ast.arguments) -> None:
+        for default in args.defaults:
+            self.visit(default)
+        for default in args.kw_defaults:
+            if default is not None:
+                self.visit(default)
+        for arg in (
+            *args.posonlyargs,
+            *args.args,
+            *args.kwonlyargs,
+            *(arg for arg in (args.vararg, args.kwarg) if arg is not None),
+        ):
+            if arg.annotation is not None:
+                self.visit(arg.annotation)
+
+
+def _statement_scope_names(stmt: ast.stmt) -> _CurrentScopeNames:
+    names = _CurrentScopeNames()
+    names.visit(stmt)
+    return names
+
+
+def _script_function_dependencies(code: str) -> dict[tuple[str, int], set[str]]:
+    table = symtable.symtable(code, "<ImageTool script provenance>", "exec")
+
+    def child_dependencies(child: symtable.SymbolTable) -> set[str]:
+        deps = {
+            symbol.get_name()
+            for symbol in child.get_symbols()
+            if symbol.is_referenced()
+            and (symbol.is_global() or symbol.is_free())
+            and symbol.get_name() != child.get_name()
+        }
+        for nested in child.get_children():
+            deps.update(child_dependencies(nested))
+        return deps
+
+    output: dict[tuple[str, int], set[str]] = {}
+    for child in table.get_children():
+        if child.get_type() != "function":
+            continue
+        lineno = child.get_lineno()
+        if lineno is None:
+            continue
+        output[(child.get_name(), lineno)] = child_dependencies(child)
+    return output
+
+
+def _validate_script_code_names(
+    code: str,
+    available_names: set[str],
+    function_dependencies: dict[str, set[str]],
+) -> None:
+    module = ast.parse(code, mode="exec")
+    new_function_dependencies = _script_function_dependencies(code)
+
+    def require(name: str, visiting: set[str] | None = None) -> str | None:
+        if name not in available_names:
+            return name
+        deps = function_dependencies.get(name)
+        if not deps:
+            return None
+        if visiting is None:
+            visiting = set()
+        if name in visiting:
+            return None
+        visiting.add(name)
+        for dependency in deps:
+            missing = require(dependency, visiting)
+            if missing is not None:
+                return missing
+        visiting.remove(name)
+        return None
+
+    for stmt in module.body:
+        names = _statement_scope_names(stmt)
+        for name in sorted(names.loads):
+            missing = require(name)
+            if missing is not None:
+                raise ReplayGraphError(
+                    f"Script provenance references unresolved name {missing!r}"
+                )
+        if isinstance(stmt, ast.FunctionDef):
+            function_dependencies[stmt.name] = new_function_dependencies.get(
+                (stmt.name, stmt.lineno),
+                set(),
+            )
+        available_names.update(names.stores)
+
+
+def _simple_assignment_source_name(code: str, target_name: str) -> str | None:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return None
+    if len(module.body) != 1:
+        return None
+    stmt = module.body[0]
+    if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+        target = stmt.targets[0]
+        value = stmt.value
+    elif isinstance(stmt, ast.AnnAssign) and stmt.simple and stmt.value is not None:
+        target = stmt.target
+        value = stmt.value
+    else:
+        return None
+    if (
+        isinstance(target, ast.Name)
+        and target.id == target_name
+        and isinstance(value, ast.Name)
+    ):
+        return value.id
+    return None
+
+
+def _validate_script_provenance(
+    spec: typing.Any, *, external_input_names: set[str] | None = None
+) -> None:
     prov = _prov()
     if spec.kind != "script":
         raise ReplayGraphError("Expected script provenance")
@@ -126,33 +297,97 @@ def _script_replay_codes(spec: typing.Any) -> tuple[str, ...]:
             "Script provenance cannot be replayed without active_name"
         )
 
-    codes: list[str] = []
+    available_names = {
+        "erlab",
+        "np",
+        "numpy",
+        "xr",
+        "xarray",
+        *_REPLAY_ALIASES,
+        *prov._SCRIPT_REPLAY_ALLOWED_BUILTINS,
+    }
+    if spec.script_inputs:
+        available_names.update(script_input.name for script_input in spec.script_inputs)
+    elif external_input_names is not None:
+        available_names.update(external_input_names)
+    function_dependencies: dict[str, set[str]] = {}
+    has_replay_step = False
+    active_available = spec.active_name in available_names
     if spec.seed_code:
-        codes.append(spec.seed_code)
-    for operation in spec.operations:
-        if not isinstance(operation, prov.ScriptCodeOperation):
-            raise ReplayGraphError(
-                "Only script_code operations can be replayed as script provenance"
-            )
-        if not operation.copyable or operation.code is None:
-            raise ReplayGraphError("Script provenance contains non-replayable code")
-        codes.append(operation.code)
-    if not codes:
-        raise ReplayGraphError("Script provenance has no replay code")
-    for code in codes:
+        has_replay_step = True
         try:
-            prov._validate_script_replay_code(code)
+            prov._validate_script_replay_code(spec.seed_code)
         except (TypeError, ValueError) as exc:
             raise ReplayGraphError(str(exc)) from exc
-    return tuple(codes)
+        _validate_script_code_names(
+            spec.seed_code,
+            available_names,
+            function_dependencies,
+        )
+        active_available = active_available or prov._code_stores_name(
+            spec.seed_code, spec.active_name
+        )
+    for operation in spec.operations:
+        if isinstance(operation, prov.ScriptCodeOperation):
+            if not operation.copyable or operation.code is None:
+                raise ReplayGraphError("Script provenance contains non-replayable code")
+            has_replay_step = True
+            try:
+                prov._validate_script_replay_code(operation.code)
+            except (TypeError, ValueError) as exc:
+                raise ReplayGraphError(str(exc)) from exc
+            _validate_script_code_names(
+                operation.code,
+                available_names,
+                function_dependencies,
+            )
+            active_available = active_available or prov._code_stores_name(
+                operation.code, spec.active_name
+            )
+            continue
+        if not active_available:
+            raise ReplayGraphError("Script provenance has no replay code")
+        if not operation.live_applicable:
+            raise ReplayGraphError(
+                "Script provenance contains non-replayable operation"
+            )
+        has_replay_step = True
+        available_names.add(spec.active_name)
+        active_available = True
+    if not has_replay_step:
+        raise ReplayGraphError("Script provenance has no replay code")
+    if not active_available:
+        raise ReplayGraphError("Script provenance has no replay code")
 
 
 def _file_seed_code_parts(seed_code: str, active_name: str) -> tuple[str | None, str]:
     prov = _prov()
 
-    def module_code(body: Sequence[ast.stmt]) -> str | None:
+    def module_code(
+        body: Sequence[ast.stmt],
+        *,
+        strip_standard_imports: bool = False,
+    ) -> str | None:
         if not body:
             return None
+        if strip_standard_imports:
+            filtered_body: list[ast.stmt] = []
+            for stmt in body:
+                if isinstance(stmt, ast.Import):
+                    names = [
+                        alias
+                        for alias in stmt.names
+                        if alias.name != "erlab" or alias.asname not in {None, "erlab"}
+                    ]
+                    if names:
+                        stmt = copy.copy(stmt)
+                        stmt.names = names
+                        filtered_body.append(stmt)
+                    continue
+                filtered_body.append(stmt)
+            body = filtered_body
+            if not body:
+                return None
         module = ast.Module(body=list(body), type_ignores=[])
         return ast.unparse(ast.fix_missing_locations(module))
 
@@ -172,11 +407,59 @@ def _file_seed_code_parts(seed_code: str, active_name: str) -> tuple[str | None,
     if output_stmt_idx is None:
         raise ReplayGraphError("File replay code does not assign its output")
 
-    setup_code = module_code(module.body[:output_stmt_idx])
+    setup_code = module_code(
+        module.body[:output_stmt_idx],
+        strip_standard_imports=True,
+    )
     load_code = module_code(module.body[output_stmt_idx:])
     if load_code is None:
         raise ReplayGraphError("File replay code does not assign its output")
     return setup_code, load_code
+
+
+def _operation_replay_code(
+    operation: typing.Any,
+    *,
+    active_name: str,
+    context_name: str,
+    parent_name: str | None = None,
+) -> str:
+    prov = _prov()
+    entry = operation.derivation_entry()
+    if entry.code is None:
+        raise ReplayGraphError("Operation does not provide replay code")
+    if parent_name is None:
+        try:
+            code = prov._replace_code_identifiers(
+                entry.code,
+                {"data": context_name, "derived": active_name},
+            )
+        except SyntaxError as exc:
+            raise ReplayGraphError("Operation replay code is not valid Python") from exc
+    else:
+        parent_replacement = parent_name
+        try:
+            module = ast.parse(entry.code, mode="exec")
+        except SyntaxError as exc:
+            raise ReplayGraphError("Operation replay code is not valid Python") from exc
+
+        class OperationNameReplacer(ast.NodeTransformer):
+            def visit_Name(self, node: ast.Name) -> ast.Name:
+                if node.id == "derived":
+                    if isinstance(node.ctx, ast.Store):
+                        replacement = active_name
+                    else:
+                        replacement = parent_replacement
+                    return ast.copy_location(ast.Name(replacement, ctx=node.ctx), node)
+                if node.id == "data" and isinstance(node.ctx, ast.Load):
+                    return ast.copy_location(ast.Name(context_name, ctx=node.ctx), node)
+                return node
+
+        module = typing.cast("ast.Module", OperationNameReplacer().visit(module))
+        code = ast.unparse(ast.fix_missing_locations(module))
+    if not prov._code_stores_name(code, active_name):
+        raise ReplayGraphError("Operation replay code does not assign its output")
+    return code
 
 
 def _compile_spec(
@@ -256,7 +539,10 @@ def _compile_spec(
         return current_key
 
     if parsed.kind == "script":
-        codes = _script_replay_codes(parsed)
+        _validate_script_provenance(
+            parsed,
+            external_input_names=set(external_inputs or ()),
+        )
         bindings: list[tuple[str, str]] = []
         if parsed.script_inputs:
             for script_input in parsed.script_inputs:
@@ -308,24 +594,132 @@ def _compile_spec(
                 )
                 bindings.append((name, input_key))
 
-        return graph.add_node(
-            _canonical_key(
+        active_name = typing.cast("str", parsed.active_name)
+        script_current_key: str | None = None
+        current_bindings = tuple(bindings)
+        pending_codes: list[str] = []
+
+        def relay_key(source_key: str) -> str:
+            return graph.add_node(
+                _canonical_key("relay", {"parent": source_key}),
+                "relay",
+                parents=(source_key,),
+            )
+
+        def binding_key(name: str) -> str | None:
+            for binding_name, key in current_bindings:
+                if binding_name == name:
+                    return key
+            return None
+
+        def bind_name(name: str, key: str) -> tuple[tuple[str, str], ...]:
+            output: list[tuple[str, str]] = []
+            replaced = False
+            for binding_name, binding_key_value in current_bindings:
+                if binding_name == name:
+                    if not replaced:
+                        output.append((name, key))
+                        replaced = True
+                    continue
+                output.append((binding_name, binding_key_value))
+            if not replaced:
+                output.append((name, key))
+            return tuple(output)
+
+        def apply_simple_alias(code: str) -> bool:
+            nonlocal current_bindings, script_current_key
+            if pending_codes:
+                return False
+            source_name = _simple_assignment_source_name(code, active_name)
+            if source_name is None:
+                return False
+            source_key = binding_key(source_name)
+            if source_key is None:
+                return False
+            script_current_key = relay_key(source_key)
+            current_bindings = bind_name(active_name, script_current_key)
+            return True
+
+        def flush_script() -> None:
+            nonlocal current_bindings, pending_codes, script_current_key
+            if not pending_codes:
+                return
+            script_current_key = graph.add_node(
+                _canonical_key(
+                    "script",
+                    {
+                        "active_name": active_name,
+                        "bindings": current_bindings,
+                        "codes": tuple(pending_codes),
+                    },
+                ),
                 "script",
-                {
-                    "active_name": parsed.active_name,
-                    "bindings": tuple(bindings),
-                    "codes": codes,
+                parents=tuple(key for _name, key in current_bindings),
+                cacheable=False,
+                payload={
+                    "active_name": active_name,
+                    "bindings": current_bindings,
+                    "codes": tuple(pending_codes),
                 },
-            ),
-            "script",
-            parents=tuple(key for _name, key in bindings),
-            cacheable=False,
-            payload={
-                "active_name": parsed.active_name,
-                "bindings": tuple(bindings),
-                "codes": codes,
-            },
-        )
+            )
+            current_bindings = bind_name(active_name, script_current_key)
+            pending_codes = []
+
+        if parsed.seed_code and not apply_simple_alias(parsed.seed_code):
+            pending_codes.append(parsed.seed_code)
+        for operation in parsed.operations:
+            if display:
+                entry = operation.derivation_entry()
+                if entry.code in {
+                    "derived = derived.isel()",
+                    "derived = derived.qsel()",
+                    "derived = derived.sel()",
+                } or prov._is_internal_sort_coord_order_entry(entry):
+                    continue
+            if isinstance(operation, prov.ScriptCodeOperation):
+                if not operation.copyable or operation.code is None:
+                    raise ReplayGraphError(
+                        "Script provenance contains non-replayable code"
+                    )
+                if not apply_simple_alias(operation.code):
+                    pending_codes.append(operation.code)
+                continue
+
+            if pending_codes:
+                pending_codes.append(
+                    _operation_replay_code(
+                        operation,
+                        active_name=active_name,
+                        context_name=active_name,
+                    )
+                )
+                continue
+
+            flush_script()
+            if script_current_key is None:
+                matching_inputs = [key for name, key in bindings if name == active_name]
+                if len(matching_inputs) != 1:
+                    raise ReplayGraphError("Script provenance has no replay code")
+                script_current_key = relay_key(matching_inputs[0])
+            script_current_key = graph.add_node(
+                _canonical_key(
+                    "operation",
+                    {
+                        "context": script_current_key,
+                        "operation": operation.model_dump(mode="json"),
+                        "parent": script_current_key,
+                    },
+                ),
+                "operation",
+                parents=(script_current_key, script_current_key),
+                payload={"operation": operation},
+            )
+            current_bindings = bind_name(active_name, script_current_key)
+
+        flush_script()
+        if script_current_key is None:
+            raise ReplayGraphError("Script provenance has no replay code")
+        return script_current_key
 
     raise ReplayGraphError(f"{parsed.kind!r} provenance is not self-contained")
 
@@ -354,7 +748,30 @@ def compile_replay_graph(
     return graph
 
 
-def _node_names(graph: ReplayGraph) -> dict[str, str]:
+def _node_names(
+    graph: ReplayGraph,
+    *,
+    output_name: str | None = None,
+) -> dict[str, str]:
+    node_by_key = {node.key: node for node in graph.nodes}
+
+    def emitted_key(key: str) -> str:
+        node = node_by_key[key]
+        while node.kind == "relay" or (
+            node.kind == "source_view" and node.payload["source_kind"] == "full_data"
+        ):
+            key = node.parents[0]
+            node = node_by_key[key]
+        return key
+
+    preferred_names: dict[str, str] = {}
+    for public_name, key in graph.aliases:
+        preferred_names.setdefault(emitted_key(key), public_name)
+    if output_name is not None:
+        if graph.output_key is None:
+            raise ReplayGraphError("Replay graph has no output")
+        preferred_names[emitted_key(graph.output_key)] = output_name
+
     names: dict[str, str] = {}
     used = graph.reserved_names
     counter = 0
@@ -369,21 +786,101 @@ def _node_names(graph: ReplayGraph) -> dict[str, str]:
                 return name
 
     for node in graph.nodes:
-        names[node.key] = next_temp()
+        if (
+            node.kind == "setup"
+            or node.kind == "relay"
+            or (
+                node.kind == "source_view"
+                and node.payload["source_kind"] == "full_data"
+            )
+        ):
+            continue
+        preferred_name = preferred_names.get(node.key)
+        if preferred_name is not None and preferred_name not in names.values():
+            names[node.key] = preferred_name
+            used.add(preferred_name)
+        else:
+            names[node.key] = next_temp()
+
+    for node in graph.nodes:
+        if node.kind == "relay" or (
+            node.kind == "source_view" and node.payload["source_kind"] == "full_data"
+        ):
+            names[node.key] = names[emitted_key(node.key)]
     return names
+
+
+def _inline_adjacent_replay_assignments(code: str) -> str:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return code
+
+    prov = _prov()
+    changed = False
+    while True:
+        for idx, stmt in enumerate(module.body[:-1]):
+            if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+                continue
+            target = stmt.targets[0]
+            if not isinstance(target, ast.Name) or not target.id.startswith(
+                "_itool_replay_"
+            ):
+                continue
+            next_stmt = module.body[idx + 1]
+            if not isinstance(next_stmt, (ast.Assign, ast.Expr)):
+                continue
+            if prov._statement_load_count(next_stmt, target.id) != 1:
+                continue
+            if any(
+                prov._statement_load_count(later_stmt, target.id) > 0
+                for later_stmt in module.body[idx + 2 :]
+            ):
+                continue
+
+            inline_target = target.id
+            inline_value = copy.deepcopy(stmt.value)
+
+            class ReplayNameInliner(ast.NodeTransformer):
+                def __init__(self, target_name: str, value: ast.expr) -> None:
+                    self.target_name = target_name
+                    self.value = value
+
+                def visit_Name(self, node: ast.Name) -> ast.expr:
+                    if node.id == self.target_name and isinstance(node.ctx, ast.Load):
+                        return ast.copy_location(copy.deepcopy(self.value), node)
+                    return node
+
+            module.body[idx + 1] = ast.fix_missing_locations(
+                typing.cast(
+                    "ast.stmt",
+                    ReplayNameInliner(inline_target, inline_value).visit(next_stmt),
+                )
+            )
+            del module.body[idx]
+            changed = True
+            break
+        else:
+            break
+
+    if not changed:
+        return code
+    return ast.unparse(ast.fix_missing_locations(module))
 
 
 def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> str:
     prov = _prov()
-    names = _node_names(graph)
+    names = _node_names(graph, output_name=output_name)
     node_by_key = {node.key: node for node in graph.nodes}
     lines: list[str] = []
     active_setup_key: str | None = None
 
     for node in graph.nodes:
-        name = names[node.key]
         if node.kind == "setup":
             continue
+        if node.kind == "relay":
+            continue
+        name = names[node.key]
         if node.kind == "file_load":
             active_name = typing.cast("str", node.payload["active_name"])
             load_code = typing.cast("str", node.payload["load_code"])
@@ -404,33 +901,23 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
         elif node.kind == "source_view":
             parent_name = names[node.parents[0]]
             if node.payload["source_kind"] == "full_data":
-                lines.append(f"{name} = {parent_name}")
-            else:
-                lines.append(
-                    f"{name} = erlab.interactive.imagetool.slicer."
-                    f"restore_nonuniform_dims({parent_name})"
-                )
+                continue
+            lines.append(
+                f"{name} = erlab.interactive.imagetool.slicer."
+                f"restore_nonuniform_dims({parent_name})"
+            )
         elif node.kind == "operation":
             parent_name = names[node.parents[0]]
             context_name = names[node.parents[1]]
             operation = node.payload["operation"]
-            entry = operation.derivation_entry()
-            if entry is None:
-                raise ReplayGraphError("Operation does not provide replay code")
-            lines.append(f"{name} = {parent_name}")
-            if entry.code is None:
-                raise ReplayGraphError("Operation does not provide replay code")
-            try:
-                lines.append(
-                    prov._replace_code_identifiers(
-                        entry.code,
-                        {"data": context_name, "derived": name},
-                    )
+            lines.append(
+                _operation_replay_code(
+                    operation,
+                    active_name=name,
+                    context_name=context_name,
+                    parent_name=parent_name,
                 )
-            except SyntaxError as exc:
-                raise ReplayGraphError(
-                    "Operation replay code is not valid Python"
-                ) from exc
+            )
         elif node.kind == "script":
             for input_name, input_key in typing.cast(
                 "tuple[tuple[str, str], ...]", node.payload["bindings"]
@@ -455,7 +942,7 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
         planned_name = names[key]
         if public_name != planned_name:
             lines.append(f"{public_name} = {planned_name}")
-    return "\n".join(lines)
+    return _inline_adjacent_replay_assignments("\n".join(lines))
 
 
 def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) -> str:
@@ -484,6 +971,13 @@ def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) ->
     return emit_replay_code(graph)
 
 
+def _shares_array_memory(first: xr.DataArray, second: xr.DataArray) -> bool:
+    try:
+        return bool(np.shares_memory(first.data, second.data))
+    except (TypeError, ValueError):
+        return False
+
+
 def execute_replay_graph(
     graph: ReplayGraph,
     *,
@@ -504,6 +998,8 @@ def execute_replay_graph(
             continue
         elif node.kind == "live_input":
             data = typing.cast("xr.DataArray", node.payload["data"]).copy(deep=False)
+        elif node.kind == "relay":
+            data = values[node.parents[0]].copy(deep=False)
         elif node.kind == "source_view":
             parent_data = values[node.parents[0]]
             data = prov.ToolProvenanceSpec._starting_data_for_kind(
@@ -516,6 +1012,7 @@ def execute_replay_graph(
                 parent_data=values[node.parents[1]],
             )
         elif node.kind == "script":
+            codes = typing.cast("tuple[str, ...]", node.payload["codes"])
             namespace: dict[str, typing.Any] = {
                 "__builtins__": prov._SCRIPT_REPLAY_ALLOWED_BUILTINS,
                 "erlab": erlab,
@@ -524,11 +1021,18 @@ def execute_replay_graph(
                 "xr": xr,
                 "xarray": xr,
             }
+            for alias, target in _REPLAY_ALIASES.items():
+                if not any(_code_uses_name(code, alias) for code in codes):
+                    continue
+                value: typing.Any = erlab
+                for attr in target.split(".")[1:]:
+                    value = getattr(value, attr)
+                namespace[alias] = value
             for input_name, input_key in typing.cast(
                 "tuple[tuple[str, str], ...]", node.payload["bindings"]
             ):
                 namespace[input_name] = values[input_key].copy(deep=True)
-            for code in typing.cast("tuple[str, ...]", node.payload["codes"]):
+            for code in codes:
                 compiled = compile(code, "<ImageTool script provenance>", "exec")
                 exec(compiled, namespace, namespace)  # noqa: S102
             active_name = typing.cast("str", node.payload["active_name"])
@@ -552,7 +1056,13 @@ def execute_replay_graph(
 
     if graph.output_key is None:
         raise ReplayGraphError("Replay graph has no output")
-    return values[graph.output_key]
+    output = values[graph.output_key]
+    if any(
+        node.kind == "live_input" and _shares_array_memory(output, values[node.key])
+        for node in graph.nodes
+    ):
+        return output.copy(deep=True)
+    return output
 
 
 def replay_file_provenance(
@@ -569,7 +1079,7 @@ def script_provenance_replayable(spec: typing.Any) -> bool:
     if parsed is None:
         return False
     try:
-        _script_replay_codes(parsed)
+        _validate_script_provenance(parsed)
     except (ReplayGraphError, TypeError, ValueError):
         return False
     return True
@@ -603,69 +1113,77 @@ def rebuild_script_provenance(
             "The recorded operation cannot be replayed automatically"
         )
 
-    shared_cache = {} if cache is None else cache
-    resolved_inputs: list[tuple[xr.DataArray, typing.Any]] = []
-    for script_input in parsed.script_inputs:
-        resolved = live_input_resolver(script_input) if live_input_resolver else None
-        if resolved is not None:
-            resolved_inputs.append(resolved)
-            continue
+    live_results: dict[tuple[str, str | None], tuple[xr.DataArray, typing.Any]] = {}
+    live_misses: set[tuple[str, str | None]] = set()
 
-        input_spec = script_input.parsed_provenance_spec()
-        if input_spec is None:
+    def resolve_live(
+        script_input: typing.Any,
+    ) -> tuple[xr.DataArray, typing.Any] | None:
+        if live_input_resolver is None:
+            return None
+        key = (script_input.name, script_input.node_uid)
+        if key in live_results:
+            return live_results[key]
+        if key in live_misses:
+            return None
+        resolved = live_input_resolver(script_input)
+        if resolved is None:
+            live_misses.add(key)
+            return None
+        live_results[key] = resolved
+        return resolved
+
+    def resolve_inputs(current: typing.Any, current_depth: int) -> typing.Any:
+        if current_depth > 20:
             raise ReplayGraphError(
-                f"{script_input.name} from {script_input.label} is not open and "
-                "does not contain recorded source provenance."
+                "Nested script provenance exceeded the maximum reload depth"
             )
+        resolved_inputs = []
+        for script_input in current.script_inputs:
+            resolved = resolve_live(script_input)
+            if resolved is not None:
+                resolved_inputs.append(resolved[1])
+                continue
 
-        if input_spec.kind == "file":
-            data = replay_file_provenance(input_spec, cache=shared_cache)
-            resolved_inputs.append(
-                (
-                    data,
+            input_spec = script_input.parsed_provenance_spec()
+            if input_spec is None:
+                raise ReplayGraphError(
+                    f"{script_input.name} from {script_input.label} is not open and "
+                    "does not contain recorded source provenance."
+                )
+            if input_spec.kind == "file":
+                resolved_inputs.append(
                     script_input.model_copy(
                         update={
                             "node_uid": None,
                             "node_snapshot_token": None,
                             "provenance_spec": input_spec.model_dump(mode="json"),
                         }
-                    ),
+                    )
                 )
-            )
-            continue
-
-        if input_spec.kind == "script":
-            data, rebuilt_spec = rebuild_script_provenance(
-                input_spec,
-                live_input_resolver=live_input_resolver,
-                cache=shared_cache,
-                depth=depth + 1,
-            )
-            resolved_inputs.append(
-                (
-                    data,
+                continue
+            if input_spec.kind == "script":
+                if not script_provenance_replayable(input_spec):
+                    raise ReplayGraphError(
+                        "The recorded operation cannot be replayed automatically"
+                    )
+                rebuilt_input = resolve_inputs(input_spec, current_depth + 1)
+                resolved_inputs.append(
                     script_input.model_copy(
                         update={
                             "node_uid": None,
                             "node_snapshot_token": None,
-                            "provenance_spec": rebuilt_spec.model_dump(mode="json"),
+                            "provenance_spec": rebuilt_input.model_dump(mode="json"),
                         }
-                    ),
+                    )
                 )
+                continue
+            raise ReplayGraphError(
+                f"{script_input.name} from {script_input.label} is not open and "
+                "does not contain reloadable script or file provenance."
             )
-            continue
+        return current.model_copy(update={"script_inputs": tuple(resolved_inputs)})
 
-        raise ReplayGraphError(
-            f"{script_input.name} from {script_input.label} is not open and "
-            "does not contain reloadable script or file provenance."
-        )
-
-    rebuilt_spec = parsed.model_copy(
-        update={
-            "script_inputs": tuple(
-                script_input for _data, script_input in resolved_inputs
-            )
-        }
-    )
-    input_data = {script_input.name: data for data, script_input in resolved_inputs}
-    return replay_script_provenance(rebuilt_spec, input_data), rebuilt_spec
+    rebuilt_spec = resolve_inputs(parsed, depth)
+    graph = compile_replay_graph(rebuilt_spec, live_input_resolver=resolve_live)
+    return execute_replay_graph(graph, cache=cache), rebuilt_spec

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -667,8 +667,14 @@ def _compile_spec(
 
         if parsed.seed_code and not apply_simple_alias(parsed.seed_code):
             pending_codes.append(parsed.seed_code)
-        for operation in parsed.operations:
+        operations = tuple(parsed.operations)
+        for index, operation in enumerate(operations):
             if display:
+                if isinstance(operation, prov.RenameOperation) and not any(
+                    isinstance(later_operation, prov.ScriptCodeOperation)
+                    for later_operation in operations[index + 1 :]
+                ):
+                    continue
                 entry = operation.derivation_entry()
                 if entry.code in {
                     "derived = derived.isel()",
@@ -718,7 +724,10 @@ def _compile_spec(
 
         flush_script()
         if script_current_key is None:
-            raise ReplayGraphError("Script provenance has no replay code")
+            matching_inputs = [key for name, key in bindings if name == active_name]
+            if len(matching_inputs) != 1:
+                raise ReplayGraphError("Script provenance has no replay code")
+            script_current_key = relay_key(matching_inputs[0])
         return script_current_key
 
     raise ReplayGraphError(f"{parsed.kind!r} provenance is not self-contained")

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -8,7 +8,6 @@ shared file loads and shared structured operations are emitted or replayed once.
 from __future__ import annotations
 
 import ast
-import copy
 import json
 import symtable
 import typing
@@ -380,8 +379,7 @@ def _file_seed_code_parts(seed_code: str, active_name: str) -> tuple[str | None,
                         if alias.name != "erlab" or alias.asname not in {None, "erlab"}
                     ]
                     if names:
-                        stmt = copy.copy(stmt)
-                        stmt.names = names
+                        stmt = ast.Import(names=names)
                         filtered_body.append(stmt)
                     continue
                 filtered_body.append(stmt)
@@ -682,6 +680,11 @@ def _compile_spec(
                     "derived = derived.sel()",
                 } or prov._is_internal_sort_coord_order_entry(entry):
                     continue
+                if prov._is_whole_array_rename_entry(entry) and not any(
+                    isinstance(later_operation, prov.ScriptCodeOperation)
+                    for later_operation in operations[index + 1 :]
+                ):
+                    continue
             if isinstance(operation, prov.ScriptCodeOperation):
                 if not operation.copyable or operation.code is None:
                     raise ReplayGraphError(
@@ -827,6 +830,10 @@ def _inline_adjacent_replay_assignments(code: str) -> str:
 
     prov = _prov()
     changed = False
+
+    def clone_expr(expr: ast.expr) -> ast.expr:
+        return ast.parse(ast.unparse(expr), mode="eval").body
+
     while True:
         for idx, stmt in enumerate(module.body[:-1]):
             if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
@@ -848,7 +855,7 @@ def _inline_adjacent_replay_assignments(code: str) -> str:
                 continue
 
             inline_target = target.id
-            inline_value = copy.deepcopy(stmt.value)
+            inline_value = clone_expr(stmt.value)
 
             class ReplayNameInliner(ast.NodeTransformer):
                 def __init__(self, target_name: str, value: ast.expr) -> None:
@@ -857,7 +864,7 @@ def _inline_adjacent_replay_assignments(code: str) -> str:
 
                 def visit_Name(self, node: ast.Name) -> ast.expr:
                     if node.id == self.target_name and isinstance(node.ctx, ast.Load):
-                        return ast.copy_location(copy.deepcopy(self.value), node)
+                        return ast.copy_location(clone_expr(self.value), node)
                     return node
 
             module.body[idx + 1] = ast.fix_missing_locations(

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -1395,6 +1395,8 @@ class _DerivedDataNamespace(_ConsoleDataHandleMixin):
         return self._tools_ref()
 
     def _set_console_name(self, name: str) -> None:
+        if _replay_name_reserved(name):
+            return
         self._console_name = name
 
     def _console_operand(self) -> _ConsoleOperand:

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -606,7 +606,7 @@ class ToolNamespace(_ConsoleDataHandleMixin):
             name=self._console_input_name,
             label=label,
             node_uid=self._wrapper.uid,
-            node_lineage_token=self._wrapper.lineage_token,
+            node_snapshot_token=self._wrapper.snapshot_token,
             provenance_spec=provenance_spec,
         )
 

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 __all__ = ["ToolNamespace", "ToolsNamespace", "_ImageToolManagerJupyterConsole"]
 
-import ast
 import contextlib
 import importlib
+import operator
 import sys
 import typing
 import weakref
+from dataclasses import dataclass
 
 import numpy as np
 import qtconsole.inprocess
@@ -19,6 +20,14 @@ from qtpy import QtCore, QtWidgets
 import erlab
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from IPython.core.interactiveshell import (
+        ExecutionInfo,
+        ExecutionResult,
+        InteractiveShell,
+    )
+
     from erlab.interactive.imagetool import ImageTool
     from erlab.interactive.imagetool.manager import ImageToolManager
     from erlab.interactive.imagetool.manager._wrapper import _ImageToolWrapper
@@ -58,7 +67,453 @@ def _resolve_console_namespace(
     }
 
 
-class ToolNamespace:
+def _tool_data_name(index: int) -> str:
+    return f"data_{index}"
+
+
+def _dedupe_script_inputs(
+    inputs: Sequence[erlab.interactive.imagetool.provenance.ScriptInput],
+) -> tuple[erlab.interactive.imagetool.provenance.ScriptInput, ...]:
+    deduped: list[erlab.interactive.imagetool.provenance.ScriptInput] = []
+    seen: set[str] = set()
+    for script_input in inputs:
+        if script_input.name in seen:
+            continue
+        seen.add(script_input.name)
+        deduped.append(script_input)
+    return tuple(deduped)
+
+
+@dataclass(frozen=True)
+class _ConsoleOperand:
+    value: typing.Any
+    code: str
+    script_inputs: tuple[erlab.interactive.imagetool.provenance.ScriptInput, ...] = ()
+    copyable: bool = True
+
+
+def _literal_code(value: typing.Any) -> tuple[str, bool]:
+    value = erlab.utils.misc._convert_to_native(value)
+    if value is None or isinstance(value, (bool, int, float, complex, str, bytes)):
+        return repr(value), True
+    if isinstance(value, slice):
+        start, start_copyable = _literal_code(value.start)
+        stop, stop_copyable = _literal_code(value.stop)
+        step, step_copyable = _literal_code(value.step)
+        return (
+            f"slice({start}, {stop}, {step})",
+            start_copyable and stop_copyable and step_copyable,
+        )
+    if isinstance(value, tuple):
+        parts = [_literal_code(item) for item in value]
+        suffix = "," if len(parts) == 1 else ""
+        return (
+            f"({', '.join(part for part, _copyable in parts)}{suffix})",
+            all(copyable for _part, copyable in parts),
+        )
+    if isinstance(value, list):
+        parts = [_literal_code(item) for item in value]
+        return (
+            f"[{', '.join(part for part, _copyable in parts)}]",
+            all(copyable for _part, copyable in parts),
+        )
+    if isinstance(value, dict):
+        dict_parts: list[str] = []
+        copyable = True
+        for key, item in value.items():
+            key_code, key_copyable = _literal_code(key)
+            item_code, item_copyable = _literal_code(item)
+            dict_parts.append(f"{key_code}: {item_code}")
+            copyable = copyable and key_copyable and item_copyable
+        return f"{{{', '.join(dict_parts)}}}", copyable
+    return repr(value), False
+
+
+def _merge_operands(
+    *operands: _ConsoleOperand,
+) -> tuple[tuple[erlab.interactive.imagetool.provenance.ScriptInput, ...], bool]:
+    return (
+        _dedupe_script_inputs(
+            tuple(
+                script_input
+                for operand in operands
+                for script_input in operand.script_inputs
+            )
+        ),
+        all(operand.copyable for operand in operands),
+    )
+
+
+def _derived_operand_code(expression: str) -> str:
+    if any(symbol in expression for symbol in (" + ", " - ", " * ", " / ", " // ")):
+        return f"({expression})"
+    if any(symbol in expression for symbol in (" % ", " ** ", " & ", " | ", " ^ ")):
+        return f"({expression})"
+    if any(
+        symbol in expression
+        for symbol in (" < ", " <= ", " > ", " >= ", " == ", " != ")
+    ):
+        return f"({expression})"
+    return expression
+
+
+def _unwrap_console_value(value: typing.Any) -> typing.Any:
+    if isinstance(value, _ConsoleDataHandleMixin):
+        return value.data
+    if isinstance(value, tuple):
+        return tuple(_unwrap_console_value(item) for item in value)
+    if isinstance(value, list):
+        return [_unwrap_console_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            _unwrap_console_value(key): _unwrap_console_value(item)
+            for key, item in value.items()
+        }
+    return value
+
+
+def _operand_from_value(value: typing.Any) -> _ConsoleOperand:
+    if isinstance(value, _ConsoleDataHandleMixin):
+        return value._console_operand()
+    if isinstance(value, tuple):
+        item_operands = tuple(_operand_from_value(item) for item in value)
+        suffix = "," if len(item_operands) == 1 else ""
+        inputs, copyable = _merge_operands(*item_operands)
+        return _ConsoleOperand(
+            tuple(operand.value for operand in item_operands),
+            f"({', '.join(operand.code for operand in item_operands)}{suffix})",
+            inputs,
+            copyable,
+        )
+    if isinstance(value, list):
+        item_operands = tuple(_operand_from_value(item) for item in value)
+        inputs, copyable = _merge_operands(*item_operands)
+        return _ConsoleOperand(
+            [operand.value for operand in item_operands],
+            f"[{', '.join(operand.code for operand in item_operands)}]",
+            inputs,
+            copyable,
+        )
+    if isinstance(value, dict):
+        key_operands = tuple(_operand_from_value(key) for key in value)
+        value_operands = tuple(_operand_from_value(item) for item in value.values())
+        pair_operands = tuple(
+            operand
+            for pair in zip(key_operands, value_operands, strict=True)
+            for operand in pair
+        )
+        inputs, copyable = _merge_operands(*pair_operands)
+        return _ConsoleOperand(
+            {
+                key_operand.value: value_operand.value
+                for key_operand, value_operand in zip(
+                    key_operands, value_operands, strict=True
+                )
+            },
+            "{"
+            + ", ".join(
+                f"{key_operand.code}: {value_operand.code}"
+                for key_operand, value_operand in zip(
+                    key_operands, value_operands, strict=True
+                )
+            )
+            + "}",
+            inputs,
+            copyable,
+        )
+    code, copyable = _literal_code(value)
+    return _ConsoleOperand(value, code, copyable=copyable)
+
+
+def _format_call_code(
+    args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
+) -> tuple[
+    str,
+    tuple[erlab.interactive.imagetool.provenance.ScriptInput, ...],
+    tuple[typing.Any, ...],
+    dict[str, typing.Any],
+    bool,
+]:
+    arg_operands = tuple(_operand_from_value(arg) for arg in args)
+    kwarg_operands = {key: _operand_from_value(value) for key, value in kwargs.items()}
+    inputs, copyable = _merge_operands(*arg_operands, *tuple(kwarg_operands.values()))
+    parts = [operand.code for operand in arg_operands]
+    parts.extend(f"{key}={operand.code}" for key, operand in kwarg_operands.items())
+    return (
+        ", ".join(parts),
+        inputs,
+        tuple(operand.value for operand in arg_operands),
+        {key: operand.value for key, operand in kwarg_operands.items()},
+        copyable,
+    )
+
+
+class _ConsoleDataHandleMixin:
+    __array_priority__ = 1000
+
+    @property
+    def data(self) -> xr.DataArray:
+        raise NotImplementedError
+
+    @property
+    def _console_tools(self) -> ToolsNamespace | None:
+        raise NotImplementedError
+
+    @property
+    def _console_is_source(self) -> bool:
+        return False
+
+    def _console_operand(self) -> _ConsoleOperand:
+        raise NotImplementedError
+
+    def _console_provenance_spec(
+        self, *, active_name: str, label: str
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+        raise NotImplementedError
+
+    def _wrap_console_result(
+        self,
+        value: typing.Any,
+        expression: str,
+        script_inputs: Sequence[erlab.interactive.imagetool.provenance.ScriptInput],
+        *,
+        copyable: bool,
+    ) -> typing.Any:
+        if not isinstance(value, xr.DataArray):
+            return value
+        return _DerivedDataNamespace(
+            self._console_tools,
+            value,
+            expression,
+            _dedupe_script_inputs(script_inputs),
+            copyable=copyable,
+        )
+
+    def _binary_operation(
+        self,
+        other: typing.Any,
+        symbol: str,
+        operation: Callable[[typing.Any, typing.Any], typing.Any],
+        *,
+        reflected: bool = False,
+    ) -> typing.Any:
+        left_operand = (
+            _operand_from_value(other) if reflected else self._console_operand()
+        )
+        right_operand = (
+            self._console_operand() if reflected else _operand_from_value(other)
+        )
+        inputs, copyable = _merge_operands(left_operand, right_operand)
+        result = operation(left_operand.value, right_operand.value)
+        expression = f"{left_operand.code} {symbol} {right_operand.code}"
+        return self._wrap_console_result(result, expression, inputs, copyable=copyable)
+
+    def _unary_operation(
+        self, symbol: str, operation: Callable[[typing.Any], typing.Any]
+    ) -> typing.Any:
+        operand = self._console_operand()
+        result = operation(operand.value)
+        return self._wrap_console_result(
+            result,
+            f"{symbol}{operand.code}",
+            operand.script_inputs,
+            copyable=operand.copyable,
+        )
+
+    def __add__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "+", operator.add)
+
+    def __radd__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "+", operator.add, reflected=True)
+
+    def __sub__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "-", operator.sub)
+
+    def __rsub__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "-", operator.sub, reflected=True)
+
+    def __mul__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "*", operator.mul)
+
+    def __rmul__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "*", operator.mul, reflected=True)
+
+    def __matmul__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "@", operator.matmul)
+
+    def __rmatmul__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "@", operator.matmul, reflected=True)
+
+    def __truediv__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "/", operator.truediv)
+
+    def __rtruediv__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "/", operator.truediv, reflected=True)
+
+    def __floordiv__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "//", operator.floordiv)
+
+    def __rfloordiv__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "//", operator.floordiv, reflected=True)
+
+    def __mod__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "%", operator.mod)
+
+    def __rmod__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "%", operator.mod, reflected=True)
+
+    def __pow__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "**", operator.pow)
+
+    def __rpow__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "**", operator.pow, reflected=True)
+
+    def __and__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "&", operator.and_)
+
+    def __rand__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "&", operator.and_, reflected=True)
+
+    def __or__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "|", operator.or_)
+
+    def __ror__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "|", operator.or_, reflected=True)
+
+    def __xor__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "^", operator.xor)
+
+    def __rxor__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "^", operator.xor, reflected=True)
+
+    def __lt__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "<", operator.lt)
+
+    def __le__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, "<=", operator.le)
+
+    def __gt__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, ">", operator.gt)
+
+    def __ge__(self, other: typing.Any) -> typing.Any:
+        return self._binary_operation(other, ">=", operator.ge)
+
+    def __eq__(self, other: object) -> typing.Any:
+        return self._binary_operation(other, "==", operator.eq)
+
+    def __ne__(self, other: object) -> typing.Any:
+        return self._binary_operation(other, "!=", operator.ne)
+
+    def __neg__(self) -> typing.Any:
+        return self._unary_operation("-", operator.neg)
+
+    def __pos__(self) -> typing.Any:
+        return self._unary_operation("+", operator.pos)
+
+    def __abs__(self) -> typing.Any:
+        operand = self._console_operand()
+        return self._wrap_console_result(
+            abs(operand.value),
+            f"abs({operand.code})",
+            operand.script_inputs,
+            copyable=operand.copyable,
+        )
+
+    def __invert__(self) -> typing.Any:
+        return self._unary_operation("~", operator.invert)
+
+    def __array__(
+        self,
+        dtype: np.dtype[typing.Any] | None = None,
+        copy: bool | None = None,
+    ) -> np.ndarray:
+        if copy is None:
+            return np.asarray(self.data, dtype=dtype)
+        return np.array(self.data, dtype=dtype, copy=copy)
+
+    def __array_ufunc__(
+        self,
+        ufunc: np.ufunc,
+        method: str,
+        *inputs: typing.Any,
+        **kwargs: typing.Any,
+    ) -> typing.Any:
+        if method != "__call__":
+            return NotImplemented
+        input_operands = tuple(_operand_from_value(value) for value in inputs)
+        kwarg_operands = {
+            key: _operand_from_value(value) for key, value in kwargs.items()
+        }
+        script_inputs, copyable = _merge_operands(
+            *input_operands, *tuple(kwarg_operands.values())
+        )
+        raw_kwargs = {key: operand.value for key, operand in kwarg_operands.items()}
+        result = ufunc(*(operand.value for operand in input_operands), **raw_kwargs)
+        arg_code = ", ".join(
+            (
+                *(operand.code for operand in input_operands),
+                *(f"{key}={operand.code}" for key, operand in kwarg_operands.items()),
+            )
+        )
+        return self._wrap_console_result(
+            result,
+            f"np.{ufunc.__name__}({arg_code})",
+            script_inputs,
+            copyable=copyable,
+        )
+
+    def __getitem__(self, key: typing.Any) -> typing.Any:
+        key_operand = _operand_from_value(key)
+        self_operand = self._console_operand()
+        result = self.data[key_operand.value]
+        inputs, copyable = _merge_operands(self_operand, key_operand)
+        return self._wrap_console_result(
+            result,
+            f"{self_operand.code}[{key_operand.code}]",
+            inputs,
+            copyable=copyable,
+        )
+
+    def qshow(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        tools = self._console_tools
+        if tools is None:
+            return self.data.qshow(*args, **kwargs)
+        return tools._qshow_handle(self, *args, **kwargs)
+
+    def __getattr__(self, attr: str) -> typing.Any:
+        data_attr = getattr(self.data, attr)
+        if not callable(data_attr):
+            if isinstance(data_attr, xr.DataArray):
+                operand = self._console_operand()
+                return self._wrap_console_result(
+                    data_attr,
+                    f"{operand.code}.{attr}",
+                    operand.script_inputs,
+                    copyable=operand.copyable,
+                )
+            return data_attr
+
+        def _method(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            call_code, call_inputs, raw_args, raw_kwargs, args_copyable = (
+                _format_call_code(args, kwargs)
+            )
+            self_operand = self._console_operand()
+            result = data_attr(*raw_args, **raw_kwargs)
+            inputs, copyable = _merge_operands(
+                self_operand,
+                _ConsoleOperand(None, "", call_inputs, args_copyable),
+            )
+            return self._wrap_console_result(
+                result,
+                f"{self_operand.code}.{attr}({call_code})",
+                inputs,
+                copyable=copyable,
+            )
+
+        return _method
+
+
+class ToolNamespace(_ConsoleDataHandleMixin):
     """A console interface that represents a single ImageTool object.
 
     In the manager console, this namespace can be accessed with the variable
@@ -76,8 +531,11 @@ class ToolNamespace:
 
     """
 
-    def __init__(self, wrapper: _ImageToolWrapper) -> None:
+    def __init__(
+        self, wrapper: _ImageToolWrapper, tools: ToolsNamespace | None = None
+    ) -> None:
         self._wrapper_ref = weakref.ref(wrapper)
+        self._tools_ref = weakref.ref(tools) if tools is not None else None
 
     @property
     def _wrapper(self) -> _ImageToolWrapper:
@@ -97,23 +555,101 @@ class ToolNamespace:
         return self.tool.slicer_area._data
 
     @data.setter
-    def data(self, value: xr.DataArray) -> None:
-        self.tool.slicer_area.replace_source_data(value, emit_edited=True)
+    def data(self, value: xr.DataArray | _ConsoleDataHandleMixin) -> None:
+        provenance_spec = None
+        if isinstance(value, _ConsoleDataHandleMixin):
+            raw_value = value.data
+            provenance_spec = value._console_provenance_spec(
+                active_name=self._console_input_name,
+                label=f"Replace ImageTool {self._wrapper.index} data from console",
+            )
+        else:
+            raw_value = value
+        if provenance_spec is not None:
+            self._wrapper.set_detached_provenance(provenance_spec)
+        self.tool.slicer_area.replace_source_data(raw_value, emit_edited=True)
 
     def _get_data_item(self, key):
-        """Return a subset of the tool data for rewritten console assignments."""
+        """Return a subset of the tool data."""
         return self.tool.slicer_area._data[key]
 
     def _set_data_item(self, key, value) -> None:
         """Safely mutate a subset of the tool data from the console."""
-        self.tool.slicer_area._set_source_item(key, value)
+        self.tool.slicer_area._set_source_item(key, _unwrap_console_value(value))
+
+    @property
+    def _console_tools(self) -> ToolsNamespace | None:
+        if self._tools_ref is None:
+            return None
+        return self._tools_ref()
+
+    @property
+    def _console_is_source(self) -> bool:
+        return True
+
+    @property
+    def _console_input_name(self) -> str:
+        return _tool_data_name(self._wrapper.index)
+
+    def _script_input(
+        self,
+    ) -> erlab.interactive.imagetool.provenance.ScriptInput:
+        label = f"ImageTool {self._wrapper.index}"
+        if self._wrapper.name:
+            label += f": {self._wrapper.name}"
+        provenance_spec = (
+            self._wrapper.provenance_spec.model_dump(mode="json")
+            if self._wrapper.provenance_spec is not None
+            else None
+        )
+        return erlab.interactive.imagetool.provenance.ScriptInput(
+            name=self._console_input_name,
+            label=label,
+            node_uid=self._wrapper.uid,
+            node_lineage_token=self._wrapper.lineage_token,
+            provenance_spec=provenance_spec,
+        )
+
+    def _console_operand(self) -> _ConsoleOperand:
+        return _ConsoleOperand(
+            self.data,
+            self._console_input_name,
+            (self._script_input(),),
+        )
+
+    def _console_provenance_spec(
+        self, *, active_name: str, label: str
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+        return self._wrapper.provenance_spec
+
+    def __setitem__(self, key: typing.Any, value: typing.Any) -> None:
+        key_operand = _operand_from_value(key)
+        value_operand = _operand_from_value(value)
+        self_operand = self._console_operand()
+        script_inputs, copyable = _merge_operands(
+            self_operand, key_operand, value_operand
+        )
+        provenance_spec = erlab.interactive.imagetool.provenance.script(
+            erlab.interactive.imagetool.provenance.ScriptCodeOperation(
+                label=f"Set ImageTool {self._wrapper.index} data item from console",
+                code=(
+                    f"{self_operand.code}[{key_operand.code}] = {value_operand.code}"
+                ),
+                copyable=copyable,
+            ),
+            start_label="Run ImageTool manager console code",
+            active_name=self._console_input_name,
+            script_inputs=script_inputs,
+        )
+        self._set_data_item(key_operand.value, value_operand.value)
+        self._wrapper.set_detached_provenance(provenance_spec)
 
     def __getattr__(self, attr):  # implicitly wrap methods from ImageToolWrapper
         if hasattr(self._wrapper, attr):
             m = getattr(self._wrapper, attr)
             if callable(m):
                 return m
-        raise AttributeError(attr)
+        return super().__getattr__(attr)
 
     def __repr__(self) -> str:
         time_repr = self._wrapper._created_time.isoformat(sep=" ", timespec="seconds")
@@ -121,6 +657,86 @@ class ToolNamespace:
         out += f"  Added: {time_repr}\n"
         out += f"  Linked: {self.tool.slicer_area.is_linked}\n"
         return out
+
+
+class _DerivedDataNamespace(_ConsoleDataHandleMixin):
+    def __init__(
+        self,
+        tools: ToolsNamespace | None,
+        data: xr.DataArray,
+        expression: str,
+        script_inputs: Sequence[erlab.interactive.imagetool.provenance.ScriptInput],
+        *,
+        copyable: bool,
+    ) -> None:
+        self._tools_ref = weakref.ref(tools) if tools is not None else None
+        self._data = data
+        self._expression = expression
+        self._script_inputs = _dedupe_script_inputs(script_inputs)
+        self._copyable = copyable
+        self._console_name: str | None = None
+
+    @property
+    def data(self) -> xr.DataArray:
+        return self._data
+
+    @property
+    def _console_tools(self) -> ToolsNamespace | None:
+        if self._tools_ref is None:
+            return None
+        return self._tools_ref()
+
+    def _set_console_name(self, name: str) -> None:
+        self._console_name = name
+
+    def _console_operand(self) -> _ConsoleOperand:
+        if self._console_name is None:
+            return _ConsoleOperand(
+                self.data,
+                _derived_operand_code(self._expression),
+                self._script_inputs,
+                self._copyable,
+            )
+        provenance_spec = self._console_provenance_spec(
+            active_name=self._console_name,
+            label=f"Assign console variable {self._console_name!r}",
+        )
+        provenance_payload = (
+            provenance_spec.model_dump(mode="json")
+            if provenance_spec is not None
+            else None
+        )
+        return _ConsoleOperand(
+            self.data,
+            self._console_name,
+            (
+                erlab.interactive.imagetool.provenance.ScriptInput(
+                    name=self._console_name,
+                    label=f"console variable {self._console_name!r}",
+                    provenance_spec=provenance_payload,
+                ),
+            ),
+            provenance_spec is not None,
+        )
+
+    def _console_provenance_spec(
+        self, *, active_name: str, label: str
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+        if not self._script_inputs:
+            return None
+        return erlab.interactive.imagetool.provenance.script(
+            erlab.interactive.imagetool.provenance.ScriptCodeOperation(
+                label=label,
+                code=f"{active_name} = {self._expression}",
+                copyable=self._copyable,
+            ),
+            start_label="Run ImageTool manager console code",
+            active_name=active_name,
+            script_inputs=self._script_inputs,
+        )
+
+    def __repr__(self) -> str:
+        return repr(self.data)
 
 
 class ToolsNamespace:
@@ -142,6 +758,8 @@ class ToolsNamespace:
 
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager_ref = weakref.ref(manager)
+        self._shell_ref: weakref.ReferenceType[InteractiveShell] | None = None
+        self._namespace_snapshot: dict[str, int] = {}
 
     @property
     def _manager(self) -> ImageToolManager:
@@ -159,13 +777,173 @@ class ToolsNamespace:
             for idx in self._manager.tree_view.selected_imagetool_indices
         ]
 
+    @property
+    def selected(self) -> list[ToolNamespace]:
+        """Get provenance-aware handles for the selected windows."""
+        output: list[ToolNamespace] = []
+        for idx in self._manager.tree_view.selected_imagetool_indices:
+            namespace = self[idx]
+            if namespace is not None:
+                output.append(namespace)
+        return output
+
     def __getitem__(self, index: int) -> ToolNamespace | None:
         """Access a specific ImageTool object by its index."""
         if index not in self._manager._imagetool_wrappers:
             print(f"Tool {index} not found")
             return None
 
-        return ToolNamespace(self._manager._imagetool_wrappers[index])
+        return ToolNamespace(self._manager._imagetool_wrappers[index], self)
+
+    def bind_shell(self, shell: InteractiveShell) -> None:
+        self._shell_ref = weakref.ref(shell)
+        shell.events.register("pre_run_cell", self._pre_run_cell)
+        shell.events.register("post_run_cell", self._post_run_cell)
+
+    def unbind_shell(self) -> None:
+        if self._shell_ref is None:
+            return
+        shell = self._shell_ref()
+        if shell is not None:
+            with contextlib.suppress(KeyError, ValueError):
+                shell.events.unregister("pre_run_cell", self._pre_run_cell)
+            with contextlib.suppress(KeyError, ValueError):
+                shell.events.unregister("post_run_cell", self._post_run_cell)
+        self._shell_ref = None
+
+    def _pre_run_cell(self, info: ExecutionInfo | None = None) -> None:
+        if self._shell_ref is None:
+            return
+        shell = self._shell_ref()
+        if shell is None:
+            return
+        self._namespace_snapshot = {
+            name: id(value) for name, value in shell.user_ns.items()
+        }
+
+    def _post_run_cell(self, result: ExecutionResult | None = None) -> None:
+        if result is not None and (
+            result.error_before_exec is not None or result.error_in_exec is not None
+        ):
+            return
+        if self._shell_ref is not None and (shell := self._shell_ref()) is not None:
+            for name, value in shell.user_ns.items():
+                if (
+                    name.startswith("_")
+                    or self._namespace_snapshot.get(name) == id(value)
+                    or not isinstance(value, _DerivedDataNamespace)
+                ):
+                    continue
+                value._set_console_name(name)
+        if result is None or not isinstance(result.result, _DerivedDataNamespace):
+            return
+        self._show_handle(
+            result.result,
+            active_name=result.result._console_name or "derived",
+            label="Evaluate console expression",
+        )
+
+    def _manager_argument_targets_this_manager(self, value: typing.Any) -> bool:
+        if value is False:
+            return False
+        if value is None or value is True:
+            return True
+        try:
+            target = operator.index(value)
+        except TypeError:
+            return False
+        return target == getattr(self._manager, "manager_index", None)
+
+    def _show_dataarray_with_provenance(
+        self,
+        data: xr.DataArray,
+        provenance_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
+        **kwargs,
+    ) -> bool:
+        display_kwargs = dict(kwargs)
+        display_kwargs.pop("execute", None)
+        tool = erlab.interactive.itool(
+            data, manager=False, execute=False, **display_kwargs
+        )
+        if not isinstance(tool, erlab.interactive.imagetool.ImageTool):
+            return False
+        self._manager.add_imagetool(
+            tool,
+            show=True,
+            activate=True,
+            provenance_spec=provenance_spec,
+        )
+        return True
+
+    def _show_handle(
+        self,
+        handle: _ConsoleDataHandleMixin,
+        *,
+        active_name: str,
+        label: str,
+        **kwargs: typing.Any,
+    ) -> bool:
+        provenance_spec = handle._console_provenance_spec(
+            active_name=active_name,
+            label=label,
+        )
+        if provenance_spec is None:
+            return False
+        return self._show_dataarray_with_provenance(
+            handle.data, provenance_spec, **kwargs
+        )
+
+    def itool(
+        self, data: typing.Any, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Any:
+        manager = kwargs.get("manager")
+        replace = kwargs.get("replace")
+        if (
+            isinstance(data, _ConsoleDataHandleMixin)
+            and not args
+            and replace is None
+            and self._manager_argument_targets_this_manager(manager)
+        ):
+            display_kwargs = dict(kwargs)
+            display_kwargs.pop("manager", None)
+            display_kwargs.pop("replace", None)
+            if self._show_handle(
+                data,
+                active_name=(
+                    data._console_name
+                    if isinstance(data, _DerivedDataNamespace)
+                    and data._console_name is not None
+                    else "derived"
+                ),
+                label="Evaluate console expression",
+                **display_kwargs,
+            ):
+                return None
+        return erlab.interactive.itool(_unwrap_console_value(data), *args, **kwargs)
+
+    def _qshow_handle(
+        self,
+        data: _ConsoleDataHandleMixin,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> typing.Any:
+        manager = kwargs.get("manager")
+        if not args and self._manager_argument_targets_this_manager(manager):
+            display_kwargs = dict(kwargs)
+            display_kwargs.pop("manager", None)
+            if self._show_handle(
+                data,
+                active_name=(
+                    data._console_name
+                    if isinstance(data, _DerivedDataNamespace)
+                    and data._console_name is not None
+                    else "derived"
+                ),
+                label="Evaluate console expression",
+                **display_kwargs,
+            ):
+                return None
+        return data.data.qshow(*args, **kwargs)
 
     def __repr__(self) -> str:
         output = []
@@ -174,109 +952,6 @@ class ToolsNamespace:
         if not output:
             return "No tools"
         return "\n".join(output)
-
-
-class _ConsoleDataAssignmentTransformer(ast.NodeTransformer):
-    """Rewrite `tools[idx].data[...] = ...` into safe helper method calls."""
-
-    def __init__(self) -> None:
-        self.changed = False
-
-    @staticmethod
-    def _match_tool_data(target: ast.expr) -> ast.Subscript | None:
-        if not isinstance(target, ast.Attribute) or target.attr != "data":
-            return None
-        tool_expr = target.value
-        if not isinstance(tool_expr, ast.Subscript):
-            return None
-        if not isinstance(tool_expr.value, ast.Name) or tool_expr.value.id != "tools":
-            return None
-        return tool_expr
-
-    @classmethod
-    def _match_target(cls, target: ast.expr) -> tuple[ast.expr, ast.expr] | None:
-        if not isinstance(target, ast.Subscript):
-            return None
-        tool_expr = cls._match_tool_data(target.value)
-        if tool_expr is None:
-            return None
-        return tool_expr, target.slice
-
-    @staticmethod
-    def _helper_call(tool_expr: ast.expr, name: str, *args: ast.expr) -> ast.Call:
-        return ast.Call(
-            func=ast.Attribute(value=tool_expr, attr=name, ctx=ast.Load()),
-            args=list(args),
-            keywords=[],
-        )
-
-    def visit_Assign(self, node: ast.Assign) -> ast.Assign | ast.Expr:
-        self.generic_visit(node)
-        if len(node.targets) != 1:
-            return node
-        match = self._match_target(node.targets[0])
-        if match is None:
-            return node
-        tool_expr, key_expr = match
-        self.changed = True
-        return ast.copy_location(
-            ast.Expr(
-                value=self._helper_call(
-                    tool_expr, "_set_data_item", key_expr, node.value
-                )
-            ),
-            node,
-        )
-
-    def visit_AugAssign(
-        self, node: ast.AugAssign
-    ) -> ast.AugAssign | ast.Assign | ast.Expr:
-        self.generic_visit(node)
-        match = self._match_target(node.target)
-        if match is not None:
-            tool_expr, key_expr = match
-            current = self._helper_call(tool_expr, "_get_data_item", key_expr)
-            value = ast.BinOp(left=current, op=node.op, right=node.value)
-            self.changed = True
-            return ast.copy_location(
-                ast.Expr(
-                    value=self._helper_call(
-                        tool_expr, "_set_data_item", key_expr, value
-                    )
-                ),
-                node,
-            )
-
-        tool_data = self._match_tool_data(node.target)
-        if tool_data is None:
-            return node
-        self.changed = True
-        return ast.copy_location(
-            ast.Assign(
-                targets=[node.target],
-                value=ast.BinOp(
-                    left=ast.Attribute(value=tool_data, attr="data", ctx=ast.Load()),
-                    op=node.op,
-                    right=node.value,
-                ),
-            ),
-            node,
-        )
-
-
-def _rewrite_console_source(source: str) -> str:
-    """Rewrite console-only data item assignments without changing read semantics."""
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:
-        return source
-
-    transformer = _ConsoleDataAssignmentTransformer()
-    tree = transformer.visit(tree)
-    if not transformer.changed:
-        return source
-    ast.fix_missing_locations(tree)
-    return ast.unparse(tree)
 
 
 class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
@@ -316,6 +991,7 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
         self._erlab_loader_name: str | None = None
         self._erlab_data_dir: str | None = None
         self._erlab_io_hooks_registered = False
+        self._tools_namespace: ToolsNamespace | None = None
 
     def _restore_erlab_io_state(self, *args, **kwargs) -> None:
         erlab.io.set_loader(self._erlab_loader_name)
@@ -353,9 +1029,12 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
             )
 
             if self._namespace is not None:
-                self.kernel_manager.kernel.shell.push(
-                    _resolve_console_namespace(self._namespace)
-                )
+                resolved_namespace = _resolve_console_namespace(self._namespace)
+                self.kernel_manager.kernel.shell.push(resolved_namespace)
+                tools_namespace = resolved_namespace.get("tools")
+                if isinstance(tools_namespace, ToolsNamespace):
+                    self._tools_namespace = tools_namespace
+                    tools_namespace.bind_shell(self.kernel_manager.kernel.shell)
                 super().execute(
                     r"xr.set_options(keep_attrs=True)",
                     hidden=True,
@@ -370,8 +1049,6 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
     ) -> None:
         if not self.kernel_manager.kernel and not self._kernel_initializing:
             self.initialize_kernel()
-        if source is not None:
-            source = _rewrite_console_source(source)
         super().execute(source, hidden=hidden, interactive=interactive)
 
     def store_data_as(self, tool_index: int, name: str) -> None:
@@ -387,6 +1064,9 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
     @QtCore.Slot()
     def shutdown_kernel(self) -> None:
         if self.kernel_manager.kernel:
+            if self._tools_namespace is not None:
+                self._tools_namespace.unbind_shell()
+                self._tools_namespace = None
             if self._erlab_io_hooks_registered:
                 shell = self.kernel_manager.kernel.shell
                 with contextlib.suppress(KeyError, ValueError):
@@ -414,7 +1094,13 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
             return out
 
         info_str = (
-            _command_ansi("Access data", ["tools[<index>].data", "tools.selected_data"])
+            _command_ansi(
+                "Access raw data", ["tools[<index>].data", "tools.selected_data"]
+            )
+            + "\n"
+            + _command_ansi(
+                "Track provenance", ["tools[0] - tools[1]", "tools.selected[0]"]
+            )
             + "\n"
             + _command_ansi("Change data", ["tools[<index>].data = <value>"])
             + "\n"
@@ -461,6 +1147,7 @@ class _ImageToolManagerJupyterConsole(QtWidgets.QDockWidget):
 
     def __init__(self, manager: ImageToolManager) -> None:
         super().__init__("Console", manager, flags=QtCore.Qt.WindowType.Window)
+        tools_namespace = ToolsNamespace(manager)
 
         self._console_widget = _JupyterConsoleWidget(
             parent=self,
@@ -469,7 +1156,8 @@ class _ImageToolManagerJupyterConsole(QtWidgets.QDockWidget):
                 "xr": xr,
                 "erlab": erlab,
                 "eri": erlab.interactive,
-                "tools": ToolsNamespace(manager),
+                "itool": tools_namespace.itool,
+                "tools": tools_namespace,
                 "era": "erlab.analysis",
                 "eplt": "erlab.plotting",
                 "plt": "matplotlib.pyplot",

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 __all__ = ["ToolNamespace", "ToolsNamespace", "_ImageToolManagerJupyterConsole"]
 
+import ast
 import contextlib
+import functools
 import importlib
+import inspect
+import keyword
 import operator
+import symtable
 import sys
+import textwrap
+import types
 import typing
 import weakref
 from dataclasses import dataclass
@@ -64,10 +71,15 @@ def _resolve_console_namespace(
     namespace: dict[str, typing.Any],
 ) -> dict[str, typing.Any]:
     _patch_packaged_macos_matplotlib_qt_cursor()
-    return {
-        name: importlib.import_module(module) if isinstance(module, str) else module
-        for name, module in namespace.items()
-    }
+    resolved = {}
+    for name, module in namespace.items():
+        value = importlib.import_module(module) if isinstance(module, str) else module
+        if name in {"erlab", "era", "eri", "xr"} and isinstance(
+            value, types.ModuleType
+        ):
+            value = _ConsoleModuleProxy(value, name)
+        resolved[name] = value
+    return resolved
 
 
 def _tool_data_name(index: int) -> str:
@@ -87,17 +99,167 @@ def _dedupe_script_inputs(
     return tuple(deduped)
 
 
+def _dedupe_code_preludes(*groups: Sequence[str]) -> tuple[str, ...]:
+    output: list[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for code in group:
+            if code in seen:
+                continue
+            seen.add(code)
+            output.append(code)
+    return tuple(output)
+
+
+def _script_code(prelude: Sequence[str], code: str) -> str:
+    return "\n\n".join((*prelude, code)) if prelude else code
+
+
+def _replay_name_reserved(name: str) -> bool:
+    return name in {"data", "derived", "tools"} or name.startswith("data_")
+
+
+def _function_global_names(source: str, function_name: str) -> set[str] | None:
+    try:
+        table = symtable.symtable(source, "<ImageTool console function>", "exec")
+    except SyntaxError:
+        return None
+
+    names = {
+        symbol.get_name()
+        for symbol in table.get_symbols()
+        if symbol.get_name() != function_name
+        and symbol.is_referenced()
+        and symbol.is_global()
+    }
+    for child in table.get_children():
+        if child.get_name() != function_name:
+            continue
+        names.update(
+            symbol.get_name()
+            for symbol in child.get_symbols()
+            if symbol.get_name() != function_name
+            and symbol.is_referenced()
+            and (symbol.is_global() or symbol.is_free())
+        )
+        return names
+    return None
+
+
+def _callable_operand(
+    value: typing.Any, seen: set[int] | None = None
+) -> _ConsoleOperand | None:
+    if getattr(value, "_erlab_console_function_proxy", False):
+        value = value.__wrapped__
+    if (
+        not inspect.isfunction(value)
+        or value.__module__ != "__main__"
+        or value.__qualname__ != value.__name__
+        or value.__closure__ is not None
+    ):
+        return None
+
+    name = value.__name__
+    if (
+        not name.isidentifier()
+        or keyword.iskeyword(name)
+        or _replay_name_reserved(name)
+    ):
+        return None
+    if seen is None:
+        seen = set()
+    value_id = id(value)
+    if value_id in seen:
+        return None
+    seen.add(value_id)
+
+    try:
+        source = textwrap.dedent(inspect.getsource(value)).strip()
+        module = ast.parse(source)
+    except (OSError, TypeError, SyntaxError):
+        return None
+    if len(module.body) != 1 or not isinstance(module.body[0], ast.FunctionDef):
+        return None
+    function_node = module.body[0]
+    if function_node.name != name or function_node.decorator_list:
+        return None
+
+    global_names = _function_global_names(source, name)
+    if global_names is None:
+        return None
+
+    prelude: list[str] = []
+    allowed_globals = {
+        "np",
+        "numpy",
+        "xr",
+        "xarray",
+        "erlab",
+        "era",
+        "eri",
+        "eplt",
+        *erlab.interactive.imagetool.provenance._SCRIPT_REPLAY_ALLOWED_BUILTINS,
+    }
+    for global_name in sorted(global_names):
+        if global_name in allowed_globals:
+            continue
+        if _replay_name_reserved(global_name) or global_name.startswith("__"):
+            return None
+        try:
+            global_value = value.__globals__[global_name]
+        except KeyError:
+            return None
+        if inspect.isfunction(global_value) or getattr(
+            global_value, "_erlab_console_function_proxy", False
+        ):
+            dependency = _callable_operand(global_value, seen)
+            if dependency is None:
+                return None
+            prelude.extend(dependency.code_prelude)
+            if dependency.code != global_name:
+                prelude.append(f"{global_name} = {dependency.code}")
+            continue
+        global_code, copyable = _literal_code(global_value)
+        if not copyable:
+            return None
+        prelude.append(f"{global_name} = {global_code}")
+
+    code_prelude = _dedupe_code_preludes(prelude, (source,))
+    try:
+        erlab.interactive.imagetool.provenance._validate_script_replay_code(
+            _script_code(code_prelude, "derived = data")
+        )
+    except (TypeError, ValueError):
+        return None
+    return _ConsoleOperand(value, name, copyable=True, code_prelude=code_prelude)
+
+
 @dataclass(frozen=True)
 class _ConsoleOperand:
     value: typing.Any
     code: str
     script_inputs: tuple[erlab.interactive.imagetool.provenance.ScriptInput, ...] = ()
     copyable: bool = True
+    code_prelude: tuple[str, ...] = ()
+    seed_expression: str | None = None
+    operations: tuple[
+        erlab.interactive.imagetool.provenance.ToolProvenanceOperation, ...
+    ] = ()
 
 
 def _literal_code(value: typing.Any) -> tuple[str, bool]:
     value = erlab.utils.misc._convert_to_native(value)
-    if value is None or isinstance(value, (bool, int, float, complex, str, bytes)):
+    if isinstance(value, float):
+        if np.isnan(value):
+            return "np.nan", True
+        if np.isinf(value):
+            return ("np.inf" if value > 0 else "-np.inf"), True
+        return repr(value), True
+    if isinstance(value, complex):
+        real_code, _ = _literal_code(float(value.real))
+        imag_code, _ = _literal_code(float(value.imag))
+        return f"complex({real_code}, {imag_code})", True
+    if value is None or isinstance(value, (bool, int, str, bytes)):
         return repr(value), True
     if isinstance(value, slice):
         start, start_copyable = _literal_code(value.start)
@@ -134,7 +296,11 @@ def _literal_code(value: typing.Any) -> tuple[str, bool]:
 
 def _merge_operands(
     *operands: _ConsoleOperand,
-) -> tuple[tuple[erlab.interactive.imagetool.provenance.ScriptInput, ...], bool]:
+) -> tuple[
+    tuple[erlab.interactive.imagetool.provenance.ScriptInput, ...],
+    bool,
+    tuple[str, ...],
+]:
     return (
         _dedupe_script_inputs(
             tuple(
@@ -144,6 +310,7 @@ def _merge_operands(
             )
         ),
         all(operand.copyable for operand in operands),
+        _dedupe_code_preludes(*(operand.code_prelude for operand in operands)),
     )
 
 
@@ -175,27 +342,45 @@ def _unwrap_console_value(value: typing.Any) -> typing.Any:
     return value
 
 
+def _first_console_handle(value: typing.Any) -> _ConsoleDataHandleMixin | None:
+    if isinstance(value, _ConsoleDataHandleMixin):
+        return value
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            if (handle := _first_console_handle(item)) is not None:
+                return handle
+    if isinstance(value, dict):
+        for item in (*value.keys(), *value.values()):
+            if (handle := _first_console_handle(item)) is not None:
+                return handle
+    return None
+
+
 def _operand_from_value(value: typing.Any) -> _ConsoleOperand:
     if isinstance(value, _ConsoleDataHandleMixin):
         return value._console_operand()
+    if (callable_operand := _callable_operand(value)) is not None:
+        return callable_operand
     if isinstance(value, tuple):
         item_operands = tuple(_operand_from_value(item) for item in value)
         suffix = "," if len(item_operands) == 1 else ""
-        inputs, copyable = _merge_operands(*item_operands)
+        inputs, copyable, code_prelude = _merge_operands(*item_operands)
         return _ConsoleOperand(
             tuple(operand.value for operand in item_operands),
             f"({', '.join(operand.code for operand in item_operands)}{suffix})",
             inputs,
             copyable,
+            code_prelude,
         )
     if isinstance(value, list):
         item_operands = tuple(_operand_from_value(item) for item in value)
-        inputs, copyable = _merge_operands(*item_operands)
+        inputs, copyable, code_prelude = _merge_operands(*item_operands)
         return _ConsoleOperand(
             [operand.value for operand in item_operands],
             f"[{', '.join(operand.code for operand in item_operands)}]",
             inputs,
             copyable,
+            code_prelude,
         )
     if isinstance(value, dict):
         key_operands = tuple(_operand_from_value(key) for key in value)
@@ -205,7 +390,7 @@ def _operand_from_value(value: typing.Any) -> _ConsoleOperand:
             for pair in zip(key_operands, value_operands, strict=True)
             for operand in pair
         )
-        inputs, copyable = _merge_operands(*pair_operands)
+        inputs, copyable, code_prelude = _merge_operands(*pair_operands)
         return _ConsoleOperand(
             {
                 key_operand.value: value_operand.value
@@ -223,6 +408,7 @@ def _operand_from_value(value: typing.Any) -> _ConsoleOperand:
             + "}",
             inputs,
             copyable,
+            code_prelude,
         )
     code, copyable = _literal_code(value)
     return _ConsoleOperand(value, code, copyable=copyable)
@@ -236,10 +422,13 @@ def _format_call_code(
     tuple[typing.Any, ...],
     dict[str, typing.Any],
     bool,
+    tuple[str, ...],
 ]:
     arg_operands = tuple(_operand_from_value(arg) for arg in args)
     kwarg_operands = {key: _operand_from_value(value) for key, value in kwargs.items()}
-    inputs, copyable = _merge_operands(*arg_operands, *tuple(kwarg_operands.values()))
+    inputs, copyable, code_prelude = _merge_operands(
+        *arg_operands, *tuple(kwarg_operands.values())
+    )
     parts = [operand.code for operand in arg_operands]
     parts.extend(f"{key}={operand.code}" for key, operand in kwarg_operands.items())
     return (
@@ -248,7 +437,365 @@ def _format_call_code(
         tuple(operand.value for operand in arg_operands),
         {key: operand.value for key, operand in kwarg_operands.items()},
         copyable,
+        code_prelude,
     )
+
+
+def _structured_operation_from_call(
+    call: erlab.interactive.imagetool.provenance.ConsoleCall,
+) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None:
+    with contextlib.suppress(Exception):
+        return erlab.interactive.imagetool.provenance.operation_from_console_call(call)
+    return None
+
+
+def _structured_seed_and_operations(
+    source: _ConsoleOperand,
+    operation: erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None,
+) -> tuple[
+    str | None,
+    tuple[erlab.interactive.imagetool.provenance.ToolProvenanceOperation, ...],
+]:
+    if operation is None or (source.seed_expression is None and not source.copyable):
+        return None, ()
+    return source.seed_expression or source.code, (*source.operations, operation)
+
+
+class _ConsoleAccessorProxy:
+    def __init__(
+        self,
+        owner: _ConsoleDataHandleMixin,
+        accessor: typing.Any,
+        path: tuple[str, ...],
+        expression: str,
+    ) -> None:
+        self._owner = owner
+        self._accessor = accessor
+        self._path = path
+        self._expression = expression
+        self.__wrapped__ = accessor
+        for attr in ("__doc__", "__module__", "__name__", "__qualname__"):
+            with contextlib.suppress(Exception):
+                value = getattr(accessor, attr)
+                if value is not None:
+                    setattr(self, attr, value)
+        with contextlib.suppress(TypeError, ValueError):
+            self.__signature__ = inspect.signature(accessor)
+
+    def _call(
+        self,
+        func: Callable[..., typing.Any],
+        expression: str,
+        path: tuple[str, ...],
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> typing.Any:
+        (
+            call_code,
+            call_inputs,
+            raw_args,
+            raw_kwargs,
+            args_copyable,
+            call_prelude,
+        ) = _format_call_code(args, kwargs)
+        source_operand = self._owner._console_operand()
+        result = func(*raw_args, **raw_kwargs)
+        inputs, copyable, code_prelude = _merge_operands(
+            source_operand,
+            _ConsoleOperand(None, "", call_inputs, args_copyable, call_prelude),
+        )
+        call = erlab.interactive.imagetool.provenance.ConsoleCall(
+            func=func,
+            accessor_path=path,
+            args=raw_args,
+            kwargs=raw_kwargs,
+            display_code=f"{expression}({call_code})",
+            has_extra_tracked_inputs=bool(call_inputs),
+            receiver_data=source_operand.value,
+        )
+        seed_expression, operations = _structured_seed_and_operations(
+            source_operand, _structured_operation_from_call(call)
+        )
+        return self._owner._wrap_console_result(
+            result,
+            call.display_code,
+            inputs,
+            copyable=copyable,
+            code_prelude=code_prelude,
+            operations=operations,
+            seed_expression=seed_expression,
+        )
+
+    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        if not callable(self._accessor):
+            raise TypeError(f"{self._expression} is not callable")
+        return self._call(
+            self._accessor,
+            self._expression,
+            self._path,
+            *args,
+            **kwargs,
+        )
+
+    def __getattr__(self, attr: str) -> typing.Any:
+        value = getattr(self._accessor, attr)
+        expression = f"{self._expression}.{attr}"
+        path = (*self._path, attr)
+        if not callable(value):
+            if isinstance(value, xr.DataArray):
+                operand = self._owner._console_operand()
+                return self._owner._wrap_console_result(
+                    value,
+                    expression,
+                    operand.script_inputs,
+                    copyable=operand.copyable,
+                    code_prelude=operand.code_prelude,
+                )
+            return value
+
+        @functools.wraps(value)
+        def _method(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            return self._call(value, expression, path, *args, **kwargs)
+
+        return _method
+
+    def __dir__(self) -> list[str]:
+        return sorted(set(dir(self._accessor)))
+
+
+class _ConsoleCoarsenProxy:
+    def __init__(
+        self,
+        owner: _ConsoleDataHandleMixin,
+        coarsened: typing.Any,
+        source_operand: _ConsoleOperand,
+        expression: str,
+        raw_args: tuple[typing.Any, ...],
+        raw_kwargs: dict[str, typing.Any],
+        script_inputs: Sequence[erlab.interactive.imagetool.provenance.ScriptInput],
+        *,
+        copyable: bool,
+        code_prelude: Sequence[str],
+    ) -> None:
+        self._owner = owner
+        self._coarsened = coarsened
+        self._source_operand = source_operand
+        self._expression = expression
+        self._raw_args = raw_args
+        self._raw_kwargs = raw_kwargs
+        self._script_inputs = tuple(script_inputs)
+        self._copyable = copyable
+        self._code_prelude = tuple(code_prelude)
+
+    def __getattr__(self, attr: str) -> typing.Any:
+        value = getattr(self._coarsened, attr)
+        if not callable(value):
+            return value
+
+        @functools.wraps(value)
+        def _method(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            (
+                call_code,
+                call_inputs,
+                raw_args,
+                raw_kwargs,
+                args_copyable,
+                call_prelude,
+            ) = _format_call_code(args, kwargs)
+            result = value(*raw_args, **raw_kwargs)
+            inputs, copyable, code_prelude = _merge_operands(
+                _ConsoleOperand(
+                    None,
+                    "",
+                    self._script_inputs,
+                    self._copyable,
+                    self._code_prelude,
+                ),
+                _ConsoleOperand(None, "", call_inputs, args_copyable, call_prelude),
+            )
+            expression = f"{self._expression}.{attr}({call_code})"
+            operation = None
+            if not raw_args and not raw_kwargs:
+                source_names = {
+                    script_input.name
+                    for script_input in self._source_operand.script_inputs
+                }
+                call = erlab.interactive.imagetool.provenance.ConsoleCall(
+                    dataarray_method="coarsen",
+                    args=self._raw_args,
+                    kwargs={**self._raw_kwargs, "_reducer": attr},
+                    display_code=expression,
+                    has_extra_tracked_inputs=any(
+                        script_input.name not in source_names for script_input in inputs
+                    ),
+                    receiver_data=self._source_operand.value,
+                )
+                operation = _structured_operation_from_call(call)
+            seed_expression, operations = _structured_seed_and_operations(
+                self._source_operand, operation
+            )
+            return self._owner._wrap_console_result(
+                result,
+                expression,
+                inputs,
+                copyable=copyable,
+                code_prelude=code_prelude,
+                operations=operations,
+                seed_expression=seed_expression,
+            )
+
+        with contextlib.suppress(TypeError, ValueError):
+            typing.cast("typing.Any", _method).__signature__ = inspect.signature(value)
+        return _method
+
+    def __dir__(self) -> list[str]:
+        return sorted(set(dir(self._coarsened)))
+
+
+class _ConsoleModuleProxy(types.ModuleType):
+    def __init__(self, module: types.ModuleType, alias: str) -> None:
+        super().__init__(module.__name__, module.__doc__)
+        self._module = module
+        self._alias = alias
+        for attr in ("__file__", "__package__", "__spec__", "__all__"):
+            if hasattr(module, attr):
+                setattr(self, attr, getattr(module, attr))
+
+    def __getattr__(self, attr: str) -> typing.Any:
+        value = getattr(self._module, attr)
+        expression = f"{self._alias}.{attr}"
+        if isinstance(value, types.ModuleType):
+            return _ConsoleModuleProxy(value, expression)
+        if isinstance(value, type):
+            return value
+        if not callable(value):
+            return value
+
+        @functools.wraps(value)
+        def _function(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            (
+                call_code,
+                call_inputs,
+                raw_args,
+                raw_kwargs,
+                args_copyable,
+                call_prelude,
+            ) = _format_call_code(args, kwargs)
+            result = value(*raw_args, **raw_kwargs)
+            if not call_inputs:
+                return result
+            source_operand = None
+            call_args = raw_args
+            call_kwargs = raw_kwargs
+            with contextlib.suppress(TypeError, ValueError):
+                signature = inspect.signature(value)
+                bound_args = signature.bind_partial(*args, **kwargs).arguments
+                raw_bound_args = signature.bind_partial(
+                    *raw_args, **raw_kwargs
+                ).arguments
+                source_param = next(
+                    (
+                        name
+                        for name, arg in bound_args.items()
+                        if isinstance(arg, _ConsoleDataHandleMixin)
+                    ),
+                    None,
+                )
+                if source_param is not None:
+                    source = bound_args[source_param]
+                    if isinstance(source, _ConsoleDataHandleMixin):
+                        source_operand = source._console_operand()
+                        call_args = ()
+                        call_kwargs = {
+                            key: arg
+                            for key, arg in raw_bound_args.items()
+                            if key != source_param
+                        }
+            operation = None
+            seed_expression = None
+            operations: tuple[
+                erlab.interactive.imagetool.provenance.ToolProvenanceOperation, ...
+            ] = ()
+            if source_operand is not None:
+                source_inputs = source_operand.script_inputs
+                source_names = {script_input.name for script_input in source_inputs}
+                call = erlab.interactive.imagetool.provenance.ConsoleCall(
+                    func=value,
+                    args=call_args,
+                    kwargs=call_kwargs,
+                    display_code=f"{expression}({call_code})",
+                    has_extra_tracked_inputs=any(
+                        script_input.name not in source_names
+                        for script_input in call_inputs
+                    ),
+                    receiver_data=source_operand.value,
+                )
+                operation = _structured_operation_from_call(call)
+                seed_expression, operations = _structured_seed_and_operations(
+                    source_operand, operation
+                )
+            owner = _first_console_handle(args)
+            if owner is None:
+                owner = _first_console_handle(kwargs)
+            if owner is None:
+                return result
+            return owner._wrap_console_result(
+                result,
+                f"{expression}({call_code})",
+                call_inputs,
+                copyable=args_copyable,
+                code_prelude=call_prelude,
+                operations=operations,
+                seed_expression=seed_expression,
+            )
+
+        return _function
+
+    def __dir__(self) -> list[str]:
+        return sorted(set(dir(self._module)))
+
+
+class _ConsoleFunctionProxy:
+    _erlab_console_function_proxy = True
+
+    def __init__(self, function: typing.Any) -> None:
+        self._function = function
+        functools.update_wrapper(self, function)
+
+    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        (
+            call_code,
+            call_inputs,
+            raw_args,
+            raw_kwargs,
+            args_copyable,
+            call_prelude,
+        ) = _format_call_code(args, kwargs)
+        result = self._function(*raw_args, **raw_kwargs)
+        owner = _first_console_handle(args)
+        if owner is None:
+            owner = _first_console_handle(kwargs)
+        if owner is None:
+            return result
+
+        function_operand = _callable_operand(self)
+        function_code = typing.cast("str", getattr(self, "__name__", ""))
+        if not function_code:
+            function_code = typing.cast("str", self._function.__name__)
+        function_copyable = False
+        function_prelude: tuple[str, ...] = ()
+        if function_operand is not None:
+            function_code = function_operand.code
+            function_copyable = function_operand.copyable
+            function_prelude = function_operand.code_prelude
+
+        return owner._wrap_console_result(
+            result,
+            f"{function_code}({call_code})",
+            call_inputs,
+            copyable=function_copyable and args_copyable,
+            code_prelude=_dedupe_code_preludes(function_prelude, call_prelude),
+        )
 
 
 class _ConsoleDataHandleMixin:
@@ -281,6 +828,11 @@ class _ConsoleDataHandleMixin:
         script_inputs: Sequence[erlab.interactive.imagetool.provenance.ScriptInput],
         *,
         copyable: bool,
+        code_prelude: Sequence[str] = (),
+        operations: Sequence[
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation
+        ] = (),
+        seed_expression: str | None = None,
     ) -> typing.Any:
         if not isinstance(value, xr.DataArray):
             return value
@@ -290,6 +842,9 @@ class _ConsoleDataHandleMixin:
             expression,
             _dedupe_script_inputs(script_inputs),
             copyable=copyable,
+            code_prelude=_dedupe_code_preludes(code_prelude),
+            operations=operations,
+            seed_expression=seed_expression,
         )
 
     def _binary_operation(
@@ -306,10 +861,16 @@ class _ConsoleDataHandleMixin:
         right_operand = (
             self._console_operand() if reflected else _operand_from_value(other)
         )
-        inputs, copyable = _merge_operands(left_operand, right_operand)
+        inputs, copyable, code_prelude = _merge_operands(left_operand, right_operand)
         result = operation(left_operand.value, right_operand.value)
         expression = f"{left_operand.code} {symbol} {right_operand.code}"
-        return self._wrap_console_result(result, expression, inputs, copyable=copyable)
+        return self._wrap_console_result(
+            result,
+            expression,
+            inputs,
+            copyable=copyable,
+            code_prelude=code_prelude,
+        )
 
     def _unary_operation(
         self, symbol: str, operation: Callable[[typing.Any], typing.Any]
@@ -321,6 +882,7 @@ class _ConsoleDataHandleMixin:
             f"{symbol}{operand.code}",
             operand.script_inputs,
             copyable=operand.copyable,
+            code_prelude=operand.code_prelude,
         )
 
     def __add__(self, other: typing.Any) -> typing.Any:
@@ -420,6 +982,7 @@ class _ConsoleDataHandleMixin:
             f"abs({operand.code})",
             operand.script_inputs,
             copyable=operand.copyable,
+            code_prelude=operand.code_prelude,
         )
 
     def __invert__(self) -> typing.Any:
@@ -447,7 +1010,7 @@ class _ConsoleDataHandleMixin:
         kwarg_operands = {
             key: _operand_from_value(value) for key, value in kwargs.items()
         }
-        script_inputs, copyable = _merge_operands(
+        script_inputs, copyable, code_prelude = _merge_operands(
             *input_operands, *tuple(kwarg_operands.values())
         )
         raw_kwargs = {key: operand.value for key, operand in kwarg_operands.items()}
@@ -463,18 +1026,20 @@ class _ConsoleDataHandleMixin:
             f"np.{ufunc.__name__}({arg_code})",
             script_inputs,
             copyable=copyable,
+            code_prelude=code_prelude,
         )
 
     def __getitem__(self, key: typing.Any) -> typing.Any:
         key_operand = _operand_from_value(key)
         self_operand = self._console_operand()
         result = self.data[key_operand.value]
-        inputs, copyable = _merge_operands(self_operand, key_operand)
+        inputs, copyable, code_prelude = _merge_operands(self_operand, key_operand)
         return self._wrap_console_result(
             result,
             f"{self_operand.code}[{key_operand.code}]",
             inputs,
             copyable=copyable,
+            code_prelude=code_prelude,
         )
 
     def qshow(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
@@ -485,6 +1050,14 @@ class _ConsoleDataHandleMixin:
 
     def __getattr__(self, attr: str) -> typing.Any:
         data_attr = getattr(self.data, attr)
+        if attr in {"qsel", "qshow", "qplot", "qinfo", "kspace", "xlm", "modelfit"}:
+            operand = self._console_operand()
+            return _ConsoleAccessorProxy(
+                self,
+                data_attr,
+                (attr,),
+                f"{operand.code}.{attr}",
+            )
         if not callable(data_attr):
             if isinstance(data_attr, xr.DataArray):
                 operand = self._console_operand()
@@ -493,39 +1066,91 @@ class _ConsoleDataHandleMixin:
                     f"{operand.code}.{attr}",
                     operand.script_inputs,
                     copyable=operand.copyable,
+                    code_prelude=operand.code_prelude,
                 )
             return data_attr
 
+        @functools.wraps(data_attr)
         def _method(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
-            call_code, call_inputs, raw_args, raw_kwargs, args_copyable = (
-                _format_call_code(args, kwargs)
-            )
+            (
+                call_code,
+                call_inputs,
+                raw_args,
+                raw_kwargs,
+                args_copyable,
+                call_prelude,
+            ) = _format_call_code(args, kwargs)
             self_operand = self._console_operand()
             result = data_attr(*raw_args, **raw_kwargs)
-            inputs, copyable = _merge_operands(
+            inputs, copyable, code_prelude = _merge_operands(
                 self_operand,
-                _ConsoleOperand(None, "", call_inputs, args_copyable),
+                _ConsoleOperand(None, "", call_inputs, args_copyable, call_prelude),
+            )
+            expression = f"{self_operand.code}.{attr}({call_code})"
+            if attr == "coarsen" and not isinstance(result, xr.DataArray):
+                return _ConsoleCoarsenProxy(
+                    self,
+                    result,
+                    self_operand,
+                    expression,
+                    raw_args,
+                    raw_kwargs,
+                    inputs,
+                    copyable=copyable,
+                    code_prelude=code_prelude,
+                )
+            call = erlab.interactive.imagetool.provenance.ConsoleCall(
+                func=data_attr,
+                dataarray_method=attr,
+                args=raw_args,
+                kwargs=raw_kwargs,
+                display_code=expression,
+                has_extra_tracked_inputs=bool(call_inputs),
+                receiver_data=self_operand.value,
+            )
+            seed_expression, operations = _structured_seed_and_operations(
+                self_operand, _structured_operation_from_call(call)
             )
             return self._wrap_console_result(
                 result,
-                f"{self_operand.code}.{attr}({call_code})",
+                expression,
                 inputs,
                 copyable=copyable,
+                code_prelude=code_prelude,
+                operations=operations,
+                seed_expression=seed_expression,
             )
 
+        with contextlib.suppress(TypeError, ValueError):
+            typing.cast("typing.Any", _method).__signature__ = inspect.signature(
+                data_attr
+            )
         return _method
+
+    def __dir__(self) -> list[str]:
+        names = set(super().__dir__())
+        with contextlib.suppress(Exception):
+            names.update(dir(self.data))
+        return sorted(names)
 
 
 class ToolNamespace(_ConsoleDataHandleMixin):
-    """A console interface that represents a single ImageTool object.
+    """Provenance-aware console handle for one managed ImageTool.
 
-    In the manager console, this namespace can be accessed with the variable
-    ``tools[idx]``, where ``idx`` is the index of a top-level ImageTool to access.
-    Child ImageTools are available through ``tools[idx].children``.
+    In the manager console, ``tools[idx]`` accesses a top-level ImageTool, and
+    ``tools[idx].children[j]`` accesses a child ImageTool in manager tree order. The
+    handle delegates DataArray attributes, methods, operators, and supported ERLab
+    calls to the underlying array while preserving provenance for derived results.
+    ``.data`` remains exact raw :class:`xarray.DataArray` access for compatibility and
+    is not provenance-aware.
 
     Examples
     --------
-    - Access the underlying DataArray of an ImageTool:
+    - Build a provenance-backed result:
+
+      >>> tools[0] - tools[1]
+
+    - Access the raw underlying DataArray of an ImageTool:
 
       >>> tools[1].data
 
@@ -557,7 +1182,7 @@ class ToolNamespace(_ConsoleDataHandleMixin):
 
     @property
     def data(self) -> xr.DataArray:
-        """The DataArray associated with the ImageTool."""
+        """Raw :class:`xarray.DataArray` displayed by the ImageTool."""
         return self.tool.slicer_area._data
 
     @data.setter
@@ -647,15 +1272,17 @@ class ToolNamespace(_ConsoleDataHandleMixin):
         key_operand = _operand_from_value(key)
         value_operand = _operand_from_value(value)
         self_operand = self._console_operand()
-        script_inputs, copyable = _merge_operands(
+        script_inputs, copyable, code_prelude = _merge_operands(
             self_operand, key_operand, value_operand
+        )
+        code = _script_code(
+            code_prelude,
+            f"{self_operand.code}[{key_operand.code}] = {value_operand.code}",
         )
         provenance_spec = erlab.interactive.imagetool.provenance.script(
             erlab.interactive.imagetool.provenance.ScriptCodeOperation(
                 label=f"Set {self._console_label} data item from console",
-                code=(
-                    f"{self_operand.code}[{key_operand.code}] = {value_operand.code}"
-                ),
+                code=code,
                 copyable=copyable,
             ),
             start_label="Run ImageTool manager console code",
@@ -733,12 +1360,20 @@ class _DerivedDataNamespace(_ConsoleDataHandleMixin):
         script_inputs: Sequence[erlab.interactive.imagetool.provenance.ScriptInput],
         *,
         copyable: bool,
+        code_prelude: Sequence[str] = (),
+        operations: Sequence[
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation
+        ] = (),
+        seed_expression: str | None = None,
     ) -> None:
         self._tools_ref = weakref.ref(tools) if tools is not None else None
         self._data = data
         self._expression = expression
         self._script_inputs = _dedupe_script_inputs(script_inputs)
         self._copyable = copyable
+        self._code_prelude = _dedupe_code_preludes(code_prelude)
+        self._operations = tuple(operations)
+        self._seed_expression = seed_expression
         self._console_name: str | None = None
 
     @property
@@ -761,6 +1396,9 @@ class _DerivedDataNamespace(_ConsoleDataHandleMixin):
                 _derived_operand_code(self._expression),
                 self._script_inputs,
                 self._copyable,
+                self._code_prelude,
+                self._seed_expression,
+                self._operations,
             )
         provenance_spec = self._console_provenance_spec(
             active_name=self._console_name,
@@ -789,10 +1427,23 @@ class _DerivedDataNamespace(_ConsoleDataHandleMixin):
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
         if not self._script_inputs:
             return None
+        if self._operations and self._seed_expression is not None:
+            seed_code = _script_code(
+                self._code_prelude,
+                f"{active_name} = {self._seed_expression}",
+            )
+            return erlab.interactive.imagetool.provenance.script(
+                *self._operations,
+                start_label="Run ImageTool manager console code",
+                seed_code=seed_code,
+                active_name=active_name,
+                script_inputs=self._script_inputs,
+            )
+        code = _script_code(self._code_prelude, f"{active_name} = {self._expression}")
         return erlab.interactive.imagetool.provenance.script(
             erlab.interactive.imagetool.provenance.ScriptCodeOperation(
                 label=label,
-                code=f"{active_name} = {self._expression}",
+                code=code,
                 copyable=self._copyable,
             ),
             start_label="Run ImageTool manager console code",
@@ -807,7 +1458,10 @@ class _DerivedDataNamespace(_ConsoleDataHandleMixin):
 class ToolsNamespace:
     """A console interface that represents the ImageToolManager and its tools.
 
-    In the manager console, this namespace can be accessed with the variable `tools`.
+    In the manager console, this namespace can be accessed with the variable ``tools``.
+    Integer indexing returns provenance-aware top-level ImageTool handles; selected
+    child ImageTools are available through :attr:`selected`, and raw arrays through
+    :attr:`selected_data`.
 
     Examples
     --------
@@ -836,7 +1490,7 @@ class ToolsNamespace:
 
     @property
     def selected_data(self) -> list[xr.DataArray]:
-        """Get a list of DataArrays from the selected windows."""
+        """Raw DataArrays from selected root or child ImageTools."""
         return [
             self._manager.get_imagetool(target).slicer_area._data
             for target in self._manager._selected_imagetool_targets()
@@ -844,14 +1498,14 @@ class ToolsNamespace:
 
     @property
     def selected(self) -> list[ToolNamespace]:
-        """Get provenance-aware handles for the selected windows."""
+        """Provenance-aware handles for selected root or child ImageTools."""
         return [
             ToolNamespace(self._manager._node_for_target(target), self)
             for target in self._manager._selected_imagetool_targets()
         ]
 
     def __getitem__(self, index: int) -> ToolNamespace | None:
-        """Access a specific ImageTool object by its index."""
+        """Access a top-level ImageTool by manager index."""
         if index not in self._manager._imagetool_wrappers:
             print(f"Tool {index} not found")
             return None
@@ -960,11 +1614,19 @@ class ToolsNamespace:
             return
         if self._shell_ref is not None and (shell := self._shell_ref()) is not None:
             for name, value in shell.user_ns.items():
-                if (
-                    name.startswith("_")
-                    or self._namespace_snapshot.get(name) == id(value)
-                    or not isinstance(value, _DerivedDataNamespace)
+                if name.startswith("_") or self._namespace_snapshot.get(name) == id(
+                    value
                 ):
+                    continue
+                if (
+                    inspect.isfunction(value)
+                    and value.__module__ == "__main__"
+                    and value.__qualname__ == value.__name__ == name
+                    and not inspect.iscoroutinefunction(value)
+                ):
+                    shell.user_ns[name] = _ConsoleFunctionProxy(value)
+                    continue
+                if not isinstance(value, _DerivedDataNamespace):
                     continue
                 value._set_console_name(name)
         if result is None or not isinstance(result.result, _DerivedDataNamespace):

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -754,6 +754,14 @@ class _ConsoleModuleProxy(types.ModuleType):
     def __dir__(self) -> list[str]:
         return sorted(set(dir(self._module)))
 
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _ConsoleModuleProxy):
+            other = other._module
+        return self._module == other
+
+    def __hash__(self) -> int:
+        return hash(self._module)
+
 
 class _ConsoleFunctionProxy:
     _erlab_console_function_proxy = True

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -30,7 +30,10 @@ if typing.TYPE_CHECKING:
 
     from erlab.interactive.imagetool import ImageTool
     from erlab.interactive.imagetool.manager import ImageToolManager
-    from erlab.interactive.imagetool.manager._wrapper import _ImageToolWrapper
+    from erlab.interactive.imagetool.manager._wrapper import (
+        _ImageToolWrapper,
+        _ManagedWindowNode,
+    )
 
 
 _MPL_QT_CURSOR_PATCH_ATTR = "_erlab_original_set_cursor"
@@ -517,7 +520,8 @@ class ToolNamespace(_ConsoleDataHandleMixin):
     """A console interface that represents a single ImageTool object.
 
     In the manager console, this namespace can be accessed with the variable
-    ``tools[idx]``, where ``idx`` is the index of the ImageTool to access.
+    ``tools[idx]``, where ``idx`` is the index of a top-level ImageTool to access.
+    Child ImageTools are available through ``tools[idx].children``.
 
     Examples
     --------
@@ -532,13 +536,15 @@ class ToolNamespace(_ConsoleDataHandleMixin):
     """
 
     def __init__(
-        self, wrapper: _ImageToolWrapper, tools: ToolsNamespace | None = None
+        self,
+        wrapper: _ImageToolWrapper | _ManagedWindowNode,
+        tools: ToolsNamespace | None = None,
     ) -> None:
         self._wrapper_ref = weakref.ref(wrapper)
         self._tools_ref = weakref.ref(tools) if tools is not None else None
 
     @property
-    def _wrapper(self) -> _ImageToolWrapper:
+    def _wrapper(self) -> _ImageToolWrapper | _ManagedWindowNode:
         wrapper = self._wrapper_ref()
         if wrapper:
             return wrapper
@@ -561,13 +567,18 @@ class ToolNamespace(_ConsoleDataHandleMixin):
             raw_value = value.data
             provenance_spec = value._console_provenance_spec(
                 active_name=self._console_input_name,
-                label=f"Replace ImageTool {self._wrapper.index} data from console",
+                label=f"Replace {self._console_label} data from console",
             )
         else:
             raw_value = value
         if provenance_spec is not None:
             self._wrapper.set_detached_provenance(provenance_spec)
         self.tool.slicer_area.replace_source_data(raw_value, emit_edited=True)
+
+    @property
+    def children(self) -> _ToolChildren:
+        """Child ImageTools displayed under this ImageTool in manager tree order."""
+        return _ToolChildren(self)
 
     def _get_data_item(self, key):
         """Return a subset of the tool data."""
@@ -589,12 +600,22 @@ class ToolNamespace(_ConsoleDataHandleMixin):
 
     @property
     def _console_input_name(self) -> str:
-        return _tool_data_name(self._wrapper.index)
+        tools = self._console_tools
+        if tools is not None:
+            return tools._node_data_name(self._wrapper)
+        return _tool_data_name(typing.cast("_ImageToolWrapper", self._wrapper).index)
+
+    @property
+    def _console_label(self) -> str:
+        tools = self._console_tools
+        if tools is not None:
+            return tools._node_label(self._wrapper, include_name=False)
+        return f"ImageTool {typing.cast('_ImageToolWrapper', self._wrapper).index}"
 
     def _script_input(
         self,
     ) -> erlab.interactive.imagetool.provenance.ScriptInput:
-        label = f"ImageTool {self._wrapper.index}"
+        label = self._console_label
         if self._wrapper.name:
             label += f": {self._wrapper.name}"
         provenance_spec = (
@@ -631,7 +652,7 @@ class ToolNamespace(_ConsoleDataHandleMixin):
         )
         provenance_spec = erlab.interactive.imagetool.provenance.script(
             erlab.interactive.imagetool.provenance.ScriptCodeOperation(
-                label=f"Set ImageTool {self._wrapper.index} data item from console",
+                label=f"Set {self._console_label} data item from console",
                 code=(
                     f"{self_operand.code}[{key_operand.code}] = {value_operand.code}"
                 ),
@@ -653,10 +674,54 @@ class ToolNamespace(_ConsoleDataHandleMixin):
 
     def __repr__(self) -> str:
         time_repr = self._wrapper._created_time.isoformat(sep=" ", timespec="seconds")
-        out = f"ImageTool {self._wrapper.index}: {self._wrapper.name}\n"
+        label = self._console_label
+        if self._wrapper.name:
+            label += f": {self._wrapper.name}"
+        out = f"{label}\n"
         out += f"  Added: {time_repr}\n"
         out += f"  Linked: {self.tool.slicer_area.is_linked}\n"
         return out
+
+
+class _ToolChildren:
+    def __init__(self, parent: ToolNamespace) -> None:
+        self._parent = parent
+
+    def _nodes(self) -> list[_ManagedWindowNode]:
+        tools = self._parent._console_tools
+        if tools is None:
+            return []
+        return tools._child_imagetool_nodes(self._parent._wrapper)
+
+    def __getitem__(self, index: int | slice) -> ToolNamespace | list[ToolNamespace]:
+        tools = self._parent._console_tools
+        if tools is None:
+            raise LookupError("Parent was destroyed")
+        nodes = self._nodes()
+        if isinstance(index, slice):
+            return [ToolNamespace(node, tools) for node in nodes[index]]
+        return ToolNamespace(nodes[index], tools)
+
+    def __iter__(self):
+        tools = self._parent._console_tools
+        if tools is None:
+            return iter(())
+        return (ToolNamespace(node, tools) for node in self._nodes())
+
+    def __len__(self) -> int:
+        return len(self._nodes())
+
+    def __repr__(self) -> str:
+        tools = self._parent._console_tools
+        if tools is None:
+            return "No child ImageTools"
+        nodes = self._nodes()
+        if not nodes:
+            return f"No child ImageTools for {self._parent._console_label}"
+        lines = [f"Child ImageTools for {self._parent._console_label}:"]
+        for index, node in enumerate(nodes):
+            lines.append(f"[{index}] {tools._node_label(node, include_name=True)}")
+        return "\n".join(lines)
 
 
 class _DerivedDataNamespace(_ConsoleDataHandleMixin):
@@ -773,19 +838,17 @@ class ToolsNamespace:
     def selected_data(self) -> list[xr.DataArray]:
         """Get a list of DataArrays from the selected windows."""
         return [
-            self._manager.get_imagetool(idx).slicer_area._data
-            for idx in self._manager.tree_view.selected_imagetool_indices
+            self._manager.get_imagetool(target).slicer_area._data
+            for target in self._manager._selected_imagetool_targets()
         ]
 
     @property
     def selected(self) -> list[ToolNamespace]:
         """Get provenance-aware handles for the selected windows."""
-        output: list[ToolNamespace] = []
-        for idx in self._manager.tree_view.selected_imagetool_indices:
-            namespace = self[idx]
-            if namespace is not None:
-                output.append(namespace)
-        return output
+        return [
+            ToolNamespace(self._manager._node_for_target(target), self)
+            for target in self._manager._selected_imagetool_targets()
+        ]
 
     def __getitem__(self, index: int) -> ToolNamespace | None:
         """Access a specific ImageTool object by its index."""
@@ -794,6 +857,75 @@ class ToolsNamespace:
             return None
 
         return ToolNamespace(self._manager._imagetool_wrappers[index], self)
+
+    def _node_path(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> list[int] | None:
+        path: list[int] = []
+        current = node
+        while current.parent_uid is not None:
+            image_parent = self._image_parent_node(current)
+            if image_parent is None:
+                return None
+            child_nodes = self._child_imagetool_nodes(image_parent)
+            child_uids = [child.uid for child in child_nodes]
+            if current.uid not in child_uids:
+                return None
+            child_index = child_uids.index(current.uid)
+            path.append(child_index)
+            current = image_parent
+        for root_index, wrapper in self._manager._imagetool_wrappers.items():
+            if wrapper.uid == current.uid:
+                return [root_index, *reversed(path)]
+        return None
+
+    def _child_imagetool_nodes(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> list[_ManagedWindowNode]:
+        output: list[_ManagedWindowNode] = []
+
+        def collect(parent: _ImageToolWrapper | _ManagedWindowNode) -> None:
+            for child_uid in parent._childtool_indices:
+                child = self._manager._all_nodes.get(child_uid)
+                if child is None:
+                    continue
+                if child.is_imagetool:
+                    output.append(child)
+                    continue
+                collect(child)
+
+        collect(node)
+        return output
+
+    def _image_parent_node(
+        self, node: _ManagedWindowNode
+    ) -> _ImageToolWrapper | _ManagedWindowNode | None:
+        parent_uid = node.parent_uid
+        while parent_uid is not None:
+            parent = self._manager._all_nodes.get(parent_uid)
+            if parent is None:
+                return None
+            if parent.is_imagetool:
+                return parent
+            parent_uid = parent.parent_uid
+        return None
+
+    def _node_data_name(self, node: _ImageToolWrapper | _ManagedWindowNode) -> str:
+        path = self._node_path(node)
+        if path is not None:
+            return "data_" + "_".join(str(index) for index in path)
+        uid_name = "".join(char if char.isalnum() else "_" for char in node.uid)
+        return f"data_{uid_name[:8]}"
+
+    def _node_label(
+        self, node: _ImageToolWrapper | _ManagedWindowNode, *, include_name: bool
+    ) -> str:
+        path = self._node_path(node)
+        display_index = ".".join(str(index) for index in path) if path else node.uid[:8]
+        label = f"ImageTool {display_index}"
+        if include_name and node.name:
+            label += f": {node.name}"
+        return label
 
     def bind_shell(self, shell: InteractiveShell) -> None:
         self._shell_ref = weakref.ref(shell)
@@ -1095,11 +1227,21 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
 
         info_str = (
             _command_ansi(
-                "Access raw data", ["tools[<index>].data", "tools.selected_data"]
+                "Access raw data",
+                [
+                    "tools[<index>].data",
+                    "tools[<index>].children[0].data",
+                    "tools.selected_data",
+                ],
             )
             + "\n"
             + _command_ansi(
-                "Track provenance", ["tools[0] - tools[1]", "tools.selected[0]"]
+                "Track provenance",
+                [
+                    "tools[0] - tools[1]",
+                    "tools[0].children[0] - tools[1]",
+                    "tools.selected[0]",
+                ],
             )
             + "\n"
             + _command_ansi("Change data", ["tools[<index>].data = <value>"])

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -109,8 +109,25 @@ class _ConcatDialog(QtWidgets.QDialog):
                 to_concat = [
                     manager.get_imagetool(idx).slicer_area._data for idx in selected
                 ]
-                erlab.interactive.imagetool.manager.show_in_manager(
-                    xr.concat(to_concat, **self.concat_kwargs())
+                concat_kwargs = self.concat_kwargs()
+                input_names = [
+                    manager._script_input_name_for_node(
+                        manager._node_for_target(target)
+                    )
+                    for target in selected
+                ]
+                operation_code = (
+                    f"derived = xr.concat([{', '.join(input_names)}], "
+                    + ", ".join(
+                        f"{key}={value!r}" for key, value in concat_kwargs.items()
+                    )
+                    + ")"
+                )
+                created_index = manager._show_multi_input_script_result(
+                    xr.concat(to_concat, **concat_kwargs),
+                    selected,
+                    operation_label="Concatenate selected ImageTools",
+                    operation_code=operation_code,
                 )
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(
@@ -119,7 +136,13 @@ class _ConcatDialog(QtWidgets.QDialog):
                     "An error occurred while concatenating data.",
                 )
             else:
-                if self._remove_original_check.isChecked():
+                if created_index is None:
+                    erlab.interactive.utils.MessageDialog.critical(
+                        self,
+                        "Error",
+                        "An error occurred while concatenating data.",
+                    )
+                elif self._remove_original_check.isChecked():
                     for index in sorted(
                         selected,
                         key=str,

--- a/src/erlab/interactive/imagetool/manager/_io.py
+++ b/src/erlab/interactive/imagetool/manager/_io.py
@@ -196,7 +196,13 @@ class _MultiFileHandler(QtCore.QObject):
     def _deliver_and_queue(
         self,
         file_path: pathlib.Path,
-        selected_data: tuple[tuple[xr.DataArray, int], ...],
+        selected_data: tuple[
+            tuple[
+                xr.DataArray,
+                erlab.interactive.imagetool.provenance.FileDataSelection,
+            ],
+            ...,
+        ],
     ) -> None:
         func: Callable | str = self._func
         func_instance = getattr(func, "__self__", None)
@@ -209,7 +215,7 @@ class _MultiFileHandler(QtCore.QObject):
                 "file_path": file_path,
                 "load_func": (func, self._kwargs.copy()),
                 "load_indices": tuple(
-                    source_index for _data_array, source_index in selected_data
+                    selection for _data_array, selection in selected_data
                 ),
             },
             show=(self.n_total == 1),

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -24,6 +24,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.slicer
 from erlab.interactive._dask import DaskMenu
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME, ImageTool
 from erlab.interactive.imagetool.manager import _desktop
@@ -89,6 +90,18 @@ _LINEAGE_STATUS_TOOLTIPS: dict[str, str] = {
     "changed": "At least one recorded live input has changed since this data was made.",
     "missing": "At least one recorded live input is no longer open.",
 }
+
+
+@dataclass(frozen=True)
+class _ScriptRebuildResult:
+    data: xr.DataArray
+    provenance_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
+
+
+class _ScriptRebuildError(RuntimeError):
+    def __init__(self, message: str, *, details: str = "") -> None:
+        super().__init__(message)
+        self.details = details
 
 
 def _manager_settings() -> QtCore.QSettings:
@@ -1206,7 +1219,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
         self.reload_action = QtWidgets.QAction("Reload Data", self)
         self.reload_action.triggered.connect(self.reload_selected)
-        self.reload_action.setToolTip("Reload selected data and refresh child paths")
+        self.reload_action.setToolTip(
+            "Reload selected data from its saved files, parent, or inputs"
+        )
         self.reload_action.setIcon(QtGui.QIcon.fromTheme("view-refresh"))
         self.reload_action.setVisible(False)
 
@@ -2115,13 +2130,18 @@ class ImageToolManager(QtWidgets.QMainWindow):
         status = self.lineage_status_for_uid(uid)
         if status is None:
             return None
-        return _LINEAGE_STATUS_TOOLTIPS[status]
+        tooltip = _LINEAGE_STATUS_TOOLTIPS[status]
+        if status == "missing" and self._missing_lineage_has_recorded_file(uid):
+            tooltip += " Recorded source files found for at least one missing input."
+        return tooltip
 
     def lineage_input_summary_for_uid(self, uid: str) -> str | None:
         refs = self._lineage_refs_for_uid(uid)
         if not refs:
             return None
 
+        node = self._all_nodes.get(uid)
+        spec = None if node is None else node.provenance_spec
         parts: list[str] = []
         seen: set[tuple[str, str, str | None]] = set()
         for ref in refs:
@@ -2136,8 +2156,56 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 current = f"currently {parent.display_text}"
             else:
                 current = "parent no longer open"
+                if self._lineage_ref_has_recorded_file(spec, ref):
+                    current += "; recorded source file found"
             parts.append(f"{ref.name}: {ref.label} ({current})")
         return "; ".join(parts)
+
+    @classmethod
+    def _script_input_has_recorded_file(
+        cls,
+        script_input: erlab.interactive.imagetool.provenance.ScriptInput,
+    ) -> bool:
+        spec = script_input.parsed_provenance_spec()
+        if spec is None:
+            return False
+        if spec.kind == "file" and spec.file_load_source is not None:
+            return pathlib.Path(spec.file_load_source.path).exists()
+        for nested_input in spec.script_inputs:
+            if cls._script_input_has_recorded_file(nested_input):
+                return True
+        return False
+
+    @classmethod
+    def _lineage_ref_has_recorded_file(
+        cls,
+        spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None,
+        ref: erlab.interactive.imagetool.provenance.ScriptInputLineageRef,
+    ) -> bool:
+        if spec is None:
+            return False
+        for script_input in spec.script_inputs:
+            if (
+                script_input.name == ref.name
+                and script_input.node_uid == ref.node_uid
+                and script_input.node_lineage_token == ref.node_lineage_token
+                and cls._script_input_has_recorded_file(script_input)
+            ):
+                return True
+            if cls._lineage_ref_has_recorded_file(
+                script_input.parsed_provenance_spec(), ref
+            ):
+                return True
+        return False
+
+    def _missing_lineage_has_recorded_file(self, uid: str) -> bool:
+        node = self._all_nodes.get(uid)
+        spec = None if node is None else node.provenance_spec
+        return any(
+            self._all_nodes.get(ref.node_uid) is None
+            and self._lineage_ref_has_recorded_file(spec, ref)
+            for ref in self._lineage_refs_for_uid(uid)
+        )
 
     def _lineage_dependent_uids(self, uid: str) -> list[str]:
         return [
@@ -2232,6 +2300,193 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 operation_code=operation_code,
             ),
         )
+
+    def _script_provenance_inputs_current(
+        self, spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
+    ) -> bool:
+        for ref in erlab.interactive.imagetool.provenance.script_input_lineage_refs(
+            spec
+        ):
+            parent = self._all_nodes.get(ref.node_uid)
+            if parent is None:
+                return False
+            if (
+                ref.node_lineage_token is not None
+                and parent.lineage_token != ref.node_lineage_token
+            ):
+                return False
+        return True
+
+    def _rebuild_script_input_for_reload(
+        self,
+        script_input: erlab.interactive.imagetool.provenance.ScriptInput,
+        spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
+        *,
+        depth: int,
+    ) -> tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput]:
+        rebuilt = self._rebuild_script_provenance(spec, depth=depth + 1)
+        return (
+            rebuilt.data,
+            script_input.model_copy(
+                update={
+                    "node_uid": None,
+                    "node_lineage_token": None,
+                    "provenance_spec": rebuilt.provenance_spec.model_dump(mode="json"),
+                }
+            ),
+        )
+
+    def _resolve_script_input_for_rebuild(
+        self,
+        script_input: erlab.interactive.imagetool.provenance.ScriptInput,
+        *,
+        depth: int,
+    ) -> tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput]:
+        if depth > 20:
+            raise _ScriptRebuildError(
+                "Could not reload data.",
+                details="Nested script provenance exceeded the maximum reload depth.",
+            )
+
+        spec = script_input.parsed_provenance_spec()
+        if script_input.node_uid is not None:
+            node = self._all_nodes.get(script_input.node_uid)
+            if node is not None:
+                if (
+                    spec is not None
+                    and spec.kind == "script"
+                    and not self._script_provenance_inputs_current(spec)
+                ):
+                    return self._rebuild_script_input_for_reload(
+                        script_input,
+                        spec,
+                        depth=depth,
+                    )
+                return (
+                    node.current_source_data(),
+                    self._script_input_for_node(node).model_copy(
+                        update={"name": script_input.name}
+                    ),
+                )
+
+        if spec is None:
+            raise _ScriptRebuildError(
+                "Could not reload data.",
+                details=(
+                    f"{script_input.name} from {script_input.label} is not open and "
+                    "does not contain recorded source provenance."
+                ),
+            )
+
+        if spec.kind == "file":
+            try:
+                data = erlab.interactive.imagetool.provenance.replay_file_provenance(
+                    spec
+                )
+            except Exception as exc:
+                raise _ScriptRebuildError(
+                    "Could not reload from recorded source files.",
+                    details=f"{script_input.name} from {script_input.label}: {exc}",
+                ) from exc
+            return (
+                data,
+                script_input.model_copy(
+                    update={
+                        "node_uid": None,
+                        "node_lineage_token": None,
+                        "provenance_spec": spec.model_dump(mode="json"),
+                    }
+                ),
+            )
+
+        if spec.kind == "script":
+            return self._rebuild_script_input_for_reload(
+                script_input,
+                spec,
+                depth=depth,
+            )
+
+        raise _ScriptRebuildError(
+            "Could not reload data.",
+            details=(
+                f"{script_input.name} from {script_input.label} is not open and "
+                "does not contain reloadable script or file provenance."
+            ),
+        )
+
+    def _rebuild_script_provenance(
+        self,
+        spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
+        *,
+        depth: int = 0,
+    ) -> _ScriptRebuildResult:
+        if spec.kind != "script":
+            raise _ScriptRebuildError(
+                "Could not reload data.",
+                details="Selected provenance is not script-derived.",
+            )
+        if not erlab.interactive.imagetool.provenance.script_provenance_replayable(
+            spec
+        ):
+            raise _ScriptRebuildError(
+                "Could not reload data.",
+                details="The recorded operation cannot be replayed automatically.",
+            )
+
+        resolved_inputs = tuple(
+            self._resolve_script_input_for_rebuild(script_input, depth=depth)
+            for script_input in spec.script_inputs
+        )
+        input_data = {script_input.name: data for data, script_input in resolved_inputs}
+        rebuilt_spec = spec.model_copy(
+            update={
+                "script_inputs": tuple(
+                    script_input for _data, script_input in resolved_inputs
+                )
+            }
+        )
+        try:
+            data = erlab.interactive.imagetool.provenance.replay_script_provenance(
+                rebuilt_spec, input_data
+            )
+        except Exception as exc:
+            raise _ScriptRebuildError(
+                "Could not reload data.",
+                details=str(exc),
+            ) from exc
+        return _ScriptRebuildResult(
+            data=data,
+            provenance_spec=rebuilt_spec,
+        )
+
+    def _node_can_reload_script_inputs(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> bool:
+        spec = node.provenance_spec
+        return (
+            node.is_imagetool
+            and node.imagetool is not None
+            and spec is not None
+            and spec.kind == "script"
+            and bool(spec.script_inputs)
+            and erlab.interactive.imagetool.provenance.script_provenance_replayable(
+                spec
+            )
+        )
+
+    def _script_reload_from_slicer_area(
+        self,
+        slicer_area: erlab.interactive.imagetool.viewer.ImageSlicerArea,
+        *,
+        execute: bool,
+    ) -> bool:
+        """Check or reload script provenance for a managed slicer area."""
+        target = self.target_from_slicer_area(slicer_area)
+        if target is None:
+            return False
+        if not self._node_can_reload_script_inputs(self._node_for_target(target)):
+            return False
+        return not execute or self._reload_script_derived_target(target)
 
     def _workspace_loaded_uid_map(
         self, loaded_targets_by_uid: Mapping[str, int | str]
@@ -3230,7 +3485,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
         )
         self.store_action.setEnabled(bool(self.tree_view.selected_imagetool_indices))
 
-        self.reload_action.setVisible(reload_targets is not None)
+        reload_available = reload_targets is not None
+        self.reload_action.setVisible(reload_available)
+        self.reload_action.setEnabled(reload_available)
         self.unwatch_action.setVisible(
             bool(imagetool_targets)
             and len(selection_watched) == len(imagetool_targets)
@@ -3533,6 +3790,142 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 continue
             for uid in child_uids:
                 self._refresh_source_chain_to_uid(uid)
+
+    @staticmethod
+    def _reload_incompatibility_details(
+        current: xr.DataArray, rebuilt: xr.DataArray
+    ) -> str:
+        lines = [
+            f"Current dims: {tuple(current.dims)} shape {tuple(current.shape)}",
+            f"Reloaded dims: {tuple(rebuilt.dims)} shape {tuple(rebuilt.shape)}",
+        ]
+        current_dims = set(current.dims)
+        rebuilt_dims = set(rebuilt.dims)
+        missing_dims = tuple(dim for dim in current.dims if dim not in rebuilt_dims)
+        new_dims = tuple(dim for dim in rebuilt.dims if dim not in current_dims)
+        if missing_dims:
+            lines.append(f"Missing reloaded dimensions: {missing_dims}")
+        if new_dims:
+            lines.append(f"New reloaded dimensions: {new_dims}")
+        for dim in current.dims:
+            if dim not in rebuilt_dims:
+                continue
+            if current.sizes[dim] != rebuilt.sizes[dim]:
+                lines.append(
+                    f"{dim}: size changed from {current.sizes[dim]} to "
+                    f"{rebuilt.sizes[dim]}"
+                )
+            old_coord = current.coords.get(dim)
+            new_coord = rebuilt.coords.get(dim)
+            if old_coord is None or new_coord is None:
+                continue
+            old_values = old_coord.values
+            new_values = new_coord.values
+            missing_count = int(
+                np.count_nonzero(~np.isin(old_values, new_values, assume_unique=True))
+            )
+            if missing_count:
+                lines.append(
+                    f"{dim}: {missing_count} current coordinate value"
+                    f"{'' if missing_count == 1 else 's'} not found in reloaded data"
+                )
+        return "\n".join(lines)
+
+    def _prompt_incompatible_reload_commit(self, details: str) -> str:
+        msg_box = QtWidgets.QMessageBox(self)
+        msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        msg_box.setWindowTitle("Reload Data")
+        msg_box.setText("The reloaded data has different coordinates.")
+        msg_box.setInformativeText(
+            "The current ImageTool view can only be preserved when the reloaded data "
+            "keeps the current cursor coordinates."
+        )
+        msg_box.setDetailedText(details)
+        replace_button = msg_box.addButton(
+            "Replace and Reset View", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+        )
+        new_button = msg_box.addButton(
+            "Open as New", QtWidgets.QMessageBox.ButtonRole.ActionRole
+        )
+        cancel_button = msg_box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+        msg_box.setDefaultButton(typing.cast("QtWidgets.QPushButton", new_button))
+        msg_box.exec()
+        clicked = msg_box.clickedButton()
+        if clicked is replace_button:
+            return "replace"
+        if clicked is new_button:
+            return "new"
+        if clicked is cancel_button:
+            return "cancel"
+        return "cancel"
+
+    def _replace_script_reload_target(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        result: _ScriptRebuildResult,
+    ) -> None:
+        node.replace_with_detached_data(
+            result.data,
+            result.provenance_spec,
+            propagate_descendants=True,
+        )
+        self.tree_view.refresh(node.uid)
+        if self._metadata_node_uid == node.uid:
+            self._set_metadata_node(node)
+
+    def _reload_script_derived_target(self, target: int | str) -> bool:
+        """Reload a script-derived ImageTool from its recorded inputs."""
+        node = self._node_for_target(target)
+        spec = node.provenance_spec
+        if spec is None:
+            return False
+        try:
+            result = self._rebuild_script_provenance(spec)
+        except _ScriptRebuildError as exc:
+            erlab.interactive.utils.MessageDialog.critical(
+                self,
+                "Error",
+                str(exc),
+                detailed_text=exc.details,
+            )
+            return False
+
+        current = node.current_source_data()
+        if erlab.interactive.imagetool.slicer.check_cursors_compatible(
+            current, result.data
+        ):
+            self._replace_script_reload_target(node, result)
+            self._status_bar.showMessage("Reloaded data from inputs", 5000)
+            return True
+
+        details = self._reload_incompatibility_details(current, result.data)
+        match self._prompt_incompatible_reload_commit(details):
+            case "replace":
+                self._replace_script_reload_target(node, result)
+                self._status_bar.showMessage("Reloaded data from inputs", 5000)
+                return True
+            case "new":
+                tool = erlab.interactive.itool(
+                    result.data, manager=False, execute=False
+                )
+                if not isinstance(tool, ImageTool):
+                    erlab.interactive.utils.MessageDialog.critical(
+                        self,
+                        "Error",
+                        "An error occurred while opening reloaded data.",
+                        detailed_text="",
+                    )
+                    return False
+                self.add_imagetool(
+                    tool,
+                    show=True,
+                    activate=True,
+                    provenance_spec=result.provenance_spec,
+                )
+                self._status_bar.showMessage("Opened reloaded data as a new tool", 5000)
+                return True
+            case _:
+                return False
 
     @QtCore.Slot()
     def remove_selected(self) -> None:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2181,7 +2181,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 if self._dependency_ref_has_recorded_file(spec, ref):
                     current += "; recorded source file found"
             parts.append(f"{ref.name}: {ref.label} ({current})")
-        return "\n".join(parts)
+        return "; ".join(parts)
 
     def _show_dependency_reload_dialog(self, target: int | str) -> None:
         node = self._node_for_target(target)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1432,6 +1432,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self.metadata_details_layout.setVerticalSpacing(2)
         self.metadata_details_layout.setColumnStretch(1, 1)
         self.metadata_details_widget.setLayout(self.metadata_details_layout)
+        self.metadata_details_widget.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Maximum,
+        )
         self.metadata_details_widget.setVisible(False)
         metadata_layout.addWidget(self.metadata_details_widget)
         self._metadata_detail_labels: dict[str, QtWidgets.QLabel] = {}
@@ -3226,7 +3230,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 if field.wrap:
                     value_label.setSizePolicy(
                         QtWidgets.QSizePolicy.Policy.Expanding,
-                        QtWidgets.QSizePolicy.Policy.Minimum,
+                        QtWidgets.QSizePolicy.Policy.Preferred,
                     )
             if field.monospace:
                 value_label.setFont(self._metadata_monospace_font)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1007,6 +1007,16 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
         self._imagetool_wrappers: dict[int, _ImageToolWrapper] = {}
         self._all_nodes: dict[str, _ImageToolWrapper | _ManagedWindowNode] = {}
+        self._dependency_ref_cache: dict[
+            str,
+            tuple[
+                int,
+                tuple[
+                    erlab.interactive.imagetool.provenance.ScriptInputDependencyRef,
+                    ...,
+                ],
+            ],
+        ] = {}
         self._pending_source_refresh_targets: dict[str, set[str]] = {}
         self._displayed_indices: list[int] = []
         self._node_uid_counter: int = 0
@@ -1465,7 +1475,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self._recent_name_filter: str | None = None
         self._recent_directory: str | None = None
         self._recent_loader_extensions_by_filter: dict[str, dict[str, typing.Any]] = {}
-        self._metadata_full_code: str | None = None
+        self._metadata_full_code_available = False
         self._metadata_node_uid: str | None = None
         self._metadata_copy_selected_action = QtGui.QAction("Copy Selected Code", self)
         self._metadata_copy_selected_action.setObjectName(
@@ -2063,6 +2073,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         node = self._all_nodes.pop(uid, None)
         if node is None:
             return
+        self._dependency_ref_cache.pop(uid, None)
         self._refresh_dependency_dependents(uid)
         self._pending_source_refresh_targets.pop(uid, None)
         for blocker_uid, target_uids in list(
@@ -2091,10 +2102,17 @@ class ImageToolManager(QtWidgets.QMainWindow):
     ) -> tuple[erlab.interactive.imagetool.provenance.ScriptInputDependencyRef, ...]:
         node = self._all_nodes.get(uid)
         if node is None or node.provenance_spec is None:
+            self._dependency_ref_cache.pop(uid, None)
             return ()
-        return erlab.interactive.imagetool.provenance.script_input_dependency_refs(
+        spec_id = id(node.provenance_spec)
+        cached = self._dependency_ref_cache.get(uid)
+        if cached is not None and cached[0] == spec_id:
+            return cached[1]
+        refs = erlab.interactive.imagetool.provenance.script_input_dependency_refs(
             node.provenance_spec
         )
+        self._dependency_ref_cache[uid] = (spec_id, refs)
+        return refs
 
     def dependency_status_for_uid(
         self, uid: str
@@ -2387,6 +2405,35 @@ class ImageToolManager(QtWidgets.QMainWindow):
             ),
         )
 
+    def _script_input_can_reload(
+        self,
+        script_input: erlab.interactive.imagetool.provenance.ScriptInput,
+    ) -> bool:
+        spec = script_input.parsed_provenance_spec()
+        if script_input.node_uid is not None:
+            node = self._all_nodes.get(script_input.node_uid)
+            if node is not None and (
+                spec is None
+                or spec.kind != "script"
+                or self._script_provenance_inputs_current(spec)
+            ):
+                return True
+        if spec is None:
+            return False
+        if spec.kind == "file":
+            return (
+                spec.file_load_source is not None
+                and pathlib.Path(spec.file_load_source.path).exists()
+            )
+        if spec.kind != "script":
+            return False
+        return erlab.interactive.imagetool.provenance.script_provenance_replayable(
+            spec
+        ) and all(
+            self._script_input_can_reload(nested_input)
+            for nested_input in spec.script_inputs
+        )
+
     def _rebuild_script_provenance(
         self,
         spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
@@ -2418,6 +2465,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
             and bool(spec.script_inputs)
             and erlab.interactive.imagetool.provenance.script_provenance_replayable(
                 spec
+            )
+            and all(
+                self._script_input_can_reload(script_input)
+                for script_input in spec.script_inputs
             )
         )
 
@@ -3094,7 +3145,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         return node.info_text
 
     def _clear_metadata(self) -> None:
-        self._metadata_full_code = None
+        self._metadata_full_code_available = False
         self._metadata_node_uid = None
         with QtCore.QSignalBlocker(self.metadata_derivation_list):
             self.metadata_derivation_list.clear()
@@ -3102,7 +3153,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self._update_metadata_pane()
 
     def _set_metadata_node(self, node: _ImageToolWrapper | _ManagedWindowNode) -> None:
-        self._metadata_full_code = node.derivation_code
+        self._metadata_full_code_available = node.provenance_spec is not None
         self._metadata_node_uid = node.uid
         self._set_metadata_fields(node.metadata_fields)
 
@@ -3264,7 +3315,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         selected_code = self._selected_derivation_code()
         self._metadata_copy_selected_action.setEnabled(bool(selected_code))
         menu.addAction(self._metadata_copy_selected_action)
-        if self._metadata_full_code:
+        if self._metadata_full_code_available:
             self._metadata_copy_full_action.setEnabled(True)
             menu.addAction(self._metadata_copy_full_action)
         return menu
@@ -3289,16 +3340,21 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
     @QtCore.Slot()
     def _copy_full_derivation_code(self) -> None:
-        if not self._metadata_full_code:
-            return
-        code = self._metadata_full_code
         node = (
             None
             if self._metadata_node_uid is None
             else self._all_nodes.get(self._metadata_node_uid)
         )
+        if node is None or not self._metadata_full_code_available:
+            return
+        code = node.derivation_code
+        if not code:
+            self._status_bar.showMessage(
+                "Replay code is unavailable for this result", 5000
+            )
+            return
         provenance = erlab.interactive.imagetool.provenance
-        if node is not None and provenance.uses_default_replay_input(code):
+        if provenance.uses_default_replay_input(code):
             load_source = self._load_source_for_replay(node)
             if load_source is None:
                 source_name = self._prompt_replay_input_name(node)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2423,9 +2423,13 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _resolve_live_script_input_for_reload(
         self,
         script_input: erlab.interactive.imagetool.provenance.ScriptInput,
+        *,
+        target_node_uid: str | None = None,
     ) -> tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput] | None:
         spec = script_input.parsed_provenance_spec()
         if script_input.node_uid is None:
+            return None
+        if target_node_uid is not None and script_input.node_uid == target_node_uid:
             return None
         node = self._all_nodes.get(script_input.node_uid)
         if node is None:
@@ -2446,9 +2450,14 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _script_input_can_reload(
         self,
         script_input: erlab.interactive.imagetool.provenance.ScriptInput,
+        *,
+        target_node_uid: str | None = None,
     ) -> bool:
         spec = script_input.parsed_provenance_spec()
-        if script_input.node_uid is not None:
+        is_target_input = (
+            target_node_uid is not None and script_input.node_uid == target_node_uid
+        )
+        if script_input.node_uid is not None and not is_target_input:
             node = self._all_nodes.get(script_input.node_uid)
             if node is not None and (
                 spec is None
@@ -2468,18 +2477,34 @@ class ImageToolManager(QtWidgets.QMainWindow):
         return erlab.interactive.imagetool.provenance.script_provenance_replayable(
             spec
         ) and all(
-            self._script_input_can_reload(nested_input)
+            self._script_input_can_reload(
+                nested_input,
+                target_node_uid=target_node_uid,
+            )
             for nested_input in spec.script_inputs
         )
 
     def _rebuild_script_provenance(
         self,
         spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
+        *,
+        target_node_uid: str | None = None,
     ) -> _ScriptRebuildResult:
+        def _resolve_live_input(
+            script_input: erlab.interactive.imagetool.provenance.ScriptInput,
+        ) -> (
+            tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput]
+            | None
+        ):
+            return self._resolve_live_script_input_for_reload(
+                script_input,
+                target_node_uid=target_node_uid,
+            )
+
         try:
             data, rebuilt_spec = _replay_graph.rebuild_script_provenance(
                 spec,
-                live_input_resolver=self._resolve_live_script_input_for_reload,
+                live_input_resolver=_resolve_live_input,
             )
         except _replay_graph.ReplayGraphError as exc:
             raise _ScriptRebuildError(
@@ -2505,7 +2530,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 spec
             )
             and all(
-                self._script_input_can_reload(script_input)
+                self._script_input_can_reload(
+                    script_input,
+                    target_node_uid=node.uid,
+                )
                 for script_input in spec.script_inputs
             )
         )
@@ -3939,7 +3967,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if spec is None:
             return False
         try:
-            result = self._rebuild_script_provenance(spec)
+            result = self._rebuild_script_provenance(
+                spec,
+                target_node_uid=node.uid,
+            )
         except _ScriptRebuildError as exc:
             erlab.interactive.utils.MessageDialog.critical(
                 self,

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3882,6 +3882,11 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _reload_incompatibility_details(
         current: xr.DataArray, rebuilt: xr.DataArray
     ) -> str:
+        current, rebuilt = (
+            erlab.interactive.imagetool.slicer._cursor_compatibility_pair(
+                current, rebuilt
+            )
+        )
         lines = [
             f"Current dims: {tuple(current.dims)} shape {tuple(current.shape)}",
             f"Reloaded dims: {tuple(rebuilt.dims)} shape {tuple(rebuilt.shape)}",

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -26,6 +26,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 import erlab.interactive.imagetool.slicer
 from erlab.interactive._dask import DaskMenu
+from erlab.interactive.imagetool import _replay_graph
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME, ImageTool
 from erlab.interactive.imagetool.manager import _desktop
 from erlab.interactive.imagetool.manager import _server as _manager_server
@@ -2363,154 +2364,39 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 return False
         return True
 
-    def _rebuild_script_input_for_reload(
+    def _resolve_live_script_input_for_reload(
         self,
         script_input: erlab.interactive.imagetool.provenance.ScriptInput,
-        spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
-        *,
-        depth: int,
-        replay_cache: dict[str, xr.DataArray],
-    ) -> tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput]:
-        rebuilt = self._rebuild_script_provenance(
-            spec,
-            depth=depth + 1,
-            replay_cache=replay_cache,
-        )
-        return (
-            rebuilt.data,
-            script_input.model_copy(
-                update={
-                    "node_uid": None,
-                    "node_snapshot_token": None,
-                    "provenance_spec": rebuilt.provenance_spec.model_dump(mode="json"),
-                }
-            ),
-        )
-
-    def _resolve_script_input_for_rebuild(
-        self,
-        script_input: erlab.interactive.imagetool.provenance.ScriptInput,
-        *,
-        depth: int,
-        replay_cache: dict[str, xr.DataArray],
-    ) -> tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput]:
-        if depth > 20:
-            raise _ScriptRebuildError(
-                "Could not reload data.",
-                details="Nested script provenance exceeded the maximum reload depth.",
-            )
-
+    ) -> tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput] | None:
         spec = script_input.parsed_provenance_spec()
-        if script_input.node_uid is not None:
-            node = self._all_nodes.get(script_input.node_uid)
-            if node is not None:
-                if (
-                    spec is not None
-                    and spec.kind == "script"
-                    and not self._script_provenance_inputs_current(spec)
-                ):
-                    return self._rebuild_script_input_for_reload(
-                        script_input,
-                        spec,
-                        depth=depth,
-                        replay_cache=replay_cache,
-                    )
-                return (
-                    node.current_source_data(),
-                    self._script_input_for_node(node).model_copy(
-                        update={"name": script_input.name}
-                    ),
-                )
-
-        if spec is None:
-            raise _ScriptRebuildError(
-                "Could not reload data.",
-                details=(
-                    f"{script_input.name} from {script_input.label} is not open and "
-                    "does not contain recorded source provenance."
-                ),
-            )
-
-        if spec.kind == "file":
-            try:
-                data = erlab.interactive.imagetool.provenance.replay_file_provenance(
-                    spec,
-                    cache=replay_cache,
-                )
-            except Exception as exc:
-                raise _ScriptRebuildError(
-                    "Could not reload from recorded source files.",
-                    details=f"{script_input.name} from {script_input.label}: {exc}",
-                ) from exc
-            return (
-                data,
-                script_input.model_copy(
-                    update={
-                        "node_uid": None,
-                        "node_snapshot_token": None,
-                        "provenance_spec": spec.model_dump(mode="json"),
-                    }
-                ),
-            )
-
-        if spec.kind == "script":
-            return self._rebuild_script_input_for_reload(
-                script_input,
-                spec,
-                depth=depth,
-                replay_cache=replay_cache,
-            )
-
-        raise _ScriptRebuildError(
-            "Could not reload data.",
-            details=(
-                f"{script_input.name} from {script_input.label} is not open and "
-                "does not contain reloadable script or file provenance."
+        if script_input.node_uid is None:
+            return None
+        node = self._all_nodes.get(script_input.node_uid)
+        if node is None:
+            return None
+        if (
+            spec is not None
+            and spec.kind == "script"
+            and not self._script_provenance_inputs_current(spec)
+        ):
+            return None
+        return (
+            node.current_source_data(),
+            self._script_input_for_node(node).model_copy(
+                update={"name": script_input.name}
             ),
         )
 
     def _rebuild_script_provenance(
         self,
         spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
-        *,
-        depth: int = 0,
-        replay_cache: dict[str, xr.DataArray] | None = None,
     ) -> _ScriptRebuildResult:
-        if spec.kind != "script":
-            raise _ScriptRebuildError(
-                "Could not reload data.",
-                details="Selected provenance is not script-derived.",
-            )
-        if not erlab.interactive.imagetool.provenance.script_provenance_replayable(
-            spec
-        ):
-            raise _ScriptRebuildError(
-                "Could not reload data.",
-                details="The recorded operation cannot be replayed automatically.",
-            )
-
-        shared_replay_cache = {} if replay_cache is None else replay_cache
-        resolved_inputs = tuple(
-            self._resolve_script_input_for_rebuild(
-                script_input,
-                depth=depth,
-                replay_cache=shared_replay_cache,
-            )
-            for script_input in spec.script_inputs
-        )
-        input_data = {script_input.name: data for data, script_input in resolved_inputs}
-        rebuilt_spec = spec.model_copy(
-            update={
-                "script_inputs": tuple(
-                    script_input for _data, script_input in resolved_inputs
-                )
-            }
-        )
         try:
-            data = erlab.interactive.imagetool.provenance.replay_script_provenance(
-                rebuilt_spec, input_data
+            data, rebuilt_spec = _replay_graph.rebuild_script_provenance(
+                spec,
+                live_input_resolver=self._resolve_live_script_input_for_reload,
             )
-        except Exception as exc:
+        except _replay_graph.ReplayGraphError as exc:
             raise _ScriptRebuildError(
                 "Could not reload data.",
                 details=str(exc),

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -76,16 +76,16 @@ _METADATA_DERIVATION_CODE_ROLE = int(QtCore.Qt.ItemDataRole.UserRole)
 _METADATA_DERIVATION_COPYABLE_ROLE = _METADATA_DERIVATION_CODE_ROLE + 1
 _RECENT_WORKSPACES_SETTINGS_KEY = "recent_workspaces"
 _MAX_RECENT_WORKSPACES = 10
-_LINEAGE_STATUS_LABELS: dict[str, str] = {
-    "current": "Current inputs",
-    "changed": "Inputs changed",
-    "missing": "Inputs missing",
+_DEPENDENCY_STATUS_LABELS: dict[str, str] = {
+    "current": "Current",
+    "changed": "Changed",
+    "missing": "Missing",
 }
-_LINEAGE_STATUS_BADGES: dict[str, str] = {
-    "changed": "Inputs changed",
-    "missing": "Inputs missing",
+_DEPENDENCY_STATUS_BADGES: dict[str, str] = {
+    "changed": "Changed",
+    "missing": "Missing",
 }
-_LINEAGE_STATUS_TOOLTIPS: dict[str, str] = {
+_DEPENDENCY_STATUS_TOOLTIPS: dict[str, str] = {
     "current": "All recorded live inputs are still open and unchanged.",
     "changed": "At least one recorded live input has changed since this data was made.",
     "missing": "At least one recorded live input is no longer open.",
@@ -2062,7 +2062,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         node = self._all_nodes.pop(uid, None)
         if node is None:
             return
-        self._refresh_lineage_dependents(uid)
+        self._refresh_dependency_dependents(uid)
         self._pending_source_refresh_targets.pop(uid, None)
         for blocker_uid, target_uids in list(
             self._pending_source_refresh_targets.items()
@@ -2085,20 +2085,20 @@ class ImageToolManager(QtWidgets.QMainWindow):
             return self._imagetool_wrappers[target]
         return self._all_nodes[target]
 
-    def _lineage_refs_for_uid(
+    def _dependency_refs_for_uid(
         self, uid: str
-    ) -> tuple[erlab.interactive.imagetool.provenance.ScriptInputLineageRef, ...]:
+    ) -> tuple[erlab.interactive.imagetool.provenance.ScriptInputDependencyRef, ...]:
         node = self._all_nodes.get(uid)
         if node is None or node.provenance_spec is None:
             return ()
-        return erlab.interactive.imagetool.provenance.script_input_lineage_refs(
+        return erlab.interactive.imagetool.provenance.script_input_dependency_refs(
             node.provenance_spec
         )
 
-    def lineage_status_for_uid(
+    def dependency_status_for_uid(
         self, uid: str
     ) -> typing.Literal["current", "changed", "missing"] | None:
-        refs = self._lineage_refs_for_uid(uid)
+        refs = self._dependency_refs_for_uid(uid)
         if not refs:
             return None
 
@@ -2108,35 +2108,38 @@ class ImageToolManager(QtWidgets.QMainWindow):
             if parent is None:
                 return "missing"
             if (
-                ref.node_lineage_token is not None
-                and parent.lineage_token != ref.node_lineage_token
+                ref.node_snapshot_token is not None
+                and parent.snapshot_token != ref.node_snapshot_token
             ):
                 changed = True
         return "changed" if changed else "current"
 
-    def lineage_status_label_for_uid(self, uid: str) -> str | None:
-        status = self.lineage_status_for_uid(uid)
+    def dependency_status_label_for_uid(self, uid: str) -> str | None:
+        status = self.dependency_status_for_uid(uid)
         if status is None:
             return None
-        return _LINEAGE_STATUS_LABELS[status]
+        return _DEPENDENCY_STATUS_LABELS[status]
 
-    def lineage_status_badge_for_uid(self, uid: str) -> str | None:
-        status = self.lineage_status_for_uid(uid)
+    def dependency_status_badge_for_uid(self, uid: str) -> str | None:
+        status = self.dependency_status_for_uid(uid)
         if status is None:
             return None
-        return _LINEAGE_STATUS_BADGES.get(status)
+        return _DEPENDENCY_STATUS_BADGES.get(status)
 
-    def lineage_status_tooltip_for_uid(self, uid: str) -> str | None:
-        status = self.lineage_status_for_uid(uid)
+    def dependency_status_tooltip_for_uid(self, uid: str) -> str | None:
+        status = self.dependency_status_for_uid(uid)
         if status is None:
             return None
-        tooltip = _LINEAGE_STATUS_TOOLTIPS[status]
-        if status == "missing" and self._missing_lineage_has_recorded_file(uid):
+        tooltip = _DEPENDENCY_STATUS_TOOLTIPS[status]
+        node = self._all_nodes.get(uid)
+        if node is not None and self._node_can_reload_script_inputs(node):
+            tooltip += " Click for Reload Data options."
+        if status == "missing" and self._missing_dependencies_have_recorded_file(uid):
             tooltip += " Recorded source files found for at least one missing input."
         return tooltip
 
-    def lineage_input_summary_for_uid(self, uid: str) -> str | None:
-        refs = self._lineage_refs_for_uid(uid)
+    def dependency_input_summary_for_uid(self, uid: str) -> str | None:
+        refs = self._dependency_refs_for_uid(uid)
         if not refs:
             return None
 
@@ -2145,7 +2148,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         parts: list[str] = []
         seen: set[tuple[str, str, str | None]] = set()
         for ref in refs:
-            key = (ref.name, ref.node_uid, ref.node_lineage_token)
+            key = (ref.name, ref.node_uid, ref.node_snapshot_token)
             if key in seen:
                 continue
             seen.add(key)
@@ -2156,10 +2159,51 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 current = f"currently {parent.display_text}"
             else:
                 current = "parent no longer open"
-                if self._lineage_ref_has_recorded_file(spec, ref):
+                if self._dependency_ref_has_recorded_file(spec, ref):
                     current += "; recorded source file found"
             parts.append(f"{ref.name}: {ref.label} ({current})")
         return "; ".join(parts)
+
+    def _show_dependency_reload_dialog(self, target: int | str) -> None:
+        node = self._node_for_target(target)
+        status = self.dependency_status_for_uid(node.uid)
+        if status is None:
+            return
+
+        details = self.dependency_input_summary_for_uid(node.uid)
+        msg_box = QtWidgets.QMessageBox(self)
+        msg_box.setWindowTitle("Reload Data")
+        if details:
+            msg_box.setDetailedText(details)
+
+        if not self._node_can_reload_script_inputs(node):
+            msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+            msg_box.setText("This result cannot be reloaded from its recorded inputs.")
+            msg_box.setInformativeText(
+                "The recorded provenance is not complete enough to replay."
+            )
+            msg_box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Close)
+            msg_box.exec()
+            return
+
+        msg_box.setIcon(QtWidgets.QMessageBox.Icon.Question)
+        if status == "changed":
+            msg_box.setText("Reload this result from the current inputs?")
+        else:
+            msg_box.setText("Reload this result from its recorded inputs?")
+        msg_box.setInformativeText(
+            "The current ImageTool data will be replaced only if reload succeeds."
+        )
+        reload_button = msg_box.addButton(
+            "Reload Data", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+        )
+        cancel_button = msg_box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+        msg_box.setDefaultButton(typing.cast("QtWidgets.QPushButton", reload_button))
+        msg_box.exec()
+        if msg_box.clickedButton() is reload_button:
+            self._reload_script_derived_target(target)
+        elif msg_box.clickedButton() is cancel_button:
+            return
 
     @classmethod
     def _script_input_has_recorded_file(
@@ -2177,10 +2221,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
         return False
 
     @classmethod
-    def _lineage_ref_has_recorded_file(
+    def _dependency_ref_has_recorded_file(
         cls,
         spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None,
-        ref: erlab.interactive.imagetool.provenance.ScriptInputLineageRef,
+        ref: erlab.interactive.imagetool.provenance.ScriptInputDependencyRef,
     ) -> bool:
         if spec is None:
             return False
@@ -2188,35 +2232,37 @@ class ImageToolManager(QtWidgets.QMainWindow):
             if (
                 script_input.name == ref.name
                 and script_input.node_uid == ref.node_uid
-                and script_input.node_lineage_token == ref.node_lineage_token
+                and script_input.node_snapshot_token == ref.node_snapshot_token
                 and cls._script_input_has_recorded_file(script_input)
             ):
                 return True
-            if cls._lineage_ref_has_recorded_file(
+            if cls._dependency_ref_has_recorded_file(
                 script_input.parsed_provenance_spec(), ref
             ):
                 return True
         return False
 
-    def _missing_lineage_has_recorded_file(self, uid: str) -> bool:
+    def _missing_dependencies_have_recorded_file(self, uid: str) -> bool:
         node = self._all_nodes.get(uid)
         spec = None if node is None else node.provenance_spec
         return any(
             self._all_nodes.get(ref.node_uid) is None
-            and self._lineage_ref_has_recorded_file(spec, ref)
-            for ref in self._lineage_refs_for_uid(uid)
+            and self._dependency_ref_has_recorded_file(spec, ref)
+            for ref in self._dependency_refs_for_uid(uid)
         )
 
-    def _lineage_dependent_uids(self, uid: str) -> list[str]:
+    def _dependency_dependent_uids(self, uid: str) -> list[str]:
         return [
             node_uid
             for node_uid in self._all_nodes
             if node_uid != uid
-            and any(ref.node_uid == uid for ref in self._lineage_refs_for_uid(node_uid))
+            and any(
+                ref.node_uid == uid for ref in self._dependency_refs_for_uid(node_uid)
+            )
         ]
 
-    def _refresh_lineage_dependents(self, uid: str) -> None:
-        for dependent_uid in self._lineage_dependent_uids(uid):
+    def _refresh_dependency_dependents(self, uid: str) -> None:
+        for dependent_uid in self._dependency_dependent_uids(uid):
             self.tree_view.refresh(dependent_uid)
             if self._metadata_node_uid == dependent_uid:
                 self._set_metadata_node(self._all_nodes[dependent_uid])
@@ -2252,7 +2298,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             name=self._script_input_name_for_node(node),
             label=label,
             node_uid=node.uid,
-            node_lineage_token=node.lineage_token,
+            node_snapshot_token=node.snapshot_token,
             provenance_spec=provenance_spec,
         )
 
@@ -2304,15 +2350,15 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _script_provenance_inputs_current(
         self, spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
     ) -> bool:
-        for ref in erlab.interactive.imagetool.provenance.script_input_lineage_refs(
+        for ref in erlab.interactive.imagetool.provenance.script_input_dependency_refs(
             spec
         ):
             parent = self._all_nodes.get(ref.node_uid)
             if parent is None:
                 return False
             if (
-                ref.node_lineage_token is not None
-                and parent.lineage_token != ref.node_lineage_token
+                ref.node_snapshot_token is not None
+                and parent.snapshot_token != ref.node_snapshot_token
             ):
                 return False
         return True
@@ -2323,14 +2369,19 @@ class ImageToolManager(QtWidgets.QMainWindow):
         spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
         *,
         depth: int,
+        replay_cache: dict[str, xr.DataArray],
     ) -> tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput]:
-        rebuilt = self._rebuild_script_provenance(spec, depth=depth + 1)
+        rebuilt = self._rebuild_script_provenance(
+            spec,
+            depth=depth + 1,
+            replay_cache=replay_cache,
+        )
         return (
             rebuilt.data,
             script_input.model_copy(
                 update={
                     "node_uid": None,
-                    "node_lineage_token": None,
+                    "node_snapshot_token": None,
                     "provenance_spec": rebuilt.provenance_spec.model_dump(mode="json"),
                 }
             ),
@@ -2341,6 +2392,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         script_input: erlab.interactive.imagetool.provenance.ScriptInput,
         *,
         depth: int,
+        replay_cache: dict[str, xr.DataArray],
     ) -> tuple[xr.DataArray, erlab.interactive.imagetool.provenance.ScriptInput]:
         if depth > 20:
             raise _ScriptRebuildError(
@@ -2361,6 +2413,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         script_input,
                         spec,
                         depth=depth,
+                        replay_cache=replay_cache,
                     )
                 return (
                     node.current_source_data(),
@@ -2381,7 +2434,8 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if spec.kind == "file":
             try:
                 data = erlab.interactive.imagetool.provenance.replay_file_provenance(
-                    spec
+                    spec,
+                    cache=replay_cache,
                 )
             except Exception as exc:
                 raise _ScriptRebuildError(
@@ -2393,7 +2447,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 script_input.model_copy(
                     update={
                         "node_uid": None,
-                        "node_lineage_token": None,
+                        "node_snapshot_token": None,
                         "provenance_spec": spec.model_dump(mode="json"),
                     }
                 ),
@@ -2404,6 +2458,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 script_input,
                 spec,
                 depth=depth,
+                replay_cache=replay_cache,
             )
 
         raise _ScriptRebuildError(
@@ -2419,6 +2474,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
         *,
         depth: int = 0,
+        replay_cache: dict[str, xr.DataArray] | None = None,
     ) -> _ScriptRebuildResult:
         if spec.kind != "script":
             raise _ScriptRebuildError(
@@ -2433,8 +2489,13 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 details="The recorded operation cannot be replayed automatically.",
             )
 
+        shared_replay_cache = {} if replay_cache is None else replay_cache
         resolved_inputs = tuple(
-            self._resolve_script_input_for_rebuild(script_input, depth=depth)
+            self._resolve_script_input_for_rebuild(
+                script_input,
+                depth=depth,
+                replay_cache=shared_replay_cache,
+            )
             for script_input in spec.script_inputs
         )
         input_data = {script_input.name: data for data, script_input in resolved_inputs}
@@ -2501,7 +2562,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 uid_map[saved_uid] = actual_uid
         return uid_map
 
-    def _rebase_loaded_workspace_lineage_refs(
+    def _rebase_loaded_workspace_dependency_refs(
         self, loaded_targets_by_uid: Mapping[str, int | str]
     ) -> None:
         uid_map = self._workspace_loaded_uid_map(loaded_targets_by_uid)
@@ -2522,7 +2583,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 )
             )
             if rebased != node.provenance_spec:
-                node.set_displayed_provenance(rebased, advance_lineage=False)
+                node.set_displayed_provenance(rebased, advance_snapshot=False)
 
     def _child_node(self, uid: str) -> _ManagedWindowNode:
         node = self._all_nodes[uid]
@@ -3074,7 +3135,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         index: int | None = None,
-        lineage_token: str | None = None,
+        snapshot_token: str | None = None,
     ) -> int:
         """Add a new ImageTool window to the manager and show it.
 
@@ -3121,7 +3182,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             source_binding=source_binding,
             source_auto_update=source_auto_update,
             source_state=source_state,
-            lineage_token=lineage_token,
+            snapshot_token=snapshot_token,
         )
         self._imagetool_wrappers[index] = wrapper
         self._register_root_wrapper(wrapper)
@@ -3536,7 +3597,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
         self._imagetool_wrappers.pop(index)
         self._all_nodes.pop(wrapper.uid, None)
-        self._refresh_lineage_dependents(wrapper.uid)
+        self._refresh_dependency_dependents(wrapper.uid)
         wrapper.dispose()
         wrapper.deleteLater()
 
@@ -4077,7 +4138,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         created_time = node._created_time
         recent_geometry = node._recent_geometry
         provenance_spec = node.provenance_spec
-        lineage_token = node.lineage_token
+        snapshot_token = node.snapshot_token
 
         self.tree_view.childtool_removed(uid)
         self._unregister_node(uid)
@@ -4088,7 +4149,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 show=False,
                 uid=uid,
                 provenance_spec=provenance_spec,
-                lineage_token=lineage_token,
+                snapshot_token=snapshot_token,
             )
         wrapper = self._imagetool_wrappers[new_index]
         wrapper._created_time = created_time
@@ -4113,7 +4174,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self.tree_view.setCurrentIndex(promoted_index)
         self.tree_view.scrollTo(promoted_index)
         self.tree_view.refresh(new_index)
-        self._refresh_lineage_dependents(uid)
+        self._refresh_dependency_dependents(uid)
         self._update_actions()
         self._mark_workspace_structure_dirty("Promoted child ImageTool")
         return new_index
@@ -4303,7 +4364,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
     ) -> xr.Dataset:
         ds.attrs["manager_node_uid"] = node.uid
         ds.attrs["manager_node_kind"] = kind
-        ds.attrs["manager_node_lineage_token"] = node.lineage_token
+        ds.attrs["manager_node_snapshot_token"] = node.snapshot_token
         if node.provenance_spec is not None:
             ds.attrs["manager_node_provenance_spec"] = json.dumps(
                 node.provenance_spec.model_dump(mode="json")
@@ -4486,7 +4547,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 )
         kwargs: dict[str, typing.Any] = {
             "uid": uid,
-            "lineage_token": ds.attrs.get("manager_node_lineage_token"),
+            "snapshot_token": ds.attrs.get("manager_node_snapshot_token"),
             "provenance_spec": parsed_provenance_spec,
             "source_spec": parsed_source_spec,
             "source_binding": parsed_source_binding,
@@ -4569,7 +4630,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             parent_target,
             show=ds.attrs.get("tool_visible", True),
             uid=ds.attrs.get("manager_node_uid"),
-            lineage_token=ds.attrs.get("manager_node_lineage_token"),
+            snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
         )
 
     @staticmethod
@@ -4914,7 +4975,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     self.remove_all_tools()
                 for root_path in root_paths:
                     _load_path(root_path)
-                self._rebase_loaded_workspace_lineage_refs(loaded_targets_by_uid)
+                self._rebase_loaded_workspace_dependency_refs(loaded_targets_by_uid)
                 self._restore_workspace_link_groups(manifest, loaded_targets_by_uid)
                 if not mark_dirty:
                     self._drain_workspace_deferred_events()
@@ -5023,7 +5084,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         workspace_file_path=workspace_file_path,
                         loaded_targets_by_uid=loaded_targets_by_uid,
                     )
-                    self._rebase_loaded_workspace_lineage_refs(loaded_targets_by_uid)
+                    self._rebase_loaded_workspace_dependency_refs(loaded_targets_by_uid)
                     self._restore_workspace_link_groups(manifest, loaded_targets_by_uid)
                     if not mark_dirty:
                         self._drain_workspace_deferred_events()
@@ -7013,7 +7074,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         *,
         show: bool = True,
         uid: str | None = None,
-        lineage_token: str | None = None,
+        snapshot_token: str | None = None,
     ) -> str:
         """Register a child tool window.
 
@@ -7035,7 +7096,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             self._next_node_uid(uid),
             parent.uid,
             tool,
-            lineage_token=lineage_token,
+            snapshot_token=snapshot_token,
         )
         if not tool._tool_display_name:
             tool._tool_display_name = parent.name
@@ -7073,7 +7134,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         output_id: str | None = None,
-        lineage_token: str | None = None,
+        snapshot_token: str | None = None,
     ) -> str:
         parent_node = self._node_for_target(parent)
         if source_spec is None and source_binding is not None:
@@ -7099,7 +7160,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             source_auto_update=source_auto_update,
             source_state=source_state,
             output_id=output_id,
-            lineage_token=lineage_token,
+            snapshot_token=snapshot_token,
         )
         self._register_child_node(node)
         if output_id is not None and parent_node.tool_window is not None:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2181,7 +2181,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 if self._dependency_ref_has_recorded_file(spec, ref):
                     current += "; recorded source file found"
             parts.append(f"{ref.name}: {ref.label} ({current})")
-        return "; ".join(parts)
+        return "\n".join(parts)
 
     def _show_dependency_reload_dialog(self, target: int | str) -> None:
         node = self._node_for_target(target)
@@ -3190,6 +3190,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
             key_label = QtWidgets.QLabel(field.label, self.metadata_details_widget)
             key_label.setForegroundRole(QtGui.QPalette.ColorRole.Text)
             key_label.setEnabled(False)
+            key_label.setAlignment(
+                QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
+            )
             value_label: QtWidgets.QLabel
             if field.details is not None:
                 value_label = _ElidedInteractiveLabel(
@@ -3211,6 +3214,14 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 value_label.setWordWrap(field.wrap)
                 value_label.setToolTip(field.value)
                 value_label.setMinimumWidth(0)
+                value_label.setAlignment(
+                    QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
+                )
+                if field.wrap:
+                    value_label.setSizePolicy(
+                        QtWidgets.QSizePolicy.Policy.Expanding,
+                        QtWidgets.QSizePolicy.Policy.Minimum,
+                    )
             if field.monospace:
                 value_label.setFont(self._metadata_monospace_font)
             self.metadata_details_layout.addWidget(key_label, row, 0)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2180,8 +2180,14 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 current = "parent no longer open"
                 if self._dependency_ref_has_recorded_file(spec, ref):
                     current += "; recorded source file found"
-            parts.append(f"{ref.name}: {ref.label} ({current})")
-        return "; ".join(parts)
+            name = " ".join(ref.name.split())
+            label = " ".join(ref.label.split())
+            current = " ".join(current.split())
+            if name and label and current:
+                parts.append(f"{name}: {label} ({current})")
+        if not parts:
+            return None
+        return "\n".join(parts)
 
     def _show_dependency_reload_dialog(self, target: int | str) -> None:
         node = self._node_for_target(target)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -165,6 +165,28 @@ class _MetadataDerivationListWidget(QtWidgets.QListWidget):
         super().keyPressEvent(event)
 
 
+class _HeightForWidthFrame(QtWidgets.QFrame):
+    def sync_height_for_width(self) -> None:
+        if self.isVisible() and self.hasHeightForWidth() and self.width() > 0:
+            height = self.heightForWidth(self.width())
+            self.setMinimumHeight(height)
+            self.setMaximumHeight(height)
+        else:
+            self.setMinimumHeight(0)
+            self.setMaximumHeight(QtWidgets.QWIDGETSIZE_MAX)
+        self.updateGeometry()
+
+    def sizeHint(self) -> QtCore.QSize:
+        hint = super().sizeHint()
+        if self.hasHeightForWidth() and self.width() > 0:
+            hint.setHeight(self.heightForWidth(self.width()))
+        return hint
+
+    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
+        super().resizeEvent(event)
+        self.sync_height_for_width()
+
+
 class _ElidedInteractiveLabel(QtWidgets.QLabel):
     clicked = QtCore.Signal()
 
@@ -1402,8 +1424,14 @@ class ImageToolManager(QtWidgets.QMainWindow):
         left_layout.addWidget(self.tree_view)
 
         # Construct right side of splitter
+        right_panel = QtWidgets.QWidget(self)
+        right_layout = QtWidgets.QVBoxLayout(right_panel)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(0)
+        main_splitter.addWidget(right_panel)
+
         right_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
-        main_splitter.addWidget(right_splitter)
+        right_layout.addWidget(right_splitter, 1)
 
         self.text_box = QtWidgets.QTextEdit(self)
         self.text_box.setReadOnly(True)
@@ -1412,7 +1440,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self.preview_widget = _SingleImagePreview(self)
         right_splitter.addWidget(self.preview_widget)
 
-        self.metadata_group = QtWidgets.QFrame(self)
+        self.metadata_group = _HeightForWidthFrame(self)
         self.metadata_group.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
         self.metadata_group.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Preferred,
@@ -1423,7 +1451,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         metadata_layout.setSpacing(4)
         self.metadata_group.setLayout(metadata_layout)
 
-        self.metadata_details_widget = QtWidgets.QWidget(self.metadata_group)
+        self.metadata_details_widget = _HeightForWidthFrame(self.metadata_group)
         self.metadata_details_layout = QtWidgets.QGridLayout(
             self.metadata_details_widget
         )
@@ -1469,10 +1497,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
         )
         self.metadata_derivation_list.setVisible(False)
         metadata_layout.addWidget(self.metadata_derivation_list)
-        right_splitter.addWidget(self.metadata_group)
+        right_layout.addWidget(self.metadata_group, 0)
 
         # Set initial splitter sizes
-        right_splitter.setSizes([280, 140, 96])
+        right_splitter.setSizes([280, 140])
         main_splitter.setSizes([100, 150])
 
         # Store most recent name filter and directory for new windows
@@ -3228,10 +3256,12 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
                 )
                 if field.wrap:
-                    value_label.setSizePolicy(
+                    size_policy = QtWidgets.QSizePolicy(
                         QtWidgets.QSizePolicy.Policy.Expanding,
                         QtWidgets.QSizePolicy.Policy.Preferred,
                     )
+                    size_policy.setHeightForWidth(True)
+                    value_label.setSizePolicy(size_policy)
             if field.monospace:
                 value_label.setFont(self._metadata_monospace_font)
             self.metadata_details_layout.addWidget(key_label, row, 0)
@@ -3297,16 +3327,21 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if derivation_count == 0:
             self.metadata_derivation_list.setMinimumHeight(0)
             self.metadata_derivation_list.setMaximumHeight(0)
-            return
+        else:
+            row_height = self.metadata_derivation_list.sizeHintForRow(0)
+            if row_height <= 0:
+                row_height = self.fontMetrics().height() + 8
+            visible_rows = min(derivation_count, 4)
+            frame = self.metadata_derivation_list.frameWidth() * 2
+            height = visible_rows * row_height + frame + 4
+            self.metadata_derivation_list.setMinimumHeight(height)
+            self.metadata_derivation_list.setMaximumHeight(height)
 
-        row_height = self.metadata_derivation_list.sizeHintForRow(0)
-        if row_height <= 0:
-            row_height = self.fontMetrics().height() + 8
-        visible_rows = min(derivation_count, 4)
-        frame = self.metadata_derivation_list.frameWidth() * 2
-        height = visible_rows * row_height + frame + 4
-        self.metadata_derivation_list.setMinimumHeight(height)
-        self.metadata_derivation_list.setMaximumHeight(height)
+        self.metadata_details_widget.updateGeometry()
+        self.metadata_derivation_list.updateGeometry()
+        self.metadata_details_widget.sync_height_for_width()
+        self.metadata_group.sync_height_for_width()
+        self.metadata_group.updateGeometry()
 
     def _selected_derivation_items(self) -> list[QtWidgets.QListWidgetItem]:
         items = list(self.metadata_derivation_list.selectedItems())

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -6480,13 +6480,13 @@ class ImageToolManager(QtWidgets.QMainWindow):
             watched_metadata.setdefault("workspace_link_id", self._workspace_link_id)
 
         for i, d in enumerate(data):
-            # Set index-specific load function if provided
-            load_index = (
-                typing.cast("Sequence[int]", load_indices)[i]
+            # Set selection-specific load function if provided
+            load_selection = (
+                typing.cast("Sequence[typing.Any]", load_indices)[i]
                 if load_indices is not None
                 else i
             )
-            this_load_func = (*load_func[:2], load_index) if load_func else None
+            this_load_func = (*load_func[:2], load_selection) if load_func else None
             try:
                 indices.append(
                     self.add_imagetool(

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -75,6 +75,20 @@ _METADATA_DERIVATION_CODE_ROLE = int(QtCore.Qt.ItemDataRole.UserRole)
 _METADATA_DERIVATION_COPYABLE_ROLE = _METADATA_DERIVATION_CODE_ROLE + 1
 _RECENT_WORKSPACES_SETTINGS_KEY = "recent_workspaces"
 _MAX_RECENT_WORKSPACES = 10
+_LINEAGE_STATUS_LABELS: dict[str, str] = {
+    "current": "Current inputs",
+    "changed": "Inputs changed",
+    "missing": "Inputs missing",
+}
+_LINEAGE_STATUS_BADGES: dict[str, str] = {
+    "changed": "Inputs changed",
+    "missing": "Inputs missing",
+}
+_LINEAGE_STATUS_TOOLTIPS: dict[str, str] = {
+    "current": "All recorded live inputs are still open and unchanged.",
+    "changed": "At least one recorded live input has changed since this data was made.",
+    "missing": "At least one recorded live input is no longer open.",
+}
 
 
 def _manager_settings() -> QtCore.QSettings:
@@ -2033,6 +2047,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         node = self._all_nodes.pop(uid, None)
         if node is None:
             return
+        self._refresh_lineage_dependents(uid)
         self._pending_source_refresh_targets.pop(uid, None)
         for blocker_uid, target_uids in list(
             self._pending_source_refresh_targets.items()
@@ -2054,6 +2069,205 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if isinstance(target, int):
             return self._imagetool_wrappers[target]
         return self._all_nodes[target]
+
+    def _lineage_refs_for_uid(
+        self, uid: str
+    ) -> tuple[erlab.interactive.imagetool.provenance.ScriptInputLineageRef, ...]:
+        node = self._all_nodes.get(uid)
+        if node is None or node.provenance_spec is None:
+            return ()
+        return erlab.interactive.imagetool.provenance.script_input_lineage_refs(
+            node.provenance_spec
+        )
+
+    def lineage_status_for_uid(
+        self, uid: str
+    ) -> typing.Literal["current", "changed", "missing"] | None:
+        refs = self._lineage_refs_for_uid(uid)
+        if not refs:
+            return None
+
+        changed = False
+        for ref in refs:
+            parent = self._all_nodes.get(ref.node_uid)
+            if parent is None:
+                return "missing"
+            if (
+                ref.node_lineage_token is not None
+                and parent.lineage_token != ref.node_lineage_token
+            ):
+                changed = True
+        return "changed" if changed else "current"
+
+    def lineage_status_label_for_uid(self, uid: str) -> str | None:
+        status = self.lineage_status_for_uid(uid)
+        if status is None:
+            return None
+        return _LINEAGE_STATUS_LABELS[status]
+
+    def lineage_status_badge_for_uid(self, uid: str) -> str | None:
+        status = self.lineage_status_for_uid(uid)
+        if status is None:
+            return None
+        return _LINEAGE_STATUS_BADGES.get(status)
+
+    def lineage_status_tooltip_for_uid(self, uid: str) -> str | None:
+        status = self.lineage_status_for_uid(uid)
+        if status is None:
+            return None
+        return _LINEAGE_STATUS_TOOLTIPS[status]
+
+    def lineage_input_summary_for_uid(self, uid: str) -> str | None:
+        refs = self._lineage_refs_for_uid(uid)
+        if not refs:
+            return None
+
+        parts: list[str] = []
+        seen: set[tuple[str, str, str | None]] = set()
+        for ref in refs:
+            key = (ref.name, ref.node_uid, ref.node_lineage_token)
+            if key in seen:
+                continue
+            seen.add(key)
+            parent = self._all_nodes.get(ref.node_uid)
+            if isinstance(parent, _ImageToolWrapper):
+                current = f"currently ImageTool {parent.index}"
+            elif parent is not None:
+                current = f"currently {parent.display_text}"
+            else:
+                current = "parent no longer open"
+            parts.append(f"{ref.name}: {ref.label} ({current})")
+        return "; ".join(parts)
+
+    def _lineage_dependent_uids(self, uid: str) -> list[str]:
+        return [
+            node_uid
+            for node_uid in self._all_nodes
+            if node_uid != uid
+            and any(ref.node_uid == uid for ref in self._lineage_refs_for_uid(node_uid))
+        ]
+
+    def _refresh_lineage_dependents(self, uid: str) -> None:
+        for dependent_uid in self._lineage_dependent_uids(uid):
+            self.tree_view.refresh(dependent_uid)
+            if self._metadata_node_uid == dependent_uid:
+                self._set_metadata_node(self._all_nodes[dependent_uid])
+
+    def _script_input_name_for_node(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> str:
+        if isinstance(node, _ImageToolWrapper):
+            return f"data_{node.index}"
+        suffix = "".join(
+            character if character.isalnum() or character == "_" else "_"
+            for character in node.uid
+        )
+        if not suffix or suffix[0].isdigit():
+            suffix = f"_{suffix}"
+        return f"data_{suffix}"
+
+    def _script_input_for_node(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> erlab.interactive.imagetool.provenance.ScriptInput:
+        provenance_spec = (
+            node.provenance_spec.model_dump(mode="json")
+            if node.provenance_spec is not None
+            else None
+        )
+        if isinstance(node, _ImageToolWrapper):
+            label = f"ImageTool {node.index}"
+        else:
+            label = node.display_text
+        if isinstance(node, _ImageToolWrapper) and node.name:
+            label += f": {node.name}"
+        return erlab.interactive.imagetool.provenance.ScriptInput(
+            name=self._script_input_name_for_node(node),
+            label=label,
+            node_uid=node.uid,
+            node_lineage_token=node.lineage_token,
+            provenance_spec=provenance_spec,
+        )
+
+    def _multi_input_script_provenance(
+        self,
+        input_targets: Iterable[int | str],
+        *,
+        operation_label: str,
+        operation_code: str,
+        active_name: str = "derived",
+        start_label: str = "Run ImageTool manager action",
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec:
+        return erlab.interactive.imagetool.provenance.script(
+            erlab.interactive.imagetool.provenance.ScriptCodeOperation(
+                label=operation_label,
+                code=operation_code,
+            ),
+            start_label=start_label,
+            active_name=active_name,
+            script_inputs=tuple(
+                self._script_input_for_node(self._node_for_target(target))
+                for target in input_targets
+            ),
+        )
+
+    def _show_multi_input_script_result(
+        self,
+        data: xr.DataArray,
+        input_targets: Iterable[int | str],
+        *,
+        operation_label: str,
+        operation_code: str,
+    ) -> int | None:
+        input_targets = tuple(input_targets)
+        tool = erlab.interactive.itool(data, manager=False, execute=False)
+        if not isinstance(tool, ImageTool):
+            return None
+        return self.add_imagetool(
+            tool,
+            show=True,
+            activate=True,
+            provenance_spec=self._multi_input_script_provenance(
+                input_targets,
+                operation_label=operation_label,
+                operation_code=operation_code,
+            ),
+        )
+
+    def _workspace_loaded_uid_map(
+        self, loaded_targets_by_uid: Mapping[str, int | str]
+    ) -> dict[str, str]:
+        uid_map: dict[str, str] = {}
+        for saved_uid, target in loaded_targets_by_uid.items():
+            try:
+                actual_uid = self._node_for_target(target).uid
+            except KeyError:
+                continue
+            if actual_uid != saved_uid:
+                uid_map[saved_uid] = actual_uid
+        return uid_map
+
+    def _rebase_loaded_workspace_lineage_refs(
+        self, loaded_targets_by_uid: Mapping[str, int | str]
+    ) -> None:
+        uid_map = self._workspace_loaded_uid_map(loaded_targets_by_uid)
+        if not uid_map:
+            return
+
+        for target in loaded_targets_by_uid.values():
+            try:
+                node = self._node_for_target(target)
+            except KeyError:
+                continue
+            if node.provenance_spec is None:
+                continue
+            rebased = (
+                erlab.interactive.imagetool.provenance.rebase_script_input_node_uids(
+                    node.provenance_spec,
+                    uid_map,
+                )
+            )
+            if rebased != node.provenance_spec:
+                node.set_displayed_provenance(rebased, advance_lineage=False)
 
     def _child_node(self, uid: str) -> _ManagedWindowNode:
         node = self._all_nodes[uid]
@@ -2605,6 +2819,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         index: int | None = None,
+        lineage_token: str | None = None,
     ) -> int:
         """Add a new ImageTool window to the manager and show it.
 
@@ -2651,6 +2866,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             source_binding=source_binding,
             source_auto_update=source_auto_update,
             source_state=source_state,
+            lineage_token=lineage_token,
         )
         self._imagetool_wrappers[index] = wrapper
         self._register_root_wrapper(wrapper)
@@ -3063,6 +3279,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
         self._imagetool_wrappers.pop(index)
         self._all_nodes.pop(wrapper.uid, None)
+        self._refresh_lineage_dependents(wrapper.uid)
         wrapper.dispose()
         wrapper.deleteLater()
 
@@ -3467,6 +3684,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         created_time = node._created_time
         recent_geometry = node._recent_geometry
         provenance_spec = node.provenance_spec
+        lineage_token = node.lineage_token
 
         self.tree_view.childtool_removed(uid)
         self._unregister_node(uid)
@@ -3477,6 +3695,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 show=False,
                 uid=uid,
                 provenance_spec=provenance_spec,
+                lineage_token=lineage_token,
             )
         wrapper = self._imagetool_wrappers[new_index]
         wrapper._created_time = created_time
@@ -3501,6 +3720,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self.tree_view.setCurrentIndex(promoted_index)
         self.tree_view.scrollTo(promoted_index)
         self.tree_view.refresh(new_index)
+        self._refresh_lineage_dependents(uid)
         self._update_actions()
         self._mark_workspace_structure_dirty("Promoted child ImageTool")
         return new_index
@@ -3690,6 +3910,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
     ) -> xr.Dataset:
         ds.attrs["manager_node_uid"] = node.uid
         ds.attrs["manager_node_kind"] = kind
+        ds.attrs["manager_node_lineage_token"] = node.lineage_token
         if node.provenance_spec is not None:
             ds.attrs["manager_node_provenance_spec"] = json.dumps(
                 node.provenance_spec.model_dump(mode="json")
@@ -3872,6 +4093,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 )
         kwargs: dict[str, typing.Any] = {
             "uid": uid,
+            "lineage_token": ds.attrs.get("manager_node_lineage_token"),
             "provenance_spec": parsed_provenance_spec,
             "source_spec": parsed_source_spec,
             "source_binding": parsed_source_binding,
@@ -3954,6 +4176,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             parent_target,
             show=ds.attrs.get("tool_visible", True),
             uid=ds.attrs.get("manager_node_uid"),
+            lineage_token=ds.attrs.get("manager_node_lineage_token"),
         )
 
     @staticmethod
@@ -4298,6 +4521,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     self.remove_all_tools()
                 for root_path in root_paths:
                     _load_path(root_path)
+                self._rebase_loaded_workspace_lineage_refs(loaded_targets_by_uid)
                 self._restore_workspace_link_groups(manifest, loaded_targets_by_uid)
                 if not mark_dirty:
                     self._drain_workspace_deferred_events()
@@ -4406,6 +4630,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
                         workspace_file_path=workspace_file_path,
                         loaded_targets_by_uid=loaded_targets_by_uid,
                     )
+                    self._rebase_loaded_workspace_lineage_refs(loaded_targets_by_uid)
                     self._restore_workspace_link_groups(manifest, loaded_targets_by_uid)
                     if not mark_dirty:
                         self._drain_workspace_deferred_events()
@@ -6395,6 +6620,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         *,
         show: bool = True,
         uid: str | None = None,
+        lineage_token: str | None = None,
     ) -> str:
         """Register a child tool window.
 
@@ -6416,6 +6642,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             self._next_node_uid(uid),
             parent.uid,
             tool,
+            lineage_token=lineage_token,
         )
         if not tool._tool_display_name:
             tool._tool_display_name = parent.name
@@ -6453,6 +6680,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         output_id: str | None = None,
+        lineage_token: str | None = None,
     ) -> str:
         parent_node = self._node_for_target(parent)
         if source_spec is None and source_binding is not None:
@@ -6478,6 +6706,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             source_auto_update=source_auto_update,
             source_state=source_state,
             output_id=output_id,
+            lineage_token=lineage_token,
         )
         self._register_child_node(node)
         if output_id is not None and parent_node.tool_window is not None:

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 _NODE_UID_ROLE = int(QtCore.Qt.ItemDataRole.UserRole) + 128
 _TOOL_TYPE_ROLE = int(QtCore.Qt.ItemDataRole.UserRole) + 129
 _RowBadgeKind = typing.Literal[
-    "dask", "link", "watched", "tool_type", "source_status", "lineage_status"
+    "dask", "link", "watched", "tool_type", "source_status", "dependency_status"
 ]
 
 
@@ -177,7 +177,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                         right_edge=dask_rect.left() if dask_rect is not None else None,
                     )
                     if status_rect is None:
-                        status_rect, _, _ = self._compute_lineage_status_info(
+                        status_rect, _, _ = self._compute_dependency_status_info(
                             option,
                             child_node,
                             right_edge=(
@@ -371,12 +371,14 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         icon_rects = [
             rect for rect in (dask_rect, link_rect, watched_rect) if rect is not None
         ]
-        lineage_rect, lineage_text, lineage_color = self._compute_lineage_status_info(
-            option,
-            tool_wrapper,
-            right_edge=(
-                min(rect.left() for rect in icon_rects) if icon_rects else None
-            ),
+        dependency_rect, dependency_text, dependency_color = (
+            self._compute_dependency_status_info(
+                option,
+                tool_wrapper,
+                right_edge=(
+                    min(rect.left() for rect in icon_rects) if icon_rects else None
+                ),
+            )
         )
 
         # Draw label (skip while editing for inline editor)
@@ -397,14 +399,14 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             fm = QtGui.QFontMetrics(option.font)
             text = index.data(role=QtCore.Qt.ItemDataRole.DisplayRole)
             text_rect = QtCore.QRect(option.rect)
-            if lineage_rect is not None:
-                text_rect.setRight(lineage_rect.left() - self.icon_right_pad)
+            if dependency_rect is not None:
+                text_rect.setRight(dependency_rect.left() - self.icon_right_pad)
             elided = fm.elidedText(
                 text,
                 view.textElideMode(),
                 (
                     max(text_rect.width(), 0)
-                    if lineage_rect is not None
+                    if dependency_rect is not None
                     else option.rect.width() - self.icon_right_pad - icons_width
                 ),
             )
@@ -458,25 +460,27 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             )
             painter.restore()
 
-        if lineage_rect and lineage_text and lineage_color:
+        if dependency_rect and dependency_text and dependency_color:
             _fill_rounded_rect(
                 painter,
-                lineage_rect,
+                dependency_rect,
                 facecolor=option.palette.base(),
-                edgecolor=lineage_color,
+                edgecolor=dependency_color,
                 linewidth=self.icon_border_width,
                 radius=self.icon_corner_radius,
             )
-            lineage_font = QtGui.QFont(option.font)
-            lineage_font.setPointSizeF(self._font_size * self.child_status_font_scale)
+            dependency_font = QtGui.QFont(option.font)
+            dependency_font.setPointSizeF(
+                self._font_size * self.child_status_font_scale
+            )
             painter.save()
-            painter.setFont(lineage_font)
-            painter.setPen(lineage_color)
+            painter.setFont(dependency_font)
+            painter.setPen(dependency_color)
             painter.drawText(
-                lineage_rect,
+                dependency_rect,
                 QtCore.Qt.AlignmentFlag.AlignVCenter
                 | QtCore.Qt.AlignmentFlag.AlignCenter,
-                lineage_text,
+                dependency_text,
             )
             painter.restore()
 
@@ -528,7 +532,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             )
             if status_rect is None:
                 status_rect, status_text, status_color = (
-                    self._compute_lineage_status_info(
+                    self._compute_dependency_status_info(
                         option,
                         child_node,
                         right_edge=dask_rect.left() if dask_rect is not None else None,
@@ -715,18 +719,18 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         rect_x = right_edge - badge_width - self.icon_right_pad
         return QtCore.QRect(rect_x, rect_y, badge_width, rect_size), text, color
 
-    def _compute_lineage_status_info(
+    def _compute_dependency_status_info(
         self,
         option: QtWidgets.QStyleOptionViewItem,
         node: _ImageToolWrapper | _ManagedWindowNode,
         *,
         right_edge: int | None = None,
     ) -> tuple[QtCore.QRect | None, str | None, QtGui.QColor | None]:
-        text = self.manager.lineage_status_badge_for_uid(node.uid)
+        text = self.manager.dependency_status_badge_for_uid(node.uid)
         if text is None:
             return None, None, None
 
-        match self.manager.lineage_status_for_uid(node.uid):
+        match self.manager.dependency_status_for_uid(node.uid):
             case "changed":
                 color = QtGui.QColor("#8a6d00")
             case "missing":
@@ -792,7 +796,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 for rect in (dask_rect, link_rect, watched_rect)
                 if rect is not None
             ]
-            lineage_rect, _, _ = self._compute_lineage_status_info(
+            dependency_rect, _, _ = self._compute_dependency_status_info(
                 option,
                 node,
                 right_edge=(
@@ -833,10 +837,10 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                     watched_rect,
                     tooltip,
                 )
-            if lineage_rect is not None and lineage_rect.contains(pos):
-                tooltip = self.manager.lineage_status_tooltip_for_uid(node.uid)
+            if dependency_rect is not None and dependency_rect.contains(pos):
+                tooltip = self.manager.dependency_status_tooltip_for_uid(node.uid)
                 if tooltip is not None:
-                    return _RowBadge("lineage_status", lineage_rect, tooltip)
+                    return _RowBadge("dependency_status", dependency_rect, tooltip)
             return None
 
         if not isinstance(node, str):
@@ -862,7 +866,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         )
         source_status = status_rect is not None
         if status_rect is None:
-            status_rect, _, _ = self._compute_lineage_status_info(
+            status_rect, _, _ = self._compute_dependency_status_info(
                 option,
                 child_node,
                 right_edge=dask_rect.left() if dask_rect is not None else None,
@@ -882,10 +886,10 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         if status_rect is None or not status_rect.contains(pos):
             return None
         if not source_status:
-            tooltip = self.manager.lineage_status_tooltip_for_uid(child_node.uid)
+            tooltip = self.manager.dependency_status_tooltip_for_uid(child_node.uid)
             if tooltip is None:
                 return None
-            return _RowBadge("lineage_status", status_rect, tooltip)
+            return _RowBadge("dependency_status", status_rect, tooltip)
 
         match child_node.source_state:
             case "stale":
@@ -1737,6 +1741,16 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
                     except KeyError:
                         return
                     child_node.show_source_update_dialog(parent=self._model.manager)
+            case "dependency_status":
+                if isinstance(node, _ImageToolWrapper):
+                    target: int | str | None = node.index
+                elif isinstance(node, str):
+                    target = node
+                else:
+                    target = None
+                if target is None:
+                    return
+                self._model.manager._show_dependency_reload_dialog(target)
 
     def _show_dask_badge_menu(
         self,

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -31,7 +31,9 @@ logger = logging.getLogger(__name__)
 
 _NODE_UID_ROLE = int(QtCore.Qt.ItemDataRole.UserRole) + 128
 _TOOL_TYPE_ROLE = int(QtCore.Qt.ItemDataRole.UserRole) + 129
-_RowBadgeKind = typing.Literal["dask", "link", "watched", "tool_type", "source_status"]
+_RowBadgeKind = typing.Literal[
+    "dask", "link", "watched", "tool_type", "source_status", "lineage_status"
+]
 
 
 @dataclass(frozen=True)
@@ -174,6 +176,14 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                         child_node,
                         right_edge=dask_rect.left() if dask_rect is not None else None,
                     )
+                    if status_rect is None:
+                        status_rect, _, _ = self._compute_lineage_status_info(
+                            option,
+                            child_node,
+                            right_edge=(
+                                dask_rect.left() if dask_rect is not None else None
+                            ),
+                        )
                     right_badge_rect = status_rect or dask_rect
                     if right_badge_rect is not None:
                         rect.setRight(right_badge_rect.left() - self.icon_right_pad)
@@ -358,6 +368,16 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         icons_width, dask_rect, link_rect, watched_rect = self._compute_icons_info(
             option, tool_wrapper
         )
+        icon_rects = [
+            rect for rect in (dask_rect, link_rect, watched_rect) if rect is not None
+        ]
+        lineage_rect, lineage_text, lineage_color = self._compute_lineage_status_info(
+            option,
+            tool_wrapper,
+            right_edge=(
+                min(rect.left() for rect in icon_rects) if icon_rects else None
+            ),
+        )
 
         # Draw label (skip while editing for inline editor)
         if not is_editing:  # pragma: no branch
@@ -376,14 +396,21 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             # Elide text to leave room for icons on the right
             fm = QtGui.QFontMetrics(option.font)
             text = index.data(role=QtCore.Qt.ItemDataRole.DisplayRole)
+            text_rect = QtCore.QRect(option.rect)
+            if lineage_rect is not None:
+                text_rect.setRight(lineage_rect.left() - self.icon_right_pad)
             elided = fm.elidedText(
                 text,
                 view.textElideMode(),
-                option.rect.width() - self.icon_right_pad - icons_width,
+                (
+                    max(text_rect.width(), 0)
+                    if lineage_rect is not None
+                    else option.rect.width() - self.icon_right_pad - icons_width
+                ),
             )
             painter.setPen(palette.color(color_group, role))
             painter.drawText(
-                option.rect,
+                text_rect,
                 QtCore.Qt.AlignmentFlag.AlignVCenter
                 | QtCore.Qt.AlignmentFlag.AlignLeft,
                 elided,
@@ -428,6 +455,28 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 QtCore.Qt.AlignmentFlag.AlignVCenter
                 | QtCore.Qt.AlignmentFlag.AlignCenter,
                 watched_varname,
+            )
+            painter.restore()
+
+        if lineage_rect and lineage_text and lineage_color:
+            _fill_rounded_rect(
+                painter,
+                lineage_rect,
+                facecolor=option.palette.base(),
+                edgecolor=lineage_color,
+                linewidth=self.icon_border_width,
+                radius=self.icon_corner_radius,
+            )
+            lineage_font = QtGui.QFont(option.font)
+            lineage_font.setPointSizeF(self._font_size * self.child_status_font_scale)
+            painter.save()
+            painter.setFont(lineage_font)
+            painter.setPen(lineage_color)
+            painter.drawText(
+                lineage_rect,
+                QtCore.Qt.AlignmentFlag.AlignVCenter
+                | QtCore.Qt.AlignmentFlag.AlignCenter,
+                lineage_text,
             )
             painter.restore()
 
@@ -477,6 +526,14 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 child_node,
                 right_edge=dask_rect.left() if dask_rect is not None else None,
             )
+            if status_rect is None:
+                status_rect, status_text, status_color = (
+                    self._compute_lineage_status_info(
+                        option,
+                        child_node,
+                        right_edge=dask_rect.left() if dask_rect is not None else None,
+                    )
+                )
 
         if type_rect and type_text and type_color:
             _fill_rounded_rect(
@@ -658,6 +715,38 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         rect_x = right_edge - badge_width - self.icon_right_pad
         return QtCore.QRect(rect_x, rect_y, badge_width, rect_size), text, color
 
+    def _compute_lineage_status_info(
+        self,
+        option: QtWidgets.QStyleOptionViewItem,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        *,
+        right_edge: int | None = None,
+    ) -> tuple[QtCore.QRect | None, str | None, QtGui.QColor | None]:
+        text = self.manager.lineage_status_badge_for_uid(node.uid)
+        if text is None:
+            return None, None, None
+
+        match self.manager.lineage_status_for_uid(node.uid):
+            case "changed":
+                color = QtGui.QColor("#8a6d00")
+            case "missing":
+                color = QtGui.QColor("#59636e")
+            case _:
+                return None, None, None
+
+        rect_size = self.icon_size + 2 * self.icon_inner_pad
+        rect_y = option.rect.center().y() - (rect_size // 2)
+        badge_font = QtGui.QFont(option.font)
+        badge_font.setPointSizeF(self._font_size * self.child_status_font_scale)
+        badge_width = (
+            QtGui.QFontMetrics(badge_font).boundingRect(text).width()
+            + self.child_status_rect_hpad * 2
+        )
+        if right_edge is None:
+            right_edge = option.rect.right()
+        rect_x = right_edge - badge_width - self.icon_right_pad
+        return QtCore.QRect(rect_x, rect_y, badge_width, rect_size), text, color
+
     def _option_for_index(
         self,
         view: QtWidgets.QAbstractItemView,
@@ -698,6 +787,18 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             _, dask_rect, link_rect, watched_rect = self._compute_icons_info(
                 option, node
             )
+            icon_rects = [
+                rect
+                for rect in (dask_rect, link_rect, watched_rect)
+                if rect is not None
+            ]
+            lineage_rect, _, _ = self._compute_lineage_status_info(
+                option,
+                node,
+                right_edge=(
+                    min(rect.left() for rect in icon_rects) if icon_rects else None
+                ),
+            )
             if dask_rect is not None and dask_rect.contains(pos):
                 tooltip = (
                     "Dask-backed data. Click to open Dask and chunk controls."
@@ -732,6 +833,10 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                     watched_rect,
                     tooltip,
                 )
+            if lineage_rect is not None and lineage_rect.contains(pos):
+                tooltip = self.manager.lineage_status_tooltip_for_uid(node.uid)
+                if tooltip is not None:
+                    return _RowBadge("lineage_status", lineage_rect, tooltip)
             return None
 
         if not isinstance(node, str):
@@ -755,6 +860,13 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             child_node,
             right_edge=dask_rect.left() if dask_rect is not None else None,
         )
+        source_status = status_rect is not None
+        if status_rect is None:
+            status_rect, _, _ = self._compute_lineage_status_info(
+                option,
+                child_node,
+                right_edge=dask_rect.left() if dask_rect is not None else None,
+            )
         if dask_rect is not None and dask_rect.contains(pos):
             tooltip = (
                 "Dask-backed data. Click to open Dask and chunk controls."
@@ -769,6 +881,12 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
 
         if status_rect is None or not status_rect.contains(pos):
             return None
+        if not source_status:
+            tooltip = self.manager.lineage_status_tooltip_for_uid(child_node.uid)
+            if tooltip is None:
+                return None
+            return _RowBadge("lineage_status", status_rect, tooltip)
+
         match child_node.source_state:
             case "stale":
                 tooltip = (

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -726,14 +726,12 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         *,
         right_edge: int | None = None,
     ) -> tuple[QtCore.QRect | None, str | None, QtGui.QColor | None]:
-        text = self.manager.dependency_status_badge_for_uid(node.uid)
-        if text is None:
-            return None, None, None
-
         match self.manager.dependency_status_for_uid(node.uid):
             case "changed":
+                text = "Changed"
                 color = QtGui.QColor("#8a6d00")
             case "missing":
+                text = "Missing"
                 color = QtGui.QColor("#59636e")
             case _:
                 return None, None, None

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -802,6 +802,25 @@ class _ManagedWindowNode(QtCore.QObject):
             else:
                 self.manager._mark_descendants_source_state(self.uid, state)
 
+    def replace_with_detached_data(
+        self,
+        data: xr.DataArray,
+        provenance_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
+        | None,
+        *,
+        propagate_descendants: bool = True,
+    ) -> None:
+        """Replace displayed ImageTool data with detached provenance."""
+        self._source_spec = None
+        self._source_auto_update = False
+        self._output_id = None
+        self._replace_imagetool_data(
+            data,
+            provenance_spec,
+            state="fresh",
+            propagate_descendants=propagate_descendants,
+        )
+
     def _handle_tool_data_changed(self) -> None:
         self.manager._mark_node_data_dirty(self.uid)
         self._advance_lineage_token()

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -125,7 +125,7 @@ class _ManagedWindowNode(QtCore.QObject):
         source_auto_update: bool = False,
         source_state: _source_state_type = "fresh",
         output_id: str | None = None,
-        lineage_token: str | None = None,
+        snapshot_token: str | None = None,
     ) -> None:
         super().__init__(manager)
         self._manager = weakref.ref(manager)
@@ -159,8 +159,10 @@ class _ManagedWindowNode(QtCore.QObject):
         self._source_auto_update: bool = False
         self._output_id: str | None = None
         self._suspend_descendant_signal_propagation: bool = False
-        self._lineage_token = str(lineage_token) if lineage_token else uuid.uuid4().hex
-        self._suspend_lineage_token_updates = True
+        self._snapshot_token = (
+            str(snapshot_token) if snapshot_token else uuid.uuid4().hex
+        )
+        self._suspend_snapshot_token_updates = True
 
         self.window = window
         try:
@@ -192,7 +194,7 @@ class _ManagedWindowNode(QtCore.QObject):
             elif isinstance(window, ImageTool) and window.provenance_spec is not None:
                 self.set_detached_provenance(window.provenance_spec)
         finally:
-            self._suspend_lineage_token_updates = False
+            self._suspend_snapshot_token_updates = False
 
     @property
     def manager(self) -> ImageToolManager:
@@ -477,12 +479,12 @@ class _ManagedWindowNode(QtCore.QObject):
                     details=load_source_details,
                 )
             )
-        lineage_label = self.manager.lineage_status_label_for_uid(self.uid)
-        if lineage_label is not None:
-            fields.append(_MetadataField("Lineage", lineage_label))
-        lineage_inputs = self.manager.lineage_input_summary_for_uid(self.uid)
-        if lineage_inputs is not None:
-            fields.append(_MetadataField("Inputs", lineage_inputs, wrap=True))
+        dependency_label = self.manager.dependency_status_label_for_uid(self.uid)
+        if dependency_label is not None:
+            fields.append(_MetadataField("Inputs", dependency_label))
+        dependency_inputs = self.manager.dependency_input_summary_for_uid(self.uid)
+        if dependency_inputs is not None:
+            fields.append(_MetadataField("Inputs", dependency_inputs, wrap=True))
         if data is not None and data.chunks is not None:
             fields.append(
                 _MetadataField(
@@ -524,16 +526,16 @@ class _ManagedWindowNode(QtCore.QObject):
         return self._source_spec
 
     @property
-    def lineage_token(self) -> str:
-        return self._lineage_token
+    def snapshot_token(self) -> str:
+        return self._snapshot_token
 
-    def _advance_lineage_token(self) -> None:
-        if self._suspend_lineage_token_updates:
+    def _advance_snapshot_token(self) -> None:
+        if self._suspend_snapshot_token_updates:
             return
-        self._lineage_token = uuid.uuid4().hex
+        self._snapshot_token = uuid.uuid4().hex
         self.manager.tree_view.refresh(self.uid)
         self.manager._update_info(uid=self.uid)
-        self.manager._refresh_lineage_dependents(self.uid)
+        self.manager._refresh_dependency_dependents(self.uid)
         self.manager._mark_node_state_dirty(self.uid)
 
     @property
@@ -567,7 +569,7 @@ class _ManagedWindowNode(QtCore.QObject):
         provenance_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         | None,
         *,
-        advance_lineage: bool = True,
+        advance_snapshot: bool = True,
     ) -> None:
         self._provenance_spec = (
             erlab.interactive.imagetool.provenance.parse_tool_provenance_spec(
@@ -576,8 +578,8 @@ class _ManagedWindowNode(QtCore.QObject):
         )
         if self.imagetool is not None:
             self.imagetool.set_provenance_spec(self.provenance_spec)
-        if advance_lineage:
-            self._advance_lineage_token()
+        if advance_snapshot:
+            self._advance_snapshot_token()
 
     @property
     def derivation_entries(
@@ -773,13 +775,13 @@ class _ManagedWindowNode(QtCore.QObject):
             self._suspend_descendant_signal_propagation = previous
 
     @contextlib.contextmanager
-    def _suspend_lineage_updates(self) -> Iterator[None]:
-        previous = self._suspend_lineage_token_updates
-        self._suspend_lineage_token_updates = True
+    def _suspend_snapshot_updates(self) -> Iterator[None]:
+        previous = self._suspend_snapshot_token_updates
+        self._suspend_snapshot_token_updates = True
         try:
             yield
         finally:
-            self._suspend_lineage_token_updates = previous
+            self._suspend_snapshot_token_updates = previous
 
     def _replace_imagetool_data(
         self,
@@ -790,10 +792,10 @@ class _ManagedWindowNode(QtCore.QObject):
         state: _source_state_type = "fresh",
         propagate_descendants: bool,
     ) -> None:
-        with self._suspend_descendant_propagation(), self._suspend_lineage_updates():
+        with self._suspend_descendant_propagation(), self._suspend_snapshot_updates():
             self.slicer_area.replace_source_data(data)
-        self.set_displayed_provenance(provenance_spec, advance_lineage=False)
-        self._advance_lineage_token()
+        self.set_displayed_provenance(provenance_spec, advance_snapshot=False)
+        self._advance_snapshot_token()
         self._set_source_state(state)
         self.manager._mark_node_data_dirty(self.uid)
         if propagate_descendants:
@@ -823,7 +825,7 @@ class _ManagedWindowNode(QtCore.QObject):
 
     def _handle_tool_data_changed(self) -> None:
         self.manager._mark_node_data_dirty(self.uid)
-        self._advance_lineage_token()
+        self._advance_snapshot_token()
         if self._suspend_descendant_signal_propagation:
             return
         tool_window = self.tool_window
@@ -968,12 +970,12 @@ class _ManagedWindowNode(QtCore.QObject):
     @QtCore.Slot()
     def _handle_imagetool_data_edited(self) -> None:
         self.manager._mark_node_data_dirty(self.uid)
-        self._advance_lineage_token()
+        self._advance_snapshot_token()
 
     @QtCore.Slot()
     def _handle_imagetool_backing_changed(self) -> None:
         self.manager._mark_node_data_dirty(self.uid)
-        self._advance_lineage_token()
+        self._advance_snapshot_token()
         self._refresh_node_info()
 
     def _update_from_parent_source(self) -> bool:
@@ -1110,7 +1112,7 @@ class _ManagedWindowNode(QtCore.QObject):
     @QtCore.Slot(object)
     def _handle_source_data_replaced(self, parent_data: object) -> None:
         self.manager._mark_node_data_dirty(self.uid)
-        self._advance_lineage_token()
+        self._advance_snapshot_token()
         if self._suspend_descendant_signal_propagation:
             return
         if not isinstance(parent_data, xr.DataArray):
@@ -1146,7 +1148,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         source_binding: ImageToolSelectionSourceBinding | None = None,
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
-        lineage_token: str | None = None,
+        snapshot_token: str | None = None,
     ) -> None:
         self._index = index
         self._watched_varname: str | None = None
@@ -1178,7 +1180,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
             source_binding=source_binding,
             source_auto_update=source_auto_update,
             source_state=source_state,
-            lineage_token=lineage_token,
+            snapshot_token=snapshot_token,
         )
 
     @property

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -9,6 +9,7 @@ import datetime
 import keyword
 import sys
 import typing
+import uuid
 import weakref
 from dataclasses import dataclass
 
@@ -124,6 +125,7 @@ class _ManagedWindowNode(QtCore.QObject):
         source_auto_update: bool = False,
         source_state: _source_state_type = "fresh",
         output_id: str | None = None,
+        lineage_token: str | None = None,
     ) -> None:
         super().__init__(manager)
         self._manager = weakref.ref(manager)
@@ -157,35 +159,40 @@ class _ManagedWindowNode(QtCore.QObject):
         self._source_auto_update: bool = False
         self._output_id: str | None = None
         self._suspend_descendant_signal_propagation: bool = False
+        self._lineage_token = str(lineage_token) if lineage_token else uuid.uuid4().hex
+        self._suspend_lineage_token_updates = True
 
         self.window = window
-        if source_spec is not None:
-            self.set_source_binding(
-                source_spec,
-                source_binding=source_binding,
-                provenance_spec=provenance_spec,
-                auto_update=source_auto_update,
-                state=source_state,
-            )
-        elif source_binding is not None:
-            self.set_source_binding(
-                None,
-                source_binding=source_binding,
-                provenance_spec=provenance_spec,
-                auto_update=source_auto_update,
-                state=source_state,
-            )
-        elif output_id is not None:
-            self.set_output_binding(
-                output_id,
-                provenance_spec=provenance_spec,
-                auto_update=source_auto_update,
-                state=source_state,
-            )
-        elif provenance_spec is not None:
-            self.set_detached_provenance(provenance_spec)
-        elif isinstance(window, ImageTool) and window.provenance_spec is not None:
-            self.set_detached_provenance(window.provenance_spec)
+        try:
+            if source_spec is not None:
+                self.set_source_binding(
+                    source_spec,
+                    source_binding=source_binding,
+                    provenance_spec=provenance_spec,
+                    auto_update=source_auto_update,
+                    state=source_state,
+                )
+            elif source_binding is not None:
+                self.set_source_binding(
+                    None,
+                    source_binding=source_binding,
+                    provenance_spec=provenance_spec,
+                    auto_update=source_auto_update,
+                    state=source_state,
+                )
+            elif output_id is not None:
+                self.set_output_binding(
+                    output_id,
+                    provenance_spec=provenance_spec,
+                    auto_update=source_auto_update,
+                    state=source_state,
+                )
+            elif provenance_spec is not None:
+                self.set_detached_provenance(provenance_spec)
+            elif isinstance(window, ImageTool) and window.provenance_spec is not None:
+                self.set_detached_provenance(window.provenance_spec)
+        finally:
+            self._suspend_lineage_token_updates = False
 
     @property
     def manager(self) -> ImageToolManager:
@@ -470,6 +477,12 @@ class _ManagedWindowNode(QtCore.QObject):
                     details=load_source_details,
                 )
             )
+        lineage_label = self.manager.lineage_status_label_for_uid(self.uid)
+        if lineage_label is not None:
+            fields.append(_MetadataField("Lineage", lineage_label))
+        lineage_inputs = self.manager.lineage_input_summary_for_uid(self.uid)
+        if lineage_inputs is not None:
+            fields.append(_MetadataField("Inputs", lineage_inputs, wrap=True))
         if data is not None and data.chunks is not None:
             fields.append(
                 _MetadataField(
@@ -511,6 +524,19 @@ class _ManagedWindowNode(QtCore.QObject):
         return self._source_spec
 
     @property
+    def lineage_token(self) -> str:
+        return self._lineage_token
+
+    def _advance_lineage_token(self) -> None:
+        if self._suspend_lineage_token_updates:
+            return
+        self._lineage_token = uuid.uuid4().hex
+        self.manager.tree_view.refresh(self.uid)
+        self.manager._update_info(uid=self.uid)
+        self.manager._refresh_lineage_dependents(self.uid)
+        self.manager._mark_node_state_dirty(self.uid)
+
+    @property
     def source_state(self) -> _source_state_type:
         if self.tool_window is not None:
             return self.tool_window.source_state
@@ -540,6 +566,8 @@ class _ManagedWindowNode(QtCore.QObject):
         self,
         provenance_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
         | None,
+        *,
+        advance_lineage: bool = True,
     ) -> None:
         self._provenance_spec = (
             erlab.interactive.imagetool.provenance.parse_tool_provenance_spec(
@@ -548,6 +576,8 @@ class _ManagedWindowNode(QtCore.QObject):
         )
         if self.imagetool is not None:
             self.imagetool.set_provenance_spec(self.provenance_spec)
+        if advance_lineage:
+            self._advance_lineage_token()
 
     @property
     def derivation_entries(
@@ -742,6 +772,15 @@ class _ManagedWindowNode(QtCore.QObject):
         finally:
             self._suspend_descendant_signal_propagation = previous
 
+    @contextlib.contextmanager
+    def _suspend_lineage_updates(self) -> Iterator[None]:
+        previous = self._suspend_lineage_token_updates
+        self._suspend_lineage_token_updates = True
+        try:
+            yield
+        finally:
+            self._suspend_lineage_token_updates = previous
+
     def _replace_imagetool_data(
         self,
         data: xr.DataArray,
@@ -751,9 +790,10 @@ class _ManagedWindowNode(QtCore.QObject):
         state: _source_state_type = "fresh",
         propagate_descendants: bool,
     ) -> None:
-        with self._suspend_descendant_propagation():
+        with self._suspend_descendant_propagation(), self._suspend_lineage_updates():
             self.slicer_area.replace_source_data(data)
-        self.set_displayed_provenance(provenance_spec)
+        self.set_displayed_provenance(provenance_spec, advance_lineage=False)
+        self._advance_lineage_token()
         self._set_source_state(state)
         self.manager._mark_node_data_dirty(self.uid)
         if propagate_descendants:
@@ -764,6 +804,7 @@ class _ManagedWindowNode(QtCore.QObject):
 
     def _handle_tool_data_changed(self) -> None:
         self.manager._mark_node_data_dirty(self.uid)
+        self._advance_lineage_token()
         if self._suspend_descendant_signal_propagation:
             return
         tool_window = self.tool_window
@@ -908,10 +949,12 @@ class _ManagedWindowNode(QtCore.QObject):
     @QtCore.Slot()
     def _handle_imagetool_data_edited(self) -> None:
         self.manager._mark_node_data_dirty(self.uid)
+        self._advance_lineage_token()
 
     @QtCore.Slot()
     def _handle_imagetool_backing_changed(self) -> None:
         self.manager._mark_node_data_dirty(self.uid)
+        self._advance_lineage_token()
         self._refresh_node_info()
 
     def _update_from_parent_source(self) -> bool:
@@ -1048,6 +1091,7 @@ class _ManagedWindowNode(QtCore.QObject):
     @QtCore.Slot(object)
     def _handle_source_data_replaced(self, parent_data: object) -> None:
         self.manager._mark_node_data_dirty(self.uid)
+        self._advance_lineage_token()
         if self._suspend_descendant_signal_propagation:
             return
         if not isinstance(parent_data, xr.DataArray):
@@ -1083,6 +1127,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         source_binding: ImageToolSelectionSourceBinding | None = None,
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
+        lineage_token: str | None = None,
     ) -> None:
         self._index = index
         self._watched_varname: str | None = None
@@ -1114,6 +1159,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
             source_binding=source_binding,
             source_auto_update=source_auto_update,
             source_state=source_state,
+            lineage_token=lineage_token,
         )
 
     @property

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -479,9 +479,6 @@ class _ManagedWindowNode(QtCore.QObject):
                     details=load_source_details,
                 )
             )
-        dependency_label = self.manager.dependency_status_label_for_uid(self.uid)
-        if dependency_label is not None:
-            fields.append(_MetadataField("Inputs", dependency_label))
         dependency_inputs = self.manager.dependency_input_summary_for_uid(self.uid)
         if dependency_inputs is not None:
             fields.append(_MetadataField("Inputs", dependency_inputs, wrap=True))

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -91,7 +91,7 @@ __all__ = [
     "RotateOperation",
     "ScriptCodeOperation",
     "ScriptInput",
-    "ScriptInputLineageRef",
+    "ScriptInputDependencyRef",
     "SelOperation",
     "SelectCoordOperation",
     "SliceAlongPathOperation",
@@ -120,7 +120,7 @@ __all__ = [
     "replay_script_provenance",
     "require_live_source_spec",
     "script",
-    "script_input_lineage_refs",
+    "script_input_dependency_refs",
     "script_provenance_replayable",
     "selection",
     "to_replay_provenance_spec",
@@ -131,6 +131,7 @@ import ast
 import base64
 import contextlib
 import importlib
+import json
 import keyword
 import pathlib
 import typing
@@ -208,13 +209,13 @@ class DerivationEntry:
 
 
 @dataclass(frozen=True)
-class ScriptInputLineageRef:
-    """Live manager lineage captured by a script input."""
+class ScriptInputDependencyRef:
+    """Live manager dependency captured by a script input."""
 
     name: str
     label: str
     node_uid: str
-    node_lineage_token: str | None = None
+    node_snapshot_token: str | None = None
 
 
 def _encode_fit_dataset(value: xr.Dataset) -> str:
@@ -415,6 +416,31 @@ def _clone_expr(node: ast.expr) -> ast.expr:
 
 def _clone_stmt(node: ast.stmt) -> ast.stmt:
     return ast.parse(ast.unparse(node), mode="exec").body[0]
+
+
+class _IdentifierReplacer(ast.NodeTransformer):
+    def __init__(self, replacements: Mapping[str, str]) -> None:
+        self._replacements = dict(replacements)
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        replacement = self._replacements.get(node.id)
+        if replacement is None:
+            return node
+        return ast.copy_location(ast.Name(id=replacement, ctx=node.ctx), node)
+
+
+def _replace_code_identifiers(code: str, replacements: Mapping[str, str]) -> str:
+    module = ast.parse(code, mode="exec")
+    replaced = typing.cast(
+        "ast.Module",
+        _IdentifierReplacer(replacements).visit(module),
+    )
+    return ast.unparse(ast.fix_missing_locations(replaced))
+
+
+def _code_stores_name(code: str, name: str) -> bool:
+    module = ast.parse(code, mode="exec")
+    return any(_statement_store_count(stmt, name) > 0 for stmt in module.body)
 
 
 def _simplify_display_code(code: str, *, inline_targets: set[str] | None = None) -> str:
@@ -941,7 +967,7 @@ class ScriptInput(pydantic.BaseModel):
     name: str
     label: str
     node_uid: str | None = None
-    node_lineage_token: str | None = None
+    node_snapshot_token: str | None = None
     provenance_spec: dict[str, typing.Any] | None = None
 
     model_config = pydantic.ConfigDict(
@@ -974,14 +1000,14 @@ class ScriptInput(pydantic.BaseModel):
             return None
         return str(value)
 
-    @pydantic.field_validator("node_lineage_token", mode="before")
+    @pydantic.field_validator("node_snapshot_token", mode="before")
     @classmethod
-    def _validate_node_lineage_token(cls, value: typing.Any) -> str | None:
+    def _validate_node_snapshot_token(cls, value: typing.Any) -> str | None:
         if value is None:
             return None
         token = str(value)
         if not token:
-            raise ValueError("script input lineage token must not be empty")
+            raise ValueError("script input snapshot token must not be empty")
         return token
 
     @pydantic.field_validator("provenance_spec", mode="before")
@@ -1017,7 +1043,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
 
     .. versionchanged:: 3.23.0
        Script provenance can describe multiple manager inputs and records manager
-       lineage tokens so derived tools can show whether the live inputs still match
+       snapshot tokens so derived tools can show whether the live inputs still match
        the inputs used to create them.
     """
 
@@ -1289,8 +1315,9 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         """Normalize the spec into a replay-only script form.
 
         Replay specs are the canonical, composable form used for derivation metadata,
-        copy-code, save/load, and manager lineage. Structured file provenance remains
-        structured so runtime reloads can replay typed operations without ``exec``.
+        copy-code, save/load, and manager dependencies. Structured file provenance
+        remains structured so runtime reloads can replay typed operations without
+        ``exec``.
         Live updates from ImageTool use the original non-script spec via
         :func:`require_live_source_spec`.
         """
@@ -1357,6 +1384,10 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         if not self.script_inputs:
             return None
 
+        planned = _planned_script_inputs_code(self.script_inputs, display=display)
+        if planned is not None:
+            return planned
+
         lines: list[str] = []
         for script_input in self.script_inputs:
             input_spec = script_input.parsed_provenance_spec()
@@ -1410,7 +1441,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         """Return streamlined derivation entries for UI and copy-code output.
 
         The display path hides internal ImageTool normalization steps while keeping the
-        raw replay lineage available through :meth:`derivation_entries`.
+        recorded replay steps available through :meth:`derivation_entries`.
         """
         entries = [self._start_entry()]
 
@@ -1488,9 +1519,185 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             return None
         if not step_codes and prefix == _DEFAULT_REPLAY_SEED_CODE:
             return None
-        return _simplify_display_code(
-            "\n".join(part for part in (prefix, *step_codes) if part)
+        inline_targets = (
+            {"derived"} if self.kind == "script" and self.script_inputs else None
         )
+        return _simplify_display_code(
+            "\n".join(part for part in (prefix, *step_codes) if part),
+            inline_targets=inline_targets,
+        )
+
+
+def _canonical_replay_key(kind: str, payload: Mapping[str, typing.Any]) -> str:
+    return json.dumps(
+        {"kind": kind, **dict(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _file_load_replay_key(load_source: FileLoadSource) -> str:
+    return _canonical_replay_key(
+        "file_load",
+        {
+            "path": load_source.path,
+            "replay_call": (
+                None
+                if load_source.replay_call is None
+                else load_source.replay_call.model_dump(mode="json")
+            ),
+        },
+    )
+
+
+def _replay_stage_replay_key(parent_key: str, stage: ReplayStage) -> str:
+    return _canonical_replay_key(
+        "replay_stage",
+        {
+            "parent": parent_key,
+            "stage": stage.model_dump(mode="json"),
+        },
+    )
+
+
+def _stage_code_lines(
+    stage: ReplayStage,
+    *,
+    parent_name: str,
+    output_name: str,
+    display: bool,
+) -> tuple[str, ...] | None:
+    if stage.source_kind == "full_data":
+        lines = [f"{output_name} = {parent_name}"]
+    else:
+        lines = [
+            f"{output_name} = erlab.interactive.imagetool.slicer."
+            f"restore_nonuniform_dims({parent_name})"
+        ]
+
+    operations: Sequence[ToolProvenanceOperation] = stage.operations
+    if display:
+        operations = ToolProvenanceSpec._streamlined_operations(
+            stage.source_kind,
+            operations,
+        )
+
+    for operation in operations:
+        entry = operation.derivation_entry()
+        if entry is None:
+            continue
+        if entry.code is None:
+            return None
+        try:
+            lines.append(
+                _replace_code_identifiers(
+                    entry.code,
+                    {"data": parent_name, "derived": output_name},
+                )
+            )
+        except SyntaxError:
+            return None
+    return tuple(lines)
+
+
+def _planned_script_inputs_code(
+    script_inputs: Sequence[ScriptInput],
+    *,
+    display: bool,
+) -> str | None:
+    """Return DAG-emitted setup code for structured script inputs, if possible."""
+    used_names = {script_input.name for script_input in script_inputs}
+    node_names: dict[str, str] = {}
+    lines: list[str] = []
+    counter = 0
+
+    def _next_name() -> str:
+        nonlocal counter
+        while True:
+            name = f"_itool_replay_{counter}"
+            counter += 1
+            if name not in used_names:
+                used_names.add(name)
+                return name
+
+    def _add_node(
+        key: str,
+        build_lines: Callable[[str], tuple[str, ...] | None],
+    ) -> str | None:
+        existing = node_names.get(key)
+        if existing is not None:
+            return existing
+        name = _next_name()
+        built = build_lines(name)
+        if built is None:
+            return None
+        node_names[key] = name
+        lines.extend(built)
+        return name
+
+    def _file_chain(spec: ToolProvenanceSpec) -> tuple[str, str] | None:
+        if spec.kind != "file" or spec.file_load_source is None:
+            return None
+        active_name = spec.active_name
+        if active_name is None or spec.seed_code is None:
+            return None
+        seed_code = spec.seed_code
+
+        load_key = _file_load_replay_key(spec.file_load_source)
+
+        def _load_lines(name: str) -> tuple[str, ...] | None:
+            try:
+                code = _replace_code_identifiers(seed_code, {active_name: name})
+            except SyntaxError:
+                return None
+            if not _code_stores_name(code, name):
+                return None
+            return (code,)
+
+        parent_name = _add_node(load_key, _load_lines)
+        if parent_name is None:
+            return None
+        parent_key = load_key
+
+        for stage in spec.replay_stages:
+            stage_key = _replay_stage_replay_key(parent_key, stage)
+
+            def _build_stage_lines(
+                name: str,
+                *,
+                current_stage: ReplayStage = stage,
+                current_parent: str = parent_name,
+            ) -> tuple[str, ...] | None:
+                return _stage_code_lines(
+                    current_stage,
+                    parent_name=current_parent,
+                    output_name=name,
+                    display=display,
+                )
+
+            stage_name = _add_node(stage_key, _build_stage_lines)
+            if stage_name is None:
+                return None
+            parent_key = stage_key
+            parent_name = stage_name
+
+        return parent_key, parent_name
+
+    aliases: list[tuple[str, str]] = []
+    for script_input in script_inputs:
+        input_spec = script_input.parsed_provenance_spec()
+        if input_spec is None:
+            return None
+        planned = _file_chain(input_spec)
+        if planned is None:
+            return None
+        _key, input_name = planned
+        aliases.append((script_input.name, input_name))
+
+    for public_name, planned_name in aliases:
+        if public_name != planned_name:
+            lines.append(f"{public_name} = {planned_name}")
+    return "\n".join(lines)
 
 
 def parse_tool_provenance_spec(
@@ -1511,25 +1718,25 @@ def parse_tool_provenance_spec(
     return ToolProvenanceSpec.model_validate(value)
 
 
-def script_input_lineage_refs(
+def script_input_dependency_refs(
     value: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
-) -> tuple[ScriptInputLineageRef, ...]:
-    """Return all live manager lineage references stored in script inputs."""
+) -> tuple[ScriptInputDependencyRef, ...]:
+    """Return all live manager dependency references stored in script inputs."""
     spec = parse_tool_provenance_spec(value)
     if spec is None:
         return ()
 
-    refs: list[ScriptInputLineageRef] = []
+    refs: list[ScriptInputDependencyRef] = []
 
     def _collect(current: ToolProvenanceSpec) -> None:
         for script_input in current.script_inputs:
             if script_input.node_uid is not None:
                 refs.append(
-                    ScriptInputLineageRef(
+                    ScriptInputDependencyRef(
                         name=script_input.name,
                         label=script_input.label,
                         node_uid=script_input.node_uid,
-                        node_lineage_token=script_input.node_lineage_token,
+                        node_snapshot_token=script_input.node_snapshot_token,
                     )
                 )
             nested = script_input.parsed_provenance_spec()
@@ -1748,9 +1955,9 @@ def compose_full_provenance(
     parent: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
     local: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
 ) -> ToolProvenanceSpec | None:
-    """Compose canonical full provenance from parent and local lineage.
+    """Compose canonical full provenance from parent and local provenance.
 
-    ``parent`` represents the replay lineage for the current input data. ``local``
+    ``parent`` represents the replay provenance for the current input data. ``local``
     represents the additional steps performed by the current node. File-backed parents
     remain structured when composed with live-source specs so runtime reloads can avoid
     executing generated Python.
@@ -2106,15 +2313,30 @@ def _apply_replay_stage(stage: ReplayStage, parent_data: xr.DataArray) -> xr.Dat
 
 def replay_file_provenance(
     spec: ToolProvenanceSpec | Mapping[str, typing.Any],
+    *,
+    cache: dict[str, xr.DataArray] | None = None,
 ) -> xr.DataArray:
     """Replay structured file provenance without executing generated Python."""
     parsed = parse_tool_provenance_spec(spec)
     if parsed is None or parsed.kind != "file" or parsed.file_load_source is None:
         raise TypeError("Expected structured file provenance")
 
-    data = _load_file_source_data(parsed.file_load_source)
+    replay_cache = {} if cache is None else cache
+    load_key = _file_load_replay_key(parsed.file_load_source)
+    if load_key in replay_cache:
+        data = replay_cache[load_key].copy(deep=False)
+    else:
+        data = _load_file_source_data(parsed.file_load_source)
+        replay_cache[load_key] = data.copy(deep=False)
+    parent_key = load_key
     for stage in parsed.replay_stages:
-        data = _apply_replay_stage(stage, data)
+        stage_key = _replay_stage_replay_key(parent_key, stage)
+        if stage_key in replay_cache:
+            data = replay_cache[stage_key].copy(deep=False)
+        else:
+            data = _apply_replay_stage(stage, data)
+            replay_cache[stage_key] = data.copy(deep=False)
+        parent_key = stage_key
     return data
 
 

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -90,6 +90,8 @@ __all__ = [
     "RestoreNonuniformDimsOperation",
     "RotateOperation",
     "ScriptCodeOperation",
+    "ScriptInput",
+    "ScriptInputLineageRef",
     "SelOperation",
     "SelectCoordOperation",
     "SliceAlongPathOperation",
@@ -113,9 +115,11 @@ __all__ = [
     "parse_tool_provenance_spec",
     "public_data",
     "rebase_default_replay_input",
+    "rebase_script_input_node_uids",
     "replay_file_provenance",
     "require_live_source_spec",
     "script",
+    "script_input_lineage_refs",
     "selection",
     "to_replay_provenance_spec",
     "uses_default_replay_input",
@@ -158,6 +162,16 @@ class DerivationEntry:
     label: str
     code: str | None
     copyable: bool = False
+
+
+@dataclass(frozen=True)
+class ScriptInputLineageRef:
+    """Live manager lineage captured by a script input."""
+
+    name: str
+    label: str
+    node_uid: str
+    node_lineage_token: str | None = None
 
 
 def _encode_fit_dataset(value: xr.Dataset) -> str:
@@ -878,17 +892,90 @@ class FileLoadSource(pydantic.BaseModel):
         return str(value)
 
 
+class ScriptInput(pydantic.BaseModel):
+    """One named input used by replay-only script provenance."""
+
+    name: str
+    label: str
+    node_uid: str | None = None
+    node_lineage_token: str | None = None
+    provenance_spec: dict[str, typing.Any] | None = None
+
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        extra="forbid",
+    )
+
+    @pydantic.field_validator("name", mode="before")
+    @classmethod
+    def _validate_name(cls, value: typing.Any) -> str:
+        name = _validate_active_name(value)
+        if name is None:
+            raise ValueError("script input name must not be None")
+        return name
+
+    @pydantic.field_validator("label", mode="before")
+    @classmethod
+    def _validate_label(cls, value: typing.Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("script input label must be a string")
+        if not value:
+            raise ValueError("script input label must not be empty")
+        return value
+
+    @pydantic.field_validator("node_uid", mode="before")
+    @classmethod
+    def _validate_node_uid(cls, value: typing.Any) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
+    @pydantic.field_validator("node_lineage_token", mode="before")
+    @classmethod
+    def _validate_node_lineage_token(cls, value: typing.Any) -> str | None:
+        if value is None:
+            return None
+        token = str(value)
+        if not token:
+            raise ValueError("script input lineage token must not be empty")
+        return token
+
+    @pydantic.field_validator("provenance_spec", mode="before")
+    @classmethod
+    def _validate_provenance_spec(
+        cls, value: typing.Any
+    ) -> dict[str, typing.Any] | None:
+        if value is None:
+            return None
+        if isinstance(value, ToolProvenanceSpec):
+            return value.model_dump(mode="json")
+        if isinstance(value, Mapping):
+            return dict(value)
+        raise TypeError(
+            "script input provenance must be a ToolProvenanceSpec or mapping"
+        )
+
+    def parsed_provenance_spec(self) -> ToolProvenanceSpec | None:
+        return parse_tool_provenance_spec(self.provenance_spec)
+
+
 class ToolProvenanceSpec(pydantic.BaseModel):
     """Immutable provenance recipe for rebuilding tool data from a parent ImageTool.
 
-    Author new specs with :func:`full_data`, :func:`public_data`, or
-    :func:`selection` plus operation instances from this module. Deserialize saved
-    payloads with :func:`parse_tool_provenance_spec`.
+    Author new specs with :func:`full_data`, :func:`public_data`, or :func:`selection`
+    plus concrete operation instances from this module. Deserialize saved payloads
+    with :func:`parse_tool_provenance_spec`.
 
     A spec records the exact operation arguments used for replay, copied code, and
     derivation display. Manager children opened from ImageTool cursor or bin selections
     should keep :class:`ImageToolSelectionSourceBinding` as their refresh state; that
     binding builds a spec before refresh so edited parent coordinates are used.
+
+    .. versionchanged:: 3.23.0
+       Script provenance can describe multiple manager inputs and records manager
+       lineage tokens so derived tools can show whether the live inputs still match
+       the inputs used to create them.
     """
 
     schema_version: typing.Literal[2] = 2
@@ -899,6 +986,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
     operations: tuple[pydantic.SerializeAsAny[ToolProvenanceOperation], ...] = ()
     file_load_source: FileLoadSource | None = None
     replay_stages: tuple[ReplayStage, ...] = ()
+    script_inputs: tuple[ScriptInput, ...] = ()
 
     model_config = pydantic.ConfigDict(
         frozen=True,
@@ -950,6 +1038,18 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             for item in value
         )
 
+    @pydantic.field_validator("script_inputs", mode="before")
+    @classmethod
+    def _validate_script_inputs(cls, value: typing.Any) -> tuple[ScriptInput, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise TypeError("Serialized script inputs must be a sequence")
+        return tuple(
+            item if isinstance(item, ScriptInput) else ScriptInput.model_validate(item)
+            for item in value
+        )
+
     @pydantic.model_validator(mode="after")
     def _validate_kind_fields(self) -> typing.Self:
         if self.kind == "script":
@@ -978,10 +1078,12 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             or self.active_name is not None
             or self.file_load_source is not None
             or self.replay_stages
+            or self.script_inputs
         ):
             raise ValueError(
                 "Only script or file provenance specs may define `start_label`, "
-                "`seed_code`, `active_name`, `file_load_source`, or `replay_stages`"
+                "`seed_code`, `active_name`, `file_load_source`, `replay_stages`, "
+                "or `script_inputs`"
             )
         return self
 
@@ -1184,6 +1286,15 @@ class ToolProvenanceSpec(pydantic.BaseModel):
 
     def derivation_entries(self) -> list[DerivationEntry]:
         entries: list[DerivationEntry] = [self._start_entry()]
+        if self.kind == "script":
+            entries.extend(
+                DerivationEntry(
+                    f"Use {script_input.name} from {script_input.label}",
+                    None,
+                    False,
+                )
+                for script_input in self.script_inputs
+            )
         operations: Sequence[ToolProvenanceOperation]
         if self.kind == "file":
             operations = tuple(
@@ -1199,12 +1310,46 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 entries.append(entry)
         return entries
 
+    def _script_inputs_code(self, *, display: bool) -> str | None:
+        if not self.script_inputs:
+            return None
+
+        lines: list[str] = []
+        for script_input in self.script_inputs:
+            input_spec = script_input.parsed_provenance_spec()
+            if input_spec is None:
+                return None
+            code = (
+                input_spec.display_code() if display else input_spec.derivation_code()
+            )
+            if not code:
+                return None
+            lines.append(code)
+            active_name = replay_input_name(input_spec) or input_spec.active_name
+            if active_name is None:
+                return None
+            if active_name != script_input.name:
+                lines.append(f"{script_input.name} = {active_name}")
+        return "\n".join(lines)
+
     def derivation_code(self) -> str | None:
         prefix: str | None = None
-        if self.kind in {"script", "file"}:
+        if self.kind == "script" and self.script_inputs:
+            input_code = self._script_inputs_code(display=False)
+            if input_code is None:
+                return None
+            prefix = "\n".join(part for part in (input_code, self.seed_code) if part)
+        elif self.kind in {"script", "file"}:
             prefix = self.seed_code
         step_codes: list[str] = []
-        for entry in self.derivation_entries()[1:]:
+        code_entries = self.derivation_entries()[1:]
+        if self.kind == "script" and self.script_inputs:
+            code_entries = [
+                entry
+                for operation in self.operations
+                if (entry := operation.derivation_entry()) is not None
+            ]
+        for entry in code_entries:
             if entry.code is None:
                 return None
             step_codes.append(entry.code)
@@ -1271,11 +1416,23 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         no-op and normalization steps from copied provenance code.
         """
         prefix: str | None = None
-        if self.kind in {"script", "file"}:
+        if self.kind == "script" and self.script_inputs:
+            input_code = self._script_inputs_code(display=True)
+            if input_code is None:
+                return None
+            prefix = "\n".join(part for part in (input_code, self.seed_code) if part)
+        elif self.kind in {"script", "file"}:
             prefix = self.seed_code
 
         step_codes: list[str] = []
-        for entry in self.display_entries(parent_data=parent_data)[1:]:
+        code_entries = self.display_entries(parent_data=parent_data)[1:]
+        if self.kind == "script" and self.script_inputs:
+            code_entries = [
+                entry
+                for operation in self.operations
+                if (entry := operation.derivation_entry()) is not None
+            ]
+        for entry in code_entries:
             if entry.code is None:
                 return None
             step_codes.append(entry.code)
@@ -1309,6 +1466,76 @@ def parse_tool_provenance_spec(
         value = dict(value)
         value["schema_version"] = 2
     return ToolProvenanceSpec.model_validate(value)
+
+
+def script_input_lineage_refs(
+    value: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
+) -> tuple[ScriptInputLineageRef, ...]:
+    """Return all live manager lineage references stored in script inputs."""
+    spec = parse_tool_provenance_spec(value)
+    if spec is None:
+        return ()
+
+    refs: list[ScriptInputLineageRef] = []
+
+    def _collect(current: ToolProvenanceSpec) -> None:
+        for script_input in current.script_inputs:
+            if script_input.node_uid is not None:
+                refs.append(
+                    ScriptInputLineageRef(
+                        name=script_input.name,
+                        label=script_input.label,
+                        node_uid=script_input.node_uid,
+                        node_lineage_token=script_input.node_lineage_token,
+                    )
+                )
+            nested = script_input.parsed_provenance_spec()
+            if nested is not None:
+                _collect(nested)
+
+    _collect(spec)
+    return tuple(refs)
+
+
+def rebase_script_input_node_uids(
+    value: ToolProvenanceSpec | Mapping[str, typing.Any],
+    uid_map: Mapping[str, str],
+) -> ToolProvenanceSpec:
+    """Return ``value`` with script input node UIDs remapped recursively."""
+    spec = parse_tool_provenance_spec(value)
+    if spec is None:
+        raise TypeError("Expected provenance spec")
+    if not uid_map or not spec.script_inputs:
+        return spec
+
+    def _rebase(current: ToolProvenanceSpec) -> ToolProvenanceSpec:
+        if not current.script_inputs:
+            return current
+
+        changed = False
+        script_inputs: list[ScriptInput] = []
+        for script_input in current.script_inputs:
+            updates: dict[str, typing.Any] = {}
+            if script_input.node_uid is not None and script_input.node_uid in uid_map:
+                updates["node_uid"] = uid_map[script_input.node_uid]
+
+            nested = script_input.parsed_provenance_spec()
+            if nested is not None:
+                rebased_nested = _rebase(nested)
+                if rebased_nested != nested:
+                    updates["provenance_spec"] = rebased_nested.model_dump(mode="json")
+
+            if updates:
+                changed = True
+                script_inputs.append(script_input.model_copy(update=updates))
+            else:
+                script_inputs.append(script_input)
+
+        if not changed:
+            return current
+        return current.model_copy(update={"script_inputs": tuple(script_inputs)})
+
+    return _rebase(spec)
 
 
 def to_replay_provenance_spec(
@@ -1403,6 +1630,7 @@ def direct_replay_input_name(
     if (
         spec is None
         or spec.operations
+        or spec.script_inputs
         or spec.seed_code is None
         or spec.seed_code == _DEFAULT_REPLAY_SEED_CODE
     ):
@@ -1545,6 +1773,7 @@ def compose_full_provenance(
         seed_code=parent_spec.seed_code,
         active_name=local_spec.active_name or parent_spec.active_name,
         file_load_source=parent_spec.file_load_source or local_spec.file_load_source,
+        script_inputs=(*parent_spec.script_inputs, *local_spec.script_inputs),
         operations=(*parent_spec.operations, *local_operations),
     )
 
@@ -1699,6 +1928,7 @@ def script(
     seed_code: str | None = None,
     active_name: str | None = None,
     file_load_source: FileLoadSource | None = None,
+    script_inputs: Sequence[ScriptInput] = (),
 ) -> ToolProvenanceSpec:
     """Build a replay-only provenance spec for generated code."""
     return ToolProvenanceSpec(
@@ -1707,6 +1937,7 @@ def script(
         seed_code=seed_code,
         active_name=active_name,
         file_load_source=file_load_source,
+        script_inputs=tuple(script_inputs),
     ).append_operations(*operations)
 
 

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -1468,9 +1468,10 @@ class ScriptInput(pydantic.BaseModel):
     def _validate_label(cls, value: typing.Any) -> str:
         if not isinstance(value, str):
             raise TypeError("script input label must be a string")
-        if not value:
+        label = " ".join(value.split())
+        if not label:
             raise ValueError("script input label must not be empty")
-        return value
+        return label
 
     @pydantic.field_validator("node_uid", mode="before")
     @classmethod

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -263,6 +263,46 @@ def _is_internal_sort_coord_order_entry(entry: DerivationEntry) -> bool:
     )
 
 
+def _is_whole_array_rename_entry(entry: DerivationEntry) -> bool:
+    code = entry.code
+    if code is None:
+        return False
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return False
+    match module.body:
+        case [
+            ast.Assign(
+                targets=[ast.Name(id=target_name, ctx=ast.Store())],
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id=receiver_name, ctx=ast.Load()),
+                        attr="rename",
+                    ),
+                    args=args,
+                    keywords=keywords,
+                ),
+            )
+        ] if target_name == receiver_name:
+            pass
+        case _:
+            return False
+
+    if len(args) == 1 and not keywords:
+        return isinstance(args[0], ast.Constant) and isinstance(
+            args[0].value, (str, type(None))
+        )
+    if args or len(keywords) != 1:
+        return False
+    keyword = keywords[0]
+    return (
+        keyword.arg == "new_name_or_name_dict"
+        and isinstance(keyword.value, ast.Constant)
+        and isinstance(keyword.value.value, (str, type(None)))
+    )
+
+
 def encode_provenance_value(value: typing.Any) -> typing.Any:
     """Encode non-JSON provenance values into a JSON-safe representation."""
     if isinstance(value, xr.Dataset):
@@ -1740,6 +1780,11 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                     "derived = derived.qsel()",
                     "derived = derived.sel()",
                 } or _is_internal_sort_coord_order_entry(entry)
+                if not hide_operation and _is_whole_array_rename_entry(entry):
+                    hide_operation = not any(
+                        isinstance(later_operation, ScriptCodeOperation)
+                        for later_operation in operations[index + 1 :]
+                    )
             # Rule 1: drop empty selection operations.
             elif isinstance(operation, (QSelOperation, IselOperation, SelOperation)):
                 hide_operation = not operation.decoded_kwargs
@@ -1904,10 +1949,10 @@ class ToolProvenanceSpec(pydantic.BaseModel):
     def derivation_code(self) -> str | None:
         prefix: str | None = None
         if self.kind == "script" and self.script_inputs:
-            return self._script_graph_code(display=False)
+            return self._script_graph_code(display=True)
         if self.kind in {"script", "file"}:
             prefix = self.seed_code
-        step_codes = self._code_lines_from_entries(self.derivation_entries()[1:])
+        step_codes = self._code_lines_from_entries(self.display_entries()[1:])
         if step_codes is None:
             return None
         if prefix is None and self.kind != "script":

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -1,23 +1,36 @@
-"""Helpers for recording and replaying actions in ImageTool windows.
+"""Helpers for recording, displaying, and replaying ImageTool provenance.
 
-The provenance model stores how a tool's data should be reconstructed from a parent
-ImageTool window. A :class:`ToolProvenanceSpec` answers two questions:
+The saved provenance model stores enough history to explain or rebuild an ImageTool
+without persisting runtime-only replay state. :class:`ToolProvenanceSpec` has a small
+set of source forms:
 
-1. What should be used as the starting point?
+1. Live single-parent source specs.
 
-   - Use :func:`full_data` when the derived tool should begin from the parent's current
-     array exactly as shown to the caller.
+   - Use :func:`full_data` when the derived tool should begin from the parent
+     ImageTool's current array exactly as shown to the caller.
 
-   - Use :func:`public_data` when the derived tool should begin from the parent's
-     public data model, including restoration of non-uniform dimensions.
+   - Use :func:`public_data` when the derived tool should begin from the parent
+     ImageTool's public data model, including restoration of non-uniform dimensions.
 
-   - Use :func:`selection` when the derived tool should begin from the public ImageTool
-     selection model, including restoration of non-uniform dimensions.
+   - Use :func:`selection` when the derived tool should begin from the public
+     ImageTool selection model, including restoration of non-uniform dimensions.
 
-2. Which operations should be replayed on that starting point?
+2. Durable replay specs.
 
-   - Each operation is represented by an immutable :class:`ToolProvenanceOperation`
-     subclass whose serialized fields are safe to persist in JSON.
+   - Use :func:`file_load` for data that can be reloaded from a recorded file source
+     and replayed through structured :class:`ReplayStage` operations.
+
+   - Use :func:`script` for console-derived and other multi-input results. Script
+     specs may reference any number of :class:`ScriptInput` records. Each input stores
+     an immutable replay name, a historical display label, optional live manager node
+     identity and ``node_snapshot_token``, and an optional nested provenance snapshot.
+
+Each transformation is represented by an immutable
+:class:`ToolProvenanceOperation` subclass whose serialized fields are safe to persist
+in JSON. Persisted specs are the source of truth for workspace save/load. Runtime
+reload, copied code, and shared-input deduplication compile those specs on demand
+through :mod:`erlab.interactive.imagetool._replay_graph`; the graph itself is not
+saved.
 
 Manager children opened from an ImageTool cursor or bin selection do not keep the
 first generated ``qsel`` arguments as their refresh state. They store the selected
@@ -27,7 +40,8 @@ parent indices in :class:`ImageToolSelectionSourceBinding` and rebuild ``qsel`` 
 Adding a new provenance-carrying operation follows the same pattern every time:
 
 1. Define a new :class:`ToolProvenanceOperation` subclass with a unique ``op``
-   discriminator literal.
+   discriminator literal. Subclasses register themselves automatically so serialized
+   payloads can dispatch to the right model.
 
 2. Prefer the annotated provenance field aliases defined in this module for hashable
    dimension identifiers and dim-keyed mappings so runtime values stay decoded while
@@ -43,23 +57,31 @@ Adding a new provenance-carrying operation follows the same pattern every time:
    access to parent coordinates or ordering.
 
 5. Implement :meth:`ToolProvenanceOperation.derivation_entry` so the manager can display
-   a user-facing summary and optional copyable code. Return ``None`` only when the
-   operation should be omitted from the derivation list and copied provenance code while
-   still being replayed at runtime.
+   a user-facing summary and optional copyable code. Return a :class:`DerivationEntry`
+   for every concrete operation; use ``code=None`` when the step should be visible but
+   copied/replay code cannot be emitted safely.
 
-6. Give the class a unique ``op`` discriminator literal. Subclasses register themselves
-   automatically so serialized payloads can dispatch to the right model.
+6. If the operation maps cleanly from manager-console calls, declare
+   :attr:`ToolProvenanceOperation.console_patterns` or implement
+   :meth:`ToolProvenanceOperation.from_console_call`. Unsupported or ambiguous console
+   calls should return ``None`` so they remain valid script provenance instead of being
+   recorded as lossy structured operations.
 
-7. Export the operation class from this module so runtime call sites can instantiate
+7. Make generated code executable in the replay namespace. Use the literal helpers in
+   this module for persisted values and make sure code assigns the ``derived`` replay
+   variable; the replay graph may rebase ``data`` and ``derived`` to internal names.
+
+8. Export the operation class from this module so runtime call sites can instantiate
    it directly.
 
-8. Add tests that cover round-trip validation, :meth:`apply`, and derivation text/code,
-   plus any save/load path that persists the new operation.
+9. Add tests that cover round-trip validation, :meth:`apply`, derivation text/code,
+   console matching when supported, and any save/load or reload path that persists the
+   new operation.
 
 Parsing of serialized payloads happens only through :func:`parse_tool_provenance_spec`
 and :func:`parse_tool_provenance_operation`. Runtime authoring code should create specs
-with :func:`full_data`, :func:`public_data`, or :func:`selection`, then instantiate
-operation models from this module directly.
+with :func:`full_data`, :func:`public_data`, :func:`selection`, :func:`file_load`, or
+:func:`script`, then instantiate operation models from this module directly.
 """
 
 from __future__ import annotations
@@ -131,7 +153,9 @@ import ast
 import base64
 import contextlib
 import importlib
+import inspect
 import keyword
+import math
 import pathlib
 import typing
 from collections.abc import Callable, Hashable, Mapping, Sequence
@@ -182,7 +206,6 @@ _SCRIPT_REPLAY_FORBIDDEN_NODES = (
     ast.ClassDef,
     ast.Delete,
     ast.For,
-    ast.FunctionDef,
     ast.Global,
     ast.Import,
     ast.ImportFrom,
@@ -314,6 +337,57 @@ def decode_provenance_value(value: typing.Any) -> typing.Any:
     return erlab.utils.misc._convert_to_native(value)
 
 
+def _provenance_value_code(value: typing.Any) -> str:
+    value = erlab.utils.misc._convert_to_native(value)
+    if isinstance(value, np.ndarray):
+        return f"np.array({_provenance_value_code(value.tolist())})"
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "np.nan"
+        if math.isinf(value):
+            return "np.inf" if value > 0 else "-np.inf"
+        return repr(value)
+    if isinstance(value, complex):
+        return (
+            f"complex({_provenance_value_code(float(value.real))}, "
+            f"{_provenance_value_code(float(value.imag))})"
+        )
+    if value is None or isinstance(value, (bool, int, str, bytes)):
+        return repr(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_provenance_value_code(item) for item in value) + "]"
+    if isinstance(value, tuple):
+        suffix = "," if len(value) == 1 else ""
+        return (
+            "("
+            + ", ".join(_provenance_value_code(item) for item in value)
+            + suffix
+            + ")"
+        )
+    if isinstance(value, Mapping):
+        return (
+            "{"
+            + ", ".join(
+                f"{_provenance_value_code(key)}: {_provenance_value_code(item)}"
+                for key, item in value.items()
+            )
+            + "}"
+        )
+    raise TypeError(f"Cannot generate replay code for {type(value).__name__!r}")
+
+
+def _provenance_numeric_array_code(values: typing.Any) -> str:
+    values = np.asarray(values)
+    if (
+        values.ndim == 1
+        and np.issubdtype(values.dtype, np.number)
+        and not np.issubdtype(values.dtype, np.complexfloating)
+        and np.all(np.isfinite(values.astype(np.float64, copy=False)))
+    ):
+        return erlab.interactive.utils.format_1d_numeric_array_code(values)
+    return _provenance_value_code(values)
+
+
 def _normalize_provenance_hashable(value: typing.Any) -> Hashable:
     value = erlab.utils.misc._convert_to_native(value)
     if isinstance(value, tuple):
@@ -383,23 +457,65 @@ def _validate_active_name(value: typing.Any) -> str | None:
     return value
 
 
-def _statement_load_count(stmt: ast.stmt, target: str) -> int:
-    count = 0
-    for node in ast.walk(stmt):
-        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
-            count += node.id == target
-    return count
+class _CurrentScopeNameCounter(ast.NodeVisitor):
+    def __init__(
+        self,
+        target: str,
+        contexts: tuple[type[ast.expr_context], ...],
+        *,
+        count_definition_names: bool = True,
+    ) -> None:
+        self.target = target
+        self.contexts = contexts
+        self.count_definition_names = count_definition_names
+        self.count = 0
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if node.id == self.target and isinstance(node.ctx, self.contexts):
+            self.count += 1
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if self.count_definition_names and ast.Store in self.contexts:
+            self.count += node.name == self.target
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_argument_expressions(node.args)
+        if node.returns is not None:
+            self.visit(node.returns)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.visit_FunctionDef(typing.cast("ast.FunctionDef", node))
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_argument_expressions(node.args)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        if self.count_definition_names and ast.Store in self.contexts:
+            self.count += node.name == self.target
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword_arg in node.keywords:
+            self.visit(keyword_arg)
+
+    def _visit_argument_expressions(self, args: ast.arguments) -> None:
+        for default in args.defaults:
+            self.visit(default)
+        for default in args.kw_defaults:
+            if default is not None:
+                self.visit(default)
+        for arg in (
+            *args.posonlyargs,
+            *args.args,
+            *args.kwonlyargs,
+            *(arg for arg in (args.vararg, args.kwarg) if arg is not None),
+        ):
+            if arg.annotation is not None:
+                self.visit(arg.annotation)
 
 
-def _statement_store_count(stmt: ast.stmt, target: str) -> int:
-    count = 0
-    for node in ast.walk(stmt):
-        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
-            count += node.id == target
-    return count
-
-
-class _NameReplacer(ast.NodeTransformer):
+class _ScopedNameReplacer(ast.NodeTransformer):
     def __init__(self, target: str, replacement: ast.expr) -> None:
         self._target = target
         self._replacement = replacement
@@ -408,6 +524,75 @@ class _NameReplacer(ast.NodeTransformer):
         if isinstance(node.ctx, ast.Load) and node.id == self._target:
             return _clone_expr(self._replacement)
         return node
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        node.decorator_list = [
+            typing.cast("ast.expr", self.visit(decorator))
+            for decorator in node.decorator_list
+        ]
+        self._visit_argument_expressions(node.args)
+        if node.returns is not None:
+            node.returns = typing.cast("ast.expr", self.visit(node.returns))
+        return node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AST:
+        return self.visit_FunctionDef(typing.cast("ast.FunctionDef", node))
+
+    def visit_Lambda(self, node: ast.Lambda) -> ast.AST:
+        self._visit_argument_expressions(node.args)
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
+        node.decorator_list = [
+            typing.cast("ast.expr", self.visit(decorator))
+            for decorator in node.decorator_list
+        ]
+        node.bases = [typing.cast("ast.expr", self.visit(base)) for base in node.bases]
+        node.keywords = [
+            typing.cast("ast.keyword", self.visit(keyword_arg))
+            for keyword_arg in node.keywords
+        ]
+        return node
+
+    def _visit_argument_expressions(self, args: ast.arguments) -> None:
+        args.defaults = [
+            typing.cast("ast.expr", self.visit(default)) for default in args.defaults
+        ]
+        args.kw_defaults = [
+            None if default is None else typing.cast("ast.expr", self.visit(default))
+            for default in args.kw_defaults
+        ]
+        for arg in (
+            *args.posonlyargs,
+            *args.args,
+            *args.kwonlyargs,
+            *(arg for arg in (args.vararg, args.kwarg) if arg is not None),
+        ):
+            if arg.annotation is not None:
+                arg.annotation = typing.cast("ast.expr", self.visit(arg.annotation))
+
+
+def _statement_load_count(stmt: ast.stmt, target: str) -> int:
+    counter = _CurrentScopeNameCounter(target, (ast.Load,))
+    counter.visit(stmt)
+    return counter.count
+
+
+def _statement_store_count(
+    stmt: ast.stmt, target: str, *, count_definition_names: bool = False
+) -> int:
+    counter = _CurrentScopeNameCounter(
+        target,
+        (ast.Store, ast.Del),
+        count_definition_names=count_definition_names,
+    )
+    counter.visit(stmt)
+    return counter.count
+
+
+class _NameReplacer(_ScopedNameReplacer):
+    def __init__(self, target: str, replacement: ast.expr) -> None:
+        super().__init__(target, replacement)
 
 
 def _clone_expr(node: ast.expr) -> ast.expr:
@@ -427,6 +612,55 @@ class _IdentifierReplacer(ast.NodeTransformer):
         if replacement is None:
             return node
         return ast.copy_location(ast.Name(id=replacement, ctx=node.ctx), node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        node.decorator_list = [
+            typing.cast("ast.expr", self.visit(decorator))
+            for decorator in node.decorator_list
+        ]
+        _visit_argument_expressions_with_transformer(node.args, self)
+        if node.returns is not None:
+            node.returns = typing.cast("ast.expr", self.visit(node.returns))
+        return node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AST:
+        return self.visit_FunctionDef(typing.cast("ast.FunctionDef", node))
+
+    def visit_Lambda(self, node: ast.Lambda) -> ast.AST:
+        _visit_argument_expressions_with_transformer(node.args, self)
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
+        node.decorator_list = [
+            typing.cast("ast.expr", self.visit(decorator))
+            for decorator in node.decorator_list
+        ]
+        node.bases = [typing.cast("ast.expr", self.visit(base)) for base in node.bases]
+        node.keywords = [
+            typing.cast("ast.keyword", self.visit(keyword_arg))
+            for keyword_arg in node.keywords
+        ]
+        return node
+
+
+def _visit_argument_expressions_with_transformer(
+    args: ast.arguments, transformer: ast.NodeTransformer
+) -> None:
+    args.defaults = [
+        typing.cast("ast.expr", transformer.visit(default)) for default in args.defaults
+    ]
+    args.kw_defaults = [
+        None if default is None else typing.cast("ast.expr", transformer.visit(default))
+        for default in args.kw_defaults
+    ]
+    for arg in (
+        *args.posonlyargs,
+        *args.args,
+        *args.kwonlyargs,
+        *(arg for arg in (args.vararg, args.kwarg) if arg is not None),
+    ):
+        if arg.annotation is not None:
+            arg.annotation = typing.cast("ast.expr", transformer.visit(arg.annotation))
 
 
 def _replace_code_identifiers(code: str, replacements: Mapping[str, str]) -> str:
@@ -526,12 +760,7 @@ def _code_uses_name(code: str, name: str) -> bool:
         module = ast.parse(code, mode="exec")
     except SyntaxError:
         return False
-    return any(
-        isinstance(node, ast.Name)
-        and isinstance(node.ctx, ast.Load)
-        and node.id == name
-        for node in ast.walk(module)
-    )
+    return any(_statement_load_count(stmt, name) > 0 for stmt in module.body)
 
 
 def rebase_default_replay_input(code: str, input_name: str) -> str:
@@ -565,22 +794,232 @@ def uses_default_replay_input(code: str) -> bool:
 _OPERATION_TYPES: dict[str, type[ToolProvenanceOperation]] = {}
 
 
+def _callable_paths(func: Callable[..., typing.Any]) -> set[str]:
+    paths: set[str] = set()
+    for value in (func, inspect.unwrap(func)):
+        module = getattr(value, "__module__", None)
+        if not isinstance(module, str):
+            continue
+        for attr in ("__qualname__", "__name__"):
+            name = getattr(value, attr, None)
+            if isinstance(name, str):
+                paths.add(f"{module}.{name}")
+    return paths
+
+
+class ConsoleCall:
+    """Normalized runtime call observed by the ImageTool manager console.
+
+    Console proxies create this descriptor after unwrapping provenance-aware tool
+    handles to raw :class:`xarray.DataArray` arguments. Operation classes inspect the
+    invoked callable, DataArray method/accessor context, and raw arguments to decide
+    whether the call can be represented as structured provenance.
+    """
+
+    __slots__ = (
+        "accessor_path",
+        "args",
+        "dataarray_method",
+        "display_code",
+        "func",
+        "has_extra_tracked_inputs",
+        "kwargs",
+        "receiver_data",
+    )
+
+    def __init__(
+        self,
+        *,
+        func: Callable[..., typing.Any] | None = None,
+        dataarray_method: str | None = None,
+        accessor_path: Sequence[str] = (),
+        args: Sequence[typing.Any] = (),
+        kwargs: Mapping[str, typing.Any] | None = None,
+        display_code: str,
+        has_extra_tracked_inputs: bool,
+        receiver_data: xr.DataArray | None = None,
+    ) -> None:
+        self.func = func
+        self.dataarray_method = dataarray_method
+        self.accessor_path = tuple(accessor_path)
+        self.args = tuple(args)
+        self.kwargs = dict(kwargs or {})
+        self.display_code = display_code
+        self.has_extra_tracked_inputs = has_extra_tracked_inputs
+        self.receiver_data = receiver_data
+
+
+class ConsoleOperationPattern:
+    """Declarative matcher for direct console-to-operation mappings.
+
+    Use this for calls where public arguments map directly onto operation model
+    fields. Store module-function targets as strings so importing this module does not
+    resolve lazy ERLab analysis modules; the matcher compares those strings with the
+    callable that the console actually invoked. More complex calls should implement
+    :meth:`ToolProvenanceOperation.from_console_call`.
+    """
+
+    __slots__ = (
+        "accessor_path",
+        "dataarray_method",
+        "defaults",
+        "field_aliases",
+        "fields",
+        "ignored_defaults",
+        "kwargs_field",
+        "mapping_kwargs",
+        "targets",
+    )
+
+    def __init__(
+        self,
+        *,
+        target: Callable[..., typing.Any] | str | None = None,
+        dataarray_method: str | None = None,
+        accessor_path: Sequence[str] = (),
+        fields: Sequence[str] = (),
+        field_aliases: Mapping[str, str] | None = None,
+        kwargs_field: str | None = None,
+        mapping_kwarg: str | Sequence[str] | None = None,
+        defaults: Mapping[str, typing.Any] | None = None,
+        ignored_defaults: Mapping[str, typing.Any] | None = None,
+    ) -> None:
+        self.targets = () if target is None else (target,)
+        self.dataarray_method = dataarray_method
+        self.accessor_path = tuple(accessor_path)
+        self.fields = tuple(fields)
+        self.field_aliases = dict(field_aliases or {})
+        self.kwargs_field = kwargs_field
+        mapping_kwargs: tuple[str, ...]
+        if isinstance(mapping_kwarg, str):
+            mapping_kwargs = (mapping_kwarg,)
+        else:
+            mapping_kwargs = tuple(mapping_kwarg or ())
+        self.mapping_kwargs = mapping_kwargs
+        self.defaults = dict(defaults or {})
+        self.ignored_defaults = dict(ignored_defaults or {})
+
+    def match(self, call: ConsoleCall) -> dict[str, typing.Any] | None:
+        if call.has_extra_tracked_inputs:
+            return None
+        if self.targets:
+            if call.func is None:
+                return None
+            call_paths = _callable_paths(call.func)
+            if not any(
+                target in call_paths
+                if isinstance(target, str)
+                else inspect.unwrap(call.func) is inspect.unwrap(target)
+                for target in self.targets
+            ):
+                return None
+        if self.dataarray_method is not None:
+            if call.dataarray_method != self.dataarray_method:
+                return None
+        elif call.dataarray_method is not None:
+            return None
+        if self.accessor_path != call.accessor_path:
+            return None
+
+        kwargs = dict(call.kwargs)
+        for public_name, field_name in self.field_aliases.items():
+            if public_name not in kwargs:
+                continue
+            if field_name in kwargs:
+                return None
+            kwargs[field_name] = kwargs.pop(public_name)
+        for key, default in self.ignored_defaults.items():
+            if key not in kwargs:
+                continue
+            if not _console_values_equal(kwargs[key], default):
+                return None
+            kwargs.pop(key)
+
+        if self.kwargs_field is not None:
+            mapped = _console_mapping_values(
+                call.args, kwargs, mapping_kwargs=self.mapping_kwargs
+            )
+            if mapped is None:
+                return None
+            return {self.kwargs_field: mapped}
+
+        if len(call.args) > len(self.fields):
+            return None
+        values: dict[str, typing.Any] = dict(zip(self.fields, call.args, strict=False))
+        for field in self.fields[len(call.args) :]:
+            if field in kwargs:
+                values[field] = kwargs.pop(field)
+            elif field in self.defaults:
+                values[field] = self.defaults[field]
+            else:
+                return None
+        for key, value in kwargs.items():
+            if key not in self.defaults:
+                return None
+            values[key] = value
+        for key, value in self.defaults.items():
+            values.setdefault(key, value)
+        return values
+
+
+def _console_values_equal(value: typing.Any, default: typing.Any) -> bool:
+    if (
+        isinstance(value, float)
+        and isinstance(default, float)
+        and np.isnan(value)
+        and np.isnan(default)
+    ):
+        return True
+    return value == default
+
+
+def _console_mapping_values(
+    args: Sequence[typing.Any],
+    kwargs: Mapping[str, typing.Any],
+    *,
+    mapping_kwargs: Sequence[str] = (),
+) -> dict[typing.Any, typing.Any] | None:
+    if len(args) > 1:
+        return None
+    mapped: dict[typing.Any, typing.Any] = {}
+    remaining = dict(kwargs)
+    if args:
+        if args[0] is None:
+            pass
+        elif not isinstance(args[0], Mapping):
+            return None
+        else:
+            mapped.update(args[0])
+    for mapping_kwarg in mapping_kwargs:
+        if mapping_kwarg not in remaining:
+            continue
+        value = remaining.pop(mapping_kwarg)
+        if value is None:
+            continue
+        if not isinstance(value, Mapping):
+            return None
+        mapped.update(value)
+    mapped.update(remaining)
+    return mapped
+
+
 class ToolProvenanceOperation(pydantic.BaseModel):
-    """Base class for operations stored in :class:`ToolProvenanceSpec`.
+    """Base class for typed operations stored in :class:`ToolProvenanceSpec`.
 
     New operations should keep runtime fields in their decoded Python form, prefer the
     annotated provenance field aliases in this module for lossless JSON serialization,
     implement :meth:`apply` to replay the transformation, and implement
     :meth:`derivation_entry` to describe the step in manager UI.
 
-    Operation instances store the exact arguments used by replay, copied code, and
-    derivation display. For ImageTool cursor or bin children that refresh after parent
-    coordinate edits, store the selected indices in
-    :class:`ImageToolSelectionSourceBinding` and rebuild ``qsel`` operations before
-    applying the spec.
+    Operation instances store the exact arguments used by live refresh, replay graph
+    execution, copied code, and derivation display. If a public console call maps
+    exactly to an operation, expose it with ``console_patterns`` or
+    :meth:`from_console_call`; ambiguous calls should return ``None`` so script
+    provenance records the original code instead.
     """
 
     live_applicable: typing.ClassVar[bool] = True
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = ()
 
     model_config = pydantic.ConfigDict(
         frozen=True,
@@ -683,24 +1122,58 @@ class ToolProvenanceOperation(pydantic.BaseModel):
         """
         raise NotImplementedError
 
-    def derivation_entry(self) -> DerivationEntry | None:
+    def derivation_entry(self) -> DerivationEntry:
         """Return the user-visible derivation entry for this operation.
 
-        Return a :class:`DerivationEntry` when the operation should appear in derivation
-        listings and contribute code to :meth:`ToolProvenanceSpec.derivation_code` or
-        :meth:`ToolProvenanceSpec.display_code`.
-
-        Return ``None`` only for replayed operations that should stay hidden from the
-        derivation UI and copied provenance code. Hidden operations are still kept in
-        the spec and still run through :meth:`apply`; they are simply omitted from the
-        rendered derivation list. In the current implementation this is used for
-        internal bookkeeping steps such as a final rename.
+        Every concrete operation returns a :class:`DerivationEntry` so the manager can
+        display it and copied provenance code has a single replay contract.
 
         Use ``DerivationEntry(..., code=None)`` instead when the step should remain
         visible in the derivation list but code generation should stop and return
         ``None``.
         """
         raise NotImplementedError
+
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        for pattern in cls.console_patterns:
+            values = pattern.match(call)
+            if values is None:
+                continue
+            with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+                return cls(**values)
+        return None
+
+
+def operation_from_console_call(call: ConsoleCall) -> ToolProvenanceOperation | None:
+    """Return the structured operation represented by a console call, if known."""
+    for operation_type in _OPERATION_TYPES.values():
+        operation = operation_type.from_console_call(call)
+        if operation is not None:
+            return operation
+    return None
+
+
+def _single_assign_coord(call: ConsoleCall) -> tuple[typing.Any, typing.Any] | None:
+    if (
+        call.has_extra_tracked_inputs
+        or call.dataarray_method != "assign_coords"
+        or call.accessor_path
+        or len(call.args) > 1
+    ):
+        return None
+    coords = _console_mapping_values(call.args, call.kwargs, mapping_kwargs=("coords",))
+    if coords is None:
+        return None
+    if len(coords) != 1:
+        return None
+    return next(iter(coords.items()))
+
+
+def _scalar_coord_value(value: typing.Any) -> bool:
+    encoded = encode_provenance_value(value)
+    decoded = decode_provenance_value(encoded)
+    return not isinstance(decoded, (Mapping, Sequence)) or isinstance(decoded, str)
 
 
 def _coerce_nullable_hashable_tuple_field(
@@ -940,7 +1413,7 @@ class ReplayStage(pydantic.BaseModel):
 
 
 class FileLoadSource(pydantic.BaseModel):
-    """Serializable file origin used by replay-only ImageTool provenance."""
+    """Serializable file origin used by saved file-backed provenance."""
 
     path: str
     loader_label: str
@@ -962,7 +1435,13 @@ class FileLoadSource(pydantic.BaseModel):
 
 
 class ScriptInput(pydantic.BaseModel):
-    """One named input used by replay-only script provenance."""
+    """Named input captured by script or multi-tool provenance.
+
+    ``name`` is the immutable replay variable, ``label`` is the historical display
+    label, ``node_uid`` and ``node_snapshot_token`` identify the live manager input
+    that was used, and ``provenance_spec`` stores the historical replay source used
+    when that live input is unavailable.
+    """
 
     name: str
     label: str
@@ -1030,16 +1509,19 @@ class ScriptInput(pydantic.BaseModel):
 
 
 class ToolProvenanceSpec(pydantic.BaseModel):
-    """Immutable provenance recipe for rebuilding tool data from a parent ImageTool.
+    """Saved provenance recipe for ImageTool data.
 
-    Author new specs with :func:`full_data`, :func:`public_data`, or :func:`selection`
-    plus concrete operation instances from this module. Deserialize saved payloads
-    with :func:`parse_tool_provenance_spec`.
+    Live child-tool refresh uses single-parent specs from :func:`full_data`,
+    :func:`public_data`, or :func:`selection`. Durable reload and copied code use
+    ``file`` and ``script`` specs, including multi-input ``script_inputs`` for console
+    or UI actions that combine several ImageTools. Deserialize saved payloads with
+    :func:`parse_tool_provenance_spec`.
 
-    A spec records the exact operation arguments used for replay, copied code, and
-    derivation display. Manager children opened from ImageTool cursor or bin selections
-    should keep :class:`ImageToolSelectionSourceBinding` as their refresh state; that
-    binding builds a spec before refresh so edited parent coordinates are used.
+    A spec records exact operation arguments for live refresh, runtime replay, copied
+    code, and derivation display. Manager children opened from ImageTool cursor or bin
+    selections should keep :class:`ImageToolSelectionSourceBinding` as their refresh
+    state; that binding builds a spec before refresh so edited parent coordinates are
+    used.
 
     .. versionchanged:: 3.23.0
        Script provenance can describe multiple manager inputs and records manager
@@ -1312,13 +1794,13 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         )
 
     def to_replay_spec(self) -> ToolProvenanceSpec:
-        """Normalize the spec into a replay-only script form.
+        """Return the durable replay form for this spec.
 
         Replay specs are the canonical, composable form used for derivation metadata,
-        copy-code, save/load, and manager dependencies. Structured file provenance
-        remains structured so runtime reloads can replay typed operations without
-        ``exec``.
-        Live updates from ImageTool use the original non-script spec via
+        copied code, workspace save/load, and manager dependency status. Structured
+        file provenance remains structured so runtime reloads can replay typed
+        operations without ``exec``. Live ImageTool refresh uses the original
+        single-parent spec via
         :func:`require_live_source_spec`.
         """
         if self.kind in {"script", "file"}:
@@ -1376,40 +1858,41 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             operations = self.operations
         for operation in operations:
             entry = operation.derivation_entry()
-            if entry is not None:
-                entries.append(entry)
+            entries.append(entry)
         return entries
 
-    def _script_inputs_code(self, *, display: bool) -> str | None:
+    def _script_graph_code(self, *, display: bool) -> str | None:
         if not self.script_inputs:
             return None
 
         try:
-            return _replay_graph.script_inputs_code(self.script_inputs, display=display)
+            graph = _replay_graph.compile_replay_graph(self, display=display)
+            return _replay_graph.emit_replay_code(
+                graph,
+                output_name=typing.cast("str", self.active_name),
+            )
         except _replay_graph.ReplayGraphError:
             return None
+
+    def _code_lines_from_entries(
+        self, entries: Sequence[DerivationEntry]
+    ) -> list[str] | None:
+        codes = []
+        for entry in entries:
+            if entry.code is None:
+                return None
+            codes.append(entry.code)
+        return codes
 
     def derivation_code(self) -> str | None:
         prefix: str | None = None
         if self.kind == "script" and self.script_inputs:
-            input_code = self._script_inputs_code(display=False)
-            if input_code is None:
-                return None
-            prefix = "\n".join(part for part in (input_code, self.seed_code) if part)
-        elif self.kind in {"script", "file"}:
+            return self._script_graph_code(display=False)
+        if self.kind in {"script", "file"}:
             prefix = self.seed_code
-        step_codes: list[str] = []
-        code_entries = self.derivation_entries()[1:]
-        if self.kind == "script" and self.script_inputs:
-            code_entries = [
-                entry
-                for operation in self.operations
-                if (entry := operation.derivation_entry()) is not None
-            ]
-        for entry in code_entries:
-            if entry.code is None:
-                return None
-            step_codes.append(entry.code)
+        step_codes = self._code_lines_from_entries(self.derivation_entries()[1:])
+        if step_codes is None:
+            return None
         if prefix is None and self.kind != "script":
             if not step_codes:
                 return None
@@ -1451,8 +1934,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                     parent_data=current_data,
                 ):
                     operation_entry = operation.derivation_entry()
-                    if operation_entry is not None:
-                        entries.append(operation_entry)
+                    entries.append(operation_entry)
                 if current_data is not None:
                     try:
                         current_data = _apply_replay_stage(stage, current_data)
@@ -1460,10 +1942,10 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                         current_data = None
             return entries
 
-        for operation in self._display_operations(parent_data=parent_data):
-            e = operation.derivation_entry()
-            if e is not None:
-                entries.append(e)
+        entries.extend(
+            operation.derivation_entry()
+            for operation in self._display_operations(parent_data=parent_data)
+        )
         return entries
 
     def display_code(self, *, parent_data: xr.DataArray | None = None) -> str | None:
@@ -1474,25 +1956,15 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         """
         prefix: str | None = None
         if self.kind == "script" and self.script_inputs:
-            input_code = self._script_inputs_code(display=True)
-            if input_code is None:
-                return None
-            prefix = "\n".join(part for part in (input_code, self.seed_code) if part)
-        elif self.kind in {"script", "file"}:
+            return self._script_graph_code(display=True)
+        if self.kind in {"script", "file"}:
             prefix = self.seed_code
 
-        step_codes: list[str] = []
-        code_entries = self.display_entries(parent_data=parent_data)[1:]
-        if self.kind == "script" and self.script_inputs:
-            code_entries = [
-                entry
-                for operation in self.operations
-                if (entry := operation.derivation_entry()) is not None
-            ]
-        for entry in code_entries:
-            if entry.code is None:
-                return None
-            step_codes.append(entry.code)
+        step_codes = self._code_lines_from_entries(
+            self.display_entries(parent_data=parent_data)[1:]
+        )
+        if step_codes is None:
+            return None
 
         if prefix is None and self.kind != "script":
             if not step_codes:
@@ -1991,7 +2463,7 @@ def script(
     file_load_source: FileLoadSource | None = None,
     script_inputs: Sequence[ScriptInput] = (),
 ) -> ToolProvenanceSpec:
-    """Build a replay-only provenance spec for generated code."""
+    """Build script provenance from code, structured steps, and named inputs."""
     return ToolProvenanceSpec(
         kind="script",
         start_label=start_label,
@@ -2160,7 +2632,11 @@ def _validate_script_replay_code(code: str) -> None:
 def script_provenance_replayable(
     spec: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
 ) -> bool:
-    """Return whether script provenance can be replayed from resolved inputs."""
+    """Return whether script provenance is self-contained enough to execute.
+
+    This checks the saved code and structured operations. It does not mean live
+    manager inputs are present; callers still need to resolve ``script_inputs``.
+    """
     return _replay_graph.script_provenance_replayable(spec)
 
 
@@ -2168,7 +2644,12 @@ def replay_script_provenance(
     spec: ToolProvenanceSpec | Mapping[str, typing.Any],
     inputs: Mapping[str, xr.DataArray],
 ) -> xr.DataArray:
-    """Execute trusted script provenance from already resolved input arrays."""
+    """Execute script provenance from already resolved input arrays.
+
+    The caller is responsible for trust and input resolution. This function only
+    validates the provenance shape, compiles it through the replay graph, and returns
+    the replayed :class:`xarray.DataArray`.
+    """
     try:
         return _replay_graph.replay_script_provenance(spec, inputs)
     except _replay_graph.ReplayGraphError as exc:
@@ -2196,6 +2677,13 @@ class ScriptCodeOperation(ToolProvenanceOperation):
 
 class QSelOperation(ToolProvenanceOperation):
     op: typing.Literal["qsel"] = "qsel"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            accessor_path=("qsel",),
+            kwargs_field="kwargs",
+            mapping_kwarg="indexers",
+        ),
+    )
     kwargs: ProvenanceMapping = pydantic.Field(default_factory=dict)
 
     @property
@@ -2216,6 +2704,14 @@ class QSelOperation(ToolProvenanceOperation):
 
 class IselOperation(ToolProvenanceOperation):
     op: typing.Literal["isel"] = "isel"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            dataarray_method="isel",
+            kwargs_field="kwargs",
+            mapping_kwarg="indexers",
+            ignored_defaults={"drop": False, "missing_dims": "raise"},
+        ),
+    )
     kwargs: ProvenanceMapping = pydantic.Field(default_factory=dict)
 
     @property
@@ -2236,6 +2732,14 @@ class IselOperation(ToolProvenanceOperation):
 
 class SelOperation(ToolProvenanceOperation):
     op: typing.Literal["sel"] = "sel"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            dataarray_method="sel",
+            kwargs_field="kwargs",
+            mapping_kwarg="indexers",
+            ignored_defaults={"method": None, "tolerance": None, "drop": False},
+        ),
+    )
     kwargs: ProvenanceMapping = pydantic.Field(default_factory=dict)
 
     @property
@@ -2289,6 +2793,27 @@ class TransposeOperation(ToolProvenanceOperation):
     op: typing.Literal["transpose"] = "transpose"
     dims: NullableProvenanceHashableTuple = None
 
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method != "transpose"
+            or call.accessor_path
+        ):
+            return None
+        kwargs = dict(call.kwargs)
+        for key, default in {"transpose_coords": True, "missing_dims": "raise"}.items():
+            if key not in kwargs:
+                continue
+            if not _console_values_equal(kwargs[key], default):
+                return None
+            kwargs.pop(key)
+        if kwargs:
+            return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(dims=tuple(call.args) or None)
+        return None
+
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         if self.dims:
             return data.transpose(*self.dims)
@@ -2313,6 +2838,24 @@ class TransposeOperation(ToolProvenanceOperation):
 class SqueezeOperation(ToolProvenanceOperation):
     op: typing.Literal["squeeze"] = "squeeze"
 
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method != "squeeze"
+            or call.accessor_path
+            or call.args
+        ):
+            return None
+        for key, default in {"dim": None, "axis": None, "drop": False}.items():
+            if key not in call.kwargs:
+                continue
+            if not _console_values_equal(call.kwargs[key], default):
+                return None
+        if set(call.kwargs).difference({"dim", "axis", "drop"}):
+            return None
+        return cls()
+
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.squeeze()
 
@@ -2324,11 +2867,31 @@ class RenameOperation(ToolProvenanceOperation):
     op: typing.Literal["rename"] = "rename"
     name: str
 
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method != "rename"
+            or call.accessor_path
+            or call.kwargs
+            or len(call.args) != 1
+            or isinstance(call.args[0], Mapping)
+        ):
+            return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(name=call.args[0])
+        return None
+
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.rename(self.name)
 
-    def derivation_entry(self) -> None:
-        return None
+    def derivation_entry(self) -> DerivationEntry:
+        name_code = erlab.interactive.utils._parse_single_arg(self.name)
+        return DerivationEntry(
+            f"rename({_format_derivation_value(self.name)})",
+            f"derived = derived.rename({name_code})",
+            True,
+        )
 
 
 class RestoreNonuniformDimsOperation(ToolProvenanceOperation):
@@ -2348,6 +2911,19 @@ class RestoreNonuniformDimsOperation(ToolProvenanceOperation):
 
 class RotateOperation(ToolProvenanceOperation):
     op: typing.Literal["rotate"] = "rotate"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            target="erlab.analysis.transform.rotate",
+            fields=("angle", "axes", "center"),
+            defaults={
+                "axes": (0, 1),
+                "center": (0.0, 0.0),
+                "reshape": True,
+                "order": 1,
+            },
+            ignored_defaults={"mode": "constant", "cval": np.nan, "prefilter": True},
+        ),
+    )
     angle: float
     axes: ProvenanceHashablePair
     center: tuple[float, float]
@@ -2404,6 +2980,29 @@ class AverageOperation(ToolProvenanceOperation):
     op: typing.Literal["average"] = "average"
     dims: ProvenanceHashableTuple
 
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method is not None
+            or call.accessor_path != ("qsel", "average")
+            or len(call.args) > 1
+        ):
+            return None
+        kwargs = dict(call.kwargs)
+        if call.args:
+            if "dim" in kwargs:
+                return None
+            dim = call.args[0]
+        else:
+            dim = kwargs.pop("dim", None)
+        if kwargs or dim is None:
+            return None
+        dims = (dim,) if isinstance(dim, str) or not isinstance(dim, Sequence) else dim
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(dims=typing.cast("tuple[Hashable, ...]", dims))
+        return None
+
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.qsel.mean(self.dims)
 
@@ -2421,6 +3020,36 @@ class QSelAggregationOperation(ToolProvenanceOperation):
     op: typing.Literal["qsel_aggregate"] = "qsel_aggregate"
     dims: ProvenanceHashableTuple
     func: typing.Literal["mean", "min", "max", "sum"] = "mean"
+
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        func = call.accessor_path[1] if len(call.accessor_path) == 2 else None
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method is not None
+            or len(call.accessor_path) != 2
+            or call.accessor_path[0] != "qsel"
+            or func not in {"mean", "min", "max", "sum"}
+            or len(call.args) > 1
+        ):
+            return None
+        kwargs = dict(call.kwargs)
+        if call.args:
+            if "dim" in kwargs:
+                return None
+            dim = call.args[0]
+        else:
+            dim = kwargs.pop("dim", None)
+        if kwargs or dim is None:
+            return None
+        dims = (dim,) if isinstance(dim, str) or not isinstance(dim, Sequence) else dim
+        func = typing.cast("typing.Literal['mean', 'min', 'max', 'sum']", func)
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(
+                dims=typing.cast("tuple[Hashable, ...]", dims),
+                func=func,
+            )
+        return None
 
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return typing.cast("xr.DataArray", getattr(data.qsel, self.func)(self.dims))
@@ -2440,6 +3069,36 @@ class InterpolationOperation(ToolProvenanceOperation):
     dim: ProvenanceHashable
     values: typing.Any
     method: typing.Literal["linear", "nearest"] = "linear"
+
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method != "interp"
+            or call.accessor_path
+        ):
+            return None
+        kwargs = dict(call.kwargs)
+        method = kwargs.pop("method", "linear")
+        if method not in {"linear", "nearest"}:
+            return None
+        for key, default in {"assume_sorted": False, "kwargs": None}.items():
+            if key not in kwargs:
+                continue
+            if not _console_values_equal(kwargs[key], default):
+                return None
+            kwargs.pop(key)
+        coords = _console_mapping_values(call.args, kwargs, mapping_kwargs=("coords",))
+        if coords is None:
+            return None
+        if len(coords) != 1:
+            return None
+        ((dim, values),) = coords.items()
+        if not isinstance(dim, Hashable):
+            return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(dim=dim, values=values, method=method)
+        return None
 
     @pydantic.field_validator("values", mode="before")
     @classmethod
@@ -2501,6 +3160,17 @@ class InterpolationOperation(ToolProvenanceOperation):
 
 class LeadingEdgeOperation(ToolProvenanceOperation):
     op: typing.Literal["leading_edge"] = "leading_edge"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            target="erlab.analysis.interpolate.leading_edge",
+            fields=("fraction", "dim", "direction"),
+            defaults={
+                "fraction": 0.5,
+                "dim": "eV",
+                "direction": "positive",
+            },
+        ),
+    )
     fraction: float = pydantic.Field(default=0.5, gt=0.0, le=1.0)
     dim: ProvenanceHashable = "eV"
     direction: typing.Literal["positive", "negative"] = "positive"
@@ -2576,6 +3246,45 @@ class CoarsenOperation(ToolProvenanceOperation):
     coord_func: str
     reducer: str
 
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method != "coarsen"
+            or call.accessor_path
+            or len(call.args) > 1
+        ):
+            return None
+        kwargs = dict(call.kwargs)
+        reducer = kwargs.pop("_reducer", None)
+        if not isinstance(reducer, str):
+            return None
+        dim: dict[typing.Any, typing.Any] = {}
+        if call.args:
+            if not isinstance(call.args[0], Mapping):
+                return None
+            dim.update(call.args[0])
+        dim.update(kwargs.pop("dim", {}) or {})
+        dim.update(
+            {
+                key: kwargs.pop(key)
+                for key in list(kwargs)
+                if key not in {"boundary", "side", "coord_func"}
+            }
+        )
+        values = {
+            "dim": dim,
+            "boundary": kwargs.pop("boundary", "exact"),
+            "side": kwargs.pop("side", "left"),
+            "coord_func": kwargs.pop("coord_func", "mean"),
+            "reducer": reducer,
+        }
+        if kwargs:
+            return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(**values)
+        return None
+
     @property
     def coarsen_kwargs(self) -> dict[str, typing.Any]:
         return {
@@ -2619,6 +3328,36 @@ class ThinOperation(ToolProvenanceOperation):
     factor: int | None = None
     factors: ProvenanceIntMapping = pydantic.Field(default_factory=dict)
 
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method != "thin"
+            or call.accessor_path
+        ):
+            return None
+        if (
+            len(call.args) == 1
+            and not call.kwargs
+            and not isinstance(call.args[0], Mapping)
+        ):
+            with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+                return cls(mode="global", factor=call.args[0])
+            return None
+        if len(call.args) > 1:
+            return None
+        factors: typing.Any = dict(call.kwargs)
+        if call.args:
+            if call.args[0] is None:
+                pass
+            elif isinstance(call.args[0], Mapping):
+                factors = {**call.args[0], **factors}
+            else:
+                return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(mode="per_dim", factors=factors)
+        return None
+
     @pydantic.model_validator(mode="after")
     def _check_mode(self) -> typing.Self:
         if self.mode == "global" and self.factor is None:
@@ -2655,6 +3394,19 @@ class ThinOperation(ToolProvenanceOperation):
 
 class SymmetrizeOperation(ToolProvenanceOperation):
     op: typing.Literal["symmetrize"] = "symmetrize"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            target="erlab.analysis.transform.symmetrize",
+            fields=("dim",),
+            defaults={
+                "center": 0.0,
+                "subtract": False,
+                "mode": "full",
+                "part": "both",
+            },
+            ignored_defaults={"interp_kw": None},
+        ),
+    )
     dim: ProvenanceHashable
     center: float
     subtract: bool = False
@@ -2691,11 +3443,38 @@ class SymmetrizeOperation(ToolProvenanceOperation):
 
 class SymmetrizeNfoldOperation(ToolProvenanceOperation):
     op: typing.Literal["symmetrize_nfold"] = "symmetrize_nfold"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            target="erlab.analysis.transform.symmetrize_nfold",
+            fields=("fold", "axes", "center"),
+            defaults={
+                "axes": (0, 1),
+                "center": (0.0, 0.0),
+                "reshape": True,
+                "order": 1,
+            },
+            ignored_defaults={"mode": "constant", "cval": np.nan, "prefilter": True},
+        ),
+    )
     fold: int
     axes: ProvenanceHashablePair
-    center: ProvenanceFloatMapping = pydantic.Field(default_factory=dict)
+    center: typing.Any = (0.0, 0.0)
     reshape: bool = True
     order: int = 1
+
+    @pydantic.field_validator("center", mode="before")
+    @classmethod
+    def _validate_center(cls, value: typing.Any) -> typing.Any:
+        decoded = decode_provenance_value(value)
+        if isinstance(decoded, Mapping):
+            return _coerce_float_mapping_field(decoded)
+        return _ensure_float_tuple(
+            typing.cast("Sequence[typing.Any]", decoded), expected_len=2
+        )
+
+    @pydantic.field_serializer("center", when_used="json")
+    def _serialize_center(self, value: typing.Any) -> typing.Any:
+        return encode_provenance_value(value)
 
     @property
     def kwargs(self) -> dict[str, typing.Any]:
@@ -2727,6 +3506,14 @@ class SymmetrizeNfoldOperation(ToolProvenanceOperation):
 
 class CorrectWithEdgeOperation(ToolProvenanceOperation):
     op: typing.Literal["correct_with_edge"] = "correct_with_edge"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            target="erlab.analysis.gold.correct_with_edge",
+            fields=("edge_fit",),
+            field_aliases={"modelresult": "edge_fit"},
+            defaults={"shift_coords": True},
+        ),
+    )
     edge_fit: typing.Any
     shift_coords: bool = True
 
@@ -2762,15 +3549,35 @@ class CorrectWithEdgeOperation(ToolProvenanceOperation):
             "edge_fit": self.edge_fit,
             "shift_coords": self.shift_coords,
         }
+        edge_fit_code = _provenance_value_code(self.edge_fit)
+        edge_fit_expr = (
+            "erlab.interactive.imagetool.provenance.decode_provenance_value("
+            f"{edge_fit_code})"
+        )
+        code = erlab.interactive.utils.generate_code(
+            erlab.analysis.gold.correct_with_edge,
+            ["|derived|", f"|{edge_fit_expr}|"],
+            {"shift_coords": self.shift_coords},
+            module="era.gold",
+            name="correct_with_edge",
+            assign="derived",
+        )
         return DerivationEntry(
             f"Edge Correction({_format_derivation_value(label_kwargs)})",
-            None,
-            False,
+            code,
+            True,
         )
 
 
 class SwapDimsOperation(ToolProvenanceOperation):
     op: typing.Literal["swap_dims"] = "swap_dims"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            dataarray_method="swap_dims",
+            kwargs_field="mapping",
+            mapping_kwarg="dims_dict",
+        ),
+    )
     mapping: ProvenanceHashableMapping = pydantic.Field(default_factory=dict)
 
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
@@ -2788,6 +3595,26 @@ class SwapDimsOperation(ToolProvenanceOperation):
 class RenameDimsCoordsOperation(ToolProvenanceOperation):
     op: typing.Literal["rename_dims_coords"] = "rename_dims_coords"
     mapping: ProvenanceHashableMapping = pydantic.Field(default_factory=dict)
+
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method != "rename"
+            or call.accessor_path
+            or len(call.args) > 1
+        ):
+            return None
+        mapping = _console_mapping_values(
+            call.args, call.kwargs, mapping_kwargs=("new_name_or_name_dict",)
+        )
+        if mapping is None:
+            return None
+        if not mapping:
+            return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(mapping=mapping)
+        return None
 
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.rename(self.mapping)
@@ -2847,6 +3674,30 @@ class AssignCoordsOperation(ToolProvenanceOperation):
     coord_name: str
     values: typing.Any
 
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        coord = _single_assign_coord(call)
+        if coord is None or call.receiver_data is None:
+            return None
+        coord_name, values = coord
+        if (
+            not isinstance(coord_name, str)
+            or coord_name not in call.receiver_data.coords
+        ):
+            return None
+        if (
+            isinstance(values, Sequence)
+            and not isinstance(values, str)
+            and len(values) == 2
+            and isinstance(values[0], Hashable)
+        ):
+            return None
+        if _scalar_coord_value(values):
+            return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(coord_name=coord_name, values=values)
+        return None
+
     @pydantic.field_validator("values", mode="before")
     @classmethod
     def _validate_values(cls, value: typing.Any) -> typing.Any:
@@ -2875,7 +3726,7 @@ class AssignCoordsOperation(ToolProvenanceOperation):
     def derivation_entry(self) -> DerivationEntry:
         coord_name_code = repr(self.coord_name)
         values = self.decoded_values
-        values_code = erlab.interactive.utils.format_1d_numeric_array_code(values)
+        values_code = _provenance_numeric_array_code(values)
         code = (
             f"derived = derived.assign_coords({{{coord_name_code}: "
             f"derived[{coord_name_code}].copy(data={values_code})}})"
@@ -2895,6 +3746,18 @@ class AssignScalarCoordOperation(ToolProvenanceOperation):
     op: typing.Literal["assign_scalar_coord"] = "assign_scalar_coord"
     coord_name: ProvenanceHashable
     value: typing.Any
+
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        coord = _single_assign_coord(call)
+        if coord is None:
+            return None
+        coord_name, value = coord
+        if not _scalar_coord_value(value):
+            return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(coord_name=coord_name, value=value)
+        return None
 
     @pydantic.field_validator("value", mode="before")
     @classmethod
@@ -2918,7 +3781,7 @@ class AssignScalarCoordOperation(ToolProvenanceOperation):
 
     def derivation_entry(self) -> DerivationEntry:
         coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
-        value_code = erlab.interactive.utils._parse_single_arg(self.decoded_value)
+        value_code = _provenance_value_code(self.decoded_value)
         code = f"derived = derived.assign_coords({{{coord_name_code}: {value_code}}})"
         label_kwargs = {
             "coord_name": self.coord_name,
@@ -2936,6 +3799,28 @@ class AssignCoord1DOperation(ToolProvenanceOperation):
     coord_name: ProvenanceHashable
     dim: ProvenanceHashable
     values: typing.Any
+
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        coord = _single_assign_coord(call)
+        if coord is None:
+            return None
+        coord_name, value = coord
+        if not isinstance(value, Sequence) or isinstance(value, str) or len(value) != 2:
+            return None
+        dim, values = value
+        if not isinstance(dim, Hashable) or (
+            isinstance(dim, Sequence) and not isinstance(dim, str)
+        ):
+            return None
+        try:
+            if np.asarray(values).ndim != 1:
+                return None
+        except (TypeError, ValueError):
+            return None
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(coord_name=coord_name, dim=dim, values=values)
+        return None
 
     @pydantic.field_validator("values", mode="before")
     @classmethod
@@ -2973,7 +3858,7 @@ class AssignCoord1DOperation(ToolProvenanceOperation):
     def derivation_entry(self) -> DerivationEntry:
         coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
         dim_code = erlab.interactive.utils._parse_single_arg(self.dim)
-        values_code = erlab.interactive.utils._parse_single_arg(self.decoded_values)
+        values_code = _provenance_numeric_array_code(self.decoded_values)
         code = (
             f"derived = derived.assign_coords({{{coord_name_code}: "
             f"({dim_code}, {values_code})}})"
@@ -2992,22 +3877,33 @@ class AssignCoord1DOperation(ToolProvenanceOperation):
 
 class AssignAttrsOperation(ToolProvenanceOperation):
     op: typing.Literal["assign_attrs"] = "assign_attrs"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(dataarray_method="assign_attrs", kwargs_field="attrs"),
+    )
     attrs: ProvenanceMapping = pydantic.Field(default_factory=dict)
 
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.assign_attrs(self.attrs)
 
     def derivation_entry(self) -> DerivationEntry:
-        kwargs = erlab.interactive.utils.format_call_kwargs(self.attrs)
+        attrs_code = _provenance_value_code(self.attrs)
         return DerivationEntry(
             f"Assign Attributes({_format_derivation_value(self.attrs)})",
-            f"derived = derived.assign_attrs({kwargs})",
+            f"derived = derived.assign_attrs({attrs_code})",
             True,
         )
 
 
 class SliceAlongPathOperation(ToolProvenanceOperation):
     op: typing.Literal["slice_along_path"] = "slice_along_path"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            target="erlab.analysis.interpolate.slice_along_path",
+            fields=("vertices", "step_size", "dim_name"),
+            defaults={"dim_name": "path"},
+            ignored_defaults={"interp_kwargs": None},
+        ),
+    )
     vertices: ProvenanceFloatSequenceMapping = pydantic.Field(default_factory=dict)
     step_size: float
     dim_name: str
@@ -3040,6 +3936,13 @@ class SliceAlongPathOperation(ToolProvenanceOperation):
 
 class MaskWithPolygonOperation(ToolProvenanceOperation):
     op: typing.Literal["mask_with_polygon"] = "mask_with_polygon"
+    console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
+        ConsoleOperationPattern(
+            target="erlab.analysis.mask.mask_with_polygon",
+            fields=("vertices", "dims"),
+            defaults={"invert": False, "drop": False},
+        ),
+    )
     vertices: typing.Any
     dims: ProvenanceHashableTuple
     invert: bool = False

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -97,6 +97,7 @@ __all__ = [
     "CorrectWithEdgeOperation",
     "DerivationEntry",
     "DivideByCoordOperation",
+    "FileDataSelection",
     "FileLoadSource",
     "FileReplayCall",
     "ImageToolSelectionSourceBinding",
@@ -1378,13 +1379,78 @@ def parse_tool_provenance_operation(
     return operation_type.model_validate(value)
 
 
+class FileDataSelection(pydantic.BaseModel):
+    """Serializable selection of one displayable array from a loaded file object.
+
+    New provenance stores stable Dataset variable names and DataTree data paths instead
+    of the positional parsed-array index used by older workspaces.
+
+    .. versionchanged:: 3.23.0
+       Added Dataset variable and DataTree path selectors for file-backed ImageTool
+       provenance. Older ``selected_index`` replay payloads remain readable as
+       ``parsed_index`` selections.
+    """
+
+    kind: typing.Literal[
+        "dataarray",
+        "dataset_variable",
+        "datatree_path",
+        "parsed_index",
+    ]
+    value: typing.Any = None
+
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        extra="forbid",
+    )
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _validate_serialized_shape(cls, value: typing.Any) -> typing.Any:
+        if isinstance(value, np.integer):
+            return {"kind": "parsed_index", "value": int(value)}
+        if isinstance(value, int) and not isinstance(value, bool):
+            return {"kind": "parsed_index", "value": value}
+        return value
+
+    @pydantic.model_validator(mode="after")
+    def _validate_value(self) -> typing.Self:
+        if self.kind == "dataarray":
+            if self.value is not None:
+                raise ValueError("dataarray file selections must not define a value")
+            return self
+        if self.kind == "dataset_variable":
+            value = _normalize_provenance_hashable(decode_provenance_value(self.value))
+            if value != self.value:
+                return self.model_copy(update={"value": value})
+            return self
+        if self.kind == "datatree_path":
+            if not isinstance(self.value, str) or not self.value.startswith("/"):
+                raise ValueError("datatree file selections must use an absolute path")
+            return self
+
+        value = int(self.value) if isinstance(self.value, np.integer) else self.value
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError("parsed file selection index must be non-negative")
+        if value != self.value:
+            return self.model_copy(update={"value": value})
+        return self
+
+    @pydantic.field_serializer("value", when_used="json")
+    def _serialize_value(self, value: typing.Any) -> typing.Any:
+        if self.kind == "dataset_variable":
+            return _encode_provenance_hashable(value)
+        return value
+
+
 class FileReplayCall(pydantic.BaseModel):
     """Serializable call information used to reload file-backed provenance."""
 
     kind: typing.Literal["erlab_loader", "callable"]
     target: str
     kwargs: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
-    selected_index: int
+    selection: FileDataSelection
     cast_float64: bool = False
 
     model_config = pydantic.ConfigDict(
@@ -1393,10 +1459,22 @@ class FileReplayCall(pydantic.BaseModel):
         extra="forbid",
     )
 
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _validate_serialized_shape(cls, value: typing.Any) -> typing.Any:
+        if not isinstance(value, Mapping):
+            return value
+        payload = dict(value)
+        selected_index = payload.pop("selected_index", None)
+        if "selection" not in payload and selected_index is not None:
+            payload["selection"] = {
+                "kind": "parsed_index",
+                "value": selected_index,
+            }
+        return payload
+
     @pydantic.model_validator(mode="after")
     def _validate_replay_call(self) -> typing.Self:
-        if self.selected_index < 0:
-            raise ValueError("selected_index must be non-negative")
         if not self.target:
             raise ValueError("target must not be empty")
         if any(not isinstance(key, str) for key in self.kwargs):
@@ -2601,6 +2679,61 @@ def _parse_replay_input(data: typing.Any) -> list[xr.DataArray]:
     ]
 
 
+def _require_replay_dataarray(data: typing.Any) -> xr.DataArray:
+    if isinstance(data, np.ndarray):
+        data = xr.DataArray(data)
+    if not isinstance(data, xr.DataArray):
+        raise TypeError(
+            f"Selected file data must be a DataArray, got {type(data).__name__!r}"
+        )
+    if not _supported_replay_shape(data):
+        raise ValueError("Selected file data is not valid for ImageTool")
+    return data
+
+
+def _select_replay_input(
+    data: typing.Any,
+    selection: FileDataSelection | Mapping[str, typing.Any] | int,
+) -> xr.DataArray:
+    selection = FileDataSelection.model_validate(selection)
+    if selection.kind == "dataarray":
+        return _require_replay_dataarray(data)
+    if selection.kind == "dataset_variable":
+        if not isinstance(data, xr.Dataset):
+            raise TypeError(
+                "Dataset variable file selections require the loader to return "
+                "a Dataset"
+            )
+        try:
+            selected = data[selection.value]
+        except KeyError as err:
+            raise KeyError(
+                f"Selected file variable {selection.value!r} was not found"
+            ) from err
+        return _require_replay_dataarray(selected)
+    if selection.kind == "datatree_path":
+        if not isinstance(data, xr.DataTree):
+            raise TypeError(
+                "DataTree path file selections require the loader to return a DataTree"
+            )
+        try:
+            selected = data[selection.value]
+        except KeyError as err:
+            raise KeyError(
+                f"Selected file DataTree path {selection.value!r} was not found"
+            ) from err
+        return _require_replay_dataarray(selected)
+
+    parsed = _parse_replay_input(data)
+    index = typing.cast("int", selection.value)
+    if index >= len(parsed):
+        raise IndexError(
+            f"Selected file replay index {index} is out of range for "
+            f"{len(parsed)} parsed arrays"
+        )
+    return parsed[index]
+
+
 def _resolve_importable_callable(target: str) -> Callable[..., typing.Any]:
     parts = target.split(".")
     if len(parts) < 2:
@@ -2640,13 +2773,7 @@ def _load_file_source_data(load_source: FileLoadSource) -> xr.DataArray:
         func = _resolve_importable_callable(call.target)
 
     loaded = func(file_path, **dict(call.kwargs))
-    parsed = _parse_replay_input(loaded)
-    if call.selected_index >= len(parsed):
-        raise IndexError(
-            f"Selected file replay index {call.selected_index} is out of range for "
-            f"{len(parsed)} parsed arrays"
-        )
-    data = parsed[call.selected_index]
+    data = _select_replay_input(loaded, call.selection)
     if call.cast_float64:
         data = data.astype(np.float64)
     return data

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -131,7 +131,6 @@ import ast
 import base64
 import contextlib
 import importlib
-import json
 import keyword
 import pathlib
 import typing
@@ -143,6 +142,7 @@ import pydantic
 import xarray as xr
 
 import erlab
+from erlab.interactive.imagetool import _replay_graph
 
 _SLICE_MARKER = "__erlab_slice__"
 _DATASET_MARKER = "__erlab_xarray_dataset__"
@@ -1384,27 +1384,10 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         if not self.script_inputs:
             return None
 
-        planned = _planned_script_inputs_code(self.script_inputs, display=display)
-        if planned is not None:
-            return planned
-
-        lines: list[str] = []
-        for script_input in self.script_inputs:
-            input_spec = script_input.parsed_provenance_spec()
-            if input_spec is None:
-                return None
-            code = (
-                input_spec.display_code() if display else input_spec.derivation_code()
-            )
-            if not code:
-                return None
-            lines.append(code)
-            active_name = replay_input_name(input_spec) or input_spec.active_name
-            if active_name is None:
-                return None
-            if active_name != script_input.name:
-                lines.append(f"{script_input.name} = {active_name}")
-        return "\n".join(lines)
+        try:
+            return _replay_graph.script_inputs_code(self.script_inputs, display=display)
+        except _replay_graph.ReplayGraphError:
+            return None
 
     def derivation_code(self) -> str | None:
         prefix: str | None = None
@@ -1526,178 +1509,6 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             "\n".join(part for part in (prefix, *step_codes) if part),
             inline_targets=inline_targets,
         )
-
-
-def _canonical_replay_key(kind: str, payload: Mapping[str, typing.Any]) -> str:
-    return json.dumps(
-        {"kind": kind, **dict(payload)},
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-
-
-def _file_load_replay_key(load_source: FileLoadSource) -> str:
-    return _canonical_replay_key(
-        "file_load",
-        {
-            "path": load_source.path,
-            "replay_call": (
-                None
-                if load_source.replay_call is None
-                else load_source.replay_call.model_dump(mode="json")
-            ),
-        },
-    )
-
-
-def _replay_stage_replay_key(parent_key: str, stage: ReplayStage) -> str:
-    return _canonical_replay_key(
-        "replay_stage",
-        {
-            "parent": parent_key,
-            "stage": stage.model_dump(mode="json"),
-        },
-    )
-
-
-def _stage_code_lines(
-    stage: ReplayStage,
-    *,
-    parent_name: str,
-    output_name: str,
-    display: bool,
-) -> tuple[str, ...] | None:
-    if stage.source_kind == "full_data":
-        lines = [f"{output_name} = {parent_name}"]
-    else:
-        lines = [
-            f"{output_name} = erlab.interactive.imagetool.slicer."
-            f"restore_nonuniform_dims({parent_name})"
-        ]
-
-    operations: Sequence[ToolProvenanceOperation] = stage.operations
-    if display:
-        operations = ToolProvenanceSpec._streamlined_operations(
-            stage.source_kind,
-            operations,
-        )
-
-    for operation in operations:
-        entry = operation.derivation_entry()
-        if entry is None:
-            continue
-        if entry.code is None:
-            return None
-        try:
-            lines.append(
-                _replace_code_identifiers(
-                    entry.code,
-                    {"data": parent_name, "derived": output_name},
-                )
-            )
-        except SyntaxError:
-            return None
-    return tuple(lines)
-
-
-def _planned_script_inputs_code(
-    script_inputs: Sequence[ScriptInput],
-    *,
-    display: bool,
-) -> str | None:
-    """Return DAG-emitted setup code for structured script inputs, if possible."""
-    used_names = {script_input.name for script_input in script_inputs}
-    node_names: dict[str, str] = {}
-    lines: list[str] = []
-    counter = 0
-
-    def _next_name() -> str:
-        nonlocal counter
-        while True:
-            name = f"_itool_replay_{counter}"
-            counter += 1
-            if name not in used_names:
-                used_names.add(name)
-                return name
-
-    def _add_node(
-        key: str,
-        build_lines: Callable[[str], tuple[str, ...] | None],
-    ) -> str | None:
-        existing = node_names.get(key)
-        if existing is not None:
-            return existing
-        name = _next_name()
-        built = build_lines(name)
-        if built is None:
-            return None
-        node_names[key] = name
-        lines.extend(built)
-        return name
-
-    def _file_chain(spec: ToolProvenanceSpec) -> tuple[str, str] | None:
-        if spec.kind != "file" or spec.file_load_source is None:
-            return None
-        active_name = spec.active_name
-        if active_name is None or spec.seed_code is None:
-            return None
-        seed_code = spec.seed_code
-
-        load_key = _file_load_replay_key(spec.file_load_source)
-
-        def _load_lines(name: str) -> tuple[str, ...] | None:
-            try:
-                code = _replace_code_identifiers(seed_code, {active_name: name})
-            except SyntaxError:
-                return None
-            if not _code_stores_name(code, name):
-                return None
-            return (code,)
-
-        parent_name = _add_node(load_key, _load_lines)
-        if parent_name is None:
-            return None
-        parent_key = load_key
-
-        for stage in spec.replay_stages:
-            stage_key = _replay_stage_replay_key(parent_key, stage)
-
-            def _build_stage_lines(
-                name: str,
-                *,
-                current_stage: ReplayStage = stage,
-                current_parent: str = parent_name,
-            ) -> tuple[str, ...] | None:
-                return _stage_code_lines(
-                    current_stage,
-                    parent_name=current_parent,
-                    output_name=name,
-                    display=display,
-                )
-
-            stage_name = _add_node(stage_key, _build_stage_lines)
-            if stage_name is None:
-                return None
-            parent_key = stage_key
-            parent_name = stage_name
-
-        return parent_key, parent_name
-
-    aliases: list[tuple[str, str]] = []
-    for script_input in script_inputs:
-        input_spec = script_input.parsed_provenance_spec()
-        if input_spec is None:
-            return None
-        planned = _file_chain(input_spec)
-        if planned is None:
-            return None
-        _key, input_name = planned
-        aliases.append((script_input.name, input_name))
-
-    for public_name, planned_name in aliases:
-        if public_name != planned_name:
-            lines.append(f"{public_name} = {planned_name}")
-    return "\n".join(lines)
 
 
 def parse_tool_provenance_spec(
@@ -2317,27 +2128,10 @@ def replay_file_provenance(
     cache: dict[str, xr.DataArray] | None = None,
 ) -> xr.DataArray:
     """Replay structured file provenance without executing generated Python."""
-    parsed = parse_tool_provenance_spec(spec)
-    if parsed is None or parsed.kind != "file" or parsed.file_load_source is None:
-        raise TypeError("Expected structured file provenance")
-
-    replay_cache = {} if cache is None else cache
-    load_key = _file_load_replay_key(parsed.file_load_source)
-    if load_key in replay_cache:
-        data = replay_cache[load_key].copy(deep=False)
-    else:
-        data = _load_file_source_data(parsed.file_load_source)
-        replay_cache[load_key] = data.copy(deep=False)
-    parent_key = load_key
-    for stage in parsed.replay_stages:
-        stage_key = _replay_stage_replay_key(parent_key, stage)
-        if stage_key in replay_cache:
-            data = replay_cache[stage_key].copy(deep=False)
-        else:
-            data = _apply_replay_stage(stage, data)
-            replay_cache[stage_key] = data.copy(deep=False)
-        parent_key = stage_key
-    return data
+    try:
+        return _replay_graph.replay_file_provenance(spec, cache=cache)
+    except _replay_graph.ReplayGraphError as exc:
+        raise TypeError("Expected structured file provenance") from exc
 
 
 def _validate_script_replay_code(code: str) -> None:
@@ -2363,42 +2157,11 @@ def _validate_script_replay_code(code: str) -> None:
             raise ValueError(f"Script replay code cannot call {node.func.id!r}")
 
 
-def _script_replay_codes(spec: ToolProvenanceSpec) -> tuple[str, ...]:
-    if spec.kind != "script":
-        raise TypeError("Expected script provenance")
-    if spec.active_name is None:
-        raise ValueError("Script provenance cannot be replayed without active_name")
-
-    codes: list[str] = []
-    if spec.seed_code:
-        codes.append(spec.seed_code)
-    for operation in spec.operations:
-        if not isinstance(operation, ScriptCodeOperation):
-            raise TypeError(
-                "Only script_code operations can be replayed as script provenance"
-            )
-        if not operation.copyable or operation.code is None:
-            raise ValueError("Script provenance contains non-replayable code")
-        codes.append(operation.code)
-    if not codes:
-        raise ValueError("Script provenance has no replay code")
-    for code in codes:
-        _validate_script_replay_code(code)
-    return tuple(codes)
-
-
 def script_provenance_replayable(
     spec: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
 ) -> bool:
     """Return whether script provenance can be replayed from resolved inputs."""
-    parsed = parse_tool_provenance_spec(spec)
-    if parsed is None:
-        return False
-    try:
-        _script_replay_codes(parsed)
-    except (TypeError, ValueError):
-        return False
-    return True
+    return _replay_graph.script_provenance_replayable(spec)
 
 
 def replay_script_provenance(
@@ -2406,34 +2169,12 @@ def replay_script_provenance(
     inputs: Mapping[str, xr.DataArray],
 ) -> xr.DataArray:
     """Execute trusted script provenance from already resolved input arrays."""
-    parsed = parse_tool_provenance_spec(spec)
-    if parsed is None:
-        raise TypeError("Expected script provenance")
-    codes = _script_replay_codes(parsed)
-    namespace: dict[str, typing.Any] = {
-        "__builtins__": _SCRIPT_REPLAY_ALLOWED_BUILTINS,
-        "erlab": erlab,
-        "np": np,
-        "numpy": np,
-        "xr": xr,
-        "xarray": xr,
-    }
-    namespace.update({name: data.copy(deep=True) for name, data in inputs.items()})
-    for code in codes:
-        compiled = compile(code, "<ImageTool script provenance>", "exec")
-        exec(compiled, namespace, namespace)  # noqa: S102
-
-    active_name = typing.cast("str", parsed.active_name)
-    if active_name not in namespace:
-        raise RuntimeError(
-            f"Script provenance did not create active variable {active_name!r}"
-        )
-    result = namespace[active_name]
-    if not isinstance(result, xr.DataArray):
-        raise TypeError(
-            f"Script provenance did not produce an xarray.DataArray for {active_name!r}"
-        )
-    return result
+    try:
+        return _replay_graph.replay_script_provenance(spec, inputs)
+    except _replay_graph.ReplayGraphError as exc:
+        if "non-replayable" in str(exc):
+            raise ValueError(str(exc)) from exc
+        raise TypeError(str(exc)) from exc
 
 
 class ScriptCodeOperation(ToolProvenanceOperation):

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -117,9 +117,11 @@ __all__ = [
     "rebase_default_replay_input",
     "rebase_script_input_node_uids",
     "replay_file_provenance",
+    "replay_script_provenance",
     "require_live_source_spec",
     "script",
     "script_input_lineage_refs",
+    "script_provenance_replayable",
     "selection",
     "to_replay_provenance_spec",
     "uses_default_replay_input",
@@ -153,6 +155,47 @@ _SORT_COORD_ORDER_DERIVATION_LABEL = "Sort coordinates to parent order"
 _SORT_COORD_ORDER_DERIVATION_CODE = (
     "derived = erlab.utils.array.sort_coord_order(derived, data.coords.keys())"
 )
+_SCRIPT_REPLAY_ALLOWED_BUILTINS = {
+    "abs": abs,
+    "bool": bool,
+    "complex": complex,
+    "dict": dict,
+    "float": float,
+    "int": int,
+    "len": len,
+    "list": list,
+    "max": max,
+    "min": min,
+    "range": range,
+    "set": set,
+    "slice": slice,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+}
+_SCRIPT_REPLAY_FORBIDDEN_NODES = (
+    ast.AsyncFor,
+    ast.AsyncFunctionDef,
+    ast.AsyncWith,
+    ast.Await,
+    ast.ClassDef,
+    ast.Delete,
+    ast.For,
+    ast.FunctionDef,
+    ast.Global,
+    ast.Import,
+    ast.ImportFrom,
+    ast.Lambda,
+    ast.Match,
+    ast.Nonlocal,
+    ast.Raise,
+    ast.Try,
+    ast.While,
+    ast.With,
+    ast.Yield,
+    ast.YieldFrom,
+)
+_SCRIPT_REPLAY_FORBIDDEN_CALLS = {"__import__", "compile", "eval", "exec", "open"}
 
 
 @dataclass(frozen=True)
@@ -2073,6 +2116,102 @@ def replay_file_provenance(
     for stage in parsed.replay_stages:
         data = _apply_replay_stage(stage, data)
     return data
+
+
+def _validate_script_replay_code(code: str) -> None:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError as exc:
+        raise ValueError(f"Script replay code is not valid Python: {exc}") from exc
+
+    for node in ast.walk(module):
+        if isinstance(node, _SCRIPT_REPLAY_FORBIDDEN_NODES):
+            raise TypeError(
+                f"Script replay code contains unsupported {type(node).__name__}"
+            )
+        if isinstance(node, ast.Name) and node.id.startswith("__"):
+            raise ValueError("Script replay code cannot access dunder names")
+        if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            raise ValueError("Script replay code cannot access dunder attributes")
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in _SCRIPT_REPLAY_FORBIDDEN_CALLS
+        ):
+            raise ValueError(f"Script replay code cannot call {node.func.id!r}")
+
+
+def _script_replay_codes(spec: ToolProvenanceSpec) -> tuple[str, ...]:
+    if spec.kind != "script":
+        raise TypeError("Expected script provenance")
+    if spec.active_name is None:
+        raise ValueError("Script provenance cannot be replayed without active_name")
+
+    codes: list[str] = []
+    if spec.seed_code:
+        codes.append(spec.seed_code)
+    for operation in spec.operations:
+        if not isinstance(operation, ScriptCodeOperation):
+            raise TypeError(
+                "Only script_code operations can be replayed as script provenance"
+            )
+        if not operation.copyable or operation.code is None:
+            raise ValueError("Script provenance contains non-replayable code")
+        codes.append(operation.code)
+    if not codes:
+        raise ValueError("Script provenance has no replay code")
+    for code in codes:
+        _validate_script_replay_code(code)
+    return tuple(codes)
+
+
+def script_provenance_replayable(
+    spec: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
+) -> bool:
+    """Return whether script provenance can be replayed from resolved inputs."""
+    parsed = parse_tool_provenance_spec(spec)
+    if parsed is None:
+        return False
+    try:
+        _script_replay_codes(parsed)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def replay_script_provenance(
+    spec: ToolProvenanceSpec | Mapping[str, typing.Any],
+    inputs: Mapping[str, xr.DataArray],
+) -> xr.DataArray:
+    """Execute trusted script provenance from already resolved input arrays."""
+    parsed = parse_tool_provenance_spec(spec)
+    if parsed is None:
+        raise TypeError("Expected script provenance")
+    codes = _script_replay_codes(parsed)
+    namespace: dict[str, typing.Any] = {
+        "__builtins__": _SCRIPT_REPLAY_ALLOWED_BUILTINS,
+        "erlab": erlab,
+        "np": np,
+        "numpy": np,
+        "xr": xr,
+        "xarray": xr,
+    }
+    namespace.update({name: data.copy(deep=True) for name, data in inputs.items()})
+    for code in codes:
+        compiled = compile(code, "<ImageTool script provenance>", "exec")
+        exec(compiled, namespace, namespace)  # noqa: S102
+
+    active_name = typing.cast("str", parsed.active_name)
+    if active_name not in namespace:
+        raise RuntimeError(
+            f"Script provenance did not create active variable {active_name!r}"
+        )
+    result = namespace[active_name]
+    if not isinstance(result, xr.DataArray):
+        raise TypeError(
+            f"Script provenance did not produce an xarray.DataArray for {active_name!r}"
+        )
+    return result
 
 
 class ScriptCodeOperation(ToolProvenanceOperation):

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -1730,11 +1730,18 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             )
 
         streamlined: list[ToolProvenanceOperation] = []
-        for operation in operations:
+        for index, operation in enumerate(operations):
             hide_operation = False
 
+            if isinstance(operation, ScriptCodeOperation):
+                entry = operation.derivation_entry()
+                hide_operation = entry.code in {
+                    "derived = derived.isel()",
+                    "derived = derived.qsel()",
+                    "derived = derived.sel()",
+                } or _is_internal_sort_coord_order_entry(entry)
             # Rule 1: drop empty selection operations.
-            if isinstance(operation, (QSelOperation, IselOperation, SelOperation)):
+            elif isinstance(operation, (QSelOperation, IselOperation, SelOperation)):
                 hide_operation = not operation.decoded_kwargs
             # Rule 2: hide internal coordinate-order normalization.
             elif isinstance(operation, SortCoordOrderOperation):
@@ -1761,11 +1768,20 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                     ).dims
                     == current_data.dims
                 )
+            # Rule 6: drop whole-array name changes. ImageTool appends names such as
+            # ``_avg`` to keep displayed tools distinct, but the DataArray name is not
+            # an analysis step. Dimension and coordinate renames use
+            # RenameDimsCoordsOperation and remain visible.
+            elif isinstance(operation, RenameOperation):
+                hide_operation = not any(
+                    isinstance(later_operation, ScriptCodeOperation)
+                    for later_operation in operations[index + 1 :]
+                )
 
             if not hide_operation:
                 streamlined.append(operation)
 
-            # Rule 6: keep anything ambiguous. If replaying an operation fails while
+            # Rule 7: keep anything ambiguous. If replaying an operation fails while
             # building the heuristic context, stop making data-dependent decisions for
             # later steps and preserve them verbatim.
             if current_data is None or parent_data is None:
@@ -1913,18 +1929,21 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         entries = [self._start_entry()]
 
         if self.kind == "script":
-            for entry in self.derivation_entries()[1:]:
-                # Rule 1: drop empty selection operations.
-                if entry.code in {
-                    "derived = derived.isel()",
-                    "derived = derived.qsel()",
-                    "derived = derived.sel()",
-                }:
-                    continue
-                # Rule 2: hide internal coordinate-order normalization.
-                if _is_internal_sort_coord_order_entry(entry):
-                    continue
-                entries.append(entry)
+            entries.extend(
+                DerivationEntry(
+                    f"Use {script_input.name} from {script_input.label}",
+                    None,
+                    False,
+                )
+                for script_input in self.script_inputs
+            )
+            entries.extend(
+                operation.derivation_entry()
+                for operation in self._streamlined_operations(
+                    "full_data",
+                    self.operations,
+                )
+            )
             return entries
         if self.kind == "file":
             current_data = parent_data

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -48,10 +48,17 @@ def check_cursors_compatible(old: xr.DataArray, new: xr.DataArray) -> bool:
     new
         The new DataArray.
     """
+    old, new = _cursor_compatibility_pair(old, new)
     if set(old.dims) != set(new.dims):
         return False
     for d in old.dims:
-        if not np.isin(old[d].values, new[d].values, assume_unique=True).all():
+        old_coord = old.coords.get(d)
+        new_coord = new.coords.get(d)
+        if old_coord is None or new_coord is None:
+            if old.sizes[d] != new.sizes[d]:
+                return False
+            continue
+        if not np.isin(old_coord.values, new_coord.values, assume_unique=True).all():
             return False
     return True
 
@@ -65,6 +72,24 @@ def _is_uniform(arr: npt.NDArray[np.float64]) -> bool:
         # Treat constant coordinate array as non-uniform
         return False
     return np.allclose(dif, dif[0], rtol=3e-05, atol=3e-05, equal_nan=True)
+
+
+def _nonuniform_dim_name(darr: xr.DataArray, dim: Hashable) -> str | None:
+    if not str(dim).endswith("_idx"):
+        return None
+    stripped = str(dim).removesuffix("_idx")
+    coord = darr.coords.get(stripped)
+    if coord is None:
+        return None
+    if coord.ndim != 1 or coord.dims != (dim,) or coord.size != darr.sizes[dim]:
+        return None
+    try:
+        values = coord.values.astype(np.float64)
+    except (TypeError, ValueError):
+        return None
+    if _is_uniform(values):
+        return None
+    return stripped
 
 
 def make_dims_uniform(darr: xr.DataArray) -> xr.DataArray:
@@ -116,12 +141,31 @@ def restore_nonuniform_dims(darr: xr.DataArray) -> xr.DataArray:
     """
     nonuniform_dims: list[Hashable] = []
     for d in darr.dims:
-        if str(d).endswith("_idx"):
-            stripped = str(d).removesuffix("_idx")
-            if stripped in darr.coords:
-                nonuniform_dims.append(d)
-                darr = darr.swap_dims({d: stripped})
+        stripped = _nonuniform_dim_name(darr, d)
+        if stripped is not None:
+            nonuniform_dims.append(d)
+            darr = darr.swap_dims({d: stripped})
     return darr.drop_vars(nonuniform_dims)
+
+
+def _drop_unmatched_stack_dim(data: xr.DataArray, other: xr.DataArray) -> xr.DataArray:
+    if (
+        "stack_dim" in data.dims
+        and "stack_dim" not in other.dims
+        and data.sizes["stack_dim"] == 1
+    ):
+        return data.squeeze("stack_dim", drop=True)
+    return data
+
+
+def _cursor_compatibility_pair(
+    old: xr.DataArray, new: xr.DataArray
+) -> tuple[xr.DataArray, xr.DataArray]:
+    old_view = restore_nonuniform_dims(old.copy(deep=False))
+    new_view = restore_nonuniform_dims(new.copy(deep=False))
+    old_view = _drop_unmatched_stack_dim(old_view, new_view)
+    new_view = _drop_unmatched_stack_dim(new_view, old_view)
+    return old_view, new_view
 
 
 def _get_inc(coord):
@@ -809,15 +853,7 @@ class ArraySlicer(QtCore.QObject):
         # positives when users provide their own *_idx dimensions.
         self._nonuniform_axes = []
         for i, d in enumerate(self._obj.dims):
-            if not str(d).endswith("_idx"):
-                continue
-            stripped = str(d).removesuffix("_idx")
-            if stripped not in self._obj.coords:
-                continue
-            coord = self._obj.coords[stripped]
-            if coord.ndim != 1 or coord.size != self._obj.sizes[d]:
-                continue
-            if not _is_uniform(coord.values.astype(np.float64)):
+            if _nonuniform_dim_name(self._obj, d) is not None:
                 self._nonuniform_axes.append(i)
         self._nonuniform_axes_set: set[int] = set(self._nonuniform_axes)
         self._all_axes: tuple[int, ...] = tuple(range(self._obj.ndim))

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -2674,9 +2674,21 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 return False
             return True
         manager = self._manager_instance if self._in_manager else None
-        return manager is not None and manager._script_reload_from_slicer_area(
+        if manager is not None and manager._script_reload_from_slicer_area(
             self, execute=True
-        )
+        ):
+            return True
+        if not self.reloadable:
+            return False
+        try:
+            data, kwargs = self._fetch_reload_data()
+            self.replace_source_data(data, **kwargs)
+        except Exception:
+            erlab.interactive.utils.MessageDialog.critical(
+                self, "Error", "An error occurred while reloading data."
+            )
+            return False
+        return True
 
     @QtCore.Slot()
     def reload(self) -> None:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -13,7 +13,6 @@ import copy
 import functools
 import importlib
 import inspect
-import itertools
 import logging
 import os
 import pathlib
@@ -54,6 +53,15 @@ else:
     qtawesome = _lazy.load("qtawesome")
 
 logger = logging.getLogger(__name__)
+
+_FileDataSelection = erlab.interactive.imagetool.provenance.FileDataSelection
+_FileSelection: typing.TypeAlias = int | dict[str, typing.Any] | _FileDataSelection
+_LoadFunc: typing.TypeAlias = tuple[
+    collections.abc.Callable[..., typing.Any] | str,
+    dict[str, typing.Any],
+    _FileSelection,
+]
+_ParsedInputData: typing.TypeAlias = tuple[xr.DataArray, _FileDataSelection]
 
 
 class ColorMapState(typing.TypedDict):
@@ -99,7 +107,9 @@ class ImageSlicerState(typing.TypedDict):
     cursor_colors: list[str]
     controls_visible: typing.NotRequired[bool]
     file_path: typing.NotRequired[str | None]
-    load_func: typing.NotRequired[tuple[str, dict[str, typing.Any], int] | None]
+    load_func: typing.NotRequired[
+        tuple[str, dict[str, typing.Any], _FileSelection] | None
+    ]
     splitter_sizes: typing.NotRequired[list[list[int]]]
     plotitem_states: typing.NotRequired[list[PlotItemState]]
 
@@ -144,6 +154,14 @@ def _parse_dataset(ds: xr.Dataset) -> tuple[xr.DataArray, ...]:
     return tuple(d for d in ds.data_vars.values() if _supported_shape(d))
 
 
+def _datatree_dataarray_path(source_path: str, variable_name: Hashable) -> str:
+    source_path = source_path.rstrip("/")
+    variable_path = str(variable_name).strip("/")
+    if not source_path:
+        return f"/{variable_path}"
+    return f"{source_path}/{variable_path}"
+
+
 class _SelectDataArraysDialog(QtWidgets.QDialog):
     def __init__(
         self,
@@ -152,6 +170,7 @@ class _SelectDataArraysDialog(QtWidgets.QDialog):
     ) -> None:
         super().__init__(parent)
         self._data_arrays: list[xr.DataArray] = []
+        self._selections: list[_FileDataSelection] = []
         self._source_paths: list[str] = []
         variable_names: list[str] = []
 
@@ -159,6 +178,12 @@ class _SelectDataArraysDialog(QtWidgets.QDialog):
             for variable_name, darr in data.data_vars.items():
                 if _supported_shape(darr):
                     self._data_arrays.append(darr)
+                    self._selections.append(
+                        _FileDataSelection(
+                            kind="dataset_variable",
+                            value=variable_name,
+                        )
+                    )
                     self._source_paths.append("/")
                     variable_names.append(str(variable_name))
         else:
@@ -167,6 +192,14 @@ class _SelectDataArraysDialog(QtWidgets.QDialog):
                 for variable_name, darr in leaf.dataset.data_vars.items():
                     if _supported_shape(darr):
                         self._data_arrays.append(darr)
+                        self._selections.append(
+                            _FileDataSelection(
+                                kind="datatree_path",
+                                value=_datatree_dataarray_path(
+                                    source_path, variable_name
+                                ),
+                            )
+                        )
                         self._source_paths.append(source_path)
                         variable_names.append(str(variable_name))
 
@@ -434,14 +467,14 @@ class _SelectDataArraysDialog(QtWidgets.QDialog):
         self._path_tree.setCurrentIndex(QtCore.QModelIndex())
         self._filter_for_path(None)
 
-    def selected_dataarrays(self) -> tuple[tuple[xr.DataArray, int], ...]:
-        selected: list[tuple[xr.DataArray, int]] = []
+    def selected_dataarrays(self) -> tuple[_ParsedInputData, ...]:
+        selected: list[_ParsedInputData] = []
         for item in self._items():
             if self._item_checkbox(item).isChecked():
                 index = typing.cast(
                     "int", item.data(0, QtCore.Qt.ItemDataRole.UserRole)
                 )
-                selected.append((self._data_arrays[index], index))
+                selected.append((self._data_arrays[index], self._selections[index]))
         return tuple(selected)
 
     def _update_ok_enabled(self, *_args: object) -> None:
@@ -525,9 +558,9 @@ def _select_input_dataarrays(
     | xr.Dataset
     | xr.DataTree,
     parent: QtWidgets.QWidget | None = None,
-) -> tuple[tuple[xr.DataArray, int], ...] | None:
-    data_arrays = tuple(enumerate(_parse_input(data)))
-    if len(data_arrays) > 1 and isinstance(data, xr.Dataset | xr.DataTree):
+) -> tuple[_ParsedInputData, ...] | None:
+    parsed_data = _parse_input_data(data)
+    if len(parsed_data) > 1 and isinstance(data, xr.Dataset | xr.DataTree):
         dialog = _SelectDataArraysDialog(parent, data)
         if not dialog.exec():
             return None
@@ -535,7 +568,7 @@ def _select_input_dataarrays(
         if not selected:
             return None
         return selected
-    return tuple((darr, source_index) for source_index, darr in data_arrays)
+    return tuple(parsed_data)
 
 
 def _make_cursor_colors(
@@ -595,28 +628,72 @@ def _parse_input(
     | xr.Dataset
     | xr.DataTree,
 ) -> list[xr.DataArray]:
+    return [darr for darr, _selection in _parse_input_data(data)]
+
+
+def _parse_input_data(
+    data: Collection[xr.DataArray | npt.NDArray]
+    | xr.DataArray
+    | npt.NDArray
+    | xr.Dataset
+    | xr.DataTree,
+) -> list[_ParsedInputData]:
     input_cls: str = data.__class__.__name__
     if isinstance(data, np.ndarray | xr.DataArray):
-        data = (data,)
-    elif isinstance(data, xr.Dataset):
-        data = _parse_dataset(data)
-    elif isinstance(data, xr.DataTree):
-        data = tuple(
-            itertools.chain.from_iterable(
-                _parse_dataset(leaf.dataset) for leaf in data.leaves
-            )
+        parsed = (
+            (
+                xr.DataArray(data) if not isinstance(data, xr.DataArray) else data,
+                _FileDataSelection(kind="dataarray"),
+            ),
         )
+    elif isinstance(data, xr.Dataset):
+        parsed = tuple(
+            (
+                darr,
+                _FileDataSelection(kind="dataset_variable", value=variable_name),
+            )
+            for variable_name, darr in data.data_vars.items()
+            if _supported_shape(darr)
+        )
+    elif isinstance(data, xr.DataTree):
+        parsed = tuple(
+            (
+                darr,
+                _FileDataSelection(
+                    kind="datatree_path",
+                    value=_datatree_dataarray_path(str(leaf.path), variable_name),
+                ),
+            )
+            for leaf in data.leaves
+            for variable_name, darr in leaf.dataset.data_vars.items()
+            if _supported_shape(darr)
+        )
+    else:
+        if not isinstance(data, collections.abc.Collection):
+            raise TypeError(
+                f"Unsupported input type {input_cls}. Expected DataArray, Dataset, "
+                "DataTree, numpy array, or a list of DataArray or numpy arrays."
+            )
+        parsed_list: list[_ParsedInputData] = []
+        for index, d in enumerate(data):
+            if not isinstance(d, xr.DataArray | np.ndarray):
+                raise TypeError(
+                    f"Unsupported input type {input_cls}. Expected DataArray, "
+                    "Dataset, DataTree, numpy array, or a list of DataArray or "
+                    "numpy arrays."
+                )
+            parsed_list.append(
+                (
+                    xr.DataArray(d) if not isinstance(d, xr.DataArray) else d,
+                    _FileDataSelection(kind="parsed_index", value=index),
+                )
+            )
+        parsed = tuple(parsed_list)
 
-    if len(data) == 0:
+    if len(parsed) == 0:
         raise ValueError(f"No valid data for ImageTool found in {input_cls}")
 
-    if not isinstance(next(iter(data)), xr.DataArray | np.ndarray):
-        raise TypeError(
-            f"Unsupported input type {input_cls}. Expected DataArray, Dataset, "
-            "DataTree, numpy array, or a list of DataArray or numpy arrays."
-        )
-
-    return [xr.DataArray(d) if not isinstance(d, xr.DataArray) else d for d in data]
+    return list(parsed)
 
 
 def _link_splitters(
@@ -950,10 +1027,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
         data, ``load_func`` must also be provided.
     load_func
         3-tuple containing the function, a dictionary of keyword arguments, and the
-        index of the data variable used when loading the data. The function is called
-        when reloading the data. If using a data loader plugin, the function may be as a
-        string representing the loader name. If the function always returns a single
-        DataArray, the last element should be 0.
+        selection of the data variable used when loading the data. The function is
+        called when reloading the data. If using a data loader plugin, the function may
+        be given as a string representing the loader name.
 
     Signals
     -------
@@ -1074,7 +1150,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         bench: bool = False,
         state: ImageSlicerState | None = None,
         file_path: str | os.PathLike | None = None,
-        load_func: tuple[Callable | str, dict[str, typing.Any], int] | None = None,
+        load_func: _LoadFunc | None = None,
         auto_compute: bool = True,
         image_cls=None,
         plotdata_cls=None,
@@ -1264,7 +1340,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._splitters[6].addWidget(self._plots[i])
 
         self._file_path: pathlib.Path | None = None
-        self._load_func: tuple[Callable | str, dict[str, typing.Any], int] | None = None
+        self._load_func: _LoadFunc | None = None
         self._source_input_dtype: np.dtype[typing.Any] | None = None
         self.current_cursor: int = 0
         self._data: xr.DataArray
@@ -1361,7 +1437,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if load_func is not None:
             fn = load_func[0]
             func_name = f"{fn.__module__}:{fn.__qualname__}" if callable(fn) else fn
-            load_func = (func_name, *load_func[1:])
+            selection = load_func[2]
+            if isinstance(selection, _FileDataSelection):
+                selection = selection.model_dump(mode="json")
+            load_func = (func_name, load_func[1], selection)
         return {
             "color": self.colormap_properties,
             "slice": self.array_slicer.state,
@@ -2375,7 +2454,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         data: xr.DataArray | npt.NDArray,
         rad2deg: bool | Iterable[str] = False,
         file_path: str | os.PathLike | None = None,
-        load_func: tuple[Callable | str, dict[str, typing.Any], int] | None = None,
+        load_func: _LoadFunc | None = None,
         auto_compute: bool = True,
         *,
         source_replaced: bool = False,
@@ -2400,10 +2479,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
             reload the data, ``load_func`` must also be provided.
         load_func
             3-tuple containing the function, a dictionary of keyword arguments, and the
-            index of the data variable used when loading the data. The function is
+            selection of the data variable used when loading the data. The function is
             called when reloading the data. If using a data loader plugin, the function
-            be given as a string representing the loader name. If the function always
-            returns a single DataArray, the last element should be 0.
+            may be given as a string representing the loader name.
         auto_compute
             If `True` and the data is dask-backed, automatically compute the data if its
             size is below the threshold defined in options.
@@ -2547,7 +2625,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         data: xr.DataArray | npt.NDArray,
         rad2deg: bool | Iterable[str] = False,
         file_path: str | os.PathLike | None = None,
-        load_func: tuple[Callable | str, dict[str, typing.Any], int] | None = None,
+        load_func: _LoadFunc | None = None,
         auto_compute: bool = True,
         *,
         emit_edited: bool = False,
@@ -2632,7 +2710,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
             "xr.DataArray | xr.Dataset | xr.DataTree",
             func(file_path, **load_func[1]),
         )
-        return _parse_input(reloaded)[load_func[2]]
+        return erlab.interactive.imagetool.provenance._select_replay_input(
+            reloaded,
+            load_func[2],
+        )
 
     def _fetch_for_provenance_reload(self) -> xr.DataArray:
         """Replay file-rooted provenance and return the active displayed data."""

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1966,7 +1966,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self.reload_act = QtWidgets.QAction("&Reload Data", self)
         self.reload_act.setShortcut(QtGui.QKeySequence.StandardKey.Refresh)
         self.reload_act.triggered.connect(self.reload)
-        self.reload_act.setToolTip("Reload data from the original source")
+        self.reload_act.setToolTip(
+            "Reload data from its saved files, parent, or inputs"
+        )
         self.reload_act.setIcon(QtGui.QIcon.fromTheme("view-refresh"))
 
         self.view_all_act = QtWidgets.QAction("View &All", self)
@@ -2581,13 +2583,20 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         Direct file-backed windows reload from their stored loader. Detached
         file-rooted provenance reloads by replaying its self-contained code.
+        Managed script-derived ImageTools reload through the manager from their
+        recorded inputs.
 
         Returns
         -------
         bool
             `True` if the data can be reloaded, `False` otherwise.
         """
-        return self._direct_reloadable() or self._provenance_reloadable()
+        if self._direct_reloadable() or self._provenance_reloadable():
+            return True
+        manager = self._manager_instance if self._in_manager else None
+        return manager is not None and manager._script_reload_from_slicer_area(
+            self, execute=False
+        )
 
     def _direct_reloadable(self) -> bool:
         """Return whether direct file metadata can reload the current source."""
@@ -2654,7 +2663,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     def _reload(self) -> bool:
         """Reload the displayed data and return whether the reload succeeded."""
-        if self.reloadable:  # pragma: no branch
+        if self._direct_reloadable() or self._provenance_reloadable():
             try:
                 data, kwargs = self._fetch_reload_data()
                 self.replace_source_data(data, **kwargs)
@@ -2664,11 +2673,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 )
                 return False
             return True
-        return False
+        manager = self._manager_instance if self._in_manager else None
+        return manager is not None and manager._script_reload_from_slicer_area(
+            self, execute=True
+        )
 
     @QtCore.Slot()
     def reload(self) -> None:
-        """Reload the displayed data from direct file state or file-rooted provenance.
+        """Reload the displayed data from recorded source information.
 
         Silently fails if the data cannot be reloaded. If an error occurs while
         reloading the data, a message is shown to the user.

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -2674,10 +2674,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 return False
             return True
         manager = self._manager_instance if self._in_manager else None
-        if manager is not None and manager._script_reload_from_slicer_area(
-            self, execute=True
-        ):
-            return True
+        if manager is not None:
+            return manager._script_reload_from_slicer_area(self, execute=True)
         if not self.reloadable:
             return False
         try:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3250,7 +3250,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         ]
         | None,
     ) -> None:
-        """Set the callback used to resolve lineage for future source refreshes."""
+        """Set the callback used to resolve provenance for future source refreshes."""
         self._input_provenance_parent_fetcher = fetcher
         if fetcher is not None and self._source_state == "fresh":
             self._sync_input_provenance_snapshot()
@@ -3287,7 +3287,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         )
 
     def _sync_input_provenance_snapshot(self) -> None:
-        """Refresh the stored input-lineage snapshot for the displayed tool data."""
+        """Refresh the stored input provenance snapshot for the displayed tool data."""
         self._input_provenance_spec = self._snapshot_input_provenance()
 
     def _effective_input_provenance_spec(
@@ -3551,8 +3551,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Return replay provenance for an unbound ImageTool opened from this tool.
 
         Override this only when an unbound ImageTool should display different replay
-        lineage from `current_provenance_spec()`. Standalone and managed detached
-        launches both preserve the returned lineage, so this hook must stay free of
+        provenance from `current_provenance_spec()`. Standalone and managed detached
+        launches both preserve the returned provenance, so this hook must stay free of
         blocking side effects such as warning dialogs.
         """
         del data, source

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3501,7 +3501,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             if input_provenance is None:
                 raise RuntimeError("Direct replay input requires input provenance.")
             if local_spec is None:
-                return input_provenance
+                return None
             replay_spec = (
                 erlab.interactive.imagetool.provenance.to_replay_provenance_spec(
                     local_spec

--- a/src/erlab/io/plugins/merlin.py
+++ b/src/erlab/io/plugins/merlin.py
@@ -18,6 +18,8 @@ import erlab
 from erlab.io.dataloader import LoaderBase
 from erlab.io.plugins._merlin_bcs import load_bcs
 
+load_bcs.__module__ = __name__
+
 
 def _format_polarization(val) -> str:
     val = round(float(val))

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -4815,7 +4815,7 @@ def test_itool_average(qtbot, accept_dialog) -> None:
     )
     derived = display_namespace["derived"]
     assert isinstance(derived, xr.DataArray)
-    xarray.testing.assert_identical(derived, data.qsel.mean("x"))
+    xarray.testing.assert_identical(derived, data.qsel.mean("x").rename("avg"))
     win.close()
 
 
@@ -4867,7 +4867,7 @@ def test_itool_aggregate_sum(qtbot, accept_dialog) -> None:
     )
     derived = display_namespace["derived"]
     assert isinstance(derived, xr.DataArray)
-    xarray.testing.assert_identical(derived, expected)
+    xarray.testing.assert_identical(derived, expected.rename("sum"))
 
     win.close()
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1660,7 +1660,7 @@ def test_itool_load(qtbot, monkeypatch, move_and_compare_values, accept_dialog) 
     win.close()
 
 
-def test_itool_file_open_uses_selected_variable_source_index(
+def test_itool_file_open_uses_selected_dataset_variable(
     qtbot,
     monkeypatch,
     accept_dialog,
@@ -1673,15 +1673,23 @@ def test_itool_file_open_uses_selected_variable_source_index(
         coords={"u": np.arange(4), "v": np.arange(5)},
         name="second",
     )
+    updated_second = second + 2.0
+    selection = erlab.interactive.imagetool.provenance.FileDataSelection(
+        kind="dataset_variable",
+        value="second",
+    )
     file_path = tmp_path / "multi.h5"
     file_path.touch()
+    datasets = {
+        "current": xr.Dataset({"first": first, "second": second}),
+    }
 
     def _load_multi(_path: str) -> xr.Dataset:
-        return xr.Dataset({"first": first, "second": second})
+        return datasets["current"]
 
     def _select_second(data, parent=None):
         assert parent is not None
-        return ((data["second"], 1),)
+        return ((data["second"], selection),)
 
     monkeypatch.setattr(
         erlab.interactive.utils,
@@ -1708,7 +1716,18 @@ def test_itool_file_open_uses_selected_variable_source_index(
     assert isinstance(win, ImageTool)
     xr.testing.assert_identical(win.slicer_area.data, second)
     assert win.slicer_area._load_func is not None
-    assert win.slicer_area._load_func[2] == 1
+    assert win.slicer_area._load_func[2] == selection
+
+    datasets["current"] = xr.Dataset(
+        {
+            "inserted": xr.DataArray(np.full((2, 3), 5.0), dims=("x", "y")),
+            "second": updated_second,
+            "first": first,
+        }
+    )
+    with qtbot.wait_signal(win.slicer_area.sigDataChanged):
+        win.slicer_area.reload()
+    xr.testing.assert_identical(win.slicer_area.data, updated_second)
 
     win.close()
 
@@ -2416,7 +2435,8 @@ def test_parse_input() -> None:
         )
 
 
-def test_select_dataarrays_dialog_preserves_tree_source_indices(qtbot) -> None:
+def test_select_dataarrays_dialog_preserves_tree_source_paths(qtbot) -> None:
+    prov = erlab.interactive.imagetool.provenance
     first = xr.DataArray(
         np.zeros((2, 3), dtype=np.float32),
         dims=("alpha", "eV"),
@@ -2438,7 +2458,10 @@ def test_select_dataarrays_dialog_preserves_tree_source_indices(qtbot) -> None:
     qtbot.addWidget(dialog)
     selected_data = dialog.selected_dataarrays()
 
-    assert [source_index for _data_array, source_index in selected_data] == [0, 1]
+    assert [selection for _data_array, selection in selected_data] == [
+        prov.FileDataSelection(kind="datatree_path", value="/branch_a/signal"),
+        prov.FileDataSelection(kind="datatree_path", value="/branch_b/signal"),
+    ]
     assert dialog._tree_widget.topLevelItem(0).text(1) == "branch_a"
     assert dialog._tree_widget.topLevelItem(0).text(2) == "signal"
     assert dialog._tree_widget.topLevelItem(1).text(1) == "branch_b"
@@ -2505,7 +2528,12 @@ def test_select_dataarrays_dialog_formats_selected_dataarray(
     dialog._tree_widget.setCurrentItem(second_item)
 
     selected_data = dialog.selected_dataarrays()
-    assert [source_index for _data_array, source_index in selected_data] == [1]
+    assert [selection for _data_array, selection in selected_data] == [
+        erlab.interactive.imagetool.provenance.FileDataSelection(
+            kind="dataset_variable",
+            value="second",
+        )
+    ]
     xr.testing.assert_identical(selected_data[0][0], ds["second"])
     xr.testing.assert_identical(formatted[-1][0], ds["second"])
     assert formatted[-1][1] is False
@@ -2605,9 +2633,12 @@ def test_select_dataarrays_dialog_nests_datatree_paths(qtbot) -> None:
 
     dialog._item_checkbox(signal_item).setChecked(False)
 
-    assert [
-        source_index for _data_array, source_index in dialog.selected_dataarrays()
-    ] == [0]
+    assert [selection for _data_array, selection in dialog.selected_dataarrays()] == [
+        erlab.interactive.imagetool.provenance.FileDataSelection(
+            kind="datatree_path",
+            value="/branch_a/sweep_0/signal",
+        )
+    ]
 
     empty_item = QtWidgets.QTreeWidgetItem(["missing"])
     empty_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, "/missing")
@@ -2697,6 +2728,23 @@ def test_select_input_dataarrays_dialog_branches(
     else:
         assert result is not None
         assert [source_index for _data_array, source_index in result] == list(expected)
+
+
+def test_parse_input_data_records_dataset_and_datatree_selectors() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    image = xr.DataArray(np.ones((2, 3)), dims=("x", "y"), name="image")
+    ds = xr.Dataset({"image": image})
+    tree = xr.DataTree.from_dict({"diag": xr.Dataset({"image": image})})
+
+    dataset_parsed = imagetool_viewer._parse_input_data(ds)
+    datatree_parsed = imagetool_viewer._parse_input_data(tree)
+
+    assert dataset_parsed[0][1] == prov.FileDataSelection(
+        kind="dataset_variable", value="image"
+    )
+    assert datatree_parsed[0][1] == prov.FileDataSelection(
+        kind="datatree_path", value="/diag/image"
+    )
 
 
 def test_itool_dataset_selection_returns_selected_variable(qtbot, monkeypatch) -> None:

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -4815,7 +4815,10 @@ def test_itool_average(qtbot, accept_dialog) -> None:
     )
     derived = display_namespace["derived"]
     assert isinstance(derived, xr.DataArray)
-    xarray.testing.assert_identical(derived, data.qsel.mean("x").rename("avg"))
+    assert ".rename(" not in display_code
+    xarray.testing.assert_identical(
+        derived.rename(None), data.qsel.mean("x").rename(None)
+    )
     win.close()
 
 
@@ -4867,7 +4870,8 @@ def test_itool_aggregate_sum(qtbot, accept_dialog) -> None:
     )
     derived = display_namespace["derived"]
     assert isinstance(derived, xr.DataArray)
-    xarray.testing.assert_identical(derived, expected.rename("sum"))
+    assert ".rename(" not in display_code
+    xarray.testing.assert_identical(derived.rename(None), expected.rename(None))
 
     win.close()
 

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -16410,6 +16410,28 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
             manager._metadata_detail_labels["Inputs"].sizePolicy().verticalPolicy()
             == QtWidgets.QSizePolicy.Policy.Preferred
         )
+        assert (
+            manager.metadata_group.sizePolicy().verticalPolicy()
+            == QtWidgets.QSizePolicy.Policy.Maximum
+        )
+        assert not isinstance(
+            manager.metadata_group.parentWidget(), QtWidgets.QSplitter
+        )
+        metadata_layout = manager.metadata_group.layout()
+        assert metadata_layout is not None
+        assert (
+            manager.metadata_derivation_list.y()
+            == manager.metadata_details_widget.y()
+            + manager.metadata_details_widget.height()
+            + metadata_layout.spacing()
+        )
+        qtbot.wait_until(
+            lambda: (
+                manager.metadata_group.height()
+                <= manager.metadata_group.sizeHint().height() + 1
+            ),
+            timeout=5000,
+        )
         assert "\n" in details["Inputs"]
         assert "\n\n" not in details["Inputs"]
         assert all(line.strip() for line in details["Inputs"].splitlines())

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -15478,6 +15478,111 @@ def test_manager_console_selected_expression_opens_provenance_root(
         InteractiveShell.clear_instance()
 
 
+def test_manager_console_child_imagetool_access_tracks_provenance(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+        name="parent",
+    )
+    data1 = data0 + 2.0
+    data1.name = "right"
+    child_data = data0 + 10.0
+    child_data.name = "child"
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        intermediate_uid = manager.add_childtool(
+            erlab.interactive.utils.ToolWindow(), 0, show=False
+        )
+        child_tool = itool(child_data, manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool, intermediate_uid, show=False
+        )
+        child_node = manager._child_node(child_uid)
+
+        shell = manager.console._console_widget.kernel_manager.kernel.shell
+
+        manager.console._console_widget.execute("child_handles = tools[0].children")
+        child_handles = shell.user_ns["child_handles"]
+        assert len(child_handles) == 1
+        assert "[0]" in repr(child_handles)
+        assert child_node.name in repr(child_handles)
+
+        manager.console._console_widget.execute(
+            "isinstance(tools[0].children[0].data, xr.DataArray)"
+        )
+        assert shell.user_ns["_"] is True
+        xr.testing.assert_identical(child_handles[0].data, child_data)
+
+        manager.console._console_widget.execute("tools[0].children[0] - tools[1]")
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            child_data - data1,
+        )
+        provenance = manager._imagetool_wrappers[2].provenance_spec
+        assert provenance is not None
+        assert [source.name for source in provenance.script_inputs] == [
+            "data_0_0",
+            "data_1",
+        ]
+        assert [source.node_uid for source in provenance.script_inputs] == [
+            child_uid,
+            manager._imagetool_wrappers[1].uid,
+        ]
+        assert [source.node_snapshot_token for source in provenance.script_inputs] == [
+            child_node.snapshot_token,
+            manager._imagetool_wrappers[1].snapshot_token,
+        ]
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        manager.console._console_widget.execute("tools.selected[0].data")
+        xr.testing.assert_identical(shell.user_ns["_"], child_data)
+        manager.console._console_widget.execute("tools.selected_data")
+        assert len(shell.user_ns["_"]) == 1
+        xr.testing.assert_identical(shell.user_ns["_"][0], child_data)
+
+        derived_uid = manager._imagetool_wrappers[2].uid
+        updated_child = child_data + 5.0
+        child_tool.slicer_area.replace_source_data(updated_child)
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(derived_uid) == "changed",
+            timeout=5000,
+        )
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [2])
+        manager.reload_selected()
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            updated_child - data1,
+        )
+        assert manager.dependency_status_for_uid(derived_uid) == "current"
+
+        manager._remove_childtool(child_uid)
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(derived_uid) == "missing",
+            timeout=5000,
+        )
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
 def test_manager_console_derived_tool_reload_action_routes_to_manager(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -16404,7 +16404,7 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         details = metadata_detail_map(manager)
         assert metadata_detail_labels(manager).count("Inputs") == 1
         assert manager._metadata_detail_labels["Inputs"].wordWrap()
-        assert "\n" in details["Inputs"]
+        assert "\n" not in details["Inputs"]
         assert "recorded source file found" in details["Inputs"]
 
         manager.reload_selected()

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -5906,8 +5906,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert detached.provenance_spec.derivation_code() == (
             "derived = data\n"
             'derived = derived.qsel.mean("x")\n'
-            'derived = derived.qsel.mean("y")\n'
-            'derived = derived.rename("scan_avg_avg")'
+            'derived = derived.qsel.mean("y")'
         )
         assert detached.provenance_spec.derivation_code() != detached_derivation_before
         xr.testing.assert_identical(
@@ -14183,6 +14182,7 @@ def test_remove_imagetool_removes_childtools() -> None:
         _all_nodes={wrapper.uid: wrapper},
         _mark_removed_subtree_dirty=lambda _uid: None,
         _remove_uid_target=lambda child_uid: removed_uids.append(child_uid),
+        _refresh_dependency_dependents=lambda _uid: None,
         tree_view=types.SimpleNamespace(
             imagetool_removed=lambda index: removed_rows.append(index)
         ),

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -1,4 +1,3 @@
-import ast
 import concurrent.futures
 import contextlib
 import dataclasses
@@ -69,11 +68,7 @@ from erlab.interactive.imagetool.manager import (
     load_in_manager,
     replace_data,
 )
-from erlab.interactive.imagetool.manager._console import (
-    ToolNamespace,
-    _ConsoleDataAssignmentTransformer,
-    _rewrite_console_source,
-)
+from erlab.interactive.imagetool.manager._console import ToolNamespace
 from erlab.interactive.imagetool.manager._dialogs import (
     _ChooseFromDataTreeDialog,
     _ConcatDialog,
@@ -14956,6 +14951,16 @@ def test_manager_console(
         manager.console._console_widget.execute("tools")
         assert str(_get_last_output_contents()) == "0: \n1: "
         manager.console._console_widget.execute("tools[0]")
+        manager.console._console_widget.execute(
+            "isinstance(tools[0].data, xr.DataArray)"
+        )
+        assert _get_last_output_contents() is True
+        manager.console._console_widget.execute(
+            "lst = [1]\nalias = lst\nlst += [2]",
+        )
+        shell = manager.console._console_widget.kernel_manager.kernel.shell
+        assert shell.user_ns["lst"] == [1, 2]
+        assert shell.user_ns["alias"] is shell.user_ns["lst"]
 
         # Select all
         select_tools(manager, list(manager._imagetool_wrappers.keys()))
@@ -15187,7 +15192,7 @@ def test_tool_namespace_set_data_item_marks_child_tools_stale(
         namespace = ToolNamespace(manager._imagetool_wrappers[0])
         child = next(iter(manager._imagetool_wrappers[0]._childtools.values()))
 
-        namespace._set_data_item((0, 0), -5.0)
+        namespace[(0, 0)] = -5.0
 
         assert float(parent_tool.slicer_area._data.values[0, 0]) == -5.0
         qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
@@ -15217,39 +15222,403 @@ def test_tool_namespace_set_data_item_failure_keeps_child_tools_fresh(
         child = next(iter(manager._imagetool_wrappers[0]._childtools.values()))
 
         with pytest.raises(IndexError, match="too many indices"):
-            namespace._set_data_item((0, 0, 0), -5.0)
+            namespace[(0, 0, 0)] = -5.0
 
         assert child.source_state == "fresh"
         assert float(parent_tool.slicer_area._data.values[0, 0]) == 0.0
 
 
-def test_console_assignment_transformer_match_helpers() -> None:
-    plain_name = typing.cast("ast.Expr", ast.parse("value").body[0]).value
-    attr_without_subscript = typing.cast(
-        "ast.Expr", ast.parse("tool.data").body[0]
-    ).value
-    other_tool = typing.cast("ast.Expr", ast.parse("other[0].data").body[0]).value
-    subscript_target = typing.cast(
-        "ast.Expr", ast.parse("other[0].data[1]").body[0]
-    ).value
-
-    assert _ConsoleDataAssignmentTransformer._match_tool_data(plain_name) is None
-    assert (
-        _ConsoleDataAssignmentTransformer._match_tool_data(attr_without_subscript)
-        is None
+def test_manager_console_bare_expression_opens_provenance_root(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(9, dtype=float).reshape(3, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(3), "y": np.arange(3)},
+        name="left",
     )
-    assert _ConsoleDataAssignmentTransformer._match_tool_data(other_tool) is None
-    assert _ConsoleDataAssignmentTransformer._match_target(subscript_target) is None
+    data1 = data0 + 1.0
+    data1.name = "right"
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        manager.console._console_widget.execute(
+            "raw_diff = tools[0].data - tools[1].data"
+        )
+        assert manager.ntools == 2
+        shell = manager.console._console_widget.kernel_manager.kernel.shell
+        assert isinstance(shell.user_ns["raw_diff"], xr.DataArray)
+
+        manager.console._console_widget.execute("tools[0] - tools[1]")
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data, data0 - data1
+        )
+        provenance = manager._imagetool_wrappers[2].provenance_spec
+        assert provenance is not None
+        assert [source.name for source in provenance.script_inputs] == [
+            "data_0",
+            "data_1",
+        ]
+        assert [source.node_uid for source in provenance.script_inputs] == [
+            manager._imagetool_wrappers[0].uid,
+            manager._imagetool_wrappers[1].uid,
+        ]
+        assert [source.node_lineage_token for source in provenance.script_inputs] == [
+            manager._imagetool_wrappers[0].lineage_token,
+            manager._imagetool_wrappers[1].lineage_token,
+        ]
+        assert (
+            manager.lineage_status_for_uid(manager._imagetool_wrappers[2].uid)
+            == "current"
+        )
+        assert provenance.operations
+        assert "data_0 - data_1" in typing.cast(
+            "str", provenance.operations[-1].derivation_entry().code
+        )
+
+        tree = manager._to_datatree()
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+        for node in tree.values():
+            manager._load_workspace_node(typing.cast("xr.DataTree", node))
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        loaded = [
+            wrapper.provenance_spec
+            for wrapper in manager._imagetool_wrappers.values()
+            if wrapper.provenance_spec is not None
+            and len(wrapper.provenance_spec.script_inputs) == 2
+        ]
+        assert len(loaded) == 1
+        assert [source.name for source in loaded[0].script_inputs] == [
+            "data_0",
+            "data_1",
+        ]
+        derived_uid = manager._imagetool_wrappers[2].uid
+        assert manager.lineage_status_for_uid(derived_uid) == "current"
+
+        original_difference = manager.get_imagetool(2).slicer_area.data.copy()
+        manager.get_imagetool(0).slicer_area.replace_source_data(data0 + 10.0)
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(derived_uid) == "changed",
+            timeout=5000,
+        )
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            original_difference,
+        )
+
+        manager.remove_imagetool(1)
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(derived_uid) == "missing",
+            timeout=5000,
+        )
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            original_difference,
+        )
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
 
 
-def test_rewrite_console_source_handles_augassign_and_passthrough() -> None:
-    rewritten = _rewrite_console_source("tools[1].data[0, 0] += 1")
+def test_manager_console_assignment_tracks_until_explicit_show(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 2.0
 
-    assert "_get_data_item" in rewritten
-    assert "_set_data_item" in rewritten
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
 
-    assert _rewrite_console_source("left = right = 1") == "left = right = 1"
-    assert _rewrite_console_source("value += 1") == "value += 1"
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        manager.console._console_widget.execute("diff = tools[0] - tools[1]")
+        assert manager.ntools == 2
+
+        manager.console._console_widget.execute(
+            "diff.qshow(manager=True, execute=False)"
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data, data0 - data1
+        )
+        qshow_provenance = manager._imagetool_wrappers[2].provenance_spec
+        assert qshow_provenance is not None
+        assert qshow_provenance.active_name == "diff"
+
+        manager.console._console_widget.execute(
+            "non_manager = itool(diff, manager=False, execute=False)"
+        )
+        assert manager.ntools == 3
+
+        manager.console._console_widget.execute(
+            "itool(diff, manager=True, execute=False)"
+        )
+        qtbot.wait_until(lambda: manager.ntools == 4, timeout=5000)
+        xr.testing.assert_identical(
+            manager.get_imagetool(3).slicer_area.data, data0 - data1
+        )
+        itool_provenance = manager._imagetool_wrappers[3].provenance_spec
+        assert itool_provenance == qshow_provenance
+
+        manager.console._console_widget.execute("diff + tools[0]")
+        qtbot.wait_until(lambda: manager.ntools == 5, timeout=5000)
+        xr.testing.assert_identical(
+            manager.get_imagetool(4).slicer_area.data,
+            data0 - data1 + data0,
+        )
+        nested_provenance = manager._imagetool_wrappers[4].provenance_spec
+        assert nested_provenance is not None
+        assert [source.name for source in nested_provenance.script_inputs] == [
+            "diff",
+            "data_0",
+        ]
+        nested_uid = manager._imagetool_wrappers[4].uid
+        assert manager.lineage_status_for_uid(nested_uid) == "current"
+        nested_data = manager.get_imagetool(4).slicer_area.data.copy()
+        manager.get_imagetool(1).slicer_area.replace_source_data(data1 + 5.0)
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(nested_uid) == "changed",
+            timeout=5000,
+        )
+        xr.testing.assert_identical(
+            manager.get_imagetool(4).slicer_area.data,
+            nested_data,
+        )
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
+def test_manager_console_selected_expression_opens_provenance_root(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 3.0
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        manager.console._console_widget.execute("xr.DataArray([1.0], dims=['x'])")
+        assert manager.ntools == 2
+
+        select_tools(manager, [0, 1])
+        manager.console._console_widget.execute("tools.selected[0] - tools.selected[1]")
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            data0 - data1,
+        )
+        provenance = manager._imagetool_wrappers[2].provenance_spec
+        assert provenance is not None
+        assert [source.name for source in provenance.script_inputs] == [
+            "data_0",
+            "data_1",
+        ]
+        assert (
+            provenance.operations[-1].derivation_entry().code
+            == "derived = data_0 - data_1"
+        )
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
+def test_manager_concat_records_lineage_and_handles_removed_inputs(
+    qtbot,
+    accept_dialog,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 10.0
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        expected = xr.concat(
+            [
+                manager.get_imagetool(0).slicer_area.data,
+                manager.get_imagetool(1).slicer_area.data,
+            ],
+            dim="concat_dim",
+            coords="minimal",
+            compat="override",
+            join="outer",
+            combine_attrs="override",
+        )
+        expected = expected.assign_coords(concat_dim=np.arange(2))
+
+        select_tools(manager, [0, 1])
+        accept_dialog(manager.concat_action.trigger)
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, expected)
+        concat_wrapper = manager._imagetool_wrappers[2]
+        provenance = concat_wrapper.provenance_spec
+        assert provenance is not None
+        assert [source.name for source in provenance.script_inputs] == [
+            "data_0",
+            "data_1",
+        ]
+        assert [source.node_uid for source in provenance.script_inputs] == [
+            manager._imagetool_wrappers[0].uid,
+            manager._imagetool_wrappers[1].uid,
+        ]
+        assert [source.node_lineage_token for source in provenance.script_inputs] == [
+            manager._imagetool_wrappers[0].lineage_token,
+            manager._imagetool_wrappers[1].lineage_token,
+        ]
+        operation_entry = provenance.operations[-1].derivation_entry()
+        assert operation_entry.label == "Concatenate selected ImageTools"
+        assert operation_entry.code is not None
+        assert "xr.concat([data_0, data_1]" in operation_entry.code
+        assert manager.lineage_status_for_uid(concat_wrapper.uid) == "current"
+
+        manager.get_imagetool(0).slicer_area.replace_source_data(data0 + 1.0)
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(concat_wrapper.uid) == "changed",
+            timeout=5000,
+        )
+        xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, expected)
+
+        select_tools(manager, [0, 1])
+        expected_removed_inputs = xr.concat(
+            [
+                manager.get_imagetool(0).slicer_area.data,
+                manager.get_imagetool(1).slicer_area.data,
+            ],
+            dim="concat_dim",
+            coords="minimal",
+            compat="override",
+            join="outer",
+            combine_attrs="override",
+        )
+        expected_removed_inputs = expected_removed_inputs.assign_coords(
+            concat_dim=np.arange(2)
+        )
+
+        def _remove_originals(dialog: _ConcatDialog) -> None:
+            dialog._remove_original_check.setChecked(True)
+
+        accept_dialog(manager.concat_action.trigger, pre_call=_remove_originals)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        removed_inputs_wrapper = manager._imagetool_wrappers[3]
+        assert manager.lineage_status_for_uid(removed_inputs_wrapper.uid) == "missing"
+        xr.testing.assert_identical(
+            manager.get_imagetool(3).slicer_area.data,
+            expected_removed_inputs,
+        )
+
+
+def test_manager_console_replacement_updates_provenance_and_descendants(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(25, dtype=float).reshape(5, 5),
+        dims=("x", "y"),
+        coords={"x": np.arange(5), "y": np.arange(5)},
+    )
+    data1 = data0.assign_coords(time=("x", np.linspace(10.0, 50.0, 5)))
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1,
+            timeout=5000,
+        )
+        child = next(iter(manager._imagetool_wrappers[0]._childtools.values()))
+
+        manager.console._console_widget.execute(
+            "tools[0].data = tools[0].assign_coords(time=tools[1].time)"
+        )
+        qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data,
+            data0.assign_coords(time=data1.time),
+        )
+        provenance = manager._imagetool_wrappers[0].provenance_spec
+        assert provenance is not None
+        assert manager._imagetool_wrappers[0].source_spec is None
+        assert [source.name for source in provenance.script_inputs] == [
+            "data_0",
+            "data_1",
+        ]
+        assert (
+            provenance.operations[-1].derivation_entry().code
+            == "data_0 = data_0.assign_coords(time=data_1.time)"
+        )
+
+        tree = manager._to_datatree()
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+        for node in tree.values():
+            manager._load_workspace_node(typing.cast("xr.DataTree", node))
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        loaded_provenance = manager._imagetool_wrappers[0].provenance_spec
+        assert loaded_provenance is not None
+        assert [source.name for source in loaded_provenance.script_inputs] == [
+            "data_0",
+            "data_1",
+        ]
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
 
 
 def test_manager_hover_tooltip(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -16404,6 +16404,14 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         details = metadata_detail_map(manager)
         assert metadata_detail_labels(manager).count("Inputs") == 1
         assert manager._metadata_detail_labels["Inputs"].wordWrap()
+        assert (
+            manager.metadata_details_widget.sizePolicy().verticalPolicy()
+            == QtWidgets.QSizePolicy.Policy.Maximum
+        )
+        assert (
+            manager._metadata_detail_labels["Inputs"].sizePolicy().verticalPolicy()
+            == QtWidgets.QSizePolicy.Policy.Preferred
+        )
         assert "\n" in details["Inputs"]
         assert "\n\n" not in details["Inputs"]
         assert all(line.strip() for line in details["Inputs"].splitlines())

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -108,6 +108,17 @@ from erlab.interactive.ptable import PeriodicTableWindow
 logger = logging.getLogger(__name__)
 
 
+CONSOLE_HELPER_OFFSET = 2.5
+
+
+def console_helper_dependency(value):
+    return value + CONSOLE_HELPER_OFFSET
+
+
+def console_helper(value):
+    return console_helper_dependency(value)
+
+
 @pytest.fixture(scope="module")
 def test_data():
     return xr.DataArray(
@@ -15451,6 +15462,426 @@ def test_manager_console_reserved_result_name_replays_without_shadowing() -> Non
     )
 
 
+def test_manager_console_helpers_preserve_nested_operands() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+    )
+    handle = manager_console._DerivedDataNamespace(
+        None,
+        data,
+        "data_0",
+        (prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+        copyable=True,
+    )
+
+    namespace = {"np": np}
+    for value in (
+        np.nan,
+        np.inf,
+        -np.inf,
+        complex(np.nan, np.inf),
+        (1, np.nan),
+        [1, np.inf],
+        {"offset": -np.inf},
+    ):
+        code, copyable = manager_console._literal_code(value)
+        assert copyable
+        evaluated = eval(code, namespace)  # noqa: S307
+        np.testing.assert_equal(evaluated, erlab.utils.misc._convert_to_native(value))
+
+    assert manager_console._literal_code(object())[1] is False
+    assert manager_console._derived_operand_code("data_0 + data_1").startswith("(")
+    assert manager_console._derived_operand_code("data_0 == data_1").startswith("(")
+    assert manager_console._derived_operand_code("data_0.sel(x=0)") == "data_0.sel(x=0)"
+
+    nested = {"left": [handle, slice(0, 1)], "right": (handle,)}
+    assert manager_console._first_console_handle(nested) is handle
+    unwrapped = manager_console._unwrap_console_value(nested)
+    xr.testing.assert_identical(unwrapped["left"][0], data)
+    xr.testing.assert_identical(unwrapped["right"][0], data)
+
+    operand = manager_console._operand_from_value(nested)
+    assert [script_input.name for script_input in operand.script_inputs] == ["data_0"]
+    assert operand.copyable
+    assert operand.value["left"][1] == slice(0, 1)
+
+
+def test_manager_console_namespace_protocols_and_proxies() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+    )
+    handle = manager_console._DerivedDataNamespace(
+        None,
+        data,
+        "data_0",
+        (prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+        copyable=True,
+    )
+
+    for result, expected in (
+        (-handle, -data),
+        (+handle, +data),
+        (abs(handle - 2.0), abs(data - 2.0)),
+        (np.sin(handle), np.sin(data)),
+        (handle[{"x": 0}], data[{"x": 0}]),
+        (handle.x, data.x),
+        (handle.coarsen(y=2).mean(), data.coarsen(y=2).mean()),
+    ):
+        assert isinstance(result, manager_console._DerivedDataNamespace)
+        xr.testing.assert_identical(result.data, expected)
+
+    bool_handle = manager_console._DerivedDataNamespace(
+        None,
+        xr.DataArray([True, False], dims=("x",)),
+        "data_1",
+        (prov.ScriptInput(name="data_1", label="ImageTool 1"),),
+        copyable=True,
+    )
+    inverted = ~bool_handle
+    assert isinstance(inverted, manager_console._DerivedDataNamespace)
+    xr.testing.assert_identical(inverted.data, xr.DataArray([False, True], dims=("x",)))
+
+    assert handle.__array_ufunc__(np.add, "reduce", handle) is NotImplemented
+    np.testing.assert_array_equal(np.asarray(handle), data.values)
+    np.testing.assert_array_equal(handle.__array__(copy=True), data.values)
+
+    coarsened = handle.coarsen(y=2).mean()
+    spec = coarsened._console_provenance_spec(
+        active_name="derived",
+        label="Evaluate console expression",
+    )
+    assert spec is not None
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(spec, {"data_0": data}),
+        coarsened.data,
+    )
+
+    module_proxy = manager_console._ConsoleModuleProxy(np, "np")
+    assert isinstance(module_proxy.linalg, manager_console._ConsoleModuleProxy)
+    assert module_proxy.float64 is np.float64
+    assert module_proxy.pi == np.pi
+    np.testing.assert_allclose(module_proxy.sin(np.array([0.0, np.pi / 2])), [0.0, 1.0])
+    module_result = module_proxy.sin(handle)
+    assert isinstance(module_result, manager_console._DerivedDataNamespace)
+    xr.testing.assert_allclose(module_result.data, np.sin(data))
+
+    def add_one(value):
+        return value + 1
+
+    function_proxy = manager_console._ConsoleFunctionProxy(add_one)
+    xr.testing.assert_identical(function_proxy(data), data + 1)
+    function_proxy.__name__ = ""
+    function_result = function_proxy(handle)
+    assert isinstance(function_result, manager_console._DerivedDataNamespace)
+    xr.testing.assert_identical(function_result.data, data + 1)
+
+
+def test_manager_console_operator_and_proxy_branches() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(1, 5).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0, 1], "y": [0, 1]},
+    )
+    handle = manager_console._DerivedDataNamespace(
+        None,
+        data,
+        "data_0",
+        (prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+        copyable=True,
+    )
+
+    operations = (
+        (lambda: 10 + handle, 10 + data),
+        (lambda: 10 - handle, 10 - data),
+        (lambda: 2 * handle, 2 * data),
+        (lambda: handle @ data, data @ data),
+        (lambda: handle.__rmatmul__(data), data @ data),
+        (lambda: handle / 2, data / 2),
+        (lambda: 10 / handle, 10 / data),
+        (lambda: handle // 2, data // 2),
+        (lambda: 10 // handle, 10 // data),
+        (lambda: handle % 2, data % 2),
+        (lambda: 10 % handle, 10 % data),
+        (lambda: handle**2, data**2),
+        (lambda: 2**handle, 2**data),
+        (lambda: handle < 3, data < 3),
+        (lambda: handle <= 3, data <= 3),
+        (lambda: handle > 3, data > 3),
+        (lambda: handle >= 3, data >= 3),
+        (lambda: handle == 3, data == 3),
+        (lambda: handle != 3, data != 3),
+    )
+    for operation, expected in operations:
+        result = operation()
+        assert isinstance(result, manager_console._DerivedDataNamespace)
+        xr.testing.assert_identical(result.data, expected)
+
+    int_handle = manager_console._DerivedDataNamespace(
+        None,
+        data.astype(int),
+        "data_1",
+        (prov.ScriptInput(name="data_1", label="ImageTool 1"),),
+        copyable=True,
+    )
+    for operation, expected in (
+        (lambda: int_handle & 1, data.astype(int) & 1),
+        (lambda: 1 & int_handle, 1 & data.astype(int)),
+        (lambda: int_handle | 1, data.astype(int) | 1),
+        (lambda: 1 | int_handle, 1 | data.astype(int)),
+        (lambda: int_handle ^ 1, data.astype(int) ^ 1),
+        (lambda: 1 ^ int_handle, 1 ^ data.astype(int)),
+    ):
+        result = operation()
+        assert isinstance(result, manager_console._DerivedDataNamespace)
+        xr.testing.assert_identical(result.data, expected)
+
+    assert handle.qsel.__doc__
+    assert handle._wrap_console_result(1, "one", (), copyable=True) == 1
+    with pytest.raises(TypeError, match="not callable"):
+        manager_console._ConsoleAccessorProxy(
+            handle,
+            types.SimpleNamespace(value=10),
+            ("fake",),
+            "data_0.fake",
+        )()
+    accessor_proxy = manager_console._ConsoleAccessorProxy(
+        handle,
+        types.SimpleNamespace(array=data, value=10),
+        ("fake",),
+        "data_0.fake",
+    )
+    accessor_array = accessor_proxy.array
+    assert isinstance(accessor_array, manager_console._DerivedDataNamespace)
+    xr.testing.assert_identical(accessor_array.data, data)
+    assert accessor_proxy.value == 10
+    coarsened_with_kwargs = handle.coarsen(y=2).mean(skipna=True)
+    assert isinstance(coarsened_with_kwargs, manager_console._DerivedDataNamespace)
+    xr.testing.assert_identical(
+        coarsened_with_kwargs.data,
+        data.coarsen(y=2).mean(skipna=True),
+    )
+    assert "mean" in dir(handle.coarsen(y=2))
+
+    custom_module = types.ModuleType("custom_console_module")
+    custom_module.__file__ = "custom_console_module.py"
+
+    def scale(value, *, offset=0):
+        return value + offset
+
+    custom_module.scale = scale
+    module_proxy = manager_console._ConsoleModuleProxy(custom_module, "custom")
+    assert module_proxy.__file__ == "custom_console_module.py"
+    module_result = module_proxy.scale(handle, offset=2)
+    assert isinstance(module_result, manager_console._DerivedDataNamespace)
+    xr.testing.assert_identical(module_result.data, data + 2)
+    assert module_proxy == custom_module
+    assert module_proxy == manager_console._ConsoleModuleProxy(custom_module, "alias")
+    assert hash(module_proxy) == hash(custom_module)
+
+    class ParentWithoutTools:
+        _console_label = "Parent"
+
+        @property
+        def _console_tools(self):
+            return None
+
+    children = manager_console._ToolChildren(ParentWithoutTools())
+    assert len(children) == 0
+    assert list(children) == []
+    assert "No child" in repr(children)
+    with pytest.raises(LookupError):
+        children[0]
+
+
+def test_manager_console_tools_namespace_helper_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+
+    class FakeManager:
+        manager_index = 3
+
+        def __init__(self) -> None:
+            self._imagetool_wrappers = {}
+            self.added: list[tuple[xr.DataArray, typing.Any]] = []
+
+        def add_imagetool(self, tool, **kwargs) -> None:
+            self.added.append((tool.slicer_area.data, kwargs["provenance_spec"]))
+
+    fake_manager = FakeManager()
+    tools = manager_console.ToolsNamespace(fake_manager)
+    assert repr(tools) == "No tools"
+    assert tools._manager_argument_targets_this_manager(None)
+    assert tools._manager_argument_targets_this_manager(True)
+    assert tools._manager_argument_targets_this_manager(3)
+    assert not tools._manager_argument_targets_this_manager(False)
+    assert not tools._manager_argument_targets_this_manager(4)
+    assert not tools._manager_argument_targets_this_manager("manager-3")
+    tools.unbind_shell()
+    tools._pre_run_cell()
+
+    result_with_error = types.SimpleNamespace(
+        error_before_exec=RuntimeError("before"),
+        error_in_exec=None,
+        result=None,
+    )
+    tools._post_run_cell(result_with_error)
+
+    handle_without_provenance = manager_console._DerivedDataNamespace(
+        None,
+        data,
+        "data_0",
+        (),
+        copyable=False,
+    )
+    monkeypatch.setattr(
+        handle_without_provenance, "_console_provenance_spec", lambda **_kwargs: None
+    )
+    assert not tools._show_handle(
+        handle_without_provenance,
+        active_name="derived",
+        label="Evaluate console expression",
+    )
+
+    monkeypatch.setattr(erlab.interactive, "itool", lambda *_args, **_kwargs: object())
+    shown = tools._show_dataarray_with_provenance(
+        data,
+        prov.script(
+            prov.ScriptCodeOperation(label="Copy", code="derived = data_0"),
+            start_label="Run script",
+            active_name="derived",
+            script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+        ),
+        execute=True,
+    )
+    assert not shown
+    assert not fake_manager.added
+
+
+def test_manager_console_callable_operand_captures_replayable_functions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+    monkeypatch.setattr(console_helper, "__module__", "__main__")
+    monkeypatch.setattr(console_helper_dependency, "__module__", "__main__")
+
+    operand = manager_console._callable_operand(console_helper)
+
+    assert operand is not None
+    assert operand.copyable
+    namespace: dict[str, typing.Any] = {
+        "data": data,
+        "np": np,
+        "xr": xr,
+        "erlab": erlab,
+        "era": erlab.analysis,
+    }
+    exec(  # noqa: S102
+        manager_console._script_code(
+            operand.code_prelude,
+            f"derived = {operand.code}(data)",
+        ),
+        namespace,
+        namespace,
+    )
+    xr.testing.assert_identical(namespace["derived"], console_helper(data))
+
+    assert manager_console._function_global_names("def f(:", "f") is None
+    assert (
+        manager_console._function_global_names("def f():\n    return missing", "g")
+        is None
+    )
+
+    with monkeypatch.context() as patch:
+        patch.setattr(console_helper, "__name__", "data")
+        patch.setattr(console_helper, "__qualname__", "data")
+        assert manager_console._callable_operand(console_helper) is None
+
+    with monkeypatch.context() as patch:
+        patch.setattr(console_helper, "__module__", "__main__")
+
+        def raise_oserror(_value):
+            raise OSError
+
+        patch.setattr(manager_console.inspect, "getsource", raise_oserror)
+        assert manager_console._callable_operand(console_helper) is None
+
+
+def test_manager_console_callable_operand_rejects_unreplayable_globals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(console_helper, "__module__", "__main__")
+    monkeypatch.setattr(console_helper_dependency, "__module__", "__main__")
+
+    source_cases = (
+        "def console_helper(value):\n"
+        "    return value\n\n"
+        "def extra():\n"
+        "    return value",
+        "@decorator\ndef console_helper(value):\n    return value",
+    )
+    for source in source_cases:
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager_console.inspect,
+                "getsource",
+                lambda _value, source=source: source,
+            )
+            assert manager_console._callable_operand(console_helper) is None
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            manager_console, "_function_global_names", lambda _source, _name: None
+        )
+        assert manager_console._callable_operand(console_helper) is None
+
+    for global_names in ({"data_0"}, {"missing_global"}):
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager_console,
+                "_function_global_names",
+                lambda _source, _name, names=global_names: names,
+            )
+            assert manager_console._callable_operand(console_helper) is None
+
+    def local_dependency(value):
+        return value
+
+    with monkeypatch.context() as patch:
+        patch.setitem(console_helper.__globals__, "local_dependency", local_dependency)
+        patch.setattr(
+            manager_console,
+            "_function_global_names",
+            lambda _source, _name: {"local_dependency"},
+        )
+        assert manager_console._callable_operand(console_helper) is None
+
+    with monkeypatch.context() as patch:
+        patch.setitem(console_helper.__globals__, "uncopyable_global", object())
+        patch.setattr(
+            manager_console,
+            "_function_global_names",
+            lambda _source, _name: {"uncopyable_global"},
+        )
+        assert manager_console._callable_operand(console_helper) is None
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            erlab.interactive.imagetool.provenance,
+            "_validate_script_replay_code",
+            lambda _code: (_ for _ in ()).throw(ValueError),
+        )
+        assert manager_console._callable_operand(console_helper) is None
+
+
 def test_manager_console_assignment_tracks_until_explicit_show(
     qtbot,
     manager_context: Callable[
@@ -16662,6 +17093,291 @@ def test_manager_reload_script_inputs_missing_parent_without_source_noops(
 
         xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, original)
         assert not errors
+
+
+def test_manager_reload_helper_status_dialog_and_workspace_branches(
+    qtbot,
+    tmp_path,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 1.0
+    path = tmp_path / "recorded.nc"
+    data0.to_netcdf(path)
+    file_spec = prov.file_load(
+        start_label="Load recorded",
+        seed_code=f"derived = xr.load_dataarray({str(path)!r})",
+        file_load_source=prov.FileLoadSource(
+            path=str(path),
+            loader_label="xarray.load_dataarray",
+            loader_text="xarray.load_dataarray",
+            kwargs_text="",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=0,
+            ),
+        ),
+    )
+
+    class FakeMessageBox:
+        Icon = types.SimpleNamespace(Warning=object(), Question=object())
+        ButtonRole = types.SimpleNamespace(AcceptRole=object(), ActionRole=object())
+        StandardButton = types.SimpleNamespace(Cancel=object(), Close=object())
+        clicked_index: int | None = 0
+        instances: typing.ClassVar[list["FakeMessageBox"]] = []
+
+        def __init__(self, _parent=None) -> None:
+            self.buttons: list[object] = []
+            self.clicked: object | None = None
+            self.standard_buttons = None
+            FakeMessageBox.instances.append(self)
+
+        def setWindowTitle(self, _value) -> None: ...
+
+        def setDetailedText(self, _value) -> None: ...
+
+        def setIcon(self, _value) -> None: ...
+
+        def setText(self, _value) -> None: ...
+
+        def setInformativeText(self, _value) -> None: ...
+
+        def setStandardButtons(self, value) -> None:
+            self.standard_buttons = value
+
+        def addButton(self, *_args) -> object:
+            button = object()
+            self.buttons.append(button)
+            return button
+
+        def setDefaultButton(self, _value) -> None: ...
+
+        def exec(self) -> None:
+            if (
+                FakeMessageBox.clicked_index is not None
+                and FakeMessageBox.clicked_index < len(self.buttons)
+            ):
+                self.clicked = self.buttons[FakeMessageBox.clicked_index]
+
+        def clickedButton(self) -> object | None:
+            return self.clicked
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                data0 - data1,
+                (0, 1),
+                operation_label="Subtract inputs",
+                operation_code="derived = data_0 - data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+        derived_wrapper = manager._imagetool_wrappers[2]
+        derived_uid = derived_wrapper.uid
+        script_spec = derived_wrapper.provenance_spec
+        assert script_spec is not None
+
+        assert manager.dependency_status_label_for_uid(derived_uid) is not None
+        manager.dependency_status_badge_for_uid(derived_uid)
+        assert manager.dependency_status_tooltip_for_uid(derived_uid) is not None
+        assert manager.dependency_input_summary_for_uid(derived_uid) is not None
+        assert manager.dependency_status_label_for_uid("missing") is None
+        assert manager.dependency_status_badge_for_uid("missing") is None
+        assert manager.dependency_status_tooltip_for_uid("missing") is None
+        assert manager.dependency_input_summary_for_uid("missing") is None
+        assert not manager._missing_dependencies_have_recorded_file("missing")
+        assert manager._script_provenance_inputs_current(script_spec)
+        stale_input = script_spec.script_inputs[0].model_copy(
+            update={"node_snapshot_token": "stale"}
+        )
+        stale_spec = script_spec.model_copy(
+            update={"script_inputs": (stale_input, *script_spec.script_inputs[1:])}
+        )
+        missing_input = script_spec.script_inputs[0].model_copy(
+            update={"node_uid": "missing-parent"}
+        )
+        missing_spec = script_spec.model_copy(
+            update={"script_inputs": (missing_input, *script_spec.script_inputs[1:])}
+        )
+        assert not manager._script_provenance_inputs_current(stale_spec)
+        assert not manager._script_provenance_inputs_current(missing_spec)
+
+        full_data_input = prov.ScriptInput(
+            name="full",
+            label="Full data",
+            provenance_spec=prov.full_data().model_dump(mode="json"),
+        )
+        assert not manager._script_input_can_reload(full_data_input)
+        missing_file_input = prov.ScriptInput(
+            name="missing_file",
+            label="Missing file",
+            provenance_spec=file_spec.model_copy(
+                update={
+                    "file_load_source": file_spec.file_load_source.model_copy(
+                        update={"path": str(tmp_path / "missing.nc")}
+                    )
+                }
+            ).model_dump(mode="json"),
+        )
+        assert not manager._script_input_has_recorded_file(missing_file_input)
+
+        file_marker = "file-marker"
+        child_marker = "child-marker"
+        saved_marker = "saved-marker"
+        file_input = prov.ScriptInput(
+            name="file_input",
+            label="File input",
+            node_uid="missing-file-node",
+            node_snapshot_token=file_marker,
+            provenance_spec=file_spec.model_dump(mode="json"),
+        )
+        nested_spec = prov.script(
+            prov.ScriptCodeOperation(label="Use file", code="derived = file_input"),
+            start_label="Run script",
+            active_name="derived",
+            script_inputs=(file_input,),
+        )
+        nested_input = prov.ScriptInput(
+            name="nested",
+            label="Nested input",
+            provenance_spec=nested_spec.model_dump(mode="json"),
+        )
+        ref = prov.ScriptInputDependencyRef(
+            name="file_input",
+            label="File input",
+            node_uid="missing-file-node",
+            node_snapshot_token=file_marker,
+        )
+        assert manager._script_input_has_recorded_file(file_input)
+        assert manager._script_input_has_recorded_file(nested_input)
+        assert manager._dependency_ref_has_recorded_file(nested_spec, ref)
+        assert not manager._dependency_ref_has_recorded_file(None, ref)
+        derived_wrapper.set_displayed_provenance(nested_spec)
+        assert manager._missing_dependencies_have_recorded_file(derived_uid)
+
+        fake_child = types.SimpleNamespace(
+            uid="1 child-node",
+            provenance_spec=file_spec,
+            display_text="Child node",
+            snapshot_token=child_marker,
+        )
+        script_input = manager._script_input_for_node(fake_child)
+        assert script_input.name.startswith("data__1_child")
+        assert script_input.parsed_provenance_spec() == file_spec
+
+        monkeypatch.setattr(manager_mainwindow.QtWidgets, "QMessageBox", FakeMessageBox)
+        FakeMessageBox.instances.clear()
+        manager._show_dependency_reload_dialog(0)
+        assert not FakeMessageBox.instances
+
+        with monkeypatch.context() as patch:
+            patch.setattr(manager, "dependency_status_for_uid", lambda _uid: "current")
+            patch.setattr(
+                manager, "dependency_input_summary_for_uid", lambda _uid: None
+            )
+            patch.setattr(
+                manager, "_node_can_reload_script_inputs", lambda _node: False
+            )
+            manager._show_dependency_reload_dialog(0)
+        assert (
+            FakeMessageBox.instances[-1].standard_buttons
+            is FakeMessageBox.StandardButton.Close
+        )
+
+        reload_targets: list[int | str] = []
+        with monkeypatch.context() as patch:
+            patch.setattr(manager, "dependency_status_for_uid", lambda _uid: "changed")
+            patch.setattr(
+                manager, "dependency_input_summary_for_uid", lambda _uid: "details"
+            )
+            patch.setattr(manager, "_node_can_reload_script_inputs", lambda _node: True)
+            patch.setattr(
+                manager, "_reload_script_derived_target", reload_targets.append
+            )
+            FakeMessageBox.clicked_index = 0
+            manager._show_dependency_reload_dialog(0)
+            FakeMessageBox.clicked_index = 1
+            manager._show_dependency_reload_dialog(0)
+        assert reload_targets == [0]
+
+        for clicked_index, expected in (
+            (0, "replace"),
+            (1, "new"),
+            (2, "cancel"),
+            (None, "cancel"),
+        ):
+            FakeMessageBox.clicked_index = clicked_index
+            assert manager._prompt_incompatible_reload_commit("details") == expected
+
+        details = manager._reload_incompatibility_details(
+            data0,
+            data0.rename({"x": "energy"}).assign_coords(y=[10.0, 11.0]),
+        )
+        assert "Current dims" in details
+        assert "Reloaded dims" in details
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                erlab.interactive, "itool", lambda *_args, **_kwargs: object()
+            )
+            assert (
+                manager._show_multi_input_script_result(
+                    data0,
+                    (0,),
+                    operation_label="No tool",
+                    operation_code="derived = data_0",
+                )
+                is None
+            )
+
+        with monkeypatch.context() as patch:
+            patch.setattr(manager, "target_from_slicer_area", lambda _area: None)
+            assert not manager._script_reload_from_slicer_area(object(), execute=False)
+        with monkeypatch.context() as patch:
+            patch.setattr(manager, "target_from_slicer_area", lambda _area: 0)
+            patch.setattr(manager, "_node_can_reload_script_inputs", lambda _node: True)
+            assert manager._script_reload_from_slicer_area(object(), execute=False)
+
+        old_parent_uid = "saved-parent"
+        derived_wrapper.set_displayed_provenance(
+            prov.script(
+                prov.ScriptCodeOperation(label="Copy", code="derived = data_0"),
+                start_label="Run script",
+                active_name="derived",
+                script_inputs=(
+                    prov.ScriptInput(
+                        name="data_0",
+                        label="Saved parent",
+                        node_uid=old_parent_uid,
+                        node_snapshot_token=saved_marker,
+                    ),
+                ),
+            )
+        )
+        assert manager._workspace_loaded_uid_map(
+            {old_parent_uid: 0, "missing": "missing"}
+        ) == {old_parent_uid: manager._imagetool_wrappers[0].uid}
+        manager._rebase_loaded_workspace_dependency_refs(
+            {old_parent_uid: 0, derived_wrapper.uid: 2, "missing": "missing"}
+        )
+        rebased_spec = derived_wrapper.provenance_spec
+        assert rebased_spec is not None
+        assert (
+            rebased_spec.script_inputs[0].node_uid == manager._imagetool_wrappers[0].uid
+        )
 
 
 def test_manager_reload_self_replacement_uses_recorded_source(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -591,6 +591,51 @@ def copy_full_code_for_uid(
     return copied[-1]
 
 
+def test_manager_metadata_full_code_generated_only_when_copied(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    calls: list[str] = []
+    copied: list[str] = []
+
+    def fake_derivation_code(wrapper):
+        calls.append(wrapper.uid)
+        return "derived = xr.DataArray([1.0])"
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "copy_to_clipboard",
+        lambda text: copied.append(text) or text,
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        itool(xr.DataArray([1.0], dims=("x",)), manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        wrapper = manager._imagetool_wrappers[0]
+        wrapper.set_detached_provenance(
+            prov.full_data(prov.RenameOperation(name="renamed")).to_replay_spec()
+        )
+
+        monkeypatch.setattr(
+            type(wrapper),
+            "derivation_code",
+            property(fake_derivation_code),
+        )
+        manager._set_metadata_node(wrapper)
+
+        assert not calls
+        menu = manager._build_metadata_derivation_menu()
+        assert menu is not None
+        trigger_menu_action(menu, manager._metadata_copy_full_action)
+        assert calls == [wrapper.uid]
+        assert copied == ["derived = xr.DataArray([1.0])"]
+
+
 def test_load_source_details_dialog_kwargs_editor_wraps_and_highlights(
     qtbot, tmp_path
 ) -> None:
@@ -2614,7 +2659,6 @@ def test_load_code_from_file_details_uses_erlab_io_loader_syntax(
     )
 
     expected = (
-        "import erlab\n\n"
         "erlab.io.set_loader('merlin')\n"
         f"data = erlab.io.load({str(file_path)!r}, "
         '**{"bad-key": 1, "single": True})'
@@ -2638,7 +2682,6 @@ def test_load_code_from_file_details_uses_erlab_io_loader_syntax(
         ),
     )
     assert extension_code == (
-        "import erlab\n\n"
         "erlab.io.set_loader('example')\n"
         f"data = erlab.io.load({str(file_path)!r}, "
         'loader_extensions={"additional_coords": {"gui_extra": 7.0}})'
@@ -2652,7 +2695,6 @@ def test_load_code_from_file_details_prefers_scan_number_for_erlab_loader(
     file_path = example_data_dir / "data_002.h5"
     code = _load_code_from_file_details(file_path, ("example", {}, 0))
     assert code == (
-        "import erlab\n\n"
         "erlab.io.set_loader('example')\n"
         f"data = erlab.io.load(2, data_dir={str(example_data_dir)!r})"
     )
@@ -2661,7 +2703,6 @@ def test_load_code_from_file_details_prefers_scan_number_for_erlab_loader(
         example_data_dir / "data_001_S001.h5", ("example", {}, 0)
     )
     assert multi_file_code == (
-        "import erlab\n\n"
         "erlab.io.set_loader('example')\n"
         f"data = erlab.io.load(1, data_dir={str(example_data_dir)!r})"
     )
@@ -2670,7 +2711,6 @@ def test_load_code_from_file_details_prefers_scan_number_for_erlab_loader(
         file_path, ("example", {"single": True}, 0)
     )
     assert single_file_code == (
-        "import erlab\n\n"
         "erlab.io.set_loader('example')\n"
         f"data = erlab.io.load({str(file_path)!r}, single=True)"
     )
@@ -2684,7 +2724,6 @@ def test_load_code_from_file_details_prefers_scan_number_for_erlab_loader(
         ),
     )
     assert extension_code == (
-        "import erlab\n\n"
         "erlab.io.set_loader('example')\n"
         f"data = erlab.io.load(2, data_dir={str(example_data_dir)!r}, "
         'loader_extensions={"additional_coords": {"gui_extra": 7.0}})'
@@ -3601,7 +3640,6 @@ def test_wrapper_loader_code_and_metadata_helper_branches(
     assert provenance.file_load_source.replay_call.target == "xarray.load_dataarray"
     selected_code = _load_code_from_file_details(file_path, ("example", {}, 1))
     assert selected_code == (
-        "import erlab\n\n"
         "erlab.io.set_loader('example')\n"
         "data = erlab.interactive.imagetool.viewer._parse_input("
         f"erlab.io.load({str(file_path)!r}))[1]"
@@ -5703,7 +5741,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert "Added" in details
         derivation = metadata_derivation_texts(manager)
         assert any("Aggregate" in line for line in derivation)
-        assert all("rename(" not in line for line in derivation)
+        assert any("rename(" in line for line in derivation)
 
         copied: list[str] = []
         monkeypatch.setattr(
@@ -5737,11 +5775,12 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         manager._update_info(uid=child_uid)
         derivation = metadata_derivation_texts(manager)
         assert derivation[0] == "Start from current parent ImageTool data"
-        assert len(derivation) == 3
+        assert len(derivation) == 4
         assert "Aggregate" in derivation[1]
         assert "dims=" in derivation[1]
         assert "Aggregate" in derivation[2]
         assert "dims=" in derivation[2]
+        assert "rename(" in derivation[3]
         manager.metadata_derivation_list.setFocus()
         select_metadata_rows(manager, [0])
         qtbot.keyClick(
@@ -5801,7 +5840,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
             full_result.rename(None),
             data.qsel.mean("x").qsel.mean("y").rename(None),
         )
-        assert ".rename(" not in copied[-1]
+        assert ".rename(" in copied[-1]
 
         manual = xr.DataArray(
             np.arange(5, dtype=float) + 100.0,
@@ -5858,7 +5897,8 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert detached.provenance_spec.derivation_code() == (
             "derived = data\n"
             'derived = derived.qsel.mean("x")\n'
-            'derived = derived.qsel.mean("y")'
+            'derived = derived.qsel.mean("y")\n'
+            'derived = derived.rename("scan_avg_avg")'
         )
         assert detached.provenance_spec.derivation_code() != detached_derivation_before
         xr.testing.assert_identical(
@@ -5872,9 +5912,10 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         manager._update_info()
         detached_derivation = metadata_derivation_texts(manager)
         assert detached_derivation[0] == "Start from current parent ImageTool data"
-        assert len(detached_derivation) == 3
+        assert len(detached_derivation) == 4
         assert "Aggregate" in detached_derivation[1]
         assert "Aggregate" in detached_derivation[2]
+        assert "rename(" in detached_derivation[3]
 
         duplicated_detached_index = typing.cast("int", manager.duplicate_imagetool(1))
         duplicated_detached = manager._imagetool_wrappers[duplicated_detached_index]
@@ -6855,7 +6896,7 @@ def test_manager_selecting_unfit_ftool_child_does_not_warn(
         assert manager.preview_widget.isVisible()
         assert not manager_preview_pixmap(manager).isNull()
         assert metadata_detail_map(manager)["Kind"] == "ftool_2d"
-        assert "modelfit" not in (manager._metadata_full_code or "")
+        assert not manager._metadata_full_code_available
         assert not warnings
 
 
@@ -15583,6 +15624,273 @@ def test_manager_console_child_imagetool_access_tracks_provenance(
         InteractiveShell.clear_instance()
 
 
+def test_manager_console_structures_erlab_and_xarray_calls(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("alpha", "eV"),
+        coords={"alpha": np.arange(3.0), "eV": np.linspace(-1.0, 1.0, 4)},
+    )
+    data1 = data0 + 10.0
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        shell = manager.console._console_widget.kernel_manager.kernel.shell
+
+        manager.console._console_widget.execute("tools[0].qsel(alpha=slice(0.0, 1.0))")
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+        qsel_spec = manager._imagetool_wrappers[2].provenance_spec
+        assert qsel_spec is not None
+        assert [operation.op for operation in qsel_spec.operations] == ["qsel"]
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            data0.qsel(alpha=slice(0.0, 1.0)),
+        )
+
+        manager.console._console_widget.execute("avg = tools[0].qsel.average('alpha')")
+        assert manager.ntools == 3
+        manager.console._console_widget.execute(
+            "itool(avg, manager=True, execute=False)"
+        )
+        qtbot.wait_until(lambda: manager.ntools == 4, timeout=5000)
+        avg_spec = manager._imagetool_wrappers[3].provenance_spec
+        assert avg_spec is not None
+        assert [operation.op for operation in avg_spec.operations] == ["average"]
+        avg_data = manager.get_imagetool(3).slicer_area.data
+        xr.testing.assert_identical(
+            avg_data.isel(stack_dim=0, drop=True),
+            data0.qsel.average("alpha"),
+        )
+
+        manager.console._console_widget.execute("summed = tools[0].qsel.sum('alpha')")
+        summed = shell.user_ns["summed"]
+        assert [operation.op for operation in summed._operations] == ["qsel_aggregate"]
+        assert summed._operations[0].func == "sum"
+        xr.testing.assert_identical(summed.data, data0.qsel.sum("alpha"))
+
+        manager.console._console_widget.execute(
+            "rot = era.transform.rotate("
+            "tools[0], 5.0, axes=('alpha', 'eV'), center=(1.0, 0.0), "
+            "reshape=False)"
+        )
+        manager.console._console_widget.execute(
+            "itool(rot, manager=True, execute=False)"
+        )
+        qtbot.wait_until(lambda: manager.ntools == 5, timeout=5000)
+        rotate_spec = manager._imagetool_wrappers[4].provenance_spec
+        assert rotate_spec is not None
+        assert [operation.op for operation in rotate_spec.operations] == ["rotate"]
+        xr.testing.assert_identical(
+            manager.get_imagetool(4).slicer_area.data,
+            erlab.analysis.transform.rotate(
+                data0,
+                5.0,
+                axes=("alpha", "eV"),
+                center=(1.0, 0.0),
+                reshape=False,
+            ),
+        )
+
+        manager.console._console_widget.execute(
+            "rot_kw = era.transform.rotate("
+            "darr=tools[0], angle=0.0, axes=('alpha', 'eV'), "
+            "center=(1.0, 0.0), reshape=False)"
+        )
+        manager.console._console_widget.execute(
+            "itool(rot_kw, manager=True, execute=False)"
+        )
+        qtbot.wait_until(lambda: manager.ntools == 6, timeout=5000)
+        rotate_kw_spec = manager._imagetool_wrappers[5].provenance_spec
+        assert rotate_kw_spec is not None
+        assert [operation.op for operation in rotate_kw_spec.operations] == ["rotate"]
+        xr.testing.assert_identical(
+            manager.get_imagetool(5).slicer_area.data,
+            erlab.analysis.transform.rotate(
+                data0,
+                0.0,
+                axes=("alpha", "eV"),
+                center=(1.0, 0.0),
+                reshape=False,
+            ),
+        )
+
+        manager.console._console_widget.execute(
+            "cat = xr.concat([tools[0], tools[1]], dim='source')"
+        )
+        assert manager.ntools == 6
+        manager.console._console_widget.execute(
+            "itool(cat, manager=True, execute=False)"
+        )
+        qtbot.wait_until(lambda: manager.ntools == 7, timeout=5000)
+        concat_spec = manager._imagetool_wrappers[6].provenance_spec
+        assert concat_spec is not None
+        assert [source.name for source in concat_spec.script_inputs] == [
+            "data_0",
+            "data_1",
+        ]
+        assert [operation.op for operation in concat_spec.operations] == ["script_code"]
+        xr.testing.assert_identical(
+            manager.get_imagetool(6).slicer_area.data,
+            xr.concat([data0, data1], dim=xr.IndexVariable("source", [0, 1])),
+        )
+
+        manager.console._console_widget.execute(
+            "chain = tools[0].interp(eV=np.array([-0.5, 0.5])).transpose('eV', 'alpha')"
+        )
+        manager.console._console_widget.execute(
+            "itool(chain, manager=True, execute=False)"
+        )
+        qtbot.wait_until(lambda: manager.ntools == 8, timeout=5000)
+        chain_spec = manager._imagetool_wrappers[7].provenance_spec
+        assert chain_spec is not None
+        assert chain_spec.seed_code == "chain = data_0"
+        assert [operation.op for operation in chain_spec.operations] == [
+            "interpolate",
+            "transpose",
+        ]
+        expected_chain = data0.interp(eV=np.array([-0.5, 0.5])).transpose("eV", "alpha")
+        xr.testing.assert_identical(
+            manager.get_imagetool(7).slicer_area.data,
+            expected_chain,
+        )
+        xr.testing.assert_identical(
+            erlab.interactive.imagetool.provenance.replay_script_provenance(
+                chain_spec, {"data_0": data0}
+            ),
+            expected_chain,
+        )
+
+        manager.console._console_widget.execute(
+            "import importlib, inspect\n"
+            "real_rotate = importlib.import_module("
+            "'erlab.analysis.transform').rotate\n"
+            "signature_ok = str(inspect.signature(era.transform.rotate)) "
+            "== str(inspect.signature(real_rotate))\n"
+            "wrapped_ok = era.transform.rotate.__wrapped__ is real_rotate\n"
+            "dir_ok = 'rotate' in dir(era.transform)\n"
+            "qsel_signature_ok = str(inspect.signature(tools[0].qsel)) "
+            "== str(inspect.signature(tools[0].data.qsel))\n"
+            "qsel_wrapped_signature_ok = str("
+            "inspect.signature(tools[0].qsel.__wrapped__)) "
+            "== str(inspect.signature(tools[0].data.qsel))\n"
+            "qsel_doc_ok = tools[0].qsel.__doc__ == tools[0].data.qsel.__doc__\n"
+            "interp_signature_ok = str(inspect.signature(tools[0].interp)) "
+            "== str(inspect.signature(tools[0].data.interp))\n"
+            "interp_wrapped_signature_ok = str("
+            "inspect.signature(tools[0].interp.__wrapped__)) "
+            "== str(inspect.signature(tools[0].data.interp))\n"
+            "interp_doc_ok = tools[0].interp.__doc__ == tools[0].data.interp.__doc__\n"
+            "interp_dir_ok = 'interp' in dir(tools[0])\n"
+            "assign_coords_dir_ok = 'assign_coords' in dir(tools[0])\n"
+            "qsel_dir_ok = 'average' in dir(tools[0].qsel)\n"
+            "qsel_sum_dir_ok = 'sum' in dir(tools[0].qsel)\n"
+            "leading_edge_dir_ok = 'leading_edge' in dir(era.interpolate)"
+        )
+        assert shell.user_ns["signature_ok"]
+        assert shell.user_ns["wrapped_ok"]
+        assert shell.user_ns["dir_ok"]
+        assert shell.user_ns["qsel_signature_ok"]
+        assert shell.user_ns["qsel_wrapped_signature_ok"]
+        assert shell.user_ns["qsel_doc_ok"]
+        assert shell.user_ns["interp_signature_ok"]
+        assert shell.user_ns["interp_wrapped_signature_ok"]
+        assert shell.user_ns["interp_doc_ok"]
+        assert shell.user_ns["interp_dir_ok"]
+        assert shell.user_ns["assign_coords_dir_ok"]
+        assert shell.user_ns["qsel_dir_ok"]
+        assert shell.user_ns["qsel_sum_dir_ok"]
+        assert shell.user_ns["leading_edge_dir_ok"]
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
+def test_manager_console_captures_self_contained_function_source(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        shell = manager.console._console_widget.kernel_manager.kernel.shell
+
+        manager.console._console_widget.execute(
+            "scale = 2.0\n"
+            "def add_scale(data):\n"
+            "    return data + scale\n"
+            "\n"
+            "def offset_data(data):\n"
+            "    return add_scale(data)\n"
+        )
+        manager.console._console_widget.execute(
+            "import inspect\n"
+            "function_help_ok = offset_data.__wrapped__.__name__ == 'offset_data'\n"
+            "function_signature_ok = str(inspect.signature(offset_data)) == '(data)'"
+        )
+        assert shell.user_ns["function_help_ok"]
+        assert shell.user_ns["function_signature_ok"]
+
+        manager.console._console_widget.execute("shifted = offset_data(tools[0])")
+        shifted = shell.user_ns["shifted"]
+        assert shifted._copyable is True
+
+        manager.console._console_widget.execute(
+            "itool(shifted, manager=True, execute=False)"
+        )
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        shifted_spec = manager._imagetool_wrappers[1].provenance_spec
+        assert shifted_spec is not None
+        shifted_code = shifted_spec.derivation_entries()[-1].code
+        assert shifted_code is not None
+        assert "def add_scale(data):" in shifted_code
+        assert "def offset_data(data):" in shifted_code
+        xr.testing.assert_identical(
+            erlab.interactive.imagetool.provenance.replay_script_provenance(
+                shifted_spec, {"data_0": data}
+            ),
+            data + 2.0,
+        )
+        manager.console._console_widget.execute("piped = tools[0].pipe(offset_data)")
+        piped = shell.user_ns["piped"]
+        assert piped._copyable is True
+
+        manager.console._console_widget.execute(
+            "runtime_object = object()\n"
+            "def uses_runtime_object(data):\n"
+            "    _ = runtime_object\n"
+            "    return data\n"
+        )
+        manager.console._console_widget.execute(
+            "opaque = tools[0].pipe(uses_runtime_object)"
+        )
+        opaque = shell.user_ns["opaque"]
+        assert opaque._copyable is False
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
 def test_manager_console_derived_tool_reload_action_routes_to_manager(
     qtbot,
     manager_context: Callable[
@@ -16253,16 +16561,18 @@ def test_manager_reload_script_inputs_missing_parent_without_source_noops(
         manager.remove_imagetool(1)
         manager.tree_view.deselect_all()
         select_tools(manager, [2])
+        manager._update_actions()
+
+        assert not manager.reload_action.isVisible()
         manager.reload_selected()
 
         xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, original)
-        assert errors
-        assert errors[-1][1] == "Could not reload data."
-        assert "does not contain recorded source provenance" in errors[-1][3]
+        assert not errors
 
 
 def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
     qtbot,
+    monkeypatch,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -16297,6 +16607,12 @@ def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
         manager._update_actions()
 
         assert not manager.reload_action.isVisible()
+        copied: list[str] = []
+        monkeypatch.setattr(erlab.interactive.utils, "copy_to_clipboard", copied.append)
+        manager._set_metadata_node(wrapper)
+        manager._copy_full_derivation_code()
+        assert not copied
+        assert manager._status_bar.currentMessage()
 
 
 def test_manager_console_replacement_updates_provenance_and_descendants(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -16404,7 +16404,9 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         details = metadata_detail_map(manager)
         assert metadata_detail_labels(manager).count("Inputs") == 1
         assert manager._metadata_detail_labels["Inputs"].wordWrap()
-        assert "\n" not in details["Inputs"]
+        assert "\n" in details["Inputs"]
+        assert "\n\n" not in details["Inputs"]
+        assert all(line.strip() for line in details["Inputs"].splitlines())
         assert "recorded source file found" in details["Inputs"]
 
         manager.reload_selected()

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -16614,6 +16614,108 @@ def test_manager_reload_script_inputs_missing_parent_without_source_noops(
         assert not errors
 
 
+def test_manager_reload_self_replacement_uses_recorded_source(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+        name="source",
+    )
+    path = tmp_path / "source.nc"
+    data.to_netcdf(path)
+    file_spec = prov.file_load(
+        start_label="Load source",
+        seed_code=f"derived = xr.load_dataarray({str(path)!r})",
+        file_load_source=prov.FileLoadSource(
+            path=str(path),
+            loader_label="xarray.load_dataarray",
+            loader_text="xarray.load_dataarray",
+            kwargs_text="",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=0,
+            ),
+        ),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        wrapper = manager._imagetool_wrappers[0]
+        wrapper.set_detached_provenance(file_spec)
+
+        manager.console._console_widget.execute("tools[0].data = tools[0] + 1.0")
+        expected = data + 1.0
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+
+        manager.tree_view.deselect_all()
+        select_tools(manager, [0])
+        manager._update_actions()
+        assert manager.reload_action.isVisible()
+        assert manager.reload_action.isEnabled()
+
+        manager.reload_selected()
+
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+        rebuilt_spec = wrapper.provenance_spec
+        assert rebuilt_spec is not None
+        assert rebuilt_spec.script_inputs[0].node_uid is None
+        assert rebuilt_spec.script_inputs[0].node_snapshot_token is None
+        assert rebuilt_spec.script_inputs[0].parsed_provenance_spec() == file_spec
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
+def test_manager_reload_raw_self_replacement_unavailable(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        manager.console._console_widget.execute("tools[0].data = tools[0] + 1.0")
+        expected = data + 1.0
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+
+        wrapper = manager._imagetool_wrappers[0]
+        manager.tree_view.deselect_all()
+        select_tools(manager, [0])
+        manager._update_actions()
+        assert not manager._node_can_reload_script_inputs(wrapper)
+        assert not manager.reload_action.isVisible()
+
+        manager.reload_selected()
+
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
 def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -4813,12 +4813,6 @@ def test_manager_open_in_new_window_nests_imagetool_children(
         manager._update_info()
         root_index = manager.tree_view._model._row_index(0)
         assert root_index.data(_NODE_UID_ROLE) == parent.uid
-        right_splitter = typing.cast(
-            "QtWidgets.QSplitter", manager.text_box.parentWidget()
-        )
-        assert right_splitter.indexOf(manager.preview_widget) < right_splitter.indexOf(
-            manager.metadata_group
-        )
         details = metadata_detail_map(manager)
         assert details["Kind"] == "ImageTool"
         assert details["File"] == str(file_path)

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -5751,7 +5751,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert "Added" in details
         derivation = metadata_derivation_texts(manager)
         assert any("Aggregate" in line for line in derivation)
-        assert any("rename(" in line for line in derivation)
+        assert not any("rename(" in line for line in derivation)
 
         copied: list[str] = []
         monkeypatch.setattr(
@@ -5785,12 +5785,11 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         manager._update_info(uid=child_uid)
         derivation = metadata_derivation_texts(manager)
         assert derivation[0] == "Start from current parent ImageTool data"
-        assert len(derivation) == 4
+        assert len(derivation) == 3
         assert "Aggregate" in derivation[1]
         assert "dims=" in derivation[1]
         assert "Aggregate" in derivation[2]
         assert "dims=" in derivation[2]
-        assert "rename(" in derivation[3]
         manager.metadata_derivation_list.setFocus()
         select_metadata_rows(manager, [0])
         qtbot.keyClick(
@@ -5850,7 +5849,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
             full_result.rename(None),
             data.qsel.mean("x").qsel.mean("y").rename(None),
         )
-        assert ".rename(" in copied[-1]
+        assert ".rename(" not in copied[-1]
 
         manual = xr.DataArray(
             np.arange(5, dtype=float) + 100.0,
@@ -5922,10 +5921,9 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         manager._update_info()
         detached_derivation = metadata_derivation_texts(manager)
         assert detached_derivation[0] == "Start from current parent ImageTool data"
-        assert len(detached_derivation) == 4
+        assert len(detached_derivation) == 3
         assert "Aggregate" in detached_derivation[1]
         assert "Aggregate" in detached_derivation[2]
-        assert "rename(" in detached_derivation[3]
 
         duplicated_detached_index = typing.cast("int", manager.duplicate_imagetool(1))
         duplicated_detached = manager._imagetool_wrappers[duplicated_detached_index]

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -213,6 +213,25 @@ def child_status_badge(
     return badge_rect, badge_text, index
 
 
+def dependency_status_badge(
+    manager: ImageToolManager, target: int | str
+) -> tuple[QtCore.QRect, QtCore.QModelIndex]:
+    model = typing.cast("_ImageToolWrapperItemModel", manager.tree_view.model())
+    delegate = typing.cast(
+        "_ImageToolWrapperItemDelegate", manager.tree_view.itemDelegate()
+    )
+
+    index = model._row_index(target)
+    manager.tree_view.scrollTo(index)
+    option = delegate._option_for_index(manager.tree_view, index)
+    badge_rect, badge_text, _ = delegate._compute_dependency_status_info(
+        option, manager._node_for_target(target)
+    )
+    assert badge_rect is not None
+    assert badge_text is not None
+    return badge_rect, index
+
+
 def click_child_status_badge(
     manager: ImageToolManager,
     uid: str,
@@ -3870,7 +3889,7 @@ def test_manager_metadata_uses_streamlined_child_derivation(
         assert ".transpose(" in copied
 
 
-def test_manager_nested_imagetool_refresh_updates_descendant_lineage(
+def test_manager_nested_imagetool_refresh_updates_descendant_dependency(
     qtbot,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -15274,12 +15293,12 @@ def test_manager_console_bare_expression_opens_provenance_root(
             manager._imagetool_wrappers[0].uid,
             manager._imagetool_wrappers[1].uid,
         ]
-        assert [source.node_lineage_token for source in provenance.script_inputs] == [
-            manager._imagetool_wrappers[0].lineage_token,
-            manager._imagetool_wrappers[1].lineage_token,
+        assert [source.node_snapshot_token for source in provenance.script_inputs] == [
+            manager._imagetool_wrappers[0].snapshot_token,
+            manager._imagetool_wrappers[1].snapshot_token,
         ]
         assert (
-            manager.lineage_status_for_uid(manager._imagetool_wrappers[2].uid)
+            manager.dependency_status_for_uid(manager._imagetool_wrappers[2].uid)
             == "current"
         )
         assert provenance.operations
@@ -15306,12 +15325,12 @@ def test_manager_console_bare_expression_opens_provenance_root(
             "data_1",
         ]
         derived_uid = manager._imagetool_wrappers[2].uid
-        assert manager.lineage_status_for_uid(derived_uid) == "current"
+        assert manager.dependency_status_for_uid(derived_uid) == "current"
 
         original_difference = manager.get_imagetool(2).slicer_area.data.copy()
         manager.get_imagetool(0).slicer_area.replace_source_data(data0 + 10.0)
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(derived_uid) == "changed",
+            lambda: manager.dependency_status_for_uid(derived_uid) == "changed",
             timeout=5000,
         )
         xr.testing.assert_identical(
@@ -15321,7 +15340,7 @@ def test_manager_console_bare_expression_opens_provenance_root(
 
         manager.remove_imagetool(1)
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(derived_uid) == "missing",
+            lambda: manager.dependency_status_for_uid(derived_uid) == "missing",
             timeout=5000,
         )
         xr.testing.assert_identical(
@@ -15396,11 +15415,11 @@ def test_manager_console_assignment_tracks_until_explicit_show(
             "data_0",
         ]
         nested_uid = manager._imagetool_wrappers[4].uid
-        assert manager.lineage_status_for_uid(nested_uid) == "current"
+        assert manager.dependency_status_for_uid(nested_uid) == "current"
         nested_data = manager.get_imagetool(4).slicer_area.data.copy()
         manager.get_imagetool(1).slicer_area.replace_source_data(data1 + 5.0)
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(nested_uid) == "changed",
+            lambda: manager.dependency_status_for_uid(nested_uid) == "changed",
             timeout=5000,
         )
         xr.testing.assert_identical(
@@ -15488,7 +15507,7 @@ def test_manager_console_derived_tool_reload_action_routes_to_manager(
         updated0 = data0 + 10.0
         manager.get_imagetool(0).slicer_area.replace_source_data(updated0)
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(derived_uid) == "changed",
+            lambda: manager.dependency_status_for_uid(derived_uid) == "changed",
             timeout=5000,
         )
 
@@ -15502,13 +15521,13 @@ def test_manager_console_derived_tool_reload_action_routes_to_manager(
             derived.slicer_area.data,
             updated0 - data1,
         )
-        assert manager.lineage_status_for_uid(derived_uid) == "current"
+        assert manager.dependency_status_for_uid(derived_uid) == "current"
 
         manager.console._console_widget.shutdown_kernel()
         InteractiveShell.clear_instance()
 
 
-def test_manager_concat_records_lineage_and_handles_removed_inputs(
+def test_manager_concat_records_dependencies_and_handles_removed_inputs(
     qtbot,
     accept_dialog,
     manager_context: Callable[
@@ -15555,19 +15574,19 @@ def test_manager_concat_records_lineage_and_handles_removed_inputs(
             manager._imagetool_wrappers[0].uid,
             manager._imagetool_wrappers[1].uid,
         ]
-        assert [source.node_lineage_token for source in provenance.script_inputs] == [
-            manager._imagetool_wrappers[0].lineage_token,
-            manager._imagetool_wrappers[1].lineage_token,
+        assert [source.node_snapshot_token for source in provenance.script_inputs] == [
+            manager._imagetool_wrappers[0].snapshot_token,
+            manager._imagetool_wrappers[1].snapshot_token,
         ]
         operation_entry = provenance.operations[-1].derivation_entry()
         assert operation_entry.label == "Concatenate selected ImageTools"
         assert operation_entry.code is not None
         assert "xr.concat([data_0, data_1]" in operation_entry.code
-        assert manager.lineage_status_for_uid(concat_wrapper.uid) == "current"
+        assert manager.dependency_status_for_uid(concat_wrapper.uid) == "current"
 
         manager.get_imagetool(0).slicer_area.replace_source_data(data0 + 1.0)
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(concat_wrapper.uid) == "changed",
+            lambda: manager.dependency_status_for_uid(concat_wrapper.uid) == "changed",
             timeout=5000,
         )
         xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, expected)
@@ -15595,7 +15614,9 @@ def test_manager_concat_records_lineage_and_handles_removed_inputs(
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
 
         removed_inputs_wrapper = manager._imagetool_wrappers[3]
-        assert manager.lineage_status_for_uid(removed_inputs_wrapper.uid) == "missing"
+        assert (
+            manager.dependency_status_for_uid(removed_inputs_wrapper.uid) == "missing"
+        )
         xr.testing.assert_identical(
             manager.get_imagetool(3).slicer_area.data,
             expected_removed_inputs,
@@ -15604,6 +15625,7 @@ def test_manager_concat_records_lineage_and_handles_removed_inputs(
 
 def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(
     qtbot,
+    accept_dialog,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -15632,11 +15654,11 @@ def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(
 
         derived = manager.get_imagetool(2)
         derived.slicer_area.array_slicer.set_indices(0, [2, 1], update=False)
-        before_token = manager._imagetool_wrappers[2].lineage_token
+        before_token = manager._imagetool_wrappers[2].snapshot_token
         manager.get_imagetool(0).slicer_area.replace_source_data(data0 + 10.0)
         derived_uid = manager._imagetool_wrappers[2].uid
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(derived_uid) == "changed",
+            lambda: manager.dependency_status_for_uid(derived_uid) == "changed",
             timeout=5000,
         )
 
@@ -15647,7 +15669,40 @@ def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(
         assert manager.reload_action.isEnabled()
         assert manager.tree_view._menu.actions().count(manager.reload_action) == 1
         assert not hasattr(manager, "rebuild_inputs_action")
-        manager.reload_selected()
+        badge_rect, badge_index = dependency_status_badge(manager, 2)
+        delegate = typing.cast(
+            "_ImageToolWrapperItemDelegate", manager.tree_view.itemDelegate()
+        )
+        badge = delegate._badge_at(
+            delegate._option_for_index(manager.tree_view, badge_index),
+            badge_index,
+            badge_rect.center(),
+        )
+        assert badge is not None
+        assert badge.kind == "dependency_status"
+        manager.tree_view.deselect_all()
+        select_tools(manager, [0])
+
+        def _cancel_reload(dialog: QtWidgets.QDialog) -> None:
+            assert isinstance(dialog, QtWidgets.QMessageBox)
+            cancel_button = dialog.button(QtWidgets.QMessageBox.StandardButton.Cancel)
+            assert cancel_button is not None
+            cancel_button.click()
+
+        accept_dialog(
+            lambda: click_tree_view_pos(manager.tree_view, badge_rect.center()),
+            accept_call=_cancel_reload,
+        )
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            data0 - data1,
+        )
+        assert manager.dependency_status_for_uid(derived_uid) == "changed"
+        assert manager._imagetool_wrappers[2].snapshot_token == before_token
+
+        accept_dialog(
+            lambda: click_tree_view_pos(manager.tree_view, badge_rect.center())
+        )
 
         xr.testing.assert_identical(
             manager.get_imagetool(2).slicer_area.data,
@@ -15657,8 +15712,8 @@ def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(
             2,
             1,
         ]
-        assert manager.lineage_status_for_uid(derived_uid) == "current"
-        assert manager._imagetool_wrappers[2].lineage_token != before_token
+        assert manager.dependency_status_for_uid(derived_uid) == "current"
+        assert manager._imagetool_wrappers[2].snapshot_token != before_token
 
 
 def test_manager_reload_script_inputs_rebuilds_live_nested_input(
@@ -15703,7 +15758,7 @@ def test_manager_reload_script_inputs_rebuilds_live_nested_input(
         updated0 = data0 + 10.0
         manager.get_imagetool(0).slicer_area.replace_source_data(updated0)
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(final_uid) == "changed",
+            lambda: manager.dependency_status_for_uid(final_uid) == "changed",
             timeout=5000,
         )
 
@@ -15715,7 +15770,7 @@ def test_manager_reload_script_inputs_rebuilds_live_nested_input(
             manager.get_imagetool(3).slicer_area.data,
             (updated0 - data1) + updated0,
         )
-        assert manager.lineage_status_for_uid(final_uid) == "current"
+        assert manager.dependency_status_for_uid(final_uid) == "current"
         rebuilt_spec = manager._imagetool_wrappers[3].provenance_spec
         assert rebuilt_spec is not None
         assert rebuilt_spec.script_inputs[0].node_uid is None
@@ -15776,19 +15831,19 @@ def test_manager_reload_script_inputs_after_workspace_roundtrip(
             manager._imagetool_wrappers[0].uid,
             manager._imagetool_wrappers[1].uid,
         ]
-        assert manager.lineage_status_for_uid(derived_uid) == "current"
+        assert manager.dependency_status_for_uid(derived_uid) == "current"
 
         updated0 = data0 + 10.0
         manager.get_imagetool(0).slicer_area.replace_source_data(updated0)
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(derived_uid) == "changed",
+            lambda: manager.dependency_status_for_uid(derived_uid) == "changed",
             timeout=5000,
         )
         xr.testing.assert_identical(
             manager.get_imagetool(2).slicer_area.data, loaded_result
         )
 
-        before_token = manager._imagetool_wrappers[2].lineage_token
+        before_token = manager._imagetool_wrappers[2].snapshot_token
         manager.tree_view.deselect_all()
         select_tools(manager, [2])
         manager._update_actions()
@@ -15800,8 +15855,8 @@ def test_manager_reload_script_inputs_after_workspace_roundtrip(
             manager.get_imagetool(2).slicer_area.data,
             updated0 - data1,
         )
-        assert manager.lineage_status_for_uid(derived_uid) == "current"
-        assert manager._imagetool_wrappers[2].lineage_token != before_token
+        assert manager.dependency_status_for_uid(derived_uid) == "current"
+        assert manager._imagetool_wrappers[2].snapshot_token != before_token
 
 
 def test_manager_reload_script_inputs_incompatible_prompt_paths(
@@ -15917,7 +15972,7 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         manager.remove_imagetool(1)
         derived_uid = manager._imagetool_wrappers[2].uid
         qtbot.wait_until(
-            lambda: manager.lineage_status_for_uid(derived_uid) == "missing",
+            lambda: manager.dependency_status_for_uid(derived_uid) == "missing",
             timeout=5000,
         )
         manager.tree_view.deselect_all()
@@ -15938,6 +15993,117 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         )
         assert rebuilt_spec.script_inputs[1].node_uid is None
         assert rebuilt_spec.script_inputs[1].parsed_provenance_spec() == file_spec
+
+
+def test_manager_reload_script_inputs_reuses_shared_recorded_file_prefix(
+    qtbot,
+    tmp_path,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    source = xr.DataArray(
+        np.arange(24.0).reshape(2, 2, 3, 2),
+        dims=("pol", "energy", "k", "beta"),
+        coords={
+            "pol": ["LH", "LV"],
+            "energy": [0.0, 1.0],
+            "k": [0, 1, 2],
+            "beta": [10.0, 20.0],
+        },
+    )
+    path = tmp_path / "polarization.nc"
+    source.to_netcdf(path)
+    file_spec = prov.file_load(
+        start_label="Load both polarizations",
+        seed_code=f"derived = xr.load_dataarray({str(path)!r})",
+        file_load_source=prov.FileLoadSource(
+            path=str(path),
+            loader_label="xarray.load_dataarray",
+            loader_text="xarray.load_dataarray",
+            kwargs_text="",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=0,
+            ),
+        ),
+    )
+    shared_stage = prov.full_data(prov.AverageOperation(dims=("k",)))
+    left_stage = prov.selection(
+        prov.SelOperation(kwargs={"pol": "LH"}),
+        prov.SqueezeOperation(),
+    )
+    right_stage = prov.selection(
+        prov.SelOperation(kwargs={"pol": "LV"}),
+        prov.SqueezeOperation(),
+    )
+    left_data = left_stage.apply(shared_stage.apply(source))
+    right_data = right_stage.apply(shared_stage.apply(source))
+    left_spec = prov.compose_full_provenance(
+        prov.compose_full_provenance(file_spec, shared_stage),
+        left_stage,
+    )
+    right_spec = prov.compose_full_provenance(
+        prov.compose_full_provenance(file_spec, shared_stage),
+        right_stage,
+    )
+    assert left_spec is not None
+    assert right_spec is not None
+    load_count = 0
+
+    def _load_shared_source(_load_source: typing.Any) -> xr.DataArray:
+        nonlocal load_count
+        load_count += 1
+        return source
+
+    monkeypatch.setattr(prov, "_load_file_source_data", _load_shared_source)
+
+    with manager_context() as manager:
+        manager.show()
+        itool([left_data, right_data], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        manager._imagetool_wrappers[0].set_detached_provenance(left_spec)
+        manager._imagetool_wrappers[1].set_detached_provenance(right_spec)
+        assert (
+            manager._show_multi_input_script_result(
+                left_data - right_data,
+                (0, 1),
+                operation_label="Subtract inputs",
+                operation_code="derived = data_0 - data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        workspace_path = tmp_path / "shared-replay.itws"
+        manager._save_workspace_document(workspace_path, force_full=True)
+        assert manager._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+        load_count = 0
+
+        manager.remove_imagetool(1)
+        manager.remove_imagetool(0)
+        monkeypatch.setattr(
+            manager,
+            "_prompt_incompatible_reload_commit",
+            lambda _details: "replace",
+        )
+        assert manager._reload_script_derived_target(2)
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            left_data - right_data,
+        )
+        assert load_count == 1
 
 
 def test_manager_reload_script_inputs_missing_parent_without_source_noops(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -413,6 +413,16 @@ def metadata_detail_map(manager: ImageToolManager) -> dict[str, str]:
     return details
 
 
+def metadata_detail_labels(manager: ImageToolManager) -> list[str]:
+    labels: list[str] = []
+    for row in range(manager.metadata_details_layout.rowCount()):
+        item = manager.metadata_details_layout.itemAtPosition(row, 0)
+        widget = None if item is None else item.widget()
+        if isinstance(widget, QtWidgets.QLabel):
+            labels.append(widget.text())
+    return labels
+
+
 def select_metadata_rows(
     manager: ImageToolManager, rows: list[int], clear: bool = True
 ) -> None:
@@ -16391,7 +16401,11 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         manager.tree_view.deselect_all()
         select_tools(manager, [2])
         manager._update_info()
-        assert "recorded source file found" in metadata_detail_map(manager)["Inputs"]
+        details = metadata_detail_map(manager)
+        assert metadata_detail_labels(manager).count("Inputs") == 1
+        assert manager._metadata_detail_labels["Inputs"].wordWrap()
+        assert "\n" in details["Inputs"]
+        assert "recorded source file found" in details["Inputs"]
 
         manager.reload_selected()
 

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -2674,9 +2674,12 @@ def test_load_code_from_file_details_uses_erlab_io_loader_syntax(
     example_loader,
 ) -> None:
     file_path = tmp_path / "example.pxt"
+    dataarray_selection = erlab.interactive.imagetool.provenance.FileDataSelection(
+        kind="dataarray"
+    )
     code = _load_code_from_file_details(
         file_path,
-        ("merlin", {"bad-key": 1, "single": True}, 0),
+        ("merlin", {"bad-key": 1, "single": True}, dataarray_selection),
     )
 
     expected = (
@@ -2687,19 +2690,21 @@ def test_load_code_from_file_details_uses_erlab_io_loader_syntax(
     assert code == expected
     assigned_code = _load_code_from_file_details(
         file_path,
-        ("merlin", {"bad-key": 1, "single": True}, 0),
+        ("merlin", {"bad-key": 1, "single": True}, dataarray_selection),
         assign="source_scan",
     )
     assert assigned_code == expected.replace("data = ", "source_scan = ")
     with pytest.raises(ValueError, match="assign"):
-        _load_code_from_file_details(file_path, ("merlin", {}, 0), assign="bad-name")
+        _load_code_from_file_details(
+            file_path, ("merlin", {}, dataarray_selection), assign="bad-name"
+        )
 
     extension_code = _load_code_from_file_details(
         file_path,
         (
             "example",
             {"loader_extensions": {"additional_coords": {"gui_extra": 7.0}}},
-            0,
+            dataarray_selection,
         ),
     )
     assert extension_code == (
@@ -2709,19 +2714,78 @@ def test_load_code_from_file_details_uses_erlab_io_loader_syntax(
     )
 
 
+def test_load_code_from_file_details_uses_stable_file_selectors(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    file_path = tmp_path / "scan.h5"
+
+    dataset_code = _load_code_from_file_details(
+        file_path,
+        (
+            xr.load_dataset,
+            {"engine": "h5netcdf"},
+            prov.FileDataSelection(kind="dataset_variable", value="second"),
+        ),
+    )
+    assert dataset_code == (
+        "import xarray\n\n"
+        f'data = xarray.load_dataset({str(file_path)!r}, engine="h5netcdf")'
+        "['second']"
+    )
+    assert "_parse_input" not in dataset_code
+
+    datatree_code = _load_code_from_file_details(
+        file_path,
+        (
+            xr.load_datatree,
+            {"engine": "h5netcdf"},
+            prov.FileDataSelection(kind="datatree_path", value="/diag/image"),
+        ),
+    )
+    assert datatree_code == (
+        "import xarray\n\n"
+        f'data = xarray.load_datatree({str(file_path)!r}, engine="h5netcdf")'
+        "['/diag/image']"
+    )
+    assert "_parse_input" not in datatree_code
+
+
+def test_load_code_from_file_details_uses_public_merlin_bcs_import(
+    tmp_path: pathlib.Path,
+) -> None:
+    from erlab.io.plugins.merlin import load_bcs
+
+    dataarray_selection = erlab.interactive.imagetool.provenance.FileDataSelection(
+        kind="dataarray"
+    )
+    file_path = tmp_path / "scan.txt"
+
+    code = _load_code_from_file_details(file_path, (load_bcs, {}, dataarray_selection))
+
+    assert code == (
+        "import erlab.io.plugins.merlin\n\n"
+        f"data = erlab.io.plugins.merlin.load_bcs({str(file_path)!r})"
+    )
+    assert "_merlin_bcs" not in code
+
+
 def test_load_code_from_file_details_prefers_scan_number_for_erlab_loader(
     example_loader,
     example_data_dir: pathlib.Path,
 ) -> None:
     file_path = example_data_dir / "data_002.h5"
-    code = _load_code_from_file_details(file_path, ("example", {}, 0))
+    dataarray_selection = erlab.interactive.imagetool.provenance.FileDataSelection(
+        kind="dataarray"
+    )
+    code = _load_code_from_file_details(file_path, ("example", {}, dataarray_selection))
     assert code == (
         "erlab.io.set_loader('example')\n"
         f"data = erlab.io.load(2, data_dir={str(example_data_dir)!r})"
     )
 
     multi_file_code = _load_code_from_file_details(
-        example_data_dir / "data_001_S001.h5", ("example", {}, 0)
+        example_data_dir / "data_001_S001.h5", ("example", {}, dataarray_selection)
     )
     assert multi_file_code == (
         "erlab.io.set_loader('example')\n"
@@ -2729,7 +2793,7 @@ def test_load_code_from_file_details_prefers_scan_number_for_erlab_loader(
     )
 
     single_file_code = _load_code_from_file_details(
-        file_path, ("example", {"single": True}, 0)
+        file_path, ("example", {"single": True}, dataarray_selection)
     )
     assert single_file_code == (
         "erlab.io.set_loader('example')\n"
@@ -2741,7 +2805,7 @@ def test_load_code_from_file_details_prefers_scan_number_for_erlab_loader(
         (
             "example",
             {"loader_extensions": {"additional_coords": {"gui_extra": 7.0}}},
-            0,
+            dataarray_selection,
         ),
     )
     assert extension_code == (
@@ -2752,7 +2816,7 @@ def test_load_code_from_file_details_prefers_scan_number_for_erlab_loader(
 
     del example_loader
     bound_loader_code = _load_code_from_file_details(
-        file_path, (erlab.io.loaders["example"].load, {}, 0)
+        file_path, (erlab.io.loaders["example"].load, {}, dataarray_selection)
     )
     assert bound_loader_code == code
 
@@ -3647,6 +3711,9 @@ def test_wrapper_loader_code_and_metadata_helper_branches(
 
     _missing_attr_loader.__module__ = "math"
     _missing_attr_loader.__qualname__ = "missing_loader"
+    dataarray_selection = erlab.interactive.imagetool.provenance.FileDataSelection(
+        kind="dataarray"
+    )
 
     assert _load_code_from_file_details(file_path, None) is None
     assert _load_provenance_from_file_details(file_path, None) is None
@@ -3681,7 +3748,7 @@ def test_wrapper_loader_code_and_metadata_helper_branches(
 
     math_code = _load_code_from_file_details(
         file_path,
-        (math.sqrt, {"bad-key": 1}, 0),
+        (math.sqrt, {"bad-key": 1}, dataarray_selection),
     )
     assert math_code == (
         f'import math\n\ndata = math.sqrt({str(file_path)!r}, **{{"bad-key": 1}})'
@@ -3689,7 +3756,7 @@ def test_wrapper_loader_code_and_metadata_helper_branches(
 
     missing_module_code = _load_code_from_file_details(
         file_path,
-        (_missing_module_loader, {}, 0),
+        (_missing_module_loader, {}, dataarray_selection),
     )
     assert missing_module_code == (
         "import missing_erlab_loader_module\n\n"
@@ -14556,7 +14623,7 @@ def test_manager_open_files(
         )
 
 
-def test_manager_file_open_uses_selected_variable_source_index(
+def test_manager_file_open_uses_selected_dataset_variable(
     qtbot,
     monkeypatch,
     tmp_path: pathlib.Path,
@@ -14578,6 +14645,10 @@ def test_manager_file_open_uses_selected_variable_source_index(
         coords={"u": np.arange(4), "v": np.arange(5)},
         name="second",
     )
+    selection = erlab.interactive.imagetool.provenance.FileDataSelection(
+        kind="dataset_variable",
+        value="second",
+    )
     datasets = {
         "current": xr.Dataset(
             {
@@ -14592,7 +14663,7 @@ def test_manager_file_open_uses_selected_variable_source_index(
 
     def _select_second(data, parent=None):
         assert parent is not None
-        return ((data["second"], 1),)
+        return ((data["second"], selection),)
 
     monkeypatch.setattr(
         imagetool_viewer,
@@ -14616,12 +14687,13 @@ def test_manager_file_open_uses_selected_variable_source_index(
 
         xr.testing.assert_identical(tool.slicer_area.data, initial_second)
         assert tool.slicer_area._load_func is not None
-        assert tool.slicer_area._load_func[2] == 1
+        assert tool.slicer_area._load_func[2] == selection
 
         datasets["current"] = xr.Dataset(
             {
-                "first": xr.DataArray(np.zeros((2, 3)), dims=("x", "y")),
+                "inserted": xr.DataArray(np.full((2, 3), 5.0), dims=("x", "y")),
                 "second": updated_second,
+                "first": xr.DataArray(np.zeros((2, 3)), dims=("x", "y")),
             }
         )
         with qtbot.wait_signal(tool.slicer_area.sigDataChanged):

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -15459,6 +15459,55 @@ def test_manager_console_selected_expression_opens_provenance_root(
         InteractiveShell.clear_instance()
 
 
+def test_manager_console_derived_tool_reload_action_routes_to_manager(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(9.0).reshape(3, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(3), "y": np.arange(3)},
+    )
+    data1 = data0 + 1.0
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        manager.console._console_widget.execute("tools[0] - tools[1]")
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        derived = manager.get_imagetool(2)
+        derived_uid = manager._imagetool_wrappers[2].uid
+        updated0 = data0 + 10.0
+        manager.get_imagetool(0).slicer_area.replace_source_data(updated0)
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(derived_uid) == "changed",
+            timeout=5000,
+        )
+
+        assert derived.slicer_area.reloadable
+        menu_bar = typing.cast("typing.Any", derived.menuBar())
+        menu_bar._file_menu_visibility()
+        assert derived.slicer_area.reload_act.isVisible()
+        derived.slicer_area.reload_act.trigger()
+
+        xr.testing.assert_identical(
+            derived.slicer_area.data,
+            updated0 - data1,
+        )
+        assert manager.lineage_status_for_uid(derived_uid) == "current"
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
 def test_manager_concat_records_lineage_and_handles_removed_inputs(
     qtbot,
     accept_dialog,
@@ -15551,6 +15600,432 @@ def test_manager_concat_records_lineage_and_handles_removed_inputs(
             manager.get_imagetool(3).slicer_area.data,
             expected_removed_inputs,
         )
+
+
+def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(9.0).reshape(3, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(3), "y": np.arange(3)},
+    )
+    data1 = data0 + 1.0
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                data0 - data1,
+                (0, 1),
+                operation_label="Subtract inputs",
+                operation_code="derived = data_0 - data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        derived = manager.get_imagetool(2)
+        derived.slicer_area.array_slicer.set_indices(0, [2, 1], update=False)
+        before_token = manager._imagetool_wrappers[2].lineage_token
+        manager.get_imagetool(0).slicer_area.replace_source_data(data0 + 10.0)
+        derived_uid = manager._imagetool_wrappers[2].uid
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(derived_uid) == "changed",
+            timeout=5000,
+        )
+
+        manager.tree_view.deselect_all()
+        select_tools(manager, [2])
+        manager._update_actions()
+        assert manager.reload_action.isVisible()
+        assert manager.reload_action.isEnabled()
+        assert manager.tree_view._menu.actions().count(manager.reload_action) == 1
+        assert not hasattr(manager, "rebuild_inputs_action")
+        manager.reload_selected()
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            (data0 + 10.0) - data1,
+        )
+        assert manager.get_imagetool(2).slicer_area.array_slicer.get_indices(0) == [
+            2,
+            1,
+        ]
+        assert manager.lineage_status_for_uid(derived_uid) == "current"
+        assert manager._imagetool_wrappers[2].lineage_token != before_token
+
+
+def test_manager_reload_script_inputs_rebuilds_live_nested_input(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(9.0).reshape(3, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(3), "y": np.arange(3)},
+    )
+    data1 = data0 + 1.0
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                data0 - data1,
+                (0, 1),
+                operation_label="Subtract inputs",
+                operation_code="derived = data_0 - data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                (data0 - data1) + data0,
+                (2, 0),
+                operation_label="Add derived input",
+                operation_code="derived = data_2 + data_0",
+            )
+            == 3
+        )
+        qtbot.wait_until(lambda: manager.ntools == 4, timeout=5000)
+
+        final_uid = manager._imagetool_wrappers[3].uid
+        updated0 = data0 + 10.0
+        manager.get_imagetool(0).slicer_area.replace_source_data(updated0)
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(final_uid) == "changed",
+            timeout=5000,
+        )
+
+        manager.tree_view.deselect_all()
+        select_tools(manager, [3])
+        manager.reload_selected()
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(3).slicer_area.data,
+            (updated0 - data1) + updated0,
+        )
+        assert manager.lineage_status_for_uid(final_uid) == "current"
+        rebuilt_spec = manager._imagetool_wrappers[3].provenance_spec
+        assert rebuilt_spec is not None
+        assert rebuilt_spec.script_inputs[0].node_uid is None
+        nested_spec = rebuilt_spec.script_inputs[0].parsed_provenance_spec()
+        assert nested_spec is not None
+        assert [source.node_uid for source in nested_spec.script_inputs] == [
+            manager._imagetool_wrappers[0].uid,
+            manager._imagetool_wrappers[1].uid,
+        ]
+
+
+def test_manager_reload_script_inputs_after_workspace_roundtrip(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(9.0).reshape(3, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(3), "y": np.arange(3)},
+    )
+    data1 = data0 + 1.0
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                data0 - data1,
+                (0, 1),
+                operation_label="Subtract inputs",
+                operation_code="derived = data_0 - data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        workspace_path = tmp_path / "script-derived-reload.itws"
+        manager._save_workspace_document(workspace_path, force_full=True)
+        assert manager._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        loaded_result = manager.get_imagetool(2).slicer_area.data.copy()
+        xr.testing.assert_identical(loaded_result, data0 - data1)
+        derived_uid = manager._imagetool_wrappers[2].uid
+        provenance = manager._imagetool_wrappers[2].provenance_spec
+        assert provenance is not None
+        assert [source.node_uid for source in provenance.script_inputs] == [
+            manager._imagetool_wrappers[0].uid,
+            manager._imagetool_wrappers[1].uid,
+        ]
+        assert manager.lineage_status_for_uid(derived_uid) == "current"
+
+        updated0 = data0 + 10.0
+        manager.get_imagetool(0).slicer_area.replace_source_data(updated0)
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(derived_uid) == "changed",
+            timeout=5000,
+        )
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data, loaded_result
+        )
+
+        before_token = manager._imagetool_wrappers[2].lineage_token
+        manager.tree_view.deselect_all()
+        select_tools(manager, [2])
+        manager._update_actions()
+        assert manager.reload_action.isVisible()
+        assert manager.reload_action.isEnabled()
+        manager.reload_selected()
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            updated0 - data1,
+        )
+        assert manager.lineage_status_for_uid(derived_uid) == "current"
+        assert manager._imagetool_wrappers[2].lineage_token != before_token
+
+
+def test_manager_reload_script_inputs_incompatible_prompt_paths(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+    )
+    data1 = data0 + 1.0
+    shifted0 = data0.assign_coords(x=[10.0, 11.0]) + 10.0
+    shifted1 = data1.assign_coords(x=[10.0, 11.0])
+    expected = shifted0 - shifted1
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                data0 - data1,
+                (0, 1),
+                operation_label="Subtract inputs",
+                operation_code="derived = data_0 - data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        original = manager.get_imagetool(2).slicer_area.data.copy()
+        manager.get_imagetool(0).slicer_area.replace_source_data(shifted0)
+        manager.get_imagetool(1).slicer_area.replace_source_data(shifted1)
+        manager.tree_view.deselect_all()
+        select_tools(manager, [2])
+
+        monkeypatch.setattr(
+            manager, "_prompt_incompatible_reload_commit", lambda _details: "cancel"
+        )
+        manager.reload_selected()
+        assert manager.ntools == 3
+        xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, original)
+
+        monkeypatch.setattr(
+            manager, "_prompt_incompatible_reload_commit", lambda _details: "new"
+        )
+        manager.reload_selected()
+        qtbot.wait_until(lambda: manager.ntools == 4, timeout=5000)
+        xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, original)
+        xr.testing.assert_identical(manager.get_imagetool(3).slicer_area.data, expected)
+
+        manager.tree_view.deselect_all()
+        select_tools(manager, [2])
+        monkeypatch.setattr(
+            manager, "_prompt_incompatible_reload_commit", lambda _details: "replace"
+        )
+        manager.reload_selected()
+        xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, expected)
+
+
+def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 5.0
+    path1 = tmp_path / "right.nc"
+    data1.to_netcdf(path1)
+    file_spec = prov.file_load(
+        start_label="Load right",
+        seed_code=f"derived = xr.load_dataarray({str(path1)!r})",
+        file_load_source=prov.FileLoadSource(
+            path=str(path1),
+            loader_label="xarray.load_dataarray",
+            loader_text="xarray.load_dataarray",
+            kwargs_text="",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=0,
+            ),
+        ),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        manager._imagetool_wrappers[1].set_detached_provenance(file_spec)
+        assert (
+            manager._show_multi_input_script_result(
+                data0 - data1,
+                (0, 1),
+                operation_label="Subtract inputs",
+                operation_code="derived = data_0 - data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        manager.remove_imagetool(1)
+        derived_uid = manager._imagetool_wrappers[2].uid
+        qtbot.wait_until(
+            lambda: manager.lineage_status_for_uid(derived_uid) == "missing",
+            timeout=5000,
+        )
+        manager.tree_view.deselect_all()
+        select_tools(manager, [2])
+        manager._update_info()
+        assert "recorded source file found" in metadata_detail_map(manager)["Inputs"]
+
+        manager.reload_selected()
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(2).slicer_area.data,
+            data0 - data1,
+        )
+        rebuilt_spec = manager._imagetool_wrappers[2].provenance_spec
+        assert rebuilt_spec is not None
+        assert (
+            rebuilt_spec.script_inputs[0].node_uid == manager._imagetool_wrappers[0].uid
+        )
+        assert rebuilt_spec.script_inputs[1].node_uid is None
+        assert rebuilt_spec.script_inputs[1].parsed_provenance_spec() == file_spec
+
+
+def test_manager_reload_script_inputs_missing_parent_without_source_noops(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 1.0
+    errors: list[tuple[str, str, str, str]] = []
+
+    def _critical(
+        parent, title, text, informative_text="", detailed_text=None, buttons=None
+    ):
+        errors.append((title, text, informative_text, detailed_text or ""))
+        return QtWidgets.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(erlab.interactive.utils.MessageDialog, "critical", _critical)
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                data0 - data1,
+                (0, 1),
+                operation_label="Subtract inputs",
+                operation_code="derived = data_0 - data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+        original = manager.get_imagetool(2).slicer_area.data.copy()
+
+        manager.remove_imagetool(1)
+        manager.tree_view.deselect_all()
+        select_tools(manager, [2])
+        manager.reload_selected()
+
+        xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, original)
+        assert errors
+        assert errors[-1][1] == "Could not reload data."
+        assert "does not contain recorded source provenance" in errors[-1][3]
+
+
+def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        wrapper = manager._imagetool_wrappers[0]
+        wrapper.set_detached_provenance(
+            prov.script(
+                prov.ScriptCodeOperation(
+                    label="Run opaque code",
+                    code=None,
+                    copyable=False,
+                ),
+                start_label="Run opaque code",
+                active_name="derived",
+                script_inputs=(manager._script_input_for_node(wrapper),),
+            )
+        )
+
+        manager.tree_view.deselect_all()
+        select_tools(manager, [0])
+        manager._update_actions()
+
+        assert not manager.reload_action.isVisible()
 
 
 def test_manager_console_replacement_updates_provenance_and_descendants(

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -15395,6 +15395,62 @@ def test_manager_console_bare_expression_opens_provenance_root(
         InteractiveShell.clear_instance()
 
 
+@pytest.mark.parametrize("reserved_name", ["data", "derived", "tools", "data_0"])
+def test_manager_console_rejects_reserved_result_names_for_provenance(
+    reserved_name: str,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(2.0), dims=("x",))
+    result = manager_console._DerivedDataNamespace(
+        None,
+        data + 1.0,
+        "data_1 + 1.0",
+        (prov.ScriptInput(name="data_1", label="ImageTool 1"),),
+        copyable=True,
+    )
+
+    result._set_console_name(reserved_name)
+
+    operand = result._console_operand()
+    assert [script_input.name for script_input in operand.script_inputs] == ["data_1"]
+
+
+def test_manager_console_reserved_result_name_replays_without_shadowing() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data0 = xr.DataArray(np.array([10.0]), dims=("x",))
+    data1 = xr.DataArray(np.array([1.0]), dims=("x",))
+    source = manager_console._DerivedDataNamespace(
+        None,
+        data0,
+        "data_0",
+        (prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+        copyable=True,
+    )
+    result = manager_console._DerivedDataNamespace(
+        None,
+        data1 + 1.0,
+        "data_1 + 1.0",
+        (prov.ScriptInput(name="data_1", label="ImageTool 1"),),
+        copyable=True,
+    )
+    result._set_console_name("data_0")
+
+    combined = result + source
+    spec = combined._console_provenance_spec(
+        active_name="derived", label="Evaluate console expression"
+    )
+
+    assert spec is not None
+    assert [script_input.name for script_input in spec.script_inputs] == [
+        "data_1",
+        "data_0",
+    ]
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(spec, {"data_0": data0, "data_1": data1}),
+        combined.data,
+    )
+
+
 def test_manager_console_assignment_tracks_until_explicit_show(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -16618,6 +16618,127 @@ def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(
         assert manager._imagetool_wrappers[2].snapshot_token != before_token
 
 
+def test_manager_reload_script_inputs_normalizes_derived_1d_stack_dim(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(9.0).reshape(3, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(3.0), "y": np.arange(3.0)},
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                data.mean("y"),
+                (0,),
+                operation_label="Average input",
+                operation_code='derived = data_0.mean("y")',
+            )
+            == 1
+        )
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        derived = manager.get_imagetool(1)
+        assert derived.slicer_area.data.dims == ("x", "stack_dim")
+        derived.slicer_area.array_slicer.set_indices(0, [2, 0], update=False)
+        before_token = manager._imagetool_wrappers[1].snapshot_token
+        updated = data + 10.0
+        manager.get_imagetool(0).slicer_area.replace_source_data(updated)
+        derived_uid = manager._imagetool_wrappers[1].uid
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(derived_uid) == "changed",
+            timeout=5000,
+        )
+
+        monkeypatch.setattr(
+            manager,
+            "_prompt_incompatible_reload_commit",
+            lambda _details: pytest.fail("compatible 1D reload prompted"),
+        )
+        manager.tree_view.deselect_all()
+        select_tools(manager, [1])
+        manager.reload_selected()
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(1).slicer_area.data.squeeze("stack_dim", drop=True),
+            updated.mean("y"),
+        )
+        assert manager.get_imagetool(1).slicer_area.array_slicer.get_indices(0) == [
+            2,
+            0,
+        ]
+        assert manager.dependency_status_for_uid(derived_uid) == "current"
+        assert manager._imagetool_wrappers[1].snapshot_token != before_token
+
+
+def test_manager_reload_script_inputs_normalizes_nonuniform_idx_dims(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(4, 3),
+        dims=("x", "y"),
+        coords={"x": [0.0, 0.2, 0.8, 1.5], "y": np.arange(3.0)},
+    )
+    operation_code = (
+        "derived = "
+        "erlab.interactive.imagetool.slicer.restore_nonuniform_dims(data_0) + 1"
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        assert manager.get_imagetool(0).slicer_area.data.dims == ("x_idx", "y")
+        assert (
+            manager._show_multi_input_script_result(
+                data + 1.0,
+                (0,),
+                operation_label="Offset restored input",
+                operation_code=operation_code,
+            )
+            == 1
+        )
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert manager.get_imagetool(1).slicer_area.data.dims == ("x_idx", "y")
+
+        updated = data + 10.0
+        manager.get_imagetool(0).slicer_area.replace_source_data(updated)
+        derived_uid = manager._imagetool_wrappers[1].uid
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(derived_uid) == "changed",
+            timeout=5000,
+        )
+
+        monkeypatch.setattr(
+            manager,
+            "_prompt_incompatible_reload_commit",
+            lambda _details: pytest.fail("compatible nonuniform reload prompted"),
+        )
+        manager.tree_view.deselect_all()
+        select_tools(manager, [1])
+        manager.reload_selected()
+
+        xr.testing.assert_identical(
+            erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+                manager.get_imagetool(1).slicer_area.data
+            ),
+            updated + 1.0,
+        )
+        assert manager.dependency_status_for_uid(derived_uid) == "current"
+
+
 def test_manager_reload_script_inputs_rebuilds_live_nested_input(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1828,6 +1828,139 @@ def test_file_provenance_compose_fallbacks_and_replay_aliases() -> None:
     ) == prov.to_replay_provenance_spec(watched_parent)
 
 
+def test_script_provenance_supports_named_console_inputs() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    left = prov.script(
+        start_label="Load left",
+        seed_code="data_0 = xr.DataArray([1.0, 2.0], dims=['x'])",
+        active_name="data_0",
+    )
+    right = prov.script(
+        start_label="Load right",
+        seed_code="data_1 = xr.DataArray([0.5, 1.5], dims=['x'])",
+        active_name="data_1",
+    )
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Subtract console inputs",
+            code="derived = data_0 - data_1",
+        ),
+        start_label="Run ImageTool manager console code",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="ImageTool 0",
+                node_uid="left",
+                provenance_spec=left,
+            ),
+            prov.ScriptInput(
+                name="data_1",
+                label="ImageTool 1",
+                node_uid="right",
+                provenance_spec=right,
+            ),
+        ),
+    )
+
+    reparsed = prov.parse_tool_provenance_spec(spec.model_dump(mode="json"))
+
+    assert reparsed == spec
+    assert [entry.label for entry in spec.display_entries()] == [
+        "Run ImageTool manager console code",
+        "Use data_0 from ImageTool 0",
+        "Use data_1 from ImageTool 1",
+        "Subtract console inputs",
+    ]
+    code = typing.cast("str", spec.derivation_code())
+    namespace = _exec_generated_code(code, {})
+    xr.testing.assert_identical(
+        namespace["derived"],
+        xr.DataArray([0.5, 0.5], dims=["x"]),
+    )
+
+
+def test_script_input_lineage_refs_recurse_and_rebase() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    left_lineage_id = "left-lineage"
+    right_lineage_id = "right-lineage"
+    extra_lineage_id = "extra-lineage"
+    nested = prov.script(
+        prov.ScriptCodeOperation(
+            label="Subtract console inputs",
+            code="diff = data_0 - data_1",
+        ),
+        start_label="Run ImageTool manager console code",
+        active_name="diff",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="ImageTool 0",
+                node_uid="old-left",
+                node_lineage_token=left_lineage_id,
+            ),
+            prov.ScriptInput(
+                name="data_1",
+                label="ImageTool 1",
+                node_uid="old-right",
+                node_lineage_token=right_lineage_id,
+            ),
+        ),
+    )
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Add nested input",
+            code="derived = diff + data_2",
+        ),
+        start_label="Run ImageTool manager console code",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="diff",
+                label="console variable 'diff'",
+                provenance_spec=nested,
+            ),
+            prov.ScriptInput(
+                name="data_2",
+                label="ImageTool 2",
+                node_uid="old-extra",
+                node_lineage_token=extra_lineage_id,
+            ),
+        ),
+    )
+
+    refs = prov.script_input_lineage_refs(spec)
+    assert [(ref.name, ref.node_uid, ref.node_lineage_token) for ref in refs] == [
+        ("data_0", "old-left", left_lineage_id),
+        ("data_1", "old-right", right_lineage_id),
+        ("data_2", "old-extra", extra_lineage_id),
+    ]
+
+    rebased = prov.rebase_script_input_node_uids(
+        spec,
+        {
+            "old-left": "new-left",
+            "old-right": "new-right",
+            "old-extra": "new-extra",
+        },
+    )
+
+    assert [source.name for source in rebased.script_inputs] == ["diff", "data_2"]
+    assert rebased.script_inputs[1].node_uid == "new-extra"
+    assert rebased.script_inputs[1].label == "ImageTool 2"
+    assert typing.cast("str", rebased.operations[-1].derivation_entry().code) == (
+        "derived = diff + data_2"
+    )
+    assert [
+        (ref.name, ref.node_uid, ref.node_lineage_token)
+        for ref in prov.script_input_lineage_refs(rebased)
+    ] == [
+        ("data_0", "new-left", left_lineage_id),
+        ("data_1", "new-right", right_lineage_id),
+        ("data_2", "new-extra", extra_lineage_id),
+    ]
+
+
 def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -> None:
     prov = erlab.interactive.imagetool.provenance
     image = xr.DataArray(

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -247,10 +247,7 @@ def test_tool_provenance_parse_final_payload_and_migrate_legacy_schema() -> None
         "Start from current parent ImageTool data",
         'Average(dims=("x",))',
     ]
-    assert (
-        spec.derivation_code() == 'derived = data\nderived = derived.qsel.mean("x")\n'
-        'derived = derived.rename("avg")'
-    )
+    assert spec.derivation_code() == 'derived = data\nderived = derived.qsel.mean("x")'
     display_code = typing.cast("str", spec.display_code())
     assert ".rename(" not in display_code
     namespace = _exec_generated_code(display_code, {"data": _base_data()})

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1,6 +1,8 @@
 import ast
 import json
 import pathlib
+import subprocess
+import sys
 import typing
 
 import numpy as np
@@ -82,6 +84,64 @@ def _string_key_data() -> xr.DataArray:
         coords={"k-space": [0.0, 1.0, 2.0]},
         name="data",
     )
+
+
+def test_provenance_import_keeps_analysis_targets_lazy() -> None:
+    code = (
+        "import sys\n"
+        "import erlab.interactive.imagetool.provenance\n"
+        "loaded = sorted("
+        "name for name in sys.modules if name.startswith('erlab.analysis.') "
+        "or name.startswith('scipy.interpolate') or name.startswith('scipy.linalg')"
+        ")\n"
+        "if loaded:\n"
+        "    print('\\n'.join(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout == ""
+
+
+def test_script_replay_keeps_unused_aliases_lazy() -> None:
+    code = (
+        "import sys\n"
+        "import numpy as np\n"
+        "import xarray as xr\n"
+        "import erlab.interactive.imagetool.provenance as prov\n"
+        "data = xr.DataArray(np.arange(2.0), dims=('x',))\n"
+        "spec = prov.script(\n"
+        "    prov.ScriptCodeOperation(label='Subtract', "
+        "code='derived = data_0 - data_1'),\n"
+        "    start_label='Run script',\n"
+        "    active_name='derived',\n"
+        "    script_inputs=(\n"
+        "        prov.ScriptInput(name='data_0', label='A'),\n"
+        "        prov.ScriptInput(name='data_1', label='B'),\n"
+        "    ),\n"
+        ")\n"
+        "prov.replay_script_provenance(spec, {'data_0': data, 'data_1': data})\n"
+        "loaded = sorted(\n"
+        "    name for name in sys.modules\n"
+        "    if name.startswith('erlab.analysis.')\n"
+        "    or name.startswith('erlab.plotting')\n"
+        "    or name.startswith('matplotlib')\n"
+        ")\n"
+        "if loaded:\n"
+        "    print('\\n'.join(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout == ""
 
 
 def _file_replay_source(
@@ -181,8 +241,12 @@ def test_tool_provenance_parse_final_payload_and_migrate_legacy_schema() -> None
     assert [entry.label for entry in spec.derivation_entries()] == [
         "Start from current parent ImageTool data",
         'Average(dims=("x",))',
+        "rename('avg')",
     ]
-    assert spec.derivation_code() == 'derived = data\nderived = derived.qsel.mean("x")'
+    assert (
+        spec.derivation_code() == 'derived = data\nderived = derived.qsel.mean("x")\n'
+        'derived = derived.rename("avg")'
+    )
 
     dumped = spec.model_dump(mode="json")
     assert dumped["schema_version"] == 2
@@ -229,6 +293,16 @@ def test_tool_provenance_parse_final_payload_and_migrate_legacy_schema() -> None
         prov.parse_tool_provenance_spec(
             {"kind": "full_data", "operations": {"op": "average", "dims": ["x"]}}
         )
+
+
+def test_registered_provenance_operations_define_derivation_entries() -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    assert [
+        op
+        for op, operation_type in prov._OPERATION_TYPES.items()
+        if "derivation_entry" not in operation_type.__dict__
+    ] == []
 
 
 def test_tool_provenance_parse_legacy_file_script_metadata() -> None:
@@ -571,6 +645,54 @@ def test_tool_provenance_assign_scalar_coord_operation() -> None:
     namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
     xr.testing.assert_identical(
         namespace["derived"], data.assign_coords(temperature=21.5)
+    )
+
+
+def test_tool_provenance_nonfinite_coord_and_attr_code() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data()
+
+    scalar_spec = prov.full_data(
+        prov.AssignScalarCoordOperation(coord_name="temperature", value=np.nan)
+    )
+    scalar_code = typing.cast("str", scalar_spec.derivation_code())
+    assert "np.nan" in scalar_code
+    scalar_namespace = _exec_generated_code(scalar_code, {"data": data.copy(deep=True)})
+    assert np.isnan(scalar_namespace["derived"].coords["temperature"].item())
+
+    attrs_spec = prov.full_data(
+        prov.AssignAttrsOperation(
+            attrs={
+                "offset": np.inf,
+                "bad": np.nan,
+                "complex": complex(float("nan"), float("inf")),
+            }
+        )
+    )
+    attrs_code = typing.cast("str", attrs_spec.derivation_code())
+    assert "np.nan" in attrs_code
+    assert "np.inf" in attrs_code
+    assert "complex(np.nan, np.inf)" in attrs_code
+    attrs_namespace = _exec_generated_code(attrs_code, {"data": data.copy(deep=True)})
+    assert np.isinf(attrs_namespace["derived"].attrs["offset"])
+    assert np.isnan(attrs_namespace["derived"].attrs["bad"])
+    assert np.isnan(attrs_namespace["derived"].attrs["complex"].real)
+    assert np.isinf(attrs_namespace["derived"].attrs["complex"].imag)
+
+    coord_spec = prov.full_data(
+        prov.AssignCoord1DOperation(
+            coord_name="temperature",
+            dim="x",
+            values=np.array([np.nan, np.inf, -np.inf]),
+        )
+    )
+    coord_code = typing.cast("str", coord_spec.derivation_code())
+    assert "np.nan" in coord_code
+    assert "np.inf" in coord_code
+    coord_namespace = _exec_generated_code(coord_code, {"data": data.copy(deep=True)})
+    np.testing.assert_equal(
+        coord_namespace["derived"].coords["temperature"].values,
+        np.array([np.nan, np.inf, -np.inf]),
     )
 
 
@@ -1140,6 +1262,31 @@ def test_tool_provenance_validation_helpers_and_error_branches() -> None:
     assert "derived" not in rebased_namespace
     assert prov.uses_default_replay_input("result = data + 1")
     assert not prov.uses_default_replay_input("result = source_data + 1")
+    helper_code = (
+        "def normalize(data):\n"
+        "    return data / data.max()\n"
+        "\n"
+        "derived = normalize(data_0)"
+    )
+    assert not prov.uses_default_replay_input(helper_code)
+    assert prov.rebase_default_replay_input(helper_code, "source_data") == helper_code
+    mixed_helper_code = (
+        "def normalize(data):\n"
+        "    return data / data.max()\n"
+        "\n"
+        "derived = normalize(data)"
+    )
+    rebased_helper_code = prov.rebase_default_replay_input(
+        mixed_helper_code, "source_data"
+    )
+    assert "def normalize(data):\n    return data / data.max()" in rebased_helper_code
+    assert "derived = normalize(source_data)" in rebased_helper_code
+    replaced_helper_code = prov._replace_code_identifiers(
+        "def normalize(data):\n    return data / data.max()\n\nderived = data",
+        {"data": "source_data", "derived": "result"},
+    )
+    assert "def normalize(data):\n    return data / data.max()" in replaced_helper_code
+    assert "result = source_data" in replaced_helper_code
 
     with pytest.raises(ValueError, match="Expected 2 items"):
         prov._ensure_float_tuple([1.0], expected_len=2)
@@ -1216,16 +1363,23 @@ def test_tool_provenance_remaining_operation_and_display_branches(monkeypatch) -
     assert (
         prov.SelOperation(kwargs={"x": 1.0}).derivation_entry().label.startswith("sel(")
     )
+    rename_entry = prov.RenameOperation(name="renamed").derivation_entry()
+    assert rename_entry.copyable is True
+    assert rename_entry.code is not None
+    namespace = _exec_generated_code(
+        rename_entry.code,
+        {"derived": data.copy(deep=True)},
+    )
+    xr.testing.assert_identical(namespace["derived"], data.rename("renamed"))
     assert prov.full_data().derivation_code() is None
     assert (
         prov.script(start_label="Start", active_name="derived").display_code() is None
     )
-    assert (
-        prov.full_data(
-            prov.CorrectWithEdgeOperation(edge_fit=xr.Dataset(), shift_coords=True)
-        ).display_code()
-        is None
-    )
+    edge_entry = prov.CorrectWithEdgeOperation(
+        edge_fit=xr.Dataset(), shift_coords=True
+    ).derivation_entry()
+    assert edge_entry.copyable is True
+    assert edge_entry.code is not None
 
     with pytest.raises(TypeError, match="script_code operations"):
         prov.ScriptCodeOperation(label="Step", code="derived = data").apply(
@@ -1258,6 +1412,12 @@ def test_tool_provenance_remaining_operation_and_display_branches(monkeypatch) -
         prov.SymmetrizeNfoldOperation(fold=4, axes=("x", "y")).derivation_entry().code
         == "derived = generated()"
     )
+    symmetrize_nfold_payload = prov.SymmetrizeNfoldOperation(
+        fold=4, axes=("x", "y"), center=(0.0, 0.0)
+    ).model_dump(mode="json")
+    assert prov.parse_tool_provenance_operation(
+        symmetrize_nfold_payload
+    ) == prov.SymmetrizeNfoldOperation(fold=4, axes=("x", "y"), center=(0.0, 0.0))
 
     assign_entry = prov.AssignCoordsOperation(
         coord_name="x", values=np.array([2.0, 1.0, 0.0])
@@ -1370,9 +1530,9 @@ def test_tool_provenance_apply_analysis_operations(monkeypatch) -> None:
     )
     assert edge_spec.apply(data).attrs["last_op"] == "correct_with_edge"
     entries = edge_spec.derivation_entries()
-    assert entries[-1].copyable is False
-    assert entries[-1].code is None
-    assert edge_spec.derivation_code() is None
+    assert entries[-1].copyable is True
+    assert entries[-1].code is not None
+    assert edge_spec.derivation_code() is not None
 
     path_spec = erlab.interactive.imagetool.provenance.full_data(
         erlab.interactive.imagetool.provenance.SliceAlongPathOperation(
@@ -1447,9 +1607,34 @@ def test_tool_provenance_roundtrip_correct_with_edge(monkeypatch) -> None:
     assert reparsed_spec is not None
     assert reparsed_spec.apply(data).attrs["last_op"] == "correct_with_edge"
     entries = reparsed_spec.derivation_entries()
-    assert entries[-1].copyable is False
-    assert entries[-1].code is None
-    assert reparsed_spec.derivation_code() is None
+    assert entries[-1].copyable is True
+    assert entries[-1].code is not None
+    namespace = _exec_generated_code(
+        typing.cast("str", reparsed_spec.derivation_code()),
+        {"data": data.copy(deep=True)},
+    )
+    assert namespace["derived"].attrs["last_op"] == "correct_with_edge"
+
+
+def test_correct_with_edge_code_handles_nonfinite_dataset(monkeypatch) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data()
+    edge_fit = xr.Dataset({"edge": ("x", [np.nan, np.inf, -np.inf])})
+
+    def correct_with_edge(data_arg, edge_fit_arg, *, shift_coords=True):
+        xr.testing.assert_identical(edge_fit_arg, edge_fit)
+        return data_arg.assign_attrs(shift_coords=shift_coords)
+
+    monkeypatch.setattr(erlab.analysis.gold, "correct_with_edge", correct_with_edge)
+    spec = prov.full_data(
+        prov.CorrectWithEdgeOperation(edge_fit=edge_fit, shift_coords=False)
+    )
+    code = typing.cast("str", spec.derivation_code())
+
+    assert "np.nan" in code
+    assert "np.inf" in code
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    assert namespace["derived"].attrs["shift_coords"] is False
 
 
 def test_tool_provenance_roundtrip_correct_with_edge_fit_dataset(
@@ -1602,9 +1787,7 @@ def test_file_load_source_replay_call_round_trips() -> None:
             kwargs={},
             selected_index=0,
         ),
-        load_code=(
-            "import erlab\n\nerlab.io.set_loader('example')\ndata = erlab.io.load(2)"
-        ),
+        load_code="erlab.io.set_loader('example')\ndata = erlab.io.load(2)",
     )
     parsed_erlab = prov.FileLoadSource.model_validate(
         erlab_source.model_dump(mode="json")
@@ -1950,7 +2133,7 @@ def test_script_input_code_reuses_shared_file_replay_prefix(
     code = typing.cast("str", spec.display_code())
 
     assert code.count("xarray.load_dataarray") == 1
-    assert code.count(".qsel.average") == 1
+    assert code.count(".qsel.mean") == 1
     assert "data_0 =" in code
     assert "data_1 =" in code
     namespace = _exec_generated_code(code, {})
@@ -2140,13 +2323,332 @@ def test_replay_script_provenance_rejects_unsupported_or_incomplete_code() -> No
         active_name="derived",
         script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
     )
+    missing_seed = prov.script(
+        prov.AverageOperation(dims=("x",)),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    active_input = prov.script(
+        prov.AverageOperation(dims=("x",)),
+        start_label="Run script",
+        active_name="data_0",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    rename_input = prov.script(
+        prov.RenameOperation(name="renamed"),
+        start_label="Run script",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    external_active_input = prov.script(
+        prov.AverageOperation(dims=("x",)),
+        start_label="Run script",
+        active_name="data_0",
+    )
+    function_local_active = prov.script(
+        prov.ScriptCodeOperation(
+            label="Helper",
+            code="def helper(data):\n    derived = data\n",
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    missing_helper = prov.script(
+        prov.ScriptCodeOperation(
+            label="Missing helper",
+            code="derived = helper(data_0)",
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    missing_helper_global = prov.script(
+        prov.ScriptCodeOperation(
+            label="Missing helper global",
+            code=(
+                "def helper(data):\n    return data + scale\n\nderived = helper(data_0)"
+            ),
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    captured_helper_global = prov.script(
+        prov.ScriptCodeOperation(
+            label="Captured helper global",
+            code=(
+                "scale = 2.0\n"
+                "\n"
+                "def helper(data):\n"
+                "    return data + scale\n"
+                "\n"
+                "derived = helper(data_0)"
+            ),
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    late_helper_global = prov.script(
+        prov.ScriptCodeOperation(
+            label="Late helper global",
+            code=(
+                "def helper(data):\n"
+                "    return data + scale\n"
+                "\n"
+                "derived = helper(data_0)\n"
+                "scale = 2.0"
+            ),
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    redefined_helper = prov.script(
+        prov.ScriptCodeOperation(
+            label="Redefined helper",
+            code=(
+                "def helper(data):\n"
+                "    return data + missing\n"
+                "\n"
+                "def helper(data):\n"
+                "    return data\n"
+                "\n"
+                "derived = helper(data_0)"
+            ),
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
 
     assert not prov.script_provenance_replayable(unsupported)
     assert not prov.script_provenance_replayable(incomplete)
+    assert not prov.script_provenance_replayable(missing_seed)
+    assert not prov.script_provenance_replayable(function_local_active)
+    assert not prov.script_provenance_replayable(missing_helper)
+    assert not prov.script_provenance_replayable(missing_helper_global)
+    assert not prov.script_provenance_replayable(late_helper_global)
+    assert prov.script_provenance_replayable(active_input)
+    assert prov.script_provenance_replayable(rename_input)
+    assert prov.script_provenance_replayable(captured_helper_global)
+    assert prov.script_provenance_replayable(redefined_helper)
     with pytest.raises(TypeError, match="unsupported Import"):
         prov.replay_script_provenance(unsupported, {"data_0": data})
     with pytest.raises(ValueError, match="non-replayable"):
         prov.replay_script_provenance(incomplete, {"data_0": data})
+    with pytest.raises(TypeError, match="no replay code"):
+        prov.replay_script_provenance(missing_seed, {"data_0": data})
+    with pytest.raises(TypeError, match="no replay code"):
+        prov.replay_script_provenance(function_local_active, {"data_0": data})
+    with pytest.raises(TypeError, match="unresolved name 'helper'"):
+        prov.replay_script_provenance(missing_helper, {"data_0": data})
+    with pytest.raises(TypeError, match="unresolved name 'scale'"):
+        prov.replay_script_provenance(missing_helper_global, {"data_0": data})
+    with pytest.raises(TypeError, match="unresolved name 'scale'"):
+        prov.replay_script_provenance(late_helper_global, {"data_0": data})
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(active_input, {"data_0": data}),
+        data.qsel.average("x"),
+    )
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(rename_input, {"data_0": data}),
+        data.rename("renamed"),
+    )
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(external_active_input, {"data_0": data}),
+        data.qsel.average("x"),
+    )
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(captured_helper_global, {"data_0": data}),
+        data + 2.0,
+    )
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(redefined_helper, {"data_0": data}),
+        data,
+    )
+
+
+def test_replay_script_provenance_accepts_console_module_aliases() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+    )
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Rotate",
+            code=(
+                "derived = era.transform.rotate("
+                "data_0, 0.0, axes=('x', 'y'), reshape=False)"
+            ),
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+
+    assert prov.script_provenance_replayable(spec)
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(spec, {"data_0": data}),
+        erlab.analysis.transform.rotate(data, 0.0, axes=("x", "y"), reshape=False),
+    )
+
+
+def test_console_pattern_expands_named_xarray_mapping_arguments() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray([1.0, 2.0], dims=("x",), coords={"x": [0.0, 1.0]})
+
+    qsel_operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            accessor_path=("qsel",),
+            kwargs={"indexers": {"x": 1.0}},
+            display_code="data.qsel(indexers={'x': 1.0})",
+            has_extra_tracked_inputs=False,
+            receiver_data=data,
+        )
+    )
+    isel_operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            dataarray_method="isel",
+            kwargs={"indexers": {"x": 1}},
+            display_code="data.isel(indexers={'x': 1})",
+            has_extra_tracked_inputs=False,
+            receiver_data=data,
+        )
+    )
+    sel_operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            dataarray_method="sel",
+            kwargs={"indexers": {"x": 1.0}},
+            display_code="data.sel(indexers={'x': 1.0})",
+            has_extra_tracked_inputs=False,
+            receiver_data=data,
+        )
+    )
+    interp_operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            dataarray_method="interp",
+            kwargs={"coords": {"x": [0.25, 0.75]}},
+            display_code="data.interp(coords={'x': [0.25, 0.75]})",
+            has_extra_tracked_inputs=False,
+            receiver_data=data,
+        )
+    )
+    rename_operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            dataarray_method="rename",
+            kwargs={"new_name_or_name_dict": {"x": "energy"}},
+            display_code="data.rename(new_name_or_name_dict={'x': 'energy'})",
+            has_extra_tracked_inputs=False,
+            receiver_data=data,
+        )
+    )
+    multidim_coord_operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            dataarray_method="assign_coords",
+            kwargs={"foo": (("x", "y"), np.ones((2, 2)))},
+            display_code="data.assign_coords(foo=(('x', 'y'), values))",
+            has_extra_tracked_inputs=False,
+            receiver_data=xr.DataArray(np.ones((2, 2)), dims=("x", "y")),
+        )
+    )
+
+    assert qsel_operation == prov.QSelOperation(kwargs={"x": 1.0})
+    assert isel_operation == prov.IselOperation(kwargs={"x": 1})
+    assert sel_operation == prov.SelOperation(kwargs={"x": 1.0})
+    assert interp_operation == prov.InterpolationOperation(dim="x", values=[0.25, 0.75])
+    assert rename_operation == prov.RenameDimsCoordsOperation(mapping={"x": "energy"})
+    assert multidim_coord_operation is None
+    assert isinstance(qsel_operation, prov.QSelOperation)
+    assert isinstance(isel_operation, prov.IselOperation)
+    assert isinstance(sel_operation, prov.SelOperation)
+    assert isinstance(interp_operation, prov.InterpolationOperation)
+    assert isinstance(rename_operation, prov.RenameDimsCoordsOperation)
+    xr.testing.assert_identical(
+        qsel_operation.apply(data, parent_data=data),
+        data.qsel(indexers={"x": 1.0}),
+    )
+    xr.testing.assert_identical(
+        isel_operation.apply(data, parent_data=data),
+        data.isel(indexers={"x": 1}),
+    )
+    xr.testing.assert_identical(
+        sel_operation.apply(data, parent_data=data),
+        data.sel(indexers={"x": 1.0}),
+    )
+    xr.testing.assert_identical(
+        interp_operation.apply(data, parent_data=data),
+        data.interp(coords={"x": [0.25, 0.75]}),
+    )
+    xr.testing.assert_identical(
+        rename_operation.apply(data, parent_data=data),
+        data.rename(new_name_or_name_dict={"x": "energy"}),
+    )
+
+
+def test_console_pattern_matches_public_parameter_aliases() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    edge_fit = xr.Dataset({"center": ("x", [0.0, 1.0])})
+
+    operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            func=erlab.analysis.gold.correct_with_edge,
+            kwargs={"modelresult": edge_fit, "shift_coords": False},
+            display_code="era.gold.correct_with_edge(data, modelresult=edge_fit)",
+            has_extra_tracked_inputs=False,
+        )
+    )
+
+    assert isinstance(operation, prov.CorrectWithEdgeOperation)
+    assert not operation.shift_coords
+    xr.testing.assert_identical(operation.decoded_edge_fit, edge_fit)
+
+
+def test_console_pattern_matches_new_replayable_operations() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "eV"),
+        coords={"x": [0.0, 1.0], "eV": [0.0, 1.0, 2.0]},
+    )
+
+    aggregate_operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            accessor_path=("qsel", "sum"),
+            args=("x",),
+            display_code='data.qsel.sum("x")',
+            has_extra_tracked_inputs=False,
+            receiver_data=data,
+        )
+    )
+    leading_edge_operation = prov.operation_from_console_call(
+        prov.ConsoleCall(
+            func=erlab.analysis.interpolate.leading_edge,
+            kwargs={"fraction": 0.25, "dim": "eV", "direction": "negative"},
+            display_code=(
+                "era.interpolate.leading_edge("
+                "data, fraction=0.25, dim='eV', direction='negative')"
+            ),
+            has_extra_tracked_inputs=False,
+            receiver_data=data,
+        )
+    )
+
+    assert aggregate_operation == prov.QSelAggregationOperation(dims=("x",), func="sum")
+    assert leading_edge_operation == prov.LeadingEdgeOperation(
+        fraction=0.25,
+        dim="eV",
+        direction="negative",
+    )
+    xr.testing.assert_identical(
+        aggregate_operation.apply(data, parent_data=data),
+        data.qsel.sum("x"),
+    )
 
 
 def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -> None:

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import pathlib
 import typing
 
 import numpy as np
@@ -1510,7 +1511,7 @@ def test_tool_provenance_script_specs_reject_live_source() -> None:
         prov.require_live_source_spec(reparsed_script)
 
 
-def test_tool_replay_provenance_helpers_compose_parent_lineage() -> None:
+def test_tool_replay_provenance_helpers_compose_parent_provenance() -> None:
     prov = erlab.interactive.imagetool.provenance
 
     parent = prov.selection(prov.IselOperation(kwargs={"x": slice(0, 2)}))
@@ -1880,11 +1881,138 @@ def test_script_provenance_supports_named_console_inputs() -> None:
     )
 
 
-def test_script_input_lineage_refs_recurse_and_rebase() -> None:
+def test_script_input_code_reuses_shared_file_replay_prefix(
+    tmp_path: pathlib.Path,
+) -> None:
     prov = erlab.interactive.imagetool.provenance
-    left_lineage_id = "left-lineage"
-    right_lineage_id = "right-lineage"
-    extra_lineage_id = "extra-lineage"
+    path = tmp_path / "polarization.nc"
+    source = xr.DataArray(
+        np.arange(12.0).reshape(2, 2, 3),
+        dims=("pol", "energy", "k"),
+        coords={"pol": ["LH", "LV"], "energy": [0.0, 1.0], "k": [0, 1, 2]},
+    )
+    source.to_netcdf(path)
+    file_spec = prov.file_load(
+        start_label="Load both polarizations",
+        seed_code=f"import xarray\n\nderived = xarray.load_dataarray({str(path)!r})",
+        file_load_source=prov.FileLoadSource(
+            path=str(path),
+            loader_label="xarray.load_dataarray",
+            loader_text="xarray.load_dataarray",
+            kwargs_text="",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=0,
+            ),
+        ),
+    )
+    shared_stage = prov.full_data(prov.AverageOperation(dims=("k",)))
+    left_stage = prov.selection(
+        prov.SelOperation(kwargs={"pol": "LH"}),
+        prov.SqueezeOperation(),
+    )
+    right_stage = prov.selection(
+        prov.SelOperation(kwargs={"pol": "LV"}),
+        prov.SqueezeOperation(),
+    )
+    left_spec = prov.compose_full_provenance(
+        prov.compose_full_provenance(file_spec, shared_stage),
+        left_stage,
+    )
+    right_spec = prov.compose_full_provenance(
+        prov.compose_full_provenance(file_spec, shared_stage),
+        right_stage,
+    )
+    assert left_spec is not None
+    assert right_spec is not None
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Subtract polarizations",
+            code="derived = data_0 - data_1",
+        ),
+        start_label="Run ImageTool manager console code",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="ImageTool 0: LH",
+                provenance_spec=left_spec,
+            ),
+            prov.ScriptInput(
+                name="data_1",
+                label="ImageTool 1: LV",
+                provenance_spec=right_spec,
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.display_code())
+
+    assert code.count("xarray.load_dataarray") == 1
+    assert code.count(".qsel.average") == 1
+    assert "data_0 =" in code
+    assert "data_1 =" in code
+    namespace = _exec_generated_code(code, {})
+    expected = left_stage.apply(shared_stage.apply(source)) - right_stage.apply(
+        shared_stage.apply(source)
+    )
+    xr.testing.assert_identical(namespace["derived"], expected)
+
+
+def test_script_input_code_keeps_distinct_structured_replay_nodes() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    first = prov.file_load(
+        start_label="Load first",
+        seed_code="import xarray\n\nderived = xarray.load_dataarray('scan.h5')",
+        file_load_source=_file_replay_source(
+            "scan.h5",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=0,
+            ),
+        ),
+    )
+    second = prov.file_load(
+        start_label="Load second",
+        seed_code="import xarray\n\nderived = xarray.load_dataarray('scan.h5')",
+        file_load_source=_file_replay_source(
+            "scan.h5",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=1,
+            ),
+        ),
+    )
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Subtract inputs",
+            code="derived = data_0 - data_1",
+        ),
+        start_label="Run ImageTool manager console code",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="ImageTool 0", provenance_spec=first),
+            prov.ScriptInput(
+                name="data_1",
+                label="ImageTool 1",
+                provenance_spec=second,
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+
+    assert code.count("xarray.load_dataarray") == 2
+
+
+def test_script_input_dependency_refs_recurse_and_rebase() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    left_snapshot_id = "left-snapshot"
+    right_snapshot_id = "right-snapshot"
+    extra_snapshot_id = "extra-snapshot"
     nested = prov.script(
         prov.ScriptCodeOperation(
             label="Subtract console inputs",
@@ -1897,13 +2025,13 @@ def test_script_input_lineage_refs_recurse_and_rebase() -> None:
                 name="data_0",
                 label="ImageTool 0",
                 node_uid="old-left",
-                node_lineage_token=left_lineage_id,
+                node_snapshot_token=left_snapshot_id,
             ),
             prov.ScriptInput(
                 name="data_1",
                 label="ImageTool 1",
                 node_uid="old-right",
-                node_lineage_token=right_lineage_id,
+                node_snapshot_token=right_snapshot_id,
             ),
         ),
     )
@@ -1924,16 +2052,16 @@ def test_script_input_lineage_refs_recurse_and_rebase() -> None:
                 name="data_2",
                 label="ImageTool 2",
                 node_uid="old-extra",
-                node_lineage_token=extra_lineage_id,
+                node_snapshot_token=extra_snapshot_id,
             ),
         ),
     )
 
-    refs = prov.script_input_lineage_refs(spec)
-    assert [(ref.name, ref.node_uid, ref.node_lineage_token) for ref in refs] == [
-        ("data_0", "old-left", left_lineage_id),
-        ("data_1", "old-right", right_lineage_id),
-        ("data_2", "old-extra", extra_lineage_id),
+    refs = prov.script_input_dependency_refs(spec)
+    assert [(ref.name, ref.node_uid, ref.node_snapshot_token) for ref in refs] == [
+        ("data_0", "old-left", left_snapshot_id),
+        ("data_1", "old-right", right_snapshot_id),
+        ("data_2", "old-extra", extra_snapshot_id),
     ]
 
     rebased = prov.rebase_script_input_node_uids(
@@ -1952,12 +2080,12 @@ def test_script_input_lineage_refs_recurse_and_rebase() -> None:
         "derived = diff + data_2"
     )
     assert [
-        (ref.name, ref.node_uid, ref.node_lineage_token)
-        for ref in prov.script_input_lineage_refs(rebased)
+        (ref.name, ref.node_uid, ref.node_snapshot_token)
+        for ref in prov.script_input_dependency_refs(rebased)
     ] == [
-        ("data_0", "new-left", left_lineage_id),
-        ("data_1", "new-right", right_lineage_id),
-        ("data_2", "new-extra", extra_lineage_id),
+        ("data_0", "new-left", left_snapshot_id),
+        ("data_1", "new-right", right_snapshot_id),
+        ("data_2", "new-extra", extra_snapshot_id),
     ]
 
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -2272,6 +2272,19 @@ def test_script_input_dependency_refs_recurse_and_rebase() -> None:
     ]
 
 
+def test_script_input_label_is_single_line_display_text() -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    script_input = prov.ScriptInput(
+        name="data_0",
+        label="  ImageTool 0:\n\n  processed data  ",
+    )
+
+    assert script_input.label == "ImageTool 0: processed data"
+    with pytest.raises(ValidationError):
+        prov.ScriptInput(name="data_0", label="\n  \t")
+
+
 def test_replay_script_provenance_uses_resolved_inputs_without_mutating() -> None:
     prov = erlab.interactive.imagetool.provenance
     left = xr.DataArray([1.0, 2.0], dims=("x",), coords={"x": [0, 1]})

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -243,9 +243,20 @@ def test_tool_provenance_parse_final_payload_and_migrate_legacy_schema() -> None
         'Average(dims=("x",))',
         "rename('avg')",
     ]
+    assert [entry.label for entry in spec.display_entries()] == [
+        "Start from current parent ImageTool data",
+        'Average(dims=("x",))',
+    ]
     assert (
         spec.derivation_code() == 'derived = data\nderived = derived.qsel.mean("x")\n'
         'derived = derived.rename("avg")'
+    )
+    display_code = typing.cast("str", spec.display_code())
+    assert ".rename(" not in display_code
+    namespace = _exec_generated_code(display_code, {"data": _base_data()})
+    xr.testing.assert_identical(
+        namespace["derived"].rename(None),
+        _base_data().qsel.mean("x").rename(None),
     )
 
     dumped = spec.model_dump(mode="json")
@@ -1116,6 +1127,27 @@ def test_tool_provenance_display_entries_keep_ambiguous_script_steps() -> None:
         derived,
         _base_data().transpose(*("x", "y", "z")).squeeze(),
     )
+
+
+def test_tool_provenance_display_keeps_name_rename_before_script_code() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data().rename("source")
+    spec = prov.script(
+        prov.RenameOperation(name="renamed"),
+        prov.ScriptCodeOperation(
+            label="Use DataArray name",
+            code="derived = derived.rename(derived.name + '_used')",
+        ),
+        start_label="Run script",
+        seed_code="derived = data",
+        active_name="derived",
+    )
+
+    code = typing.cast("str", spec.display_code())
+
+    assert ".rename(" in code
+    namespace = _exec_generated_code(code, {"data": data})
+    xr.testing.assert_identical(namespace["derived"], data.rename("renamed_used"))
 
 
 def test_imagetool_selection_source_binding_materializes_current_coordinates() -> None:
@@ -2853,6 +2885,8 @@ def test_file_provenance_composes_structured_stages_and_replays_modified_source(
     assert code is not None
     assert "import xarray" in code
     assert "xarray.load_dataarray" in code
+    assert '.rename("avg")' not in code
+    assert ".rename(y=" in code
     assert "data =" not in code
     namespace = _exec_generated_code(code, {})
     assert isinstance(namespace["derived"], xr.DataArray)

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1792,7 +1792,7 @@ def test_file_load_source_replay_call_round_trips() -> None:
             kind="callable",
             target="xarray.load_dataarray",
             kwargs={"engine": "h5netcdf"},
-            selected_index=0,
+            selection=prov.FileDataSelection(kind="dataarray"),
             cast_float64=True,
         ),
         load_code='import xarray\n\ndata = xarray.load_dataarray("/tmp/scan.h5")',
@@ -1804,7 +1804,20 @@ def test_file_load_source_replay_call_round_trips() -> None:
     assert parsed_xarray.replay_call.kind == "callable"
     assert parsed_xarray.replay_call.target == "xarray.load_dataarray"
     assert parsed_xarray.replay_call.kwargs == {"engine": "h5netcdf"}
+    assert parsed_xarray.replay_call.selection == prov.FileDataSelection(
+        kind="dataarray"
+    )
     assert parsed_xarray.replay_call.cast_float64 is True
+
+    legacy_call = prov.FileReplayCall.model_validate(
+        {
+            "kind": "callable",
+            "target": "xarray.load_dataarray",
+            "selected_index": 2,
+        }
+    )
+    assert legacy_call.selection == prov.FileDataSelection(kind="parsed_index", value=2)
+    assert "selected_index" not in legacy_call.model_dump(mode="json")
 
     erlab_source = prov.FileLoadSource(
         path="data_002.h5",
@@ -1815,7 +1828,7 @@ def test_file_load_source_replay_call_round_trips() -> None:
             kind="erlab_loader",
             target="example",
             kwargs={},
-            selected_index=0,
+            selection=prov.FileDataSelection(kind="dataarray"),
         ),
         load_code="erlab.io.set_loader('example')\ndata = erlab.io.load(2)",
     )
@@ -1832,7 +1845,7 @@ def test_file_provenance_validation_rejects_invalid_payloads() -> None:
     replay_stage = prov.ReplayStage(source_kind="full_data")
     file_source = _file_replay_source()
 
-    with pytest.raises(ValidationError, match="selected_index"):
+    with pytest.raises(ValidationError, match="parsed file selection index"):
         prov.FileReplayCall(
             kind="callable", target="xarray.load_dataarray", selected_index=-1
         )
@@ -1843,7 +1856,7 @@ def test_file_provenance_validation_rejects_invalid_payloads() -> None:
         kind="callable",
         target="xarray.load_dataarray",
         kwargs={1: "bad"},
-        selected_index=0,
+        selection=prov.FileDataSelection(kind="dataarray"),
     )
     with pytest.raises(TypeError, match="string keys"):
         bad_kwargs_call._validate_replay_call()
@@ -3218,6 +3231,22 @@ def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -
 
     tree = xr.DataTree.from_dict({"leaf": xr.Dataset({"image": image})})
     assert [darr.name for darr in prov._parse_replay_input(tree)] == ["image"]
+    xr.testing.assert_identical(
+        prov._select_replay_input(
+            dataset, prov.FileDataSelection(kind="dataset_variable", value="image")
+        ),
+        image,
+    )
+    xr.testing.assert_identical(
+        prov._select_replay_input(
+            tree, prov.FileDataSelection(kind="datatree_path", value="/leaf/image")
+        ),
+        image,
+    )
+    assert prov._select_replay_input(
+        np.arange(6).reshape((2, 3)),
+        prov.FileDataSelection(kind="dataarray"),
+    ).shape == (2, 3)
 
     with pytest.raises(ValueError, match="No valid data"):
         prov._parse_replay_input([])
@@ -3225,6 +3254,14 @@ def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -
         prov._parse_replay_input(xr.Dataset({"scalar": xr.DataArray(1.0)}))
     with pytest.raises(TypeError, match="Unsupported input type list"):
         prov._parse_replay_input([object()])
+    with pytest.raises(KeyError, match="Selected file variable"):
+        prov._select_replay_input(
+            dataset, prov.FileDataSelection(kind="dataset_variable", value="missing")
+        )
+    with pytest.raises(KeyError, match="Selected file DataTree path"):
+        prov._select_replay_input(
+            tree, prov.FileDataSelection(kind="datatree_path", value="/missing/image")
+        )
 
     assert (
         prov._resolve_importable_callable("xarray.load_dataarray") is xr.load_dataarray
@@ -3249,6 +3286,44 @@ def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -
 
     source_file = tmp_path / "source.h5"
     image.to_netcdf(source_file, engine="h5netcdf")
+    dataset_file = tmp_path / "dataset.h5"
+    dataset.to_netcdf(dataset_file, engine="h5netcdf")
+    xr.testing.assert_identical(
+        prov._load_file_source_data(
+            _file_replay_source(
+                dataset_file,
+                replay_call=prov.FileReplayCall(
+                    kind="callable",
+                    target="xarray.load_dataset",
+                    kwargs={"engine": "h5netcdf"},
+                    selection=prov.FileDataSelection(
+                        kind="dataset_variable",
+                        value="image",
+                    ),
+                ),
+            )
+        ),
+        image,
+    )
+    datatree_file = tmp_path / "tree.h5"
+    tree.to_netcdf(datatree_file, engine="h5netcdf")
+    xr.testing.assert_identical(
+        prov._load_file_source_data(
+            _file_replay_source(
+                datatree_file,
+                replay_call=prov.FileReplayCall(
+                    kind="callable",
+                    target="xarray.load_datatree",
+                    kwargs={"engine": "h5netcdf"},
+                    selection=prov.FileDataSelection(
+                        kind="datatree_path",
+                        value="/leaf/image",
+                    ),
+                ),
+            )
+        ),
+        image,
+    )
     with pytest.raises(IndexError, match="out of range"):
         prov._load_file_source_data(
             _file_replay_source(

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1961,6 +1961,66 @@ def test_script_input_lineage_refs_recurse_and_rebase() -> None:
     ]
 
 
+def test_replay_script_provenance_uses_resolved_inputs_without_mutating() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    left = xr.DataArray([1.0, 2.0], dims=("x",), coords={"x": [0, 1]})
+    right = xr.DataArray([0.5, 1.5], dims=("x",), coords={"x": [0, 1]})
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Mutate local input",
+            code="data_0[0] = 10.0\nderived = data_0 - data_1",
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="ImageTool 0"),
+            prov.ScriptInput(name="data_1", label="ImageTool 1"),
+        ),
+    )
+
+    assert prov.script_provenance_replayable(spec)
+    result = prov.replay_script_provenance(
+        spec,
+        {"data_0": left, "data_1": right},
+    )
+
+    xr.testing.assert_identical(
+        result,
+        xr.DataArray([9.5, 0.5], dims=("x",), coords={"x": [0, 1]}),
+    )
+    xr.testing.assert_identical(
+        left,
+        xr.DataArray([1.0, 2.0], dims=("x",), coords={"x": [0, 1]}),
+    )
+
+
+def test_replay_script_provenance_rejects_unsupported_or_incomplete_code() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray([1.0], dims=("x",))
+    unsupported = prov.script(
+        prov.ScriptCodeOperation(
+            label="Unsupported",
+            code="import os\nderived = data_0",
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    incomplete = prov.script(
+        prov.ScriptCodeOperation(label="Incomplete", code=None),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+
+    assert not prov.script_provenance_replayable(unsupported)
+    assert not prov.script_provenance_replayable(incomplete)
+    with pytest.raises(TypeError, match="unsupported Import"):
+        prov.replay_script_provenance(unsupported, {"data_0": data})
+    with pytest.raises(ValueError, match="non-replayable"):
+        prov.replay_script_provenance(incomplete, {"data_0": data})
+
+
 def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -> None:
     prov = erlab.interactive.imagetool.provenance
     image = xr.DataArray(

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -3,6 +3,7 @@ import json
 import pathlib
 import subprocess
 import sys
+import types
 import typing
 
 import numpy as np
@@ -2299,6 +2300,167 @@ def test_script_input_dependency_refs_recurse_and_rebase() -> None:
         ("data_1", "new-right", right_snapshot_id),
         ("data_2", "new-extra", extra_snapshot_id),
     ]
+    assert prov.script_input_dependency_refs(None) == ()
+    assert prov.rebase_script_input_node_uids(spec, {}) is spec
+    with pytest.raises(TypeError, match="Expected provenance spec"):
+        prov.rebase_script_input_node_uids(None, {})
+
+
+def test_low_level_provenance_replay_helper_branches() -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    assert not prov._is_whole_array_rename_entry(
+        prov.DerivationEntry("rename", "derived =")
+    )
+    assert not prov._is_whole_array_rename_entry(
+        prov.DerivationEntry("rename", "derived = derived.rename('a', 'b')")
+    )
+    assert not prov._is_whole_array_rename_entry(
+        prov.DerivationEntry("rename", "derived = derived.rename(mapping={'x': 'y'})")
+    )
+    assert prov._is_whole_array_rename_entry(
+        prov.DerivationEntry(
+            "rename",
+            "derived = derived.rename(new_name_or_name_dict=None)",
+        )
+    )
+
+    assert prov._provenance_value_code({"left": (1,)}) == "{'left': (1,)}"
+    with pytest.raises(TypeError, match="Cannot generate replay code"):
+        prov._provenance_value_code(object())
+    with pytest.raises(TypeError, match="hashable fields"):
+        prov._normalize_provenance_hashable(object())
+    assert prov._encode_provenance_hashable(("x", 1)) == {prov._TUPLE_MARKER: ["x", 1]}
+    with pytest.raises(ValueError, match="Expected 2 items"):
+        prov._ensure_float_tuple([1], expected_len=2)
+    for value in (1, "abc"):
+        with pytest.raises(TypeError, match="array-like sequence"):
+            prov._coerce_float_sequence(value)
+    assert prov._format_selection_step("sel", {}) == "derived = derived.sel()"
+    assert prov._validate_active_name(None) is None
+    for value, error in ((1, TypeError), ("class", ValueError)):
+        with pytest.raises(error):
+            prov._validate_active_name(value)
+
+    code = """
+@decorator
+def helper(value=data_0, *, scale=data_1) -> data_2:
+    return value
+
+async def async_helper(value=data_3):
+    return value
+
+lambda_value = lambda value=data_4: value
+
+@class_decorator
+class Child(Base, metaclass=data_5):
+    pass
+"""
+    statements = ast.parse(code).body
+    assert prov._statement_load_count(statements[0], "data_0") == 1
+    assert prov._statement_load_count(statements[0], "data_1") == 1
+    assert prov._statement_load_count(statements[0], "data_2") == 1
+    assert (
+        prov._statement_store_count(
+            statements[0], "helper", count_definition_names=True
+        )
+        == 1
+    )
+    assert prov._statement_load_count(statements[1], "data_3") == 1
+    assert prov._statement_load_count(statements[2], "data_4") == 1
+    assert prov._statement_load_count(statements[3], "class_decorator") == 1
+    assert prov._statement_load_count(statements[3], "data_5") == 1
+    assert (
+        prov._statement_store_count(statements[3], "Child", count_definition_names=True)
+        == 1
+    )
+    assert "source_data" in prov._replace_code_identifiers(
+        code,
+        {"data_0": "source_data"},
+    )
+    rebased = prov.rebase_default_replay_input(
+        """
+def normalize(value=data) -> data:
+    return value
+
+lambda_value = lambda value=data: value
+
+class Child(data):
+    pass
+
+derived = data
+""",
+        "source_data",
+    )
+    assert "source_data" in rebased
+    assert (
+        prov.rebase_default_replay_input("derived = data", "not valid python(")
+        == "derived = data"
+    )
+    assert prov._simplify_display_code("derived =") == "derived ="
+    assert prov._simplify_display_code("") == ""
+    assert prov._simplify_display_code("for item in data:\n    pass") == (
+        "for item in data:\n    pass"
+    )
+    assert prov._simplify_display_code("left = right = data\nresult = left") == (
+        "left = right = data\nresult = left"
+    )
+    assert prov._simplify_display_code("tmp = data\nresult = tmp") == "result = data"
+    assert (
+        prov._simplify_display_code(
+            "tmp = data\nother = 1\nresult = tmp",
+            inline_targets={"missing"},
+        )
+        == "tmp = data\nother = 1\nresult = tmp"
+    )
+
+    wrapped = staticmethod(lambda: None)
+    assert any(path.endswith(".<lambda>") for path in prov._callable_paths(wrapped))
+    assert (
+        prov._callable_paths(types.SimpleNamespace(__module__=1, __name__=2)) == set()
+    )
+
+    with pytest.raises(ValidationError):
+        prov.ScriptInput(name=None, label="Input")
+    with pytest.raises(TypeError, match="script input label"):
+        prov.ScriptInput(name="data_0", label=1)
+    with pytest.raises(ValidationError):
+        prov.ScriptInput(name="data_0", label="   ")
+    with pytest.raises(ValidationError):
+        prov.ScriptInput(name="data_0", label="Input", node_snapshot_token="")
+    with pytest.raises(TypeError, match="script input provenance"):
+        prov.ScriptInput(name="data_0", label="Input", provenance_spec=object())
+    with pytest.raises(TypeError, match="Serialized replay stages"):
+        prov.ToolProvenanceSpec(kind="full_data", replay_stages="bad")
+    with pytest.raises(TypeError, match="Serialized script inputs"):
+        prov.ToolProvenanceSpec(
+            kind="script",
+            start_label="Run",
+            active_name="derived",
+            script_inputs="bad",
+        )
+
+    assert (
+        prov.script(start_label="Run", active_name="derived")._script_graph_code(
+            display=True
+        )
+        is None
+    )
+    assert (
+        prov.full_data(
+            prov.ScriptCodeOperation(label="Opaque", code=None, copyable=False)
+        ).derivation_code()
+        is None
+    )
+    with pytest.raises(ValueError, match="not valid Python"):
+        prov._validate_script_replay_code("derived =")
+    for code_snippet, message in (
+        ("derived = __name__", "dunder names"),
+        ("derived = data.__class__", "dunder attributes"),
+        ("derived = open('path')", "cannot call"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            prov._validate_script_replay_code(code_snippet)
 
 
 def test_script_input_label_is_single_line_display_text() -> None:
@@ -2690,6 +2852,335 @@ def test_console_pattern_matches_new_replayable_operations() -> None:
     xr.testing.assert_identical(
         aggregate_operation.apply(data, parent_data=data),
         data.qsel.sum("x"),
+    )
+
+
+def test_console_pattern_rejects_ambiguous_calls_and_expands_defaults() -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    assert prov._console_values_equal(np.nan, np.nan)
+    assert prov._console_mapping_values(
+        (None,), {"coords": None, "x": 1}, mapping_kwargs=("coords",)
+    ) == {"x": 1}
+    assert prov._console_mapping_values(
+        ({"x": 1},), {"coords": {"y": 2}}, mapping_kwargs=("coords",)
+    ) == {"x": 1, "y": 2}
+    assert prov._console_mapping_values((1, 2), {}) is None
+    assert prov._console_mapping_values((1,), {}) is None
+    assert (
+        prov._console_mapping_values((), {"coords": 1}, mapping_kwargs=("coords",))
+        is None
+    )
+
+    pattern = prov.ConsoleOperationPattern(
+        target="builtins.abs",
+        fields=("value",),
+        field_aliases={"old_value": "value"},
+        defaults={"scale": 1},
+        ignored_defaults={"drop": False},
+    )
+
+    assert (
+        pattern.match(
+            prov.ConsoleCall(
+                display_code="abs(3)",
+                has_extra_tracked_inputs=True,
+            )
+        )
+        is None
+    )
+    assert (
+        pattern.match(
+            prov.ConsoleCall(
+                display_code="abs(3)",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert (
+        pattern.match(
+            prov.ConsoleCall(
+                func=len,
+                args=(3,),
+                display_code="len(3)",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert (
+        pattern.match(
+            prov.ConsoleCall(
+                func=abs,
+                kwargs={"old_value": 3, "value": 4},
+                display_code="abs(old_value=3, value=4)",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert (
+        pattern.match(
+            prov.ConsoleCall(
+                func=abs,
+                args=(3,),
+                kwargs={"drop": True},
+                display_code="abs(3, drop=True)",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert pattern.match(
+        prov.ConsoleCall(
+            func=abs,
+            args=(3,),
+            kwargs={"scale": 2, "drop": False},
+            display_code="abs(3, scale=2, drop=False)",
+            has_extra_tracked_inputs=False,
+        )
+    ) == {"value": 3, "scale": 2}
+
+    assert (
+        prov.ConsoleOperationPattern(dataarray_method="isel").match(
+            prov.ConsoleCall(
+                dataarray_method="sel",
+                display_code="data.sel()",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert (
+        prov.ConsoleOperationPattern().match(
+            prov.ConsoleCall(
+                dataarray_method="isel",
+                display_code="data.isel()",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert (
+        prov.ConsoleOperationPattern(accessor_path=("qsel",)).match(
+            prov.ConsoleCall(
+                accessor_path=("qsel", "mean"),
+                display_code="data.qsel.mean()",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert (
+        prov.ConsoleOperationPattern(fields=("required",)).match(
+            prov.ConsoleCall(
+                display_code="data.call()",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert (
+        prov.ConsoleOperationPattern().match(
+            prov.ConsoleCall(
+                kwargs={"unexpected": 1},
+                display_code="data.call(unexpected=1)",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+    assert (
+        prov.ConsoleOperationPattern(kwargs_field="mapping").match(
+            prov.ConsoleCall(
+                args=(1,),
+                display_code="data.call(1)",
+                has_extra_tracked_inputs=False,
+            )
+        )
+        is None
+    )
+
+
+def test_console_operations_match_branch_specific_calls() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+    )
+
+    def call(**kwargs: typing.Any) -> typing.Any:
+        kwargs.setdefault("display_code", "data.call()")
+        kwargs.setdefault("has_extra_tracked_inputs", False)
+        kwargs.setdefault("receiver_data", data)
+        return prov.ConsoleCall(**kwargs)
+
+    assert prov.TransposeOperation.from_console_call(
+        call(
+            dataarray_method="transpose",
+            args=("y", "x"),
+            kwargs={"transpose_coords": True, "missing_dims": "raise"},
+        )
+    ) == prov.TransposeOperation(dims=("y", "x"))
+    assert (
+        prov.TransposeOperation.from_console_call(
+            call(dataarray_method="transpose", kwargs={"transpose_coords": False})
+        )
+        is None
+    )
+
+    assert (
+        prov.SqueezeOperation.from_console_call(
+            call(dataarray_method="squeeze", kwargs={"dim": None, "axis": None})
+        )
+        == prov.SqueezeOperation()
+    )
+    assert (
+        prov.SqueezeOperation.from_console_call(
+            call(dataarray_method="squeeze", kwargs={"drop": True})
+        )
+        is None
+    )
+
+    assert prov.RenameOperation.from_console_call(
+        call(dataarray_method="rename", args=("renamed",))
+    ) == prov.RenameOperation(name="renamed")
+    assert (
+        prov.RenameOperation.from_console_call(
+            call(dataarray_method="rename", args=("renamed",), kwargs={"bad": 1})
+        )
+        is None
+    )
+
+    assert prov.AverageOperation.from_console_call(
+        call(accessor_path=("qsel", "average"), kwargs={"dim": "x"})
+    ) == prov.AverageOperation(dims=("x",))
+    assert (
+        prov.AverageOperation.from_console_call(
+            call(accessor_path=("qsel", "average"), args=("x",), kwargs={"dim": "x"})
+        )
+        is None
+    )
+
+    assert prov.QSelAggregationOperation.from_console_call(
+        call(accessor_path=("qsel", "mean"), kwargs={"dim": ("x", "y")})
+    ) == prov.QSelAggregationOperation(dims=("x", "y"), func="mean")
+    assert (
+        prov.QSelAggregationOperation.from_console_call(
+            call(accessor_path=("qsel", "median"), kwargs={"dim": "x"})
+        )
+        is None
+    )
+
+    assert prov.InterpolationOperation.from_console_call(
+        call(
+            dataarray_method="interp",
+            args=({"x": [0.25, 0.75]},),
+            kwargs={"method": "nearest", "assume_sorted": False, "kwargs": None},
+        )
+    ) == prov.InterpolationOperation(dim="x", values=[0.25, 0.75], method="nearest")
+    for bad_call in (
+        call(dataarray_method="interp", kwargs={"method": "cubic", "x": [0.5]}),
+        call(dataarray_method="interp", kwargs={"x": [0.5], "assume_sorted": True}),
+        call(dataarray_method="interp", args=({"x": [0.5], "y": [0.5]},)),
+        call(dataarray_method="interp", kwargs={"x": [[0.0, 1.0]]}),
+    ):
+        assert prov.InterpolationOperation.from_console_call(bad_call) is None
+
+    assert prov.CoarsenOperation.from_console_call(
+        call(
+            dataarray_method="coarsen",
+            args=({"x": 2},),
+            kwargs={"_reducer": "mean", "boundary": "trim"},
+        )
+    ) == prov.CoarsenOperation(
+        dim={"x": 2},
+        boundary="trim",
+        side="left",
+        coord_func="mean",
+        reducer="mean",
+    )
+    for bad_call in (
+        call(dataarray_method="coarsen", kwargs={"x": 2}),
+        call(dataarray_method="coarsen", args=(2,), kwargs={"_reducer": "mean"}),
+        call(
+            dataarray_method="coarsen",
+            args=({"x": "bad"},),
+            kwargs={"_reducer": "mean"},
+        ),
+        call(
+            dataarray_method="coarsen",
+            args=({"x": 2},),
+            kwargs={"_reducer": "mean", "extra": object()},
+        ),
+    ):
+        assert prov.CoarsenOperation.from_console_call(bad_call) is None
+
+    assert prov.ThinOperation.from_console_call(
+        call(dataarray_method="thin", args=(2,))
+    ) == prov.ThinOperation(mode="global", factor=2)
+    assert prov.ThinOperation.from_console_call(
+        call(dataarray_method="thin", args=(None,), kwargs={"x": 2})
+    ) == prov.ThinOperation(mode="per_dim", factors={"x": 2})
+    assert prov.ThinOperation.from_console_call(
+        call(dataarray_method="thin", args=({"x": 2},), kwargs={"y": 2})
+    ) == prov.ThinOperation(mode="per_dim", factors={"x": 2, "y": 2})
+    for bad_call in (
+        call(dataarray_method="thin", args=(1, 2)),
+        call(dataarray_method="thin", args=(1,), kwargs={"x": 2}),
+    ):
+        assert prov.ThinOperation.from_console_call(bad_call) is None
+
+    assert prov.RenameDimsCoordsOperation.from_console_call(
+        call(dataarray_method="rename", kwargs={"new_name_or_name_dict": {"x": "kx"}})
+    ) == prov.RenameDimsCoordsOperation(mapping={"x": "kx"})
+    assert (
+        prov.RenameDimsCoordsOperation.from_console_call(
+            call(dataarray_method="rename", args=(None,))
+        )
+        is None
+    )
+
+    assigned = prov.AssignCoordsOperation.from_console_call(
+        call(dataarray_method="assign_coords", kwargs={"x": np.array([2.0, 3.0])})
+    )
+    assert isinstance(assigned, prov.AssignCoordsOperation)
+    np.testing.assert_allclose(assigned.decoded_values, [2.0, 3.0])
+    assert prov.AssignScalarCoordOperation.from_console_call(
+        call(dataarray_method="assign_coords", kwargs={"temperature": 21.5})
+    ) == prov.AssignScalarCoordOperation(coord_name="temperature", value=21.5)
+    assert prov.AssignCoord1DOperation.from_console_call(
+        call(
+            dataarray_method="assign_coords",
+            kwargs={"temperature": ("x", [100, 101])},
+        )
+    ) == prov.AssignCoord1DOperation(
+        coord_name="temperature", dim="x", values=[100, 101]
+    )
+    for bad_call in (
+        call(dataarray_method="assign_coords", args=(1, 2)),
+        call(dataarray_method="assign_coords", kwargs={"z": np.array([1.0, 2.0])}),
+        call(
+            dataarray_method="assign_coords",
+            kwargs={"temperature": (["x"], [1, 2])},
+        ),
+        call(
+            dataarray_method="assign_coords",
+            kwargs={"temperature": ("x", np.ones((2, 2)))},
+        ),
+    ):
+        assert prov.AssignCoordsOperation.from_console_call(bad_call) is None
+        assert prov.AssignCoord1DOperation.from_console_call(bad_call) is None
+    assert (
+        prov.AssignCoordsOperation.from_console_call(
+            call(
+                dataarray_method="assign_coords",
+                kwargs={"x": ("x", [2.0, 3.0])},
+            )
+        )
+        is None
     )
 
 

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -1,0 +1,321 @@
+import pathlib
+import typing
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import erlab
+from erlab.interactive.imagetool import _replay_graph
+
+
+def _exec_generated_code(code: str) -> dict[str, typing.Any]:
+    namespace: dict[str, typing.Any] = {
+        "erlab": erlab,
+        "np": np,
+        "numpy": np,
+        "xr": xr,
+        "xarray": xr,
+    }
+    exec(code, namespace, namespace)  # noqa: S102
+    return namespace
+
+
+def _file_replay_source(path: pathlib.Path | str, *, selected_index: int = 0):
+    prov = erlab.interactive.imagetool.provenance
+    return prov.FileLoadSource(
+        path=str(path),
+        loader_label="xarray.load_dataarray",
+        loader_text="xarray.load_dataarray",
+        kwargs_text="",
+        replay_call=prov.FileReplayCall(
+            kind="callable",
+            target="xarray.load_dataarray",
+            selected_index=selected_index,
+        ),
+    )
+
+
+def _file_spec(path: pathlib.Path | str, *, selected_index: int = 0):
+    prov = erlab.interactive.imagetool.provenance
+    return prov.file_load(
+        start_label="Load source",
+        seed_code=f"derived = xr.load_dataarray({str(path)!r})",
+        file_load_source=_file_replay_source(path, selected_index=selected_index),
+    )
+
+
+def _erlab_file_spec(path: pathlib.Path | str, loader: str):
+    prov = erlab.interactive.imagetool.provenance
+    return prov.file_load(
+        start_label=f"Load {path}",
+        seed_code=(
+            "import erlab\n\n"
+            f"erlab.io.set_loader({loader!r})\n"
+            f"derived = erlab.io.load({str(path)!r})"
+        ),
+        file_load_source=prov.FileLoadSource(
+            path=str(path),
+            loader_label="Loader",
+            loader_text=loader,
+            kwargs_text="",
+            replay_call=prov.FileReplayCall(
+                kind="erlab_loader",
+                target=loader,
+                selected_index=0,
+            ),
+        ),
+    )
+
+
+def _polarization_source(path: pathlib.Path) -> xr.DataArray:
+    source = xr.DataArray(
+        np.arange(12.0).reshape(2, 2, 3),
+        dims=("pol", "energy", "k"),
+        coords={"pol": ["LH", "LV"], "energy": [0.0, 1.0], "k": [0, 1, 2]},
+    )
+    source.to_netcdf(path)
+    return source
+
+
+def test_replay_graph_emits_shared_file_and_operation_prefix(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "polarization.nc"
+    source = _polarization_source(path)
+    file_spec = _file_spec(path)
+    shared_stage = prov.full_data(prov.AverageOperation(dims=("k",)))
+    left_stage = prov.selection(
+        prov.SelOperation(kwargs={"pol": "LH"}),
+        prov.SqueezeOperation(),
+    )
+    right_stage = prov.selection(
+        prov.SelOperation(kwargs={"pol": "LV"}),
+        prov.SqueezeOperation(),
+    )
+    left_spec = prov.compose_full_provenance(
+        prov.compose_full_provenance(file_spec, shared_stage),
+        left_stage,
+    )
+    right_spec = prov.compose_full_provenance(
+        prov.compose_full_provenance(file_spec, shared_stage),
+        right_stage,
+    )
+    assert left_spec is not None
+    assert right_spec is not None
+    spec = prov.script(
+        prov.ScriptCodeOperation(label="Subtract", code="derived = data_0 - data_1"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="LH", provenance_spec=left_spec),
+            prov.ScriptInput(name="data_1", label="LV", provenance_spec=right_spec),
+        ),
+    )
+
+    code = typing.cast("str", spec.display_code())
+
+    assert code.count("xr.load_dataarray") == 1
+    assert code.count(".qsel.average") == 1
+    namespace = _exec_generated_code(code)
+    expected = left_stage.apply(shared_stage.apply(source)) - right_stage.apply(
+        shared_stage.apply(source)
+    )
+    xr.testing.assert_identical(namespace["derived"], expected)
+
+
+def test_replay_graph_keeps_structurally_distinct_file_loads() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    first = _file_spec("scan.h5", selected_index=0)
+    second = _file_spec("scan.h5", selected_index=1)
+    spec = prov.script(
+        prov.ScriptCodeOperation(label="Subtract", code="derived = data_0 - data_1"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="First", provenance_spec=first),
+            prov.ScriptInput(name="data_1", label="Second", provenance_spec=second),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+
+    assert code.count("xr.load_dataarray") == 2
+
+
+def test_replay_graph_reuses_shared_loader_setup() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Add",
+            code="derived = data_0 + data_1",
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="First",
+                provenance_spec=_erlab_file_spec("scan0.h5", "example"),
+            ),
+            prov.ScriptInput(
+                name="data_1",
+                label="Second",
+                provenance_spec=_erlab_file_spec("scan1.h5", "example"),
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+
+    assert code.count("erlab.io.set_loader('example')") == 1
+    assert code.count("erlab.io.load") == 2
+
+
+def test_replay_graph_reemits_stateful_setup_after_loader_change() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Add",
+            code="derived = data_0 + data_1 + data_2",
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Alpha 0",
+                provenance_spec=_erlab_file_spec("alpha0.h5", "alpha"),
+            ),
+            prov.ScriptInput(
+                name="data_1",
+                label="Beta",
+                provenance_spec=_erlab_file_spec("beta.h5", "beta"),
+            ),
+            prov.ScriptInput(
+                name="data_2",
+                label="Alpha 1",
+                provenance_spec=_erlab_file_spec("alpha1.h5", "alpha"),
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+
+    assert code.count("erlab.io.set_loader('alpha')") == 2
+    assert code.count("erlab.io.set_loader('beta')") == 1
+
+
+def test_replay_graph_does_not_merge_operations_with_different_contexts() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    file_spec = _file_spec("scan.h5")
+    first_spec = prov.compose_full_provenance(
+        file_spec,
+        prov.full_data(prov.IselOperation(kwargs={"pol": 0})),
+    )
+    second_spec = prov.compose_full_provenance(
+        file_spec,
+        prov.selection(prov.IselOperation(kwargs={"pol": 0})),
+    )
+    assert first_spec is not None
+    assert second_spec is not None
+    spec = prov.script(
+        prov.ScriptCodeOperation(label="Subtract", code="derived = data_0 - data_1"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="Full", provenance_spec=first_spec),
+            prov.ScriptInput(
+                name="data_1",
+                label="Selection",
+                provenance_spec=second_spec,
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+
+    assert code.count(".isel") == 2
+
+
+def test_replay_graph_script_nodes_are_not_deduplicated() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    first = prov.script(
+        start_label="Make first",
+        seed_code="derived = xr.DataArray([1.0, 2.0], dims=['x'])",
+        active_name="derived",
+    )
+    second = prov.script(
+        start_label="Make second",
+        seed_code="derived = xr.DataArray([10.0, 20.0], dims=['x'])",
+        active_name="derived",
+    )
+    spec = prov.script(
+        prov.ScriptCodeOperation(label="Add", code="derived = data_0 + data_1"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="First", provenance_spec=first),
+            prov.ScriptInput(name="data_1", label="Second", provenance_spec=second),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+    namespace = _exec_generated_code(code)
+
+    assert code.count("xr.DataArray") == 2
+    xr.testing.assert_identical(
+        namespace["derived"],
+        xr.DataArray([11.0, 22.0], dims=["x"]),
+    )
+
+
+def test_replay_graph_raises_typed_errors_for_unsupported_script() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray([1.0], dims=("x",))
+    spec = prov.script(
+        prov.ScriptCodeOperation(label="Unsupported", code="import os\nderived = data"),
+        start_label="Run script",
+        active_name="derived",
+    )
+
+    with pytest.raises(_replay_graph.ReplayGraphError, match="unsupported Import"):
+        _replay_graph.compile_replay_graph(spec, external_inputs={"data": data})
+
+
+def test_replay_graph_rejects_operations_without_replay_code() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    spec = prov.compose_full_provenance(
+        _file_spec("scan.h5"),
+        prov.full_data(prov.RenameOperation(name="renamed")),
+    )
+    assert spec is not None
+
+    graph = _replay_graph.compile_replay_graph(spec)
+
+    with pytest.raises(_replay_graph.ReplayGraphError, match="replay code"):
+        _replay_graph.emit_replay_code(graph)
+
+
+def test_replay_graph_execution_matches_emitted_code(tmp_path: pathlib.Path) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "source.nc"
+    source = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0, 1], "y": [0, 1, 2]},
+    )
+    source.to_netcdf(path)
+    spec = prov.compose_full_provenance(
+        _file_spec(path),
+        prov.full_data(prov.AverageOperation(dims=("y",))),
+    )
+    assert spec is not None
+
+    graph = _replay_graph.compile_replay_graph(spec)
+    replayed = _replay_graph.execute_replay_graph(graph)
+    code = _replay_graph.emit_replay_code(graph, output_name="derived")
+    namespace = _exec_generated_code(code)
+
+    xr.testing.assert_identical(replayed, namespace["derived"])

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -313,7 +313,8 @@ def test_replay_graph_rebases_context_in_script_input_code(
         ),
     )
 
-    code = typing.cast("str", spec.derivation_code())
+    graph = _replay_graph.compile_replay_graph(spec, display=False)
+    code = _replay_graph.emit_replay_code(graph, output_name="derived")
 
     assert "data.coords" not in code
     assert "derived.coords.keys()" in code

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -12,6 +12,7 @@ from erlab.interactive.imagetool import _replay_graph
 def _exec_generated_code(code: str) -> dict[str, typing.Any]:
     namespace: dict[str, typing.Any] = {
         "erlab": erlab,
+        "era": erlab.analysis,
         "np": np,
         "numpy": np,
         "xr": xr,
@@ -50,9 +51,7 @@ def _erlab_file_spec(path: pathlib.Path | str, loader: str):
     return prov.file_load(
         start_label=f"Load {path}",
         seed_code=(
-            "import erlab\n\n"
-            f"erlab.io.set_loader({loader!r})\n"
-            f"derived = erlab.io.load({str(path)!r})"
+            f"erlab.io.set_loader({loader!r})\nderived = erlab.io.load({str(path)!r})"
         ),
         file_load_source=prov.FileLoadSource(
             path=str(path),
@@ -117,12 +116,396 @@ def test_replay_graph_emits_shared_file_and_operation_prefix(
     code = typing.cast("str", spec.display_code())
 
     assert code.count("xr.load_dataarray") == 1
-    assert code.count(".qsel.average") == 1
+    assert code.count(".qsel.mean") == 1
     namespace = _exec_generated_code(code)
     expected = left_stage.apply(shared_stage.apply(source)) - right_stage.apply(
         shared_stage.apply(source)
     )
     xr.testing.assert_identical(namespace["derived"], expected)
+
+
+def test_replay_graph_handles_structured_script_operations(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "scan.nc"
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("alpha", "eV"),
+        coords={"alpha": [0.0, 1.0], "eV": [0.0, 1.0, 2.0]},
+    )
+    data.to_netcdf(path)
+    spec = prov.script(
+        prov.AverageOperation(dims=("alpha",)),
+        start_label="Run script",
+        seed_code="avg = data_0",
+        active_name="avg",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Scan",
+                provenance_spec=_file_spec(path),
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+    assert ".qsel.mean" in code
+    namespace = _exec_generated_code(code)
+    xr.testing.assert_identical(namespace["avg"], data.qsel.mean("alpha"))
+
+    graph = _replay_graph.compile_replay_graph(spec)
+    xr.testing.assert_identical(
+        _replay_graph.execute_replay_graph(graph),
+        data.qsel.mean("alpha"),
+    )
+
+
+def test_replay_graph_emits_structured_script_operation_without_identity_relays(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "scan.nc"
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("polarization", "eV"),
+        coords={"polarization": [-1, 1], "eV": [0.0, 1.0]},
+    )
+    data.to_netcdf(path)
+    spec = prov.script(
+        prov.SelOperation(kwargs={"polarization": -1}),
+        start_label="Run script",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Scan",
+                provenance_spec=_file_spec(path),
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+    lines = code.splitlines()
+
+    assert not any(line.startswith("_itool_replay_") for line in lines)
+    assert "derived = xr.load_dataarray" in code
+    assert ".sel(polarization=-1)" in code
+    xr.testing.assert_identical(
+        _exec_generated_code(code)["derived"],
+        data.sel(polarization=-1),
+    )
+
+
+def test_replay_graph_preserves_script_inputs_after_structured_operation() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+    spec = prov.script(
+        prov.AverageOperation(dims=("x",)),
+        prov.ScriptCodeOperation(
+            label="Use original input",
+            code="derived = derived + data_0.qsel.average('x')",
+        ),
+        start_label="Run script",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+    )
+
+    graph = _replay_graph.compile_replay_graph(spec, external_inputs={"data_0": data})
+    script_nodes = [node for node in graph.nodes if node.kind == "script"]
+
+    assert script_nodes
+    assert any(
+        input_name == "data_0"
+        for node in script_nodes
+        for input_name, _key in node.payload["bindings"]
+    )
+    xr.testing.assert_identical(
+        _replay_graph.execute_replay_graph(graph),
+        data.qsel.average("x") + data.qsel.average("x"),
+    )
+
+
+def test_replay_graph_keeps_structured_operations_in_opaque_script() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+    spec = prov.script(
+        prov.AverageOperation(dims=("x",)),
+        prov.ScriptCodeOperation(
+            label="Use temp",
+            code="derived = derived + tmp.qsel.average('x') + data_0.qsel.average('x')",
+        ),
+        start_label="Run script",
+        seed_code="tmp = data_0 + 1\nderived = tmp",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+    )
+
+    graph = _replay_graph.compile_replay_graph(spec, external_inputs={"data_0": data})
+    script_nodes = [node for node in graph.nodes if node.kind == "script"]
+
+    assert len(script_nodes) == 1
+    assert not any(node.kind == "operation" for node in graph.nodes)
+    assert any(
+        "derived = derived.qsel.mean(" in code
+        for code in script_nodes[0].payload["codes"]
+    )
+    xr.testing.assert_identical(
+        _replay_graph.execute_replay_graph(graph),
+        (data + 1).qsel.average("x")
+        + (data + 1).qsel.average("x")
+        + data.qsel.average("x"),
+    )
+
+
+def test_replay_graph_rebases_context_for_inlined_operation() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0, 2.0]},
+    )
+    spec = prov.script(
+        prov.SortCoordOrderOperation(),
+        start_label="Run script",
+        seed_code="tmp = data_0 + 1\nderived = tmp",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+    )
+
+    graph = _replay_graph.compile_replay_graph(spec, external_inputs={"data_0": data})
+    script_nodes = [node for node in graph.nodes if node.kind == "script"]
+    inlined_code = "\n".join(script_nodes[0].payload["codes"])
+
+    assert prov.script_provenance_replayable(spec)
+    assert "data.coords" not in inlined_code
+    assert "derived.coords.keys()" in inlined_code
+    xr.testing.assert_identical(
+        prov.replay_script_provenance(spec, {"data_0": data}),
+        erlab.utils.array.sort_coord_order(data + 1, (data + 1).coords.keys()),
+    )
+
+
+def test_replay_graph_rebases_context_in_script_input_code(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "scan.nc"
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0, 2.0]},
+    )
+    data.to_netcdf(path)
+    spec = prov.script(
+        prov.SortCoordOrderOperation(),
+        start_label="Run script",
+        seed_code="tmp = data_0 + 1\nderived = tmp",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Input",
+                provenance_spec=_file_spec(path),
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+
+    assert "data.coords" not in code
+    assert "derived.coords.keys()" in code
+    namespace = _exec_generated_code(code)
+    xr.testing.assert_identical(
+        namespace["derived"],
+        erlab.utils.array.sort_coord_order(data + 1, (data + 1).coords.keys()),
+    )
+
+
+def test_replay_graph_shares_structured_console_alias_prefixes(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "polarization.nc"
+    source = _polarization_source(path)
+    averaged = prov.script(
+        prov.AverageOperation(dims=("k",)),
+        start_label="Run script",
+        seed_code="avg = data_0",
+        active_name="avg",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Scan",
+                provenance_spec=_file_spec(path),
+            ),
+        ),
+    )
+    spec = prov.script(
+        prov.ScriptCodeOperation(label="Subtract", code="derived = data_0 - data_1"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="LH", provenance_spec=averaged),
+            prov.ScriptInput(name="data_1", label="LV", provenance_spec=averaged),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+    graph = _replay_graph.compile_replay_graph(spec)
+
+    assert code.count("xr.load_dataarray") == 1
+    assert code.count(".qsel.mean") == 1
+    assert ".copy(" not in code
+    assert (
+        sum(
+            node.kind == "operation" and node.payload["operation"].op == "average"
+            for node in graph.nodes
+        )
+        == 1
+    )
+    expected = source.qsel.mean("k") - source.qsel.mean("k")
+    xr.testing.assert_identical(_exec_generated_code(code)["derived"], expected)
+    xr.testing.assert_identical(_replay_graph.execute_replay_graph(graph), expected)
+
+
+@pytest.mark.parametrize(
+    ("seed_code", "active_name"),
+    [
+        ("derived = data_0", "derived"),
+        (None, "data_0"),
+    ],
+)
+def test_replay_graph_structured_script_inputs_keep_execution_copy_boundary(
+    seed_code: str | None,
+    active_name: str,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+    spec = prov.script(
+        prov.RenameOperation(name="renamed"),
+        start_label="Run script",
+        seed_code=seed_code,
+        active_name=active_name,
+        script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+    )
+
+    graph = _replay_graph.compile_replay_graph(spec, external_inputs={"data_0": data})
+    replayed = _replay_graph.execute_replay_graph(graph)
+
+    assert any(node.kind == "relay" for node in graph.nodes)
+    assert replayed.name == "renamed"
+    assert not np.shares_memory(replayed.data, data.data)
+
+
+def test_script_replayability_does_not_generate_structured_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    spec = prov.script(
+        prov.RenameOperation(name="renamed"),
+        start_label="Run script",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+    )
+
+    def fail_derivation_entry(self):
+        raise AssertionError("replayability checks must not generate copied code")
+
+    monkeypatch.setattr(prov.RenameOperation, "derivation_entry", fail_derivation_entry)
+
+    assert prov.script_provenance_replayable(spec)
+
+
+def test_replay_graph_uses_existing_console_alias_for_script_code(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "scan.nc"
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+    )
+    data.to_netcdf(path)
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Rotate",
+            code=(
+                "derived = era.transform.rotate("
+                "data_0, 0.0, axes=('x', 'y'), reshape=False)"
+            ),
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Scan",
+                provenance_spec=_file_spec(path),
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+    namespace = _exec_generated_code(code)
+
+    assert "era = erlab.analysis" not in code
+    xr.testing.assert_identical(
+        namespace["derived"],
+        erlab.analysis.transform.rotate(data, 0.0, axes=("x", "y"), reshape=False),
+    )
+
+
+def test_replay_graph_uses_existing_console_alias_for_structured_code(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "scan.nc"
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+    )
+    data.to_netcdf(path)
+    spec = prov.script(
+        prov.RotateOperation(
+            angle=123.456,
+            axes=("x", "y"),
+            center=(1.234, 5.678),
+            reshape=False,
+            order=3,
+        ),
+        start_label="Run script",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Scan",
+                provenance_spec=_file_spec(path),
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+    namespace = _exec_generated_code(code)
+
+    assert "era = erlab.analysis" not in code
+    xr.testing.assert_identical(
+        namespace["derived"],
+        erlab.analysis.transform.rotate(
+            data,
+            123.456,
+            axes=("x", "y"),
+            center=(1.234, 5.678),
+            reshape=False,
+            order=3,
+        ),
+    )
 
 
 def test_replay_graph_keeps_structurally_distinct_file_loads() -> None:
@@ -169,6 +552,7 @@ def test_replay_graph_reuses_shared_loader_setup() -> None:
 
     code = typing.cast("str", spec.derivation_code())
 
+    assert "import erlab" not in code
     assert code.count("erlab.io.set_loader('example')") == 1
     assert code.count("erlab.io.load") == 2
 
@@ -205,6 +589,9 @@ def test_replay_graph_reemits_stateful_setup_after_loader_change() -> None:
 
     assert code.count("erlab.io.set_loader('alpha')") == 2
     assert code.count("erlab.io.set_loader('beta')") == 1
+    assert code.index("erlab.io.load('alpha0.h5')") < code.index(
+        "erlab.io.set_loader('beta')"
+    )
 
 
 def test_replay_graph_does_not_merge_operations_with_different_contexts() -> None:
@@ -284,18 +671,35 @@ def test_replay_graph_raises_typed_errors_for_unsupported_script() -> None:
         _replay_graph.compile_replay_graph(spec, external_inputs={"data": data})
 
 
-def test_replay_graph_rejects_operations_without_replay_code() -> None:
+def test_replay_graph_emits_correct_with_edge_operation_code(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "scan.nc"
+    data = xr.DataArray([1.0, 2.0], dims=("x",), coords={"x": [0.0, 1.0]})
+    data.to_netcdf(path)
+    edge_fit = xr.Dataset({"center": ("x", [0.0, 1.0])})
+
+    def correct_with_edge(data_arg, edge_fit_arg, *, shift_coords=True):
+        xr.testing.assert_identical(edge_fit_arg, edge_fit)
+        return data_arg.assign_attrs(shift_coords=shift_coords)
+
+    monkeypatch.setattr(erlab.analysis.gold, "correct_with_edge", correct_with_edge)
     spec = prov.compose_full_provenance(
-        _file_spec("scan.h5"),
-        prov.full_data(prov.RenameOperation(name="renamed")),
+        _file_spec(path),
+        prov.full_data(
+            prov.CorrectWithEdgeOperation(edge_fit=edge_fit, shift_coords=False)
+        ),
     )
     assert spec is not None
 
     graph = _replay_graph.compile_replay_graph(spec)
+    code = _replay_graph.emit_replay_code(graph, output_name="derived")
+    namespace = _exec_generated_code(code)
 
-    with pytest.raises(_replay_graph.ReplayGraphError, match="replay code"):
-        _replay_graph.emit_replay_code(graph)
+    assert namespace["derived"].attrs["shift_coords"] is False
+    assert _replay_graph.execute_replay_graph(graph).attrs["shift_coords"] is False
 
 
 def test_replay_graph_execution_matches_emitted_code(tmp_path: pathlib.Path) -> None:

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -400,6 +400,74 @@ def test_replay_graph_structured_script_inputs_keep_execution_copy_boundary(
     assert not np.shares_memory(replayed.data, data.data)
 
 
+def test_replay_graph_display_skips_whole_array_rename(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="source")
+    path = tmp_path / "source.nc"
+    data.to_netcdf(path)
+    spec = prov.script(
+        prov.RenameOperation(name="renamed"),
+        start_label="Run script",
+        active_name="data_0",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Input",
+                provenance_spec=_file_spec(path),
+            ),
+        ),
+    )
+
+    graph = _replay_graph.compile_replay_graph(
+        spec,
+        display=True,
+    )
+    code = _replay_graph.emit_replay_code(graph, output_name="derived")
+
+    assert ".rename(" not in code
+    xr.testing.assert_identical(_exec_generated_code(code)["derived"], data)
+
+
+def test_replay_graph_display_keeps_name_rename_before_script_code(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="source")
+    path = tmp_path / "source.nc"
+    data.to_netcdf(path)
+    spec = prov.script(
+        prov.RenameOperation(name="renamed"),
+        prov.ScriptCodeOperation(
+            label="Use DataArray name",
+            code="derived = derived.rename(derived.name + '_used')",
+        ),
+        start_label="Run script",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Input",
+                provenance_spec=_file_spec(path),
+            ),
+        ),
+    )
+
+    graph = _replay_graph.compile_replay_graph(
+        spec,
+        display=True,
+    )
+    code = _replay_graph.emit_replay_code(graph, output_name="derived")
+
+    assert ".rename(" in code
+    xr.testing.assert_identical(
+        _exec_generated_code(code)["derived"],
+        data.rename("renamed_used"),
+    )
+
+
 def test_script_replayability_does_not_generate_structured_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -1,4 +1,6 @@
+import ast
 import pathlib
+import types
 import typing
 
 import numpy as np
@@ -75,6 +77,372 @@ def _polarization_source(path: pathlib.Path) -> xr.DataArray:
     )
     source.to_netcdf(path)
     return source
+
+
+def test_replay_graph_low_level_validation_helpers() -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    assert _replay_graph._code_uses_name("derived = data", "data")
+    assert not _replay_graph._code_uses_name("derived =", "data")
+    assert (
+        _replay_graph._simple_assignment_source_name("target = source", "target")
+        == "source"
+    )
+    assert (
+        _replay_graph._simple_assignment_source_name(
+            "target: xr.DataArray = source",
+            "target",
+        )
+        == "source"
+    )
+    assert _replay_graph._simple_assignment_source_name("target =", "target") is None
+    assert (
+        _replay_graph._simple_assignment_source_name(
+            "target = source\nother = source", "target"
+        )
+        is None
+    )
+
+    module = ast.parse(
+        """
+@decorator
+def helper(value=data_0, *, scale=data_1) -> data_2:
+    return value
+
+async def async_helper(value=data_3):
+    return value
+
+lambda_value = lambda value=data_4: value
+
+@class_decorator
+class Child(Base, metaclass=data_5):
+    pass
+"""
+    )
+    names = [_replay_graph._statement_scope_names(stmt) for stmt in module.body]
+    loads = set().union(*(item.loads for item in names))
+    stores = set().union(*(item.stores for item in names))
+    assert {
+        "decorator",
+        "data_0",
+        "data_1",
+        "data_2",
+        "data_3",
+        "data_4",
+        "class_decorator",
+    }.issubset(loads)
+    assert {"Base", "data_5"}.issubset(loads)
+    assert {"helper", "async_helper", "lambda_value", "Child"}.issubset(stores)
+
+    deps = _replay_graph._script_function_dependencies(
+        "def helper():\n"
+        "    def nested():\n"
+        "        return missing\n"
+        "    return nested()\n"
+    )
+    assert deps[("helper", 1)] == {"missing"}
+    with pytest.raises(_replay_graph.ReplayGraphError, match="unresolved name"):
+        _replay_graph._validate_script_code_names(
+            "def helper():\n    return missing\nresult = helper()",
+            set(),
+            {},
+        )
+
+    with pytest.raises(_replay_graph.ReplayGraphError, match="Expected script"):
+        _replay_graph._validate_script_provenance(
+            prov.full_data(prov.SqueezeOperation())
+        )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="without active_name"):
+        _replay_graph._validate_script_provenance(
+            types.SimpleNamespace(kind="script", active_name=None)
+        )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="unsupported Import"):
+        _replay_graph._validate_script_provenance(
+            prov.script(
+                start_label="Run script",
+                seed_code="import os",
+                active_name="derived",
+                script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+            )
+        )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="no replay code"):
+        _replay_graph._validate_script_provenance(
+            prov.script(
+                prov.AverageOperation(dims=("x",)),
+                start_label="Run script",
+                active_name="derived",
+            )
+        )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="no replay code"):
+        _replay_graph._validate_script_provenance(
+            prov.script(start_label="Run script", active_name="derived")
+        )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="non-replayable"):
+        _replay_graph._validate_script_provenance(
+            prov.script(
+                prov.ScriptCodeOperation(
+                    label="Opaque",
+                    code=None,
+                    copyable=False,
+                ),
+                start_label="Run script",
+                active_name="derived",
+                script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+            )
+        )
+    assert not _replay_graph.script_provenance_replayable(None)
+
+
+def test_replay_graph_manual_error_and_cache_paths() -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+
+    graph = _replay_graph.ReplayGraph()
+    live_key = graph.add_node("live", "live_input", payload={"data": data})
+    graph.output_key = live_key
+    with pytest.raises(_replay_graph.ReplayGraphError, match="Live inputs"):
+        _replay_graph.emit_replay_code(graph)
+    xr.testing.assert_identical(
+        _replay_graph.execute_replay_graph(graph, cache={live_key: data + 1.0}),
+        data + 1.0,
+    )
+    replayed = _replay_graph.execute_replay_graph(graph)
+    xr.testing.assert_identical(replayed, data)
+    assert not np.shares_memory(replayed.data, data.data)
+
+    relay_graph = _replay_graph.ReplayGraph()
+    relay_live_key = relay_graph.add_node("live", "live_input", payload={"data": data})
+    relay_key = relay_graph.add_node("relay", "relay", parents=(relay_live_key,))
+    relay_graph.output_key = relay_key
+    xr.testing.assert_identical(_replay_graph.execute_replay_graph(relay_graph), data)
+
+    for load_code, message in (
+        ("derived =", "not valid Python"),
+        ("other = xr.DataArray([1.0], dims=('x',))", "does not assign"),
+    ):
+        file_graph = _replay_graph.ReplayGraph()
+        file_key = file_graph.add_node(
+            f"file-{message}",
+            "file_load",
+            payload={
+                "active_name": "derived",
+                "load_code": load_code,
+                "load_source": None,
+            },
+        )
+        file_graph.output_key = file_key
+        with pytest.raises(_replay_graph.ReplayGraphError, match=message):
+            _replay_graph.emit_replay_code(file_graph)
+
+    for codes, message in (
+        (("other = xr.DataArray([1.0], dims=('x',))",), "did not create"),
+        (("derived = 1",), "did not produce"),
+    ):
+        script_graph = _replay_graph.ReplayGraph()
+        script_key = script_graph.add_node(
+            f"script-{message}",
+            "script",
+            payload={"bindings": (), "codes": codes, "active_name": "derived"},
+        )
+        script_graph.output_key = script_key
+        with pytest.raises(_replay_graph.ReplayGraphError, match=message):
+            _replay_graph.execute_replay_graph(script_graph)
+
+    unknown_graph = _replay_graph.ReplayGraph()
+    unknown_key = unknown_graph.add_node("unknown", "unknown")
+    unknown_graph.output_key = unknown_key
+    with pytest.raises(_replay_graph.ReplayGraphError, match="Unknown replay"):
+        _replay_graph.emit_replay_code(unknown_graph)
+    with pytest.raises(_replay_graph.ReplayGraphError, match="Unknown replay"):
+        _replay_graph.execute_replay_graph(unknown_graph)
+
+    empty_graph = _replay_graph.ReplayGraph()
+    with pytest.raises(_replay_graph.ReplayGraphError, match="no output"):
+        _replay_graph.emit_replay_code(empty_graph, output_name="derived")
+    with pytest.raises(_replay_graph.ReplayGraphError, match="no output"):
+        _replay_graph.execute_replay_graph(empty_graph)
+
+
+def test_replay_graph_file_script_input_and_rebuild_edges(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+    path = tmp_path / "source.nc"
+    data.to_netcdf(path)
+    file_spec = _file_spec(path)
+
+    setup_code, load_code = _replay_graph._file_seed_code_parts(
+        "import erlab\nimport numpy as np\nderived = xr.load_dataarray('source.nc')",
+        "derived",
+    )
+    assert setup_code == "import numpy as np"
+    assert "xr.load_dataarray" in load_code
+    for seed_code, message in (
+        ("derived =", "not valid Python"),
+        ("other = xr.DataArray([1.0], dims=('x',))", "does not assign"),
+    ):
+        with pytest.raises(_replay_graph.ReplayGraphError, match=message):
+            _replay_graph._file_seed_code_parts(seed_code, "derived")
+
+    loaded_input = prov.ScriptInput(
+        name="loaded",
+        label="Loaded source",
+        provenance_spec=file_spec,
+    )
+    code = _replay_graph.script_inputs_code((loaded_input,), display=False)
+    namespace = _exec_generated_code(code)
+    xr.testing.assert_identical(namespace["loaded"], data)
+    with pytest.raises(_replay_graph.ReplayGraphError, match="recorded source"):
+        _replay_graph.script_inputs_code(
+            (prov.ScriptInput(name="missing", label="Missing source"),),
+            display=False,
+        )
+
+    with pytest.raises(_replay_graph.ReplayGraphError, match="script-derived"):
+        _replay_graph.rebuild_script_provenance(file_spec)
+    script_spec = prov.script(
+        prov.ScriptCodeOperation(label="Add one", code="derived = data_0 + 1.0"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Loaded source",
+                provenance_spec=file_spec,
+            ),
+        ),
+    )
+    rebuilt, rebuilt_spec = _replay_graph.rebuild_script_provenance(script_spec)
+    xr.testing.assert_identical(rebuilt, data + 1.0)
+    assert rebuilt_spec.script_inputs[0].node_uid is None
+
+    with pytest.raises(_replay_graph.ReplayGraphError, match="maximum reload depth"):
+        _replay_graph.rebuild_script_provenance(script_spec, depth=21)
+    missing_spec = prov.script(
+        prov.ScriptCodeOperation(label="Add one", code="derived = data_0 + 1.0"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="Closed input"),),
+    )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="not open"):
+        _replay_graph.rebuild_script_provenance(missing_spec)
+
+    live_calls = 0
+    initial_marker = "initial-marker"
+    current_marker = "current-marker"
+    live_input = prov.ScriptInput(
+        name="data_0",
+        label="Live input",
+        node_uid="uid-0",
+        node_snapshot_token=initial_marker,
+    )
+    live_spec = prov.script(
+        prov.ScriptCodeOperation(label="Double", code="derived = data_0 * 2.0"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(live_input,),
+    )
+
+    def resolve_live(_script_input):
+        nonlocal live_calls
+        live_calls += 1
+        return data, live_input.model_copy(
+            update={"node_snapshot_token": current_marker}
+        )
+
+    live_rebuilt, live_rebuilt_spec = _replay_graph.rebuild_script_provenance(
+        live_spec,
+        live_input_resolver=resolve_live,
+    )
+    xr.testing.assert_identical(live_rebuilt, data * 2.0)
+    assert live_calls == 1
+    assert live_rebuilt_spec.script_inputs[0].node_snapshot_token == current_marker
+
+    miss_calls = 0
+    duplicate_file_input = prov.ScriptInput(
+        name="data_0",
+        label="Closed file input",
+        node_uid="same-uid",
+        provenance_spec=file_spec,
+    )
+    duplicate_file_spec = prov.script(
+        prov.ScriptCodeOperation(label="Copy", code="derived = data_0"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(duplicate_file_input, duplicate_file_input),
+    )
+
+    def miss_live(_script_input):
+        nonlocal miss_calls
+        miss_calls += 1
+        return
+
+    rebuilt_from_miss, _rebuilt_from_miss_spec = (
+        _replay_graph.rebuild_script_provenance(
+            duplicate_file_spec,
+            live_input_resolver=miss_live,
+        )
+    )
+    xr.testing.assert_identical(rebuilt_from_miss, data)
+    assert miss_calls == 2
+
+    unsupported_nested = prov.script(
+        prov.ScriptCodeOperation(label="Opaque", code=None, copyable=False),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(prov.ScriptInput(name="data_0", label="Input"),),
+    )
+    unsupported_input = prov.ScriptInput(
+        name="data_0",
+        label="Unsupported nested input",
+        provenance_spec=unsupported_nested,
+    )
+    unsupported_spec = prov.script(
+        prov.ScriptCodeOperation(label="Copy", code="derived = data_0"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(unsupported_input,),
+    )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="cannot be replayed"):
+        _replay_graph.rebuild_script_provenance(unsupported_spec)
+
+    full_data_spec = prov.script(
+        prov.ScriptCodeOperation(label="Copy", code="derived = data_0"),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Full data",
+                provenance_spec=prov.full_data(),
+            ),
+        ),
+    )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="reloadable"):
+        _replay_graph.rebuild_script_provenance(full_data_spec)
+
+
+def test_replay_graph_operation_code_error_edges() -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    class Operation:
+        def __init__(self, code: str | None) -> None:
+            self._code = code
+
+        def derivation_entry(self) -> prov.DerivationEntry:
+            return prov.DerivationEntry("Operation", self._code, True)
+
+    for operation, message in (
+        (Operation(None), "does not provide"),
+        (Operation("derived ="), "not valid Python"),
+        (Operation("other = data"), "does not assign"),
+    ):
+        with pytest.raises(_replay_graph.ReplayGraphError, match=message):
+            _replay_graph._operation_replay_code(
+                operation,
+                active_name="derived",
+                context_name="data",
+            )
 
 
 def test_replay_graph_emits_shared_file_and_operation_prefix(

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -8,7 +8,9 @@ from erlab.interactive.imagetool.slicer import (
     _display_safe_float,
     _display_safe_minmax,
     _display_safe_values,
+    check_cursors_compatible,
     qsel_args_from_indexers,
+    restore_nonuniform_dims,
 )
 
 
@@ -35,6 +37,54 @@ def test_nonuniform_axes_detects_generated_idx_dim(qtbot) -> None:
 
     assert str(slicer._obj.dims[0]).endswith("_idx")
     assert slicer._nonuniform_axes == [0]
+
+
+def test_restore_nonuniform_dims_ignores_user_idx_dim() -> None:
+    data = xr.DataArray(
+        np.zeros((3, 4)),
+        dims=("x_idx", "y"),
+        coords={
+            "x_idx": np.arange(3),
+            "x": ("x_idx", np.arange(3)),
+            "y": np.arange(4),
+        },
+    )
+
+    restored = restore_nonuniform_dims(data)
+
+    xr.testing.assert_identical(restored, data)
+
+
+def test_check_cursors_compatible_normalizes_promoted_1d_stack_dim() -> None:
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+    )
+    promoted = ArraySlicer.validate_array(data, copy_values=False)
+
+    assert promoted.dims == ("x", "stack_dim")
+    assert check_cursors_compatible(promoted, data)
+    assert check_cursors_compatible(data, promoted)
+    assert not check_cursors_compatible(
+        promoted, data.assign_coords(x=[0.0, 1.0, 2.0, 4.0])
+    )
+
+
+def test_check_cursors_compatible_normalizes_nonuniform_idx_dims() -> None:
+    public = xr.DataArray(
+        np.arange(12.0).reshape(4, 3),
+        dims=("x", "y"),
+        coords={"x": [0.0, 0.2, 0.8, 1.5], "y": np.arange(3.0)},
+    )
+    internal = ArraySlicer.validate_array(public, copy_values=False)
+
+    assert internal.dims == ("x_idx", "y")
+    assert check_cursors_compatible(internal, public)
+    assert check_cursors_compatible(public, internal)
+    assert not check_cursors_compatible(
+        internal, public.assign_coords(x=[0.0, 0.2, 0.9, 1.5])
+    )
 
 
 def test_set_array_shallow_copy_does_not_require_deep_copy(qtbot) -> None:

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -628,7 +628,9 @@ def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
     assert tool.source_state == "unavailable"
 
 
-def test_tool_copy_code_includes_parent_lineage_for_standalone_imagetool(qtbot) -> None:
+def test_tool_copy_code_includes_parent_provenance_for_standalone_imagetool(
+    qtbot,
+) -> None:
     class _DummyState(BaseModel):
         value: int = 0
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1670,6 +1670,9 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
         def _mark_node_data_dirty(self, _uid: str) -> None:
             return
 
+        def _refresh_dependency_dependents(self, _uid: str) -> None:
+            return
+
     manager = _FakeManager()
     qtbot.addWidget(manager)
     tool = _PersistentTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
@@ -1873,6 +1876,9 @@ def test_managed_tool_window_node_detached_update_branches(
             return
 
         def _mark_node_data_dirty(self, _uid: str) -> None:
+            return
+
+        def _refresh_dependency_dependents(self, _uid: str) -> None:
             return
 
     parent_tool = _OutputTool(parent_data)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1171,7 +1171,7 @@ def test_tool_script_provenance_rejects_invalid_expression(qtbot) -> None:
         tool.current_provenance_spec()
 
 
-def test_tool_window_dynamic_expression_provenance_uses_input_lineage(qtbot) -> None:
+def test_tool_window_dynamic_expression_provenance_uses_input_provenance(qtbot) -> None:
     prov = erlab.interactive.imagetool.provenance
 
     class _DynamicTool(erlab.interactive.utils.ToolWindow[_PersistentToolState]):


### PR DESCRIPTION
## Summary

Adds provenance-aware multi-input ImageTool workflows across the manager, console, UI actions, workspace persistence, and reload/copy-code paths.

Key user-visible changes:
- `tools[i]` is now a provenance-aware console handle while `tools[i].data` remains the raw `xarray.DataArray`.
- Console expressions such as `tools[0] - tools[1]`, `tools[0].sel(...)`, structured ERLab/xarray calls, and `itool(..., manager=True)` can create derived ImageTools with recorded dependencies.
- Child ImageTools are accessible through `tools[i].children[j]` and selected child tools participate in the same provenance API.
- Derived tools record dependency snapshots, show current/changed/missing input state, and can use **Reload Data** to replay from live or recorded inputs.
- Replay/code generation now uses a shared replay graph so common file loads and structured operations are emitted/replayed once, with cleaner copied code.

## Notes

The branch keeps derived outputs as durable ImageTools. Dependency status describes whether live inputs still match the recorded inputs; it does not invalidate displayed data or trigger automatic recomputation.

## Validation

- `uv run pytest tests/interactive/imagetool/test_replay_graph.py tests/interactive/imagetool/test_provenance.py -q`
- `QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/test_imagetool_manager.py::test_load_code_from_file_details_uses_erlab_io_loader_syntax tests/interactive/imagetool/test_imagetool_manager.py::test_load_code_from_file_details_prefers_scan_number_for_erlab_loader tests/interactive/imagetool/test_imagetool_manager.py::test_manager_console_structures_erlab_and_xarray_calls -q`
- `uv run ruff check src/erlab/interactive/imagetool/_load_source.py src/erlab/interactive/imagetool/_replay_graph.py tests/interactive/imagetool/test_imagetool_manager.py tests/interactive/imagetool/test_provenance.py tests/interactive/imagetool/test_replay_graph.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/_load_source.py src/erlab/interactive/imagetool/_replay_graph.py tests/interactive/imagetool/test_imagetool_manager.py tests/interactive/imagetool/test_provenance.py tests/interactive/imagetool/test_replay_graph.py`
- `uv run mypy src/erlab/interactive/imagetool/_load_source.py src/erlab/interactive/imagetool/_replay_graph.py`
- `git diff --check`
