### PR TITLE
[codex] Stage high-risk workspace saves locally

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -6,6 +6,7 @@ import json
 import os
 import pathlib
 import sys
+import tempfile
 import time
 import traceback
 import typing
@@ -1428,12 +1429,22 @@ def _write_full_workspace_tree_file(
 
     import h5py
 
-    fname = str(fname)
-    tmp_fname = f"{fname}.tmp-{uuid.uuid4().hex}"
+    fname = os.fsdecode(fname)
+    use_scratch = _workspace_path_is_high_risk(fname)
+    tmp_dir: tempfile.TemporaryDirectory[str] | None = None
+    destination_tmp: str | None = None
+    if use_scratch:
+        tmp_dir = tempfile.TemporaryDirectory(prefix="erlab-itws-")
+        tmp_fname = str(pathlib.Path(tmp_dir.name) / pathlib.Path(fname).name)
+    else:
+        tmp_fname = f"{fname}.tmp-{uuid.uuid4().hex}"
     try:
         copied_paths: set[str] = set()
         _xarray.ensure_workspace_hdf5_filters_registered()
         copy_groups_tuple = tuple(copy_groups)
+        if use_scratch and _workspace_path_is_likely_network_path(fname):
+            copy_source = None
+            copy_groups_tuple = ()
         if copy_source is not None and copy_groups_tuple:
             with _xarray._workspace_file_lock(copy_source):
                 shutil.copyfile(copy_source, tmp_fname)
@@ -1489,11 +1500,28 @@ def _write_full_workspace_tree_file(
 
         _validate_workspace_h5_file(tmp_fname)
         _fsync_file(tmp_fname)
-        os.replace(tmp_fname, fname)
-        _fsync_parent_directory(fname)
+        if use_scratch:
+            try:
+                os.replace(tmp_fname, fname)
+            except OSError as err:
+                if err.errno != errno.EXDEV:
+                    raise
+                destination_tmp = f"{fname}.tmp-{uuid.uuid4().hex}"
+                shutil.copyfile(tmp_fname, destination_tmp)
+                _fsync_file(destination_tmp)
+                os.replace(destination_tmp, fname)
+            _fsync_parent_directory(fname)
+        else:
+            os.replace(tmp_fname, fname)
+            _fsync_parent_directory(fname)
     finally:
         with contextlib.suppress(FileNotFoundError):
             os.remove(tmp_fname)
+        if destination_tmp is not None:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(destination_tmp)
+        if tmp_dir is not None:
+            tmp_dir.cleanup()
 
 
 def _validate_workspace_h5_file(fname: str | os.PathLike[str]) -> None:

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -1840,6 +1840,87 @@ def test_write_full_workspace_tree_file_replaces_stale_root_attrs(tmp_path) -> N
         assert manifest == {"schema_version": 4, "root_order": [0], "nodes": []}
 
 
+def test_write_full_workspace_tree_file_local_path_uses_destination_temp(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "local.itws"
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(1.0, title="local")}
+    )
+    write_targets: list[pathlib.Path] = []
+    original_write = manager_workspace._write_workspace_dataset_group_to_file
+
+    def _record_write(target, *args, **kwargs):
+        write_targets.append(pathlib.Path(target))
+        return original_write(target, *args, **kwargs)
+
+    monkeypatch.setattr(
+        manager_workspace, "_write_workspace_dataset_group_to_file", _record_write
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_network_path", lambda _path: False
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_cloud_path", lambda _path: False
+    )
+    try:
+        manager_workspace._write_full_workspace_tree_file(
+            fname, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+
+    assert write_targets
+    assert all(target.parent == fname.parent for target in write_targets)
+    assert all(target.name.startswith(f"{fname.name}.tmp-") for target in write_targets)
+
+
+def test_write_full_workspace_tree_file_cloud_path_uses_scratch_and_replace_first(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "Dropbox" / "cloud.itws"
+    fname.parent.mkdir()
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="cloud")}
+    )
+    write_targets: list[pathlib.Path] = []
+    replace_calls: list[tuple[pathlib.Path, pathlib.Path]] = []
+    original_write = manager_workspace._write_workspace_dataset_group_to_file
+
+    def _record_write(target, *args, **kwargs):
+        write_targets.append(pathlib.Path(target))
+        return original_write(target, *args, **kwargs)
+
+    def _replace_by_copy(src, dst):
+        src_path = pathlib.Path(src)
+        dst_path = pathlib.Path(dst)
+        replace_calls.append((src_path, dst_path))
+        dst_path.write_bytes(src_path.read_bytes())
+        src_path.unlink()
+
+    monkeypatch.setattr(
+        manager_workspace, "_write_workspace_dataset_group_to_file", _record_write
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_network_path", lambda _path: False
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_cloud_path", lambda _path: True
+    )
+    monkeypatch.setattr(manager_workspace.os, "replace", _replace_by_copy)
+    try:
+        manager_workspace._write_full_workspace_tree_file(
+            fname, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+
+    assert write_targets
+    assert all(target.parent != fname.parent for target in write_targets)
+    assert replace_calls == [(write_targets[0], fname)]
+    assert _read_transaction_test_value(fname) == 2.0
+
+
 def test_write_full_workspace_tree_file_copies_unchanged_payload_groups(
     monkeypatch,
     tmp_path,
@@ -1903,6 +1984,178 @@ def test_write_full_workspace_tree_file_copies_unchanged_payload_groups(
             group[manager_mainwindow._ITOOL_DATA_NAME][...],
             np.arange(12, dtype=np.float64).reshape(3, 4),
         )
+
+
+def test_write_full_workspace_tree_file_network_scratch_skips_copy_reuse(
+    monkeypatch, tmp_path
+) -> None:
+    import shutil
+
+    fname = tmp_path / "network-copy-reuse.itws"
+    _write_transaction_test_workspace(fname)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(3.0, title="rewritten")}
+    )
+
+    def _fail_copyfile(*_args, **_kwargs):
+        raise AssertionError("network scratch save should not copy old workspace")
+
+    def _replace_by_copy(src, dst):
+        src_path = pathlib.Path(src)
+        dst_path = pathlib.Path(dst)
+        dst_path.write_bytes(src_path.read_bytes())
+        src_path.unlink()
+
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_network_path", lambda _path: True
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_cloud_path", lambda _path: False
+    )
+    monkeypatch.setattr(shutil, "copyfile", _fail_copyfile)
+    monkeypatch.setattr(manager_workspace.os, "replace", _replace_by_copy)
+    try:
+        manager_workspace._write_full_workspace_tree_file(
+            fname,
+            tree,
+            _transaction_test_root_attrs(),
+            copy_source=fname,
+            copy_groups=(("0/imagetool", "0/imagetool", None),),
+        )
+    finally:
+        tree.close()
+
+    assert _read_transaction_test_value(fname) == 3.0
+
+
+def test_write_full_workspace_tree_file_scratch_exdev_fallback(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "fallback.itws"
+    _write_transaction_test_workspace(fname)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(4.0, title="fallback")}
+    )
+    original_replace = manager_workspace.os.replace
+    replace_calls: list[tuple[pathlib.Path, pathlib.Path]] = []
+    scratch_path: pathlib.Path | None = None
+
+    def _replace_with_exdev(src, dst):
+        nonlocal scratch_path
+        src_path = pathlib.Path(src)
+        dst_path = pathlib.Path(dst)
+        replace_calls.append((src_path, dst_path))
+        if dst_path == fname and src_path.parent != fname.parent:
+            scratch_path = src_path
+            raise OSError(errno.EXDEV, "cross-device link")
+        return original_replace(src, dst)
+
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_network_path", lambda _path: False
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_cloud_path", lambda _path: True
+    )
+    monkeypatch.setattr(manager_workspace.os, "replace", _replace_with_exdev)
+    try:
+        manager_workspace._write_full_workspace_tree_file(
+            fname, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+
+    assert _read_transaction_test_value(fname) == 4.0
+    assert scratch_path is not None
+    assert not scratch_path.exists()
+    assert len(replace_calls) == 2
+    assert replace_calls[0] == (scratch_path, fname)
+    assert replace_calls[1][0].parent == fname.parent
+    assert replace_calls[1][1] == fname
+    assert not list(fname.parent.glob(f"{fname.name}.tmp-*"))
+
+
+def test_write_full_workspace_tree_file_scratch_replace_failure_preserves_old(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "replace-failure.itws"
+    _write_transaction_test_workspace(fname)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(5.0, title="failure")}
+    )
+    scratch_paths: list[pathlib.Path] = []
+
+    def _fail_replace(src, dst):
+        src_path = pathlib.Path(src)
+        if pathlib.Path(dst) == fname:
+            scratch_paths.append(src_path)
+        raise OSError(errno.EPERM, "replace failed")
+
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_network_path", lambda _path: False
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_cloud_path", lambda _path: True
+    )
+    monkeypatch.setattr(manager_workspace.os, "replace", _fail_replace)
+    with pytest.raises(OSError, match="replace failed"):
+        try:
+            manager_workspace._write_full_workspace_tree_file(
+                fname, tree, _transaction_test_root_attrs()
+            )
+        finally:
+            tree.close()
+
+    assert _read_transaction_test_value(fname) == 1.0
+    assert scratch_paths
+    assert all(not scratch_path.exists() for scratch_path in scratch_paths)
+    assert not list(fname.parent.glob(f"{fname.name}.tmp-*"))
+
+
+def test_write_full_workspace_tree_file_scratch_copy_failure_cleans_destination_tmp(
+    monkeypatch, tmp_path
+) -> None:
+    import shutil
+
+    fname = tmp_path / "copy-failure.itws"
+    _write_transaction_test_workspace(fname)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(6.0, title="failure")}
+    )
+    original_replace = manager_workspace.os.replace
+    scratch_paths: list[pathlib.Path] = []
+
+    def _replace_with_exdev(src, dst):
+        src_path = pathlib.Path(src)
+        dst_path = pathlib.Path(dst)
+        if dst_path == fname and src_path.parent != fname.parent:
+            scratch_paths.append(src_path)
+            raise OSError(errno.EXDEV, "cross-device link")
+        return original_replace(src, dst)
+
+    def _fail_copyfile(src, dst):
+        pathlib.Path(dst).write_bytes(b"partial")
+        raise OSError(errno.EIO, "copy failed")
+
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_network_path", lambda _path: False
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_cloud_path", lambda _path: True
+    )
+    monkeypatch.setattr(manager_workspace.os, "replace", _replace_with_exdev)
+    monkeypatch.setattr(shutil, "copyfile", _fail_copyfile)
+    with pytest.raises(OSError, match="copy failed"):
+        try:
+            manager_workspace._write_full_workspace_tree_file(
+                fname, tree, _transaction_test_root_attrs()
+            )
+        finally:
+            tree.close()
+
+    assert _read_transaction_test_value(fname) == 1.0
+    assert scratch_paths
+    assert all(not scratch_path.exists() for scratch_path in scratch_paths)
+    assert not list(fname.parent.glob(f"{fname.name}.tmp-*"))
 
 
 def test_workspace_recovery_discards_pending_only_transaction(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- build full ImageTool Manager workspace saves in scratch storage for network and cloud-sync paths
- commit scratch-staged saves with direct `os.replace` first, falling back to copy-to-destination-temp only on `EXDEV`
- keep normal local full saves on the existing same-directory temp path and skip whole-file copy-reuse for scratch-staged network saves

## Testing
- `uv run --group pyqt6 pytest tests/interactive/imagetool/manager/test_workspace.py`
- `uv run ruff check src/erlab/interactive/imagetool/manager/_workspace.py tests/interactive/imagetool/manager/test_workspace.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/manager/_workspace.py tests/interactive/imagetool/manager/test_workspace.py`
- `uv run mypy src/erlab/interactive/imagetool/manager/_workspace.py`
- `git diff --check`