### PR TITLE
Refine ImageTool provenance and copied code generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,12 @@ Pytest enforces strict markers and `xfail_strict`; name files `test_<feature>.py
 - Tests and monkeypatched stubs must implement the current runtime contract. Do not add production fallbacks or compatibility branches only to accommodate outdated fake objects in tests.
 - Do not assert user-facing text label content in tests; prefer stable metadata, object names, roles, or behavioral state. When testing generated or copied code, execute the code with `exec()` in an explicit namespace and assert the produced object/value exactly matches the expected result. Do not compare copied code strings or formatting unless the exact text is the behavior under test.
 
+## Generated Code & Provenance
+
+User-facing generated/copied/replay code must be as clean and direct as possible. Treat readability of generated code as product behavior, not a cosmetic afterthought. Copied code is also teaching material for users moving between scripts and the GUI, so prefer public APIs, semantic variable names, complete expressions, and best-practice examples. Avoid meaningless relay assignments, repeated scratch variables, reused generic names such as `derived` across unrelated subexpressions, leaked internal manager helpers, and temporaries that do not carry semantic value. Prefer semantic names from watched variables, console assignments, provenance inputs, or visible actions, and inline one-use aliases when it is safe to do so.
+
+When changing provenance or code-generation paths, scan the emitted code for redundant reassignments and internal implementation details. Add property-style tests for cleanliness when it is the behavior under test, while still executing the generated code and asserting the resulting object/value exactly.
+
 ## Interactive Qt Notes
 
 - All Qt-facing runtime code and tests must behave the same under both PyQt6 and PySide6. Prefer `qtpy` APIs that are binding-neutral, avoid binding-specific signal/metaobject assumptions, and when lower-level Qt behavior is unavoidable, add a compatibility helper and validate the touched path under both bindings.

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -3002,8 +3002,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
         data_name = str(data_name)
         if not erlab.interactive.utils._is_kwarg_name(data_name):
-            lines.append(f"target = {data_name}")
-            data_name = "target"
+            lines.append(f"input_data = {data_name}")
+            data_name = "input_data"
         model_name = str(self._model_name)
         if not erlab.interactive.utils._is_kwarg_name(model_name):
             model_name = "model"
@@ -3040,6 +3040,28 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
         return data_name, model_name, lines
 
+    def _copy_fit_data_name(
+        self,
+        data_name: str,
+        *,
+        lines: list[str] | None = None,
+    ) -> str:
+        fit_domain = self._fit_domain()
+        if fit_domain is not None:
+            sel_kw = erlab.interactive.utils.format_kwargs(
+                {self._coord_name: slice(*fit_domain)}
+            )
+            if lines is not None:
+                lines.append(f"{data_name}_crop = {data_name}.sel({sel_kw})")
+            data_name = f"{data_name}_crop"
+
+        if self.normalize_check.isChecked():
+            if lines is not None:
+                lines.append(f"{data_name}_norm = {data_name} / {data_name}.mean()")
+            data_name = f"{data_name}_norm"
+
+        return data_name
+
     def _copy_prelude(
         self,
         *,
@@ -3050,19 +3072,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             input_name or self._data_name
         )
 
-        fit_domain = self._fit_domain()
-        if fit_domain is not None:
-            sel_kw = erlab.interactive.utils.format_kwargs(
-                {self._coord_name: slice(*fit_domain)}
-            )
-            lines.append(f"{data_name}_crop = {data_name}.sel({sel_kw})")
-            data_name = f"{data_name}_crop"
-
-        if self.normalize_check.isChecked():
-            lines.append(f"{data_name}_norm = {data_name} / {data_name}.mean()")
-            data_name = f"{data_name}_norm"
-
-        lines.append(f"_fit_data = {data_name}")
+        self._copy_fit_data_name(data_name, lines=lines)
 
         param_entries: list[str] = []
         param_kwargs: dict[str, typing.Any] = {}
@@ -3113,7 +3123,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         input_name: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
-        _, model_name, _ = self._make_model_code(input_name or self._data_name)
+        data_name, model_name, _ = self._make_model_code(input_name or self._data_name)
+        data_name = self._copy_fit_data_name(data_name)
         return erlab.interactive.utils.generate_code(
             self._data.xlm.modelfit,
             args=[self._coord_name],
@@ -3123,7 +3134,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 "method": self.method_combo.currentText(),
             },
             name="modelfit",
-            module="_fit_data.xlm",
+            module=f"{data_name}.xlm",
         )
 
     @QtCore.Slot()

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -1671,26 +1671,11 @@ class Fit2DTool(Fit1DTool):
             {self._y_dim_name: self._y_range_slice()}
         )
 
-        fit_domain = self._fit_domain()
-        if fit_domain is not None:
-            sel_kw = erlab.interactive.utils.format_kwargs(
-                {self._coord_name: slice(*fit_domain)}
-            )
-            lines.append(
-                f"{data_name}_crop = {data_name}.sel({sel_kw}).isel({isel_kw})"
-            )
-        else:
-            lines.append(f"{data_name}_crop = {data_name}.isel({isel_kw})")
-        data_name = f"{data_name}_crop"
-
-        if self.normalize_check.isChecked():
-            lines.append(
-                f"{data_name}_norm = "
-                f'{data_name} / {data_name}.mean("{self._coord_name}")'
-            )
-            data_name = f"{data_name}_norm"
-
-        lines.append(f"_fit_data = {data_name}")
+        data_name = self._full_copy_fit_data_name(
+            data_name,
+            isel_kw=isel_kw,
+            lines=lines,
+        )
 
         param_names: list[str] = []
         param_names_all: list[str] = []
@@ -1837,13 +1822,52 @@ class Fit2DTool(Fit1DTool):
         lines.extend(["params = {", "\n    ".join(param_entries), "}\n"])
         return "\n".join(lines)
 
+    def _full_copy_fit_data_name(
+        self,
+        data_name: str,
+        *,
+        isel_kw: str | None = None,
+        lines: list[str] | None = None,
+    ) -> str:
+        if isel_kw is None:
+            isel_kw = erlab.interactive.utils.format_kwargs(
+                {self._y_dim_name: self._y_range_slice()}
+            )
+
+        fit_domain = self._fit_domain()
+        if fit_domain is not None:
+            sel_kw = erlab.interactive.utils.format_kwargs(
+                {self._coord_name: slice(*fit_domain)}
+            )
+            if lines is not None:
+                lines.append(
+                    f"{data_name}_crop = {data_name}.sel({sel_kw}).isel({isel_kw})"
+                )
+        else:
+            if lines is not None:
+                lines.append(f"{data_name}_crop = {data_name}.isel({isel_kw})")
+        data_name = f"{data_name}_crop"
+
+        if self.normalize_check.isChecked():
+            if lines is not None:
+                lines.append(
+                    f"{data_name}_norm = "
+                    f'{data_name} / {data_name}.mean("{self._coord_name}")'
+                )
+            data_name = f"{data_name}_norm"
+
+        return data_name
+
     def _full_fit_expression(
         self,
         *,
         input_name: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
-        _, model_name, _ = self._make_model_code(input_name or self._data_name_full)
+        data_name, model_name, _ = self._make_model_code(
+            input_name or self._data_name_full
+        )
+        data_name = self._full_copy_fit_data_name(data_name)
         return erlab.interactive.utils.generate_code(
             self._data_full.xlm.modelfit,
             args=[self._coord_name],
@@ -1853,7 +1877,7 @@ class Fit2DTool(Fit1DTool):
                 "method": self.method_combo.currentText(),
             },
             name="modelfit",
-            module="_fit_data.xlm",
+            module=f"{data_name}.xlm",
         )
 
     def _checked_full_copy_prelude(

--- a/src/erlab/interactive/derivative.py
+++ b/src/erlab/interactive/derivative.py
@@ -513,11 +513,11 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
                     args=[],
                     kwargs=arg_dict,
                     module=data_name,
-                    assign="_processed",
+                    assign="processed",
                 )
             )
 
-            data_name = "_processed"
+            data_name = "processed"
 
         if self.smooth_group.isChecked():
             match self.smooth_combo.currentIndex():
@@ -537,17 +537,17 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
                     [f"|{data_name}|"],
                     smooth_kwargs,
                     module="era.image",
-                    assign="_processed",
+                    assign="processed",
                 )
                 lines.append(smooth_func_code)
             else:
-                lines.append(f"_processed = {data_name}.copy()")
+                lines.append(f"processed = {data_name}.copy()")
                 smooth_func_code = erlab.interactive.utils.generate_code(
                     smooth_func,
-                    ["|_processed|"],
+                    ["|processed|"],
                     smooth_kwargs,
                     module="era.image",
-                    assign="_processed",
+                    assign="processed",
                 )
                 lines.extend(
                     (
@@ -555,7 +555,7 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
                         textwrap.indent(smooth_func_code, "    "),
                     )
                 )
-            data_name = "_processed"
+            data_name = "processed"
 
         lines.append(
             erlab.interactive.utils.generate_code(

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -1189,7 +1189,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         )
         return erlab.interactive.utils.generate_code(
             erlab.analysis.gold.correct_with_edge,
-            args=[f"|{corrected_target}|", "|modelresult|"],
+            args=[f"|{corrected_target}|", "|model_result|"],
             kwargs={"along": self._along_dim, "shift_coords": p1["Shift coords"]},
             module="era.gold",
         )
@@ -1226,7 +1226,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         input_name: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
-        return "corrected" if self.data_corr is not None else "modelresult"
+        return "corrected" if self.data_corr is not None else "model_result"
 
     def _current_mode_corrected_label(
         self,
@@ -1260,7 +1260,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     ) -> str:
         if self.data_corr is None:
             return ""
-        return "modelresult = " + self._fit_expression(
+        return "model_result = " + self._fit_expression(
             self._current_fit_mode(),
             input_name=input_name,
         )
@@ -1271,7 +1271,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         input_name: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
-        return "modelresult = " + self._fit_expression(
+        return "model_result = " + self._fit_expression(
             self._current_fit_mode(),
             input_name=input_name,
         )

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ast
 import json
+import keyword
 import symtable
 import typing
 from collections.abc import Callable, Mapping, Sequence
@@ -49,18 +50,32 @@ class ReplayNode:
 
 
 class ReplayGraph:
-    __slots__ = ("_cacheable_keys", "_reserved_names", "aliases", "nodes", "output_key")
+    __slots__ = (
+        "_cacheable_keys",
+        "_reserved_names",
+        "aliases",
+        "display",
+        "nodes",
+        "output_key",
+    )
 
-    def __init__(self, *, reserved_names: set[str] | None = None) -> None:
+    def __init__(
+        self, *, reserved_names: set[str] | None = None, display: bool = False
+    ) -> None:
         self.nodes: list[ReplayNode] = []
         self._cacheable_keys: dict[str, str] = {}
         self._reserved_names = set(reserved_names or ())
         self.aliases: list[tuple[str, str]] = []
+        self.display = bool(display)
         self.output_key: str | None = None
 
     @property
     def reserved_names(self) -> set[str]:
         return set(self._reserved_names)
+
+    def add_alias(self, public_name: str, key: str) -> None:
+        if _is_semantic_replay_name(public_name):
+            self.aliases.append((public_name, key))
 
     def add_node(
         self,
@@ -94,6 +109,8 @@ _REPLAY_ALIASES = {
     "eri": "erlab.interactive",
     "eplt": "erlab.plotting",
 }
+_REPLAY_RESERVED_PUBLIC_NAMES = {"data", "derived", "tools"}
+_REPLAY_TEMP_PREFIX = "_itool_replay_"
 
 
 def _prov():
@@ -107,6 +124,17 @@ def _canonical_key(kind: str, payload: Mapping[str, typing.Any]) -> str:
         {"kind": kind, **dict(payload)},
         sort_keys=True,
         separators=(",", ":"),
+    )
+
+
+def _is_semantic_replay_name(name: str) -> bool:
+    return (
+        name.isidentifier()
+        and not keyword.iskeyword(name)
+        and name not in _REPLAY_RESERVED_PUBLIC_NAMES
+        and not name.startswith("data_")
+        and not name.startswith(_REPLAY_TEMP_PREFIX)
+        and not name.startswith("__")
     )
 
 
@@ -167,8 +195,8 @@ class _CurrentScopeNames(ast.NodeVisitor):
             self.visit(decorator)
         for base in node.bases:
             self.visit(base)
-        for keyword in node.keywords:
-            self.visit(keyword)
+        for keyword_arg in node.keywords:
+            self.visit(keyword_arg)
 
     def _visit_argument_expressions(self, args: ast.arguments) -> None:
         for default in args.defaults:
@@ -286,7 +314,10 @@ def _simple_assignment_source_name(code: str, target_name: str) -> str | None:
 
 
 def _validate_script_provenance(
-    spec: typing.Any, *, external_input_names: set[str] | None = None
+    spec: typing.Any,
+    *,
+    external_input_names: set[str] | None = None,
+    allow_free_seed_names: bool = False,
 ) -> None:
     prov = _prov()
     if spec.kind != "script":
@@ -318,11 +349,19 @@ def _validate_script_provenance(
             prov._validate_script_replay_code(spec.seed_code)
         except (TypeError, ValueError) as exc:
             raise ReplayGraphError(str(exc)) from exc
-        _validate_script_code_names(
-            spec.seed_code,
-            available_names,
-            function_dependencies,
-        )
+        if allow_free_seed_names:
+            module = ast.parse(spec.seed_code, mode="exec")
+            for stmt in module.body:
+                names = _statement_scope_names(stmt)
+                if isinstance(stmt, ast.FunctionDef):
+                    function_dependencies[stmt.name] = set()
+                available_names.update(names.stores)
+        else:
+            _validate_script_code_names(
+                spec.seed_code,
+                available_names,
+                function_dependencies,
+            )
         active_available = active_available or prov._code_stores_name(
             spec.seed_code, spec.active_name
         )
@@ -423,38 +462,21 @@ def _operation_replay_code(
     parent_name: str | None = None,
 ) -> str:
     prov = _prov()
-    entry = operation.derivation_entry()
-    if entry.code is None:
+    input_name = active_name if parent_name is None else parent_name
+    try:
+        code = operation.replay_code(
+            input_name,
+            output_name=active_name,
+            source_name=context_name,
+        )
+    except (AttributeError, NotImplementedError) as exc:
+        raise ReplayGraphError("Operation does not provide replay code") from exc
+    if code is None:
         raise ReplayGraphError("Operation does not provide replay code")
-    if parent_name is None:
-        try:
-            code = prov._replace_code_identifiers(
-                entry.code,
-                {"data": context_name, "derived": active_name},
-            )
-        except SyntaxError as exc:
-            raise ReplayGraphError("Operation replay code is not valid Python") from exc
-    else:
-        parent_replacement = parent_name
-        try:
-            module = ast.parse(entry.code, mode="exec")
-        except SyntaxError as exc:
-            raise ReplayGraphError("Operation replay code is not valid Python") from exc
-
-        class OperationNameReplacer(ast.NodeTransformer):
-            def visit_Name(self, node: ast.Name) -> ast.Name:
-                if node.id == "derived":
-                    if isinstance(node.ctx, ast.Store):
-                        replacement = active_name
-                    else:
-                        replacement = parent_replacement
-                    return ast.copy_location(ast.Name(replacement, ctx=node.ctx), node)
-                if node.id == "data" and isinstance(node.ctx, ast.Load):
-                    return ast.copy_location(ast.Name(context_name, ctx=node.ctx), node)
-                return node
-
-        module = typing.cast("ast.Module", OperationNameReplacer().visit(module))
-        code = ast.unparse(ast.fix_missing_locations(module))
+    try:
+        ast.parse(code, mode="exec")
+    except SyntaxError as exc:
+        raise ReplayGraphError("Operation replay code is not valid Python") from exc
     if not prov._code_stores_name(code, active_name):
         raise ReplayGraphError("Operation replay code does not assign its output")
     return code
@@ -540,6 +562,9 @@ def _compile_spec(
         _validate_script_provenance(
             parsed,
             external_input_names=set(external_inputs or ()),
+            allow_free_seed_names=display
+            and not parsed.script_inputs
+            and not external_inputs,
         )
         bindings: list[tuple[str, str]] = []
         if parsed.script_inputs:
@@ -581,6 +606,8 @@ def _compile_spec(
                         external_inputs=external_inputs,
                         live_input_resolver=live_input_resolver,
                     )
+                    if display:
+                        graph.add_alias(script_input.name, input_key)
                 bindings.append((script_input.name, input_key))
         elif external_inputs:
             for name, data in external_inputs.items():
@@ -731,6 +758,8 @@ def _compile_spec(
             if len(matching_inputs) != 1:
                 raise ReplayGraphError("Script provenance has no replay code")
             script_current_key = relay_key(matching_inputs[0])
+        if display:
+            graph.add_alias(active_name, script_current_key)
         return script_current_key
 
     raise ReplayGraphError(f"{parsed.kind!r} provenance is not self-contained")
@@ -749,7 +778,7 @@ def compile_replay_graph(
     reserved_names = _reserved_names_from_spec(parsed)
     if external_inputs:
         reserved_names.update(external_inputs)
-    graph = ReplayGraph(reserved_names=reserved_names)
+    graph = ReplayGraph(reserved_names=reserved_names, display=display)
     graph.output_key = _compile_spec(
         graph,
         parsed,
@@ -758,6 +787,12 @@ def compile_replay_graph(
         live_input_resolver=live_input_resolver,
     )
     return graph
+
+
+def _source_view_emits_code(graph: ReplayGraph, node: ReplayNode) -> bool:
+    if node.payload["source_kind"] == "full_data":
+        return False
+    return not graph.display
 
 
 def _node_names(
@@ -770,7 +805,7 @@ def _node_names(
     def emitted_key(key: str) -> str:
         node = node_by_key[key]
         while node.kind == "relay" or (
-            node.kind == "source_view" and node.payload["source_kind"] == "full_data"
+            node.kind == "source_view" and not _source_view_emits_code(graph, node)
         ):
             key = node.parents[0]
             node = node_by_key[key]
@@ -778,7 +813,7 @@ def _node_names(
 
     preferred_names: dict[str, str] = {}
     for public_name, key in graph.aliases:
-        preferred_names.setdefault(emitted_key(key), public_name)
+        preferred_names[emitted_key(key)] = public_name
     if output_name is not None:
         if graph.output_key is None:
             raise ReplayGraphError("Replay graph has no output")
@@ -791,7 +826,7 @@ def _node_names(
     def next_temp() -> str:
         nonlocal counter
         while True:
-            name = f"_itool_replay_{counter}"
+            name = f"{_REPLAY_TEMP_PREFIX}{counter}"
             counter += 1
             if name not in used:
                 used.add(name)
@@ -801,10 +836,7 @@ def _node_names(
         if (
             node.kind == "setup"
             or node.kind == "relay"
-            or (
-                node.kind == "source_view"
-                and node.payload["source_kind"] == "full_data"
-            )
+            or (node.kind == "source_view" and not _source_view_emits_code(graph, node))
         ):
             continue
         preferred_name = preferred_names.get(node.key)
@@ -816,7 +848,7 @@ def _node_names(
 
     for node in graph.nodes:
         if node.kind == "relay" or (
-            node.kind == "source_view" and node.payload["source_kind"] == "full_data"
+            node.kind == "source_view" and not _source_view_emits_code(graph, node)
         ):
             names[node.key] = names[emitted_key(node.key)]
     return names
@@ -840,7 +872,7 @@ def _inline_adjacent_replay_assignments(code: str) -> str:
                 continue
             target = stmt.targets[0]
             if not isinstance(target, ast.Name) or not target.id.startswith(
-                "_itool_replay_"
+                _REPLAY_TEMP_PREFIX
             ):
                 continue
             next_stmt = module.body[idx + 1]
@@ -884,6 +916,156 @@ def _inline_adjacent_replay_assignments(code: str) -> str:
     return ast.unparse(ast.fix_missing_locations(module))
 
 
+def _inline_single_use_replay_expressions(code: str) -> str:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return code
+
+    prov = _prov()
+    changed = False
+
+    def clone_expr(expr: ast.expr) -> ast.expr:
+        return ast.parse(ast.unparse(expr), mode="eval").body
+
+    def has_call(expr: ast.expr) -> bool:
+        return any(isinstance(node, ast.Call) for node in ast.walk(expr))
+
+    while True:
+        for idx, stmt in enumerate(module.body[:-1]):
+            if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+                continue
+            target = stmt.targets[0]
+            if not isinstance(target, ast.Name) or not target.id.startswith(
+                _REPLAY_TEMP_PREFIX
+            ):
+                continue
+            if has_call(stmt.value):
+                continue
+
+            later_loads = [
+                later_idx
+                for later_idx, later in enumerate(module.body[idx + 1 :], start=idx + 1)
+                if prov._statement_load_count(later, target.id) > 0
+            ]
+            if len(later_loads) != 1:
+                continue
+            use_idx = later_loads[0]
+            use_stmt = module.body[use_idx]
+            if prov._statement_load_count(use_stmt, target.id) != 1:
+                continue
+
+            replacement_load_names = {
+                node.id
+                for node in ast.walk(stmt.value)
+                if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+            }
+            intervening = module.body[idx + 1 : use_idx]
+            if any(
+                prov._statement_store_count(item, target.id) for item in intervening
+            ):
+                continue
+            if any(
+                prov._statement_store_count(item, name)
+                for item in intervening
+                for name in replacement_load_names
+            ):
+                continue
+
+            inline_target = target.id
+            inline_value = clone_expr(stmt.value)
+
+            class ReplayExpressionInliner(ast.NodeTransformer):
+                def __init__(self, target_name: str, value: ast.expr) -> None:
+                    self.target_name = target_name
+                    self.value = value
+
+                def visit_Name(self, node: ast.Name) -> ast.expr:
+                    if node.id == self.target_name and isinstance(node.ctx, ast.Load):
+                        return ast.copy_location(clone_expr(self.value), node)
+                    return node
+
+            module.body[use_idx] = ast.fix_missing_locations(
+                typing.cast(
+                    "ast.stmt",
+                    ReplayExpressionInliner(inline_target, inline_value).visit(
+                        use_stmt
+                    ),
+                )
+            )
+            del module.body[idx]
+            changed = True
+            break
+        else:
+            break
+
+    if not changed:
+        return code
+    return ast.unparse(ast.fix_missing_locations(module))
+
+
+def _compact_replay_temp_names(code: str) -> str:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return code
+
+    replacements: dict[str, str] = {}
+    used_names = {
+        node.id
+        for node in ast.walk(module)
+        if isinstance(node, ast.Name) and not node.id.startswith(_REPLAY_TEMP_PREFIX)
+    }
+
+    def compact_name(name: str) -> str:
+        if not name.startswith(_REPLAY_TEMP_PREFIX):
+            return name
+        if name in replacements:
+            return replacements[name]
+        index = len(replacements)
+        while True:
+            candidate = f"{_REPLAY_TEMP_PREFIX}{index}"
+            index += 1
+            if candidate not in used_names and candidate not in replacements.values():
+                replacements[name] = candidate
+                return candidate
+
+    for node in ast.walk(module):
+        if isinstance(node, ast.Name):
+            compact_name(node.id)
+    if not replacements or all(key == value for key, value in replacements.items()):
+        return code
+
+    class ReplayTempCompactor(ast.NodeTransformer):
+        def visit_Name(self, node: ast.Name) -> ast.Name:
+            replacement = replacements.get(node.id)
+            if replacement is None:
+                return node
+            return ast.copy_location(ast.Name(replacement, ctx=node.ctx), node)
+
+    compacted = typing.cast("ast.Module", ReplayTempCompactor().visit(module))
+    return ast.unparse(ast.fix_missing_locations(compacted))
+
+
+def _code_has_scoped_definition(code: str) -> bool:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return True
+    return any(
+        isinstance(
+            node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef, ast.Lambda)
+        )
+        for node in ast.walk(module)
+    )
+
+
+def _cleanup_emitted_replay_code(code: str) -> str:
+    code = _inline_adjacent_replay_assignments(code)
+    code = _inline_single_use_replay_expressions(code)
+    return _compact_replay_temp_names(code)
+
+
 def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> str:
     prov = _prov()
     names = _node_names(graph, output_name=output_name)
@@ -916,7 +1098,7 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
             raise ReplayGraphError("Live inputs cannot be emitted as replay code")
         elif node.kind == "source_view":
             parent_name = names[node.parents[0]]
-            if node.payload["source_kind"] == "full_data":
+            if not _source_view_emits_code(graph, node):
                 continue
             lines.append(
                 f"{name} = erlab.interactive.imagetool.slicer."
@@ -935,14 +1117,48 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
                 )
             )
         elif node.kind == "script":
+            codes = list(typing.cast("tuple[str, ...]", node.payload["codes"]))
+            active_name = typing.cast("str", node.payload["active_name"])
+            input_replacements: dict[str, str] = {}
             for input_name, input_key in typing.cast(
                 "tuple[tuple[str, str], ...]", node.payload["bindings"]
             ):
                 input_value_name = names[input_key]
-                if input_name != input_value_name:
+                if input_name == input_value_name:
+                    continue
+                if (
+                    graph.display
+                    and not _is_semantic_replay_name(input_name)
+                    and not any(_code_has_scoped_definition(code) for code in codes)
+                    and not any(
+                        prov._code_stores_name(code, input_name) for code in codes
+                    )
+                ):
+                    input_replacements[input_name] = input_value_name
+                else:
                     lines.append(f"{input_name} = {input_value_name}")
-            lines.extend(typing.cast("tuple[str, ...]", node.payload["codes"]))
-            active_name = typing.cast("str", node.payload["active_name"])
+            if input_replacements:
+                try:
+                    codes = [
+                        prov._replace_code_identifiers(code, input_replacements)
+                        for code in codes
+                    ]
+                except SyntaxError as exc:
+                    raise ReplayGraphError(
+                        "Script replay code is not valid Python"
+                    ) from exc
+            if graph.display and active_name != name:
+                try:
+                    codes = [
+                        prov._replace_code_identifiers(code, {active_name: name})
+                        for code in codes
+                    ]
+                except SyntaxError as exc:
+                    raise ReplayGraphError(
+                        "Script replay code is not valid Python"
+                    ) from exc
+                active_name = name
+            lines.extend(codes)
             if active_name != name:
                 lines.append(f"{name} = {active_name}")
             active_setup_key = None
@@ -958,7 +1174,7 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
         planned_name = names[key]
         if public_name != planned_name:
             lines.append(f"{public_name} = {planned_name}")
-    return _inline_adjacent_replay_assignments("\n".join(lines))
+    return _cleanup_emitted_replay_code("\n".join(lines))
 
 
 def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) -> str:
@@ -968,7 +1184,7 @@ def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) ->
         reserved_names.update(
             _reserved_names_from_spec(script_input.parsed_provenance_spec())
         )
-    graph = ReplayGraph(reserved_names=reserved_names)
+    graph = ReplayGraph(reserved_names=reserved_names, display=display)
     for script_input in script_inputs:
         input_spec = script_input.parsed_provenance_spec()
         if input_spec is None:
@@ -983,7 +1199,7 @@ def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) ->
             external_inputs=None,
             live_input_resolver=None,
         )
-        graph.aliases.append((script_input.name, input_key))
+        graph.add_alias(script_input.name, input_key)
     return emit_replay_code(graph)
 
 

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -564,7 +564,8 @@ class DataFilterDialog(_DataManipulationDialog):
     - Override method `process_data` to implement the filter. The output must be a new
       DataArray with the same shape as the input.
 
-    - Override method `make_code` to generate code that can be copied to the clipboard.
+    - Override `filter_operation` to generate operation-backed copy code and provenance
+      for the displayed filtered data.
 
     - Override attribute `title` to set the title of the dialog window.
 
@@ -591,7 +592,10 @@ class DataFilterDialog(_DataManipulationDialog):
     @QtCore.Slot()
     def _preview(self):
         self._previewed = True
-        self.slicer_area.apply_func(self.process_data)
+        self.slicer_area.apply_func(
+            self.process_data,
+            operation=self.filter_operation(),
+        )
 
     @QtCore.Slot()
     def reject(self) -> None:
@@ -602,13 +606,36 @@ class DataFilterDialog(_DataManipulationDialog):
     @QtCore.Slot()
     def accept(self) -> None:
         try:
-            self.slicer_area.apply_func(self.process_data)
+            self.slicer_area.apply_func(
+                self.process_data,
+                operation=self.filter_operation(),
+            )
         except Exception:
             erlab.interactive.utils.MessageDialog.critical(
                 self, "Error", "An error occurred while processing data."
             )
             return
         super().accept()
+
+    def filter_operation(
+        self,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None:
+        return None
+
+    def filter_operations(
+        self,
+    ) -> list[erlab.interactive.imagetool.provenance.ToolProvenanceOperation]:
+        operation = self.filter_operation()
+        return [] if operation is None else [operation]
+
+    def make_code(self) -> str:
+        try:
+            return erlab.interactive.imagetool.provenance.operations_expression_code(
+                self.filter_operations(),
+                self._copy_data_name(),
+            )
+        except Exception:
+            return ""
 
 
 class RotationDialog(DataTransformDialog):
@@ -2135,8 +2162,11 @@ class CropDialog(_BaseCropDialog):
 
 class NormalizeDialog(DataFilterDialog):
     title = "Normalize"
-    enable_copy = False
+    enable_copy = True
     denominator_rtol: float = 1e-12
+    _MODES: typing.ClassVar[
+        tuple[typing.Literal["area", "minmax", "min", "min_area"], ...]
+    ] = ("area", "minmax", "min", "min_area")
 
     def setup_widgets(self) -> None:
         dim_group = QtWidgets.QGroupBox("Dimensions")
@@ -2166,54 +2196,33 @@ class NormalizeDialog(DataFilterDialog):
         self.layout_.addRow(dim_group)
         self.layout_.addRow(option_group)
 
-    def _safe_denominator(
-        self, denominator: xr.DataArray, scale: xr.DataArray
-    ) -> xr.DataArray:
-        threshold = np.maximum(
-            scale * self.denominator_rtol,
-            np.finfo(np.float64).tiny,
-        )
-        return denominator.where(
-            np.isfinite(denominator)
-            & np.isfinite(scale)
-            & (np.abs(denominator) > threshold)
-        )
+    @property
+    def _norm_dims(self) -> tuple[Hashable, ...]:
+        return tuple(k for k, v in self.dim_checks.items() if v.isChecked())
+
+    @property
+    def _mode(self) -> typing.Literal["area", "minmax", "min", "min_area"]:
+        return self._MODES[
+            next(i for i, opt in enumerate(self.opts) if opt.isChecked())
+        ]
 
     def process_data(self, data: xr.DataArray) -> xr.DataArray:
-        norm_dims = tuple(k for k, v in self.dim_checks.items() if v.isChecked())
-        if len(norm_dims) == 0:
+        operation = self.filter_operation()
+        if operation is None:
             return data
+        return operation.apply(data, parent_data=data)
 
-        calc_area: bool = self.opts[0].isChecked() or self.opts[3].isChecked()
-        calc_minimum: bool = not self.opts[0].isChecked()
-        calc_maximum: bool = self.opts[1].isChecked()
-        if calc_area:
-            finite_abs_scale = (
-                abs(data).where(np.isfinite(data)).max(norm_dims, skipna=True)
-            )
-
-        if calc_area:
-            area = self._safe_denominator(data.mean(norm_dims), finite_abs_scale)
-
-        if calc_minimum:
-            minimum = data.min(norm_dims)
-
-        if calc_maximum:
-            maximum = data.max(norm_dims)
-
-        if self.opts[0].isChecked():
-            return data / area
-
-        if self.opts[1].isChecked():
-            finite_abs_scale = np.maximum(np.abs(minimum), np.abs(maximum))
-            return (data - minimum) / self._safe_denominator(
-                maximum - minimum, finite_abs_scale
-            )
-
-        if self.opts[2].isChecked():
-            return data - minimum
-
-        return (data - minimum) / area
+    def filter_operation(
+        self,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None:
+        norm_dims = self._norm_dims
+        if not norm_dims:
+            return None
+        return erlab.interactive.imagetool.provenance.NormalizeOperation(
+            dims=norm_dims,
+            mode=self._mode,
+            denominator_rtol=self.denominator_rtol,
+        )
 
 
 class DivideByCoordDialog(DataTransformDialog):
@@ -2502,16 +2511,14 @@ class GaussianFilterDialog(DataFilterDialog):
             return data
         return erlab.analysis.image.gaussian_filter(data, sigma=sigma_values)
 
-    def make_code(self) -> str:
-        _, sigma_literals = self._sigma_values()
-        if not sigma_literals:
-            return ""
-
-        return erlab.interactive.utils.generate_code(
-            erlab.analysis.image.gaussian_filter,
-            [f"|{self._copy_data_name()}|"],
-            {"sigma": {dim: f"|{literal}|" for dim, literal in sigma_literals.items()}},
-            module="era.image",
+    def filter_operation(
+        self,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None:
+        sigma_values, _ = self._sigma_values()
+        if not sigma_values:
+            return None
+        return erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+            sigma=sigma_values
         )
 
 

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -153,6 +153,9 @@ class _DataManipulationDialog(QtWidgets.QDialog):
         # Overridden by subclasses
         return ""
 
+    def _copy_data_name(self) -> str:
+        return self.slicer_area.watched_data_name or "data"
+
 
 class DataTransformDialog(_DataManipulationDialog):
     """Parent class for implementing data changes that affect both shape and values.
@@ -164,7 +167,8 @@ class DataTransformDialog(_DataManipulationDialog):
 
     - Override method `process_data` to implement the data transformation.
 
-    - Override method `make_code` to generate code that can be copied to the clipboard.
+    - Override `source_transform_operation` or `source_operations` to generate
+      operation-backed copy code, or override `make_code` only for non-operation code.
 
     - Override attribute `title` to set the title of the dialog window.
 
@@ -392,6 +396,15 @@ class DataTransformDialog(_DataManipulationDialog):
 
     def process_data(self, data: xr.DataArray) -> xr.DataArray:
         return self._apply_source_transform(data)
+
+    def make_code(self) -> str:
+        try:
+            return erlab.interactive.imagetool.provenance.operations_expression_code(
+                self.source_operations(),
+                self._copy_data_name(),
+            )
+        except Exception:
+            return ""
 
     def _itool_kwargs(self, processed) -> dict[str, typing.Any]:
         itool_kw: dict[str, typing.Any] = {
@@ -676,15 +689,6 @@ class RotationDialog(DataTransformDialog):
             **self._rotate_params
         )
 
-    def make_code(self) -> str:
-        placeholder = self.slicer_area.watched_data_name or " "
-        return erlab.interactive.utils.generate_code(
-            erlab.analysis.transform.rotate,
-            [f"|{placeholder}|"],
-            self._rotate_params,
-            module="era.transform",
-        )
-
 
 class AggregateDialog(DataTransformDialog):
     title = "Aggregate Over Dimensions"
@@ -737,6 +741,8 @@ class AggregateDialog(DataTransformDialog):
     def source_transform_operation(
         self,
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation:
+        if not self._target_dims:
+            raise ValueError("No dimensions selected")
         return erlab.interactive.imagetool.provenance.QSelAggregationOperation(
             dims=self._target_dims,
             func=self._reducer,
@@ -762,15 +768,6 @@ class AggregateDialog(DataTransformDialog):
             return
 
         super().accept()
-
-    def make_code(self) -> str:
-        placeholder = self.slicer_area.watched_data_name or ""
-        arg = (
-            erlab.interactive.utils._parse_single_arg(self._target_dims[0])
-            if len(self._target_dims) == 1 and isinstance(self._target_dims[0], str)
-            else erlab.interactive.utils._parse_single_arg(self._target_dims)
-        )
-        return f"{placeholder}.qsel.{self._reducer}({arg})"
 
 
 AverageDialog = AggregateDialog
@@ -1103,18 +1100,6 @@ class SelectionDialog(DataTransformDialog):
             data = data.qsel(qsel_kwargs)
         return data
 
-    def make_code(self) -> str:
-        placeholder = self.slicer_area.watched_data_name or ""
-        code = placeholder
-        for method, kwargs in zip(
-            ("isel", "sel", "qsel"),
-            self._selection_kwargs(),
-            strict=True,
-        ):
-            if kwargs:
-                code += f".{method}({erlab.interactive.utils.format_kwargs(kwargs)})"
-        return code
-
     @QtCore.Slot()
     @QtCore.Slot(int)
     @QtCore.Slot(bool)
@@ -1282,6 +1267,9 @@ class InterpolationDialog(DataTransformDialog):
         dim = self._selected_dim
         if dim is None:
             raise ValueError("No dimension selected")
+        source_error = self._source_coord_error(dim)
+        if source_error is not None:
+            raise ValueError(source_error)
         return erlab.interactive.imagetool.provenance.InterpolationOperation(
             dim=dim,
             values=self._target_values(),
@@ -1320,17 +1308,6 @@ class InterpolationDialog(DataTransformDialog):
             return
 
         super().accept()
-
-    def make_code(self) -> str:
-        dim = self._selected_dim
-        if dim is None or self._source_coord_error(dim) is not None:
-            return ""
-        try:
-            operation = self.source_transform_operation()
-        except Exception:
-            return ""
-        placeholder = self.slicer_area.watched_data_name or ""
-        return operation.code(placeholder)
 
 
 class LeadingEdgeDialog(DataTransformDialog):
@@ -1416,6 +1393,9 @@ class LeadingEdgeDialog(DataTransformDialog):
         dim = self._selected_dim
         if dim is None:
             raise ValueError("No dimension selected")
+        source_error = self._source_coord_error(dim)
+        if source_error is not None:
+            raise ValueError(source_error)
         return erlab.interactive.imagetool.provenance.LeadingEdgeOperation(
             fraction=float(self.fraction_spin.value()),
             dim=dim,
@@ -1441,17 +1421,6 @@ class LeadingEdgeDialog(DataTransformDialog):
             return
 
         super().accept()
-
-    def make_code(self) -> str:
-        dim = self._selected_dim
-        if dim is None or self._source_coord_error(dim) is not None:
-            return ""
-        try:
-            operation = self.source_transform_operation()
-        except Exception:
-            return ""
-        placeholder = self.slicer_area.watched_data_name or "data"
-        return operation.code(placeholder)
 
 
 class CoarsenDialog(DataTransformDialog):
@@ -1555,18 +1524,11 @@ class CoarsenDialog(DataTransformDialog):
     def _reducer(self) -> str:
         return self.reducer_combo.currentText()
 
-    @property
-    def _coarsen_kwargs(self) -> dict[str, typing.Any]:
-        kwargs: dict[str, typing.Any] = {}
-        kwargs["dim"] = self._selected_windows
-        kwargs["boundary"] = self.boundary_combo.currentText()
-        kwargs["side"] = self.side_combo.currentText()
-        kwargs["coord_func"] = self._coord_func
-        return kwargs
-
     def source_transform_operation(
         self,
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation:
+        if not self._selected_windows:
+            raise ValueError("No dimensions selected")
         return erlab.interactive.imagetool.provenance.CoarsenOperation(
             dim=self._selected_windows,
             boundary=self.boundary_combo.currentText(),
@@ -1617,29 +1579,6 @@ class CoarsenDialog(DataTransformDialog):
                 return
 
         super().accept()
-
-    def make_code(self) -> str:
-        if not self._selected_windows:
-            return ""
-        placeholder = self.slicer_area.watched_data_name or ""
-
-        kwargs = self._coarsen_kwargs.copy()
-        if all(
-            erlab.interactive.utils._is_kwarg_name(k)
-            for k in self._coarsen_kwargs["dim"]
-        ):  # pragma: no branch
-            window_kwargs = kwargs.pop("dim")
-            kwargs = dict(**window_kwargs, **kwargs)
-
-        return (
-            erlab.interactive.utils.generate_code(
-                type(self._source_data).coarsen,
-                args=[],
-                kwargs=kwargs,
-                module=placeholder,
-            )
-            + f".{self._reducer}()"
-        )
 
 
 class ThinDialog(DataTransformDialog):
@@ -1744,9 +1683,13 @@ class ThinDialog(DataTransformDialog):
         self,
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation:
         if self._use_global_mode:
+            if self.global_spin.value() <= 1:
+                raise ValueError("No thinning requested")
             return erlab.interactive.imagetool.provenance.ThinOperation(
                 mode="global", factor=self.global_spin.value()
             )
+        if not self._effective_factors:
+            raise ValueError("No thinning requested")
         return erlab.interactive.imagetool.provenance.ThinOperation(
             mode="per_dim", factors=self._effective_factors
         )
@@ -1770,18 +1713,6 @@ class ThinDialog(DataTransformDialog):
             return
 
         super().accept()
-
-    def make_code(self) -> str:
-        placeholder = self.slicer_area.watched_data_name or ""
-        if self._use_global_mode:
-            if self.global_spin.value() <= 1:
-                return ""
-            return f"{placeholder}.thin({self.global_spin.value()})"
-
-        if not self._effective_factors:
-            return ""
-        kwargs = erlab.interactive.utils.format_call_kwargs(self._effective_factors)
-        return f"{placeholder}.thin({kwargs})"
 
 
 class SymmetrizeDialog(DataTransformDialog):
@@ -1887,15 +1818,6 @@ class SymmetrizeDialog(DataTransformDialog):
             **self._params
         )
 
-    def make_code(self) -> str:
-        placeholder = self.slicer_area.watched_data_name or " "
-        return erlab.interactive.utils.generate_code(
-            erlab.analysis.transform.symmetrize,
-            [f"|{placeholder}|"],
-            self._params,
-            module="era.transform",
-        )
-
 
 class SymmetrizeNfoldDialog(DataTransformDialog):
     title = "Rotational Symmetrize"
@@ -1984,15 +1906,6 @@ class SymmetrizeNfoldDialog(DataTransformDialog):
             **self._params
         )
 
-    def make_code(self) -> str:
-        placeholder = self.slicer_area.watched_data_name or " "
-        return erlab.interactive.utils.generate_code(
-            erlab.analysis.transform.symmetrize_nfold,
-            [f"|{placeholder}|"],
-            self._params,
-            module="era.transform",
-        )
-
 
 class EdgeCorrectionDialog(DataTransformDialog):
     title = "Edge Correction"
@@ -2065,22 +1978,6 @@ class _BaseCropDialog(DataTransformDialog):
 
     def process_data(self, data: xr.DataArray) -> xr.DataArray:
         return data.sel(self._slice_kwargs)
-
-    def make_code(self) -> str:
-        sel_kwargs: dict[Hashable, slice] = dict(self._slice_kwargs)
-        isel_kwargs: dict[Hashable, slice] = {}
-
-        for k in list(sel_kwargs.keys()):
-            if isinstance(k, str) and k.endswith("_idx"):
-                isel_kwargs[k.removesuffix("_idx")] = sel_kwargs.pop(k)
-
-        out: str = self.slicer_area.watched_data_name or ""
-        if sel_kwargs:
-            out += f".sel({erlab.interactive.utils.format_kwargs(sel_kwargs)})"
-        if isel_kwargs:
-            out += f".isel({erlab.interactive.utils.format_kwargs(isel_kwargs)})"
-
-        return out
 
 
 class CropToViewDialog(_BaseCropDialog):
@@ -2428,16 +2325,6 @@ class DivideByCoordDialog(DataTransformDialog):
             coord_name=coord_name
         )
 
-    def make_code(self) -> str:
-        coord_name = self._selected_coord_name
-        if coord_name is None:
-            return ""
-        placeholder = self.slicer_area.watched_data_name or "data"
-        operation = erlab.interactive.imagetool.provenance.DivideByCoordOperation(
-            coord_name=coord_name
-        )
-        return f"{placeholder} / {operation.divisor_code(placeholder)}"
-
 
 class GaussianFilterDialog(DataFilterDialog):
     title = "Gaussian Filter"
@@ -2620,10 +2507,9 @@ class GaussianFilterDialog(DataFilterDialog):
         if not sigma_literals:
             return ""
 
-        placeholder = self.slicer_area.watched_data_name or " "
         return erlab.interactive.utils.generate_code(
             erlab.analysis.image.gaussian_filter,
-            [f"|{placeholder}|"],
+            [f"|{self._copy_data_name()}|"],
             {"sigma": {dim: f"|{literal}|" for dim, literal in sigma_literals.items()}},
             module="era.image",
         )
@@ -2729,17 +2615,11 @@ class SwapDimsDialog(DataTransformDialog):
     def source_transform_operation(
         self,
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation:
+        if not self._swap_mapping:
+            raise ValueError("No dimensions changed")
         return erlab.interactive.imagetool.provenance.SwapDimsOperation(
             mapping=self._swap_mapping
         )
-
-    def make_code(self) -> str:
-        if not self._swap_mapping:
-            return ""
-
-        placeholder = self.slicer_area.watched_data_name or ""
-        kwargs = erlab.interactive.utils.format_call_kwargs(self._swap_mapping)
-        return f"{placeholder}.swap_dims({kwargs})"
 
 
 class RenameDimsCoordsDialog(DataTransformDialog):
@@ -2866,17 +2746,11 @@ class RenameDimsCoordsDialog(DataTransformDialog):
     def source_transform_operation(
         self,
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation:
+        if not self._rename_mapping:
+            raise ValueError("No names changed")
         return erlab.interactive.imagetool.provenance.RenameDimsCoordsOperation(
             mapping=typing.cast("dict[Hashable, Hashable]", self._rename_mapping)
         )
-
-    def make_code(self) -> str:
-        if not self._rename_mapping:
-            return ""
-
-        placeholder = self.slicer_area.watched_data_name or ""
-        kwargs = erlab.interactive.utils.format_call_kwargs(self._rename_mapping)
-        return f"{placeholder}.rename({kwargs})"
 
 
 class AssignCoordsDialog(DataTransformDialog):
@@ -3377,15 +3251,6 @@ class ROIPathDialog(DataTransformDialog):
             **self._params
         )
 
-    def make_code(self) -> str:
-        placeholder = self.slicer_area.watched_data_name or " "
-        return erlab.interactive.utils.generate_code(
-            erlab.analysis.interpolate.slice_along_path,
-            [f"|{placeholder}|"],
-            self._params,
-            module="era.interpolate",
-        )
-
 
 class ROIMaskDialog(DataTransformDialog):
     title = "Mask with ROI"
@@ -3433,13 +3298,4 @@ class ROIMaskDialog(DataTransformDialog):
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation:
         return erlab.interactive.imagetool.provenance.MaskWithPolygonOperation(
             **self._params
-        )
-
-    def make_code(self) -> str:
-        placeholder = self.slicer_area.watched_data_name or " "
-        return erlab.interactive.utils.generate_code(
-            erlab.analysis.mask.mask_with_polygon,
-            [f"|{placeholder}|"],
-            self._params,
-            module="era.mask",
         )

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -7142,7 +7142,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         def _parent_provenance_fetcher(
             parent_uid: str = parent.uid,
         ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
-            return self._node_for_target(parent_uid).provenance_spec
+            return self._node_for_target(parent_uid).displayed_provenance_spec
 
         tool.set_source_parent_fetcher(_parent_source_fetcher)
         tool.set_input_provenance_parent_fetcher(_parent_provenance_fetcher)

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -523,6 +523,14 @@ class _ManagedWindowNode(QtCore.QObject):
         return self._source_spec
 
     @property
+    def displayed_provenance_spec(
+        self,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+        if self.imagetool is not None:
+            return self.slicer_area.displayed_provenance_spec(self.provenance_spec)
+        return self.provenance_spec
+
+    @property
     def snapshot_token(self) -> str:
         return self._snapshot_token
 

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -102,11 +102,13 @@ __all__ = [
     "FileDataSelection",
     "FileLoadSource",
     "FileReplayCall",
+    "GaussianFilterOperation",
     "ImageToolSelectionSourceBinding",
     "InterpolationOperation",
     "IselOperation",
     "LeadingEdgeOperation",
     "MaskWithPolygonOperation",
+    "NormalizeOperation",
     "QSelAggregationOperation",
     "QSelOperation",
     "RenameDimsCoordsOperation",
@@ -3555,6 +3557,121 @@ class DivideByCoordOperation(ToolProvenanceOperation):
         self, input_name: str, *, source_name: str | None = None
     ) -> str:
         return f"{input_name} / {self.divisor_code(input_name)}"
+
+
+class GaussianFilterOperation(ToolProvenanceOperation):
+    op: typing.Literal["gaussian_filter"] = "gaussian_filter"
+    sigma: ProvenanceFloatMapping = pydantic.Field(default_factory=dict)
+
+    def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
+        return erlab.analysis.image.gaussian_filter(data, sigma=self.sigma)
+
+    def derivation_label(self) -> str:
+        label_kwargs = {"sigma": self.sigma}
+        return f"Gaussian Filter({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return erlab.interactive.utils.generate_code(
+            erlab.analysis.image.gaussian_filter,
+            [f"|{input_name}|"],
+            {"sigma": self.sigma},
+            module="era.image",
+        )
+
+
+class NormalizeOperation(ToolProvenanceOperation):
+    op: typing.Literal["normalize"] = "normalize"
+    dims: ProvenanceHashableTuple = ()
+    mode: typing.Literal["area", "minmax", "min", "min_area"] = "area"
+    denominator_rtol: float = 1e-12
+
+    @staticmethod
+    def _safe_denominator(
+        denominator: xr.DataArray, scale: xr.DataArray, rtol: float
+    ) -> xr.DataArray:
+        threshold = np.maximum(
+            scale * rtol,
+            np.finfo(np.float64).tiny,
+        )
+        return denominator.where(
+            np.isfinite(denominator)
+            & np.isfinite(scale)
+            & (np.abs(denominator) > threshold)
+        )
+
+    @staticmethod
+    def _dims_code(dims: tuple[Hashable, ...]) -> str:
+        return _format_qsel_dims_arg(dims)
+
+    def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
+        if not self.dims:
+            return data
+
+        if self.mode == "area":
+            finite_abs_scale = (
+                abs(data).where(np.isfinite(data)).max(self.dims, skipna=True)
+            )
+            area = self._safe_denominator(
+                data.mean(self.dims),
+                finite_abs_scale,
+                self.denominator_rtol,
+            )
+            return data / area
+
+        if self.mode == "minmax":
+            minimum = data.min(self.dims)
+            maximum = data.max(self.dims)
+            finite_abs_scale = xr.where(
+                abs(minimum) > abs(maximum),
+                abs(minimum),
+                abs(maximum),
+            )
+            denominator = self._safe_denominator(
+                maximum - minimum,
+                finite_abs_scale,
+                self.denominator_rtol,
+            )
+            return (data - minimum) / denominator
+
+        if self.mode == "min":
+            minimum = data.min(self.dims)
+            return data - minimum
+
+        minimum = data.min(self.dims)
+        finite_abs_scale = (
+            abs(data).where(np.isfinite(data)).max(self.dims, skipna=True)
+        )
+        area = self._safe_denominator(
+            data.mean(self.dims),
+            finite_abs_scale,
+            self.denominator_rtol,
+        )
+        return (data - minimum) / area
+
+    def derivation_label(self) -> str:
+        label_kwargs = {
+            "dims": self.dims,
+            "mode": self.mode,
+            "denominator_rtol": self.denominator_rtol,
+        }
+        return f"Normalize({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        dims_code = self._dims_code(self.dims)
+        if self.mode == "area":
+            return f"{input_name} / {input_name}.mean({dims_code})"
+        if self.mode == "minmax":
+            minimum: str = f"{input_name}.min({dims_code})"
+            maximum: str = f"{input_name}.max({dims_code})"
+            return f"({input_name} - {minimum}) / ({maximum} - {minimum})"
+        if self.mode == "min":
+            return f"{input_name} - {input_name}.min({dims_code})"
+        minimum = f"{input_name}.min({dims_code})"
+        return f"({input_name} - {minimum}) / {input_name}.mean({dims_code})"
 
 
 class CoarsenOperation(ToolProvenanceOperation):

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -1196,6 +1196,11 @@ class ToolProvenanceOperation(pydantic.BaseModel):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         """Apply this operation to the current derived array.
 
+        Subclasses that participate in live refresh or executable provenance replay
+        should reimplement this method. The implementation must be deterministic for
+        the operation's stored model fields and must not mutate ``data`` or
+        ``parent_data`` in place.
+
         Parameters
         ----------
         data
@@ -1219,6 +1224,20 @@ class ToolProvenanceOperation(pydantic.BaseModel):
     def derivation_entry(self) -> DerivationEntry:
         """Return the user-visible derivation entry for this operation.
 
+        Structured transform subclasses should normally reimplement
+        :meth:`derivation_label` and :meth:`expression_code` instead of overriding this
+        method. Override this method only for operations whose display entry cannot be
+        represented as a label plus parameterized operation code, such as stored
+        free-form script code.
+
+        Returns
+        -------
+        DerivationEntry
+            Label, replay code, and copyability flag shown in derivation UI and used by
+            legacy derivation-code paths.
+
+        Notes
+        -----
         The base implementation keeps the legacy ``derived`` replay contract while
         letting concrete operations emit expression code for any input variable.
 
@@ -1233,13 +1252,47 @@ class ToolProvenanceOperation(pydantic.BaseModel):
         )
 
     def derivation_label(self) -> str:
-        """Return the derivation-list label for this operation."""
+        """Return the derivation-list label for this operation.
+
+        Subclasses should reimplement this for every structured operation that uses
+        the base :meth:`derivation_entry` implementation.
+
+        Returns
+        -------
+        str
+            Human-readable operation label for derivation/history UI. Include the
+            operation's meaningful parameters when they help explain the produced
+            data.
+        """
         raise NotImplementedError
 
     def expression_code(
         self, input_name: str, *, source_name: str | None = None
     ) -> str:
-        """Return a Python expression applying this operation to ``input_name``."""
+        """Return a Python expression applying this operation to an input name.
+
+        Subclasses should reimplement this for every structured operation that can be
+        represented as ordinary user-facing Python code. The emitted expression should
+        be complete, public-API-based, and free of assignment to hardcoded temporary
+        names.
+
+        Parameters
+        ----------
+        input_name
+            Python expression or identifier for the array produced by the previous
+            replay step. Use this exact value as the operation receiver/input instead
+            of assuming a variable name such as ``derived``.
+        source_name
+            Python expression or identifier for the original public input array for
+            the enclosing replay sequence. Operations that need parent/source context,
+            such as coordinate-order restoration, should use this name for that
+            context. Operations that only transform ``input_name`` may ignore it.
+
+        Returns
+        -------
+        str
+            Python expression that evaluates to the transformed DataArray.
+        """
         raise NotImplementedError
 
     def replay_code(
@@ -1249,7 +1302,30 @@ class ToolProvenanceOperation(pydantic.BaseModel):
         output_name: str | None = None,
         source_name: str | None = None,
     ) -> str:
-        """Return replay code for this operation with caller-selected names."""
+        """Return replay code for this operation with caller-selected names.
+
+        This method usually should not be reimplemented by subclasses. Implement
+        :meth:`expression_code` instead so replay graph emission, dialog copy code, and
+        derivation entries all share the same operation expression.
+
+        Parameters
+        ----------
+        input_name
+            Python expression or identifier for the array produced by the previous
+            replay step.
+        output_name
+            Variable name to assign the transformed value to. If ``None``, return only
+            the expression from :meth:`expression_code`.
+        source_name
+            Python expression or identifier for the original public input array for
+            the enclosing replay sequence. Passed through to :meth:`expression_code`.
+
+        Returns
+        -------
+        str
+            Either an assignment statement when ``output_name`` is provided, or a bare
+            expression when it is ``None``.
+        """
         expression = self.expression_code(input_name, source_name=source_name)
         if output_name is None:
             return expression
@@ -1257,6 +1333,26 @@ class ToolProvenanceOperation(pydantic.BaseModel):
 
     @classmethod
     def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        """Build an operation from a normalized manager-console call.
+
+        Subclasses should reimplement this when a console call maps cleanly to the
+        operation but cannot be expressed with declarative ``console_patterns`` alone.
+        Return ``None`` for unsupported, ambiguous, or lossy calls so the original
+        console code remains recorded as script provenance.
+
+        Parameters
+        ----------
+        call
+            Normalized descriptor for the function, method, or accessor call observed
+            by the ImageTool manager console, including unwrapped arguments, keyword
+            arguments, display code, and receiver data when available.
+
+        Returns
+        -------
+        ToolProvenanceOperation or None
+            Operation instance when the call is exactly representable by this
+            operation class; otherwise ``None``.
+        """
         for pattern in cls.console_patterns:
             values = pattern.match(call)
             if values is None:

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -56,10 +56,11 @@ Adding a new provenance-carrying operation follows the same pattern every time:
    using the recorded parameters. ``parent_data`` is provided when the operation needs
    access to parent coordinates or ordering.
 
-5. Implement :meth:`ToolProvenanceOperation.derivation_entry` so the manager can display
-   a user-facing summary and optional copyable code. Return a :class:`DerivationEntry`
-   for every concrete operation; use ``code=None`` when the step should be visible but
-   copied/replay code cannot be emitted safely.
+5. Implement :meth:`ToolProvenanceOperation.expression_code` and
+   :meth:`ToolProvenanceOperation.derivation_label` so copied code and manager
+   derivation entries come from the same operation metadata. Override
+   :meth:`ToolProvenanceOperation.derivation_entry` only when the operation is not a
+   structured transform, such as free-form script code.
 
 6. If the operation maps cleanly from manager-console calls, declare
    :attr:`ToolProvenanceOperation.console_patterns` or implement
@@ -68,8 +69,9 @@ Adding a new provenance-carrying operation follows the same pattern every time:
    recorded as lossy structured operations.
 
 7. Make generated code executable in the replay namespace. Use the literal helpers in
-   this module for persisted values and make sure code assigns the ``derived`` replay
-   variable; the replay graph may rebase ``data`` and ``derived`` to internal names.
+   this module for persisted values, and make ``expression_code`` honor the input name
+   it is given. The base ``replay_code`` wrapper assigns the caller-selected output
+   name.
 
 8. Export the operation class from this module so runtime call sites can instantiate
    it directly.
@@ -135,6 +137,7 @@ __all__ = [
     "file_load",
     "full_data",
     "mark_promoted_1d_source",
+    "operations_expression_code",
     "parse_tool_provenance_spec",
     "public_data",
     "rebase_default_replay_input",
@@ -481,11 +484,17 @@ def _coerce_float_sequence(value: typing.Any) -> list[float]:
     return [float(item) for item in value]
 
 
-def _format_selection_step(method: str, kwargs: Mapping[Hashable, typing.Any]) -> str:
+def _format_selection_expr(
+    input_name: str, method: str, kwargs: Mapping[Hashable, typing.Any]
+) -> str:
     if not kwargs:
-        return f"derived = derived.{method}()"
+        return f"{input_name}.{method}()"
     args = erlab.interactive.utils.format_kwargs(dict(kwargs))
-    return f"derived = derived.{method}({args})"
+    return f"{input_name}.{method}({args})"
+
+
+def _format_selection_step(method: str, kwargs: Mapping[Hashable, typing.Any]) -> str:
+    return f"derived = {_format_selection_expr('derived', method, kwargs)}"
 
 
 def _validate_active_name(value: typing.Any) -> str | None:
@@ -728,23 +737,54 @@ def _simplify_display_code(code: str, *, inline_targets: set[str] | None = None)
     if not body:
         return code
 
+    changed = False
+
+    def current_code() -> str:
+        if not changed:
+            return code
+        return ast.unparse(ast.fix_missing_locations(module))
+
+    def drop_unused_inline_targets() -> None:
+        nonlocal changed
+        if inline_targets is None:
+            return
+
+        idx = 0
+        while idx < len(body) - 1:
+            stmt = body[idx]
+            if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+                idx += 1
+                continue
+            target_expr = stmt.targets[0]
+            if (
+                isinstance(target_expr, ast.Name)
+                and target_expr.id in inline_targets
+                and not any(
+                    _statement_load_count(later, target_expr.id) > 0
+                    for later in body[idx + 1 :]
+                )
+            ):
+                del body[idx]
+                changed = True
+                continue
+            idx += 1
+
+    drop_unused_inline_targets()
+
     for stmt in body:
         if not isinstance(stmt, (ast.Assign, ast.Expr, ast.Import, ast.ImportFrom)):
-            return code
-        if isinstance(stmt, ast.Assign) and (
-            len(stmt.targets) != 1 or not isinstance(stmt.targets[0], ast.Name)
-        ):
-            return code
+            return current_code()
 
-    changed = False
     while True:
         for idx, stmt in enumerate(body[:-1]):
             if not isinstance(stmt, ast.Assign):
                 continue
+            if len(stmt.targets) != 1:
+                continue
 
             target_expr = stmt.targets[0]
             if not isinstance(target_expr, ast.Name):
-                return code
+                continue
             target = target_expr.id
             if inline_targets is not None and target not in inline_targets:
                 continue
@@ -765,6 +805,13 @@ def _simplify_display_code(code: str, *, inline_targets: set[str] | None = None)
             }
             if (
                 not isinstance(next_stmt, (ast.Assign, ast.Expr))
+                or (
+                    isinstance(next_stmt, ast.Assign)
+                    and (
+                        len(next_stmt.targets) != 1
+                        or not isinstance(next_stmt.targets[0], ast.Name)
+                    )
+                )
                 or _statement_load_count(next_stmt, target) != 1
                 or any(
                     _statement_store_count(intervening, target)
@@ -790,6 +837,8 @@ def _simplify_display_code(code: str, *, inline_targets: set[str] | None = None)
             break
         else:
             break
+
+    drop_unused_inline_targets()
 
     if not changed:
         return code
@@ -1049,8 +1098,10 @@ class ToolProvenanceOperation(pydantic.BaseModel):
 
     New operations should keep runtime fields in their decoded Python form, prefer the
     annotated provenance field aliases in this module for lossless JSON serialization,
-    implement :meth:`apply` to replay the transformation, and implement
-    :meth:`derivation_entry` to describe the step in manager UI.
+    implement :meth:`apply` to replay the transformation, implement
+    :meth:`expression_code` to emit the public Python expression for the same
+    transformation, and implement :meth:`derivation_label` to describe the step in
+    manager UI.
 
     Operation instances store the exact arguments used by live refresh, replay graph
     execution, copied code, and derivation display. If a public console call maps
@@ -1166,14 +1217,41 @@ class ToolProvenanceOperation(pydantic.BaseModel):
     def derivation_entry(self) -> DerivationEntry:
         """Return the user-visible derivation entry for this operation.
 
-        Every concrete operation returns a :class:`DerivationEntry` so the manager can
-        display it and copied provenance code has a single replay contract.
+        The base implementation keeps the legacy ``derived`` replay contract while
+        letting concrete operations emit expression code for any input variable.
 
         Use ``DerivationEntry(..., code=None)`` instead when the step should remain
         visible in the derivation list but code generation should stop and return
         ``None``.
         """
+        return DerivationEntry(
+            self.derivation_label(),
+            self.replay_code("derived", output_name="derived", source_name="data"),
+            True,
+        )
+
+    def derivation_label(self) -> str:
+        """Return the derivation-list label for this operation."""
         raise NotImplementedError
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        """Return a Python expression applying this operation to ``input_name``."""
+        raise NotImplementedError
+
+    def replay_code(
+        self,
+        input_name: str,
+        *,
+        output_name: str | None = None,
+        source_name: str | None = None,
+    ) -> str:
+        """Return replay code for this operation with caller-selected names."""
+        expression = self.expression_code(input_name, source_name=source_name)
+        if output_name is None:
+            return expression
+        return f"{output_name} = {expression}"
 
     @classmethod
     def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
@@ -1184,6 +1262,43 @@ class ToolProvenanceOperation(pydantic.BaseModel):
             with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
                 return cls(**values)
         return None
+
+
+def _expression_receiver_code(expression: str) -> str:
+    """Return ``expression`` in a form that can safely receive another operation."""
+    try:
+        parsed = ast.parse(expression, mode="eval")
+    except SyntaxError:
+        return f"({expression})"
+    if isinstance(
+        parsed.body,
+        ast.Name | ast.Attribute | ast.Subscript | ast.Call,
+    ):
+        return expression
+    return f"({expression})"
+
+
+def operations_expression_code(
+    operations: Sequence[ToolProvenanceOperation],
+    input_name: str,
+    *,
+    source_name: str | None = None,
+) -> str:
+    """Return chained expression code for structured operations.
+
+    ``source_name`` is the public/source array name passed to operations that need
+    context beyond the transformed input, such as coordinate-order restoration.
+    """
+    if not operations:
+        return ""
+    source_name = input_name if source_name is None else source_name
+    expression = input_name
+    for operation in operations:
+        expression = operation.expression_code(
+            _expression_receiver_code(expression),
+            source_name=source_name,
+        )
+    return expression
 
 
 def operation_from_console_call(call: ConsoleCall) -> ToolProvenanceOperation | None:
@@ -2118,7 +2233,9 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         if not step_codes and prefix == _DEFAULT_REPLAY_SEED_CODE:
             return None
         inline_targets = (
-            {"derived"} if self.kind == "script" and self.script_inputs else None
+            {"derived"}
+            if self.kind == "script" and self.active_name != "derived"
+            else None
         )
         return _simplify_display_code(
             "\n".join(part for part in (prefix, *step_codes) if part),
@@ -2415,7 +2532,7 @@ def compose_full_provenance(
         seed_code: str | None = local_spec.seed_code
         if seed_code == _DEFAULT_REPLAY_SEED_CODE:
             parent_input = replay_input_name(parent_spec)
-            if parent_input == "derived":
+            if parent_input == "derived" or parent_spec.active_name == "derived":
                 seed_code = None
             elif parent_input is not None:
                 seed_code = f"derived = {parent_input}"
@@ -2885,13 +3002,13 @@ class QSelOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.qsel(self.decoded_kwargs)
 
-    def derivation_entry(self) -> DerivationEntry:
-        kwargs = self.decoded_kwargs
-        return DerivationEntry(
-            f"qsel({_format_derivation_value(self.kwargs)})",
-            _format_selection_step("qsel", kwargs),
-            True,
-        )
+    def derivation_label(self) -> str:
+        return f"qsel({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return _format_selection_expr(input_name, "qsel", self.decoded_kwargs)
 
 
 class IselOperation(ToolProvenanceOperation):
@@ -2913,13 +3030,13 @@ class IselOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.isel(self.decoded_kwargs)
 
-    def derivation_entry(self) -> DerivationEntry:
-        kwargs = self.decoded_kwargs
-        return DerivationEntry(
-            f"isel({_format_derivation_value(self.kwargs)})",
-            _format_selection_step("isel", kwargs),
-            True,
-        )
+    def derivation_label(self) -> str:
+        return f"isel({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return _format_selection_expr(input_name, "isel", self.decoded_kwargs)
 
 
 class SelOperation(ToolProvenanceOperation):
@@ -2941,13 +3058,13 @@ class SelOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.sel(self.decoded_kwargs)
 
-    def derivation_entry(self) -> DerivationEntry:
-        kwargs = self.decoded_kwargs
-        return DerivationEntry(
-            f"sel({_format_derivation_value(self.kwargs)})",
-            _format_selection_step("sel", kwargs),
-            True,
-        )
+    def derivation_label(self) -> str:
+        return f"sel({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return _format_selection_expr(input_name, "sel", self.decoded_kwargs)
 
 
 class SortCoordOrderOperation(ToolProvenanceOperation):
@@ -2956,11 +3073,16 @@ class SortCoordOrderOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.utils.array.sort_coord_order(data, parent_data.coords.keys())
 
-    def derivation_entry(self) -> DerivationEntry:
-        return DerivationEntry(
-            _SORT_COORD_ORDER_DERIVATION_LABEL,
-            _SORT_COORD_ORDER_DERIVATION_CODE,
-            True,
+    def derivation_label(self) -> str:
+        return _SORT_COORD_ORDER_DERIVATION_LABEL
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        source_name = input_name if source_name is None else source_name
+        return (
+            "erlab.utils.array.sort_coord_order("
+            f"{input_name}, {source_name}.coords.keys())"
         )
 
 
@@ -2971,14 +3093,15 @@ class SelectCoordOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.coords[self.coord_name].copy(deep=False)
 
-    def derivation_entry(self) -> DerivationEntry:
-        coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
+    def derivation_label(self) -> str:
         label_kwargs = {"coord_name": self.coord_name}
-        return DerivationEntry(
-            f"Select Coordinate({_format_derivation_value(label_kwargs)})",
-            f"derived = derived.coords[{coord_name_code}]",
-            True,
-        )
+        return f"Select Coordinate({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
+        return f"{input_name}.coords[{coord_name_code}]"
 
 
 class TransposeOperation(ToolProvenanceOperation):
@@ -3011,20 +3134,22 @@ class TransposeOperation(ToolProvenanceOperation):
             return data.transpose(*self.dims)
         return data.transpose(*reversed(data.dims))
 
-    def derivation_entry(self) -> DerivationEntry:
+    def derivation_label(self) -> str:
         if self.dims:
             dims_tuple = tuple(self.dims)
-            return DerivationEntry(
-                f"transpose({_format_derivation_value(dims_tuple)})",
-                "derived = derived.transpose(*"
-                f"{erlab.interactive.utils._parse_single_arg(dims_tuple)})",
-                True,
+            return f"transpose({_format_derivation_value(dims_tuple)})"
+        return "transpose()"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        if self.dims:
+            dims_tuple = tuple(self.dims)
+            return (
+                f"{input_name}.transpose(*"
+                f"{erlab.interactive.utils._parse_single_arg(dims_tuple)})"
             )
-        return DerivationEntry(
-            "transpose()",
-            "derived = derived.transpose(*reversed(derived.dims))",
-            True,
-        )
+        return f"{input_name}.transpose(*reversed({input_name}.dims))"
 
 
 class SqueezeOperation(ToolProvenanceOperation):
@@ -3051,8 +3176,13 @@ class SqueezeOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.squeeze()
 
-    def derivation_entry(self) -> DerivationEntry:
-        return DerivationEntry("squeeze()", "derived = derived.squeeze()", True)
+    def derivation_label(self) -> str:
+        return "squeeze()"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return f"{input_name}.squeeze()"
 
 
 class RenameOperation(ToolProvenanceOperation):
@@ -3077,13 +3207,14 @@ class RenameOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.rename(self.name)
 
-    def derivation_entry(self) -> DerivationEntry:
+    def derivation_label(self) -> str:
+        return f"rename({_format_derivation_value(self.name)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
         name_code = erlab.interactive.utils._parse_single_arg(self.name)
-        return DerivationEntry(
-            f"rename({_format_derivation_value(self.name)})",
-            f"derived = derived.rename({name_code})",
-            True,
-        )
+        return f"{input_name}.rename({name_code})"
 
 
 class RestoreNonuniformDimsOperation(ToolProvenanceOperation):
@@ -3092,12 +3223,14 @@ class RestoreNonuniformDimsOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.interactive.imagetool.slicer.restore_nonuniform_dims(data)
 
-    def derivation_entry(self) -> DerivationEntry:
-        return DerivationEntry(
-            "Restore nonuniform dimensions",
-            "derived = erlab.interactive.imagetool.slicer."
-            "restore_nonuniform_dims(derived)",
-            True,
+    def derivation_label(self) -> str:
+        return "Restore nonuniform dimensions"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return (
+            f"erlab.interactive.imagetool.slicer.restore_nonuniform_dims({input_name})"
         )
 
 
@@ -3145,18 +3278,17 @@ class RotateOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.analysis.transform.rotate(data, **self.kwargs)
 
-    def derivation_entry(self) -> DerivationEntry:
-        code = erlab.interactive.utils.generate_code(
+    def derivation_label(self) -> str:
+        return f"Rotate({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return erlab.interactive.utils.generate_code(
             erlab.analysis.transform.rotate,
-            ["|derived|"],
+            [f"|{input_name}|"],
             self.kwargs,
             module="era.transform",
-            assign="derived",
-        )
-        return DerivationEntry(
-            f"Rotate({_format_derivation_value(self.kwargs)})",
-            code,
-            True,
         )
 
 
@@ -3198,14 +3330,15 @@ class AverageOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.qsel.mean(self.dims)
 
-    def derivation_entry(self) -> DerivationEntry:
-        arg = _format_qsel_dims_arg(self.dims)
+    def derivation_label(self) -> str:
         label_kwargs = {"dims": self.dims}
-        return DerivationEntry(
-            f"Average({_format_derivation_value(label_kwargs)})",
-            f"derived = derived.qsel.mean({arg})",
-            True,
-        )
+        return f"Average({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        arg = _format_qsel_dims_arg(self.dims)
+        return f"{input_name}.qsel.mean({arg})"
 
 
 class QSelAggregationOperation(ToolProvenanceOperation):
@@ -3246,14 +3379,15 @@ class QSelAggregationOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return typing.cast("xr.DataArray", getattr(data.qsel, self.func)(self.dims))
 
-    def derivation_entry(self) -> DerivationEntry:
-        arg = _format_qsel_dims_arg(self.dims)
+    def derivation_label(self) -> str:
         label_kwargs = {"dims": self.dims, "func": self.func}
-        return DerivationEntry(
-            f"Aggregate({_format_derivation_value(label_kwargs)})",
-            f"derived = derived.qsel.{self.func}({arg})",
-            True,
-        )
+        return f"Aggregate({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        arg = _format_qsel_dims_arg(self.dims)
+        return f"{input_name}.qsel.{self.func}({arg})"
 
 
 class InterpolationOperation(ToolProvenanceOperation):
@@ -3324,30 +3458,25 @@ class InterpolationOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.interp({self.dim: self.decoded_values}, method=self.method)
 
-    def code(self, data_name: str, *, assign: str | None = None) -> str:
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
         dim_code = erlab.interactive.utils._parse_single_arg(self.dim)
         values_code = erlab.interactive.utils.format_1d_numeric_array_code(
             self.decoded_values
         )
         method_code = erlab.interactive.utils._parse_single_arg(self.method)
-        code = (
-            f"{data_name}.interp({{{dim_code}: {values_code}}}, method={method_code})"
+        return (
+            f"{input_name}.interp({{{dim_code}: {values_code}}}, method={method_code})"
         )
-        if assign is not None:
-            return f"{assign} = {code}"
-        return code
 
-    def derivation_entry(self) -> DerivationEntry:
+    def derivation_label(self) -> str:
         label_kwargs = {
             "dim": self.dim,
             "values": self.values,
             "method": self.method,
         }
-        return DerivationEntry(
-            f"Interpolate({_format_derivation_value(label_kwargs)})",
-            self.code("derived", assign="derived"),
-            True,
-        )
+        return f"Interpolate({_format_derivation_value(label_kwargs)})"
 
 
 class LeadingEdgeOperation(ToolProvenanceOperation):
@@ -3378,20 +3507,17 @@ class LeadingEdgeOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.analysis.interpolate.leading_edge(data, **self.kwargs)
 
-    def code(self, data_name: str, *, assign: str | None = None) -> str:
+    def derivation_label(self) -> str:
+        return f"Leading Edge({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
         return erlab.interactive.utils.generate_code(
             erlab.analysis.interpolate.leading_edge,
-            [f"|{data_name}|"],
+            [f"|{input_name}|"],
             self.kwargs,
             module="era.interpolate",
-            assign=assign,
-        )
-
-    def derivation_entry(self) -> DerivationEntry:
-        return DerivationEntry(
-            f"Leading Edge({_format_derivation_value(self.kwargs)})",
-            self.code("derived", assign="derived"),
-            True,
         )
 
 
@@ -3421,13 +3547,14 @@ class DivideByCoordOperation(ToolProvenanceOperation):
         self._raise_if_zero(coord)
         return data / coord
 
-    def derivation_entry(self) -> DerivationEntry:
+    def derivation_label(self) -> str:
         label_kwargs = {"coord_name": self.coord_name}
-        return DerivationEntry(
-            f"Divide by Coordinate({_format_derivation_value(label_kwargs)})",
-            f"derived = derived / {self.divisor_code('derived')}",
-            True,
-        )
+        return f"Divide by Coordinate({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return f"{input_name} / {self.divisor_code(input_name)}"
 
 
 class CoarsenOperation(ToolProvenanceOperation):
@@ -3490,7 +3617,7 @@ class CoarsenOperation(ToolProvenanceOperation):
         coarsened = data.coarsen(**self.coarsen_kwargs)
         return typing.cast("xr.DataArray", getattr(coarsened, self.reducer)())
 
-    def derivation_entry(self) -> DerivationEntry:
+    def _code_coarsen_kwargs(self) -> Mapping[typing.Any, typing.Any]:
         coarsen_kwargs: Mapping[typing.Any, typing.Any]
         if _is_identifier_string_mapping(self.dim):
             coarsen_kwargs = {
@@ -3504,14 +3631,19 @@ class CoarsenOperation(ToolProvenanceOperation):
         coarsen_kwargs = erlab.interactive.utils._remove_default_kwargs(
             xr.DataArray.coarsen, dict(coarsen_kwargs)
         )
-        formatted_kwargs = erlab.interactive.utils.format_kwargs(coarsen_kwargs)
-        code = f"derived = derived.coarsen({formatted_kwargs}).{self.reducer}()"
+        return coarsen_kwargs
+
+    def derivation_label(self) -> str:
         label_kwargs = {"coarsen_kwargs": self.coarsen_kwargs, "reducer": self.reducer}
-        return DerivationEntry(
-            f"Coarsen({_format_derivation_value(label_kwargs)})",
-            code,
-            True,
+        return f"Coarsen({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        formatted_kwargs = erlab.interactive.utils.format_kwargs(
+            self._code_coarsen_kwargs()
         )
+        return f"{input_name}.coarsen({formatted_kwargs}).{self.reducer}()"
 
 
 class ThinOperation(ToolProvenanceOperation):
@@ -3569,18 +3701,17 @@ class ThinOperation(ToolProvenanceOperation):
             return data.thin(int(typing.cast("int", self.factor)))
         return data.thin(self.factors)
 
-    def derivation_entry(self) -> DerivationEntry:
+    def derivation_label(self) -> str:
+        return f"Thin({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
         if self.mode == "global":
-            code = f"derived = derived.thin({int(typing.cast('int', self.factor))})"
-        else:
-            code = (
-                "derived = derived.thin("
-                f"{erlab.interactive.utils.format_call_kwargs(self.factors)})"
-            )
-        return DerivationEntry(
-            f"Thin({_format_derivation_value(self.kwargs)})",
-            code,
-            True,
+            return f"{input_name}.thin({int(typing.cast('int', self.factor))})"
+        return (
+            f"{input_name}.thin("
+            f"{erlab.interactive.utils.format_call_kwargs(self.factors)})"
         )
 
 
@@ -3618,18 +3749,17 @@ class SymmetrizeOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.analysis.transform.symmetrize(data, **self.kwargs)
 
-    def derivation_entry(self) -> DerivationEntry:
-        code = erlab.interactive.utils.generate_code(
+    def derivation_label(self) -> str:
+        return f"Symmetrize({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return erlab.interactive.utils.generate_code(
             erlab.analysis.transform.symmetrize,
-            ["|derived|"],
+            [f"|{input_name}|"],
             self.kwargs,
             module="era.transform",
-            assign="derived",
-        )
-        return DerivationEntry(
-            f"Symmetrize({_format_derivation_value(self.kwargs)})",
-            code,
-            True,
         )
 
 
@@ -3681,18 +3811,17 @@ class SymmetrizeNfoldOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.analysis.transform.symmetrize_nfold(data, **self.kwargs)
 
-    def derivation_entry(self) -> DerivationEntry:
-        code = erlab.interactive.utils.generate_code(
+    def derivation_label(self) -> str:
+        return f"Rotational Symmetrize({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return erlab.interactive.utils.generate_code(
             erlab.analysis.transform.symmetrize_nfold,
-            ["|derived|"],
+            [f"|{input_name}|"],
             self.kwargs,
             module="era.transform",
-            assign="derived",
-        )
-        return DerivationEntry(
-            f"Rotational Symmetrize({_format_derivation_value(self.kwargs)})",
-            code,
-            True,
         )
 
 
@@ -3736,28 +3865,27 @@ class CorrectWithEdgeOperation(ToolProvenanceOperation):
             shift_coords=self.shift_coords,
         )
 
-    def derivation_entry(self) -> DerivationEntry:
+    def derivation_label(self) -> str:
         label_kwargs = {
             "edge_fit": self.edge_fit,
             "shift_coords": self.shift_coords,
         }
+        return f"Edge Correction({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
         edge_fit_code = _provenance_value_code(self.edge_fit)
         edge_fit_expr = (
             "erlab.interactive.imagetool.provenance.decode_provenance_value("
             f"{edge_fit_code})"
         )
-        code = erlab.interactive.utils.generate_code(
+        return erlab.interactive.utils.generate_code(
             erlab.analysis.gold.correct_with_edge,
-            ["|derived|", f"|{edge_fit_expr}|"],
+            [f"|{input_name}|", f"|{edge_fit_expr}|"],
             {"shift_coords": self.shift_coords},
             module="era.gold",
             name="correct_with_edge",
-            assign="derived",
-        )
-        return DerivationEntry(
-            f"Edge Correction({_format_derivation_value(label_kwargs)})",
-            code,
-            True,
         )
 
 
@@ -3775,12 +3903,15 @@ class SwapDimsOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.swap_dims(self.mapping)
 
-    def derivation_entry(self) -> DerivationEntry:
-        return DerivationEntry(
-            f"Swap Dimensions({_format_derivation_value(self.mapping)})",
-            "derived = derived.swap_dims("
-            f"{erlab.interactive.utils.format_call_kwargs(self.mapping)})",
-            True,
+    def derivation_label(self) -> str:
+        return f"Swap Dimensions({_format_derivation_value(self.mapping)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return (
+            f"{input_name}.swap_dims("
+            f"{erlab.interactive.utils.format_call_kwargs(self.mapping)})"
         )
 
 
@@ -3811,12 +3942,15 @@ class RenameDimsCoordsOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.rename(self.mapping)
 
-    def derivation_entry(self) -> DerivationEntry:
-        return DerivationEntry(
-            f"Rename({_format_derivation_value(self.mapping)})",
-            "derived = derived.rename("
-            f"{erlab.interactive.utils.format_call_kwargs(self.mapping)})",
-            True,
+    def derivation_label(self) -> str:
+        return f"Rename({_format_derivation_value(self.mapping)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return (
+            f"{input_name}.rename("
+            f"{erlab.interactive.utils.format_call_kwargs(self.mapping)})"
         )
 
 
@@ -3840,24 +3974,24 @@ class AffineCoordOperation(ToolProvenanceOperation):
             dims_first=False,
         )
 
-    def derivation_entry(self) -> DerivationEntry:
-        coord_name_code = repr(self.coord_name)
-        scale_code = erlab.interactive.utils._parse_single_arg(float(self.scale))
-        offset_code = erlab.interactive.utils._parse_single_arg(float(self.offset))
-        code = (
-            f"derived = derived.assign_coords({{{coord_name_code}: "
-            f"derived[{coord_name_code}].copy(data={scale_code} * "
-            f"derived[{coord_name_code}].values + {offset_code})}})"
-        )
+    def derivation_label(self) -> str:
         label_kwargs = {
             "coord_name": self.coord_name,
             "scale": self.scale,
             "offset": self.offset,
         }
-        return DerivationEntry(
-            f"Scale/Offset Coordinate({_format_derivation_value(label_kwargs)})",
-            code,
-            True,
+        return f"Scale/Offset Coordinate({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        coord_name_code = repr(self.coord_name)
+        scale_code = erlab.interactive.utils._parse_single_arg(float(self.scale))
+        offset_code = erlab.interactive.utils._parse_single_arg(float(self.offset))
+        return (
+            f"{input_name}.assign_coords({{{coord_name_code}: "
+            f"{input_name}[{coord_name_code}].copy(data={scale_code} * "
+            f"{input_name}[{coord_name_code}].values + {offset_code})}})"
         )
 
 
@@ -3915,22 +4049,22 @@ class AssignCoordsOperation(ToolProvenanceOperation):
             dims_first=False,
         )
 
-    def derivation_entry(self) -> DerivationEntry:
-        coord_name_code = repr(self.coord_name)
-        values = self.decoded_values
-        values_code = _provenance_numeric_array_code(values)
-        code = (
-            f"derived = derived.assign_coords({{{coord_name_code}: "
-            f"derived[{coord_name_code}].copy(data={values_code})}})"
-        )
+    def derivation_label(self) -> str:
         label_kwargs = {
             "coord_name": self.coord_name,
             "values": self.values,
         }
-        return DerivationEntry(
-            f"Assign Coordinates({_format_derivation_value(label_kwargs)})",
-            code,
-            True,
+        return f"Assign Coordinates({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        coord_name_code = repr(self.coord_name)
+        values = self.decoded_values
+        values_code = _provenance_numeric_array_code(values)
+        return (
+            f"{input_name}.assign_coords({{{coord_name_code}: "
+            f"{input_name}[{coord_name_code}].copy(data={values_code})}})"
         )
 
 
@@ -3971,19 +4105,19 @@ class AssignScalarCoordOperation(ToolProvenanceOperation):
             dims_first=False,
         )
 
-    def derivation_entry(self) -> DerivationEntry:
-        coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
-        value_code = _provenance_value_code(self.decoded_value)
-        code = f"derived = derived.assign_coords({{{coord_name_code}: {value_code}}})"
+    def derivation_label(self) -> str:
         label_kwargs = {
             "coord_name": self.coord_name,
             "value": self.value,
         }
-        return DerivationEntry(
-            f"Assign Scalar Coordinate({_format_derivation_value(label_kwargs)})",
-            code,
-            True,
-        )
+        return f"Assign Scalar Coordinate({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
+        value_code = _provenance_value_code(self.decoded_value)
+        return f"{input_name}.assign_coords({{{coord_name_code}: {value_code}}})"
 
 
 class AssignCoord1DOperation(ToolProvenanceOperation):
@@ -4047,23 +4181,23 @@ class AssignCoord1DOperation(ToolProvenanceOperation):
             dims_first=False,
         )
 
-    def derivation_entry(self) -> DerivationEntry:
-        coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
-        dim_code = erlab.interactive.utils._parse_single_arg(self.dim)
-        values_code = _provenance_numeric_array_code(self.decoded_values)
-        code = (
-            f"derived = derived.assign_coords({{{coord_name_code}: "
-            f"({dim_code}, {values_code})}})"
-        )
+    def derivation_label(self) -> str:
         label_kwargs = {
             "coord_name": self.coord_name,
             "dim": self.dim,
             "values": self.values,
         }
-        return DerivationEntry(
-            f"Assign 1D Coordinate({_format_derivation_value(label_kwargs)})",
-            code,
-            True,
+        return f"Assign 1D Coordinate({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        coord_name_code = erlab.interactive.utils._parse_single_arg(self.coord_name)
+        dim_code = erlab.interactive.utils._parse_single_arg(self.dim)
+        values_code = _provenance_numeric_array_code(self.decoded_values)
+        return (
+            f"{input_name}.assign_coords({{{coord_name_code}: "
+            f"({dim_code}, {values_code})}})"
         )
 
 
@@ -4077,13 +4211,14 @@ class AssignAttrsOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return data.assign_attrs(self.attrs)
 
-    def derivation_entry(self) -> DerivationEntry:
+    def derivation_label(self) -> str:
+        return f"Assign Attributes({_format_derivation_value(self.attrs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
         attrs_code = _provenance_value_code(self.attrs)
-        return DerivationEntry(
-            f"Assign Attributes({_format_derivation_value(self.attrs)})",
-            f"derived = derived.assign_attrs({attrs_code})",
-            True,
-        )
+        return f"{input_name}.assign_attrs({attrs_code})"
 
 
 class SliceAlongPathOperation(ToolProvenanceOperation):
@@ -4111,18 +4246,17 @@ class SliceAlongPathOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.analysis.interpolate.slice_along_path(data, **self.kwargs)
 
-    def derivation_entry(self) -> DerivationEntry:
-        code = erlab.interactive.utils.generate_code(
+    def derivation_label(self) -> str:
+        return f"Slice Along ROI Path({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return erlab.interactive.utils.generate_code(
             erlab.analysis.interpolate.slice_along_path,
-            ["|derived|"],
+            [f"|{input_name}|"],
             self.kwargs,
             module="era.interpolate",
-            assign="derived",
-        )
-        return DerivationEntry(
-            f"Slice Along ROI Path({_format_derivation_value(self.kwargs)})",
-            code,
-            True,
         )
 
 
@@ -4164,16 +4298,15 @@ class MaskWithPolygonOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.analysis.mask.mask_with_polygon(data, **self.kwargs)
 
-    def derivation_entry(self) -> DerivationEntry:
-        code = erlab.interactive.utils.generate_code(
+    def derivation_label(self) -> str:
+        return f"Mask with ROI({_format_derivation_value(self.kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        return erlab.interactive.utils.generate_code(
             erlab.analysis.mask.mask_with_polygon,
-            ["|derived|"],
+            [f"|{input_name}|"],
             self.kwargs,
             module="era.mask",
-            assign="derived",
-        )
-        return DerivationEntry(
-            f"Mask with ROI({_format_derivation_value(self.kwargs)})",
-            code,
-            True,
         )

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1189,6 +1189,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         # Applied filter function
         self._applied_func: Callable[[xr.DataArray], xr.DataArray] | None = None
+        self._applied_provenance_operation: (
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
+        ) = None
         # `_data` is the public/source array, while `ArraySlicer._obj` is the internal
         # validated view used for slicing. The two share values by default and detach
         # only when a write needs isolation.
@@ -1702,6 +1705,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._applied_func is not None or not self._obj_shares_data_values
         )
         self._applied_func = None
+        self._applied_provenance_operation = None
         restored_obj = False
 
         if self._data_shares_external_values:
@@ -2551,6 +2555,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._data_shares_external_values = shares_external_values
         self._obj_shares_data_values = True
         self._applied_func = None
+        self._applied_provenance_operation = None
 
         # Save color limits so we may restore them later
         cached_levels: tuple[float, float] | None = None
@@ -2841,8 +2846,31 @@ class ImageSlicerArea(QtWidgets.QWidget):
             # This will update colorbar limits if visible
             self.lock_levels(self.levels_locked)
 
+    def displayed_provenance_spec(
+        self,
+        base_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec
+        | None = None,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+        """Return provenance for the currently displayed data values."""
+        if base_spec is None:
+            base_spec = self.provenance_spec
+        operation = self._applied_provenance_operation
+        if operation is None:
+            return base_spec
+        return erlab.interactive.imagetool.provenance.compose_display_provenance(
+            base_spec,
+            erlab.interactive.imagetool.provenance.full_data(operation),
+            parent_data=self._data,
+        )
+
     def apply_func(
-        self, func: Callable[[xr.DataArray], xr.DataArray] | None, update: bool = True
+        self,
+        func: Callable[[xr.DataArray], xr.DataArray] | None,
+        update: bool = True,
+        *,
+        operation: (
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
+        ) = None,
     ) -> None:
         """Apply a function to the data.
 
@@ -2861,18 +2889,20 @@ class ImageSlicerArea(QtWidgets.QWidget):
             If `True`, the plots are updated after setting the new values.
 
         """
-        # `self._data` is the public/source array, while `self.data` is the current
-        # validated slicer view. Temporary filters only detach the slicer view so the
-        # source array remains unchanged and can be restored cheaply.
-        self._applied_func = func
-
         if func is None:
+            self._applied_func = None
+            self._applied_provenance_operation = None
             self._restore_obj_from_source(update=update)
             return
 
+        # `self._data` is the public/source array, while `self.data` is the current
+        # validated slicer view. Temporary filters only detach the slicer view so the
+        # source array remains unchanged and can be restored cheaply.
         filtered = func(self._data)
         if filtered.chunks is None:
             self.update_values(filtered, update=update)
+            self._applied_func = func
+            self._applied_provenance_operation = operation
             return
 
         if self.data.ndim != filtered.ndim:
@@ -2896,6 +2926,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.array_slicer.clear_val_cache()
             self.refresh_all(only_plots=True)
             self.lock_levels(self.levels_locked)
+        self._applied_func = func
+        self._applied_provenance_operation = operation
 
     def set_manual_limits(self, manual_limits: dict[str, list[float]]) -> None:
         """Set manual limits for the axes.
@@ -3451,7 +3483,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if isinstance(widget, erlab.interactive.utils.ToolWindow):
             widget.set_source_parent_fetcher(lambda: self._tool_source_parent_data())
             self.sigSourceDataReplaced.connect(widget.handle_parent_source_replaced)
-            widget.set_input_provenance_parent_fetcher(lambda: self.provenance_spec)
+            widget.set_input_provenance_parent_fetcher(self.displayed_provenance_spec)
 
         uid: str = str(uuid.uuid4())
         with self._assoc_tools_lock:

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -1034,7 +1034,7 @@ class KspaceTool(KspaceToolGUI):
         input_ref = self._copy_input_reference(input_name)
         if erlab.interactive.utils._is_kwarg_name(input_ref):
             return input_ref
-        return "target"
+        return "input_data"
 
     def _copy_prelude(
         self,

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -813,10 +813,12 @@ def test_manager_meshtool_output_child_qsel_copy_code_tracks_selected_output_id(
         copied = copy_full_code_for_uid(monkeypatch, manager, nested_uid)
         assert "corrected, mesh =" in copied
         assert "era.mesh.remove_mesh(" in copied
-        assert f"derived = {expected_name}" in copied
+        assert not any(
+            line == f"derived = {expected_name}" for line in copied.splitlines()
+        )
         assert ")[0]" not in copied
         assert ")[1]" not in copied
-        assert "derived = derived.qsel(alpha=1, alpha_width=1)" in copied
+        assert f"derived = {expected_name}.qsel(alpha=1, alpha_width=1)" in copied
 
 
 def test_manager_fit2d_output_itools_use_distinct_output_ids(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -2,6 +2,55 @@
 from ._shared import *
 
 
+def test_manager_childtool_from_filtered_parent_uses_display_provenance(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["alpha", "eV"],
+        coords={"alpha": np.arange(5, dtype=float), "eV": np.arange(5, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"alpha": 1.0}
+    )
+    expected = operation.apply(data, parent_data=data)
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.apply_func(
+            lambda darr: operation.apply(darr, parent_data=darr),
+            operation=operation,
+        )
+        parent_tool.slicer_area.open_in_meshtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1,
+            timeout=5000,
+        )
+
+        child_uid = manager._imagetool_wrappers[0]._childtool_indices[0]
+        child = manager.get_childtool(child_uid)
+        assert child.input_provenance_spec is not None
+        display_code = child.input_provenance_spec.display_code()
+        assert display_code is not None
+        assert "gaussian_filter" in display_code
+        namespace = {"data": data.copy(deep=True)}
+        exec(  # noqa: S102
+            display_code,
+            {"np": np, "xr": xr, "erlab": erlab, "era": erlab.analysis},
+            namespace,
+        )
+        xr.testing.assert_identical(namespace["derived"], expected)
+
+
 def test_manager_goldtool_output_itool_stales_when_fit_results_change(
     qtbot,
     gold,

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -51,6 +51,78 @@ def test_manager_childtool_from_filtered_parent_uses_display_provenance(
         xr.testing.assert_identical(namespace["derived"], expected)
 
 
+def test_manager_non_imagetool_node_displayed_provenance_uses_tool_provenance(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    class _StaticToolState(pydantic.BaseModel):
+        value: int = 0
+
+    class _StaticTool(erlab.interactive.utils.ToolWindow[_StaticToolState]):
+        StateModel = _StaticToolState
+        tool_name = "static-dummy"
+
+        def __init__(
+            self,
+            data: xr.DataArray,
+            provenance_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec,
+        ) -> None:
+            super().__init__()
+            self._data = data
+            self._status = _StaticToolState()
+            self._provenance_spec = provenance_spec
+
+        @property
+        def tool_status(self) -> _StaticToolState:
+            return self._status
+
+        @tool_status.setter
+        def tool_status(self, status: _StaticToolState) -> None:
+            self._status = status
+
+        @property
+        def tool_data(self) -> xr.DataArray:
+            return self._data
+
+        def update_data(self, new_data: xr.DataArray) -> bool:
+            self._data = new_data
+            return True
+
+        def current_provenance_spec(
+            self,
+        ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+            return self._provenance_spec
+
+    data = xr.DataArray(np.arange(4.0), dims=("x",))
+    provenance_spec = prov.script(
+        prov.ScriptCodeOperation(label="Double data", code="result = data * 2"),
+        start_label="Start from data",
+        seed_code="data = source",
+        active_name="result",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root_tool = itool(data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+
+        child_uid = manager.add_childtool(
+            _StaticTool(data, provenance_spec),
+            0,
+            show=False,
+        )
+        child_node = manager._child_node(child_uid)
+
+        assert child_node.displayed_provenance_spec == provenance_spec
+
+
 def test_manager_goldtool_output_itool_stales_when_fit_results_change(
     qtbot,
     gold,

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -22,6 +22,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 import erlab.interactive.imagetool._itool as itool_mod
 import erlab.interactive.imagetool._mainwindow as imagetool_mainwindow
+import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive.derivative import DerivativeTool, dtool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
@@ -154,6 +155,19 @@ def _clear_selection_dialog(dialog: SelectionDialog) -> None:
     for row in dialog.rows:
         row.use_check.setChecked(False)
         row.width_check.setChecked(False)
+
+
+def test_operation_backed_transform_dialogs_use_base_make_code() -> None:
+    custom_make_code_dialogs = [
+        name
+        for name, value in vars(imagetool_dialogs).items()
+        if isinstance(value, type)
+        and issubclass(value, imagetool_dialogs.DataTransformDialog)
+        and value is not imagetool_dialogs.DataTransformDialog
+        and "make_code" in value.__dict__
+    ]
+
+    assert custom_make_code_dialogs == []
 
 
 def _assert_guideline_state(
@@ -3807,7 +3821,7 @@ def test_itool_rotate(qtbot, accept_dialog) -> None:
     )
 
     # Test copy button
-    assert pyperclip.paste().startswith("era.transform.rotate")
+    assert pyperclip.paste().startswith("era.transform.rotate(data")
 
     # Transpose should remove guidelines
     win.slicer_area.swap_axes(0, 1)
@@ -5215,7 +5229,7 @@ def test_selection_dialog_formats_non_identifier_dim_as_mapping(qtbot) -> None:
     row.index_start_spin.setValue(1)
 
     expected = data.isel({"Fake Motor": 1})
-    assert dialog.make_code() == '.isel({"Fake Motor": 1})'
+    assert dialog.make_code() == 'data.isel({"Fake Motor": 1})'
     xarray.testing.assert_identical(
         _exec_data_fragment(data, dialog.make_code()), expected
     )
@@ -6005,8 +6019,9 @@ def test_itool_coarsen(qtbot, accept_dialog) -> None:
     )
 
     assert (
-        pyperclip.paste()
-        == '.coarsen(x=2, y=4, boundary="trim", side="right", coord_func="min").sum()'
+        pyperclip.paste() == "data.coarsen("
+        'x=2, y=4, boundary="trim", side="right", coord_func="min"'
+        ").sum()"
     )
     win.close()
 
@@ -6901,7 +6916,7 @@ def test_itool_swap_dims_multiple_and_code(qtbot, accept_dialog) -> None:
     )
 
     code = pyperclip.paste()
-    assert code == '.swap_dims(x="u", y="v")'
+    assert code == 'data.swap_dims(x="u", y="v")'
     assert "z=" not in code
     assert '"z"' not in code
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -172,6 +172,76 @@ def test_operation_backed_transform_dialogs_use_base_make_code() -> None:
     assert "make_code" not in NormalizeDialog.__dict__
 
 
+def test_operation_backed_dialog_empty_operation_edges(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    filter_dialog = imagetool_dialogs.DataFilterDialog(win.slicer_area)
+    qtbot.addWidget(filter_dialog)
+    assert filter_dialog.filter_operation() is None
+    assert filter_dialog.filter_operations() == []
+
+    def _raise_expression_code(*_args, **_kwargs) -> str:
+        raise RuntimeError("cannot emit")
+
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.provenance,
+        "operations_expression_code",
+        _raise_expression_code,
+    )
+    assert filter_dialog.make_code() == ""
+
+    aggregate_dialog = AggregateDialog(win.slicer_area)
+    qtbot.addWidget(aggregate_dialog)
+    for check in aggregate_dialog.dim_checks.values():
+        check.setChecked(False)
+    with pytest.raises(ValueError, match="No dimensions selected"):
+        aggregate_dialog.source_transform_operation()
+
+    coarsen_dialog = CoarsenDialog(win.slicer_area)
+    qtbot.addWidget(coarsen_dialog)
+    with pytest.raises(ValueError, match="No dimensions selected"):
+        coarsen_dialog.source_transform_operation()
+
+    thin_dialog = ThinDialog(win.slicer_area)
+    qtbot.addWidget(thin_dialog)
+    thin_dialog.global_radio.setChecked(True)
+    thin_dialog.global_spin.setValue(1)
+    with pytest.raises(ValueError, match="No thinning requested"):
+        thin_dialog.source_transform_operation()
+    thin_dialog.per_dim_radio.setChecked(True)
+    for spin in thin_dialog.factor_spins.values():
+        spin.setValue(1)
+    with pytest.raises(ValueError, match="No thinning requested"):
+        thin_dialog.source_transform_operation()
+
+    normalize_dialog = NormalizeDialog(win.slicer_area)
+    qtbot.addWidget(normalize_dialog)
+    assert normalize_dialog.filter_operation() is None
+    xr.testing.assert_identical(normalize_dialog.process_data(data), data)
+
+    gaussian_dialog = GaussianFilterDialog(win.slicer_area)
+    qtbot.addWidget(gaussian_dialog)
+    assert gaussian_dialog.filter_operation() is None
+
+    swap_dialog = SwapDimsDialog(win.slicer_area)
+    qtbot.addWidget(swap_dialog)
+    with pytest.raises(ValueError, match="No dimensions changed"):
+        swap_dialog.source_transform_operation()
+
+    rename_dialog = RenameDimsCoordsDialog(win.slicer_area)
+    qtbot.addWidget(rename_dialog)
+    with pytest.raises(ValueError, match="No names changed"):
+        rename_dialog.source_transform_operation()
+
+    win.close()
+
+
 def _assert_guideline_state(
     plot_item,
     *,

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -168,6 +168,8 @@ def test_operation_backed_transform_dialogs_use_base_make_code() -> None:
     ]
 
     assert custom_make_code_dialogs == []
+    assert "make_code" not in GaussianFilterDialog.__dict__
+    assert "make_code" not in NormalizeDialog.__dict__
 
 
 def _assert_guideline_state(
@@ -2275,6 +2277,41 @@ def test_itool_child_tool_source_specs_and_non_source_updates(qtbot) -> None:
     assert child.source_state == "fresh"
 
 
+def test_child_tool_from_gaussian_filtered_itool_keeps_display_provenance(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["alpha", "eV"],
+        coords={"alpha": np.arange(5, dtype=float), "eV": np.arange(5, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"alpha": 1.0}
+    )
+    expected = operation.apply(data, parent_data=data)
+
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_func(
+        lambda darr: operation.apply(darr, parent_data=darr),
+        operation=operation,
+    )
+
+    win.slicer_area.open_in_meshtool()
+    qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000)
+    child = next(iter(win.slicer_area._associated_tools.values()))
+
+    xarray.testing.assert_identical(child.tool_data, expected)
+    assert child.input_provenance_spec is not None
+    display_code = child.input_provenance_spec.display_code()
+    assert display_code is not None
+    assert "gaussian_filter" in display_code
+    namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
+    xarray.testing.assert_identical(namespace["derived"], expected)
+
+    win.close()
+
+
 def test_child_tool_copy_code_streamlines_noop_source_steps(qtbot) -> None:
     prov = erlab.interactive.imagetool.provenance
     win = itool(_TEST_DATA["2D"].copy(), execute=False)
@@ -3581,6 +3618,47 @@ def test_apply_func_preserves_source_data(qtbot) -> None:
 
     win.slicer_area.apply_func(None)
     xarray.testing.assert_identical(win.slicer_area.data, data)
+    win.close()
+
+
+def test_apply_func_keeps_display_provenance_after_failed_filter(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 1.0}
+    )
+
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+
+    win.slicer_area.apply_func(
+        lambda darr: operation.apply(darr, parent_data=darr),
+        operation=operation,
+    )
+    expected = win.slicer_area.data.copy(deep=True)
+    before = win.slicer_area.displayed_provenance_spec()
+    assert before is not None
+
+    def _raise_filter(_data: xr.DataArray) -> xr.DataArray:
+        raise RuntimeError("failed preview")
+
+    with pytest.raises(RuntimeError, match="failed preview"):
+        win.slicer_area.apply_func(
+            _raise_filter,
+            operation=erlab.interactive.imagetool.provenance.NormalizeOperation(
+                dims=("x",),
+                mode="area",
+            ),
+        )
+
+    xarray.testing.assert_identical(win.slicer_area.data, expected)
+    after = win.slicer_area.displayed_provenance_spec()
+    assert after is not None
+    assert after.display_code() == before.display_code()
+
     win.close()
 
 
@@ -7605,6 +7683,51 @@ def test_itool_gaussian_filter_sigma_path(qtbot, accept_dialog, monkeypatch) -> 
         accept_call=lambda d: d.reject(),
     )
     xarray.testing.assert_identical(win.slicer_area.data, data)
+
+    win.close()
+
+
+def test_itool_normalize_filter_copies_code_and_records_display_provenance(
+    qtbot, accept_dialog, monkeypatch
+) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    monkeypatch.setattr(
+        type(win.slicer_area),
+        "watched_data_name",
+        property(lambda _self: "data"),
+    )
+
+    def _set_normalize_params(dialog: NormalizeDialog) -> None:
+        dialog.dim_checks["x"].setChecked(True)
+        dialog.opts[1].setChecked(True)
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+
+    accept_dialog(win.mnb._normalize, pre_call=_set_normalize_params)
+
+    expected = normalize(data, ("x",), 1)
+    xarray.testing.assert_identical(win.slicer_area.data, expected)
+    assert ".min(" in pyperclip.paste()
+    assert ".max(" in pyperclip.paste()
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, pyperclip.paste()),
+        expected,
+    )
+
+    display_code = win.slicer_area.displayed_provenance_spec()
+    assert display_code is not None
+    code = display_code.display_code()
+    assert code is not None
+    assert ".min(" in code
+    assert ".max(" in code
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    xarray.testing.assert_identical(namespace["derived"], expected)
 
     win.close()
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -332,6 +332,13 @@ def test_registered_provenance_operations_define_operation_code_api() -> None:
         erlab.interactive.imagetool.provenance.DivideByCoordOperation(
             coord_name="scale"
         ),
+        erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+            sigma={"x": 0.5}
+        ),
+        erlab.interactive.imagetool.provenance.NormalizeOperation(
+            dims=("x",),
+            mode="minmax",
+        ),
         erlab.interactive.imagetool.provenance.CoarsenOperation(
             dim={"x": 2},
             boundary="trim",

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -396,6 +396,79 @@ def test_operation_replay_code_passes_source_context() -> None:
     )
 
 
+def test_operation_code_base_edges() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(np.arange(4.0), dims=("x",))
+
+    with pytest.raises(NotImplementedError):
+        prov.ToolProvenanceOperation().expression_code("data")
+
+    assert (
+        prov.IselOperation(kwargs={"x": 0}).replay_code("data", output_name=None)
+        == "data.isel(x=0)"
+    )
+    assert prov._expression_receiver_code("data +") == "(data +)"
+    assert (
+        prov._simplify_display_code(
+            "derived = data\nfor item in []:\n    pass",
+            inline_targets={"derived"},
+        )
+        == "for item in []:\n    pass"
+    )
+    xr.testing.assert_identical(
+        prov.NormalizeOperation(dims=()).apply(data, parent_data=data),
+        data,
+    )
+
+
+@pytest.mark.parametrize(
+    ("operation", "expected"),
+    [
+        (
+            erlab.interactive.imagetool.provenance.NormalizeOperation(
+                dims=("x",), mode="area"
+            ),
+            'data / data.mean("x")',
+        ),
+        (
+            erlab.interactive.imagetool.provenance.NormalizeOperation(
+                dims=("x",), mode="min"
+            ),
+            'data - data.min("x")',
+        ),
+        (
+            erlab.interactive.imagetool.provenance.NormalizeOperation(
+                dims=("x",), mode="min_area"
+            ),
+            '(data - data.min("x")) / data.mean("x")',
+        ),
+    ],
+)
+def test_normalize_operation_expression_modes(
+    operation: erlab.interactive.imagetool.provenance.NormalizeOperation,
+    expected: str,
+) -> None:
+    assert operation.expression_code("data") == expected
+
+
+def test_roi_operation_derivation_labels() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    vertices = np.array([[0.0, 0.0], [1.0, 1.0]])
+
+    path_operation = prov.SliceAlongPathOperation(
+        vertices={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+        step_size=0.1,
+        dim_name="s",
+    )
+    mask_operation = prov.MaskWithPolygonOperation(
+        vertices=vertices,
+        dims=("x", "y"),
+    )
+
+    assert path_operation.derivation_label().startswith("Slice Along ROI Path(")
+    assert mask_operation.derivation_label().startswith("Mask with ROI(")
+
+
 def test_operations_expression_code_chains_without_relay_assignments() -> None:
     prov = erlab.interactive.imagetool.provenance
     data = _base_data().assign_coords(scale=("x", [1.0, 2.0, 3.0]))

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -304,14 +304,112 @@ def test_tool_provenance_parse_final_payload_and_migrate_legacy_schema() -> None
         )
 
 
-def test_registered_provenance_operations_define_derivation_entries() -> None:
+def test_registered_provenance_operations_define_operation_code_api() -> None:
     prov = erlab.interactive.imagetool.provenance
 
-    assert [
-        op
+    structured_operation_types = [
+        operation_type
         for op, operation_type in prov._OPERATION_TYPES.items()
-        if "derivation_entry" not in operation_type.__dict__
+        if op != "script_code"
+    ]
+    assert [
+        operation_type
+        for operation_type in structured_operation_types
+        if "derivation_label" not in operation_type.__dict__
     ] == []
+    assert [
+        operation_type
+        for operation_type in structured_operation_types
+        if "expression_code" not in operation_type.__dict__
+    ] == []
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        erlab.interactive.imagetool.provenance.IselOperation(kwargs={"x": slice(0, 2)}),
+        erlab.interactive.imagetool.provenance.SelOperation(kwargs={"y": 11.0}),
+        erlab.interactive.imagetool.provenance.DivideByCoordOperation(
+            coord_name="scale"
+        ),
+        erlab.interactive.imagetool.provenance.CoarsenOperation(
+            dim={"x": 2},
+            boundary="trim",
+            side="left",
+            coord_func="mean",
+            reducer="mean",
+        ),
+        erlab.interactive.imagetool.provenance.ThinOperation(
+            mode="per_dim",
+            factors={"y": 2},
+        ),
+    ],
+)
+def test_operation_replay_code_uses_requested_names(
+    operation: erlab.interactive.imagetool.provenance.ToolProvenanceOperation,
+) -> None:
+    data = _base_data().drop_vars("x_alt").assign_coords(scale=("x", [1.0, 2.0, 3.0]))
+
+    code = operation.replay_code("data", output_name="result", source_name="source")
+    assert "derived" not in code
+
+    namespace = _exec_generated_code(
+        code,
+        {
+            "data": data.copy(deep=True),
+            "source": data.copy(deep=True),
+        },
+    )
+    xr.testing.assert_identical(
+        namespace["result"],
+        operation.apply(data, parent_data=data),
+    )
+
+
+def test_operation_replay_code_passes_source_context() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    parent = _base_data()
+    child = parent.transpose("z", "x", "y")
+    operation = prov.SortCoordOrderOperation()
+
+    code = operation.replay_code("child", output_name="result", source_name="parent")
+    assert "parent.coords.keys()" in code
+    assert "derived" not in code
+
+    namespace = _exec_generated_code(
+        code,
+        {
+            "child": child.copy(deep=True),
+            "parent": parent.copy(deep=True),
+        },
+    )
+    xr.testing.assert_identical(
+        namespace["result"],
+        operation.apply(child, parent_data=parent),
+    )
+
+
+def test_operations_expression_code_chains_without_relay_assignments() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = _base_data().assign_coords(scale=("x", [1.0, 2.0, 3.0]))
+    operations = (
+        prov.DivideByCoordOperation(coord_name="scale"),
+        prov.IselOperation(kwargs={"x": slice(0, 2)}),
+    )
+
+    code = prov.operations_expression_code(operations, "data")
+    assert code.startswith("(data / data.scale).isel(")
+    assert "derived" not in code
+
+    namespace = _exec_generated_code(
+        f"result = {code}",
+        {"data": data.copy(deep=True)},
+    )
+    expected = operations[1].apply(
+        operations[0].apply(data, parent_data=data),
+        parent_data=data,
+    )
+    xr.testing.assert_identical(namespace["result"], expected)
 
 
 def test_tool_provenance_parse_legacy_file_script_metadata() -> None:
@@ -1276,6 +1374,21 @@ def test_tool_provenance_validation_helpers_and_error_branches() -> None:
     simplified_namespace = _exec_generated_code(simplified, {"data": 3})
     assert simplified_namespace["result"] == 5
     assert "derived" not in simplified_namespace
+    assert (
+        prov._simplify_display_code(
+            "derived = data\nscale = 2\nleft, right = (data * scale, data + 1)",
+            inline_targets={"derived"},
+        )
+        == "scale = 2\nleft, right = (data * scale, data + 1)"
+    )
+    assert (
+        prov._simplify_display_code(
+            "left, right = (data - 1, data + 1)\n"
+            "derived = left\n"
+            "derived = derived.sel(x=0)"
+        )
+        == "left, right = (data - 1, data + 1)\nderived = left.sel(x=0)"
+    )
     invalidated_namespace = _exec_generated_code(
         prov._simplify_display_code(
             "derived = data + 1\ndata = other\nresult = derived"
@@ -1426,7 +1539,9 @@ def test_tool_provenance_remaining_operation_and_display_branches(monkeypatch) -
     monkeypatch.setattr(
         erlab.interactive.utils,
         "generate_code",
-        lambda *_args, assign=None, **_kwargs: f"{assign} = generated()",
+        lambda *_args, assign=None, **_kwargs: (
+            "generated()" if assign is None else f"{assign} = generated()"
+        ),
     )
     assert (
         prov.RotateOperation(angle=45.0, axes=("x", "y"), center=(0.0, 0.0))
@@ -2019,8 +2134,9 @@ def test_file_provenance_compose_fallbacks_and_replay_aliases() -> None:
     watched_composed = prov.compose_full_provenance(watched_parent, default_seed_local)
     assert watched_composed is not None
     assert watched_composed.derivation_code() == (
-        "derived = watched_data\nderived = watched_data\nresult = derived.mean()"
+        "derived = watched_data\nresult = derived.mean()"
     )
+    assert watched_composed.display_code() == "result = watched_data.mean()"
 
     result_parent = prov.script(
         prov.ScriptCodeOperation(
@@ -2177,8 +2293,9 @@ def test_script_input_code_reuses_shared_file_replay_prefix(
 
     assert code.count("xarray.load_dataarray") == 1
     assert code.count(".qsel.mean") == 1
-    assert "data_0 =" in code
-    assert "data_1 =" in code
+    assert "data_0 =" not in code
+    assert "data_1 =" not in code
+    assert "restore_nonuniform_dims" not in code
     namespace = _exec_generated_code(code, {})
     expected = left_stage.apply(shared_stage.apply(source)) - right_stage.apply(
         shared_stage.apply(source)

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -922,6 +922,115 @@ def test_replay_graph_display_normalizes_nested_derived_console_code(
     xr.testing.assert_identical(namespace["ncd"], expected)
 
 
+def test_replay_graph_cleanup_helpers_cover_edge_cases() -> None:
+    assert _replay_graph._inline_single_use_replay_expressions("bad =") == "bad ="
+    assert _replay_graph._compact_replay_temp_names("bad =") == "bad ="
+    assert _replay_graph._code_has_scoped_definition("bad =")
+
+    assert (
+        _replay_graph._inline_single_use_replay_expressions(
+            "_itool_replay_1 = source.attr\nresult = _itool_replay_1 + 1"
+        )
+        == "result = source.attr + 1"
+    )
+    assert (
+        _replay_graph._inline_single_use_replay_expressions(
+            "_itool_replay_1 = source\nresult = 0"
+        )
+        == "_itool_replay_1 = source\nresult = 0"
+    )
+    assert (
+        _replay_graph._inline_single_use_replay_expressions(
+            "_itool_replay_1 = source\nresult = _itool_replay_1 + _itool_replay_1"
+        )
+        == "_itool_replay_1 = source\nresult = _itool_replay_1 + _itool_replay_1"
+    )
+    assert (
+        _replay_graph._inline_single_use_replay_expressions(
+            "_itool_replay_1 = source\n"
+            "_itool_replay_1 = other\n"
+            "result = _itool_replay_1"
+        )
+        == "_itool_replay_1 = source\nresult = other"
+    )
+    assert (
+        _replay_graph._inline_single_use_replay_expressions(
+            "_itool_replay_1 = source\nsource = other\nresult = _itool_replay_1"
+        )
+        == "_itool_replay_1 = source\nsource = other\nresult = _itool_replay_1"
+    )
+    assert (
+        _replay_graph._inline_single_use_replay_expressions(
+            "_itool_replay_1 = source.method()\nresult = _itool_replay_1"
+        )
+        == "_itool_replay_1 = source.method()\nresult = _itool_replay_1"
+    )
+
+    assert (
+        _replay_graph._compact_replay_temp_names(
+            "_itool_replay_4 = data\n_itool_replay_8 = _itool_replay_4 + 1"
+        )
+        == "_itool_replay_0 = data\n_itool_replay_1 = _itool_replay_0 + 1"
+    )
+    assert (
+        _replay_graph._compact_replay_temp_names(
+            "_itool_replay_0 = 'reserved'\n"
+            "_itool_replay_4 = data\n"
+            "result = _itool_replay_4"
+        )
+        == "_itool_replay_0 = 'reserved'\n"
+        "_itool_replay_1 = data\n"
+        "result = _itool_replay_1"
+    )
+
+
+def test_replay_graph_emit_reports_script_rewrite_syntax_errors(monkeypatch) -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    graph = _replay_graph.ReplayGraph(display=True)
+    source_key = graph.add_node(
+        "source",
+        "file_load",
+        payload={"active_name": "loaded", "load_code": "loaded = data"},
+    )
+    graph.output_key = graph.add_node(
+        "script",
+        "script",
+        parents=(source_key,),
+        payload={
+            "codes": ("result = data_0",),
+            "active_name": "result",
+            "bindings": (("data_0", source_key),),
+        },
+    )
+
+    original_replace = prov._replace_code_identifiers
+
+    def _raise_on_input_replacement(
+        code: str, replacements: typing.Mapping[str, str]
+    ) -> str:
+        if "data_0" in replacements:
+            raise SyntaxError("bad script input")
+        return original_replace(code, replacements)
+
+    monkeypatch.setattr(prov, "_replace_code_identifiers", _raise_on_input_replacement)
+    with pytest.raises(_replay_graph.ReplayGraphError, match="Script replay code"):
+        _replay_graph.emit_replay_code(graph)
+
+    graph = _replay_graph.ReplayGraph(display=True)
+    graph.output_key = graph.add_node(
+        "script",
+        "script",
+        payload={
+            "codes": ("bad =",),
+            "active_name": "derived",
+            "bindings": (),
+        },
+    )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="Script replay code"):
+        _replay_graph.emit_replay_code(graph, output_name="result")
+
+
 def test_replay_graph_display_promotes_ui_style_script_input_names(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -1,5 +1,6 @@
 import ast
 import pathlib
+import re
 import types
 import typing
 
@@ -11,7 +12,9 @@ import erlab
 from erlab.interactive.imagetool import _replay_graph
 
 
-def _exec_generated_code(code: str) -> dict[str, typing.Any]:
+def _exec_generated_code(
+    code: str, namespace_items: dict[str, typing.Any] | None = None
+) -> dict[str, typing.Any]:
     namespace: dict[str, typing.Any] = {
         "erlab": erlab,
         "era": erlab.analysis,
@@ -20,6 +23,8 @@ def _exec_generated_code(code: str) -> dict[str, typing.Any]:
         "xr": xr,
         "xarray": xr,
     }
+    if namespace_items is not None:
+        namespace.update(namespace_items)
     exec(code, namespace, namespace)  # noqa: S102
     return namespace
 
@@ -77,6 +82,14 @@ def _polarization_source(path: pathlib.Path) -> xr.DataArray:
     )
     source.to_netcdf(path)
     return source
+
+
+def _assert_dense_replay_temps(code: str) -> None:
+    temp_ids = sorted(
+        {int(value) for value in re.findall(r"_itool_replay_(\d+)", code)}
+    )
+    if temp_ids:
+        assert temp_ids == list(range(temp_ids[-1] + 1))
 
 
 def test_replay_graph_low_level_validation_helpers() -> None:
@@ -423,16 +436,35 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
 
 
 def test_replay_graph_operation_code_error_edges() -> None:
-    prov = erlab.interactive.imagetool.provenance
+    class MissingReplayOperation:
+        pass
+
+    class MissingExpressionOperation:
+        def replay_code(
+            self,
+            input_name: str,
+            *,
+            output_name: str | None = None,
+            source_name: str | None = None,
+        ) -> str:
+            raise NotImplementedError
 
     class Operation:
         def __init__(self, code: str | None) -> None:
             self._code = code
 
-        def derivation_entry(self) -> prov.DerivationEntry:
-            return prov.DerivationEntry("Operation", self._code, True)
+        def replay_code(
+            self,
+            input_name: str,
+            *,
+            output_name: str | None = None,
+            source_name: str | None = None,
+        ) -> str | None:
+            return self._code
 
     for operation, message in (
+        (MissingReplayOperation(), "does not provide"),
+        (MissingExpressionOperation(), "does not provide"),
         (Operation(None), "does not provide"),
         (Operation("derived ="), "not valid Python"),
         (Operation("other = data"), "does not assign"),
@@ -443,6 +475,30 @@ def test_replay_graph_operation_code_error_edges() -> None:
                 active_name="derived",
                 context_name="data",
             )
+
+
+def test_replay_graph_operation_code_uses_parameterized_names() -> None:
+    class Operation:
+        def replay_code(
+            self,
+            input_name: str,
+            *,
+            output_name: str | None = None,
+            source_name: str | None = None,
+        ) -> str:
+            assert input_name == "parent_data"
+            assert output_name == "active_data"
+            assert source_name == "source_data"
+            return f"{output_name} = {input_name} + {source_name}"
+
+    code = _replay_graph._operation_replay_code(
+        Operation(),
+        active_name="active_data",
+        context_name="source_data",
+        parent_name="parent_data",
+    )
+
+    assert code == "active_data = parent_data + source_data"
 
 
 def test_replay_graph_emits_shared_file_and_operation_prefix(
@@ -738,6 +794,320 @@ def test_replay_graph_shares_structured_console_alias_prefixes(
     expected = source.qsel.mean("k") - source.qsel.mean("k")
     xr.testing.assert_identical(_exec_generated_code(code)["derived"], expected)
     xr.testing.assert_identical(_replay_graph.execute_replay_graph(graph), expected)
+
+
+def test_replay_graph_display_normalizes_nested_derived_console_code(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "cd_map.nc"
+    source = xr.DataArray(
+        np.arange(2 * 6 * 10, dtype=float).reshape(2, 6, 10) + 1.0,
+        dims=("polarization", "alpha", "eV"),
+        coords={
+            "polarization": [-1, 1],
+            "alpha": np.linspace(-1.0, 1.0, 6),
+            "eV": np.linspace(-0.5, 0.5, 10),
+            "mesh_current": (
+                ("alpha", "eV"),
+                np.linspace(1.0, 2.0, 60).reshape(6, 10),
+            ),
+        },
+    )
+    source.to_netcdf(path)
+    processed = prov.compose_full_provenance(
+        _file_spec(path),
+        prov.public_data(
+            prov.DivideByCoordOperation(coord_name="mesh_current"),
+            prov.CoarsenOperation(
+                dim={"alpha": 3, "eV": 5},
+                boundary="trim",
+                side="left",
+                coord_func="mean",
+                reducer="mean",
+            ),
+        ),
+    )
+    assert processed is not None
+
+    rc = prov.script(
+        prov.SelOperation(kwargs={"polarization": -1}),
+        start_label="Run ImageTool manager console code",
+        seed_code="rc = data_0",
+        active_name="rc",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Processed map",
+                provenance_spec=processed,
+            ),
+        ),
+    )
+    lc = prov.script(
+        prov.SelOperation(kwargs={"polarization": 1}),
+        start_label="Run ImageTool manager console code",
+        seed_code="lc = data_0",
+        active_name="lc",
+        script_inputs=(
+            prov.ScriptInput(
+                name="data_0",
+                label="Processed map",
+                provenance_spec=processed,
+            ),
+        ),
+    )
+    diff = prov.script(
+        prov.ScriptCodeOperation(
+            label="Evaluate console expression",
+            code="derived = rc - lc",
+        ),
+        start_label="Run ImageTool manager console code",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="rc", label="console variable 'rc'", provenance_spec=rc
+            ),
+            prov.ScriptInput(
+                name="lc", label="console variable 'lc'", provenance_spec=lc
+            ),
+        ),
+    )
+    total = prov.script(
+        prov.ScriptCodeOperation(
+            label="Evaluate console expression",
+            code="derived = rc + lc",
+        ),
+        start_label="Run ImageTool manager console code",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(
+                name="rc", label="console variable 'rc'", provenance_spec=rc
+            ),
+            prov.ScriptInput(
+                name="lc", label="console variable 'lc'", provenance_spec=lc
+            ),
+        ),
+    )
+    ncd = prov.script(
+        prov.ScriptCodeOperation(
+            label="Evaluate console expression",
+            code="ncd = data_1 / data_2",
+        ),
+        start_label="Run ImageTool manager console code",
+        active_name="ncd",
+        script_inputs=(
+            prov.ScriptInput(name="data_1", label="ImageTool 1", provenance_spec=diff),
+            prov.ScriptInput(name="data_2", label="ImageTool 2", provenance_spec=total),
+        ),
+    )
+
+    code = typing.cast("str", ncd.display_code())
+    namespace = _exec_generated_code(code)
+    processed_data = (
+        (source / source.mesh_current).coarsen(alpha=3, eV=5, boundary="trim").mean()
+    )
+    expected = (
+        processed_data.sel(polarization=-1) - processed_data.sel(polarization=1)
+    ) / (processed_data.sel(polarization=-1) + processed_data.sel(polarization=1))
+
+    assert code.count("xr.load_dataarray") == 1
+    assert "restore_nonuniform_dims" not in code
+    assert len(re.findall(r"^rc =", code, flags=re.MULTILINE)) == 1
+    assert len(re.findall(r"^lc =", code, flags=re.MULTILINE)) == 1
+    assert "data_1 =" not in code
+    assert "data_2 =" not in code
+    assert "derived" not in code
+    assert "ncd = (rc - lc) / (rc + lc)" in code
+    _assert_dense_replay_temps(code)
+    xr.testing.assert_identical(namespace["ncd"], expected)
+
+
+def test_replay_graph_display_promotes_ui_style_script_input_names(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "scan.nc"
+    source = _polarization_source(path)
+    left = prov.compose_full_provenance(
+        _file_spec(path),
+        prov.full_data(prov.SelOperation(kwargs={"pol": "LH"})),
+    )
+    right = prov.compose_full_provenance(
+        _file_spec(path),
+        prov.full_data(prov.SelOperation(kwargs={"pol": "LV"})),
+    )
+    assert left is not None
+    assert right is not None
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Concatenate selected inputs",
+            code="combined = xr.concat([left, right], dim='pol')",
+        ),
+        start_label="Run ImageTool manager UI action",
+        active_name="combined",
+        script_inputs=(
+            prov.ScriptInput(name="left", label="Selected left", provenance_spec=left),
+            prov.ScriptInput(
+                name="right", label="Selected right", provenance_spec=right
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.display_code())
+    namespace = _exec_generated_code(code)
+
+    assert code.count("xr.load_dataarray") == 1
+    assert "data_0 =" not in code
+    assert "data_1 =" not in code
+    assert len(re.findall(r"^left =", code, flags=re.MULTILINE)) == 1
+    assert len(re.findall(r"^right =", code, flags=re.MULTILINE)) == 1
+    assert "combined = xr.concat([left, right], dim='pol')" in code
+    _assert_dense_replay_temps(code)
+    xr.testing.assert_identical(
+        namespace["combined"],
+        xr.concat(
+            [source.sel(pol="LH"), source.sel(pol="LV")],
+            dim="pol",
+        ),
+    )
+
+
+def test_replay_graph_display_uses_watched_roots_as_raw_inputs() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    rc_data = xr.DataArray(np.arange(3.0), dims=("x",))
+    lc_data = xr.DataArray(np.arange(3.0) + 10.0, dims=("x",))
+    rc = prov.script(
+        start_label="Start from watched variable 'rc'",
+        seed_code="derived = rc",
+        active_name="derived",
+    )
+    lc = prov.script(
+        start_label="Start from watched variable 'lc'",
+        seed_code="derived = lc",
+        active_name="derived",
+    )
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Subtract selected inputs",
+            code="derived = data_0 - data_1",
+        ),
+        start_label="Run ImageTool manager action",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="ImageTool 0", provenance_spec=rc),
+            prov.ScriptInput(name="data_1", label="ImageTool 1", provenance_spec=lc),
+        ),
+    )
+
+    code = typing.cast("str", spec.display_code())
+    namespace = _exec_generated_code(code, {"rc": rc_data, "lc": lc_data})
+
+    assert code == "derived = rc - lc"
+    xr.testing.assert_identical(namespace["derived"], rc_data - lc_data)
+
+
+def test_replay_graph_display_keeps_helpers_from_raw_seed_inputs() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    raw_data = xr.DataArray(np.arange(1.0, 4.0), dims=("x",))
+    root = prov.script(
+        start_label="Start from watched variable 'raw'",
+        seed_code="def normalize():\n    return raw / raw.max()\nderived = normalize()",
+        active_name="derived",
+    )
+    spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Average normalized input",
+            code="result = data_0.mean()",
+        ),
+        start_label="Run ImageTool manager action",
+        active_name="result",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="ImageTool 0", provenance_spec=root),
+        ),
+    )
+
+    code = typing.cast("str", spec.display_code())
+    namespace = _exec_generated_code(code, {"raw": raw_data})
+
+    assert "def normalize():" in code
+    assert "raw / raw.max()" in code
+    xr.testing.assert_identical(namespace["result"], (raw_data / raw_data.max()).mean())
+
+
+def test_replay_graph_display_hides_internal_source_view_restore_only(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "nonuniform.nc"
+    source = xr.DataArray(
+        np.arange(6.0).reshape(3, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 0.2, 1.0], "y": [0.0, 1.0]},
+    )
+    source.to_netcdf(path)
+    public_spec = prov.compose_full_provenance(
+        _file_spec(path),
+        prov.public_data(prov.SelOperation(kwargs={"x": 0.2})),
+    )
+    assert public_spec is not None
+    script_input = prov.ScriptInput(
+        name="selected",
+        label="Selected nonuniform data",
+        provenance_spec=public_spec,
+    )
+
+    replay_code = _replay_graph.script_inputs_code((script_input,), display=False)
+    display_code = _replay_graph.script_inputs_code((script_input,), display=True)
+
+    assert "restore_nonuniform_dims" in replay_code
+    assert "restore_nonuniform_dims" not in display_code
+    xr.testing.assert_identical(
+        _exec_generated_code(display_code)["selected"],
+        source.sel(x=0.2),
+    )
+
+
+def test_replay_graph_display_keeps_bindings_for_scoped_or_rebound_inputs(
+    tmp_path: pathlib.Path,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    path = tmp_path / "scan.nc"
+    source = xr.DataArray(np.arange(3.0), dims=("x",))
+    source.to_netcdf(path)
+    script_input = prov.ScriptInput(
+        name="data_0",
+        label="ImageTool 0",
+        provenance_spec=_file_spec(path),
+    )
+    helper_spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Use helper",
+            code="def offset():\n    return data_0 + 1\nresult = offset()",
+        ),
+        start_label="Run script",
+        active_name="result",
+        script_inputs=(script_input,),
+    )
+    rebound_spec = prov.script(
+        prov.ScriptCodeOperation(
+            label="Rebind input",
+            code="data_0 = data_0 + 1\nresult = data_0 * 2",
+        ),
+        start_label="Run script",
+        active_name="result",
+        script_inputs=(script_input,),
+    )
+
+    helper_code = typing.cast("str", helper_spec.display_code())
+    rebound_code = typing.cast("str", rebound_spec.display_code())
+
+    assert len(re.findall(r"^data_0 =", helper_code, flags=re.MULTILINE)) == 1
+    assert len(re.findall(r"^data_0 =", rebound_code, flags=re.MULTILINE)) == 2
+    xr.testing.assert_identical(_exec_generated_code(helper_code)["result"], source + 1)
+    xr.testing.assert_identical(
+        _exec_generated_code(rebound_code)["result"],
+        (source + 1) * 2,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -116,7 +116,7 @@ def test_dtool_smoothing_copy_code_uses_readable_steps(qtbot) -> None:
     win.sn_spin.setValue(2)
     code = win.copy_code()
     assert "\t" not in code
-    assert "for _ in range(2):\n    _processed = era.image.gaussian_filter(" in code
+    assert "for _ in range(2):\n    processed = era.image.gaussian_filter(" in code
     namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
     assert isinstance(namespace["result"], xr.DataArray)
     xr.testing.assert_identical(win.result, namespace["result"])

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -108,7 +108,7 @@ def test_goldtool(
 
         xr.testing.assert_identical(
             w.result.drop_vars("modelfit_results"),
-            namespace["modelresult"].drop_vars("modelfit_results"),
+            namespace["model_result"].drop_vars("modelfit_results"),
         )
         xr.testing.assert_identical(
             w.result.drop_vars("modelfit_results"),
@@ -233,9 +233,9 @@ def test_goldtool_copy_code_includes_separate_data_corr(qtbot, gold) -> None:
 
     code = win.current_provenance_spec().display_code()
     assert code is not None
-    assert code.startswith(
-        "corrected = era.gold.correct_with_edge(corr_data, era.gold.poly(gold_data, "
-    )
+    assert "model_result = era.gold.poly(" in code
+    assert "corrected = era.gold.correct_with_edge(corr_data, model_result)" in code
+    assert "modelresult" not in code
 
 
 def test_goldtool_roi_limits_descending_coords(qtbot, gold) -> None:

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -104,6 +104,7 @@ def test_ftool_1d_param_edit_and_state(qtbot) -> None:
     code = win.copy_code()
     assert "modelfit" in code
     assert "MultiPeakModel" in code
+    assert "fit_data" not in code
 
 
 def test_fit1d_undo_redo(qtbot, exp_decay_model) -> None:

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1169,6 +1169,27 @@ def test_fit2d_reset_params_all(qtbot, monkeypatch) -> None:
     assert all(not mapping for mapping in win._params_from_coord_full)
 
 
+def test_fit2d_full_copy_fit_data_name_with_domain_and_normalization(qtbot) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    win.domain_min_line.setValue(-0.5)
+    win.domain_max_line.setValue(0.5)
+    win.normalize_check.setChecked(True)
+
+    lines: list[str] = []
+    result_name = win._full_copy_fit_data_name("data", lines=lines)
+
+    assert result_name == "data_crop_norm"
+    assert len(lines) == 2
+    assert lines[0].startswith("data_crop = data.sel(")
+    assert ".isel(" in lines[0]
+    assert lines[1] == 'data_crop_norm = data_crop / data_crop.mean("x")'
+    assert win._full_copy_fit_data_name("data") == "data_crop_norm"
+
+
 def test_fit2d_copy_code_full_inconsistent_expr_warning(qtbot, monkeypatch) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -354,6 +354,12 @@ def test_fit2d_full_provenance_handles_spaced_fit_axis(qtbot) -> None:
     assert win.current_provenance_spec() is not None
     prelude = win._detached_full_copy_prelude(input_name="derived_crop")
     assert prelude is not None
+    assert "fit_data" not in prelude
+
+    display_code = win.current_provenance_spec().display_code()
+    assert display_code is not None
+    assert "fit_data" not in display_code
+    assert ".xlm.modelfit" in display_code
 
     namespace = {"derived_crop": data}
     exec(  # noqa: S102

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -539,13 +539,13 @@ def test_ktool_copy_code_aliases_expression_input_names(qtbot) -> None:
 
     code = win.copy_code()
 
-    assert "target = my_data.astype(np.float64)" in code
-    assert "target.kspace.set_normal(" in code
-    assert "target_kconv = target.kspace.convert(" in code
+    assert "input_data = my_data.astype(np.float64)" in code
+    assert "input_data.kspace.set_normal(" in code
+    assert "input_data_kconv = input_data.kspace.convert(" in code
     assert "astype(np.float64)_kconv" not in code
     namespace = {"my_data": data.copy(deep=True), "np": np}
     exec(code, {"__builtins__": {}, "np": np}, namespace)  # noqa: S102
-    assert "target_kconv" in namespace
+    assert "input_data_kconv" in namespace
 
 
 def test_ktool_update_rate_limited(qtbot, anglemap, monkeypatch) -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1281,7 +1281,7 @@ def test_tool_window_dynamic_expression_provenance_uses_input_provenance(qtbot) 
     assert spec.active_name == "right"
     code = spec.display_code()
     assert code is not None
-    assert "derived = watched" in code
+    assert "derived = watched" not in code
     assert "scale = 2" in code
     assert "left, right = (watched * scale, watched + 1)" in code
 


### PR DESCRIPTION
## Summary
- Centralize replay and copied-code generation on `ToolProvenanceOperation` so structured operations emit parameterized, maintainable Python instead of hardcoded `derived` snippets.
- Improve ImageTool display-filter provenance so Gaussian filtering and normalization carry through to copied code and child tools opened from filtered views.
- Add regression coverage for replay graph cleanup, operation-backed dialogs, manager child-tool provenance, and cleaner generated code across interactive tools.

## Testing
- `uv run ruff check` on the touched provenance, dialog, viewer, manager, and test files
- `uv run ruff format --check` on the touched provenance, dialog, viewer, manager, and test files
- `uv run mypy` on the touched ImageTool runtime modules
- Focused ImageTool pytest suites passed, including provenance, replay graph, manager provenance, and dialog behavior