### PR TITLE
Make renaming tools better

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -150,10 +150,9 @@ If more than one manager is running and no default has been selected, calls that
 
 The left pane lists ImageTool windows, tools opened from ImageTool, and ImageTool
 windows opened from those tools. Top-level ImageTool windows use an index and optional
-name (`index: name`). Rows made from another row appear as child rows under the row that
-made them.
-Selecting entries populates the right pane with details, a steps list when available,
-and a live preview.
+data name (`index: name`). Rows derived from another row appear as child rows under the
+row that made them. Selecting entries populates the right pane with details, a steps
+list when available, and a preview of the main image.
 
 :::{note}
 Enable {guilabel}`View → Preview on Hover` to see thumbnails while moving the mouse over the list.

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import ast
 import contextlib
 import math
-import re
 import typing
 import weakref
 
@@ -202,16 +201,10 @@ class DataTransformDialog(_DataManipulationDialog):
 
     - Override attribute `enable_copy` to show or hide the copy button.
 
-    - Override attributes `prefix` and `suffix` to set the prefix and suffix of the new
-      data name.
-
     - Override attribute `keep_colors` and `keep_color_limits` to control which
       color-related settings are migrated when opening in a new window.
 
     """
-
-    prefix: str = ""
-    suffix: str = ""
 
     keep_colors: bool = True
     """Whether to keep the color settings when opening in a new window.
@@ -313,8 +306,9 @@ class DataTransformDialog(_DataManipulationDialog):
         return None
 
     def source_spec(
-        self, new_name: str
+        self, new_name: str | None = None
     ) -> erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec:
+        del new_name
         operations = self.source_operations()
         builder = (
             erlab.interactive.imagetool.provenance_framework.public_data
@@ -329,7 +323,7 @@ class DataTransformDialog(_DataManipulationDialog):
             operations.append(
                 erlab.interactive.imagetool.provenance_framework.RestoreNonuniformDimsOperation()
             )
-        return builder(*operations).append_final_rename(new_name)
+        return builder(*operations)
 
     def _detached_provenance_spec(
         self,
@@ -351,6 +345,7 @@ class DataTransformDialog(_DataManipulationDialog):
         source_spec: erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec,
         new_name: str,
     ) -> erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec:
+        del new_name
         if base_spec is None:
             return source_spec
         with contextlib.suppress(TypeError):
@@ -358,10 +353,9 @@ class DataTransformDialog(_DataManipulationDialog):
                 base_spec
             )
             if live_parent is not None:
-                operations = source_spec.drop_trailing_rename().operations
                 return live_parent.append_replacement_operations(
-                    *operations
-                ).append_final_rename(new_name)
+                    *source_spec.operations
+                )
         composed = (
             erlab.interactive.imagetool.provenance_framework.compose_full_provenance(
                 base_spec,
@@ -481,10 +475,10 @@ class DataTransformDialog(_DataManipulationDialog):
 
     @QtCore.Slot()
     def accept(self) -> None:
-        if self.slicer_area.data.name is not None:
-            new_name = f"{self.prefix}{self.slicer_area.data.name}{self.suffix}"
-        else:
-            new_name = self.suffix.lstrip("_")
+        input_name = self.slicer_area.data.name
+        new_name = ""
+        if input_name is not None:
+            new_name = str(input_name)
 
         try:
             if self.apply_on_nonuniform_data:
@@ -497,8 +491,8 @@ class DataTransformDialog(_DataManipulationDialog):
                 processed = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
                     self.process_data(self.slicer_area.data)
                 )
+            processed = processed.rename(input_name)
 
-            processed = processed.rename(new_name)
             manager, target = self._manager_target()
             source_spec = self.source_spec(new_name)
             parent_provenance = self.slicer_area.displayed_provenance_spec()
@@ -731,16 +725,6 @@ class RotationDialog(DataTransformDialog):
     enable_copy = True
 
     @property
-    def suffix(self) -> str:
-        angle_str = str(self._rotate_params["angle"])
-        return f"_rot{angle_str}"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
-
-    @property
     def _rotate_params(self) -> dict[str, typing.Any]:
         return {
             "angle": float(
@@ -810,20 +794,12 @@ class AggregateDialog(DataTransformDialog):
     title = "Aggregate Over Dimensions"
     enable_copy = True
 
-    _REDUCERS: typing.ClassVar[dict[str, tuple[str, str]]] = {
-        "mean": ("Mean", "_avg"),
-        "min": ("Minimum", "_min"),
-        "max": ("Maximum", "_max"),
-        "sum": ("Sum", "_sum"),
+    _REDUCERS: typing.ClassVar[dict[str, str]] = {
+        "mean": "Mean",
+        "min": "Minimum",
+        "max": "Maximum",
+        "sum": "Sum",
     }
-
-    @property
-    def suffix(self) -> str:
-        return self._REDUCERS[self._reducer][1]
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        pass
 
     def setup_widgets(self) -> None:
         dim_group = QtWidgets.QGroupBox("Dimensions")
@@ -839,7 +815,7 @@ class AggregateDialog(DataTransformDialog):
         self.layout_.addRow(dim_group)
 
         self.reducer_combo = QtWidgets.QComboBox()
-        for reducer, (label, _) in self._REDUCERS.items():
+        for reducer, label in self._REDUCERS.items():
             self.reducer_combo.addItem(label, userData=reducer)
         self.layout_.addRow("Reducer", self.reducer_combo)
 
@@ -1104,7 +1080,6 @@ class _SelectionRow:
 
 class SelectionDialog(DataTransformDialog):
     title = "Select Data"
-    suffix = "_sel"
     enable_copy = True
     apply_on_nonuniform_data = True
 
@@ -1326,22 +1301,6 @@ class InterpolationDialog(DataTransformDialog):
             self.dim_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
         )
 
-    @property
-    def suffix(self) -> str:
-        dim = self._selected_dim
-        suffix = "" if dim is None else str(dim)
-        suffix = re.sub(r"[^0-9A-Za-z_]+", "_", suffix).strip("_")
-        if not suffix:
-            suffix = "coord"
-        elif suffix[0].isdigit():
-            suffix = f"coord_{suffix}"
-        return f"_interp_{suffix}"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
-
     def _source_coord_values(self, dim: Hashable) -> npt.NDArray:
         if dim not in self._source_data.coords:
             return np.arange(self._source_data.sizes[dim], dtype=np.float64)
@@ -1480,22 +1439,6 @@ class LeadingEdgeDialog(DataTransformDialog):
             self.direction_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
         )
 
-    @property
-    def suffix(self) -> str:
-        dim = self._selected_dim
-        suffix = "" if dim is None else str(dim)
-        suffix = re.sub(r"[^0-9A-Za-z_]+", "_", suffix).strip("_")
-        if not suffix:
-            suffix = "coord"
-        elif suffix[0].isdigit():
-            suffix = f"coord_{suffix}"
-        return f"_leading_edge_{suffix}"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
-
     def _source_coord_error(self, dim: Hashable) -> str | None:
         coord = np.asarray(self._source_data[dim].values)
         if coord.ndim != 1:
@@ -1565,15 +1508,6 @@ class CoarsenDialog(DataTransformDialog):
         "sum",
         "var",
     )
-
-    @property
-    def suffix(self) -> str:
-        return f"_coarsen_{self._reducer}"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
 
     def setup_widgets(self) -> None:
         self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -1707,7 +1641,6 @@ class CoarsenDialog(DataTransformDialog):
 
 class ThinDialog(DataTransformDialog):
     title = "Thin Data"
-    suffix = "_thin"
     enable_copy = True
     apply_on_nonuniform_data = True
 
@@ -1843,15 +1776,6 @@ class SymmetrizeDialog(DataTransformDialog):
     title = "Symmetrize"
     enable_copy = True
 
-    @property
-    def suffix(self) -> str:
-        return f"_sym_{self._params['dim']}"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
-
     def setup_widgets(self) -> None:
         dim_group = QtWidgets.QGroupBox("Mirror plane")
         dim_layout = QtWidgets.QHBoxLayout()
@@ -1948,15 +1872,6 @@ class SymmetrizeNfoldDialog(DataTransformDialog):
     enable_copy = True
 
     @property
-    def suffix(self) -> str:
-        return f"_symC{self._params['fold']}"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
-
-    @property
     def _params(self) -> dict[str, typing.Any]:
         return {
             "fold": self.fold_spin.value(),
@@ -2035,7 +1950,6 @@ class SymmetrizeNfoldDialog(DataTransformDialog):
 
 class EdgeCorrectionDialog(DataTransformDialog):
     title = "Edge Correction"
-    suffix = "_corr"
     enable_copy = False
 
     def setup_widgets(self) -> None:
@@ -2074,7 +1988,6 @@ class EdgeCorrectionDialog(DataTransformDialog):
 
 
 class _BaseCropDialog(DataTransformDialog):
-    suffix = "_crop"
     enable_copy = True
 
     @property
@@ -2384,22 +2297,6 @@ class DivideByCoordDialog(DataTransformDialog):
             "Hashable",
             self.coord_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
         )
-
-    @property
-    def suffix(self) -> str:
-        coord_name = self._selected_coord_name
-        suffix = "" if coord_name is None else str(coord_name)
-        suffix = re.sub(r"[^0-9A-Za-z_]+", "_", suffix).strip("_")
-        if not suffix:
-            suffix = "coord"
-        elif suffix[0].isdigit():
-            suffix = f"coord_{suffix}"
-        return f"_div_{suffix}"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
 
     @QtCore.Slot()
     @QtCore.Slot(int)
@@ -3341,15 +3238,6 @@ class ROIPathDialog(DataTransformDialog):
     enable_copy = True
     apply_on_nonuniform_data = True
 
-    @property
-    def suffix(self) -> str:
-        return "_path"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
-
     def __init__(self, roi: ItoolPolyLineROI) -> None:
         self.roi = roi
         super().__init__(self.roi.plot_item.slicer_area)
@@ -3411,15 +3299,6 @@ class ROIMaskDialog(DataTransformDialog):
     title = "Mask with ROI"
     enable_copy = True
     apply_on_nonuniform_data = True
-
-    @property
-    def suffix(self) -> str:
-        return "_masked"
-
-    @suffix.setter
-    def suffix(self, value: str) -> None:
-        # To satisfy mypy
-        pass
 
     def __init__(self, roi: ItoolPolyLineROI) -> None:
         self.roi = roi

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -512,7 +512,7 @@ class _ActionsMixin:
 
     def rename_imagetool(self, index: int, new_name: str) -> None:
         """Rename the ImageTool window corresponding to the given index."""
-        self._imagetool_wrappers[index].name = new_name
+        self._imagetool_wrappers[index].name = str(new_name)
 
     def _duplicate_subtree(
         self, target: int | str, *, parent_override: int | str | None = None

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -1303,7 +1303,7 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
         ptr = index.internalPointer()
         if isinstance(ptr, _ImageToolWrapper):
             if role == QtCore.Qt.ItemDataRole.EditRole:
-                self.manager.rename_imagetool(self._imagetool_index(index), value)
+                self.manager.rename_imagetool(self._imagetool_index(index), str(value))
 
                 self.dataChanged.emit(index, index, [role])
                 return True
@@ -1312,7 +1312,7 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
             child_node = self._node_from_uid(ptr)
             if child_node is None:
                 return False
-            child_node.name = value
+            child_node.name = str(value)
 
             self.dataChanged.emit(index, index, [role])
             return True

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -110,6 +110,8 @@ def _legacy_saved_title_data_name(
             title = rest
     saved_name = str(ds.attrs.get("itool_name", ""))
     stems = _workspace_provenance_file_stems(provenance_spec)
+    if not saved_name and not stems:
+        return None
     compact_suffix = _workspace_compact_file_suffix(stems)
     if compact_suffix and title.endswith(compact_suffix):
         title = title[: -len(compact_suffix)]
@@ -120,6 +122,8 @@ def _legacy_saved_title_data_name(
         if (saved_name and title == f"{saved_name} ({stem})") or (
             not saved_name and title == stem
         ):
+            return None
+        if saved_name and saved_name == stem and title == f"{stem} ({stem})":
             return None
     return title
 
@@ -846,6 +850,9 @@ class _WorkspaceIOMixin:
         if legacy_name is not None:
             ds = ds.copy(deep=False)
             ds.attrs["itool_name"] = legacy_name
+        elif "itool_name" not in ds.attrs:
+            ds = ds.copy(deep=False)
+            ds.attrs["itool_name"] = ""
         tool = ImageTool.from_dataset(ds, **tool_kwargs)
         if parent_target is not None:
             target = self.add_imagetool_child(

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -68,6 +68,62 @@ _DEPENDENCY_STATUS_TOOLTIPS: dict[str, str] = {
 from erlab.interactive.imagetool.manager._widgets import *
 
 
+def _workspace_provenance_file_stems(
+    spec: erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec | None,
+) -> tuple[str, ...]:
+    stems: list[str] = []
+
+    def collect(
+        current: erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec
+        | None,
+    ) -> None:
+        if current is None:
+            return
+        if current.file_load_source is not None:
+            stem = pathlib.Path(current.file_load_source.path).stem
+            if stem not in stems:
+                stems.append(stem)
+        for script_input in current.script_inputs:
+            collect(script_input.parsed_provenance_spec())
+
+    collect(spec)
+    return tuple(stems)
+
+
+def _workspace_compact_file_suffix(stems: tuple[str, ...]) -> str:
+    if not stems:
+        return ""
+    if len(stems) <= 2:
+        return f" ({', '.join(stems)})"
+    return f" ({', '.join(stems[:2])}, +{len(stems) - 2})"
+
+
+def _legacy_saved_title_data_name(
+    ds: xr.Dataset,
+    provenance_spec: erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec
+    | None,
+) -> str | None:
+    title = _strip_workspace_modified_placeholder(str(ds.attrs.get("itool_title", "")))
+    if ": " in title:
+        prefix, rest = title.split(": ", maxsplit=1)
+        if prefix.isdigit():
+            title = rest
+    saved_name = str(ds.attrs.get("itool_name", ""))
+    stems = _workspace_provenance_file_stems(provenance_spec)
+    compact_suffix = _workspace_compact_file_suffix(stems)
+    if compact_suffix and title.endswith(compact_suffix):
+        title = title[: -len(compact_suffix)]
+    if not title or title == saved_name:
+        return None
+
+    for stem in stems:
+        if (saved_name and title == f"{saved_name} ({stem})") or (
+            not saved_name and title == stem
+        ):
+            return None
+    return title
+
+
 class _WorkspaceIOMixin:
     @staticmethod
     def _normalize_recent_workspace_paths(
@@ -659,15 +715,7 @@ class _WorkspaceIOMixin:
                 node.index if isinstance(node, _ImageToolWrapper) else node.uid
             )
             ds = self.get_imagetool(target).to_dataset()
-            ds.attrs["itool_title"] = _strip_workspace_modified_placeholder(
-                ds.attrs.get("itool_title", "")
-            )
-            if isinstance(node, _ImageToolWrapper):
-                ds.attrs["itool_title"] = (
-                    ds.attrs["itool_title"]
-                    .removeprefix(f"{node.index}")
-                    .removeprefix(": ")
-                )
+            ds.attrs["itool_title"] = node.name
             constructor[f"{path}/imagetool"] = self._annotate_workspace_dataset(
                 ds, node, kind="imagetool"
             )
@@ -794,6 +842,10 @@ class _WorkspaceIOMixin:
         tool_kwargs: dict[str, typing.Any] = {"_in_manager": True}
         if _ITOOL_DATA_NAME in ds and ds[_ITOOL_DATA_NAME].chunks is not None:
             tool_kwargs["auto_compute"] = False
+        legacy_name = _legacy_saved_title_data_name(ds, parsed_provenance_spec)
+        if legacy_name is not None:
+            ds = ds.copy(deep=False)
+            ds.attrs["itool_name"] = legacy_name
         tool = ImageTool.from_dataset(ds, **tool_kwargs)
         if parent_target is not None:
             target = self.add_imagetool_child(

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -449,9 +449,7 @@ class _ManagedWindowNode(QtCore.QObject):
             return
         slicer_area = self.slicer_area
         slicer_area._data = slicer_area._data.rename(name)
-        slicer_area.array_slicer.set_array(
-            slicer_area._data, validate=False, reset=False, copy_values=False
-        )
+        slicer_area.array_slicer._obj = slicer_area.array_slicer._obj.rename(name)
         if slicer_area._accepted_filter_data is not None:
             slicer_area._accepted_filter_data = (
                 slicer_area._accepted_filter_data.rename(name)

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -8,8 +8,8 @@ __all__ = ["_ImageToolWrapper", "_ManagedWindowNode"]
 import contextlib
 import datetime
 import keyword
-import pathlib
 import logging
+import pathlib
 import sys
 import typing
 import uuid

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -8,6 +8,7 @@ __all__ = ["_ImageToolWrapper", "_ManagedWindowNode"]
 import contextlib
 import datetime
 import keyword
+import pathlib
 import sys
 import typing
 import uuid
@@ -127,6 +128,64 @@ def _format_chunk_summary(data: xr.DataArray) -> str:
     return "; ".join(parts)
 
 
+def _dataarray_name(data: xr.DataArray | None) -> str:
+    if data is None or data.name is None:
+        return ""
+    name = str(data.name)
+    return "" if name.strip() == "" else name
+
+
+def _append_unique_path(paths: list[pathlib.Path], path: str | pathlib.Path) -> None:
+    normalized = pathlib.Path(path).expanduser()
+    with contextlib.suppress(OSError, RuntimeError):
+        normalized = normalized.resolve(strict=False)
+    if normalized not in paths:
+        paths.append(normalized)
+
+
+def _collect_provenance_file_paths(
+    spec: erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec | None,
+    paths: list[pathlib.Path],
+) -> None:
+    if spec is None:
+        return
+    if spec.file_load_source is not None:
+        _append_unique_path(paths, spec.file_load_source.path)
+    for script_input in spec.script_inputs:
+        _collect_provenance_file_paths(script_input.parsed_provenance_spec(), paths)
+
+
+def _compact_file_suffix(paths: typing.Sequence[pathlib.Path]) -> str:
+    if not paths:
+        return ""
+    stems = tuple(dict.fromkeys(path.stem for path in paths))
+    if len(stems) <= 2:
+        return f" ({', '.join(stems)})"
+    return f" ({', '.join(stems[:2])}, +{len(stems) - 2})"
+
+
+def _spec_with_final_data_name(
+    spec: erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec,
+    name: str,
+) -> erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec:
+    provenance = erlab.interactive.imagetool.provenance_framework
+    rename = provenance.RenameOperation(name=name)
+    if spec.kind != "file":
+        return spec.append_final_rename(name)
+
+    stages = list(spec.replay_stages)
+    if stages:
+        last_stage = stages[-1]
+        operations = tuple(last_stage.operations)
+        if operations and isinstance(operations[-1], provenance.RenameOperation):
+            stages[-1] = last_stage.model_copy(
+                update={"operations": (*operations[:-1], rename)}
+            )
+            return spec.model_copy(update={"replay_stages": tuple(stages)})
+
+    return spec.append_replay_stage(provenance.full_data(rename))
+
+
 class _ManagedWindowNode(QtCore.QObject):
     """A recursively managed window node in ImageToolManager."""
 
@@ -165,10 +224,6 @@ class _ManagedWindowNode(QtCore.QObject):
             "imagetool" if isinstance(window, ImageTool) else "tool"
         )
         self._name = window.windowTitle()
-        self._name_manually_overridden = (
-            isinstance(window, ImageTool)
-            and self._name.replace("[*]", "") != window.slicer_area.display_name
-        )
 
         self._source_spec: (
             erlab.interactive.imagetool.provenance_framework.ToolProvenanceSpec | None
@@ -363,6 +418,8 @@ class _ManagedWindowNode(QtCore.QObject):
 
     @property
     def name(self) -> str:
+        if self.imagetool is not None:
+            return _dataarray_name(self.slicer_area._data)
         if self.tool_window is not None:
             return self.tool_window._tool_display_name or self.tool_window.windowTitle()
         return self._name
@@ -372,24 +429,70 @@ class _ManagedWindowNode(QtCore.QObject):
         self._set_name(name, manual=True)
 
     def _set_name(self, name: str, *, manual: bool) -> None:
-        if manual:
-            self._name_manually_overridden = True
         if self.tool_window is not None:
             self.tool_window._tool_display_name = name
             self.manager.tree_view.refresh(self.uid)
             self.manager._mark_node_state_dirty(self.uid)
             return
-        if name == self._name and self.imagetool is not None and not manual:
+        if self.imagetool is not None:
+            self._rename_imagetool_data(name, record_provenance=manual)
             return
         self._name = name
-        if self.imagetool is not None:
-            self.imagetool.setWindowTitle(self.label_text)
         self.manager.tree_view.refresh(self.uid)
         self.manager._mark_node_state_dirty(self.uid)
 
+    def _rename_imagetool_data(self, name: str, *, record_provenance: bool) -> None:
+        if self.imagetool is None:
+            return
+        if name == self.name:
+            self.imagetool.setWindowTitle(self.label_text)
+            return
+        slicer_area = self.slicer_area
+        slicer_area._data = slicer_area._data.rename(name)
+        slicer_area.array_slicer.set_array(
+            slicer_area._data, validate=False, reset=False, copy_values=False
+        )
+        if slicer_area._accepted_filter_data is not None:
+            slicer_area._accepted_filter_data = (
+                slicer_area._accepted_filter_data.rename(name)
+            )
+        if record_provenance:
+            self._record_data_rename_provenance(name)
+        self.imagetool.setWindowTitle(self.label_text)
+        self.manager.tree_view.refresh(self.uid)
+        self.manager._update_info(uid=self.uid)
+        self.manager._refresh_dependency_dependents(self.uid)
+        self.manager._mark_node_state_dirty(self.uid)
+
+    def _record_data_rename_provenance(self, name: str) -> None:
+        spec = self.provenance_spec
+        if spec is not None:
+            self._provenance_spec = _spec_with_final_data_name(spec, name)
+            if self.imagetool is not None:
+                self.imagetool.set_provenance_spec(self._provenance_spec)
+        if self._source_spec is not None:
+            self._source_spec = erlab.interactive.imagetool.provenance_framework.require_live_source_spec(
+                _spec_with_final_data_name(self._source_spec, name)
+            )
+
+    def _file_label_paths(self) -> tuple[pathlib.Path, ...]:
+        paths: list[pathlib.Path] = []
+        if self.imagetool is not None and self.slicer_area._file_path is not None:
+            _append_unique_path(paths, self.slicer_area._file_path)
+        _collect_provenance_file_paths(self.displayed_provenance_spec, paths)
+        return tuple(paths)
+
+    @property
+    def file_suffix_text(self) -> str:
+        return _compact_file_suffix(self._file_label_paths())
+
+    @property
+    def base_label_text(self) -> str:
+        return self.name
+
     @property
     def label_text(self) -> str:
-        return self._name
+        return self.base_label_text
 
     @property
     def display_text(self) -> str:
@@ -1009,14 +1112,10 @@ class _ManagedWindowNode(QtCore.QObject):
     @QtCore.Slot()
     @QtCore.Slot(str)
     def update_title(self, title: str | None = None) -> None:
+        del title
         if self.imagetool is not None:
-            if title is None:
-                title = self.imagetool.windowTitle()
-            title = title.replace("[*]", "")
-            if self._name_manually_overridden:
-                self.imagetool.setWindowTitle(self.label_text)
-                return
-            self._set_name(title, manual=False)
+            self.imagetool.setWindowTitle(self.label_text)
+            self.manager.tree_view.refresh(self.uid)
 
     @QtCore.Slot()
     def visibility_changed(self, *, mark_dirty: bool = True) -> None:
@@ -1397,8 +1496,10 @@ class _ImageToolWrapper(_ManagedWindowNode):
     @property
     def label_text(self) -> str:
         title = f"{self.index}"
-        if self._name:
-            title += f": {self._name}"
+        base_label = self.base_label_text
+        if base_label:
+            title += f": {base_label}"
+        title += self.file_suffix_text
         return title
 
     def current_source_data(self) -> xr.DataArray:

--- a/src/erlab/interactive/imagetool/provenance_framework.py
+++ b/src/erlab/interactive/imagetool/provenance_framework.py
@@ -2109,10 +2109,8 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                     ).dims
                     == current_data.dims
                 )
-            # Rule 6: drop whole-array name changes. ImageTool appends names such as
-            # ``_avg`` to keep displayed tools distinct, but the DataArray name is not
-            # an analysis step. Dimension and coordinate renames use
-            # RenameDimsCoordsOperation and remain visible.
+            # Rule 6: hide whole-array name changes in derivation display. Dimension
+            # and coordinate renames use RenameDimsCoordsOperation and remain visible.
             elif isinstance(operation, RenameOperation):
                 hide_operation = not any(
                     isinstance(later_operation, ScriptCodeOperation)

--- a/src/erlab/interactive/imagetool/provenance_operations.py
+++ b/src/erlab/interactive/imagetool/provenance_operations.py
@@ -596,7 +596,7 @@ class DivideByCoordOperation(ToolProvenanceOperation):
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         coord = data.coords[self.coord_name]
         self._raise_if_zero(coord)
-        return data / coord
+        return (data / coord).rename(data.name)
 
     def derivation_label(self) -> str:
         label_kwargs = {"coord_name": self.coord_name}

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -2027,6 +2027,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     def _fetch_reload_data(self) -> tuple[xr.DataArray, dict[str, typing.Any]]:
         """Return reload data and replacement kwargs for the active reload source."""
+        provenance_spec = self.provenance_spec
+        if (
+            provenance_spec is not None
+            and provenance_spec.kind == "file"
+            and bool(provenance_spec.replay_stages)
+            and self._provenance_reloadable()
+        ):
+            return self._fetch_for_provenance_reload(), {}
         if self._direct_reloadable():
             return (
                 self._fetch_for_reload(),

--- a/tests/interactive/imagetool/manager/_shared.py
+++ b/tests/interactive/imagetool/manager/_shared.py
@@ -46,6 +46,7 @@ import erlab.interactive.imagetool.manager._server as manager_server
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace as manager_workspace
 import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
+import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.imagetool.manager._xarray as manager_xarray
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -959,7 +959,12 @@ def test_manager_reload_selected_preserves_manual_root_name(
             root_index.data(QtCore.Qt.ItemDataRole.DisplayRole)
             == "0: manual root name (scan)"
         )
-        assert root_tool.windowTitle() == "0: manual root name (scan)"
+        assert (
+            manager_workspace_io._strip_workspace_modified_placeholder(
+                root_tool.windowTitle()
+            )
+            == "0: manual root name (scan)"
+        )
 
         updated = (source + 100.0).rename("reloaded_scan")
         updated.to_netcdf(file_path, engine="h5netcdf")
@@ -973,7 +978,12 @@ def test_manager_reload_selected_preserves_manual_root_name(
             manager.reload_selected()
 
         assert manager.name_of_imagetool(0) == "manual root name"
-        assert root_tool.windowTitle() == "0: manual root name (scan)"
+        assert (
+            manager_workspace_io._strip_workspace_modified_placeholder(
+                root_tool.windowTitle()
+            )
+            == "0: manual root name (scan)"
+        )
         xr.testing.assert_identical(fetch(0), updated.rename("manual root name"))
 
 
@@ -1007,7 +1017,12 @@ def test_manager_file_suffix_does_not_seed_unnamed_root_name(
         assert manager.name_of_imagetool(0) == ""
         assert root_index.data(QtCore.Qt.ItemDataRole.EditRole) == ""
         assert root_index.data(QtCore.Qt.ItemDataRole.DisplayRole) == "0 (scan)"
-        assert manager.get_imagetool(0).windowTitle() == "0 (scan)"
+        assert (
+            manager_workspace_io._strip_workspace_modified_placeholder(
+                manager.get_imagetool(0).windowTitle()
+            )
+            == "0 (scan)"
+        )
 
 
 def test_manager_reload_selected_preserves_manual_child_imagetool_name(
@@ -1063,7 +1078,12 @@ def test_manager_reload_selected_preserves_manual_child_imagetool_name(
         assert (
             child_index.data(QtCore.Qt.ItemDataRole.DisplayRole) == "manual child name"
         )
-        assert child_tool.windowTitle() == "manual child name"
+        assert (
+            manager_workspace_io._strip_workspace_modified_placeholder(
+                child_tool.windowTitle()
+            )
+            == "manual child name"
+        )
 
         updated = (source + 50.0).rename("reloaded_scan")
         updated.to_netcdf(file_path, engine="h5netcdf")
@@ -1078,7 +1098,12 @@ def test_manager_reload_selected_preserves_manual_child_imagetool_name(
 
         assert child_node.source_state == "fresh"
         assert child_node.name == "manual child name"
-        assert child_tool.windowTitle() == "manual child name"
+        assert (
+            manager_workspace_io._strip_workspace_modified_placeholder(
+                child_tool.windowTitle()
+            )
+            == "manual child name"
+        )
         xr.testing.assert_identical(
             fetch(child_uid), updated.rename("manual child name")
         )

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -951,7 +951,15 @@ def test_manager_reload_selected_preserves_manual_root_name(
             "manual root name",
             QtCore.Qt.ItemDataRole.EditRole,
         )
+        root_tool = manager.get_imagetool(0)
         assert manager.name_of_imagetool(0) == "manual root name"
+        assert root_tool.slicer_area._data.name == "manual root name"
+        assert root_index.data(QtCore.Qt.ItemDataRole.EditRole) == "manual root name"
+        assert (
+            root_index.data(QtCore.Qt.ItemDataRole.DisplayRole)
+            == "0: manual root name (scan)"
+        )
+        assert root_tool.windowTitle() == "0: manual root name (scan)"
 
         updated = (source + 100.0).rename("reloaded_scan")
         updated.to_netcdf(file_path, engine="h5netcdf")
@@ -961,12 +969,45 @@ def test_manager_reload_selected_preserves_manual_root_name(
         manager._update_actions()
         assert manager.reload_action.isVisible()
 
-        root_tool = manager.get_imagetool(0)
         with qtbot.wait_signal(root_tool.slicer_area.sigDataChanged, timeout=5000):
             manager.reload_selected()
 
         assert manager.name_of_imagetool(0) == "manual root name"
-        xr.testing.assert_identical(fetch(0), updated)
+        assert root_tool.windowTitle() == "0: manual root name (scan)"
+        xr.testing.assert_identical(fetch(0), updated.rename("manual root name"))
+
+
+def test_manager_file_suffix_does_not_seed_unnamed_root_name(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = test_data.astype(float).rename(None)
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            source,
+            manager=True,
+            file_path=file_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        model = typing.cast("_ImageToolWrapperItemModel", manager.tree_view.model())
+        root_index = model._row_index(0)
+
+        assert manager.name_of_imagetool(0) == ""
+        assert root_index.data(QtCore.Qt.ItemDataRole.EditRole) == ""
+        assert root_index.data(QtCore.Qt.ItemDataRole.DisplayRole) == "0 (scan)"
+        assert manager.get_imagetool(0).windowTitle() == "0 (scan)"
 
 
 def test_manager_reload_selected_preserves_manual_child_imagetool_name(
@@ -1017,6 +1058,12 @@ def test_manager_reload_selected_preserves_manual_child_imagetool_name(
         )
         child_node = manager._child_node(child_uid)
         assert child_node.name == "manual child name"
+        assert child_tool.slicer_area._data.name == "manual child name"
+        assert child_index.data(QtCore.Qt.ItemDataRole.EditRole) == "manual child name"
+        assert (
+            child_index.data(QtCore.Qt.ItemDataRole.DisplayRole) == "manual child name"
+        )
+        assert child_tool.windowTitle() == "manual child name"
 
         updated = (source + 50.0).rename("reloaded_scan")
         updated.to_netcdf(file_path, engine="h5netcdf")
@@ -1031,7 +1078,10 @@ def test_manager_reload_selected_preserves_manual_child_imagetool_name(
 
         assert child_node.source_state == "fresh"
         assert child_node.name == "manual child name"
-        xr.testing.assert_identical(fetch(child_uid), updated)
+        assert child_tool.windowTitle() == "manual child name"
+        xr.testing.assert_identical(
+            fetch(child_uid), updated.rename("manual child name")
+        )
 
 
 def test_manager_workspace_reload_preserves_manual_root_name(
@@ -1071,6 +1121,7 @@ def test_manager_workspace_reload_preserves_manual_root_name(
         )
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         assert manager.name_of_imagetool(0) == "saved manual root"
+        assert manager.get_imagetool(0).slicer_area._data.name == "saved manual root"
 
         updated = (source + 200.0).rename("updated_scan")
         updated.to_netcdf(source_path, engine="h5netcdf")
@@ -1083,7 +1134,7 @@ def test_manager_workspace_reload_preserves_manual_root_name(
             manager.reload_selected()
 
         assert manager.name_of_imagetool(0) == "saved manual root"
-        xr.testing.assert_identical(fetch(0), updated)
+        xr.testing.assert_identical(fetch(0), updated.rename("saved manual root"))
 
 
 def test_manager_workspace_reload_preserves_manual_child_imagetool_name(
@@ -1142,6 +1193,7 @@ def test_manager_workspace_reload_preserves_manual_child_imagetool_name(
         loaded_child_node = manager._child_node(loaded_child_uid)
         loaded_child_tool = manager.get_imagetool(loaded_child_uid)
         assert loaded_child_node.name == "saved manual child"
+        assert loaded_child_tool.slicer_area._data.name == "saved manual child"
 
         updated = (source + 125.0).rename("updated_scan")
         updated.to_netcdf(source_path, engine="h5netcdf")
@@ -1155,7 +1207,9 @@ def test_manager_workspace_reload_preserves_manual_child_imagetool_name(
 
         assert loaded_child_node.source_state == "fresh"
         assert loaded_child_node.name == "saved manual child"
-        xr.testing.assert_identical(fetch(loaded_child_uid), updated)
+        xr.testing.assert_identical(
+            fetch(loaded_child_uid), updated.rename("saved manual child")
+        )
 
 
 @pytest.mark.parametrize("auto_update", [False, True], ids=["manual", "auto"])

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -1025,6 +1025,35 @@ def test_manager_file_suffix_does_not_seed_unnamed_root_name(
         )
 
 
+def test_manager_rename_updates_accepted_filter_data(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    operation = erlab.interactive.imagetool.provenance_framework.NormalizeOperation(
+        dims=("alpha",),
+        mode="min",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data.astype(float).rename("scan"), manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        root_tool = manager.get_imagetool(0)
+        root_tool.slicer_area.apply_filter_operation(operation)
+
+        manager.rename_imagetool(0, "filtered scan")
+
+        assert root_tool.slicer_area._data.name == "filtered scan"
+        assert root_tool.slicer_area._accepted_filter_data is not None
+        assert root_tool.slicer_area._accepted_filter_data.name == "filtered scan"
+        assert root_tool.slicer_area.array_slicer._obj.name == "filtered scan"
+
+
 def test_manager_reload_selected_preserves_manual_child_imagetool_name(
     qtbot,
     tmp_path: pathlib.Path,

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -331,6 +331,10 @@ def test_childtool_info_changed_debounces_manager_details_refresh(
         selection_model = manager.tree_view.selectionModel()
         selection_model.clearSelection()
         select_child_tool(manager, uid)
+        qtbot.wait_until(
+            lambda: manager.tree_view.selected_childtool_uids == [uid],
+            timeout=5000,
+        )
 
         metadata_updates: list[str] = []
         original_set_metadata_node = manager._set_metadata_node
@@ -342,13 +346,19 @@ def test_childtool_info_changed_debounces_manager_details_refresh(
         monkeypatch.setattr(manager, "_set_metadata_node", _record_metadata_rebuild)
         manager._tool_metadata_update_timer.setInterval(1)
 
-        tool.emit_info_text("updated child info")
-        tool.emit_info_text("updated child info again")
-        tool.emit_info_text("updated child info final")
+        child_node = manager._child_node(uid)
+        tool._info_text = "updated child info"
+        child_node._handle_tool_info_changed()
+        tool._info_text = "updated child info again"
+        child_node._handle_tool_info_changed()
+        tool._info_text = "updated child info final"
+        child_node._handle_tool_info_changed()
 
         assert "updated child info" not in manager.text_box.toPlainText()
         assert metadata_updates == []
-        qtbot.wait_until(lambda: metadata_updates == [uid], timeout=1000)
+        assert manager._pending_tool_metadata_update_uids == {uid}
+        manager._flush_pending_tool_metadata_updates()
+        assert metadata_updates == [uid]
         assert "updated child info final" in manager.text_box.toPlainText()
 
 

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1895,7 +1895,12 @@ def test_manager_promote_child_imagetool_rehomes_subtree_and_detaches_provenance
         child_node = manager._child_node(child_uid)
         child_tool = manager.get_imagetool(child_uid)
         child_node.name = "averaged child"
-        assert child_tool.windowTitle() == "averaged child"
+        assert (
+            manager_workspace_io._strip_workspace_modified_placeholder(
+                child_tool.windowTitle()
+            )
+            == "averaged child"
+        )
         child_before = fetch(child_uid).copy(deep=True)
 
         child_tool.slicer_area.images[0].open_in_dtool()

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -2,6 +2,48 @@
 from ._shared import *
 
 
+def _manager_provenance_file_spec(path: pathlib.Path):
+    prov = erlab.interactive.imagetool.provenance_framework
+    return prov.file_load(
+        start_label="Load source",
+        seed_code=f"derived = xr.load_dataarray({str(path)!r})",
+        file_load_source=prov.FileLoadSource(
+            path=str(path),
+            loader_label="xarray.load_dataarray",
+            loader_text="xarray.load_dataarray",
+            kwargs_text="",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=0,
+            ),
+        ),
+    )
+
+
+def test_manager_file_label_helpers_and_file_replay_rename_update(tmp_path) -> None:
+    prov = erlab.interactive.imagetool.provenance_framework
+    paths = [
+        tmp_path / "scan_a.h5",
+        tmp_path / "scan_b.h5",
+        tmp_path / "scan_c.h5",
+    ]
+
+    assert manager_wrapper._compact_file_suffix(paths) == " (scan_a, scan_b, +1)"
+
+    spec = _manager_provenance_file_spec(paths[0]).append_replay_stage(
+        prov.full_data(prov.AverageOperation(dims=("x",))).append_final_rename("old")
+    )
+    renamed = manager_wrapper._spec_with_final_data_name(spec, "new")
+
+    assert renamed.kind == "file"
+    assert renamed.replay_stages
+    assert renamed.replay_stages[-1].operations[-1] == prov.RenameOperation(name="new")
+    assert renamed.replay_stages[-1].operations[:-1] == (
+        prov.AverageOperation(dims=("x",)),
+    )
+
+
 def test_manager_childtool_from_filtered_parent_uses_display_provenance(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1233,11 +1233,11 @@ def test_manager_selection_dialog_opens_child_with_source_spec(
         child_uid = parent._childtool_indices[0]
         child_node = manager._child_node(child_uid)
         child_tool = child_node.imagetool
-        expected = data.qsel(hv=40.0).rename("scan_sel")
+        expected = data.qsel(hv=40.0)
 
         assert child_tool is not None
         assert child_node.source_spec is not None
-        assert [op.op for op in child_node.source_spec.operations] == ["qsel", "rename"]
+        assert [op.op for op in child_node.source_spec.operations] == ["qsel"]
         xarray.testing.assert_identical(
             child_node.source_spec.apply(parent_tool.slicer_area.data), expected
         )
@@ -1854,6 +1854,7 @@ def test_manager_promote_child_imagetool_rehomes_subtree_and_detaches_provenance
     qtbot,
     monkeypatch,
     accept_dialog,
+    tmp_path: pathlib.Path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -1864,12 +1865,19 @@ def test_manager_promote_child_imagetool_rehomes_subtree_and_detaches_provenance
         coords={"x": np.arange(3), "y": np.arange(4), "z": np.arange(5)},
         name="scan",
     )
+    file_path = tmp_path / "scan.h5"
+    data.to_netcdf(file_path, engine="h5netcdf")
 
     with manager_context() as manager:
         manager.show()
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
 
-        itool(data, manager=True)
+        itool(
+            data,
+            manager=True,
+            file_path=file_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         parent_tool = manager.get_imagetool(0)
@@ -1887,6 +1895,7 @@ def test_manager_promote_child_imagetool_rehomes_subtree_and_detaches_provenance
         child_node = manager._child_node(child_uid)
         child_tool = manager.get_imagetool(child_uid)
         child_node.name = "averaged child"
+        assert child_tool.windowTitle() == "averaged child"
         child_before = fetch(child_uid).copy(deep=True)
 
         child_tool.slicer_area.images[0].open_in_dtool()
@@ -1917,9 +1926,8 @@ def test_manager_promote_child_imagetool_rehomes_subtree_and_detaches_provenance
         assert manager.tree_view.selected_childtool_uids == []
         assert manager._root_wrapper_for_uid(nested_uid).index == promoted_index
         assert (
-            manager.get_imagetool(promoted_index)
-            .windowTitle()
-            .startswith(f"{promoted_index}: averaged child")
+            manager.get_imagetool(promoted_index).windowTitle()
+            == f"{promoted_index}: averaged child (scan)"
         )
         xr.testing.assert_identical(fetch(child_uid), child_before)
         xr.testing.assert_identical(
@@ -2029,7 +2037,6 @@ def test_manager_aggregate_child_refreshes_from_parent(
         assert child_node.source_spec is not None
         assert [op.op for op in child_node.source_spec.operations] == [
             "qsel_aggregate",
-            "rename",
         ]
         xr.testing.assert_identical(
             fetch(child_uid).rename(None), data.qsel.sum("x").rename(None)
@@ -2089,14 +2096,13 @@ def test_manager_replace_transform_on_filtered_source_child_keeps_live_source(
         accept_dialog(child_tool.mnb._average, pre_call=_replace_average)
 
         filtered = operation.apply(data, parent_data=data)
-        expected = filtered.qsel.mean("x").rename("scan_avg")
+        expected = filtered.qsel.mean("x")
         xr.testing.assert_identical(fetch(child_uid), expected)
         assert child_node.source_spec is not None
         assert child_node.source_spec.is_live_source
         assert [op.op for op in child_node.source_spec.operations] == [
             "gaussian_filter",
             "qsel_aggregate",
-            "rename",
         ]
 
         updated = data + 10.0
@@ -2104,7 +2110,7 @@ def test_manager_replace_transform_on_filtered_source_child_keeps_live_source(
             replace_data(0, updated)
 
         updated_filtered = operation.apply(updated, parent_data=updated)
-        updated_expected = updated_filtered.qsel.mean("x").rename("scan_avg")
+        updated_expected = updated_filtered.qsel.mean("x")
         qtbot.wait_until(
             lambda: (
                 child_node.source_state == "fresh"
@@ -2162,7 +2168,6 @@ def test_manager_file_backed_replace_current_keeps_file_provenance(
         assert root.provenance_spec.replay_stages[0].source_kind == "full_data"
         assert [op.op for op in root.provenance_spec.replay_stages[0].operations] == [
             "qsel_aggregate",
-            "rename",
         ]
         entries = root.provenance_spec.display_entries()
         assert entries[0].label == "Load data from file 'scan.h5'"
@@ -2247,7 +2252,7 @@ def test_manager_detached_file_provenance_metadata_and_reload_roundtrip(
         assert [
             operation["op"]
             for operation in provenance_payload["replay_stages"][0]["operations"]
-        ] == ["qsel_aggregate", "rename"]
+        ] == ["qsel_aggregate"]
         assert (
             provenance_payload["file_load_source"]["replay_call"]["target"]
             == "xarray.load_dataarray"
@@ -2826,7 +2831,7 @@ def test_manager_divide_by_coord_child_refresh_and_code(
         child_node = manager._child_node(child_uid)
         child_tool = manager.get_imagetool(child_uid)
 
-        expected = (data / data.mesh_current).rename("scan_div_mesh_current")
+        expected = (data / data.mesh_current).rename("scan")
         xr.testing.assert_identical(child_tool.slicer_area._data, expected)
         assert child_node.source_spec is not None
         operations = [
@@ -2858,6 +2863,7 @@ def test_manager_divide_by_coord_child_refresh_and_code(
         assert not erlab.interactive.imagetool.provenance_framework.uses_default_replay_input(
             copied[-1]
         )
+        assert ".rename(" not in copied[-1]
 
         namespace = _exec_generated_code(
             copied[-1], {"source_data": data.copy(deep=True)}

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -30,6 +30,78 @@ class _AddedTimeChildTool(erlab.interactive.utils.ToolWindow[_AddedTimeChildStat
         self._status = status
 
 
+def _workspace_test_file_spec(path: pathlib.Path):
+    prov = erlab.interactive.imagetool.provenance_framework
+    return prov.file_load(
+        start_label="Load source",
+        seed_code=f"derived = xr.load_dataarray({str(path)!r})",
+        file_load_source=prov.FileLoadSource(
+            path=str(path),
+            loader_label="xarray.load_dataarray",
+            loader_text="xarray.load_dataarray",
+            kwargs_text="",
+            replay_call=prov.FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selected_index=0,
+            ),
+        ),
+    )
+
+
+def test_workspace_file_suffix_helpers_collect_nested_inputs(tmp_path) -> None:
+    prov = erlab.interactive.imagetool.provenance_framework
+    first = _workspace_test_file_spec(tmp_path / "scan_a.h5")
+    second = _workspace_test_file_spec(tmp_path / "scan_b.h5")
+    third = _workspace_test_file_spec(tmp_path / "scan_c.h5")
+    nested = prov.script(
+        start_label="Combine",
+        seed_code="derived = data_0 + data_1",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_1", label="B", provenance_spec=second),
+            prov.ScriptInput(name="data_2", label="C", provenance_spec=third),
+            prov.ScriptInput(name="data_0", label="A duplicate", provenance_spec=first),
+        ),
+    )
+    combined = prov.script(
+        start_label="Combine nested",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(
+            prov.ScriptInput(name="data_0", label="A", provenance_spec=first),
+            prov.ScriptInput(name="nested", label="Nested", provenance_spec=nested),
+        ),
+    )
+
+    stems = manager_workspace_io._workspace_provenance_file_stems(combined)
+
+    assert stems == ("scan_a", "scan_b", "scan_c")
+    assert (
+        manager_workspace_io._workspace_compact_file_suffix(stems)
+        == " (scan_a, scan_b, +1)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("attrs", "expected"),
+    [
+        ({"itool_title": "2: manual (scan)", "itool_name": "scan"}, "manual"),
+        ({"itool_title": "scan", "itool_name": ""}, None),
+        ({"itool_title": "scan (scan)", "itool_name": "scan"}, None),
+    ],
+)
+def test_workspace_legacy_title_migration_ignores_generated_file_labels(
+    tmp_path,
+    attrs,
+    expected,
+) -> None:
+    ds = xr.Dataset(attrs=attrs)
+    spec = _workspace_test_file_spec(tmp_path / "scan.h5")
+
+    assert manager_workspace_io._legacy_saved_title_data_name(ds, spec) == expected
+
+
 def test_manager_duplicate(
     qtbot,
     test_data,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -15,6 +15,7 @@ def test_manager_duplicate(
         # Open a tool with the manager
         itool([test_data, test_data], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        manager.rename_imagetool(0, "renamed source")
 
         select_tools(manager, [0, 1])
         manager.duplicate_selected()
@@ -469,6 +470,44 @@ def test_manager_workspace_load_selection_skips_unchecked_children(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         assert manager._imagetool_wrappers[0]._childtool_indices == [child_uids[0]]
         assert child_uids[1] not in manager._all_nodes
+
+
+def test_manager_workspace_load_migrates_legacy_manual_title_to_data_name(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"], name="scan")
+    file_path = tmp_path / "scan.h5"
+    data.to_netcdf(file_path, engine="h5netcdf")
+    root = itool(
+        data,
+        manager=False,
+        execute=False,
+        file_path=file_path,
+        load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+    )
+    assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+    qtbot.addWidget(root)
+    ds = root.to_dataset()
+    root.close()
+    ds.attrs["itool_title"] = "legacy manual name (scan)"
+    ds.attrs["itool_name"] = "scan"
+    ds.attrs["manager_node_provenance_spec"] = ds.attrs["itool_provenance_spec"]
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager._load_workspace_imagetool_dataset(
+            ds,
+            parent_target=None,
+            node_path="0",
+        )
+
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        assert manager.name_of_imagetool(0) == "legacy manual name"
+        assert manager.get_imagetool(0).slicer_area._data.name == "legacy manual name"
 
 
 def _open_external_hdf5_imagetool_data(
@@ -5663,7 +5702,7 @@ def test_manager_workspace_dirty_marker_not_saved_in_titles(
 
         root.setWindowTitle("stale root title[*]")
         manager._imagetool_wrappers[0].update_title()
-        assert "stale root title" in manager._imagetool_wrappers[0].label_text
+        assert "stale root title" not in manager._imagetool_wrappers[0].label_text
         assert "[*]" not in manager._imagetool_wrappers[0].label_text
 
         root.setWindowTitle("stale root title[*]")
@@ -5695,6 +5734,7 @@ def test_manager_workspace_dirty_marker_not_saved_in_titles(
 
         assert "[*]" not in root_title
         assert "[*]" not in tool_title
+        assert root_title == "source"
 
 
 def test_manager_workspace_full_save_drops_empty_attr_name(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5254,7 +5254,7 @@ def test_itool_transform_after_filter_uses_displayed_data_and_provenance(
         )
     )
     filtered = filter_operation.apply(data, parent_data=data)
-    expected = filtered.qsel.mean("y").rename("scan_avg")
+    expected = filtered.qsel.mean("y")
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     win.slicer_area.apply_filter_operation(filter_operation)
@@ -5310,7 +5310,6 @@ def test_itool_aggregate_sum(qtbot, accept_dialog) -> None:
     assert win.provenance_spec is not None
     assert [op.op for op in win.provenance_spec.operations] == [
         "qsel_aggregate",
-        "rename",
     ]
     aggregate_op = win.provenance_spec.operations[0]
     assert isinstance(
@@ -5348,17 +5347,16 @@ def test_average_source_spec_restores_nonuniform_dims_after_refresh(qtbot) -> No
     qtbot.addWidget(dialog)
     dialog.dim_checks["y"].setChecked(True)
 
-    spec = dialog.source_spec("scan_avg")
+    spec = dialog.source_spec("ignored")
     expected = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
         dialog.process_data(win.slicer_area.data)
-    ).rename("scan_avg")
+    )
     refreshed = spec.apply(win.slicer_area.data)
 
     assert spec.kind == "full_data"
     assert [op.op for op in spec.operations] == [
         "qsel_aggregate",
         "restore_nonuniform_dims",
-        "rename",
     ]
     assert refreshed.dims == ("x",)
     xarray.testing.assert_identical(refreshed, expected)
@@ -5394,17 +5392,16 @@ def test_aggregate_source_spec_restores_nonuniform_dims_after_refresh(qtbot) -> 
     dialog.dim_checks["y"].setChecked(True)
     _set_combo_data(dialog.reducer_combo, "sum")
 
-    spec = dialog.source_spec("scan_sum")
+    spec = dialog.source_spec("ignored")
     expected = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
         dialog.process_data(win.slicer_area.data)
-    ).rename("scan_sum")
+    )
     refreshed = spec.apply(win.slicer_area.data)
 
     assert spec.kind == "full_data"
     assert [op.op for op in spec.operations] == [
         "qsel_aggregate",
         "restore_nonuniform_dims",
-        "rename",
     ]
     assert refreshed.dims == ("x",)
     xarray.testing.assert_identical(refreshed, expected)
@@ -5573,7 +5570,7 @@ def test_selection_dialog_accept_replaces_current_data(qtbot) -> None:
         win.slicer_area._data.rename(None), data.qsel(hv=40.0).rename(None)
     )
     assert win.provenance_spec is not None
-    assert [op.op for op in win.provenance_spec.operations] == ["qsel", "rename"]
+    assert [op.op for op in win.provenance_spec.operations] == ["qsel"]
 
     win.close()
 
@@ -5776,11 +5773,9 @@ def test_selection_dialog_uses_public_nonuniform_dimensions(qtbot) -> None:
     xarray.testing.assert_identical(
         _exec_data_fragment(data, dialog.make_code()), expected
     )
-    spec = dialog.source_spec("scan_sel")
+    spec = dialog.source_spec("ignored")
     assert spec.kind == "public_data"
-    xarray.testing.assert_identical(
-        spec.apply(win.slicer_area.data), expected.rename("scan_sel")
-    )
+    xarray.testing.assert_identical(spec.apply(win.slicer_area.data), expected)
 
     dialog.close()
     win.close()
@@ -6133,7 +6128,7 @@ def test_itool_leading_edge(qtbot, accept_dialog) -> None:
     xarray.testing.assert_identical(
         win.slicer_area._data.rename(None), expected.rename(None)
     )
-    assert win.slicer_area._data.name == "scan_leading_edge_eV"
+    assert win.slicer_area._data.name == "scan"
     xarray.testing.assert_identical(
         _exec_data_fragment(data, pyperclip.paste()), expected
     )
@@ -6169,8 +6164,6 @@ def test_leading_edge_dialog_rejects_no_dimension(qtbot, monkeypatch) -> None:
         return QtWidgets.QMessageBox.StandardButton.Ok
 
     monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
-    assert dialog.suffix == "_leading_edge_coord"
-    dialog.suffix = "ignored"
     assert dialog.make_code() == ""
     with pytest.raises(ValueError, match="No dimension selected"):
         dialog.source_transform_operation()
@@ -6183,7 +6176,7 @@ def test_leading_edge_dialog_rejects_no_dimension(qtbot, monkeypatch) -> None:
     win.close()
 
 
-def test_leading_edge_dialog_defaults_and_suffix(qtbot) -> None:
+def test_leading_edge_dialog_defaults_to_first_dimension(qtbot) -> None:
     data = xr.DataArray(
         np.arange(6, dtype=float).reshape((2, 3)),
         dims=["1 axis", "energy"],
@@ -6194,7 +6187,6 @@ def test_leading_edge_dialog_defaults_and_suffix(qtbot) -> None:
     dialog = LeadingEdgeDialog(win.slicer_area)
 
     assert dialog.dim_combo.currentData(QtCore.Qt.ItemDataRole.UserRole) == "1 axis"
-    assert dialog.suffix == "_leading_edge_coord_1_axis"
 
     dialog.close()
     win.close()
@@ -7784,10 +7776,11 @@ def test_itool_divide_by_coord(qtbot, accept_dialog) -> None:
 
     accept_dialog(win.mnb._divide_by_coord, pre_call=_set_dialog_params)
 
-    expected = (data / data.mesh_current).rename("scan_div_mesh_current")
+    expected = (data / data.mesh_current).rename("scan")
     xarray.testing.assert_identical(win.slicer_area._data, expected)
     copied_code = pyperclip.paste()
     assert "data.mesh_current" in copied_code
+    assert ".rename(" not in copied_code
     namespace: dict[str, typing.Any] = {"data": data.copy(deep=True)}
     exec(f"result = {copied_code}", {}, namespace)  # noqa: S102
     xarray.testing.assert_identical(
@@ -7866,11 +7859,7 @@ def test_divide_by_coord_dialog_edge_paths(qtbot, monkeypatch) -> None:
 
     dialog.coord_combo.setCurrentText("scalar_current")
     assert dialog.coord_dims_label.text() == "scalar"
-    assert dialog.suffix == "_div_scalar_current"
-    dialog.suffix = ""
-
     dialog.coord_combo.setCurrentText("2 current")
-    assert dialog.suffix == "_div_coord_2_current"
 
     warnings: list[tuple[str, str]] = []
 
@@ -7883,7 +7872,6 @@ def test_divide_by_coord_dialog_edge_paths(qtbot, monkeypatch) -> None:
     dialog.coord_combo.setCurrentIndex(-1)
     dialog._update_coord_dims_label()
     assert dialog.coord_dims_label.text() == ""
-    assert dialog.suffix == "_div_coord"
     assert dialog.make_code() == ""
     with pytest.raises(ValueError, match="No coordinate selected"):
         dialog.source_transform_operation()
@@ -7934,6 +7922,7 @@ def test_itool_divide_by_coord_nonuniform_generated_code(qtbot, accept_dialog) -
     display_code = win.provenance_spec.display_code()
     assert display_code is not None
     assert "mesh_current" in display_code
+    assert ".rename(" not in display_code
     assert "x_idx" not in display_code
     namespace = {"data": data.copy(deep=True)}
     exec(display_code, {}, namespace)  # noqa: S102

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5985,7 +5985,7 @@ def test_itool_interpolate(qtbot, accept_dialog) -> None:
     xarray.testing.assert_identical(
         win.slicer_area._data.rename(None), expected.rename(None)
     )
-    assert win.slicer_area._data.name == "scan_interp_x"
+    assert win.slicer_area._data.name == "scan"
 
     xarray.testing.assert_identical(
         _exec_data_fragment(data, pyperclip.paste()), expected

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -373,10 +373,16 @@ def test_operation_replay_code_uses_requested_names(
             "source": data.copy(deep=True),
         },
     )
-    xr.testing.assert_identical(
-        namespace["result"],
-        operation.apply(data, parent_data=data),
-    )
+    result = namespace["result"]
+    expected = operation.apply(data, parent_data=data)
+    if isinstance(
+        operation,
+        erlab.interactive.imagetool.provenance_framework.DivideByCoordOperation,
+    ):
+        result = result.rename(None)
+        expected = expected.rename(None)
+        assert ".rename(" not in code
+    xr.testing.assert_identical(result, expected)
 
 
 def test_operation_replay_code_passes_source_context() -> None:
@@ -485,6 +491,7 @@ def test_operations_expression_code_chains_without_relay_assignments() -> None:
 
     code = prov.operations_expression_code(operations, "data")
     assert code.startswith("(data / data.scale).isel(")
+    assert ".rename(" not in code
     assert "derived" not in code
 
     namespace = _exec_generated_code(
@@ -495,7 +502,7 @@ def test_operations_expression_code_chains_without_relay_assignments() -> None:
         operations[0].apply(data, parent_data=data),
         parent_data=data,
     )
-    xr.testing.assert_identical(namespace["result"], expected)
+    xr.testing.assert_identical(namespace["result"].rename(None), expected.rename(None))
 
 
 def test_tool_provenance_parse_legacy_file_script_metadata() -> None:
@@ -1013,16 +1020,18 @@ def test_tool_provenance_divide_by_coord_operation() -> None:
     data = _base_data().assign_coords(mesh_current=("x", [1.0, 2.0, 4.0]))
 
     spec = prov.full_data(prov.DivideByCoordOperation(coord_name="mesh_current"))
-    xr.testing.assert_identical(spec.apply(data), data / data.mesh_current)
+    expected = (data / data.mesh_current).rename(data.name)
+    xr.testing.assert_identical(spec.apply(data), expected)
     code = spec.derivation_code()
     assert code is not None
     assert "derived.mesh_current" in code
+    assert ".rename(" not in code
     namespace = _exec_generated_code(code, {"data": data})
     xr.testing.assert_identical(namespace["derived"], data / data.mesh_current)
 
     reparsed = prov.parse_tool_provenance_spec(spec.model_dump(mode="json"))
     assert reparsed == spec
-    xr.testing.assert_identical(reparsed.apply(data), data / data.mesh_current)
+    xr.testing.assert_identical(reparsed.apply(data), expected)
 
 
 def test_tool_provenance_divide_by_coord_fallback_code_and_broadcast() -> None:
@@ -1042,6 +1051,7 @@ def test_tool_provenance_divide_by_coord_fallback_code_and_broadcast() -> None:
     spaced_code = spaced_spec.derivation_code()
     assert spaced_code is not None
     assert 'derived.coords["mesh current"]' in spaced_code
+    assert ".rename(" not in spaced_code
     namespace = _exec_generated_code(spaced_code, {"data": data})
     xr.testing.assert_identical(
         namespace["derived"], data / data.coords["mesh current"]
@@ -1051,12 +1061,13 @@ def test_tool_provenance_divide_by_coord_fallback_code_and_broadcast() -> None:
     conflict_code = conflict_spec.derivation_code()
     assert conflict_code is not None
     assert 'derived.coords["mean"]' in conflict_code
+    assert ".rename(" not in conflict_code
     namespace = _exec_generated_code(conflict_code, {"data": data})
     xr.testing.assert_identical(namespace["derived"], data / data.coords["mean"])
 
     broadcast_spec = prov.full_data(prov.DivideByCoordOperation(coord_name="mesh_map"))
     xr.testing.assert_identical(
-        broadcast_spec.apply(data), data / data.coords["mesh_map"]
+        broadcast_spec.apply(data), (data / data.coords["mesh_map"]).rename(data.name)
     )
 
 


### PR DESCRIPTION
## Summary
Refactor ImageTool manager naming and provenance handling so user-facing names are the actual `DataArray.name`, with file provenance treated as a separate, persistent suffix.

## Motivation
The previous scheme encoded operation intent by renaming array names (for example `scan_avg`, `scan_sel`), which became misleading once provenance metadata was introduced. This change makes names reflect user intent directly and keeps file context derived from lineage instead.

## Changes

### Manager naming and rename behavior
- `ImageToolManager.rename_imagetool` now performs a direct `DataArray.rename(...)` on the managed data.
- Rename dialogs and edit controls are seeded with only the current data name (without index prefix or file suffix).
- Root list rows and window titles now render as:
  - Top-level: `index: name (file)`
  - Child: `name`
- Child rows remain label-only (no file suffix) while nested, and suffixes reappear when promoted to top-level and file lineage exists.

### File suffix from provenance
- File suffixes are now derived from direct file-load metadata and recursively from structured provenance, deduplicated in first-seen order.
- Suffixes are compacted (`(scan)`, `(scan_a, scan_b)`, `(scan_a, scan_b, +N)`).
- File suffix is retained across processing chains, reloads, duplicates, and promotion.

### Transform and generated-code cleanup
- Removed automatic operation suffixing/rename operations from transform dialogs (for example `_avg`, `_sel`, `_corr`, `_crop`).
- Transform outputs now preserve input `DataArray.name` unless the user explicitly renames.
- `DivideByCoordOperation` output and generated/copied code no longer emits a full-array `rename(...)`; code uses the direct expression form.

### Workspace compatibility
- Added load-time migration for legacy workspaces where user-assigned names only existed in saved manager titles.
- During workspace load, legacy manual titles are migrated into `DataArray.name` (stored in `itool_name`) when `itool_title` cannot be reconstructed from current metadata.
- Root `itool_title` is still serialized as a UI label while canonical name now lives in `itool_name`.

## Files
- `src/erlab/interactive/imagetool/manager/_wrapper.py`
- `src/erlab/interactive/imagetool/manager/_actions.py`
- `src/erlab/interactive/imagetool/manager/_modelview.py`
- `src/erlab/interactive/imagetool/manager/_workspace_io.py`
- `src/erlab/interactive/imagetool/dialogs.py`
- `src/erlab/interactive/imagetool/viewer.py`
- `src/erlab/interactive/imagetool/provenance_operations.py`
- `docs/source/user-guide/interactive/manager.md`
- related test updates in `tests/interactive/imagetool/*`

## Validation
- `uv run pytest tests/interactive/imagetool/manager/test_mainwindow.py tests/interactive/imagetool/manager/test_provenance.py tests/interactive/imagetool/test_provenance.py tests/interactive/imagetool/test_replay_graph.py tests/interactive/imagetool/manager/test_workspace.py::test_manager_duplicate tests/interactive/imagetool/manager/test_workspace.py::test_manager_workspace_dirty_marker_not_saved_in_titles tests/interactive/imagetool/manager/test_workspace.py::test_manager_workspace_load_migrates_legacy_manual_title_to_data_name`
- `uv run pytest` focused transform/imagetool suites (30 + 125 pass in final runs)
- `uv run ruff check --fix . && uv run ruff format --check .`
- `uv run mypy src`

## Notes
- No `versionchanged` note was added; docs changes were kept minimal and directly consistent with current behavior.
