### PR TITLE
Add Reload Data to child tools and recurse to reload ancestors

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2099,6 +2099,8 @@ class ImageToolManager(QtWidgets.QMainWindow):
         parent.add_child_reference(
             node.uid, typing.cast("QtWidgets.QWidget", node.window)
         )
+        if node.tool_window is not None:
+            node.tool_window._refresh_reload_data_action()
 
     def _unregister_node(self, uid: str) -> None:
         node = self._all_nodes.pop(uid, None)
@@ -2679,35 +2681,48 @@ class ImageToolManager(QtWidgets.QMainWindow):
             _add_reload_target(index)
 
         for uid in selected_children:
-            try:
-                current: _ImageToolWrapper | _ManagedWindowNode = self._child_node(uid)
-            except KeyError:
-                return None
-            if not current.has_source_binding:
-                return None
-
-            reload_target: int | str | None = None
-            while True:
-                try:
-                    parent = self._parent_node(current)
-                except KeyError:
-                    break
-                if parent.is_imagetool and parent.reloadable:
-                    reload_target = (
-                        parent.index
-                        if isinstance(parent, _ImageToolWrapper)
-                        else parent.uid
-                    )
-                if isinstance(parent, _ImageToolWrapper):
-                    break
-                current = parent
-
+            reload_target = self._reload_target_for_child(uid)
             if reload_target is None:
                 return None
             _add_reload_target(reload_target)
             child_targets.setdefault(reload_target, []).append(uid)
 
         return reload_targets, child_targets
+
+    def _reload_target_for_child(self, uid: str) -> int | str | None:
+        try:
+            current: _ImageToolWrapper | _ManagedWindowNode = self._child_node(uid)
+        except KeyError:
+            return None
+        if not current.has_source_binding:
+            return None
+
+        reload_target: int | str | None = None
+        while True:
+            try:
+                parent = self._parent_node(current)
+            except KeyError:
+                break
+            if parent.is_imagetool and parent.reloadable:
+                reload_target = (
+                    parent.index
+                    if isinstance(parent, _ImageToolWrapper)
+                    else parent.uid
+                )
+            if isinstance(parent, _ImageToolWrapper):
+                break
+            current = parent
+        return reload_target
+
+    def _reload_source_chain_for_child(self, uid: str) -> bool:
+        """Reload the nearest reloadable ancestor, then refresh a child node."""
+        reload_target = self._reload_target_for_child(uid)
+        if reload_target is None:
+            return False
+        node = self._node_for_target(reload_target)
+        if node.imagetool is None or not node.slicer_area._reload():
+            return False
+        return self._refresh_source_chain_to_uid(uid)
 
     @QtCore.Slot()
     def show_selected_source_updates(self) -> None:

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -225,6 +225,7 @@ class _ManagedWindowNode(QtCore.QObject):
                 old.sigDataChanged.disconnect(self._handle_tool_data_changed)
             old.removeEventFilter(self)
             old._set_managed_source_update_dialog(None)
+            old._set_managed_source_reload(None)
             old.set_source_parent_fetcher(None)
             old.set_input_provenance_parent_fetcher(None)
             old.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
@@ -266,6 +267,9 @@ class _ManagedWindowNode(QtCore.QObject):
         tool.sigDataChanged.connect(self._handle_tool_data_changed)
         tool.destroyed.connect(self._handle_tool_window_destroyed)
         tool._set_managed_source_update_dialog(self.show_source_update_dialog)
+        tool._set_managed_source_reload(
+            self.reload_source_data, self.can_reload_source_data
+        )
 
     def _handle_tool_window_destroyed(self, _obj: QtCore.QObject | None = None) -> None:
         manager = self._manager()
@@ -956,6 +960,17 @@ class _ManagedWindowNode(QtCore.QObject):
     def reload(self) -> None:
         if self.imagetool is not None:
             self.slicer_area.reload()
+
+    def reload_source_data(self) -> bool:
+        if self.tool_window is None:
+            return False
+        return self.manager._reload_source_chain_for_child(self.uid)
+
+    def can_reload_source_data(self) -> bool:
+        return (
+            self.tool_window is not None
+            and self.manager._reload_target_for_child(self.uid) is not None
+        )
 
     @QtCore.Slot()
     def _refresh_node_info(self) -> None:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3914,11 +3914,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     @QtCore.Slot()
     def _refresh_reload_data_action(self) -> None:
+        if not qt_is_valid(self.reload_data_action):
+            return
         reloadable = self._source_reloadable()
         self.reload_data_action.setVisible(reloadable)
         self.reload_data_action.setEnabled(reloadable)
+        if not qt_is_valid(self._tool_file_menu):
+            return
         menu_action = self._tool_file_menu.menuAction()
-        if menu_action is not None:
+        if menu_action is not None and qt_is_valid(menu_action):
             menu_action.setVisible(reloadable)
 
     def finalize_source_refresh(self) -> None:
@@ -3990,6 +3994,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._refresh_reload_data_action()
         if (
             self._managed_source_reload is None
+            or not qt_is_valid(self.reload_data_action)
             or not self.reload_data_action.isEnabled()
         ):
             return False

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3031,10 +3031,26 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._source_auto_update: bool = False
         self._source_parent_fetcher: Callable[[], xr.DataArray] | None = None
         self._managed_source_update_dialog: Callable[..., int] | None = None
+        self._managed_source_reload: Callable[[], bool] | None = None
+        self._managed_source_reload_available: Callable[[], bool] | None = None
         self._output_imagetool_targets: dict[str, str | QtWidgets.QWidget] = {}
 
-        # Initialize a menu bar to correctly apply keyboard shortcuts on some platforms
-        self.menuBar()
+        menu_bar = typing.cast("QtWidgets.QMenuBar", self.menuBar())
+        self._tool_file_menu = typing.cast("QtWidgets.QMenu", menu_bar.addMenu("&File"))
+        self._tool_file_menu.setObjectName("tool_file_menu")
+        self.reload_data_action = QtWidgets.QAction("&Reload Data", self)
+        self.reload_data_action.setObjectName("tool_reload_data_action")
+        self.reload_data_action.setShortcut(QtGui.QKeySequence.StandardKey.Refresh)
+        self.reload_data_action.setShortcutContext(
+            QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
+        self.reload_data_action.setIcon(QtGui.QIcon.fromTheme("view-refresh"))
+        self.reload_data_action.setVisible(False)
+        self.reload_data_action.setEnabled(False)
+        self.reload_data_action.triggered.connect(self.reload_source_data)
+        self._tool_file_menu.addAction(self.reload_data_action)
+        self._tool_file_menu.aboutToShow.connect(self._refresh_reload_data_action)
+        self._refresh_reload_data_action()
 
         # Enable closing with keyboard shortcut
         self.__close_shortcut = QtWidgets.QShortcut("Ctrl+W", self, self._hide_or_close)
@@ -3876,6 +3892,35 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Set the manager-owned source update dialog callback."""
         self._managed_source_update_dialog = callback
 
+    def _set_managed_source_reload(
+        self,
+        callback: Callable[[], bool] | None,
+        available: Callable[[], bool] | None = None,
+    ) -> None:
+        """Set the manager-owned reload callback for this tool source."""
+        self._managed_source_reload = callback
+        self._managed_source_reload_available = available
+        self._refresh_reload_data_action()
+
+    def _source_reloadable(self) -> bool:
+        if self._managed_source_reload is None:
+            return False
+        if self._managed_source_reload_available is None:
+            return True
+        try:
+            return self._managed_source_reload_available()
+        except Exception:
+            return False
+
+    @QtCore.Slot()
+    def _refresh_reload_data_action(self) -> None:
+        reloadable = self._source_reloadable()
+        self.reload_data_action.setVisible(reloadable)
+        self.reload_data_action.setEnabled(reloadable)
+        menu_action = self._tool_file_menu.menuAction()
+        if menu_action is not None:
+            menu_action.setVisible(reloadable)
+
     def finalize_source_refresh(self) -> None:
         """Record that the current source refresh has been applied to the tool."""
         self._source_refresh_deferred = False
@@ -3938,6 +3983,17 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             "}"
         )
         self._source_status_bar.show()
+
+    @QtCore.Slot()
+    def reload_source_data(self) -> bool:
+        """Reload this tool from its managed ImageTool source chain."""
+        self._refresh_reload_data_action()
+        if (
+            self._managed_source_reload is None
+            or not self.reload_data_action.isEnabled()
+        ):
+            return False
+        return self._managed_source_reload()
 
     def _materialized_source_spec(
         self, parent_data: xr.DataArray

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -1212,6 +1212,172 @@ def test_manager_reload_selected_child_tool_refreshes_from_file_parent(
         xr.testing.assert_identical(child.tool_data, updated.transpose("eV", "alpha"))
 
 
+def test_managed_child_tool_file_menu_reload_refreshes_file_parent(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = test_data.rename("scan")
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            source,
+            manager=True,
+            file_path=file_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1, timeout=5000
+        )
+
+        child_uid = manager._imagetool_wrappers[0]._childtool_indices[0]
+        child = manager.get_childtool(child_uid)
+        assert isinstance(child, DerivativeTool)
+        assert child.source_state == "fresh"
+
+        reload_action = child.findChild(QtGui.QAction, "tool_reload_data_action")
+        file_menu = child._tool_file_menu
+        assert reload_action is not None
+        assert child._source_status_bar.isHidden()
+        file_menu.aboutToShow.emit()
+        assert file_menu.menuAction().isVisible()
+        assert reload_action.isVisible()
+        assert reload_action.isEnabled()
+        refresh_key = QtGui.QKeySequence(QtGui.QKeySequence.StandardKey.Refresh)
+        assert (
+            reload_action.shortcut().matches(refresh_key)
+            == QtGui.QKeySequence.SequenceMatch.ExactMatch
+        )
+
+        updated = source.copy(deep=True)
+        updated.data = np.asarray(updated.data) + 100.0
+        updated.to_netcdf(file_path, engine="h5netcdf")
+
+        with qtbot.wait_signal(child.sigDataChanged, timeout=5000):
+            reload_action.trigger()
+
+        assert child.source_state == "fresh"
+        xr.testing.assert_identical(fetch(0), updated)
+        xr.testing.assert_identical(child.tool_data, updated.transpose("eV", "alpha"))
+
+
+def test_managed_nested_child_tool_file_menu_reload_refreshes_file_ancestor(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    prov = erlab.interactive.imagetool.provenance
+    source = test_data.rename("scan")
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            source,
+            manager=True,
+            file_path=file_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child_source_spec = prov.selection(
+            prov.IselOperation(kwargs={"alpha": slice(0, 4)})
+        )
+        child_tool = itool(
+            child_source_spec.apply(source), manager=False, execute=False
+        )
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=child_source_spec,
+            source_auto_update=False,
+        )
+
+        child_node = manager._child_node(child_uid)
+        child_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(lambda: len(child_node._childtools) == 1, timeout=5000)
+
+        tool_uid = child_node._childtool_indices[0]
+        tool = manager.get_childtool(tool_uid)
+        assert isinstance(tool, DerivativeTool)
+        assert child_node.source_state == "fresh"
+        assert tool.source_state == "fresh"
+
+        reload_action = tool.findChild(QtGui.QAction, "tool_reload_data_action")
+        assert reload_action is not None
+        assert reload_action.isEnabled()
+
+        updated = source.copy(deep=True)
+        updated.data = np.asarray(updated.data) + 100.0
+        updated.to_netcdf(file_path, engine="h5netcdf")
+
+        with qtbot.wait_signal(tool.sigDataChanged, timeout=5000):
+            reload_action.trigger()
+
+        expected_child = updated.isel(alpha=slice(0, 4))
+        assert child_node.source_state == "fresh"
+        assert tool.source_state == "fresh"
+        xr.testing.assert_identical(fetch(0), updated)
+        xr.testing.assert_identical(fetch(child_uid), expected_child)
+        xr.testing.assert_identical(
+            tool.tool_data, expected_child.transpose("eV", "alpha")
+        )
+
+
+def test_managed_child_tool_hides_reload_without_reloadable_ancestor(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.images[0].open_in_dtool()
+        qtbot.wait_until(
+            lambda: len(manager._imagetool_wrappers[0]._childtools) == 1, timeout=5000
+        )
+
+        child_uid = manager._imagetool_wrappers[0]._childtool_indices[0]
+        child = manager.get_childtool(child_uid)
+        assert isinstance(child, DerivativeTool)
+
+        reload_action = child.findChild(QtGui.QAction, "tool_reload_data_action")
+        assert reload_action is not None
+        child._tool_file_menu.aboutToShow.emit()
+        assert not child._tool_file_menu.menuAction().isVisible()
+        assert not reload_action.isVisible()
+        assert not reload_action.isEnabled()
+        assert not child.reload_source_data()
+        assert not manager._reload_source_chain_for_child(child_uid)
+
+
 def test_manager_reload_selected_nested_child_refreshes_from_file_ancestor(
     qtbot,
     tmp_path: pathlib.Path,

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -438,6 +438,21 @@ def test_qt_is_valid_rejects_deleted_widget(qtbot) -> None:
     qtbot.wait_until(lambda: not qt_is_valid(widget), timeout=1000)
 
 
+def test_tool_window_reload_refresh_ignores_deleted_file_menu(qtbot) -> None:
+    tool = erlab.interactive.utils.ToolWindow()
+    qtbot.addWidget(tool)
+    tool._set_managed_source_reload(lambda: True, lambda: True)
+
+    menu = tool._tool_file_menu
+    menu.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    QtWidgets.QApplication.processEvents()
+    qtbot.wait_until(lambda: not qt_is_valid(menu), timeout=1000)
+
+    tool._set_managed_source_reload(None)
+    assert not tool.reload_source_data()
+
+
 def test_close_shortcut_reaches_child_line_edit(qtbot) -> None:
     window = QtWidgets.QMainWindow()
     line_edit = QtWidgets.QLineEdit(window)


### PR DESCRIPTION
## Summary
- Add a fixed `Reload Data` File menu action and `Cmd+R` shortcut to managed child tools.
- Route child reloads through the manager so the nearest reloadable ancestor is refreshed before the child is recomputed.
- Keep the existing source-status UI separate for in-memory update availability.
- Hide the reload action entirely when a child has no reloadable ancestor.

## Testing
- Added UI regression coverage for direct child reload, nested child reload through a parent ImageTool, and the no-reloadable-ancestor case.
- Ran focused Qt tests for the new reload paths and existing update-dialog/source-binding behavior.
- Verified formatting, lint, type checking, and diff cleanliness on the touched modules.