### PR TITLE
Reject non-finite affine coordinate values in Edit Coordinates dialog

### DIFF
--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -1379,6 +1379,13 @@ class AffineCoordOperation(ToolProvenanceOperation):
     scale: float
     offset: float
 
+    @pydantic.field_validator("scale", "offset")
+    @classmethod
+    def _validate_finite_affine_value(cls, value: float) -> float:
+        if not np.isfinite(value):
+            raise ValueError("affine coordinate scale and offset must be finite")
+        return value
+
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         coord = data.coords[self.coord_name]
         return erlab.utils.array.sort_coord_order(
@@ -1405,12 +1412,22 @@ class AffineCoordOperation(ToolProvenanceOperation):
         self, input_name: str, *, source_name: str | None = None
     ) -> str:
         coord_name_code = repr(self.coord_name)
-        scale_code = erlab.interactive.utils._parse_single_arg(float(self.scale))
-        offset_code = erlab.interactive.utils._parse_single_arg(float(self.offset))
+        coord_values_code = f"{input_name}[{coord_name_code}].values"
+        scale = float(self.scale)
+        offset = float(self.offset)
+        data_code = coord_values_code
+        if scale != 1.0:
+            scale_code = erlab.interactive.utils._parse_single_arg(scale)
+            data_code = f"{scale_code} * {data_code}"
+        if offset > 0.0:
+            offset_code = erlab.interactive.utils._parse_single_arg(offset)
+            data_code = f"{data_code} + {offset_code}"
+        elif offset < 0.0:
+            offset_code = erlab.interactive.utils._parse_single_arg(abs(offset))
+            data_code = f"{data_code} - {offset_code}"
         return (
             f"{input_name}.assign_coords({{{coord_name_code}: "
-            f"{input_name}[{coord_name_code}].copy(data={scale_code} * "
-            f"{input_name}[{coord_name_code}].values + {offset_code})}})"
+            f"{input_name}[{coord_name_code}].copy(data={data_code})}})"
         )
 
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -6846,17 +6846,23 @@ def test_itool_assign_coords_affine(qtbot, accept_dialog) -> None:
     def _set_dialog_params(dialog: AssignCoordsDialog) -> None:
         dialog._coord_combo.setCurrentText("y")
         dialog.coord_widget.edit_mode_tabs.setCurrentIndex(1)
-        _set_spinbox_text(dialog.coord_widget.scale_spin, "2.000000000000001")
-        _set_spinbox_text(dialog.coord_widget.offset_spin, "0.5000000000000001")
+        _set_spinbox_text(dialog.coord_widget.scale_spin, "1.0")
+        _set_spinbox_text(dialog.coord_widget.offset_spin, "-3.7")
         dialog.launch_mode_combo.setCurrentText("Replace Current")
 
     accept_dialog(win.mnb._assign_coords, pre_call=_set_dialog_params, timeout=10.0)
     np.testing.assert_allclose(
         win.slicer_area._data.y.values,
-        float("2.000000000000001") * np.arange(4) + float("0.5000000000000001"),
+        np.arange(4) - 3.7,
         rtol=0,
         atol=0,
     )
+    assert win.provenance_spec is not None
+    display_code = win.provenance_spec.display_code(parent_data=data)
+    assert display_code is not None
+    assert "['y'].values - 3.7" in display_code
+    assert "1.0 *" not in display_code
+    assert "+ -3.7" not in display_code
 
 
 def _combo_index_for_data(combo: QtWidgets.QComboBox, data: object) -> int:

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1041,6 +1041,69 @@ def test_tool_provenance_affine_coord_operation(
     )
 
 
+@pytest.mark.parametrize(
+    ("scale", "offset", "expected_fragments", "forbidden_fragments"),
+    [
+        (1.0, -3.7, ("['y'].values - 3.7",), ("1.0 *", "+ -3.7")),
+        (2.0, -3.7, ("2.0 *", "['y'].values - 3.7"), ("+ -3.7",)),
+        (
+            1.0,
+            0.0,
+            ("['y'].values)",),
+            ("1.0 *", "+ 0.0", "- 0.0"),
+        ),
+    ],
+)
+def test_tool_provenance_affine_coord_display_code_formats_no_ops(
+    scale: float,
+    offset: float,
+    expected_fragments: tuple[str, ...],
+    forbidden_fragments: tuple[str, ...],
+) -> None:
+    data = _base_data()
+    operation = provenance.AffineCoordOperation(
+        coord_name="y",
+        scale=scale,
+        offset=offset,
+    )
+
+    code = (
+        provenance.full_data(operation).to_replay_spec().display_code(parent_data=data)
+    )
+    assert code is not None
+    for fragment in expected_fragments:
+        assert fragment in code
+    for fragment in forbidden_fragments:
+        assert fragment not in code
+
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    xr.testing.assert_identical(
+        namespace["derived"], _expected_affine_coord(data, "y", scale, offset)
+    )
+
+
+@pytest.mark.parametrize(
+    ("scale", "offset"),
+    [
+        (np.nan, 0.0),
+        (np.inf, 0.0),
+        (1.0, np.nan),
+        (1.0, -np.inf),
+    ],
+)
+def test_tool_provenance_affine_coord_rejects_nonfinite_values(
+    scale: float, offset: float
+) -> None:
+    with pytest.raises(
+        ValidationError, match="affine coordinate scale and offset must be finite"
+    ):
+        provenance.AffineCoordOperation(
+            coord_name="y",
+            scale=scale,
+            offset=offset,
+        )
+
+
 def test_tool_provenance_divide_by_coord_operation() -> None:
     data = _base_data().assign_coords(mesh_current=("x", [1.0, 2.0, 4.0]))
 


### PR DESCRIPTION
Implement validation to ensure affine coordinate scale and offset are finite, preventing potential errors. Also cleans up generated code so that 1.0 scale and negative offsets are handled better.