### PR TITLE
Separate interactive copy-code provenance from full manager provenance

### DIFF
--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -1908,7 +1908,10 @@ class Fit2DTool(Fit1DTool):
     @QtCore.Slot()
     def copy_code(self) -> str:
         return self._copy_provenance_code(
-            self._resolve_script_provenance(self.COPY_PROVENANCE)
+            self._resolve_script_provenance(
+                self.COPY_PROVENANCE,
+                include_parent_provenance=False,
+            )
         )
 
     @QtCore.Slot()
@@ -1918,7 +1921,10 @@ class Fit2DTool(Fit1DTool):
     @QtCore.Slot()
     def copy_code_1d(self) -> str:
         return self._copy_provenance_code(
-            self._resolve_script_provenance(Fit1DTool.COPY_PROVENANCE)
+            self._resolve_script_provenance(
+                Fit1DTool.COPY_PROVENANCE,
+                include_parent_provenance=False,
+            )
         )
 
     def detached_output_imagetool_provenance(

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3021,6 +3021,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._input_provenance_spec: (
             erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec | None
         ) = None
+        self._input_provenance_snapshot_from_parent = False
         self._input_provenance_parent_fetcher: (
             Callable[
                 [],
@@ -3262,6 +3263,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 provenance_spec
             )
         )
+        self._input_provenance_snapshot_from_parent = False
 
     def set_input_provenance_parent_fetcher(
         self,
@@ -3290,19 +3292,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def _snapshot_input_provenance(
         self,
     ) -> erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec | None:
-        parent_data: xr.DataArray | None = None
-        if self._source_parent_fetcher is not None:
-            try:
-                parent_data = self._source_parent_fetcher()
-            except Exception:
-                parent_data = None
-
+        parent_data, source_spec = self._input_source_context()
         parent_provenance = None
         if self._input_provenance_parent_fetcher is not None:
             parent_provenance = self._parent_input_provenance()
-        source_spec = self._source_spec
-        if parent_data is not None and self._source_binding is not None:
-            source_spec = self._materialized_source_spec(parent_data)
         return (
             erlab.interactive.imagetool.provenance_framework.compose_display_provenance(
                 parent_provenance,
@@ -3311,9 +3304,28 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             )
         )
 
+    def _input_source_context(
+        self,
+    ) -> tuple[
+        xr.DataArray | None,
+        erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec | None,
+    ]:
+        parent_data: xr.DataArray | None = None
+        if self._source_parent_fetcher is not None:
+            try:
+                parent_data = self._source_parent_fetcher()
+            except Exception:
+                parent_data = None
+
+        source_spec = self._source_spec
+        if parent_data is not None and self._source_binding is not None:
+            source_spec = self._materialized_source_spec(parent_data)
+        return parent_data, source_spec
+
     def _sync_input_provenance_snapshot(self) -> None:
         """Refresh the stored input provenance snapshot for the displayed tool data."""
         self._input_provenance_spec = self._snapshot_input_provenance()
+        self._input_provenance_snapshot_from_parent = True
 
     def _effective_input_provenance_spec(
         self,
@@ -3321,6 +3333,36 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if self._input_provenance_spec is not None:
             return self._input_provenance_spec
         return self._snapshot_input_provenance()
+
+    def _copy_input_provenance_spec(
+        self,
+    ) -> erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec | None:
+        if self.has_source_binding:
+            parent_data, source_spec = self._input_source_context()
+            parent_provenance = None
+            if self._input_provenance_parent_fetcher is not None:
+                fetched_parent = self._parent_input_provenance()
+                if (
+                    erlab.interactive.imagetool.provenance_framework.direct_replay_input_name(
+                        fetched_parent
+                    )
+                    is not None
+                ):
+                    parent_provenance = fetched_parent
+
+            return erlab.interactive.imagetool.provenance_framework.compose_display_provenance(
+                parent_provenance,
+                source_spec,
+                parent_data=parent_data,
+            )
+        if (
+            self._input_provenance_spec is not None
+            and not self._input_provenance_snapshot_from_parent
+        ):
+            return self._input_provenance_spec
+        if self._input_provenance_parent_fetcher is None:
+            return self._input_provenance_spec
+        return None
 
     def _call_script_provenance_method(
         self,
@@ -3508,10 +3550,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         definition: ToolScriptProvenanceDefinition | None,
         *,
         data: xr.DataArray | None = None,
+        include_parent_provenance: bool = True,
     ) -> erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec | None:
         if definition is None:
             return None
-        input_provenance = self._effective_input_provenance_spec()
+        input_provenance = (
+            self._effective_input_provenance_spec()
+            if include_parent_provenance
+            else self._copy_input_provenance_spec()
+        )
         direct_input_name = (
             erlab.interactive.imagetool.provenance_framework.direct_replay_input_name(
                 input_provenance
@@ -3599,7 +3646,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     @QtCore.Slot()
     def copy_code(self) -> str:
         """Copy the current tool provenance code to the clipboard."""
-        return self._copy_provenance_code(self.current_provenance_spec())
+        return self._copy_provenance_code(
+            self._resolve_script_provenance(
+                self.COPY_PROVENANCE,
+                include_parent_provenance=False,
+            )
+        )
 
     def _notify_data_changed(self) -> None:
         """Notify manager-facing listeners that displayed tool data has changed."""

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1326,12 +1326,24 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    prov = erlab.interactive.imagetool.provenance_framework
     with manager_context() as manager:
         manager.show()
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
 
         itool(test_data, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.set_provenance_spec(
+            prov.script(
+                prov.ScriptCodeOperation(
+                    label="Prepare parent data",
+                    code="prepared_parent = data + 1",
+                ),
+                start_label="Start from test data",
+                active_name="prepared_parent",
+            )
+        )
 
         child_uid, child = make_fit2d_child(manager, 0, exp_decay_model)
         monkeypatch.setattr(
@@ -1379,6 +1391,8 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
         )
         values_code = copy_full_code_for_uid(monkeypatch, manager, values_uid)
         stderr_code = copy_full_code_for_uid(monkeypatch, manager, stderr_uid)
+        assert "prepared_parent = data + 1" in values_code
+        assert "prepared_parent = data + 1" in stderr_code
         assert ".modelfit_coefficients.sel(param=" in values_code
         assert ".modelfit_stderr.sel(param=" in stderr_code
 

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -122,6 +122,29 @@ def test_dtool_smoothing_copy_code_uses_readable_steps(qtbot) -> None:
     xr.testing.assert_identical(win.result, namespace["result"])
 
 
+def test_dtool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> None:
+    prov = erlab.interactive.imagetool.provenance_framework
+    data = xr.DataArray(
+        np.arange(49).reshape((7, 7)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    source = prov.selection(prov.IselOperation(kwargs={"y": slice(1, 6)}))
+    parent_provenance = prov.selection(prov.IselOperation(kwargs={"x": slice(0, 2)}))
+    source_data = source.apply(data)
+    win: DerivativeTool = dtool(source_data, execute=False)
+    qtbot.addWidget(win)
+    win.set_source_binding(source)
+    win.set_input_provenance_parent_fetcher(lambda: parent_provenance)
+
+    code = win.copy_code()
+
+    assert "x=slice" not in code
+    assert "y=slice" in code
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    result = namespace["result"]
+    assert isinstance(result, xr.DataArray)
+    xr.testing.assert_identical(win.result, result)
+
+
 def test_dtool_update_data_preserves_state(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
@@ -638,7 +661,7 @@ def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
     assert tool.source_state == "unavailable"
 
 
-def test_tool_copy_code_includes_parent_provenance_for_standalone_imagetool(
+def test_tool_copy_code_uses_current_tool_input_without_parent_provenance(
     qtbot,
 ) -> None:
     class _DummyState(BaseModel):
@@ -704,7 +727,11 @@ def test_tool_copy_code_includes_parent_provenance_for_standalone_imagetool(
     parent.slicer_area.add_tool_window(tool, transfer_to_manager=False)
 
     code = tool.copy_code()
-    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    assert ".isel(" not in code
+    namespace = _exec_generated_code(
+        code,
+        {"data": tool.tool_data.copy(deep=True)},
+    )
     result = namespace["result"]
     assert isinstance(result, xr.DataArray)
     xr.testing.assert_identical(result, data.isel(x=slice(0, 2)).mean())
@@ -771,9 +798,10 @@ def test_tool_input_provenance_snapshot_tracks_applied_refreshes(qtbot) -> None:
     tool.set_input_provenance_parent_fetcher(lambda: parent_provenance["spec"])
 
     initial_code = tool.copy_code()
+    assert ".isel(" not in initial_code
     initial_namespace = _exec_generated_code(
         initial_code,
-        {"data": data.copy(deep=True)},
+        {"data": tool.tool_data.copy(deep=True)},
     )
     initial_result = initial_namespace["result"]
     assert isinstance(initial_result, xr.DataArray)
@@ -787,9 +815,10 @@ def test_tool_input_provenance_snapshot_tracks_applied_refreshes(qtbot) -> None:
         )
     )
     stale_code = tool.copy_code()
+    assert ".isel(" not in stale_code
     stale_namespace = _exec_generated_code(
         stale_code,
-        {"data": data.copy(deep=True)},
+        {"data": tool.tool_data.copy(deep=True)},
     )
     stale_result = stale_namespace["result"]
     assert isinstance(stale_result, xr.DataArray)
@@ -799,9 +828,10 @@ def test_tool_input_provenance_snapshot_tracks_applied_refreshes(qtbot) -> None:
     tool.finalize_source_refresh()
 
     refreshed_code = tool.copy_code()
+    assert ".isel(" not in refreshed_code
     refreshed_namespace = _exec_generated_code(
         refreshed_code,
-        {"data": data.copy(deep=True)},
+        {"data": tool.tool_data.copy(deep=True)},
     )
     refreshed_result = refreshed_namespace["result"]
     assert isinstance(refreshed_result, xr.DataArray)

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -548,6 +548,29 @@ def test_ktool_copy_code_aliases_expression_input_names(qtbot) -> None:
     assert "input_data_kconv" in namespace
 
 
+def test_ktool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> None:
+    prov = erlab.interactive.imagetool.provenance_framework
+    data = generate_hvdep_cuts((15, 30, 20), hvrange=(20.0, 30.0), noise=False)
+    source = prov.selection(prov.IselOperation(kwargs={"alpha": slice(2, 24)}))
+    parent_provenance = prov.selection(prov.IselOperation(kwargs={"hv": slice(0, 5)}))
+    source_data = source.apply(data)
+    win = ktool(source_data, execute=False)
+    qtbot.addWidget(win)
+    win.set_source_binding(source)
+    win.set_input_provenance_parent_fetcher(lambda: parent_provenance)
+
+    code = win.copy_code()
+
+    assert "hv=slice" not in code
+    assert "alpha=slice" in code
+    namespace = {"data": data.copy(deep=True)}
+    exec(code, {"__builtins__": {"slice": slice}}, namespace)  # noqa: S102
+    expected = win._assign_params(source_data.copy(deep=True)).kspace.convert(
+        bounds=win.bounds, resolution=win.resolution
+    )
+    xr.testing.assert_allclose(expected, namespace["derived_kconv"])
+
+
 def test_ktool_update_rate_limited(qtbot, anglemap, monkeypatch) -> None:
     win = ktool(anglemap, execute=False)
     qtbot.addWidget(win)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1008,6 +1008,89 @@ def test_tool_window_declared_output_dispatch_and_validation(qtbot) -> None:
         tool.output_imagetool_data("dummy.unknown")
 
 
+def test_tool_window_copy_code_ignores_parent_provenance_but_keeps_source(
+    qtbot,
+) -> None:
+    prov = erlab.interactive.imagetool.provenance_framework
+
+    class _DummyState(pydantic.BaseModel):
+        value: int = 0
+
+    class _DummyTool(erlab.interactive.utils.ToolWindow[_DummyState]):
+        StateModel = _DummyState
+        tool_name = "dummy"
+        COPY_PROVENANCE: typing.ClassVar = (
+            erlab.interactive.utils.ToolScriptProvenanceDefinition(
+                start_label="Start from current dummy input data",
+                label="Compute dummy output",
+                expression_method="_result_output_expression",
+                assign="result",
+            )
+        )
+
+        class Output(enum.StrEnum):
+            RESULT = "dummy.result"
+
+        IMAGE_TOOL_OUTPUTS: typing.ClassVar = {
+            Output.RESULT: erlab.interactive.utils.ToolImageOutputDefinition(
+                data_method="_result_output_data",
+                provenance=erlab.interactive.utils.ToolScriptProvenanceDefinition(
+                    start_label="Start from current dummy input data",
+                    label="Compute dummy output",
+                    expression_method="_result_output_expression",
+                    assign="result",
+                ),
+            )
+        }
+
+        def __init__(self, data: xr.DataArray) -> None:
+            super().__init__()
+            self._data = data
+
+        @property
+        def tool_status(self) -> _DummyState:
+            return _DummyState()
+
+        @tool_status.setter
+        def tool_status(self, status: _DummyState) -> None:
+            del status
+
+        @property
+        def tool_data(self) -> xr.DataArray:
+            return self._data
+
+        def update_data(self, new_data: xr.DataArray) -> None:
+            self._data = new_data
+
+        def _result_output_data(self) -> xr.DataArray:
+            return self._data.mean()
+
+        def _result_output_expression(
+            self,
+            *,
+            input_name: str | None = None,
+            data: xr.DataArray | None = None,
+        ) -> str:
+            del data
+            return f"{input_name or 'data'}.mean()"
+
+    data = xr.DataArray(np.arange(16).reshape((4, 4)), dims=("x", "y"), name="data")
+    parent_provenance = prov.selection(prov.IselOperation(kwargs={"x": slice(0, 2)}))
+    source = prov.selection(prov.IselOperation(kwargs={"y": slice(1, 3)}))
+    tool = _DummyTool(source.apply(data))
+    qtbot.addWidget(tool)
+    tool.set_source_binding(source)
+    tool.set_input_provenance_parent_fetcher(lambda: parent_provenance)
+
+    code = tool.copy_code()
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    result = namespace["result"]
+    assert isinstance(result, xr.DataArray)
+    xr.testing.assert_identical(result, data.isel(y=slice(1, 3)).mean())
+    assert "x=slice" not in code
+    assert "y=slice" in code
+
+
 def test_tool_script_provenance_definition_validates_assignments() -> None:
     with pytest.raises(ValueError, match="tuple `assign` must define `active_name`"):
         erlab.interactive.utils.ToolScriptProvenanceDefinition(


### PR DESCRIPTION
## Summary
- Make interactive tool `Copy Code` use source-local provenance instead of the full parent chain.
- Preserve direct watched-variable seeds while still including the final source/selection operation.
- Keep manager details `Copy Full Code` on the full provenance path for declared output child rows.
- Factor shared source-context resolution so the copy/full behavior stays explicit in the call sites.

## Testing
- Added focused regressions for `dtool`, `ktool`, and the generic `ToolWindow` copy-code path.
- Added a manager provenance regression covering output child full-code behavior.
- Ran the targeted interactive test modules, plus formatting, lint, and mypy checks; all passed.