### PR TITLE
Preserve accepted filter provenance across ImageTool workflows

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -345,16 +345,16 @@ script or notebook for reproducibility.
   your data exposes an `eV` axis, ImageTool can import a previously fitted edge via
   {func}`xarray_lmfit.load_fit` and shift the spectrum accordingly.
 - {guilabel}`View → Normalize` opens the {guilabel}`Normalize` dialog, which applies a
-  non-destructive filter that supports area normalization, min-max scaling, and baseline
+  reversible filter that supports area normalization, min-max scaling, and baseline
   subtraction.
 - {guilabel}`View → Gaussian Filter` opens the {guilabel}`Gaussian Filter` dialog, which
-  applies a non-destructive filter that applies coordinate-aware Gaussian broadening
-  along selected dimensions.
+  applies a reversible coordinate-aware Gaussian broadening filter along selected
+  dimensions.
 
 Use {guilabel}`Edit → Undo` and {guilabel}`Edit → Redo` to walk changes back, and
-{guilabel}`View → Reset` to remove any currently applied filter function. ImageTool also
-keeps track of additional tool windows opened from the context menus, so everything is
-closed cleanly when the main window exits.
+{guilabel}`View → Reset` to remove any currently applied filter. Reopening the dialog
+for the active filter starts from the current filter settings and replaces that active
+filter when accepted.
 
 (imagetool-roi)=
 

--- a/src/erlab/interactive/imagetool/_history.py
+++ b/src/erlab/interactive/imagetool/_history.py
@@ -557,6 +557,21 @@ def _describe_state_change_rows(
         details.append(_detail_note("Axis inversion changed"))
         _consume(changes, "axis_inversions", prefixes=("axis_inversions",))
 
+    if any(
+        path == "filter_operation" or path.startswith("filter_operation.")
+        for path in changes
+    ):
+        old_filter = prev.get("filter_operation", _MISSING)
+        new_filter = curr.get("filter_operation", _MISSING)
+        if new_filter is _MISSING or new_filter is None:
+            summaries.append("Filter cleared")
+        elif old_filter is _MISSING or old_filter is None:
+            summaries.append("Filter applied")
+        else:
+            summaries.append("Filter changed")
+        details.append(_detail_note("Filter operation changed"))
+        _consume(changes, "filter_operation", prefixes=("filter_operation",))
+
     if "plotitem_states" in changes:
         plot_summaries, plot_details = _plot_state_changes(
             prev_flat.get("plotitem_states", []), curr_flat.get("plotitem_states", [])

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -190,14 +190,13 @@ class BaseImageTool(QtWidgets.QMainWindow):
         self.set_provenance_spec(provenance_spec)
 
     def to_dataset(self) -> xr.Dataset:
-        name = self.slicer_area._data.name
+        data, state = self.slicer_area.persistence_data_and_state()
+        name = data.name
         if name is None:
             name = ""
-        ds = self.slicer_area._data.to_dataset(
-            name=_ITOOL_DATA_NAME, promote_attrs=False
-        )
+        ds = data.to_dataset(name=_ITOOL_DATA_NAME, promote_attrs=False)
         attrs = {
-            "itool_state": json.dumps(self.slicer_area.state),
+            "itool_state": json.dumps(state),
             "itool_title": self.windowTitle(),
             "itool_name": str(name),
             "itool_rect": self.geometry().getRect(),
@@ -299,8 +298,9 @@ class BaseImageTool(QtWidgets.QMainWindow):
             The duplicated ImageTool window.
 
         """
-        kwargs["state"] = self.slicer_area.state.copy()
-        new_tool = self.__class__(self.slicer_area._data.copy(deep=False), **kwargs)
+        data, state = self.slicer_area.persistence_data_and_state()
+        kwargs["state"] = state
+        new_tool = self.__class__(data.copy(deep=False), **kwargs)
         new_tool.set_provenance_spec(self.provenance_spec)
         new_tool.setGeometry(self.geometry())
         return new_tool
@@ -544,7 +544,8 @@ class ImageTool(BaseImageTool):
 
     @QtCore.Slot()
     def _export_file(self, *, native: bool = True) -> None:
-        if self.slicer_area._data is None:
+        data = self.slicer_area.displayed_data
+        if data is None:
             raise ValueError("Data is Empty!")
         dialog = QtWidgets.QFileDialog(self)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptMode.AcceptSave)
@@ -590,13 +591,13 @@ class ImageTool(BaseImageTool):
         }
 
         dialog.setNameFilters(valid_savers.keys())
-        dialog.setDirectory(f"{self.slicer_area._data.name}.h5")
+        dialog.setDirectory(f"{data.name}.h5")
         # dialog.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog)
         if dialog.exec():
             files = dialog.selectedFiles()
             fn, kargs = valid_savers[dialog.selectedNameFilter()]
             with erlab.interactive.utils.wait_dialog(self, "Saving..."):
-                fn(self.slicer_area._data, files[0], **kargs)
+                fn(data, files[0], **kargs)
 
 
 class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
@@ -870,9 +871,7 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     @QtCore.Slot()
     def _view_menu_visibility(self) -> None:
         self.slicer_area.refresh_actions_enabled()
-        self.action_dict["resetAct"].setEnabled(
-            self.slicer_area._applied_func is not None
-        )
+        self.action_dict["resetAct"].setEnabled(self.slicer_area.has_active_filter)
         self._populate_invert_axis_menu()
 
     @QtCore.Slot()
@@ -986,7 +985,13 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
 
     @QtCore.Slot()
     def _reset_filters(self) -> None:
-        self.slicer_area.apply_func(None)
+        self.slicer_area.record_history_mutation(
+            None,
+            lambda: self.slicer_area.apply_filter_operation(
+                None,
+                emit_edited=True,
+            ),
+        )
 
     @QtCore.Slot()
     def _copy_cursor_val(self) -> None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -362,16 +362,18 @@ class DataTransformDialog(_DataManipulationDialog):
         if manager is None:
             return False
         node = manager._node_for_target(target)
-        if node.source_spec is not None:
+        source_spec = node.displayed_source_spec
+        if source_spec is not None:
             node.set_source_binding(
-                self._compose_replace_source_spec(node.source_spec, new_name),
+                self._compose_replace_source_spec(source_spec, new_name),
                 auto_update=node.source_auto_update,
                 state=node.source_state,
             )
             return True
-        if node.provenance_spec is not None:
+        displayed_provenance = node.displayed_provenance_spec
+        if displayed_provenance is not None:
             node.set_detached_provenance(
-                self._compose_replace_source_spec(node.provenance_spec, new_name)
+                self._compose_replace_source_spec(displayed_provenance, new_name)
             )
             return True
         if fallback_spec is not None:
@@ -452,12 +454,7 @@ class DataTransformDialog(_DataManipulationDialog):
         else:
             new_name = self.suffix.lstrip("_")
 
-        applied_func = self.slicer_area._applied_func
         try:
-            if applied_func is not None:
-                # Transform must be done on unfiltered data
-                self.slicer_area.apply_func(None)
-
             if self.apply_on_nonuniform_data:
                 processed = self.process_data(
                     erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -472,10 +469,12 @@ class DataTransformDialog(_DataManipulationDialog):
             processed = processed.rename(new_name)
             manager, target = self._manager_target()
             source_spec = self.source_spec(new_name)
-            parent_provenance = self.slicer_area.provenance_spec
+            parent_provenance = self.slicer_area.displayed_provenance_spec()
             if manager is not None and target is not None:
                 with contextlib.suppress(Exception):
-                    parent_provenance = manager._node_for_target(target).provenance_spec
+                    parent_provenance = manager._node_for_target(
+                        target
+                    ).displayed_provenance_spec
             nested_provenance_spec = (
                 erlab.interactive.imagetool.provenance.compose_full_provenance(
                     parent_provenance,
@@ -545,9 +544,6 @@ class DataTransformDialog(_DataManipulationDialog):
                 self, "Error", "An error occurred while processing data."
             )
             return
-        finally:
-            if applied_func is not None:
-                self.slicer_area.apply_func(applied_func)
 
         super().accept()
 
@@ -561,11 +557,8 @@ class DataFilterDialog(_DataManipulationDialog):
 
     - Override method `setup_widgets` to add widgets to the dialog.
 
-    - Override method `process_data` to implement the filter. The output must be a new
-      DataArray with the same shape as the input.
-
     - Override `filter_operation` to generate operation-backed copy code and provenance
-      for the displayed filtered data.
+      for the displayed filtered data. Accepted filters must be operation-backed.
 
     - Override attribute `title` to set the title of the dialog window.
 
@@ -581,6 +574,10 @@ class DataFilterDialog(_DataManipulationDialog):
     def __init__(self, slicer_area: ImageSlicerArea) -> None:
         super().__init__(slicer_area)
         self._previewed: bool = False
+        self._starting_applied_func = self.slicer_area._applied_func
+        self._starting_filter_operation = (
+            self.slicer_area._accepted_filter_provenance_operation
+        )
 
         if self.enable_preview:
             self.preview_button = QtWidgets.QPushButton("Preview")
@@ -588,27 +585,87 @@ class DataFilterDialog(_DataManipulationDialog):
             self.buttonBox.addButton(
                 self.preview_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole
             )
+        self._restore_current_filter_operation()
+
+    def _restore_current_filter_operation(self) -> None:
+        operation = self.slicer_area._accepted_filter_provenance_operation
+        if operation is not None:
+            self.restore_filter_operation(operation)
+
+    def restore_filter_operation(
+        self,
+        operation: erlab.interactive.imagetool.provenance.ToolProvenanceOperation,
+    ) -> None:
+        """Restore widgets from an active filter operation when supported."""
+        del operation
+
+    def _uses_process_only_filter(self) -> bool:
+        return (
+            type(self).filter_operation is DataFilterDialog.filter_operation
+            and type(self).process_data is not _DataManipulationDialog.process_data
+        )
+
+    def _apply_current_filter(
+        self,
+        *,
+        update: bool = True,
+        emit_edited: bool = False,
+        preview: bool = False,
+    ) -> None:
+        operation = self.filter_operation()
+        if operation is not None:
+            self.slicer_area.apply_filter_operation(
+                operation,
+                update=update,
+                emit_edited=emit_edited,
+                preview=preview,
+            )
+            return
+        if self._uses_process_only_filter():
+            raise NotImplementedError(
+                "DataFilterDialog subclasses must implement filter_operation() "
+                "to apply accepted filters."
+            )
+        self.slicer_area.apply_filter_operation(
+            None,
+            update=update,
+            emit_edited=emit_edited,
+            preview=preview,
+        )
 
     @QtCore.Slot()
     def _preview(self):
         self._previewed = True
-        self.slicer_area.apply_func(
-            self.process_data,
-            operation=self.filter_operation(),
-        )
+        self._apply_current_filter(preview=True)
 
     @QtCore.Slot()
     def reject(self) -> None:
         if self._previewed:
-            self.slicer_area.apply_func(None)
+            if self._starting_filter_operation is not None:
+                self.slicer_area.apply_filter_operation(
+                    self._starting_filter_operation,
+                    preview=True,
+                )
+            else:
+                self.slicer_area.apply_func(
+                    self._starting_applied_func,
+                    preview=True,
+                )
         super().reject()
 
     @QtCore.Slot()
     def accept(self) -> None:
         try:
-            self.slicer_area.apply_func(
-                self.process_data,
-                operation=self.filter_operation(),
+            operation = self.filter_operation()
+            emit_edited = (
+                operation is not None
+                or self._starting_filter_operation is not None
+                or self._starting_applied_func is not None
+                or self.slicer_area.has_active_filter
+            )
+            self.slicer_area.record_history_mutation(
+                None,
+                lambda: self._apply_current_filter(emit_edited=emit_edited),
             )
         except Exception:
             erlab.interactive.utils.MessageDialog.critical(
@@ -2224,6 +2281,22 @@ class NormalizeDialog(DataFilterDialog):
             denominator_rtol=self.denominator_rtol,
         )
 
+    def restore_filter_operation(
+        self,
+        operation: erlab.interactive.imagetool.provenance.ToolProvenanceOperation,
+    ) -> None:
+        if not isinstance(
+            operation, erlab.interactive.imagetool.provenance.NormalizeOperation
+        ):
+            return
+        for check in self.dim_checks.values():
+            check.setChecked(False)
+        for dim in operation.dims:
+            if dim in self.dim_checks:
+                self.dim_checks[dim].setChecked(True)
+        self.opts[self._MODES.index(operation.mode)].setChecked(True)
+        self.denominator_rtol = operation.denominator_rtol
+
 
 class DivideByCoordDialog(DataTransformDialog):
     title = "Divide by Coordinate"
@@ -2520,6 +2593,23 @@ class GaussianFilterDialog(DataFilterDialog):
         return erlab.interactive.imagetool.provenance.GaussianFilterOperation(
             sigma=sigma_values
         )
+
+    def restore_filter_operation(
+        self,
+        operation: erlab.interactive.imagetool.provenance.ToolProvenanceOperation,
+    ) -> None:
+        if not isinstance(
+            operation, erlab.interactive.imagetool.provenance.GaussianFilterOperation
+        ):
+            return
+        for check in self.dim_checks.values():
+            check.setChecked(False)
+        for dim, sigma in operation.sigma.items():
+            if dim not in self.dim_checks or not self.dim_checks[dim].isEnabled():
+                continue
+            self.dim_checks[dim].setChecked(True)
+            self._set_synced_exact_value(self.sigma_spins[dim], float(sigma))
+            self._sync_from_sigma(dim)
 
 
 class SwapDimsDialog(DataTransformDialog):

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -1149,8 +1149,8 @@ class ToolNamespace(_ConsoleDataHandleMixin):
     ``tools[idx].children[j]`` accesses a child ImageTool in manager tree order. The
     handle delegates DataArray attributes, methods, operators, and supported ERLab
     calls to the underlying array while preserving provenance for derived results.
-    ``.data`` remains exact raw :class:`xarray.DataArray` access for compatibility and
-    is not provenance-aware.
+    ``.data`` remains exact current :class:`xarray.DataArray` access for compatibility
+    and is not provenance-aware.
 
     Examples
     --------
@@ -1158,7 +1158,7 @@ class ToolNamespace(_ConsoleDataHandleMixin):
 
       >>> tools[0] - tools[1]
 
-    - Access the raw underlying DataArray of an ImageTool:
+    - Access the current DataArray of an ImageTool:
 
       >>> tools[1].data
 
@@ -1190,8 +1190,8 @@ class ToolNamespace(_ConsoleDataHandleMixin):
 
     @property
     def data(self) -> xr.DataArray:
-        """Raw :class:`xarray.DataArray` displayed by the ImageTool."""
-        return self.tool.slicer_area._data
+        """Current :class:`xarray.DataArray` displayed by the ImageTool."""
+        return self.tool.slicer_area.displayed_data
 
     @data.setter
     def data(self, value: xr.DataArray | _ConsoleDataHandleMixin) -> None:
@@ -1215,11 +1215,33 @@ class ToolNamespace(_ConsoleDataHandleMixin):
 
     def _get_data_item(self, key):
         """Return a subset of the tool data."""
-        return self.tool.slicer_area._data[key]
+        return self.tool.slicer_area.displayed_data[key]
 
-    def _set_data_item(self, key, value) -> None:
+    def _prepare_data_item_assignment(self, key, value) -> xr.DataArray | None:
+        """Validate a console item assignment before changing provenance."""
+        value = _unwrap_console_value(value)
+        slicer_area = self.tool.slicer_area
+        if not slicer_area.has_active_filter:
+            return None
+        data = slicer_area.displayed_data.copy(deep=True)
+        data[key] = value
+        return data
+
+    def _set_data_item(
+        self,
+        key,
+        value,
+        *,
+        prepared_data: xr.DataArray | None = None,
+        emit_signals: bool = True,
+    ) -> None:
         """Safely mutate a subset of the tool data from the console."""
-        self.tool.slicer_area._set_source_item(key, _unwrap_console_value(value))
+        value = _unwrap_console_value(value)
+        slicer_area = self.tool.slicer_area
+        if prepared_data is not None:
+            slicer_area.replace_source_data(prepared_data, emit_edited=emit_signals)
+            return
+        slicer_area._set_source_item(key, value, emit_signals=emit_signals)
 
     @property
     def _console_tools(self) -> ToolsNamespace | None:
@@ -1251,9 +1273,10 @@ class ToolNamespace(_ConsoleDataHandleMixin):
         label = self._console_label
         if self._wrapper.name:
             label += f": {self._wrapper.name}"
+        wrapper_provenance = self._wrapper.displayed_provenance_spec
         provenance_spec = (
-            self._wrapper.provenance_spec.model_dump(mode="json")
-            if self._wrapper.provenance_spec is not None
+            wrapper_provenance.model_dump(mode="json")
+            if wrapper_provenance is not None
             else None
         )
         return erlab.interactive.imagetool.provenance.ScriptInput(
@@ -1274,7 +1297,7 @@ class ToolNamespace(_ConsoleDataHandleMixin):
     def _console_provenance_spec(
         self, *, active_name: str, label: str
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
-        return self._wrapper.provenance_spec
+        return self._wrapper.displayed_provenance_spec
 
     def __setitem__(self, key: typing.Any, value: typing.Any) -> None:
         key_operand = _operand_from_value(key)
@@ -1283,9 +1306,15 @@ class ToolNamespace(_ConsoleDataHandleMixin):
         script_inputs, copyable, code_prelude = _merge_operands(
             self_operand, key_operand, value_operand
         )
+        target_name = self._console_input_name
         code = _script_code(
             code_prelude,
-            f"{self_operand.code}[{key_operand.code}] = {value_operand.code}",
+            "\n".join(
+                (
+                    f"{target_name} = {self_operand.code}.copy(deep=True)",
+                    f"{target_name}[{key_operand.code}] = {value_operand.code}",
+                )
+            ),
         )
         provenance_spec = erlab.interactive.imagetool.provenance.script(
             erlab.interactive.imagetool.provenance.ScriptCodeOperation(
@@ -1294,11 +1323,31 @@ class ToolNamespace(_ConsoleDataHandleMixin):
                 copyable=copyable,
             ),
             start_label="Run ImageTool manager console code",
-            active_name=self._console_input_name,
+            active_name=target_name,
             script_inputs=script_inputs,
         )
-        self._set_data_item(key_operand.value, value_operand.value)
+        prepared_data = self._prepare_data_item_assignment(
+            key_operand.value, value_operand.value
+        )
+        if prepared_data is None:
+            self._set_data_item(
+                key_operand.value,
+                value_operand.value,
+                emit_signals=False,
+            )
+            self._wrapper.set_detached_provenance(provenance_spec)
+            slicer_area = self.tool.slicer_area
+            slicer_area.sigSourceDataReplaced.emit(
+                slicer_area._tool_source_parent_data()
+            )
+            slicer_area.sigDataEdited.emit()
+            return
         self._wrapper.set_detached_provenance(provenance_spec)
+        self._set_data_item(
+            key_operand.value,
+            value_operand.value,
+            prepared_data=prepared_data,
+        )
 
     def __getattr__(self, attr):  # implicitly wrap methods from ImageToolWrapper
         if hasattr(self._wrapper, attr):
@@ -1500,9 +1549,9 @@ class ToolsNamespace:
 
     @property
     def selected_data(self) -> list[xr.DataArray]:
-        """Raw DataArrays from selected root or child ImageTools."""
+        """Current DataArrays from selected root or child ImageTools."""
         return [
-            self._manager.get_imagetool(target).slicer_area._data
+            self._manager.get_imagetool(target).slicer_area.displayed_data
             for target in self._manager._selected_imagetool_targets()
         ]
 

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -107,7 +107,8 @@ class _ConcatDialog(QtWidgets.QDialog):
             try:
                 selected = list(manager._selected_imagetool_targets())
                 to_concat = [
-                    manager.get_imagetool(idx).slicer_area._data for idx in selected
+                    manager.get_imagetool(idx).slicer_area.displayed_data
+                    for idx in selected
                 ]
                 concat_kwargs = self.concat_kwargs()
                 input_names = [
@@ -241,7 +242,7 @@ class _StoreDialog(QtWidgets.QDialog):
         self._layout.addRow("Data to store", QtWidgets.QLabel("Stored name"))
 
         for tool_idx in target_indices:
-            data = manager.get_imagetool(tool_idx).slicer_area._data
+            data = manager.get_imagetool(tool_idx).slicer_area.displayed_data
             wrapper = manager._imagetool_wrappers[tool_idx]
             default_name = data.name
             if not erlab.interactive.utils._is_kwarg_name(default_name):

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -706,9 +706,12 @@ class _WarningNotificationHandler(logging.Handler):
         except Exception:  # pragma: no cover
             self.handleError(record)
             return
-        self._emitter.warning_received.emit(
-            record.levelname, record.levelno, message, traceback_msg
-        )
+        if not erlab.interactive.utils.qt_is_valid(self._emitter):
+            return
+        with contextlib.suppress(RuntimeError):
+            self._emitter.warning_received.emit(
+                record.levelname, record.levelno, message, traceback_msg
+            )
 
 
 class _ApplicationQuitFilter(QtCore.QObject):
@@ -2328,9 +2331,10 @@ class ImageToolManager(QtWidgets.QMainWindow):
     def _script_input_for_node(
         self, node: _ImageToolWrapper | _ManagedWindowNode
     ) -> erlab.interactive.imagetool.provenance.ScriptInput:
+        displayed_provenance = node.displayed_provenance_spec
         provenance_spec = (
-            node.provenance_spec.model_dump(mode="json")
-            if node.provenance_spec is not None
+            displayed_provenance.model_dump(mode="json")
+            if displayed_provenance is not None
             else None
         )
         if isinstance(node, _ImageToolWrapper):
@@ -3207,7 +3211,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         self._update_metadata_pane()
 
     def _set_metadata_node(self, node: _ImageToolWrapper | _ManagedWindowNode) -> None:
-        self._metadata_full_code_available = node.provenance_spec is not None
+        self._metadata_full_code_available = node.displayed_provenance_spec is not None
         self._metadata_node_uid = node.uid
         self._set_metadata_fields(node.metadata_fields)
 
@@ -3948,6 +3952,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             result.data,
             result.provenance_spec,
             propagate_descendants=True,
+            preserve_filter=True,
         )
         self.tree_view.refresh(node.uid)
         if self._metadata_node_uid == node.uid:
@@ -4159,7 +4164,8 @@ class ImageToolManager(QtWidgets.QMainWindow):
         childtools = dict(node._childtools)
         created_time = node._created_time
         recent_geometry = node._recent_geometry
-        provenance_spec = node.provenance_spec
+        persistence = node.persistence_view()
+        provenance_spec = persistence.provenance_spec
         snapshot_token = node.snapshot_token
 
         self.tree_view.childtool_removed(uid)
@@ -4278,16 +4284,18 @@ class ImageToolManager(QtWidgets.QMainWindow):
     ) -> int | str:
         node = self._node_for_target(target)
         if node.is_imagetool:
+            persistence = node.persistence_view()
             duplicated_window = self.get_imagetool(target).duplicate(_in_manager=True)
             if isinstance(node, _ImageToolWrapper):
                 new_target: int | str = self.add_imagetool(
                     duplicated_window,
                     activate=True,
                     source_input_ndim=node.source_input_ndim,
-                    provenance_spec=node.provenance_spec,
-                    source_spec=node.source_spec,
-                    source_auto_update=node.source_auto_update,
-                    source_state=node.source_state,
+                    provenance_spec=persistence.provenance_spec,
+                    source_spec=persistence.source_spec,
+                    source_binding=persistence.source_binding,
+                    source_auto_update=persistence.source_auto_update,
+                    source_state=persistence.source_state,
                 )
             else:
                 parent_target = (
@@ -4299,11 +4307,12 @@ class ImageToolManager(QtWidgets.QMainWindow):
                     duplicated_window,
                     parent_target,
                     activate=True,
-                    provenance_spec=node.provenance_spec,
-                    source_spec=node.source_spec,
-                    source_auto_update=node.source_auto_update,
-                    source_state=node.source_state,
-                    output_id=node.output_id,
+                    provenance_spec=persistence.provenance_spec,
+                    source_spec=persistence.source_spec,
+                    source_binding=persistence.source_binding,
+                    source_auto_update=persistence.source_auto_update,
+                    source_state=persistence.source_state,
+                    output_id=persistence.output_id,
                 )
         else:
             tool = typing.cast("erlab.interactive.utils.ToolWindow", node.tool_window)
@@ -4387,9 +4396,11 @@ class ImageToolManager(QtWidgets.QMainWindow):
         ds.attrs["manager_node_uid"] = node.uid
         ds.attrs["manager_node_kind"] = kind
         ds.attrs["manager_node_snapshot_token"] = node.snapshot_token
-        if node.provenance_spec is not None:
+        persistence = node.persistence_view()
+        provenance_spec = persistence.provenance_spec
+        if provenance_spec is not None:
             ds.attrs["manager_node_provenance_spec"] = json.dumps(
-                node.provenance_spec.model_dump(mode="json")
+                provenance_spec.model_dump(mode="json")
             )
         if isinstance(node, _ImageToolWrapper) and node.source_input_ndim is not None:
             ds.attrs["manager_node_source_input_ndim"] = int(node.source_input_ndim)
@@ -4415,24 +4426,28 @@ class ImageToolManager(QtWidgets.QMainWindow):
             ds.attrs["manager_node_watched_connected"] = bool(
                 watched_metadata.get("connected", False)
             )
-        output_id = node.output_id
+        output_id = persistence.output_id
         if kind == "imagetool" and output_id is not None:
             ds.attrs["manager_node_output_id"] = output_id
-        if kind == "imagetool" and node.source_spec is not None:
+        source_spec = persistence.source_spec
+        if kind == "imagetool" and source_spec is not None:
             ds.attrs["manager_node_live_source_spec"] = json.dumps(
-                node.source_spec.model_dump(mode="json")
+                source_spec.model_dump(mode="json")
             )
-        if kind == "imagetool" and node.source_binding is not None:
+        source_binding = persistence.source_binding
+        if kind == "imagetool" and source_binding is not None:
             ds.attrs["manager_node_live_source_binding"] = json.dumps(
-                node.source_binding.model_dump(mode="json")
+                source_binding.model_dump(mode="json")
             )
         if kind == "imagetool" and (
-            node.source_spec is not None
-            or node.source_binding is not None
+            source_spec is not None
+            or source_binding is not None
             or output_id is not None
         ):
-            ds.attrs["manager_node_source_state"] = node.source_state
-            ds.attrs["manager_node_source_auto_update"] = bool(node.source_auto_update)
+            ds.attrs["manager_node_source_state"] = persistence.source_state
+            ds.attrs["manager_node_source_auto_update"] = bool(
+                persistence.source_auto_update
+            )
         return ds
 
     def _serialize_workspace_node(
@@ -5222,13 +5237,8 @@ class ImageToolManager(QtWidgets.QMainWindow):
                 "display_name": node.display_text,
             }
             if node.is_imagetool and node.imagetool is not None:
-                data = node.slicer_area._data
-                if data.chunks is not None:
-                    entry["data_backing"] = "dask"
-                elif _manager_xarray.dataarray_is_file_backed(data):
-                    entry["data_backing"] = "file_lazy"
-                else:
-                    entry["data_backing"] = "memory"
+                persistence = node.persistence_view()
+                entry["data_backing"] = persistence.data_backing
                 link_info = link_metadata.get(uid)
                 if link_info is not None:
                     entry["link_group"], entry["link_colors"] = link_info
@@ -5522,14 +5532,9 @@ class ImageToolManager(QtWidgets.QMainWindow):
         for node in self._all_nodes.values():
             if not node.is_imagetool or node.imagetool is None:
                 continue
-            data = node.slicer_area._data
-            if data.chunks is not None:
-                kind = "dask"
-            elif _manager_xarray.dataarray_is_file_backed(data):
-                kind = "file_lazy"
-            else:
-                kind = "memory"
-            snapshot[node.uid] = (kind, _manager_xarray.dataarray_source_paths(data))
+            persistence = node.persistence_view()
+            kind = typing.cast("str", persistence.data_backing)
+            snapshot[node.uid] = (kind, persistence.source_paths)
         return snapshot
 
     def _rebind_workspace_backed_imagetools(
@@ -5565,7 +5570,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
             tool = node.imagetool
             if tool is None:
                 continue
-            slicer_area = tool.slicer_area
+            persistence = node.persistence_view()
             rebind_chunks: typing.Any
             if backing_snapshot is not None:
                 backing = backing_snapshot.get(node.uid)
@@ -5582,11 +5587,11 @@ class ImageToolManager(QtWidgets.QMainWindow):
             else:
                 rebind_chunks = chunks
                 if rebind_chunks is _WORKSPACE_REBIND_KEEP_CHUNKS:
-                    rebind_chunks = {} if slicer_area._data.chunks is not None else None
+                    rebind_chunks = {} if persistence.data_backing == "dask" else None
             pending.append(
                 (
                     node,
-                    copy.deepcopy(slicer_area.state),
+                    copy.deepcopy(persistence.state),
                     node.name,
                     rebind_chunks,
                 )
@@ -6676,7 +6681,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if index is None:
             return None
         with contextlib.suppress(KeyError):
-            return self.get_imagetool(index).slicer_area._data
+            return self.get_imagetool(index).slicer_area.displayed_data
         return None
 
     @QtCore.Slot(object)
@@ -7164,7 +7169,7 @@ class ImageToolManager(QtWidgets.QMainWindow):
         if provenance_spec is None and source_spec is not None:
             provenance_spec = (
                 erlab.interactive.imagetool.provenance.compose_display_provenance(
-                    parent_node.provenance_spec,
+                    parent_node.displayed_provenance_spec,
                     source_spec,
                     parent_data=parent_node.current_source_data(),
                 )

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -32,7 +32,7 @@ if typing.TYPE_CHECKING:
 
     from erlab.interactive.imagetool.manager import ImageToolManager
     from erlab.interactive.imagetool.provenance import ImageToolSelectionSourceBinding
-    from erlab.interactive.imagetool.viewer import ImageSlicerArea
+    from erlab.interactive.imagetool.viewer import ImageSlicerArea, ImageSlicerState
 
 
 def _preview_from_imagetool(
@@ -88,6 +88,20 @@ class _MetadataField:
     monospace: bool = False
     wrap: bool = False
     details: _LoadSourceDetails | None = None
+
+
+@dataclass(frozen=True)
+class _NodePersistenceView:
+    data: xr.DataArray | None
+    state: ImageSlicerState | None
+    provenance_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None
+    source_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None
+    source_binding: ImageToolSelectionSourceBinding | None
+    output_id: str | None
+    source_state: typing.Literal["fresh", "stale", "unavailable"]
+    source_auto_update: bool
+    data_backing: typing.Literal["dask", "file_lazy", "memory"] | None
+    source_paths: tuple[str, ...] = ()
 
 
 def _format_chunk_summary(data: xr.DataArray) -> str:
@@ -382,7 +396,7 @@ class _ManagedWindowNode(QtCore.QObject):
                 self.tool_window.info_text
             )
         text = erlab.utils.formatting.format_darr_html(
-            self.slicer_area._data,
+            self.slicer_area.displayed_data,
             show_size=True,
             additional_info=[
                 f"Added {self._created_time.isoformat(sep=' ', timespec='seconds')}"
@@ -396,7 +410,7 @@ class _ManagedWindowNode(QtCore.QObject):
 
     def _metadata_data(self) -> xr.DataArray | None:
         if self.imagetool is not None:
-            return self.slicer_area._data
+            return self.slicer_area.displayed_data
         if self.tool_window is not None:
             with contextlib.suppress(NotImplementedError, RuntimeError):
                 return self.tool_window.tool_data
@@ -505,6 +519,15 @@ class _ManagedWindowNode(QtCore.QObject):
         return self._source_spec
 
     @property
+    def displayed_source_spec(
+        self,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+        source_spec = self.source_spec
+        if self.imagetool is not None:
+            return self.slicer_area.displayed_live_source_spec(source_spec)
+        return source_spec
+
+    @property
     def source_binding(
         self,
     ) -> ImageToolSelectionSourceBinding | None:
@@ -529,6 +552,44 @@ class _ManagedWindowNode(QtCore.QObject):
         if self.imagetool is not None:
             return self.slicer_area.displayed_provenance_spec(self.provenance_spec)
         return self.provenance_spec
+
+    def persistence_view(self) -> _NodePersistenceView:
+        """Return the only manager persistence/clone view for this node."""
+        if self.imagetool is None:
+            return _NodePersistenceView(
+                data=None,
+                state=None,
+                provenance_spec=self.provenance_spec,
+                source_spec=self.source_spec,
+                source_binding=self.source_binding,
+                output_id=self.output_id,
+                source_state=self.source_state,
+                source_auto_update=self.source_auto_update,
+                data_backing=None,
+            )
+
+        data, state = self.slicer_area.persistence_data_and_state()
+        from erlab.interactive.imagetool.manager import _xarray as _manager_xarray
+
+        data_backing: typing.Literal["dask", "file_lazy", "memory"]
+        if data.chunks is not None:
+            data_backing = "dask"
+        elif _manager_xarray.dataarray_is_file_backed(data):
+            data_backing = "file_lazy"
+        else:
+            data_backing = "memory"
+        return _NodePersistenceView(
+            data=data,
+            state=state,
+            provenance_spec=self.provenance_spec,
+            source_spec=self.source_spec,
+            source_binding=self.source_binding,
+            output_id=self.output_id,
+            source_state=self.source_state,
+            source_auto_update=self.source_auto_update,
+            data_backing=data_backing,
+            source_paths=_manager_xarray.dataarray_source_paths(data),
+        )
 
     @property
     def snapshot_token(self) -> str:
@@ -590,9 +651,10 @@ class _ManagedWindowNode(QtCore.QObject):
     def derivation_entries(
         self,
     ) -> list[erlab.interactive.imagetool.provenance.DerivationEntry]:
-        if self.provenance_spec is None:
+        provenance_spec = self.displayed_provenance_spec
+        if provenance_spec is None:
             return []
-        return self.provenance_spec.display_entries()
+        return provenance_spec.display_entries()
 
     @property
     def derivation_lines(self) -> list[str]:
@@ -600,9 +662,10 @@ class _ManagedWindowNode(QtCore.QObject):
 
     @property
     def derivation_code(self) -> str | None:
-        if self.provenance_spec is None:
+        provenance_spec = self.displayed_provenance_spec
+        if provenance_spec is None:
             return None
-        return self.provenance_spec.display_code()
+        return provenance_spec.display_code()
 
     def add_child_reference(self, uid: str, window: QtWidgets.QWidget) -> None:
         if uid not in self._childtool_indices:
@@ -680,7 +743,7 @@ class _ManagedWindowNode(QtCore.QObject):
             source_spec = self._materialized_source_spec(parent_data)
             self.set_displayed_provenance(
                 erlab.interactive.imagetool.provenance.compose_display_provenance(
-                    parent.provenance_spec,
+                    parent.displayed_provenance_spec,
                     source_spec,
                     parent_data=parent_data,
                 )
@@ -796,9 +859,30 @@ class _ManagedWindowNode(QtCore.QObject):
         *,
         state: _source_state_type = "fresh",
         propagate_descendants: bool,
+        preserve_filter: bool = False,
     ) -> None:
+        accepted_filter_operation = None
+        filtered = None
+        if preserve_filter and self.imagetool is not None:
+            accepted_filter_operation = (
+                self.slicer_area._accepted_filter_provenance_operation
+            )
+            if accepted_filter_operation is not None:
+                filtered = self.slicer_area._filter_operation_result_for_replacement(
+                    data,
+                    accepted_filter_operation,
+                )
         with self._suspend_descendant_propagation(), self._suspend_snapshot_updates():
             self.slicer_area.replace_source_data(data)
+            if accepted_filter_operation is not None:
+                self.slicer_area._apply_filter_result(
+                    typing.cast("xr.DataArray", filtered),
+                    self.slicer_area._filter_func_from_operation(
+                        accepted_filter_operation
+                    ),
+                    operation=accepted_filter_operation,
+                    accept=True,
+                )
         self.set_displayed_provenance(provenance_spec, advance_snapshot=False)
         self._advance_snapshot_token()
         self._set_source_state(state)
@@ -816,6 +900,7 @@ class _ManagedWindowNode(QtCore.QObject):
         | None,
         *,
         propagate_descendants: bool = True,
+        preserve_filter: bool = False,
     ) -> None:
         """Replace displayed ImageTool data with detached provenance."""
         self._source_spec = None
@@ -826,6 +911,7 @@ class _ManagedWindowNode(QtCore.QObject):
             provenance_spec,
             state="fresh",
             propagate_descendants=propagate_descendants,
+            preserve_filter=preserve_filter,
         )
 
     def _handle_tool_data_changed(self) -> None:
@@ -1019,7 +1105,7 @@ class _ManagedWindowNode(QtCore.QObject):
                 resolved = source_spec.apply(parent_data)
                 provenance_spec = (
                     erlab.interactive.imagetool.provenance.compose_display_provenance(
-                        self.manager._parent_node(self).provenance_spec,
+                        self.manager._parent_node(self).displayed_provenance_spec,
                         source_spec,
                         parent_data=parent_data,
                     )
@@ -1028,6 +1114,7 @@ class _ManagedWindowNode(QtCore.QObject):
                 resolved,
                 provenance_spec,
                 propagate_descendants=True,
+                preserve_filter=True,
             )
         except Exception:
             self._set_source_state("unavailable")
@@ -1069,7 +1156,7 @@ class _ManagedWindowNode(QtCore.QObject):
                 resolved = source_spec.apply(parent_data)
                 provenance_spec = (
                     erlab.interactive.imagetool.provenance.compose_display_provenance(
-                        self.manager._parent_node(self).provenance_spec,
+                        self.manager._parent_node(self).displayed_provenance_spec,
                         source_spec,
                         parent_data=parent_data,
                     )
@@ -1084,6 +1171,7 @@ class _ManagedWindowNode(QtCore.QObject):
                     resolved,
                     provenance_spec,
                     propagate_descendants=False,
+                    preserve_filter=True,
                 )
             except Exception:
                 self._set_source_state("unavailable")

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -2092,7 +2092,7 @@ class ItoolPlotItem(pg.PlotItem):
         if isinstance(tool_window, erlab.interactive.imagetool.ImageTool):
             tool_window.set_provenance_spec(
                 erlab.interactive.imagetool.provenance.compose_display_provenance(
-                    self.slicer_area.provenance_spec,
+                    self.slicer_area.displayed_provenance_spec(),
                     source_spec,
                     parent_data=self.slicer_area._tool_source_parent_data(),
                 )

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -1990,6 +1990,20 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         """Replace a final rename, if present, then append new operation instances."""
         return self.drop_trailing_rename().append_operations(*operations)
 
+    def append_display_operation(
+        self, operation: ToolProvenanceOperation
+    ) -> ToolProvenanceSpec:
+        """Append a live display operation without making a final name stale."""
+        operation = _require_operation_instance(operation)
+        if not self.is_live_source:
+            raise TypeError("Display operations can only be appended to live sources")
+        operations = self.operations
+        if operations and isinstance(operations[-1], RenameOperation):
+            return self.model_copy(
+                update={"operations": (*operations[:-1], operation, operations[-1])}
+            )
+        return self.append_operations(operation)
+
     def append_final_rename(self, name: str) -> ToolProvenanceSpec:
         return self.drop_trailing_rename().append_operations(RenameOperation(name=name))
 

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1196,6 +1196,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._accepted_filter_provenance_operation: (
             erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
         ) = None
+        self._accepted_filter_data: xr.DataArray | None = None
         # `_data` is the public/source array, while `ArraySlicer._obj` is the internal
         # validated view used for slicing. The two share values by default and detach
         # only when a write needs isolation.
@@ -1718,9 +1719,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
         operation = self._accepted_filter_provenance_operation
         if operation is None:
             return self._data_aligned_to_dims(self._data, dims)
-        return self._filtered_data_for_dims(
-            self._filter_func_from_operation(operation), dims
-        )
+        accepted = self._accepted_filter_data
+        if accepted is None:
+            raise RuntimeError("Accepted filter data is missing")
+        return self._data_aligned_to_dims(accepted, dims)
 
     def _normalize_filter_result_for_source_dims(
         self,
@@ -1840,7 +1842,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
         emit_edited: bool = False,
     ) -> None:
         operation = self._parse_filter_operation_state(payload)
-        if operation == self._accepted_filter_provenance_operation:
+        if operation == self._accepted_filter_provenance_operation and (
+            (operation is None and self._accepted_filter_data is None)
+            or (operation is not None and self._accepted_filter_data is not None)
+        ):
             return
         self.apply_filter_operation(operation, update=False, emit_edited=emit_edited)
 
@@ -1885,6 +1890,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._applied_func = None
         self._applied_provenance_operation = None
         self._accepted_filter_provenance_operation = None
+        self._accepted_filter_data = None
         restored_obj = False
 
         if self._data_shares_external_values:
@@ -2742,6 +2748,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._applied_func = None
         self._applied_provenance_operation = None
         self._accepted_filter_provenance_operation = None
+        self._accepted_filter_data = None
 
         # Save color limits so we may restore them later
         cached_levels: tuple[float, float] | None = None
@@ -3138,6 +3145,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._restore_obj_from_source(update=update)
             if accept:
                 self._accepted_filter_provenance_operation = None
+                self._accepted_filter_data = None
             if emit_edited:
                 self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
                 self.sigDataEdited.emit()
@@ -3171,6 +3179,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._applied_provenance_operation = operation
             if accept:
                 self._accepted_filter_provenance_operation = operation
+                self._accepted_filter_data = filtered.copy(deep=True)
             if emit_edited:
                 self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
                 self.sigDataEdited.emit()
@@ -3191,6 +3200,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._applied_provenance_operation = operation
         if accept:
             self._accepted_filter_provenance_operation = operation
+            self._accepted_filter_data = filtered.copy(deep=True)
         if emit_edited:
             self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
             self.sigDataEdited.emit()
@@ -3379,8 +3389,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """
         if self.data_loadable:
             try:
+                state = copy.deepcopy(self.state)
                 with erlab.interactive.utils.wait_dialog(self, "Computing…"):
                     self.set_data(self._data.load())
+                    self.state = state
                 self.sigDataBackingChanged.emit()
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -104,6 +104,7 @@ class ImageSlicerState(typing.TypedDict):
     current_cursor: int
     manual_limits: dict[str, list[float]]
     axis_inversions: typing.NotRequired[dict[str, bool]]
+    filter_operation: typing.NotRequired[dict[str, typing.Any] | None]
     cursor_colors: list[str]
     controls_visible: typing.NotRequired[bool]
     file_path: typing.NotRequired[str | None]
@@ -1050,7 +1051,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
     sigSourceDataReplaced()
         Signal emitted when the underlying source data is replaced or otherwise
         changed at the source level, such as file open, reload, manager-driven
-        replacement, or in-place console edits.
+        replacement, accepted filters, or in-place console edits.
     sigPointValueChanged(value)
         Signal emitted when the point value at the current cursor has been computed.
         Only emitted for dask-backed data.
@@ -1187,9 +1188,12 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._associated_tools: dict[str, QtWidgets.QWidget] = {}
         self._assoc_tools_lock = threading.RLock()
 
-        # Applied filter function
+        # Current plot filter. Accepted filters are represented by the operation below.
         self._applied_func: Callable[[xr.DataArray], xr.DataArray] | None = None
         self._applied_provenance_operation: (
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
+        ) = None
+        self._accepted_filter_provenance_operation: (
             erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
         ) = None
         # `_data` is the public/source array, while `ArraySlicer._obj` is the internal
@@ -1444,7 +1448,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             if isinstance(selection, _FileDataSelection):
                 selection = selection.model_dump(mode="json")
             load_func = (func_name, load_func[1], selection)
-        return {
+        state: ImageSlicerState = {
             "color": self.colormap_properties,
             "slice": self.array_slicer.state,
             "current_cursor": int(self.current_cursor),
@@ -1457,13 +1461,22 @@ class ImageSlicerArea(QtWidgets.QWidget):
             "controls_visible": self.controls_visible,
             "plotitem_states": [p._serializable_state for p in self.axes],
         }
+        filter_operation = self._accepted_filter_provenance_operation
+        if filter_operation is not None:
+            state["filter_operation"] = filter_operation.model_dump(mode="json")
+        return state
 
     @state.setter
     def state(self, state: ImageSlicerState) -> None:
         with self.history_suppressed(), self.link_sync_suppressed():
             self._restore_state(state)
 
-    def _restore_state(self, state: ImageSlicerState) -> None:
+    def _restore_state(
+        self,
+        state: ImageSlicerState,
+        *,
+        emit_filter_edited: bool = False,
+    ) -> None:
         logger.debug("Restoring state...")
         parent = self.parent()
         if hasattr(parent, "_set_controls_visible"):
@@ -1533,6 +1546,12 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if file_path is not None:
             self.sigDataChanged.emit()
             logger.debug("Restored file path")
+
+        self._restore_filter_operation_from_state(
+            state.get("filter_operation", None),
+            emit_edited=emit_filter_edited,
+        )
+        logger.debug("Restored filter operation")
 
         # Restore colormap settings
         try:
@@ -1662,9 +1681,168 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def data(self) -> xr.DataArray:
         return self.array_slicer._obj
 
+    @property
+    def displayed_data(self) -> xr.DataArray:
+        """Return the public data values committed for derived outputs."""
+        return self._accepted_data_for_dims(tuple(self._data.dims))
+
     def _tool_source_parent_data(self) -> xr.DataArray:
         """Return the current slicer view used for source-bound child tools."""
-        return self.data.copy(deep=False)
+        return self._accepted_data_for_dims(tuple(self.data.dims)).copy(deep=False)
+
+    @property
+    def has_active_filter(self) -> bool:
+        return (
+            self._applied_func is not None
+            or self._accepted_filter_provenance_operation is not None
+        )
+
+    def persistence_data_and_state(self) -> tuple[xr.DataArray, ImageSlicerState]:
+        """Return data/state for save and clone paths."""
+        return self._data, self.state
+
+    def displayed_live_source_spec(
+        self,
+        base_spec: erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+        """Return live source provenance including the accepted display filter."""
+        source_spec = erlab.interactive.imagetool.provenance.require_live_source_spec(
+            base_spec
+        )
+        operation = self._accepted_filter_provenance_operation
+        if source_spec is None or operation is None:
+            return source_spec
+        return source_spec.append_display_operation(operation)
+
+    def _accepted_data_for_dims(self, dims: tuple[Hashable, ...]) -> xr.DataArray:
+        operation = self._accepted_filter_provenance_operation
+        if operation is None:
+            return self._data_aligned_to_dims(self._data, dims)
+        return self._filtered_data_for_dims(
+            self._filter_func_from_operation(operation), dims
+        )
+
+    def _normalize_filter_result_for_source_dims(
+        self,
+        source_data: xr.DataArray,
+        filtered: xr.DataArray,
+        dims: tuple[Hashable, ...],
+    ) -> xr.DataArray:
+        """Validate a filter result and align it with the requested data layout."""
+        if source_data.ndim != filtered.ndim:
+            raise ValueError("DataArray dimensions do not match")
+        if set(source_data.dims) != set(filtered.dims):
+            raise ValueError("DataArray dimensions do not match")
+
+        expected_source_shape = tuple(source_data.sizes[dim] for dim in filtered.dims)
+        if filtered.shape != expected_source_shape:
+            raise ValueError("DataArray shape does not match")
+
+        filtered = self._data_aligned_to_dims(filtered, dims)
+        expected_shape = self._expected_layout_shape(source_data, dims)
+        if filtered.shape != expected_shape:
+            raise ValueError("DataArray shape does not match")
+        return filtered
+
+    def _normalize_filter_result_for_dims(
+        self, filtered: xr.DataArray, dims: tuple[Hashable, ...]
+    ) -> xr.DataArray:
+        return self._normalize_filter_result_for_source_dims(self._data, filtered, dims)
+
+    def _expected_layout_shape(
+        self, source_data: xr.DataArray, dims: tuple[Hashable, ...]
+    ) -> tuple[int, ...]:
+        aligned = self._data_aligned_to_dims(source_data, dims)
+        return tuple(aligned.sizes[dim] for dim in dims)
+
+    @staticmethod
+    def _data_aligned_to_dims(
+        data: xr.DataArray, dims: tuple[Hashable, ...]
+    ) -> xr.DataArray:
+        missing_dims = tuple(dim for dim in dims if dim not in data.dims)
+        if missing_dims and any(str(dim).endswith("_idx") for dim in missing_dims):
+            data = erlab.interactive.imagetool.slicer.make_dims_uniform(data)
+            missing_dims = tuple(dim for dim in dims if dim not in data.dims)
+        if missing_dims == ("stack_dim",):
+            data = data.expand_dims("stack_dim", axis=dims.index("stack_dim"))
+        if data.dims != dims:
+            return data.transpose(*dims)
+        return data
+
+    def _filtered_data_for_dims(
+        self, func: Callable[[xr.DataArray], xr.DataArray], dims: tuple[Hashable, ...]
+    ) -> xr.DataArray:
+        return self._normalize_filter_result_for_dims(func(self._data), dims)
+
+    def _filtered_data_for_display(
+        self, func: Callable[[xr.DataArray], xr.DataArray]
+    ) -> xr.DataArray:
+        return self._filtered_data_for_dims(func, tuple(self.data.dims))
+
+    def _filter_operation_result_for_data(
+        self,
+        data: xr.DataArray,
+        operation: erlab.interactive.imagetool.provenance.ToolProvenanceOperation,
+        dims: tuple[Hashable, ...],
+    ) -> xr.DataArray:
+        return self._normalize_filter_result_for_source_dims(
+            data,
+            operation.apply(data, parent_data=data),
+            dims,
+        )
+
+    def _replacement_display_dims(self, data: xr.DataArray) -> tuple[Hashable, ...]:
+        validated = erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
+            data,
+            copy_values=False,
+        )
+        if erlab.interactive.imagetool.slicer.check_cursors_compatible(
+            self.data,
+            validated,
+        ):
+            return tuple(self.data.dims)
+        return tuple(validated.dims)
+
+    def _filter_operation_result_for_replacement(
+        self,
+        data: xr.DataArray,
+        operation: erlab.interactive.imagetool.provenance.ToolProvenanceOperation,
+    ) -> xr.DataArray:
+        return self._filter_operation_result_for_data(
+            data,
+            operation,
+            self._replacement_display_dims(data),
+        )
+
+    @staticmethod
+    def _filter_func_from_operation(
+        operation: erlab.interactive.imagetool.provenance.ToolProvenanceOperation,
+    ) -> Callable[[xr.DataArray], xr.DataArray]:
+        def _apply_filter(darr: xr.DataArray) -> xr.DataArray:
+            return operation.apply(darr, parent_data=darr)
+
+        return _apply_filter
+
+    def _parse_filter_operation_state(
+        self,
+        payload: dict[str, typing.Any] | None,
+    ) -> erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None:
+        if payload is None:
+            return None
+        return erlab.interactive.imagetool.provenance.parse_tool_provenance_operation(
+            payload
+        )
+
+    def _restore_filter_operation_from_state(
+        self,
+        payload: dict[str, typing.Any] | None,
+        *,
+        emit_edited: bool = False,
+    ) -> None:
+        operation = self._parse_filter_operation_state(payload)
+        if operation == self._accepted_filter_provenance_operation:
+            return
+        self.apply_filter_operation(operation, update=False, emit_edited=emit_edited)
 
     @staticmethod
     def _owned_values_copy(darr: xr.DataArray) -> typing.Any:
@@ -1699,13 +1877,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.refresh_all(only_plots=True)
             self.lock_levels(self.levels_locked)
 
-    def _set_source_item(self, key, value) -> None:
+    def _set_source_item(self, key, value, *, emit_signals: bool = True) -> None:
         """Safely update a subset of the public source array in place."""
         need_restore = (
             self._applied_func is not None or not self._obj_shares_data_values
         )
         self._applied_func = None
         self._applied_provenance_operation = None
+        self._accepted_filter_provenance_operation = None
         restored_obj = False
 
         if self._data_shares_external_values:
@@ -1726,7 +1905,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.array_slicer.clear_val_cache()
             self.refresh_all(only_plots=True)
             self.lock_levels(self.levels_locked)
-            if updated:
+            if updated and emit_signals:
                 self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
                 self.sigDataEdited.emit()
 
@@ -1866,8 +2045,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def _apply_history_entry(self, entry: _history.HistoryEntry, *, undo: bool) -> None:
         source = entry.before_state if undo else entry.after_state
         patched = _history.patch_state(self.state, source, entry.changed_paths)
+        emit_filter_edited = any(
+            bool(path) and path[0] == "filter_operation" for path in entry.changed_paths
+        )
         with self.history_suppressed(), self.link_sync_suppressed():
-            self.state = typing.cast("ImageSlicerState", patched)
+            self._restore_state(
+                typing.cast("ImageSlicerState", patched),
+                emit_filter_edited=emit_filter_edited,
+            )
 
     def _apply_matching_linked_history_entry(
         self, transaction_id: str, *, undo: bool
@@ -2556,6 +2741,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._obj_shares_data_values = True
         self._applied_func = None
         self._applied_provenance_operation = None
+        self._accepted_filter_provenance_operation = None
 
         # Save color limits so we may restore them later
         cached_levels: tuple[float, float] | None = None
@@ -2752,7 +2938,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if self._direct_reloadable() or self._provenance_reloadable():
             try:
                 data, kwargs = self._fetch_reload_data()
-                self.replace_source_data(data, **kwargs)
+                self._replace_reload_data(data, kwargs)
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(
                     self, "Error", "An error occurred while reloading data."
@@ -2766,13 +2952,37 @@ class ImageSlicerArea(QtWidgets.QWidget):
             return False
         try:
             data, kwargs = self._fetch_reload_data()
-            self.replace_source_data(data, **kwargs)
+            self._replace_reload_data(data, kwargs)
         except Exception:
             erlab.interactive.utils.MessageDialog.critical(
                 self, "Error", "An error occurred while reloading data."
             )
             return False
         return True
+
+    def _replace_reload_data(
+        self,
+        data: xr.DataArray,
+        kwargs: dict[str, typing.Any],
+    ) -> None:
+        """Replace source data during reload and reapply the accepted filter."""
+        accepted_filter_operation = self._accepted_filter_provenance_operation
+        if accepted_filter_operation is None:
+            self.replace_source_data(data, **kwargs)
+            return
+
+        filtered = self._filter_operation_result_for_replacement(
+            data,
+            accepted_filter_operation,
+        )
+        self.set_data(data, **kwargs)
+        self._apply_filter_result(
+            filtered,
+            self._filter_func_from_operation(accepted_filter_operation),
+            operation=accepted_filter_operation,
+            accept=True,
+            emit_edited=True,
+        )
 
     @QtCore.Slot()
     def reload(self) -> None:
@@ -2854,13 +3064,12 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """Return provenance for the currently displayed data values."""
         if base_spec is None:
             base_spec = self.provenance_spec
-        operation = self._applied_provenance_operation
+        operation = self._accepted_filter_provenance_operation
         if operation is None:
             return base_spec
-        return erlab.interactive.imagetool.provenance.compose_display_provenance(
+        return erlab.interactive.imagetool.provenance.compose_full_provenance(
             base_spec,
             erlab.interactive.imagetool.provenance.full_data(operation),
-            parent_data=self._data,
         )
 
     def apply_func(
@@ -2871,6 +3080,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
         operation: (
             erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
         ) = None,
+        emit_edited: bool = False,
+        preview: bool = True,
     ) -> None:
         """Apply a function to the data.
 
@@ -2878,8 +3089,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
         DataArray. The returned DataArray must have the same dimensions and coordinates
         as the original data.
 
-        This action is not recorded in the history, and the data is not affected. Only
-        one function can be applied at a time.
+        This preview-only action is not recorded in the history, and the source data
+        remains unchanged. Accepted filters must use :meth:`apply_filter_operation`.
+        Only one preview function can be applied at a time.
 
         Parameters
         ----------
@@ -2887,33 +3099,82 @@ class ImageSlicerArea(QtWidgets.QWidget):
             The function to apply to the data. if None, the data is restored.
         update
             If `True`, the plots are updated after setting the new values.
+        operation
+            Deprecated. Accepted filters must use :meth:`apply_filter_operation`.
+        emit_edited
+            If `True`, emit edit and source-change signals after updating the preview.
+        preview
+            Must be `True`. The argument is kept for existing internal callers.
 
         """
+        if operation is not None:
+            raise ValueError(
+                "Use apply_filter_operation() for operation-backed filters"
+            )
+        if not preview:
+            raise ValueError("apply_func() is preview-only")
+        self._apply_filter_func(
+            func,
+            update=update,
+            operation=None,
+            accept=False,
+            emit_edited=emit_edited,
+        )
+
+    def _apply_filter_func(
+        self,
+        func: Callable[[xr.DataArray], xr.DataArray] | None,
+        update: bool = True,
+        *,
+        operation: (
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
+        ) = None,
+        accept: bool = False,
+        emit_edited: bool = False,
+    ) -> None:
         if func is None:
             self._applied_func = None
             self._applied_provenance_operation = None
             self._restore_obj_from_source(update=update)
+            if accept:
+                self._accepted_filter_provenance_operation = None
+            if emit_edited:
+                self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
+                self.sigDataEdited.emit()
             return
 
-        # `self._data` is the public/source array, while `self.data` is the current
-        # validated slicer view. Temporary filters only detach the slicer view so the
-        # source array remains unchanged and can be restored cheaply.
-        filtered = func(self._data)
+        filtered = self._filtered_data_for_display(func)
+        self._apply_filter_result(
+            filtered,
+            func,
+            update=update,
+            operation=operation,
+            accept=accept,
+            emit_edited=emit_edited,
+        )
+
+    def _apply_filter_result(
+        self,
+        filtered: xr.DataArray,
+        func: Callable[[xr.DataArray], xr.DataArray],
+        update: bool = True,
+        *,
+        operation: (
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
+        ) = None,
+        accept: bool = False,
+        emit_edited: bool = False,
+    ) -> None:
         if filtered.chunks is None:
             self.update_values(filtered, update=update)
             self._applied_func = func
             self._applied_provenance_operation = operation
+            if accept:
+                self._accepted_filter_provenance_operation = operation
+            if emit_edited:
+                self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
+                self.sigDataEdited.emit()
             return
-
-        if self.data.ndim != filtered.ndim:
-            raise ValueError("DataArray dimensions do not match")
-        if set(self.data.dims) != set(filtered.dims):
-            raise ValueError("DataArray dimensions do not match")
-
-        if self.data.dims != filtered.dims:
-            filtered = filtered.transpose(*self.data.dims)
-        if self.data.shape != filtered.shape:
-            raise ValueError("DataArray shape does not match")
 
         self.array_slicer.set_array(
             filtered,
@@ -2928,6 +3189,44 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.lock_levels(self.levels_locked)
         self._applied_func = func
         self._applied_provenance_operation = operation
+        if accept:
+            self._accepted_filter_provenance_operation = operation
+        if emit_edited:
+            self.sigSourceDataReplaced.emit(self._tool_source_parent_data())
+            self.sigDataEdited.emit()
+
+    def apply_filter_operation(
+        self,
+        operation: (
+            erlab.interactive.imagetool.provenance.ToolProvenanceOperation | None
+        ),
+        update: bool = True,
+        *,
+        emit_edited: bool = False,
+        preview: bool = False,
+    ) -> None:
+        """Apply an operation-backed reversible display filter."""
+        if operation is None:
+            self._apply_filter_func(
+                None,
+                update=update,
+                accept=not preview,
+                emit_edited=emit_edited,
+            )
+            return
+        filtered = self._filter_operation_result_for_data(
+            self._data,
+            operation,
+            tuple(self.data.dims),
+        )
+        self._apply_filter_result(
+            filtered,
+            self._filter_func_from_operation(operation),
+            update=update,
+            operation=operation,
+            accept=not preview,
+            emit_edited=emit_edited,
+        )
 
     def set_manual_limits(self, manual_limits: dict[str, list[float]]) -> None:
         """Set manual limits for the axes.

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -142,6 +142,13 @@ def test_manager_console_handles_use_filtered_display_data(
         handle = tools[0]
         assert handle is not None
         xr.testing.assert_identical(handle.data, expected)
+        assert (
+            handle._console_provenance_spec(
+                active_name="derived",
+                label="Assign filtered console result",
+            )
+            == manager._imagetool_wrappers[0].displayed_provenance_spec
+        )
 
         derived = handle + 1.0
         xr.testing.assert_identical(derived.data, expected + 1.0)

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -113,6 +113,52 @@ def test_manager_console(
         InteractiveShell.clear_instance()
 
 
+def test_manager_console_handles_use_filtered_display_data(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5), "y": np.arange(5)},
+    )
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
+    expected = operation.apply(data, parent_data=data)
+
+    with manager_context() as manager:
+        manager.show()
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        tool = manager.get_imagetool(0)
+        tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+        tools = manager_console.ToolsNamespace(manager)
+        handle = tools[0]
+        assert handle is not None
+        xr.testing.assert_identical(handle.data, expected)
+
+        derived = handle + 1.0
+        xr.testing.assert_identical(derived.data, expected + 1.0)
+        spec = derived._console_provenance_spec(
+            active_name="derived",
+            label="Assign filtered console result",
+        )
+        assert spec is not None
+        code = spec.display_code()
+        assert code is not None
+        namespace = _exec_generated_code(
+            code,
+            {"data": data.copy(deep=True), "data_0": data.copy(deep=True)},
+        )
+        xr.testing.assert_identical(namespace["derived"], expected + 1.0)
+
+
 def test_packaged_macos_matplotlib_cursor_patch_applies_once(monkeypatch) -> None:
     class _Canvas:
         def set_cursor(self, cursor):
@@ -291,6 +337,146 @@ def test_tool_namespace_set_data_item_marks_child_tools_stale(
         qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
 
 
+def test_tool_namespace_set_filtered_data_item_uses_displayed_data(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = test_data.astype(float)
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={data.dims[0]: 1.0}
+    )
+    filtered = operation.apply(data, parent_data=data)
+
+    with manager_context() as manager:
+        manager.show()
+        manager.activateWindow()
+
+        itool([data], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.apply_filter_operation(operation)
+        namespace = ToolNamespace(manager._imagetool_wrappers[0])
+        expected = filtered.copy(deep=True)
+        expected[(0, 0)] = -5.0
+
+        namespace[(0, 0)] = -5.0
+
+        assert parent_tool.slicer_area._accepted_filter_provenance_operation is None
+        xr.testing.assert_identical(parent_tool.slicer_area.data, expected)
+        provenance_spec = manager._imagetool_wrappers[0].displayed_provenance_spec
+        assert provenance_spec is not None
+        display_code = provenance_spec.display_code()
+        assert display_code is not None
+        locals_ns = _exec_generated_code(
+            display_code,
+            {"data": data.copy(deep=True)},
+        )
+        xr.testing.assert_identical(
+            locals_ns[provenance_spec.active_name or "derived"], expected
+        )
+
+
+def test_tool_namespace_set_unfiltered_data_item_avoids_display_copy(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = test_data.astype(float)
+
+    with manager_context() as manager:
+        manager.show()
+        manager.activateWindow()
+
+        itool([data], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        source_data = parent_tool.slicer_area._data
+        namespace = ToolNamespace(manager._imagetool_wrappers[0])
+        copy_calls = []
+        original_copy = xr.DataArray.copy
+
+        def _record_copy(self, *args, **kwargs):
+            deep = kwargs.get("deep", args[0] if args else True)
+            if self is source_data and deep is True:
+                copy_calls.append(self)
+            return original_copy(self, *args, **kwargs)
+
+        monkeypatch.setattr(xr.DataArray, "copy", _record_copy)
+        namespace[(0, 0)] = -5.0
+
+        assert copy_calls == []
+        assert float(parent_tool.slicer_area._data.values[0, 0]) == -5.0
+        assert parent_tool.slicer_area._accepted_filter_provenance_operation is None
+
+
+def test_tool_namespace_set_filtered_data_item_updates_child_provenance(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    operation = prov.GaussianFilterOperation(sigma={"x": 1.0})
+    filtered = operation.apply(data, parent_data=data)
+    expected = filtered.copy(deep=True)
+    expected[(0, 0)] = -5.0
+
+    with manager_context() as manager:
+        manager.show()
+        manager.activateWindow()
+
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        child_tool = itool(data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=True,
+        )
+        child_node = manager._child_node(child_uid)
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+        qtbot.wait_until(lambda: fetch(child_uid).identical(filtered), timeout=5000)
+
+        namespace = ToolNamespace(manager._imagetool_wrappers[0])
+        namespace[(0, 0)] = -5.0
+
+        qtbot.wait_until(
+            lambda: (
+                child_node.source_state == "fresh"
+                and fetch(child_uid).identical(expected)
+            ),
+            timeout=5000,
+        )
+        child_spec = child_node.displayed_provenance_spec
+        assert child_spec is not None
+        display_code = child_spec.display_code()
+        assert display_code is not None
+        locals_ns = _exec_generated_code(
+            display_code,
+            {"data": data.copy(deep=True), "data_0": data.copy(deep=True)},
+        )
+        xr.testing.assert_identical(
+            locals_ns[child_spec.active_name or "derived"], expected
+        )
+
+
 def test_tool_namespace_set_data_item_failure_keeps_child_tools_fresh(
     qtbot,
     test_data,
@@ -319,6 +505,7 @@ def test_tool_namespace_set_data_item_failure_keeps_child_tools_fresh(
 
         assert child.source_state == "fresh"
         assert float(parent_tool.slicer_area._data.values[0, 0]) == 0.0
+        assert manager._imagetool_wrappers[0].provenance_spec is None
 
 
 def test_manager_console_bare_expression_opens_provenance_root(
@@ -1449,6 +1636,65 @@ def test_manager_console_derived_tool_reload_action_routes_to_manager(
         InteractiveShell.clear_instance()
 
 
+def test_manager_console_derived_reload_reapplies_filter(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(9.0).reshape(3, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(3), "y": np.arange(3)},
+    )
+    data1 = data0 + 1.0
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 1.0}
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
+
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        manager.console._console_widget.execute("tools[0] + tools[1]")
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        derived = manager.get_imagetool(2)
+        derived_uid = manager._imagetool_wrappers[2].uid
+        derived.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+        updated0 = data0 + 10.0
+        manager.get_imagetool(0).slicer_area.replace_source_data(updated0)
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(derived_uid) == "changed",
+            timeout=5000,
+        )
+
+        derived.slicer_area.reload()
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(derived_uid) == "current",
+            timeout=5000,
+        )
+
+        raw_expected = updated0 + data1
+        expected = operation.apply(raw_expected, parent_data=raw_expected)
+        xr.testing.assert_identical(derived.slicer_area.data, expected)
+        xr.testing.assert_identical(derived.slicer_area.displayed_data, expected)
+        display_spec = manager._imagetool_wrappers[2].displayed_provenance_spec
+        assert display_spec is not None
+        assert any(
+            entry.label.startswith("Gaussian Filter")
+            for entry in display_spec.display_entries()
+        )
+
+        manager.console._console_widget.shutdown_kernel()
+        InteractiveShell.clear_instance()
+
+
 def test_manager_concat_records_dependencies_and_handles_removed_inputs(
     qtbot,
     accept_dialog,
@@ -1543,6 +1789,61 @@ def test_manager_concat_records_dependencies_and_handles_removed_inputs(
             manager.get_imagetool(3).slicer_area.data,
             expected_removed_inputs,
         )
+
+
+def test_manager_concat_uses_filtered_display_data(
+    qtbot,
+    accept_dialog,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 10.0
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
+    filtered0 = operation.apply(data0, parent_data=data0)
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        manager.get_imagetool(0).slicer_area.apply_filter_operation(
+            operation,
+            emit_edited=True,
+        )
+        expected = xr.concat(
+            [filtered0, data1],
+            dim="concat_dim",
+            coords="minimal",
+            compat="override",
+            join="outer",
+            combine_attrs="override",
+        ).assign_coords(concat_dim=np.arange(2))
+
+        select_tools(manager, [0, 1])
+        accept_dialog(manager.concat_action.trigger)
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, expected)
+        provenance = manager._imagetool_wrappers[2].provenance_spec
+        assert provenance is not None
+        first_input_spec = provenance.script_inputs[0].parsed_provenance_spec()
+        assert first_input_spec is not None
+        first_input_code = first_input_spec.display_code()
+        assert first_input_code is not None
+        namespace = _exec_generated_code(
+            first_input_code,
+            {"data": data0.copy(deep=True)},
+        )
+        xr.testing.assert_identical(namespace["derived"], filtered0)
 
 
 def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(
@@ -2412,6 +2713,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         fake_child = types.SimpleNamespace(
             uid="1 child-node",
             provenance_spec=file_spec,
+            displayed_provenance_spec=file_spec,
             display_text="Child node",
             snapshot_token=child_marker,
         )

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -26,10 +26,7 @@ def test_manager_childtool_from_filtered_parent_uses_display_provenance(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         parent_tool = manager.get_imagetool(0)
-        parent_tool.slicer_area.apply_func(
-            lambda darr: operation.apply(darr, parent_data=darr),
-            operation=operation,
-        )
+        parent_tool.slicer_area.apply_filter_operation(operation)
         parent_tool.slicer_area.open_in_meshtool()
         qtbot.wait_until(
             lambda: len(manager._imagetool_wrappers[0]._childtools) == 1,
@@ -49,6 +46,380 @@ def test_manager_childtool_from_filtered_parent_uses_display_provenance(
             namespace,
         )
         xr.testing.assert_identical(namespace["derived"], expected)
+
+
+def test_manager_filtered_parent_updates_source_bound_child(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["alpha", "eV"],
+        coords={"alpha": np.arange(5, dtype=float), "eV": np.arange(5, dtype=float)},
+    )
+    operation = prov.GaussianFilterOperation(sigma={"alpha": 1.0})
+    expected = operation.apply(data, parent_data=data)
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root_tool = itool(data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+
+        child_tool = itool(data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=True,
+        )
+        child_node = manager._child_node(child_uid)
+
+        root_tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+        qtbot.wait_until(
+            lambda: (
+                child_node.source_state == "fresh"
+                and fetch(child_uid).identical(expected)
+            ),
+            timeout=5000,
+        )
+        xr.testing.assert_identical(fetch(child_uid), expected)
+        assert child_node.provenance_spec is not None
+        code = child_node.provenance_spec.display_code()
+        assert code is not None
+        namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+        xr.testing.assert_identical(namespace["derived"], expected)
+
+
+def test_manager_filtered_source_bound_child_refresh_keeps_filter(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["alpha", "eV"],
+        coords={"alpha": np.arange(5, dtype=float), "eV": np.arange(5, dtype=float)},
+    )
+    updated = data + 100.0
+    operation = prov.GaussianFilterOperation(sigma={"alpha": 1.0})
+    expected = operation.apply(updated, parent_data=updated)
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root_tool = itool(data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+
+        child_tool = itool(data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=True,
+        )
+        child_node = manager._child_node(child_uid)
+        child_tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+
+        qtbot.wait_until(
+            lambda: (
+                child_node.source_state == "fresh"
+                and fetch(child_uid).identical(expected)
+            ),
+            timeout=5000,
+        )
+        xr.testing.assert_identical(fetch(child_uid), expected)
+        display_spec = child_node.displayed_provenance_spec
+        assert display_spec is not None
+        display_code = display_spec.display_code()
+        assert display_code is not None
+        assert "gaussian_filter" in display_code
+        namespace = _exec_generated_code(
+            display_code, {"data": updated.copy(deep=True)}
+        )
+        xr.testing.assert_identical(namespace["derived"], expected)
+
+
+def test_manager_filtered_source_bound_child_failed_refresh_keeps_filter(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    bad_update = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["u", "y"],
+        coords={"u": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    operation = prov.GaussianFilterOperation(sigma={"x": 1.0})
+    expected = operation.apply(data, parent_data=data)
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root_tool = itool(data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+
+        child_tool = itool(data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=True,
+        )
+        child_node = manager._child_node(child_uid)
+        child_tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, bad_update)
+
+        qtbot.wait_until(
+            lambda: child_node.source_state == "unavailable",
+            timeout=5000,
+        )
+        xr.testing.assert_identical(fetch(child_uid), expected)
+        assert child_tool.slicer_area._accepted_filter_provenance_operation == operation
+
+
+def test_manager_duplicate_filtered_child_records_filter_once(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["alpha", "eV"],
+        coords={"alpha": np.arange(5, dtype=float), "eV": np.arange(5, dtype=float)},
+    )
+    operation = prov.GaussianFilterOperation(sigma={"alpha": 1.0})
+    expected = operation.apply(data, parent_data=data)
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root_tool = itool(data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+
+        child_tool = itool(data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=True,
+        )
+        child_tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+        duplicated_uid = manager.duplicate_childtool(child_uid)
+        duplicated_node = manager._child_node(duplicated_uid)
+        duplicated_tool = manager.get_imagetool(duplicated_uid)
+
+        assert duplicated_node.source_spec is not None
+        assert [op.op for op in duplicated_node.source_spec.operations] == []
+        displayed_source = duplicated_node.displayed_source_spec
+        assert displayed_source is not None
+        assert [op.op for op in displayed_source.operations] == ["gaussian_filter"]
+        display_code = duplicated_node.displayed_provenance_spec.display_code()
+        assert display_code is not None
+        assert display_code.count("gaussian_filter") == 1
+        xr.testing.assert_identical(duplicated_tool.slicer_area.data, expected)
+
+
+def test_manager_workspace_roundtrip_filtered_child_records_filter_once(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["alpha", "eV"],
+        coords={"alpha": np.arange(5, dtype=float), "eV": np.arange(5, dtype=float)},
+    )
+    operation = prov.GaussianFilterOperation(sigma={"alpha": 1.0})
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root_tool = itool(data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+
+        child_tool = itool(data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=True,
+        )
+        child_tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+        tree = manager._to_datatree()
+        saved = typing.cast(
+            "xr.DataTree", tree[f"0/childtools/{child_uid}/imagetool"]
+        ).to_dataset(inherit=False)
+        state = json.loads(saved.attrs["itool_state"])
+        assert state["filter_operation"]["op"] == "gaussian_filter"
+        source_payload = json.loads(saved.attrs["manager_node_live_source_spec"])
+        assert source_payload["operations"] == []
+
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+        for node in tree.values():
+            manager._load_workspace_node(typing.cast("xr.DataTree", node))
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        loaded_node = manager._child_node(child_uid)
+        displayed_source = loaded_node.displayed_source_spec
+        assert displayed_source is not None
+        assert [op.op for op in displayed_source.operations] == ["gaussian_filter"]
+
+        updated = data + 10.0
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+        expected = operation.apply(updated, parent_data=updated)
+        qtbot.wait_until(
+            lambda: fetch(child_uid).identical(expected),
+            timeout=5000,
+        )
+        xr.testing.assert_identical(fetch(child_uid), expected)
+
+
+def test_manager_operation_filter_preserves_output_binding(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+
+    class _OutputToolState(pydantic.BaseModel):
+        pass
+
+    class _OutputTool(erlab.interactive.utils.ToolWindow[_OutputToolState]):
+        StateModel = _OutputToolState
+        tool_name = "output-dummy"
+
+        def __init__(self, data: xr.DataArray) -> None:
+            super().__init__()
+            self._data = data
+            self._status = _OutputToolState()
+
+        @property
+        def tool_status(self) -> _OutputToolState:
+            return self._status
+
+        @tool_status.setter
+        def tool_status(self, status: _OutputToolState) -> None:
+            self._status = status
+
+        @property
+        def tool_data(self) -> xr.DataArray:
+            return self._data
+
+        def output_imagetool_data(
+            self, output_id: str | enum.Enum
+        ) -> xr.DataArray | None:
+            assert output_id == "out"
+            return self._data + 10.0
+
+        def output_imagetool_provenance(
+            self, output_id: str | enum.Enum, data: xr.DataArray
+        ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+            assert output_id == "out"
+            del data
+            return prov.script(
+                prov.ScriptCodeOperation(label="Use output", code="result = data + 10"),
+                start_label="Start from parent",
+                active_name="result",
+            )
+
+    data = xr.DataArray(
+        np.arange(12, dtype=float).reshape((3, 4)),
+        dims=["x", "y"],
+        coords={"x": np.arange(3), "y": np.arange(4)},
+        name="scan",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root_tool = itool(data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+
+        child = _OutputTool(data)
+        child_uid = manager.add_childtool(child, 0, show=False)
+        initial_output = typing.cast("xr.DataArray", child.output_imagetool_data("out"))
+        output_tool = itool(initial_output, manager=False, execute=False)
+        assert isinstance(output_tool, erlab.interactive.imagetool.ImageTool)
+        output_uid = manager.add_imagetool_child(
+            output_tool,
+            child_uid,
+            show=False,
+            provenance_spec=child.output_imagetool_provenance("out", initial_output),
+            source_state="fresh",
+            output_id="out",
+        )
+        operation = prov.GaussianFilterOperation(sigma={"x": 1.0})
+        output_tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+        expected = operation.apply(initial_output, parent_data=initial_output)
+
+        duplicated_uid = manager.duplicate_childtool(output_uid)
+        duplicated_node = manager._child_node(duplicated_uid)
+        assert duplicated_node.output_id == "out"
+        assert duplicated_node.source_spec is None
+        xr.testing.assert_identical(fetch(duplicated_uid), expected)
+
+        tree = manager._to_datatree()
+        saved = typing.cast(
+            "xr.DataTree",
+            tree[f"0/childtools/{child_uid}/childtools/{output_uid}/imagetool"],
+        ).to_dataset(inherit=False)
+        assert saved.attrs["manager_node_output_id"] == "out"
+        state = json.loads(saved.attrs["itool_state"])
+        assert state["filter_operation"]["op"] == "gaussian_filter"
+        xr.testing.assert_identical(
+            saved[manager_mainwindow._ITOOL_DATA_NAME].rename(initial_output.name),
+            initial_output,
+        )
 
 
 def test_manager_non_imagetool_node_displayed_provenance_uses_tool_provenance(
@@ -1668,6 +2039,78 @@ def test_manager_aggregate_child_refreshes_from_parent(
         assert child_node._update_from_parent_source() is True
         xr.testing.assert_identical(
             fetch(child_uid).rename(None), updated.qsel.sum("x").rename(None)
+        )
+
+
+def test_manager_replace_transform_on_filtered_source_child_keeps_live_source(
+    qtbot,
+    accept_dialog,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    data = xr.DataArray(
+        np.arange(12).reshape((3, 4)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(3, dtype=float), "y": np.arange(4, dtype=float)},
+        name="scan",
+    )
+    operation = prov.GaussianFilterOperation(sigma={"x": 1.0})
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root_tool = itool(data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+
+        child_tool = itool(data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=prov.full_data(),
+            source_auto_update=True,
+        )
+        child_node = manager._child_node(child_uid)
+        child_tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+        def _replace_average(dialog) -> None:
+            dialog.dim_checks["x"].setChecked(True)
+            set_transform_launch_mode(dialog, "replace")
+
+        accept_dialog(child_tool.mnb._average, pre_call=_replace_average)
+
+        filtered = operation.apply(data, parent_data=data)
+        expected = filtered.qsel.mean("x").rename("scan_avg")
+        xr.testing.assert_identical(fetch(child_uid), expected)
+        assert child_node.source_spec is not None
+        assert child_node.source_spec.is_live_source
+        assert [op.op for op in child_node.source_spec.operations] == [
+            "gaussian_filter",
+            "qsel_aggregate",
+            "rename",
+        ]
+
+        updated = data + 10.0
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+
+        updated_filtered = operation.apply(updated, parent_data=updated)
+        updated_expected = updated_filtered.qsel.mean("x").rename("scan_avg")
+        qtbot.wait_until(
+            lambda: (
+                child_node.source_state == "fresh"
+                and fetch(child_uid).identical(updated_expected)
+            ),
+            timeout=5000,
+        )
+        xr.testing.assert_identical(
+            fetch(child_uid),
+            updated_expected,
         )
 
 

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -387,6 +387,8 @@ def test_manager_operation_filter_preserves_output_binding(
 
         child = _OutputTool(data)
         child_uid = manager.add_childtool(child, 0, show=False)
+        child_node = manager._child_node(child_uid)
+        assert child_node.displayed_source_spec == child_node.source_spec
         initial_output = typing.cast("xr.DataArray", child.output_imagetool_data("out"))
         output_tool = itool(initial_output, manager=False, execute=False)
         assert isinstance(output_tool, erlab.interactive.imagetool.ImageTool)

--- a/tests/interactive/imagetool/manager/test_warnings.py
+++ b/tests/interactive/imagetool/manager/test_warnings.py
@@ -71,6 +71,30 @@ def test_warning_alert_suppressed_by_log_flag(
         QtWidgets.QApplication.processEvents()
 
 
+def test_warning_handler_ignores_deleted_emitter(qtbot) -> None:
+    emitter = manager_mainwindow._WarningEmitter()
+    handler = manager_mainwindow._WarningNotificationHandler(emitter)
+
+    emitter.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(None, 0)
+    QtWidgets.QApplication.processEvents()
+    qtbot.wait_until(
+        lambda: not erlab.interactive.utils.qt_is_valid(emitter),
+        timeout=1000,
+    )
+
+    record = logging.LogRecord(
+        name="test.warning.deleted",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg="deleted warning emitter",
+        args=(),
+        exc_info=None,
+    )
+    handler.emit(record)
+
+
 def test_error_creating_imagetool_does_not_duplicate_alert_dialog(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -34,6 +34,50 @@ def test_manager_duplicate(
             )
 
 
+def test_workspace_backing_uses_persistence_data_for_filtered_file_data(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    file_path = tmp_path / "scan.h5"
+    data = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+        name="scan",
+    )
+    data.to_netcdf(file_path, engine="h5netcdf")
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 1.0}
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        opened = xr.open_dataarray(file_path, engine="h5netcdf")
+        try:
+            itool(opened, manager=True)
+            qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+            tool = manager.get_imagetool(0)
+            tool.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+            uid = manager._imagetool_wrappers[0].uid
+            entry = next(
+                item
+                for item in manager._workspace_node_manifest_entries()
+                if item["uid"] == uid
+            )
+            assert entry["data_backing"] == "file_lazy"
+            snapshot = manager._workspace_data_backing_snapshot()
+            assert snapshot[uid][0] == "file_lazy"
+            assert str(file_path.resolve()) in snapshot[uid][1]
+        finally:
+            opened.close()
+
+
 def test_manager_duplicate_goldtool_child(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -408,6 +408,29 @@ def test_describe_state_change_reports_axis_inversions():
     assert details == ("Axis inversion changed",)
 
 
+@pytest.mark.parametrize(
+    ("old_filter", "new_filter", "expected"),
+    [
+        (None, {"op": "normalize"}, "Filter applied"),
+        ({"op": "normalize"}, {"op": "gaussian_filter"}, "Filter changed"),
+        ({"op": "normalize"}, None, "Filter cleared"),
+    ],
+)
+def test_describe_state_change_reports_filter_operation(
+    old_filter, new_filter, expected
+) -> None:
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    if old_filter is not None:
+        prev["filter_operation"] = old_filter
+    curr["filter_operation"] = new_filter
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert label == expected
+    assert details == ("Filter operation changed",)
+
+
 def test_describe_state_change_reports_added_keys_and_generic_fallback():
     prev = _base_state()
     curr = copy.deepcopy(prev)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -7999,6 +7999,8 @@ def test_itool_filter_dialog_reopens_with_current_settings(
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     win.slicer_area.apply_filter_operation(first_operation)
+    win.mnb._view_menu_visibility()
+    assert win.mnb.action_dict["resetAct"].isEnabled()
 
     def _set_gaussian_params(dialog: GaussianFilterDialog) -> None:
         assert dialog.dim_checks["x"].isChecked()
@@ -8011,6 +8013,68 @@ def test_itool_filter_dialog_reopens_with_current_settings(
     expected = erlab.analysis.image.gaussian_filter(data, sigma={"x": second_sigma})
     xarray.testing.assert_identical(win.slicer_area.data, expected)
 
+    win.close()
+
+
+def test_normalize_filter_dialog_reopens_with_current_settings(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min_area",
+        denominator_rtol=1e-9,
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation)
+
+    base_dialog = imagetool_dialogs.DataFilterDialog(win.slicer_area)
+    qtbot.addWidget(base_dialog)
+
+    dialog = NormalizeDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    assert dialog.dim_checks["x"].isChecked()
+    assert not dialog.dim_checks["y"].isChecked()
+    assert dialog.opts[3].isChecked()
+    assert dialog.denominator_rtol == pytest.approx(1e-9)
+
+    dialog.restore_filter_operation(
+        erlab.interactive.imagetool.provenance.GaussianFilterOperation(sigma={"x": 1.0})
+    )
+    assert dialog.dim_checks["x"].isChecked()
+    assert dialog.opts[3].isChecked()
+
+    base_dialog.close()
+    dialog.close()
+    win.close()
+
+
+def test_gaussian_filter_restore_skips_unknown_dimensions(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = GaussianFilterDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    dialog.restore_filter_operation(
+        erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+            sigma={"missing": 1.0, "x": 2.0}
+        )
+    )
+
+    assert dialog.dim_checks["x"].isChecked()
+    assert not dialog.dim_checks["y"].isChecked()
+    assert dialog.sigma_spins["x"].value() == pytest.approx(2.0)
+
+    dialog.close()
     win.close()
 
 
@@ -8077,6 +8141,40 @@ def test_accepted_filter_displayed_data_uses_materialized_filter(qtbot) -> None:
     xarray.testing.assert_identical(
         win.slicer_area._tool_source_parent_data(), accepted
     )
+
+    win.slicer_area._accepted_filter_data = None
+    with pytest.raises(RuntimeError, match="Accepted filter data is missing"):
+        _ = win.slicer_area.displayed_data
+    win.close()
+
+
+def test_filter_helpers_reject_invalid_normalized_results(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(9, dtype=float).reshape((3, 3)),
+        dims=["x", "y"],
+        coords={"x": np.arange(3, dtype=float), "y": np.arange(3, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+
+    func = win.slicer_area._filter_func_from_operation(operation)
+    xarray.testing.assert_identical(func(data), operation.apply(data, parent_data=data))
+
+    monkeypatch.setattr(
+        win.slicer_area,
+        "_expected_layout_shape",
+        lambda _source_data, _dims: (99, 99),
+    )
+    with pytest.raises(ValueError, match="shape does not match"):
+        win.slicer_area._normalize_filter_result_for_source_dims(
+            data,
+            data.copy(deep=True),
+            tuple(data.dims),
+        )
     win.close()
 
 
@@ -8095,12 +8193,22 @@ def test_apply_filter_operation_caches_dask_accepted_filter_lazily(qtbot) -> Non
     )
     win = ImageTool(data, auto_compute=False)
     qtbot.addWidget(win)
+    source_replaced: list[xr.DataArray] = []
+    data_edited: list[bool] = []
+    win.slicer_area.sigSourceDataReplaced.connect(source_replaced.append)
+    win.slicer_area.sigDataEdited.connect(lambda: data_edited.append(True))
 
     computed_keys: list[object] = []
     with Callback(pretask=lambda key, _dsk, _state: computed_keys.append(key)):
-        win.slicer_area.apply_filter_operation(operation, update=False)
+        win.slicer_area.apply_filter_operation(
+            operation,
+            update=False,
+            emit_edited=True,
+        )
         cached = win.slicer_area.displayed_data
 
+    assert len(source_replaced) == 1
+    assert data_edited == [True]
     assert computed_keys == []
     assert win.slicer_area.data.chunks is not None
     assert cached.chunks is not None

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2033,6 +2033,155 @@ def test_itool_save(qtbot, accept_dialog) -> None:
     win.close()
 
 
+def test_itool_save_preserves_filter_state_and_exports_displayed_data(
+    qtbot, accept_dialog
+) -> None:
+    data = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5), "y": np.arange(5)},
+        name="scan",
+    )
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
+    expected = operation.apply(data, parent_data=data)
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation)
+
+    ds = win.to_dataset()
+    xarray.testing.assert_identical(
+        ds[imagetool_mainwindow._ITOOL_DATA_NAME],
+        data.rename(imagetool_mainwindow._ITOOL_DATA_NAME),
+    )
+    restored = ImageTool.from_dataset(ds)
+    qtbot.addWidget(restored)
+    xarray.testing.assert_identical(restored.slicer_area.data, expected)
+    xarray.testing.assert_identical(restored.slicer_area._data, data)
+    display_spec = restored.slicer_area.displayed_provenance_spec(
+        erlab.interactive.imagetool.provenance.full_data()
+    )
+    assert display_spec is not None
+    code = display_spec.display_code()
+    assert code is not None
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    xarray.testing.assert_identical(namespace["derived"], expected)
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        filename = f"{tmp_dir_name}/filtered.h5"
+
+        def _go_to_file(dialog: QtWidgets.QFileDialog):
+            dialog.setDirectory(tmp_dir_name)
+            dialog.selectFile(filename)
+            focused = dialog.focusWidget()
+            if isinstance(focused, QtWidgets.QLineEdit):
+                focused.setText("filtered.h5")
+
+        accept_dialog(lambda: win._export_file(native=False), pre_call=_go_to_file)
+        xr.testing.assert_equal(
+            xr.load_dataarray(filename, engine="h5netcdf"),
+            expected,
+        )
+
+    restored.close()
+    win.close()
+
+
+def test_saved_filtered_file_data_reloads_by_reapplying_filter(
+    qtbot, tmp_path: pathlib.Path
+) -> None:
+    file_path = tmp_path / "scan.h5"
+    data = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+        name="scan",
+    )
+    updated = data + 100.0
+    data.to_netcdf(file_path, engine="h5netcdf")
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 1.0}
+    )
+
+    win = ImageTool(
+        data,
+        file_path=file_path,
+        load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+    )
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation)
+    restored = ImageTool.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert restored.slicer_area.reloadable
+
+    updated.to_netcdf(file_path, engine="h5netcdf")
+    with qtbot.wait_signal(restored.slicer_area.sigDataChanged):
+        restored.slicer_area.reload()
+
+    expected = operation.apply(updated, parent_data=updated)
+    xarray.testing.assert_identical(restored.slicer_area.data, expected)
+
+    restored.close()
+    win.close()
+
+
+def test_filter_state_restore_does_not_emit_edit_signals(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 1.0}
+    )
+    expected = operation.apply(data, parent_data=data)
+    source = itool(data, execute=False)
+    target = itool(data.copy(deep=True), execute=False)
+    qtbot.addWidget(source)
+    qtbot.addWidget(target)
+    source.slicer_area.apply_filter_operation(operation)
+    state = copy.deepcopy(source.slicer_area.state)
+    source_replaced = []
+    data_edited = []
+    target.slicer_area.sigSourceDataReplaced.connect(source_replaced.append)
+    target.slicer_area.sigDataEdited.connect(lambda: data_edited.append(True))
+
+    target.slicer_area.state = state
+
+    assert source_replaced == []
+    assert data_edited == []
+    xarray.testing.assert_identical(target.slicer_area.data, expected)
+    assert target.slicer_area._accepted_filter_provenance_operation == operation
+
+    target.close()
+    source.close()
+
+
+def test_process_only_filter_dialog_is_rejected(qtbot) -> None:
+    class OffsetFilterDialog(imagetool_dialogs.DataFilterDialog):
+        def process_data(self, data: xr.DataArray) -> xr.DataArray:
+            return data + 1
+
+    data = xr.DataArray(
+        np.arange(9, dtype=float).reshape((3, 3)),
+        dims=("x", "y"),
+        coords={"x": np.arange(3), "y": np.arange(3)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = OffsetFilterDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    with pytest.raises(NotImplementedError, match="filter_operation"):
+        dialog._apply_current_filter()
+    xarray.testing.assert_identical(win.slicer_area.data, data)
+    assert not win.slicer_area.has_active_filter
+
+    win.close()
+
+
 def test_itool_save_igor_wave(qtbot, accept_dialog) -> None:
     data = xr.DataArray(
         np.arange(25, dtype=np.float32).reshape((5, 5)), dims=["x", "y"], name="wave0"
@@ -2258,7 +2407,8 @@ def test_image_slicer_area_history_and_manual_limits(qtbot):
         area.color_for_cursor(_)
     # apply_func with None and with a function
     area.apply_func(None)
-    area.apply_func(lambda d: d + 1)
+    area.apply_func(lambda d: d + 1, preview=True)
+    area.apply_func(None)
 
     # reloadable/reload (simulate missing file/loader)
     area._file_path = None
@@ -2362,10 +2512,7 @@ def test_child_tool_from_gaussian_filtered_itool_keeps_display_provenance(
 
     win = itool(data, execute=False)
     qtbot.addWidget(win)
-    win.slicer_area.apply_func(
-        lambda darr: operation.apply(darr, parent_data=darr),
-        operation=operation,
-    )
+    win.slicer_area.apply_filter_operation(operation)
 
     win.slicer_area.open_in_meshtool()
     qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000)
@@ -2379,6 +2526,41 @@ def test_child_tool_from_gaussian_filtered_itool_keeps_display_provenance(
     namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
     xarray.testing.assert_identical(namespace["derived"], expected)
 
+    win.close()
+
+
+def test_image_child_from_gaussian_filtered_itool_keeps_display_provenance(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["alpha", "eV"],
+        coords={"alpha": np.arange(5, dtype=float), "eV": np.arange(5, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"alpha": 1.0}
+    )
+    expected = operation.apply(data, parent_data=data)
+
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation)
+
+    win.slicer_area.images[0].open_in_new_window()
+    qtbot.wait_until(
+        lambda: isinstance(win.slicer_area._associated_tools_list[-1], ImageTool),
+        timeout=5000,
+    )
+    child = typing.cast("ImageTool", win.slicer_area._associated_tools_list[-1])
+
+    xarray.testing.assert_identical(child.slicer_area.data, expected)
+    assert child.provenance_spec is not None
+    display_code = child.provenance_spec.display_code()
+    assert display_code is not None
+    namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
+    xarray.testing.assert_identical(namespace["derived"], expected)
+
+    child.close()
     win.close()
 
 
@@ -3682,7 +3864,7 @@ def test_apply_func_preserves_source_data(qtbot) -> None:
         win.show()
         win.activateWindow()
 
-    win.slicer_area.apply_func(lambda darr: darr + 1)
+    win.slicer_area.apply_func(lambda darr: darr + 1, preview=True)
     xarray.testing.assert_identical(win.slicer_area._data, data)
     xarray.testing.assert_identical(win.slicer_area.data, data + 1)
 
@@ -3691,7 +3873,7 @@ def test_apply_func_preserves_source_data(qtbot) -> None:
     win.close()
 
 
-def test_apply_func_keeps_display_provenance_after_failed_filter(qtbot) -> None:
+def test_apply_func_rejects_operation_backed_filters(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)).astype(float),
         dims=["x", "y"],
@@ -3704,25 +3886,21 @@ def test_apply_func_keeps_display_provenance_after_failed_filter(qtbot) -> None:
     win = ImageTool(data)
     qtbot.addWidget(win)
 
-    win.slicer_area.apply_func(
-        lambda darr: operation.apply(darr, parent_data=darr),
-        operation=operation,
-    )
+    win.slicer_area.apply_filter_operation(operation)
     expected = win.slicer_area.data.copy(deep=True)
     before = win.slicer_area.displayed_provenance_spec()
     assert before is not None
 
-    def _raise_filter(_data: xr.DataArray) -> xr.DataArray:
-        raise RuntimeError("failed preview")
-
-    with pytest.raises(RuntimeError, match="failed preview"):
+    with pytest.raises(ValueError, match="apply_filter_operation"):
         win.slicer_area.apply_func(
-            _raise_filter,
+            lambda darr: darr + 1,
             operation=erlab.interactive.imagetool.provenance.NormalizeOperation(
                 dims=("x",),
                 mode="area",
             ),
         )
+    with pytest.raises(ValueError, match="preview-only"):
+        win.slicer_area.apply_func(lambda darr: darr + 1, preview=False)
 
     xarray.testing.assert_identical(win.slicer_area.data, expected)
     after = win.slicer_area.displayed_provenance_spec()
@@ -3748,7 +3926,7 @@ def test_apply_func_preserves_dask_backed_preview(qtbot) -> None:
 
     computed_keys: list[object] = []
     with Callback(pretask=lambda key, _dsk, _state: computed_keys.append(key)):
-        win.slicer_area.apply_func(lambda darr: darr + 1, update=False)
+        win.slicer_area.apply_func(lambda darr: darr + 1, update=False, preview=True)
 
     assert computed_keys == []
     assert win.slicer_area.data_chunked
@@ -3777,12 +3955,18 @@ def test_apply_func_accepts_transposed_dask_preview_and_updates(qtbot) -> None:
     win = ImageTool(data, auto_compute=False)
     qtbot.addWidget(win)
 
-    win.slicer_area.apply_func(lambda darr: (darr + 1).transpose("y", "x"))
+    win.slicer_area.apply_func(
+        lambda darr: (darr + 1).transpose("y", "x"),
+        preview=True,
+    )
 
     assert win.slicer_area.data.dims == data.dims
     assert win.slicer_area.data.chunks is not None
     xarray.testing.assert_identical(
         win.slicer_area.data.compute(), (data + 1).compute()
+    )
+    xarray.testing.assert_identical(
+        win.slicer_area.displayed_data.compute(), data.compute()
     )
     win.close()
 
@@ -3800,12 +3984,16 @@ def test_apply_func_rejects_mismatched_dask_preview(qtbot) -> None:
     qtbot.addWidget(win)
 
     with pytest.raises(ValueError, match="dimensions do not match"):
-        win.slicer_area.apply_func(lambda darr: darr.expand_dims("z"), update=False)
+        win.slicer_area.apply_func(
+            lambda darr: darr.expand_dims("z"), update=False, preview=True
+        )
     with pytest.raises(ValueError, match="dimensions do not match"):
-        win.slicer_area.apply_func(lambda darr: darr.rename({"x": "z"}), update=False)
+        win.slicer_area.apply_func(
+            lambda darr: darr.rename({"x": "z"}), update=False, preview=True
+        )
     with pytest.raises(ValueError, match="shape does not match"):
         win.slicer_area.apply_func(
-            lambda darr: darr.isel(x=slice(1, None)), update=False
+            lambda darr: darr.isel(x=slice(1, None)), update=False, preview=True
         )
     win.close()
 
@@ -3827,7 +4015,7 @@ def test_eager_preview_from_dask_source_updates_readout(qtbot) -> None:
     control = win.docks[0].widget().findChild(ItoolCrosshairControls)
     assert control is not None
 
-    win.slicer_area.apply_func(lambda _darr: preview)
+    win.slicer_area.apply_func(lambda _darr: preview, preview=True)
     assert win.slicer_area.data_chunked
     assert win.slicer_area.data.chunks is None
 
@@ -3850,7 +4038,7 @@ def test_set_source_item_restores_preview_before_source_write(qtbot) -> None:
         win.show()
         win.activateWindow()
 
-    win.slicer_area.apply_func(lambda darr: darr + 10)
+    win.slicer_area.apply_func(lambda darr: darr + 10, preview=True)
     win.slicer_area._set_source_item((0, 0), -5.0)
 
     assert float(data.values[0, 0]) == 0.0
@@ -5032,6 +5220,44 @@ def test_itool_average(qtbot, accept_dialog) -> None:
     win.close()
 
 
+def test_itool_transform_after_filter_uses_displayed_data_and_provenance(
+    qtbot, accept_dialog
+) -> None:
+    data = xr.DataArray(
+        np.arange(60).reshape((3, 4, 5)).astype(float),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(3), "y": np.arange(4), "z": np.arange(5)},
+        name="scan",
+    )
+    filter_operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
+    filtered = filter_operation.apply(data, parent_data=data)
+    expected = filtered.qsel.mean("y").rename("scan_avg")
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(filter_operation)
+
+    def _set_dialog_params(dialog: AverageDialog) -> None:
+        dialog.dim_checks["y"].setChecked(True)
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._average, pre_call=_set_dialog_params)
+
+    assert win.slicer_area._applied_func is None
+    xarray.testing.assert_identical(win.slicer_area._data, expected)
+    assert win.provenance_spec is not None
+    code = win.provenance_spec.display_code()
+    assert code is not None
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    xarray.testing.assert_identical(
+        namespace["derived"].rename(None), expected.rename(None)
+    )
+
+    win.close()
+
+
 def test_itool_aggregate_sum(qtbot, accept_dialog) -> None:
     data = xr.DataArray(
         np.arange(60).reshape((3, 4, 5)).astype(float),
@@ -5604,10 +5830,10 @@ def test_transform_dialog_restores_filter_after_processing_error(
     win = itool(data, execute=False)
     qtbot.addWidget(win)
 
-    def _filter(darr: xr.DataArray) -> xr.DataArray:
-        return darr + 1
-
-    win.slicer_area.apply_func(_filter)
+    filter_operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 1.0}
+    )
+    win.slicer_area.apply_filter_operation(filter_operation)
 
     errors: list[tuple[str, str]] = []
     monkeypatch.setattr(
@@ -5626,7 +5852,7 @@ def test_transform_dialog_restores_filter_after_processing_error(
     dialog.accept()
 
     assert errors == [("Error", "An error occurred while processing data.")]
-    assert win.slicer_area._applied_func is _filter
+    assert win.slicer_area._accepted_filter_provenance_operation == filter_operation
 
     dialog.close()
     win.close()
@@ -7754,6 +7980,239 @@ def test_itool_gaussian_filter_sigma_path(qtbot, accept_dialog, monkeypatch) -> 
     )
     xarray.testing.assert_identical(win.slicer_area.data, data)
 
+    win.close()
+
+
+def test_itool_filter_dialog_reopens_with_current_settings(
+    qtbot, accept_dialog
+) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.linspace(0.0, 0.04, 5), "y": np.arange(5, dtype=float)},
+    )
+    first_sigma = 0.015
+    second_sigma = 0.02
+    first_operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": first_sigma}
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(first_operation)
+
+    def _set_gaussian_params(dialog: GaussianFilterDialog) -> None:
+        assert dialog.dim_checks["x"].isChecked()
+        np.testing.assert_allclose(dialog.sigma_spins["x"].value(), first_sigma)
+        assert not dialog.dim_checks["y"].isChecked()
+        _set_spinbox_text(dialog.sigma_spins["x"], str(second_sigma))
+
+    accept_dialog(win.mnb._gaussian_filter, pre_call=_set_gaussian_params)
+
+    expected = erlab.analysis.image.gaussian_filter(data, sigma={"x": second_sigma})
+    xarray.testing.assert_identical(win.slicer_area.data, expected)
+
+    win.close()
+
+
+def test_itool_filter_preview_reject_restores_active_filter(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.linspace(0.0, 0.04, 5), "y": np.arange(5, dtype=float)},
+    )
+    first_operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 0.015}
+    )
+    second_operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 0.02}
+    )
+    first_expected = first_operation.apply(data, parent_data=data)
+    second_expected = second_operation.apply(data, parent_data=data)
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(first_operation)
+
+    dialog = GaussianFilterDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    _set_spinbox_text(dialog.sigma_spins["x"], "0.02")
+    dialog._preview()
+    xarray.testing.assert_identical(win.slicer_area.data, second_expected)
+    xarray.testing.assert_identical(win.slicer_area.displayed_data, first_expected)
+    display_spec = win.slicer_area.displayed_provenance_spec()
+    assert display_spec is not None
+    code = display_spec.display_code()
+    assert code is not None
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    xarray.testing.assert_identical(namespace["derived"], first_expected)
+
+    dialog.reject()
+
+    xarray.testing.assert_identical(win.slicer_area.data, first_expected)
+    xarray.testing.assert_identical(win.slicer_area.displayed_data, first_expected)
+    assert win.slicer_area._applied_provenance_operation == first_operation
+    win.close()
+
+
+def test_itool_reload_reapplies_accepted_filter(qtbot, tmp_path: pathlib.Path) -> None:
+    data = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.linspace(0.0, 0.04, 5), "y": np.arange(5, dtype=float)},
+        name="scan",
+    )
+    updated = data + 100.0
+    current = {"data": data}
+    file_path = tmp_path / "scan.h5"
+    file_path.touch()
+
+    def _load_current(_path: str) -> xr.DataArray:
+        return current["data"]
+
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 0.015}
+    )
+    win = ImageTool(
+        data,
+        file_path=file_path,
+        load_func=(_load_current, {}, 0),
+    )
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation)
+
+    expected = operation.apply(data, parent_data=data)
+    xarray.testing.assert_identical(win.slicer_area.data, expected)
+    assert win.slicer_area.reloadable
+
+    current["data"] = updated
+    with qtbot.wait_signal(win.slicer_area.sigDataChanged):
+        win.slicer_area.reload()
+
+    updated_expected = operation.apply(updated, parent_data=updated)
+    xarray.testing.assert_identical(win.slicer_area._data, updated)
+    xarray.testing.assert_identical(win.slicer_area.data, updated_expected)
+    xarray.testing.assert_identical(win.slicer_area.displayed_data, updated_expected)
+    assert win.slicer_area._applied_provenance_operation == operation
+
+    win.close()
+
+
+def test_itool_reload_filter_failure_keeps_existing_filtered_data(
+    qtbot, tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    data = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["x", "y"],
+        coords={"x": np.linspace(0.0, 0.04, 5), "y": np.arange(5, dtype=float)},
+        name="scan",
+    )
+    bad_reload = xr.DataArray(
+        np.arange(25, dtype=float).reshape((5, 5)),
+        dims=["u", "y"],
+        coords={"u": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+        name="scan",
+    )
+    current = {"data": data}
+    file_path = tmp_path / "scan.h5"
+    file_path.touch()
+
+    def _load_current(_path: str) -> xr.DataArray:
+        return current["data"]
+
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 0.015}
+    )
+    win = ImageTool(
+        data,
+        file_path=file_path,
+        load_func=(_load_current, {}, 0),
+    )
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation)
+    expected_source = win.slicer_area._data.copy(deep=True)
+    expected_display = win.slicer_area.data.copy(deep=True)
+    errors: list[tuple[str, str]] = []
+
+    def _critical(parent, title, text, informative_text="", detailed_text=None):
+        del parent, informative_text, detailed_text
+        errors.append((title, text))
+
+    monkeypatch.setattr(erlab.interactive.utils.MessageDialog, "critical", _critical)
+
+    current["data"] = bad_reload
+    assert not win.slicer_area._reload()
+
+    assert errors == [("Error", "An error occurred while reloading data.")]
+    xarray.testing.assert_identical(win.slicer_area._data, expected_source)
+    xarray.testing.assert_identical(win.slicer_area.data, expected_display)
+    assert win.slicer_area._accepted_filter_provenance_operation == operation
+
+    win.close()
+
+
+def test_itool_empty_filter_accept_clears_active_filter(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.linspace(0.0, 0.04, 5), "y": np.arange(5, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": 0.015}
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation)
+
+    dialog = GaussianFilterDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    dialog.dim_checks["x"].setChecked(False)
+    dialog.accept()
+
+    assert win.slicer_area._applied_func is None
+    assert win.slicer_area._applied_provenance_operation is None
+    xarray.testing.assert_identical(win.slicer_area.data, data)
+    win.close()
+
+
+def test_itool_filter_accept_and_reset_are_undoable(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.linspace(0.0, 0.04, 5), "y": np.arange(5, dtype=float)},
+    )
+    sigma = 0.015
+    operation = erlab.interactive.imagetool.provenance.GaussianFilterOperation(
+        sigma={"x": sigma}
+    )
+    expected = operation.apply(data, parent_data=data)
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_filter(dialog: GaussianFilterDialog) -> None:
+        dialog.dim_checks["x"].setChecked(True)
+        _set_spinbox_text(dialog.sigma_spins["x"], str(sigma))
+
+    accept_dialog(win.mnb._gaussian_filter, pre_call=_set_filter)
+
+    xarray.testing.assert_identical(win.slicer_area.data, expected)
+    assert win.slicer_area.undoable
+
+    with qtbot.wait_signal(win.slicer_area.sigSourceDataReplaced):
+        win.slicer_area.undo()
+    xarray.testing.assert_identical(win.slicer_area.data, data)
+    assert win.slicer_area._accepted_filter_provenance_operation is None
+
+    with qtbot.wait_signal(win.slicer_area.sigSourceDataReplaced):
+        win.slicer_area.redo()
+    xarray.testing.assert_identical(win.slicer_area.data, expected)
+    assert win.slicer_area._accepted_filter_provenance_operation == operation
+
+    win.mnb._reset_filters()
+    xarray.testing.assert_identical(win.slicer_area.data, data)
+
+    with qtbot.wait_signal(win.slicer_area.sigSourceDataReplaced):
+        win.slicer_area.undo()
+    xarray.testing.assert_identical(win.slicer_area.data, expected)
+    assert win.slicer_area._accepted_filter_provenance_operation == operation
     win.close()
 
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -8053,6 +8053,91 @@ def test_itool_filter_preview_reject_restores_active_filter(qtbot) -> None:
     win.close()
 
 
+def test_accepted_filter_displayed_data_uses_materialized_filter(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(9, dtype=float).reshape((3, 3)),
+        dims=["x", "y"],
+        coords={"x": np.arange(3, dtype=float), "y": np.arange(3, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation)
+    accepted = win.slicer_area.data.copy(deep=True)
+
+    data.values[:] *= 2.0
+
+    recomputed = operation.apply(data, parent_data=data)
+    assert float(recomputed.values[1, 0]) != float(accepted.values[1, 0])
+    xarray.testing.assert_identical(win.slicer_area.data, accepted)
+    xarray.testing.assert_identical(win.slicer_area.displayed_data, accepted)
+    xarray.testing.assert_identical(
+        win.slicer_area._tool_source_parent_data(), accepted
+    )
+    win.close()
+
+
+def test_apply_filter_operation_caches_dask_accepted_filter_lazily(qtbot) -> None:
+    da = pytest.importorskip("dask.array")
+    from dask.callbacks import Callback
+
+    data = xr.DataArray(
+        da.from_array(np.arange(12, dtype=float).reshape((3, 4)), chunks=(2, 2)),
+        dims=["x", "y"],
+        coords={"x": np.arange(3, dtype=float), "y": np.arange(4, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+
+    computed_keys: list[object] = []
+    with Callback(pretask=lambda key, _dsk, _state: computed_keys.append(key)):
+        win.slicer_area.apply_filter_operation(operation, update=False)
+        cached = win.slicer_area.displayed_data
+
+    assert computed_keys == []
+    assert win.slicer_area.data.chunks is not None
+    assert cached.chunks is not None
+    xarray.testing.assert_identical(
+        cached.compute(),
+        operation.apply(data, parent_data=data).compute(),
+    )
+    win.close()
+
+
+def test_compute_chunked_preserves_accepted_filter(qtbot) -> None:
+    da = pytest.importorskip("dask.array")
+
+    data = xr.DataArray(
+        da.from_array(np.arange(12, dtype=float).reshape((3, 4)), chunks=(2, 2)),
+        dims=["x", "y"],
+        coords={"x": np.arange(3, dtype=float), "y": np.arange(4, dtype=float)},
+    )
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.apply_filter_operation(operation, update=False)
+
+    win.slicer_area._compute_chunked()
+
+    loaded = data.compute()
+    expected = operation.apply(loaded, parent_data=loaded)
+    assert win.slicer_area._data.chunks is None
+    assert win.slicer_area._accepted_filter_provenance_operation == operation
+    xarray.testing.assert_identical(win.slicer_area.data, expected)
+    xarray.testing.assert_identical(win.slicer_area.displayed_data, expected)
+    win.close()
+
+
 def test_itool_reload_reapplies_accepted_filter(qtbot, tmp_path: pathlib.Path) -> None:
     data = xr.DataArray(
         np.arange(25, dtype=float).reshape((5, 5)),

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1696,6 +1696,32 @@ def test_tool_provenance_remaining_operation_and_display_branches(monkeypatch) -
     assert prov.compose_full_provenance(parent, None) == parent
 
 
+def test_append_display_operation_preserves_final_rename_for_live_sources() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    operation = prov.NormalizeOperation(dims=("x",), mode="min")
+    spec = prov.full_data().append_final_rename("filtered")
+
+    displayed = spec.append_display_operation(operation)
+
+    assert [op.op for op in displayed.operations] == [
+        "normalize",
+        "rename",
+    ]
+    assert displayed.operations[-1] == prov.RenameOperation(name="filtered")
+
+
+def test_append_display_operation_rejects_non_live_sources() -> None:
+    prov = erlab.interactive.imagetool.provenance
+    operation = prov.NormalizeOperation(dims=("x",), mode="min")
+    spec = prov.script(
+        start_label="Evaluate console expression",
+        active_name="derived",
+    )
+
+    with pytest.raises(TypeError, match="live sources"):
+        spec.append_display_operation(operation)
+
+
 def test_tool_provenance_apply_analysis_operations(monkeypatch) -> None:
     data = _base_data()
     edge_fit = xr.Dataset({"edge": ("x", [1.0, 2.0, 3.0])})


### PR DESCRIPTION
## Summary
- Treat accepted filters as durable displayed state instead of replay-only preview state
- Propagate filtered data and provenance through export, console edits, reload, duplication, workspace save/load, and manager child tools
- Restore filter dialogs to the current accepted settings when reopened
- Update docs and add regression tests for filtered data behavior, reload, and warning handling

## Testing
- `uv run pytest` focused ImageTool and manager provenance/console/workspace cases
- `uv run ruff check --fix` and `uv run ruff format --check` on touched files
- `uv run mypy src/erlab/interactive/imagetool/viewer.py`