### PR TITLE
fix(docs): define imagetool entry points anchor

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -30,7 +30,9 @@ ImageTool expects *image-like* data—usually a {class}`DataArray <xarray.DataAr
 dimension for 1D data and squeezing out dimensions of size 1 for 5D+ data. Non-uniform
 coordinates gain parallel `_idx` indices so you can still slice by position. Supported
 inputs include numpy arrays, {class}`Dataset <xarray.Dataset>`, or entire
-{class}`DataTree <xarray.DataTree>` objects. (imagetool-entry-points)=
+{class}`DataTree <xarray.DataTree>` objects.
+
+(imagetool-entry-points)=
 
 ### Entry points
 


### PR DESCRIPTION
### Motivation
- Sphinx/MyST did not recognize the `(imagetool-entry-points)` target when it shared a line with surrounding text, which caused undefined `{ref}` warnings from other docs pages linking to it.

### Description
- Move the `(imagetool-entry-points)=` label onto its own line in `docs/source/user-guide/interactive/imagetool.md` so it becomes a valid cross-reference target.

### Testing
- Ran a docs build with `uv run --directory docs sphinx-build -b dummy source _build/dummy -q`, which completed and shows that the undefined-reference warnings for `imagetool-entry-points` are resolved while unrelated environment warnings about `libGL.so.1` and blocked intersphinx fetches remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17836b4eac83259252dd5f083d3f2d)