### PR TITLE
Restore manual limits after transposed workspace load

### DIFF
--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -580,9 +580,6 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 ax._serializable_state = plotitem_state
         logger.debug("Restored plotitem states")
 
-        self.set_manual_limits(state.get("manual_limits", {}))
-        logger.debug("Restored manual limits")
-
         self.make_cursors(state["cursor_colors"], update=False)
         logger.debug("Restored cursor number and colors")
 
@@ -594,6 +591,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
             if ax.is_image:
                 ax.sync_guidelines_to_active_cursor()
         logger.debug("Restored array slicer state")
+
+        self.set_manual_limits(state.get("manual_limits", {}))
+        logger.debug("Restored manual limits")
 
         axis_inversions = state.get("axis_inversions", None)
         if axis_inversions is None:

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -107,6 +107,19 @@ def _workspace_test_file_spec(path: pathlib.Path):
     )
 
 
+def _assert_manual_limits_view_ranges(
+    area: typing.Any, expected_limits: dict[str, list[float]]
+) -> None:
+    matched_dims: set[str] = set()
+    for plot_item in area.axes:
+        view_ranges = plot_item.getViewBox().viewRange()
+        for axis, axis_dim in enumerate(plot_item.axis_dims_uniform):
+            if axis_dim in expected_limits:
+                matched_dims.add(axis_dim)
+                np.testing.assert_allclose(view_ranges[axis], expected_limits[axis_dim])
+    assert matched_dims == set(expected_limits)
+
+
 def test_workspace_file_suffix_helpers_collect_nested_inputs(tmp_path) -> None:
     first = _workspace_test_file_spec(tmp_path / "scan_a.h5")
     second = _workspace_test_file_spec(tmp_path / "scan_b.h5")
@@ -6403,6 +6416,57 @@ def test_manager_workspace_load_uses_h5py_fast_path(
         assert not loaded.data_chunked
         assert not loaded.data_file_backed
         np.testing.assert_array_equal(loaded._data.values, data.values)
+
+
+def test_manager_workspace_load_preserves_transposed_inverted_axis_limits(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(125, dtype=np.float64).reshape((5, 5, 5)),
+            dims=["x", "y", "z"],
+            coords={"x": np.arange(5.0), "y": np.arange(5.0), "z": np.arange(5.0)},
+        )
+        expected_limits = {"x": [1.0, 3.0], "y": [0.0, 2.0], "z": [2.0, 4.0]}
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        root.slicer_area.set_manual_limits(expected_limits)
+        root.slicer_area.set_axis_inverted("x", True)
+        root.slicer_area.transpose_main_image()
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "transposed-inverted-limits.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+        monkeypatch.setattr(
+            manager_xarray,
+            "open_workspace_datatree",
+            lambda *args, **kwargs: pytest.fail(
+                "simple v4 load should not open the workspace DataTree"
+            ),
+        )
+
+        assert manager._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        loaded = manager.get_imagetool(0).slicer_area
+        assert loaded.data.dims == ("y", "x", "z")
+        assert loaded.manual_limits == expected_limits
+        _assert_manual_limits_view_ranges(loaded, expected_limits)
+        assert loaded.axis_inversions == {"x": True}
+        assert manager_xarray.dataarray_is_numpy_backed(loaded._data)
+        np.testing.assert_array_equal(
+            loaded._data.transpose(*data.dims).values, data.values
+        )
 
 
 def test_manager_workspace_load_h5py_fast_path_falls_back_per_payload(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -3259,6 +3259,19 @@ def _assert_dimension_inverted(area: ImageSlicerArea, dim: str, inverted: bool) 
     assert matched
 
 
+def _assert_manual_limits_view_ranges(
+    area: ImageSlicerArea, expected_limits: dict[str, list[float]]
+) -> None:
+    matched_dims: set[str] = set()
+    for plot_item in area.axes:
+        view_ranges = plot_item.getViewBox().viewRange()
+        for axis, axis_dim in enumerate(plot_item.axis_dims_uniform):
+            if axis_dim in expected_limits:
+                matched_dims.add(axis_dim)
+                np.testing.assert_allclose(view_ranges[axis], expected_limits[axis_dim])
+    assert matched_dims == set(expected_limits)
+
+
 def test_axis_inversion_viewbox_shared_undo_redo_and_roundtrip(qtbot) -> None:
     data = xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=["x", "y"])
     win = itool(data, execute=False)
@@ -3283,6 +3296,37 @@ def test_axis_inversion_viewbox_shared_undo_redo_and_roundtrip(qtbot) -> None:
     restored = ImageTool.from_dataset(win.to_dataset())
     qtbot.addWidget(restored)
     assert restored.slicer_area.axis_inversions == {"x": True}
+    _assert_dimension_inverted(restored.slicer_area, "x", True)
+
+    restored.close()
+    win.close()
+
+
+def test_axis_inversion_transposed_manual_limits_roundtrip(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(125).reshape((5, 5, 5)).astype(float),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(5.0), "y": np.arange(5.0), "z": np.arange(5.0)},
+    )
+    expected_limits = {"x": [1.0, 3.0], "y": [0.0, 2.0], "z": [2.0, 4.0]}
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    win.slicer_area.set_manual_limits(expected_limits)
+    win.slicer_area.set_axis_inverted("x", True)
+    win.slicer_area.transpose_main_image()
+    assert win.slicer_area.data.dims == ("y", "x", "z")
+
+    ds = win.to_dataset()
+    saved_state = json.loads(ds.attrs["itool_state"])
+    assert saved_state["manual_limits"] == expected_limits
+
+    restored = ImageTool.from_dataset(ds)
+    qtbot.addWidget(restored)
+
+    assert restored.slicer_area.data.dims == ("y", "x", "z")
+    assert restored.slicer_area.manual_limits == expected_limits
+    _assert_manual_limits_view_ranges(restored.slicer_area, expected_limits)
     _assert_dimension_inverted(restored.slicer_area, "x", True)
 
     restored.close()


### PR DESCRIPTION
## Summary
- Restore manual limits after slicer state is rebuilt so transposed workspaces keep their saved view ranges
- Add regression coverage for direct ImageTool state round-trips and manager workspace load with inverted, transposed axes

## Testing
- Added unit coverage for `ImageTool.from_dataset` round-trips
- Added manager workspace load coverage for a saved transposed workspace with inverted axis limits