### PR TITLE
Throttle manager details refreshes during tool info changes

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1016,6 +1016,13 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self._workspace_schema_version: int = (
             _manager_workspace._current_workspace_schema_version()
         )
+        self._pending_tool_metadata_update_uids: set[str] = set()
+        self._tool_metadata_update_timer = QtCore.QTimer(self)
+        self._tool_metadata_update_timer.setSingleShot(True)
+        self._tool_metadata_update_timer.setInterval(300)
+        self._tool_metadata_update_timer.timeout.connect(
+            self._flush_pending_tool_metadata_updates
+        )
         self._workspace_lock: QtCore.QLockFile | None = None
         self._closing_workspace_document: bool = False
         self._update_workspace_window_title()
@@ -1962,6 +1969,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
 
     def _mark_node_state_dirty(self, uid: str) -> None:
         self._mark_workspace_dirty(uid=uid, state=True)
+
+    def _mark_tool_info_dirty(self, uid: str) -> None:
+        if uid not in self._workspace_dirty_state:
+            self._mark_node_state_dirty(uid)
 
     def _mark_workspace_structure_dirty(self, reason: str) -> None:
         self._mark_workspace_dirty(structure=reason)
@@ -3509,6 +3520,18 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 )
                 self._clear_metadata()
                 self.preview_widget.setVisible(False)
+
+    def _schedule_tool_metadata_update(self, uid: str) -> None:
+        """Refresh expensive selected-tool metadata after bursty info updates settle."""
+        self._pending_tool_metadata_update_uids.add(uid)
+        self._tool_metadata_update_timer.start()
+
+    @QtCore.Slot()
+    def _flush_pending_tool_metadata_updates(self) -> None:
+        pending = self._pending_tool_metadata_update_uids
+        self._pending_tool_metadata_update_uids = set()
+        for uid in sorted(pending):
+            self._update_info(uid=uid)
 
     @QtCore.Slot()
     def _update_actions(self) -> None:

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -964,8 +964,8 @@ class _ManagedWindowNode(QtCore.QObject):
 
     @QtCore.Slot()
     def _handle_tool_info_changed(self) -> None:
-        self.manager._mark_node_state_dirty(self.uid)
-        self._refresh_node_info()
+        self.manager._mark_tool_info_dirty(self.uid)
+        self.manager._schedule_tool_metadata_update(self.uid)
 
     @QtCore.Slot()
     def _handle_imagetool_state_changed(self) -> None:

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -2,6 +2,41 @@
 from ._shared import *
 
 
+class _InfoRefreshToolState(pydantic.BaseModel):
+    value: int = 0
+
+
+class _InfoRefreshTool(erlab.interactive.utils.ToolWindow[_InfoRefreshToolState]):
+    StateModel = _InfoRefreshToolState
+    tool_name = "info-refresh"
+
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__()
+        self._data = data
+        self._status = _InfoRefreshToolState()
+        self._info_text = "initial child info"
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    @property
+    def tool_status(self) -> _InfoRefreshToolState:
+        return self._status
+
+    @tool_status.setter
+    def tool_status(self, status: _InfoRefreshToolState) -> None:
+        self._status = status
+
+    @property
+    def info_text(self) -> str:
+        return self._info_text
+
+    def emit_info_text(self, text: str) -> None:
+        self._info_text = text
+        self.sigInfoChanged.emit()
+
+
 def test_drop_mimedata(
     qtbot,
     accept_dialog,
@@ -266,6 +301,113 @@ def test_childtool_remove_after_tree_clear(
         qtbot.wait_until(
             lambda: uid not in manager._imagetool_wrappers[0]._childtools, timeout=5000
         )
+
+
+def test_childtool_info_changed_debounces_manager_details_refresh(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        test_data.qshow(manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        tool = _InfoRefreshTool(test_data)
+        uid = manager.add_childtool(tool, 0, show=False)
+        qtbot.wait_until(
+            lambda: uid in manager._imagetool_wrappers[0]._childtool_indices,
+            timeout=5000,
+        )
+        selection_model = manager.tree_view.selectionModel()
+        selection_model.clearSelection()
+        select_child_tool(manager, uid)
+
+        metadata_updates: list[str] = []
+        original_set_metadata_node = manager._set_metadata_node
+
+        def _record_metadata_rebuild(node) -> None:
+            metadata_updates.append(node.uid)
+            original_set_metadata_node(node)
+
+        monkeypatch.setattr(manager, "_set_metadata_node", _record_metadata_rebuild)
+        manager._tool_metadata_update_timer.setInterval(1)
+
+        tool.emit_info_text("updated child info")
+        tool.emit_info_text("updated child info again")
+        tool.emit_info_text("updated child info final")
+
+        assert "updated child info" not in manager.text_box.toPlainText()
+        assert metadata_updates == []
+        qtbot.wait_until(lambda: metadata_updates == [uid], timeout=1000)
+        assert "updated child info final" in manager.text_box.toPlainText()
+
+
+def test_childtool_info_changed_for_unselected_node_keeps_visible_details(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        test_data.qshow(manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        tool = _InfoRefreshTool(test_data)
+        uid = manager.add_childtool(tool, 0, show=False)
+        qtbot.wait_until(
+            lambda: uid in manager._imagetool_wrappers[0]._childtool_indices,
+            timeout=5000,
+        )
+        selection_model = manager.tree_view.selectionModel()
+        selection_model.clearSelection()
+        select_tools(manager, [0])
+        manager._update_info()
+        visible_html = manager.text_box.toHtml()
+        manager._tool_metadata_update_timer.setInterval(1)
+
+        tool.emit_info_text("updated child info")
+        qtbot.wait_until(
+            lambda: not manager._tool_metadata_update_timer.isActive(), timeout=1000
+        )
+
+        assert manager.text_box.toHtml() == visible_html
+        assert "updated child info" not in manager.text_box.toPlainText()
+
+
+def test_childtool_repeated_info_changes_mark_state_dirty_once(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        test_data.qshow(manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        tool = _InfoRefreshTool(test_data)
+        uid = manager.add_childtool(tool, 0, show=False)
+        qtbot.wait_until(
+            lambda: uid in manager._imagetool_wrappers[0]._childtool_indices,
+            timeout=5000,
+        )
+        manager._mark_workspace_clean()
+
+        tool.emit_info_text("first")
+        tool.emit_info_text("second")
+        tool.emit_info_text("third")
+
+        assert manager._workspace_dirty_state == {uid}
+        assert [
+            event for event in manager._workspace_dirty_events if event.uid == uid
+        ] == [manager._workspace_dirty_events[-1]]
 
 
 def test_remove_imagetool_removes_childtools() -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1667,6 +1667,12 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
         def _mark_node_state_dirty(self, _uid: str) -> None:
             return
 
+        def _mark_tool_info_dirty(self, uid: str) -> None:
+            self._mark_node_state_dirty(uid)
+
+        def _schedule_tool_metadata_update(self, uid: str) -> None:
+            self._update_info(uid=uid)
+
         def _mark_node_data_dirty(self, _uid: str) -> None:
             return
 
@@ -1875,6 +1881,12 @@ def test_managed_tool_window_node_detached_update_branches(
         def _mark_node_state_dirty(self, _uid: str) -> None:
             return
 
+        def _mark_tool_info_dirty(self, uid: str) -> None:
+            self._mark_node_state_dirty(uid)
+
+        def _schedule_tool_metadata_update(self, uid: str) -> None:
+            self._update_info(uid=uid)
+
         def _mark_node_data_dirty(self, _uid: str) -> None:
             return
 
@@ -2067,6 +2079,12 @@ def test_imagetool_wrapper_item_model_child_edge_branches(qtbot, monkeypatch) ->
 
         def _mark_node_state_dirty(self, _uid: str) -> None:
             return
+
+        def _mark_tool_info_dirty(self, uid: str) -> None:
+            self._mark_node_state_dirty(uid)
+
+        def _schedule_tool_metadata_update(self, uid: str) -> None:
+            self._update_info(uid=uid)
 
     manager = _FakeManager()
     qtbot.addWidget(manager)


### PR DESCRIPTION
## Summary
- Debounce expensive manager-side details refreshes for bursty `sigInfoChanged` updates from child tools.
- Keep the info path lightweight by deferring the full metadata/provenance rebuild until the signal stream settles.
- Avoid repeated dirty-event churn for a node that is already marked dirty.

## Testing
- Added manager tests covering debounced details refreshes, stale-selection behavior, and repeated dirty-state updates.
- Ran Ruff check/format, MyPy on the touched manager modules, and the focused manager pytest subset successfully.