### PR TITLE
Propagate settings tooltips to tree rows

### DIFF
--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -16,10 +16,28 @@ class _CustomParameterTree(pyqtgraph.parametertree.ParameterTree):
     def setParameters(self, *args, **kwargs):
         self._parameter = args[0] if args else None
         super().setParameters(*args, **kwargs)
+        if self._parameter is not None:
+            self._apply_parameter_tooltips(self._parameter)
 
     @property
     def parameter(self) -> pyqtgraph.parametertree.Parameter | None:
         return self._parameter
+
+    def _apply_parameter_tooltips(
+        self, parameter: pyqtgraph.parametertree.Parameter
+    ) -> None:
+        tip = parameter.opts.get("tip")
+        if tip:
+            for item in parameter.items:
+                item.setToolTip(0, tip)
+                item.setToolTip(1, tip)
+                for attr in ("layoutWidget", "displayLabel", "widget", "defaultBtn"):
+                    widget = getattr(item, attr, None)
+                    if widget is not None:
+                        widget.setToolTip(tip)
+
+        for child in parameter:
+            self._apply_parameter_tooltips(child)
 
 
 class OptionDialog(QtWidgets.QDialog):

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -32,6 +32,20 @@ def test_apply_button_enables_on_change(dialog: OptionDialog, qtbot):
     assert dialog.btn_apply.isEnabled()
 
 
+def test_dialog_parameter_tips_apply_to_label_and_row_widgets(
+    dialog: OptionDialog,
+):
+    param = dialog.tree.parameter.child("io").child("dask").child("compute_threshold")
+    tip = param.opts["tip"]
+    (item,) = tuple(param.items)
+
+    assert item.toolTip(0) == tip
+    assert item.toolTip(1) == tip
+    assert item.layoutWidget.toolTip() == tip
+    assert item.displayLabel.toolTip() == tip
+    assert item.widget.toolTip() == tip
+
+
 def test_apply_saves_settings(dialog: OptionDialog, qtbot):
     dialog.tree.parameter.child("colors").child("cmap").child("name").setValue("bwr")
     dialog.apply()


### PR DESCRIPTION
## Summary
- Propagate ParameterTree tooltip metadata onto both columns and the row widgets in the settings dialog.
- Add a Qt test that verifies tooltip metadata reaches the label and value widgets for a known option.

## Testing
- Unit/UI tests added for tooltip propagation in the options dialog.
- Existing options tree tests continue to pass.