### PR TITLE
Persist manager Added timestamps in workspace files

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -31,6 +31,7 @@ from erlab.interactive.imagetool.manager._wrapper import (
 )
 
 if typing.TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable, Iterable, Mapping
 
     from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
@@ -397,7 +398,7 @@ class _ActionsMixin:
 
         childtool_indices = list(node._childtool_indices)
         childtools = dict(node._childtools)
-        created_time = node._created_time
+        created_time = node.created_time
         recent_geometry = node._recent_geometry
         persistence = node.persistence_view()
         provenance_spec = persistence.provenance_spec
@@ -413,9 +414,9 @@ class _ActionsMixin:
                 uid=uid,
                 provenance_spec=provenance_spec,
                 snapshot_token=snapshot_token,
+                created_time=created_time,
             )
         wrapper = self._imagetool_wrappers[new_index]
-        wrapper._created_time = created_time
         wrapper._recent_geometry = recent_geometry
         wrapper._childtool_indices = childtool_indices
         wrapper._childtools = childtools
@@ -1196,6 +1197,7 @@ class _ActionsMixin:
         show: bool = True,
         uid: str | None = None,
         snapshot_token: str | None = None,
+        created_time: datetime.datetime | str | bytes | None = None,
     ) -> str:
         """Register a child tool window.
 
@@ -1218,6 +1220,7 @@ class _ActionsMixin:
             parent.uid,
             tool,
             snapshot_token=snapshot_token,
+            created_time=created_time,
         )
         if not tool._tool_display_name:
             tool._tool_display_name = parent.name
@@ -1256,6 +1259,7 @@ class _ActionsMixin:
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         output_id: str | None = None,
         snapshot_token: str | None = None,
+        created_time: datetime.datetime | str | bytes | None = None,
     ) -> str:
         parent_node = self._node_for_target(parent)
         if source_spec is None and source_binding is not None:
@@ -1280,6 +1284,7 @@ class _ActionsMixin:
             source_state=source_state,
             output_id=output_id,
             snapshot_token=snapshot_token,
+            created_time=created_time,
         )
         self._register_child_node(node)
         if output_id is not None and parent_node.tool_window is not None:

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -1370,12 +1370,11 @@ class ToolNamespace(_ConsoleDataHandleMixin):
         return super().__getattr__(attr)
 
     def __repr__(self) -> str:
-        time_repr = self._wrapper._created_time.isoformat(sep=" ", timespec="seconds")
         label = self._console_label
         if self._wrapper.name:
             label += f": {self._wrapper.name}"
         out = f"{label}\n"
-        out += f"  Added: {time_repr}\n"
+        out += f"  Added: {self._wrapper.added_time_display}\n"
         out += f"  Linked: {self.tool.slicer_area.is_linked}\n"
         return out
 

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -30,6 +30,7 @@ from erlab.interactive.imagetool.manager._wrapper import (
 )
 
 if typing.TYPE_CHECKING:
+    import datetime
     import pathlib
 
     from erlab.interactive.imagetool.provenance_framework import (
@@ -784,6 +785,7 @@ class ImageToolManager(
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         index: int | None = None,
         snapshot_token: str | None = None,
+        created_time: datetime.datetime | str | bytes | None = None,
     ) -> int:
         """Add a new ImageTool window to the manager and show it.
 
@@ -831,6 +833,7 @@ class ImageToolManager(
             source_auto_update=source_auto_update,
             source_state=source_state,
             snapshot_token=snapshot_token,
+            created_time=created_time,
         )
         self._imagetool_wrappers[index] = wrapper
         self._register_root_wrapper(wrapper)

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -592,6 +592,7 @@ class _WorkspaceIOMixin:
         ds.attrs["manager_node_uid"] = node.uid
         ds.attrs["manager_node_kind"] = kind
         ds.attrs["manager_node_snapshot_token"] = node.snapshot_token
+        ds.attrs["manager_node_added_at"] = node.added_time_iso
         persistence = node.persistence_view()
         provenance_spec = persistence.provenance_spec
         if provenance_spec is not None:
@@ -779,6 +780,7 @@ class _WorkspaceIOMixin:
         kwargs: dict[str, typing.Any] = {
             "uid": uid,
             "snapshot_token": ds.attrs.get("manager_node_snapshot_token"),
+            "created_time": ds.attrs.get("manager_node_added_at"),
             "provenance_spec": parsed_provenance_spec,
             "source_spec": parsed_source_spec,
             "source_binding": parsed_source_binding,
@@ -862,6 +864,7 @@ class _WorkspaceIOMixin:
             show=ds.attrs.get("tool_visible", True),
             uid=ds.attrs.get("manager_node_uid"),
             snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
+            created_time=ds.attrs.get("manager_node_added_at"),
         )
 
     @staticmethod

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -88,7 +88,7 @@ def _coerce_added_time(
 
 
 def _format_added_time(value: datetime.datetime) -> str:
-    return value.astimezone().isoformat(sep=" ", timespec="seconds")
+    return value.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z (%z)")
 
 
 def _preview_from_imagetool(

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -8,6 +8,7 @@ __all__ = ["_ImageToolWrapper", "_ManagedWindowNode"]
 import contextlib
 import datetime
 import keyword
+import logging
 import sys
 import typing
 import uuid
@@ -37,6 +38,57 @@ if typing.TYPE_CHECKING:
     )
     from erlab.interactive.imagetool.viewer import ImageSlicerArea
     from erlab.interactive.imagetool.viewer_state import ImageSlicerState
+
+
+logger = logging.getLogger(__name__)
+
+
+def _current_added_time() -> datetime.datetime:
+    return datetime.datetime.now().astimezone().replace(microsecond=0)
+
+
+def _coerce_added_time(
+    value: datetime.datetime | str | bytes | None, *, node_uid: str | None = None
+) -> datetime.datetime:
+    if value is None:
+        return _current_added_time()
+    if isinstance(value, bytes):
+        try:
+            value = value.decode()
+        except UnicodeDecodeError:
+            logger.warning(
+                "Ignoring invalid saved manager added timestamp for node %s",
+                node_uid,
+                exc_info=True,
+            )
+            return _current_added_time()
+    if isinstance(value, str):
+        try:
+            value = datetime.datetime.fromisoformat(value)
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid saved manager added timestamp for node %s",
+                node_uid,
+                exc_info=True,
+            )
+            return _current_added_time()
+    if not isinstance(value, datetime.datetime):
+        logger.warning(
+            "Ignoring invalid saved manager added timestamp for node %s",
+            node_uid,
+        )
+        return _current_added_time()
+    if value.tzinfo is None or value.utcoffset() is None:
+        logger.warning(
+            "Ignoring invalid saved manager added timestamp for node %s",
+            node_uid,
+        )
+        return _current_added_time()
+    return value.replace(microsecond=0)
+
+
+def _format_added_time(value: datetime.datetime) -> str:
+    return value.astimezone().isoformat(sep=" ", timespec="seconds")
 
 
 def _preview_from_imagetool(
@@ -148,13 +200,14 @@ class _ManagedWindowNode(QtCore.QObject):
         source_state: _source_state_type = "fresh",
         output_id: str | None = None,
         snapshot_token: str | None = None,
+        created_time: datetime.datetime | str | bytes | None = None,
     ) -> None:
         super().__init__(manager)
         self._manager = weakref.ref(manager)
         self.uid = uid
         self.parent_uid = parent_uid
         self._recent_geometry: QtCore.QRect | None = None
-        self._created_time = datetime.datetime.now()
+        self._created_time = _coerce_added_time(created_time, node_uid=uid)
 
         self._childtools: dict[str, QtWidgets.QWidget] = {}
         self._childtool_indices: list[str] = []
@@ -410,15 +463,25 @@ class _ManagedWindowNode(QtCore.QObject):
         text = erlab.utils.formatting.format_darr_html(
             self.slicer_area.displayed_data,
             show_size=True,
-            additional_info=[
-                f"Added {self._created_time.isoformat(sep=' ', timespec='seconds')}"
-            ],
+            additional_info=[f"Added {self.added_time_display}"],
         )
         return erlab.interactive.utils._apply_qt_accent_color(text)
 
     @property
     def tree_uid_text(self) -> str:
         return self.uid
+
+    @property
+    def created_time(self) -> datetime.datetime:
+        return self._created_time
+
+    @property
+    def added_time_iso(self) -> str:
+        return self._created_time.isoformat(timespec="seconds")
+
+    @property
+    def added_time_display(self) -> str:
+        return _format_added_time(self._created_time)
 
     def _metadata_data(self) -> xr.DataArray | None:
         if self.imagetool is not None:
@@ -489,7 +552,7 @@ class _ManagedWindowNode(QtCore.QObject):
             ),
             _MetadataField(
                 "Added",
-                self._created_time.isoformat(sep=" ", timespec="seconds"),
+                self.added_time_display,
                 monospace=True,
             ),
         ]
@@ -1269,6 +1332,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         source_auto_update: bool = False,
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         snapshot_token: str | None = None,
+        created_time: datetime.datetime | str | bytes | None = None,
     ) -> None:
         self._index = index
         self._watched_varname: str | None = None
@@ -1301,6 +1365,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
             source_auto_update=source_auto_update,
             source_state=source_state,
             snapshot_token=snapshot_token,
+            created_time=created_time,
         )
 
     @property

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -166,6 +166,44 @@ def test_manager_workspace_load_preserves_added_time(
         assert manager._child_node(tool_uid).created_time == tool_added
 
 
+def test_manager_added_time_display_uses_zone_name_and_offset(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    added = datetime.datetime(
+        2024,
+        1,
+        2,
+        3,
+        4,
+        5,
+        tzinfo=datetime.timezone(datetime.timedelta(hours=9), "KST"),
+    )
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+            created_time=added,
+        )
+
+        node = manager._imagetool_wrappers[0]
+        expected = added.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z (%z)")
+        assert node.added_time_display == expected
+        assert node.added_time_iso == added.isoformat(timespec="seconds")
+        assert (
+            next(
+                field.value for field in node.metadata_fields if field.label == "Added"
+            )
+            == expected
+        )
+        assert f"Added {expected}" in node.info_text
+
+
 @pytest.mark.parametrize("saved_attr", [None, "not-a-date"], ids=["missing", "invalid"])
 def test_manager_workspace_load_falls_back_for_legacy_or_invalid_added_time(
     qtbot,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -1,5 +1,33 @@
 # ruff: noqa: F403, F405
+import datetime
+
 from ._shared import *
+
+
+class _AddedTimeChildState(pydantic.BaseModel):
+    value: int = 0
+
+
+class _AddedTimeChildTool(erlab.interactive.utils.ToolWindow[_AddedTimeChildState]):
+    StateModel = _AddedTimeChildState
+    tool_name = "added-time-child"
+
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__()
+        self._data = data
+        self._status = _AddedTimeChildState()
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    @property
+    def tool_status(self) -> _AddedTimeChildState:
+        return self._status
+
+    @tool_status.setter
+    def tool_status(self, status: _AddedTimeChildState) -> None:
+        self._status = status
 
 
 def test_manager_duplicate(
@@ -32,6 +60,150 @@ def test_manager_duplicate(
                 manager._imagetool_wrappers[i].name
                 == manager._imagetool_wrappers[i + 2].name
             )
+
+
+def test_manager_workspace_saves_added_time_for_all_node_kinds(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    root_added = datetime.datetime(
+        2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone(datetime.timedelta(hours=9))
+    )
+    child_added = datetime.datetime(
+        2024, 1, 3, 4, 5, 6, tzinfo=datetime.timezone(datetime.timedelta(hours=-5))
+    )
+    tool_added = datetime.datetime(2024, 1, 4, 5, 6, 7, tzinfo=datetime.UTC)
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root_index = manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+            created_time=root_added,
+        )
+        child_uid = manager.add_imagetool_child(
+            erlab.interactive.imagetool.ImageTool(test_data + 1, _in_manager=True),
+            root_index,
+            show=False,
+            created_time=child_added,
+        )
+        tool_uid = manager.add_childtool(
+            _AddedTimeChildTool(test_data),
+            root_index,
+            show=False,
+            created_time=tool_added,
+        )
+
+        fname = tmp_path / "added-time.itws"
+        manager._save_workspace_document(fname, force_full=True)
+
+    with h5py.File(fname, "r") as h5_file:
+        assert h5_file["0/imagetool"].attrs[
+            "manager_node_added_at"
+        ] == root_added.isoformat(timespec="seconds")
+        assert h5_file[f"0/childtools/{child_uid}/imagetool"].attrs[
+            "manager_node_added_at"
+        ] == child_added.isoformat(timespec="seconds")
+        assert h5_file[f"0/childtools/{tool_uid}/tool"].attrs[
+            "manager_node_added_at"
+        ] == tool_added.isoformat(timespec="seconds")
+
+
+def test_manager_workspace_load_preserves_added_time(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    root_added = datetime.datetime(
+        2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone(datetime.timedelta(hours=9))
+    )
+    child_added = datetime.datetime(
+        2024, 1, 3, 4, 5, 6, tzinfo=datetime.timezone(datetime.timedelta(hours=-5))
+    )
+    tool_added = datetime.datetime(2024, 1, 4, 5, 6, 7, tzinfo=datetime.UTC)
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root_index = manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+            created_time=root_added,
+        )
+        child_uid = manager.add_imagetool_child(
+            erlab.interactive.imagetool.ImageTool(test_data + 1, _in_manager=True),
+            root_index,
+            show=False,
+            created_time=child_added,
+        )
+        tool_uid = manager.add_childtool(
+            _AddedTimeChildTool(test_data),
+            root_index,
+            show=False,
+            created_time=tool_added,
+        )
+
+        fname = tmp_path / "added-time-load.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+
+        assert manager._imagetool_wrappers[root_index].created_time == root_added
+        assert manager._child_node(child_uid).created_time == child_added
+        assert manager._child_node(tool_uid).created_time == tool_added
+
+
+@pytest.mark.parametrize("saved_attr", [None, "not-a-date"], ids=["missing", "invalid"])
+def test_manager_workspace_load_falls_back_for_legacy_or_invalid_added_time(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    saved_attr: str | None,
+) -> None:
+    import h5py
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+        )
+        fname = tmp_path / "legacy-added-time.itws"
+        manager._save_workspace_document(fname, force_full=True)
+
+        with h5py.File(fname, "a") as h5_file:
+            if saved_attr is None:
+                del h5_file["0/imagetool"].attrs["manager_node_added_at"]
+            else:
+                h5_file["0/imagetool"].attrs["manager_node_added_at"] = saved_attr
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+
+        loaded = manager._imagetool_wrappers[0].created_time
+        assert loaded.tzinfo is not None
+        assert loaded.utcoffset() is not None
 
 
 def test_workspace_backing_uses_persistence_data_for_filtered_file_data(

--- a/tests/interactive/imagetool/manager/test_wrapper.py
+++ b/tests/interactive/imagetool/manager/test_wrapper.py
@@ -1,4 +1,11 @@
 # ruff: noqa: F403, F405
+import datetime
+
+from erlab.interactive.imagetool.manager._wrapper import (
+    _coerce_added_time,
+    _format_added_time,
+)
+
 from ._shared import *
 
 
@@ -187,6 +194,46 @@ def test_wrapper_loader_code_and_metadata_helper_branches(
     ).chunk({"x": (2, 3), "y": 2})
     assert _format_chunk_summary(xr.DataArray(np.zeros(2), dims=("x",))) == "In memory"
     assert _format_chunk_summary(chunked) == "x=2, 3; y=2"
+
+
+def test_added_time_helpers_use_aware_datetimes(caplog) -> None:
+    added = datetime.datetime(
+        2024,
+        1,
+        2,
+        3,
+        4,
+        5,
+        987654,
+        tzinfo=datetime.timezone(datetime.timedelta(hours=9), "KST"),
+    )
+
+    assert _coerce_added_time(added) == added.replace(microsecond=0)
+    assert _coerce_added_time(added.isoformat().encode()) == added.replace(
+        microsecond=0
+    )
+    assert _format_added_time(added) == added.astimezone().strftime(
+        "%Y-%m-%d %H:%M:%S %Z (%z)"
+    )
+    fallback = _coerce_added_time(None)
+    assert fallback.tzinfo is not None
+    assert fallback.utcoffset() is not None
+
+    caplog.set_level(logging.WARNING)
+    for invalid in (
+        "not-a-date",
+        b"\xff",
+        object(),
+        datetime.datetime(2024, 1, 2, 3, 4, 5),
+    ):
+        fallback = _coerce_added_time(invalid, node_uid="bad-node")
+        assert fallback.tzinfo is not None
+        assert fallback.utcoffset() is not None
+
+    assert (
+        "Ignoring invalid saved manager added timestamp for node bad-node"
+        in caplog.text
+    )
 
 
 def test_wrapper_source_data_replaced_uses_parent_fallback_and_skips_missing_child(


### PR DESCRIPTION
## Summary
- Store each manager node’s Added timestamp in `.itws` payloads instead of regenerating it on every reopen.
- Keep timestamps timezone-aware, preserve the saved instant on load, and render them in the current local timezone with a readable zone label and offset.
- Reuse the same timestamp handling for manager details, console output, and promoted child ImageTools.
- Fall back cleanly for legacy or malformed saved values without changing the workspace schema.

## Testing
- Added workspace roundtrip coverage for saving, loading, and fallback behavior across root ImageTools, child ImageTools, and child tools.
- Verified linting and formatting on the touched manager files.
- Ran the focused workspace test slice and the broader workspace module slice successfully.