### PR TITLE
Replace manager file-path elision with paint-time drawing

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -151,6 +151,7 @@ class _HeightForWidthFrame(QtWidgets.QFrame):
 
 class _ElidedInteractiveLabel(QtWidgets.QLabel):
     clicked = QtCore.Signal()
+    _SIZE_HINT_EMS = 24
 
     def __init__(
         self,
@@ -160,48 +161,83 @@ class _ElidedInteractiveLabel(QtWidgets.QLabel):
         elide_mode: QtCore.Qt.TextElideMode = QtCore.Qt.TextElideMode.ElideMiddle,
     ) -> None:
         super().__init__(parent)
-        self._full_text = text
+        self._full_text = ""
         self._elide_mode = elide_mode
+        self.setTextFormat(QtCore.Qt.TextFormat.PlainText)
         self.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
         self.setMinimumWidth(0)
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Expanding,
             QtWidgets.QSizePolicy.Policy.Preferred,
         )
-        self._update_elided_text()
+        self.set_full_text(text)
 
     @property
     def full_text(self) -> str:
         return self._full_text
 
+    def setText(self, text: str | None) -> None:
+        self.set_full_text("" if text is None else text)
+
     def set_full_text(self, text: str) -> None:
+        if text == self._full_text:
+            return
         self._full_text = text
+        super().setText(text)
         self.setToolTip(text)
-        self._update_elided_text()
+        self.setAccessibleName(text)
+        self.update()
 
-    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
-        super().resizeEvent(event)
-        self._update_elided_text()
+    def sizeHint(self) -> QtCore.QSize:
+        hint = super().sizeHint()
+        hint.setWidth(self._stable_hint_width())
+        return hint
 
-    def setFont(self, font: QtGui.QFont) -> None:
-        super().setFont(font)
-        self._update_elided_text()
+    def minimumSizeHint(self) -> QtCore.QSize:
+        hint = super().minimumSizeHint()
+        hint.setWidth(0)
+        return hint
+
+    def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
+        del event
+        painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.TextAntialiasing)
+        rect = self.contentsRect()
+        margin = self.margin()
+        if margin > 0:
+            rect = rect.adjusted(margin, margin, -margin, -margin)
+        text = self.fontMetrics().elidedText(
+            self._full_text, self._elide_mode, max(rect.width(), 0)
+        )
+        style = self.style()
+        if style is None:
+            style = QtWidgets.QApplication.style()
+        if style is None:  # pragma: no cover
+            return
+        style.drawItemText(
+            painter,
+            rect,
+            int(self.alignment()) | int(QtCore.Qt.TextFlag.TextSingleLine.value),
+            self.palette(),
+            self.isEnabled(),
+            text,
+            self.foregroundRole(),
+        )
 
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent | None) -> None:
-        if event is not None and event.button() == QtCore.Qt.MouseButton.LeftButton:
+        if event is None:
+            return
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             self.clicked.emit()
             event.accept()
             return
         super().mouseReleaseEvent(event)
 
-    def _update_elided_text(self) -> None:
-        width = max(self.contentsRect().width(), 0)
-        if width <= 0:
-            super().setText("")
-            return
-        super().setText(
-            self.fontMetrics().elidedText(self._full_text, self._elide_mode, width)
-        )
+    def _stable_hint_width(self) -> int:
+        padding = 2 * (self.margin() + self.frameWidth())
+        if self.indent() > 0:
+            padding += self.indent()
+        return self.fontMetrics().horizontalAdvance("m" * self._SIZE_HINT_EMS) + padding
 
 
 class _LoadSourceArgumentsEdit(QtWidgets.QPlainTextEdit):

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -9,7 +9,7 @@ import pydantic
 import pytest
 import xarray
 import xarray as xr
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
@@ -65,6 +65,58 @@ def _manager_provenance_file_spec(path: pathlib.Path):
             ),
         ),
     )
+
+
+def test_elided_interactive_label_keeps_full_text_during_resize(qtbot) -> None:
+    class _FallbackStyleLabel(manager_widgets._ElidedInteractiveLabel):
+        def style(self) -> QtWidgets.QStyle | None:
+            return None
+
+    label = _FallbackStyleLabel("/very/long/path/to/data/scan_with_long_name.h5")
+    qtbot.addWidget(label)
+    label.setMargin(2)
+    label.setIndent(4)
+    label.resize(90, label.sizeHint().height())
+    label.show()
+
+    assert label.text() == label.full_text
+    assert label.toolTip() == label.full_text
+    assert label.sizeHint().width() > label.minimumSizeHint().width()
+    assert label.grab().isNull() is False
+    assert label.text() == label.full_text
+
+    label.setText(None)
+    assert label.text() == ""
+    assert label.full_text == ""
+
+    clicks: list[None] = []
+    label.clicked.connect(lambda: clicks.append(None))
+    click_pos = QtCore.QPointF(1, 1)
+    left_event = QtGui.QMouseEvent(
+        QtCore.QEvent.Type.MouseButtonRelease,
+        click_pos,
+        click_pos,
+        click_pos,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    label.mouseReleaseEvent(left_event)
+    assert clicks == [None]
+    assert left_event.isAccepted()
+
+    right_event = QtGui.QMouseEvent(
+        QtCore.QEvent.Type.MouseButtonRelease,
+        click_pos,
+        click_pos,
+        click_pos,
+        QtCore.Qt.MouseButton.RightButton,
+        QtCore.Qt.MouseButton.RightButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    label.mouseReleaseEvent(right_event)
+    label.mouseReleaseEvent(None)
+    assert clicks == [None]
 
 
 def test_manager_file_label_helpers_and_file_replay_rename_update(tmp_path) -> None:
@@ -1702,12 +1754,10 @@ def test_manager_open_in_new_window_nests_imagetool_children(
         file_label = manager._metadata_detail_labels["File"]
         assert file_label.toolTip() == str(file_path)
         file_label.setFixedWidth(84)
-        qtbot.waitUntil(
-            lambda: (
-                getattr(file_label, "full_text", file_label.text()) != file_label.text()
-            ),
-            timeout=2000,
-        )
+        qtbot.wait(10)
+        assert getattr(file_label, "full_text", file_label.text()) == str(file_path)
+        assert file_label.text() == str(file_path)
+        assert metadata_detail_map(manager)["File"] == str(file_path)
 
         def _inspect_source_dialog(dialog: QtWidgets.QDialog) -> None:
             assert dialog.path_edit.text() == str(file_path)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- Move the manager metadata file-path label to paint-time elision so splitter resizes no longer rewrite the label text.
- Keep the full path as the stored text, tooltip, and dialog source.
- Update the focused provenance test to assert the full path stays stable after narrowing the label.

## Testing
- `uv run ruff check` and `uv run ruff format --check` on the touched files passed.
- `uv run mypy src` passed.
- `uv run pytest tests/interactive/imagetool/manager/test_provenance.py -k metadata` passed under both `PyQt6` and `PySide6`.