### PR TITLE
fix(interactive): handle spaced coordinates in ftool saves

### DIFF
--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -335,14 +335,19 @@ class _ParameterTableModel(QtCore.QAbstractTableModel):
         return self._params
 
     def set_params(
-        self, params: lmfit.Parameters, params_from_coord: dict[str, str]
+        self,
+        params: lmfit.Parameters,
+        params_from_coord: dict[str, str],
+        *,
+        emit_changed: bool = True,
     ) -> None:
         self.beginResetModel()
         self._params = params
         self._params_from_coord = params_from_coord
         self._param_names = list(params.keys()) if params is not None else []
         self.endResetModel()
-        self.sigParamsChanged.emit()
+        if emit_changed:
+            self.sigParamsChanged.emit()
 
     def rowCount(self, parent: QtCore.QModelIndex | None = None) -> int:
         if parent is not None and parent.isValid():
@@ -2604,15 +2609,51 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             if self._legend_has_name(name):
                 self.legend.removeItem(name)
 
+    def _fit_step_paint_widgets(self) -> tuple[QtWidgets.QWidget, ...]:
+        widgets: list[QtWidgets.QWidget] = []
+        for widget in (
+            self.plot_widget.viewport(),
+            self.param_view.viewport(),
+            self.elapsed_value,
+            self.nfev_out_value,
+            self.redchi_value,
+            self.rsq_value,
+            self.aic_value,
+            self.bic_value,
+            self.fit_multi_button,
+        ):
+            if (
+                isinstance(widget, QtWidgets.QWidget)
+                and erlab.interactive.utils.qt_is_valid(widget)
+                and not any(widget is existing for existing in widgets)
+            ):
+                widgets.append(widget)
+        return tuple(widgets)
+
+    def _request_fit_step_paint(self) -> None:
+        for widget in self._fit_step_paint_widgets():
+            if widget.isVisible():
+                widget.repaint()
+
+    def _defer_next_fit_step(self, callback: Callable[[], None]) -> None:
+        self._request_fit_step_paint()
+        erlab.interactive.utils.single_shot(self, 0, callback)
+
+    def _sync_fit_result_state(self) -> None:
+        pass
+
     def _set_fit_ds(self, result_ds: xr.Dataset, t0: float) -> lmfit.Parameters:
         self._last_result_ds = result_ds.copy()
         result = self._last_result_ds.modelfit_results.compute().item()
         self._params = result.params.copy()
-        self.param_model.set_params(self._params, self._params_from_coord)
+        self.param_model.set_params(
+            self._params, self._params_from_coord, emit_changed=False
+        )
         self._update_fit_curve()
         self._refresh_slider_from_model()
         elapsed = time.perf_counter() - t0
         self._set_fit_stats(result, elapsed=elapsed)
+        self._sync_fit_result_state()
         self._mark_fit_fresh()
         self.sigFitFinished.emit(self._params.copy())
         if self._source_refresh_deferred:
@@ -2901,7 +2942,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             if self._fit_multi_step >= (self._fit_multi_total or 0):
                 self._finish_multi_fit()
             else:
-                erlab.interactive.utils.single_shot(self, 0, self._start_next_multi_fit)
+                self._defer_next_fit_step(self._start_next_multi_fit)
 
         def _on_timeout() -> None:
             if self._fit_start_time is None:

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -404,13 +404,11 @@ class Fit2DTool(Fit1DTool):
         self._params_from_coord_full[self._current_idx] = self._params_from_coord
         self._update_param_plot()
 
-    def _update_ds_full(self) -> None:
+    def _sync_fit_result_state(self) -> None:
+        self._params_full[self._current_idx] = self._params
+        self._params_from_coord_full[self._current_idx] = self._params_from_coord
         self._result_ds_full[self._current_idx] = self._last_result_ds
-
-    def _ensure_fit_finished_connections(self) -> None:
-        super()._ensure_fit_finished_connections()
-        self._connect_fit_finished_once(self._update_params_full)
-        self._connect_fit_finished_once(self._update_ds_full)
+        self._update_param_plot()
 
     def _build_ui(self) -> None:
         super()._build_ui()
@@ -1440,6 +1438,23 @@ class Fit2DTool(Fit1DTool):
         self.fit_down_button.setDisabled(running)
         self.fit_up_button.setDisabled(running)
 
+    def _fit_step_paint_widgets(self) -> tuple[QtWidgets.QWidget, ...]:
+        widgets = list(super()._fit_step_paint_widgets())
+        for widget in (
+            self.param_plot_widget.viewport(),
+            self.y_index_spin,
+            self.y_value_spin,
+            self.fit_down_button,
+            self.fit_up_button,
+        ):
+            if (
+                isinstance(widget, QtWidgets.QWidget)
+                and erlab.interactive.utils.qt_is_valid(widget)
+                and not any(widget is existing for existing in widgets)
+            ):
+                widgets.append(widget)
+        return tuple(widgets)
+
     def _fit_cancelled(self) -> None:
         if self._fit_2d_total > 0 or self._fit_2d_indices:
             self._finish_fit_2d_sequence()
@@ -1517,7 +1532,7 @@ class Fit2DTool(Fit1DTool):
                 )
                 self._finish_fit_2d_sequence()
                 return
-            erlab.interactive.utils.single_shot(self, 0, self._start_next_fit_2d)
+            self._defer_next_fit_step(self._start_next_fit_2d)
 
         def _on_timeout() -> None:
             if self._fit_start_time is None:
@@ -1757,6 +1772,8 @@ class Fit2DTool(Fit1DTool):
 
         param_entries: list[str] = []
 
+        y_coord_expr = f"{data_name}.coords[{self._y_dim_name!r}]"
+
         for name in param_names_all:
             if name in params_expr:
                 param_entries.append(f'"{name}": dict(expr="{params_expr[name]}"),')
@@ -1784,9 +1801,7 @@ class Fit2DTool(Fit1DTool):
                     continue
                 entry_kwargs_lines.append(f"value={values[0]!r}")
             else:
-                darr_line = (
-                    f"xr.DataArray({values!r}, coords=[{data_name}.{self._y_dim_name}])"
-                )
+                darr_line = f"xr.DataArray({values!r}, coords=[{y_coord_expr}])"
                 if (
                     single_min
                     and single_max
@@ -1803,7 +1818,7 @@ class Fit2DTool(Fit1DTool):
                     entry_kwargs_lines.append(f"min={mins[0]!r}")
             else:
                 entry_kwargs_lines.append(
-                    f"xr.DataArray({mins!r}, coords=[{data_name}.{self._y_dim_name}])"
+                    f"xr.DataArray({mins!r}, coords=[{y_coord_expr}])"
                 )
 
             if single_max:
@@ -1811,7 +1826,7 @@ class Fit2DTool(Fit1DTool):
                     entry_kwargs_lines.append(f"max={maxs[0]!r}")
             else:
                 entry_kwargs_lines.append(
-                    f"xr.DataArray({maxs!r}, coords=[{data_name}.{self._y_dim_name}])"
+                    f"xr.DataArray({maxs!r}, coords=[{y_coord_expr}])"
                 )
 
             if not vary:

--- a/src/erlab/interactive/imagetool/_serialization.py
+++ b/src/erlab/interactive/imagetool/_serialization.py
@@ -12,6 +12,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Hashable, Mapping
 
 ITOOL_DATA_NAME: str = "<erlab-itool-data>"
+SAVED_TOOL_DATA_NAME: str = "<saved-tool-data>"
 
 # NetCDF stores non-dimension coordinate names in a whitespace-delimited
 # ``coordinates`` attribute.  A coord named "Fake Motor" cannot round-trip there,

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -979,6 +979,8 @@ def _read_workspace_dataset_group_h5py(
 def _workspace_h5py_data_name(ds: xr.Dataset) -> typing.Hashable | None:
     if _serialization.ITOOL_DATA_NAME in ds.data_vars:
         return _serialization.ITOOL_DATA_NAME
+    if _serialization.SAVED_TOOL_DATA_NAME in ds.data_vars:
+        return _serialization.SAVED_TOOL_DATA_NAME
     if len(ds.data_vars) == 1:
         return next(iter(ds.data_vars))
     return None
@@ -1167,7 +1169,9 @@ def _write_workspace_dataset_group_to_file(
         ):
             ds = ds.load()
 
-    ds = _serialization.encode_private_coords(ds, _serialization.ITOOL_DATA_NAME)
+    data_name = _workspace_h5py_data_name(ds)
+    if data_name is not None:
+        ds = _serialization.encode_private_coords(ds, data_name)
     ds = ds.copy(deep=False)
     stale_encoding_keys = {
         "chunksizes",

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -752,6 +752,7 @@ _TOOL_SOURCE_BINDING_ATTR = "tool_source_binding"
 _TOOL_SOURCE_STATE_ATTR = "tool_source_state"
 _TOOL_SOURCE_AUTO_UPDATE_ATTR = "tool_source_auto_update"
 _TOOL_INPUT_PROVENANCE_SPEC_ATTR = "tool_input_provenance_spec"
+_SAVED_TOOL_DATA_NAME = "<saved-tool-data>"
 
 
 class _ToolWindowMeta(type(QtWidgets.QMainWindow)):  # type: ignore[misc]
@@ -1392,6 +1393,8 @@ def load_fit_ui(*, parent: QtWidgets.QWidget | None = None) -> xr.Dataset | None
 def _serialize_fit_dataset_blob(ds: xr.Dataset) -> np.ndarray:
     from xarray_lmfit._io import _dumps_result, _patch_encode4js
 
+    from erlab.interactive.imagetool import _serialization
+
     serialized = ds.copy()
     with _patch_encode4js():
         for var in serialized.data_vars:
@@ -1402,6 +1405,11 @@ def _serialize_fit_dataset_blob(ds: xr.Dataset) -> np.ndarray:
                     vectorize=True,
                     output_dtypes=[str],
                 )
+    private_coord_data_name = _fit_dataset_private_coord_data_name(serialized)
+    if private_coord_data_name is not None:
+        serialized = _serialization.encode_private_coords(
+            serialized, private_coord_data_name
+        )
     blob = serialized.to_netcdf(path=None, engine="h5netcdf", invalid_netcdf=True)
     return np.frombuffer(blob, dtype=np.uint8).copy()
 
@@ -1409,10 +1417,17 @@ def _serialize_fit_dataset_blob(ds: xr.Dataset) -> np.ndarray:
 def _deserialize_fit_dataset_blob(blob: npt.ArrayLike) -> xr.Dataset:
     from xarray_lmfit._io import _loads_result
 
+    from erlab.interactive.imagetool import _serialization
+
     restored = xr.load_dataset(
         memoryview(np.asarray(blob, dtype=np.uint8).tobytes()),
         engine="h5netcdf",
     )
+    private_coord_data_name = _fit_dataset_private_coord_data_name(restored)
+    if private_coord_data_name is not None:
+        restored = _serialization.restore_private_coords(
+            restored, private_coord_data_name
+        )
     for var in restored.data_vars:
         if str(var).endswith("modelfit_results"):
             restored[var] = xr.apply_ufunc(
@@ -1422,6 +1437,17 @@ def _deserialize_fit_dataset_blob(blob: npt.ArrayLike) -> xr.Dataset:
                 output_dtypes=[object],
             )
     return restored
+
+
+def _fit_dataset_private_coord_data_name(ds: xr.Dataset) -> Hashable | None:
+    candidates = [
+        name for name in ds.data_vars if not str(name).endswith("modelfit_results")
+    ]
+    if not candidates:
+        candidates = list(ds.data_vars)
+    if not candidates:
+        return None
+    return max(candidates, key=lambda name: ds[name].ndim)
 
 
 def make_help_actions(parent: QtCore.QObject) -> tuple[QtGui.QAction, ...]:
@@ -4174,7 +4200,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
         """
         ds = self.tool_data.to_dataset(
-            name="<saved-tool-data>", promote_attrs=False
+            name=_SAVED_TOOL_DATA_NAME, promote_attrs=False
         ).assign_attrs(self._saved_tool_attrs)
         return self._append_persistence_payload(ds)
 
@@ -4190,6 +4216,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         **kwargs
             Additional keyword arguments passed to the constructor.
         """
+        from erlab.interactive.imagetool import _serialization
+
+        ds = _serialization.restore_private_coords(ds, _SAVED_TOOL_DATA_NAME)
+
         saved_version = ds.attrs.get("erlab_version", "0.0.0")
         if erlab.utils.misc.is_newer_version(saved_version):  # pragma: no cover
             erlab.utils.misc.emit_user_level_warning(
@@ -4210,7 +4240,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         tool_data_name: str | None = ds.attrs.get("tool_data_name", "<none-value>")
         if tool_data_name == "<none-value>":
             tool_data_name = None
-        tool = cls_obj(ds["<saved-tool-data>"].rename(tool_data_name), **kwargs)
+        tool = cls_obj(ds[_SAVED_TOOL_DATA_NAME].rename(tool_data_name), **kwargs)
         tool.tool_status = cls_obj.StateModel.model_validate_json(
             ds.attrs["tool_state"]
         )
@@ -4296,7 +4326,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             The name of the target netcdf file.
 
         """
-        self.to_dataset().to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
+        from erlab.interactive.imagetool import _serialization
+
+        _serialization.encode_private_coords(
+            self.to_dataset(), _SAVED_TOOL_DATA_NAME
+        ).to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
 
     @classmethod
     def from_file(cls, filename: str | os.PathLike, **kwargs) -> typing.Self:

--- a/tests/interactive/imagetool/test_imagetool_manager.py
+++ b/tests/interactive/imagetool/test_imagetool_manager.py
@@ -8295,6 +8295,39 @@ def test_workspace_h5py_fast_path_roundtrips_scalar_coords(tmp_path) -> None:
     assert coordinates == "temperature"
 
 
+def test_workspace_writer_encodes_saved_tool_spaced_associated_coord(
+    tmp_path,
+) -> None:
+    data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={
+            "x": np.arange(2.0),
+            "y": np.arange(3.0),
+            "Fake Motor": ("x", np.linspace(10.0, 20.0, 2)),
+        },
+        name=data_name,
+    )
+    fname = tmp_path / "saved-tool-spaced-coord.itws"
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        manager_workspace._write_workspace_dataset_group_to_file(
+            fname, "0/tool", data.to_dataset()
+        )
+
+    assert not any("space in its name" in str(item.message) for item in caught)
+    loaded = manager_workspace._read_workspace_dataset_group_h5py(
+        fname, "0/tool", preferred_data_name=data_name
+    )
+
+    assert loaded is not None
+    xr.testing.assert_equal(
+        loaded[data_name].coords["Fake Motor"], data.coords["Fake Motor"]
+    )
+
+
 def test_workspace_h5py_fast_path_roundtrips_associated_coords_and_xarray(
     tmp_path,
 ) -> None:
@@ -13546,6 +13579,78 @@ def test_manager_workspace_roundtrip_fit2d_child(
         copied = copy_full_code_for_uid(monkeypatch, manager, child_uid)
         assert "modelfit" in copied
         assert not warnings
+
+
+def test_manager_workspace_roundtrip_fit2d_child_with_spaced_axis(
+    qtbot,
+    exp_decay_model,
+    test_data,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+
+        itool(test_data, link=False, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        t = np.linspace(0.0, 4.0, 25)
+        motor = np.arange(3.0)
+        data = xr.DataArray(
+            np.stack(
+                [((1.0 + 0.5 * idx) * np.exp(-t / 2.0)) for idx in motor],
+                axis=0,
+            ),
+            dims=("Fake Motor", "t"),
+            coords={
+                "Fake Motor": motor,
+                "t": t,
+                "Sample Motor": ("Fake Motor", motor + 10.0),
+            },
+            name="decay2d",
+        )
+        params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+        child = erlab.interactive.ftool(
+            data, model=exp_decay_model, params=params, execute=False
+        )
+        assert isinstance(child, Fit2DTool)
+        child_uid = manager.add_childtool(child, 0, show=False)
+        child.timeout_spin.setValue(30.0)
+        child.nfev_spin.setValue(0)
+        child.y_index_spin.setValue(child.y_min_spin.value())
+        child._run_fit_2d("up")
+        qtbot.wait_until(
+            lambda: all(ds is not None for ds in child._result_ds_full),
+            timeout=10000,
+        )
+        assert child.current_provenance_spec() is not None
+
+        fname = tmp_path / "fit2d-spaced-axis.itws"
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            manager._save_workspace_document(fname, force_full=True)
+
+        assert not any("space in its name" in str(item.message) for item in caught)
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+        assert manager._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        loaded_child = manager.get_childtool(child_uid)
+        assert isinstance(loaded_child, Fit2DTool)
+        assert loaded_child.tool_data.dims[0] == "Fake Motor"
+        xr.testing.assert_equal(
+            loaded_child.tool_data.coords["Fake Motor"], data.coords["Fake Motor"]
+        )
+        xr.testing.assert_equal(
+            loaded_child.tool_data.coords["Sample Motor"], data.coords["Sample Motor"]
+        )
+        assert loaded_child.current_provenance_spec() is not None
 
 
 def test_manager_workspace_roundtrip_recursive_nested_imagetools(

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -44,6 +44,19 @@ def _assert_fit_result_dataset_equivalent(
         assert actual_param.vary == expected_param.vary
 
 
+def _fit_result_dataset(params: lmfit.Parameters, *, nfev: int = 1) -> xr.Dataset:
+    class _Result:
+        def __init__(self) -> None:
+            self.params = params.copy()
+            self.nfev = nfev
+            self.redchi = 1.0
+            self.rsquared = 0.9
+            self.aic = 1.0
+            self.bic = 2.0
+
+    return xr.Dataset({"modelfit_results": xr.DataArray(_Result(), dims=())})
+
+
 def test_fit1d_fit_domain_descending_coords(qtbot) -> None:
     x = np.linspace(1.0, -1.0, 21)
     data = xr.DataArray(np.exp(-(x**2)), dims=("x",), coords={"x": x})
@@ -655,6 +668,143 @@ def test_fit1d_next_multi_step_is_deferred(qtbot, monkeypatch) -> None:
 
     assert started_steps == [1]
     qtbot.waitUntil(lambda: started_steps == [1, 2], timeout=1000)
+
+
+def test_fit1d_multi_step_requests_paint_before_deferred_next_step(
+    qtbot, monkeypatch
+) -> None:
+    win = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    events: list[str] = []
+
+    monkeypatch.setattr(win, "_request_fit_step_paint", lambda: events.append("paint"))
+    monkeypatch.setattr(win, "_show_warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(win, "_show_error", lambda *args, **kwargs: None)
+
+    def _start_fit_worker(
+        fit_data,
+        params,
+        *,
+        multi,
+        step=0,
+        total=0,
+        on_success,
+        on_timeout,
+        on_error,
+    ) -> bool:
+        del fit_data, params, multi, total, on_timeout, on_error
+        events.append(f"start-{step}")
+        win._fit_start_time = 0.0
+        if step == 1:
+            on_success(_fit_result_dataset(win._params))
+            return True
+        return False
+
+    monkeypatch.setattr(win, "_start_fit_worker", _start_fit_worker)
+
+    win._run_fit_multiple(2)
+
+    assert events == ["start-1", "paint"]
+    qtbot.waitUntil(lambda: events == ["start-1", "paint", "start-2"], timeout=1000)
+
+
+def test_fit1d_fit_step_paint_repaints_targets_without_queued_update(
+    qtbot, monkeypatch
+) -> None:
+    win = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    events: list[str] = []
+
+    class _PaintWidget(QtWidgets.QWidget):
+        def __init__(self, name: str, *, visible: bool = True) -> None:
+            super().__init__()
+            self._name = name
+            self._visible = visible
+
+        def update(self) -> None:
+            events.append(f"update-{self._name}")
+
+        def repaint(self) -> None:
+            events.append(f"repaint-{self._name}")
+
+        def isVisible(self) -> bool:
+            return self._visible
+
+    widgets = (
+        _PaintWidget("plot"),
+        _PaintWidget("hidden", visible=False),
+        _PaintWidget("params"),
+    )
+    for widget in widgets:
+        qtbot.addWidget(widget)
+    monkeypatch.setattr(win, "_fit_step_paint_widgets", lambda: widgets)
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "processEvents",
+        lambda *args, **kwargs: events.append("process"),
+    )
+
+    win._request_fit_step_paint()
+
+    assert events == [
+        "repaint-plot",
+        "repaint-params",
+    ]
+
+
+def test_fit1d_fit_step_paint_widgets_skip_invalid_entries(qtbot) -> None:
+    win = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    win.aic_value = object()
+    duplicate = win.bic_value
+    win.fit_multi_button = duplicate
+
+    widgets = win._fit_step_paint_widgets()
+
+    assert all(isinstance(widget, QtWidgets.QWidget) for widget in widgets)
+    assert sum(widget is duplicate for widget in widgets) == 1
+
+
+def test_fit1d_set_fit_ds_updates_without_param_changed_signal(
+    qtbot, monkeypatch
+) -> None:
+    win = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+
+    param_name = next(iter(win._params))
+    params = win._params.copy()
+    expected_value = params[param_name].value + 0.25
+    params[param_name].set(value=expected_value)
+    result_ds = _fit_result_dataset(params, nfev=7)
+
+    param_changed: list[None] = []
+    events: list[str] = []
+    stats_nfev: list[int] = []
+    win.param_model.sigParamsChanged.connect(lambda: param_changed.append(None))
+    monkeypatch.setattr(win, "_update_fit_curve", lambda: events.append("curve"))
+    monkeypatch.setattr(
+        win, "_refresh_slider_from_model", lambda: events.append("slider")
+    )
+
+    def _set_fit_stats(result, *, elapsed=None) -> None:
+        del elapsed
+        stats_nfev.append(result.nfev)
+
+    monkeypatch.setattr(win, "_set_fit_stats", _set_fit_stats)
+
+    win._set_fit_ds(result_ds, 0.0)
+
+    assert param_changed == []
+    assert win.param_model.params[param_name].value == pytest.approx(expected_value)
+    assert events == ["curve", "slider"]
+    assert stats_nfev == [7]
 
 
 def test_fit1d_cancelled_before_deferred_multi_step_stops_sequence(

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import re
 import types
+import warnings
 
 import numpy as np
 import pyqtgraph as pg
@@ -48,6 +49,19 @@ def _assert_fit_result_dataset_equivalent(
             assert actual_param.stderr == pytest.approx(expected_param.stderr)
         assert actual_param.expr == expected_param.expr
         assert actual_param.vary == expected_param.vary
+
+
+def _fit_result_dataset(params, *, nfev: int = 1) -> xr.Dataset:
+    class _Result:
+        def __init__(self) -> None:
+            self.params = params.copy()
+            self.nfev = nfev
+            self.redchi = 1.0
+            self.rsquared = 0.9
+            self.aic = 1.0
+            self.bic = 2.0
+
+    return xr.Dataset({"modelfit_results": xr.DataArray(_Result(), dims=())})
 
 
 def _assert_fit_result_list_equivalent(
@@ -311,6 +325,77 @@ def test_fit2d_run_fit(qtbot, exp_decay_model, monkeypatch) -> None:
     code = win._copy_code_full()
     assert "modelfit" in code
     assert ".isel(" in code
+
+
+def test_fit2d_full_provenance_handles_spaced_fit_axis(qtbot) -> None:
+    x = np.linspace(-1.0, 1.0, 5)
+    motor = np.array([10.0, 11.0, 12.0])
+    data = xr.DataArray(
+        np.ones((3, 5)),
+        dims=("Fake Motor", "x"),
+        coords={"Fake Motor": motor, "x": x},
+        name="derived_crop",
+    )
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    centers = [0.1, 0.2, 0.3]
+    params_full = []
+    for value in centers:
+        params = win._params.copy()
+        params["p0_center"].set(value=value)
+        params_full.append(params)
+    win._params_full = params_full
+    win._result_ds_full = [xr.Dataset() for _ in params_full]
+    win.y_min_spin.setValue(0)
+    win.y_max_spin.setValue(len(params_full) - 1)
+
+    assert win.current_provenance_spec() is not None
+    prelude = win._detached_full_copy_prelude(input_name="derived_crop")
+    assert prelude is not None
+
+    namespace = {"derived_crop": data}
+    exec(  # noqa: S102
+        prelude,
+        {
+            "__builtins__": {"dict": dict, "slice": slice},
+            "era": erlab.analysis,
+            "xr": xr,
+        },
+        namespace,
+    )
+    center_param = namespace["params"]["p0_center"]
+    assert isinstance(center_param, xr.DataArray)
+    assert center_param.dims == ("Fake Motor",)
+    np.testing.assert_allclose(center_param.values, centers)
+    xr.testing.assert_equal(
+        center_param.coords["Fake Motor"], data.coords["Fake Motor"]
+    )
+
+
+def test_fit2d_file_roundtrip_preserves_spaced_associated_coord(
+    qtbot, tmp_path
+) -> None:
+    data = _make_2d_data().assign_coords(
+        {"Fake Motor": ("y", np.linspace(10.0, 12.0, 3))}
+    )
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    fname = tmp_path / "fit2d-spaced-associated-coord.h5"
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        win.to_file(fname)
+
+    assert not any("space in its name" in str(item.message) for item in caught)
+    restored = erlab.interactive.utils.ToolWindow.from_file(fname)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit2DTool)
+    xr.testing.assert_equal(
+        restored.tool_data.coords["Fake Motor"], data.coords["Fake Motor"]
+    )
 
 
 def test_fit2d_update_data_preserves_state_and_refit(
@@ -616,6 +701,141 @@ def test_fit2d_next_step_is_deferred(qtbot, monkeypatch) -> None:
 
     assert started_steps == [1]
     qtbot.waitUntil(lambda: started_steps == [1, 2], timeout=1000)
+
+
+def test_fit2d_next_step_requests_paint_before_deferred_next_step(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    events: list[str] = []
+
+    monkeypatch.setattr(win, "_update_param_plot", lambda: events.append("plot"))
+    monkeypatch.setattr(win, "_request_fit_step_paint", lambda: events.append("paint"))
+    monkeypatch.setattr(win, "_fill_params_from", lambda *args, **kwargs: None)
+    monkeypatch.setattr(win, "_show_warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(win, "_show_error", lambda *args, **kwargs: None)
+
+    def _start_fit_worker(
+        fit_data,
+        params,
+        *,
+        multi,
+        step=0,
+        total=0,
+        on_success,
+        on_timeout,
+        on_error,
+    ) -> bool:
+        del fit_data, params, multi, total, on_timeout, on_error
+        events.append(f"start-{step}")
+        win._fit_start_time = 0.0
+        if step == 1:
+            on_success(_fit_result_dataset(win._params))
+            return True
+        return False
+
+    monkeypatch.setattr(win, "_start_fit_worker", _start_fit_worker)
+
+    win.y_index_spin.setValue(win.y_min_spin.value())
+    events.clear()
+    win._run_fit_2d("up")
+
+    assert events == ["start-1", "plot", "paint"]
+    qtbot.waitUntil(lambda: "start-2" in events, timeout=1000)
+    paint_after_first_start = events.index("paint", events.index("start-1"))
+    assert paint_after_first_start < events.index("start-2")
+
+
+def test_fit2d_paints_once_between_finished_step_and_next_worker(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    events: list[str] = []
+
+    monkeypatch.setattr(win, "_request_fit_step_paint", lambda: events.append("paint"))
+    monkeypatch.setattr(win, "_fill_params_from", lambda *args, **kwargs: None)
+    monkeypatch.setattr(win, "_show_warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(win, "_show_error", lambda *args, **kwargs: None)
+
+    def _start_fit_worker(
+        fit_data,
+        params,
+        *,
+        multi,
+        step=0,
+        total=0,
+        on_success,
+        on_timeout,
+        on_error,
+    ) -> bool:
+        del fit_data, params, multi, total, on_timeout, on_error
+        events.append(f"start-{step}")
+        win._fit_start_time = 0.0
+        if step == 1:
+            on_success(_fit_result_dataset(win._params))
+            return True
+        return False
+
+    monkeypatch.setattr(win, "_start_fit_worker", _start_fit_worker)
+
+    win.y_index_spin.setValue(win.y_min_spin.value())
+    win._run_fit_2d("up")
+    qtbot.waitUntil(lambda: events[-1:] == ["start-2"], timeout=1000)
+
+    assert events == ["start-1", "paint", "start-2"]
+
+
+def test_fit2d_set_fit_ds_updates_slice_state_before_fit_finished(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    idx = win._current_idx
+    param_name = next(iter(win._params))
+    params = win._params.copy()
+    expected_value = params[param_name].value + 0.25
+    params[param_name].set(value=expected_value)
+    result_ds = _fit_result_dataset(params)
+
+    param_changed: list[None] = []
+    events: list[str] = []
+    win.param_model.sigParamsChanged.connect(lambda: param_changed.append(None))
+    win.sigFitFinished.connect(lambda params: events.append("finished"))
+    monkeypatch.setattr(win, "_update_param_plot", lambda: events.append("plot"))
+
+    win._set_fit_ds(result_ds, 0.0)
+
+    assert param_changed == []
+    assert events == ["plot", "finished"]
+    assert win._params_full[idx][param_name].value == pytest.approx(expected_value)
+    assert win._result_ds_full[idx] is win._last_result_ds
+
+
+def test_fit2d_fit_step_paint_widgets_skip_invalid_entries(qtbot) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    win.y_value_spin = object()
+    duplicate = win.fit_down_button
+    win.fit_up_button = duplicate
+
+    widgets = win._fit_step_paint_widgets()
+
+    assert all(isinstance(widget, QtWidgets.QWidget) for widget in widgets)
+    assert sum(widget is duplicate for widget in widgets) == 1
 
 
 def test_fit2d_cancelled_before_deferred_next_step_stops_sequence(

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -328,6 +328,24 @@ def test_save_fit_ui(qtbot, accept_dialog, fit_result_ds):
     tmp_dir.cleanup()
 
 
+def test_fit_dataset_private_coord_data_name_edge_cases() -> None:
+    utils = erlab.interactive.utils
+
+    assert utils._fit_dataset_private_coord_data_name(xr.Dataset()) is None
+    result_only = xr.Dataset({"modelfit_results": xr.DataArray("serialized")})
+    assert utils._fit_dataset_private_coord_data_name(result_only) == "modelfit_results"
+
+
+def test_empty_fit_dataset_blob_roundtrip_has_no_private_coord_data() -> None:
+    utils = erlab.interactive.utils
+    empty = xr.Dataset()
+
+    blob = utils._serialize_fit_dataset_blob(empty)
+    restored = utils._deserialize_fit_dataset_blob(blob)
+
+    xr.testing.assert_identical(restored, empty)
+
+
 def test_load_ui_temporarily_disables_autoconnect(monkeypatch) -> None:
     restored_calls: list[object] = []
 


### PR DESCRIPTION
## Summary
- Fix Fit2D full-fit provenance generation for fit-axis names that are not valid Python attributes, such as `Fake Motor`.
- Reuse ImageTool private-coordinate serialization for generic `ToolWindow` saves, manager workspace saved-tool payloads, and serialized fit-result blobs.
- Add regressions for standalone ftool save/load, Fit2D provenance execution, manager workspace writing, and managed Fit2D workspace round-trip.

## Root Cause
Fit2D provenance generated parameter arrays using attribute access like `derived_crop.Fake Motor`, which is invalid Python. Separately, generic saved tools used `"<saved-tool-data>"` but bypassed the private-coordinate workaround added for ImageTool data, so associated coordinates with spaces could be demoted or warned about during save.

## Validation
- `QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/test_fit2d.py::test_fit2d_full_provenance_handles_spaced_fit_axis tests/interactive/test_fit2d.py::test_fit2d_file_roundtrip_preserves_spaced_associated_coord tests/interactive/imagetool/test_imagetool_manager.py::test_workspace_writer_encodes_saved_tool_spaced_associated_coord tests/interactive/imagetool/test_imagetool_manager.py::test_manager_workspace_roundtrip_fit2d_child_with_spaced_axis`
- `QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/test_fit1d.py tests/interactive/test_fit2d.py tests/interactive/test_utils.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run ruff check src/erlab/interactive/_fit1d.py src/erlab/interactive/_fit2d.py src/erlab/interactive/imagetool/_serialization.py src/erlab/interactive/imagetool/manager/_workspace.py src/erlab/interactive/utils.py tests/interactive/test_fit1d.py tests/interactive/test_fit2d.py tests/interactive/imagetool/test_imagetool_manager.py`
- `uv run ruff format --check src/erlab/interactive/_fit1d.py src/erlab/interactive/_fit2d.py src/erlab/interactive/imagetool/_serialization.py src/erlab/interactive/imagetool/manager/_workspace.py src/erlab/interactive/utils.py tests/interactive/test_fit1d.py tests/interactive/test_fit2d.py tests/interactive/imagetool/test_imagetool_manager.py`