### PR TITLE
Restore explicit provenance imports in ImageTool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Keep small implementation paths direct. Do not introduce dataclasses, wrapper he
 Use modern typing syntax as a default rule: use built-in generics (`list[str]`, `dict[str, int]`) and `collections.abc` types (for example `Callable`), and avoid deprecated `typing` aliases (deprecated since Python 3.9).
 Typing rule: do not write `typing.Iterable`, `typing.Iterator`, `typing.Mapping`, `typing.Sequence`, `typing.Callable`, `typing.Dict`, `typing.List`, or `typing.Tuple`. Import abstract collection types from `collections.abc` (inside `if typing.TYPE_CHECKING:` when used only for annotations) and use built-in containers such as `list[str]` and `dict[str, int]`.
 Do not use `assert` in runtime code under `src/`; use explicit `if`/`raise` checks for runtime invariants and `typing.cast` for type narrowing that should not affect runtime behavior.
+Avoid mutating `globals()` in library modules to inject symbols into module scope (for example via `globals().update`); prefer explicit imports and direct references instead.
 
 ## Testing Guidelines
 

--- a/src/erlab/interactive/imagetool/provenance_operations.py
+++ b/src/erlab/interactive/imagetool/provenance_operations.py
@@ -1,9 +1,9 @@
-# mypy: ignore-errors
-# ruff: noqa: F821
 """Concrete ImageTool provenance operations."""
 
 from __future__ import annotations
 
+import contextlib
+import keyword
 import typing
 from collections.abc import Hashable, Mapping, Sequence
 
@@ -12,10 +12,38 @@ import pydantic
 import xarray as xr
 
 import erlab
-from erlab.interactive.imagetool import provenance_framework as _framework
-
-# Concrete operations use framework models plus private coercion and formatting helpers.
-globals().update({name: getattr(_framework, name) for name in dir(_framework)})
+from erlab.interactive.imagetool.provenance_framework import (
+    _DATASET_MARKER,
+    _FIT_DATASET_MARKER,
+    _SORT_COORD_ORDER_DERIVATION_LABEL,
+    _TUPLE_MARKER,
+    ConsoleCall,
+    ConsoleOperationPattern,
+    DerivationEntry,
+    NullableProvenanceHashableTuple,
+    ProvenanceFloatMapping,
+    ProvenanceFloatSequenceMapping,
+    ProvenanceHashable,
+    ProvenanceHashableMapping,
+    ProvenanceHashablePair,
+    ProvenanceHashableTuple,
+    ProvenanceIntMapping,
+    ProvenanceMapping,
+    ToolProvenanceOperation,
+    _coerce_float_mapping_field,
+    _console_mapping_values,
+    _console_values_equal,
+    _ensure_float_tuple,
+    _format_derivation_value,
+    _format_selection_expr,
+    _is_identifier_string_mapping,
+    _provenance_numeric_array_code,
+    _provenance_value_code,
+    _scalar_coord_value,
+    _single_assign_coord,
+    decode_provenance_value,
+    encode_provenance_value,
+)
 
 
 class ScriptCodeOperation(ToolProvenanceOperation):


### PR DESCRIPTION
## Summary
- Replaced `globals().update(...)` in `provenance_operations.py` with explicit imports from `provenance_framework`
- Removed module-level mypy and ruff suppressions from the provenance operations module
- Added a general AGENTS.md rule to avoid mutating `globals()` in library modules