### PR TITLE
Fix manager workspace loads for missing colormaps

### DIFF
--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -124,6 +124,15 @@ class ColorMapComboBox(QtWidgets.QComboBox):
         self.thumbnails_loaded = False
         self.resetCmap()
 
+    def _set_current_text_if_available(self, text: str | None) -> bool:
+        if text is None:
+            return False
+        index = self.findText(text)
+        if index < 0:
+            return False
+        self.setCurrentIndex(index)
+        return True
+
     # https://forum.qt.io/topic/105012/qcombobox-specify-width-less-than-content/11
     def showPopup(self) -> None:
         maxWidth = self.maximumWidth()
@@ -187,21 +196,25 @@ class ColorMapComboBox(QtWidgets.QComboBox):
             self.setCurrentText(cmap)
 
     def resetCmap(self) -> None:
-        if self.default_cmap is None:
+        if self.default_cmap is not None and self._set_current_text_if_available(
+            self.default_cmap
+        ):
+            return
+        if self.count():
             self.setCurrentIndex(0)
-        else:
-            self.setCurrentText(self.default_cmap)
 
     def setCurrentText(self, text: str | None) -> None:
         """Set the current text of the combobox."""
         if not self._populated:
             self._populate()
-        if self.findText(text) < 0:
-            # If the value is not in the combobox, try loading all and retry
+        if self._set_current_text_if_available(text):
+            return
+        if not self.loaded_all:
+            current_text = self.currentText()
             self.load_all()
-            self.setCurrentText(text)
-        else:
-            super().setCurrentText(text)
+            if self._set_current_text_if_available(text):
+                return
+            self._set_current_text_if_available(current_text)
 
 
 class ColorMapGammaWidget(QtWidgets.QWidget):

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -123,6 +123,70 @@ def _legacy_saved_title_data_name(
 class _WorkspaceIOController:
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager = manager
+        self._missing_workspace_colormaps: list[tuple[str, str]] = []
+
+    def _record_missing_workspace_colormap(
+        self, cmap: str, node_path: str | None
+    ) -> None:
+        node_label = node_path if node_path is not None else "unknown workspace node"
+        record = (node_label, cmap)
+        if record not in self._missing_workspace_colormaps:
+            self._missing_workspace_colormaps.append(record)
+
+    def _dataset_without_missing_workspace_colormap(
+        self, ds: xr.Dataset, node_path: str | None
+    ) -> xr.Dataset:
+        state_payload = ds.attrs.get("itool_state")
+        if not isinstance(state_payload, str):
+            return ds
+        try:
+            state = json.loads(state_payload)
+        except Exception:
+            return ds
+        if not isinstance(state, dict):
+            return ds
+        color_state = state.get("color")
+        if not isinstance(color_state, dict):
+            return ds
+        cmap = color_state.get("cmap")
+        if not isinstance(cmap, str):
+            return ds
+        try:
+            erlab.interactive.colors.pg_colormap_from_name(cmap)
+        except RuntimeError:
+            color_state = dict(color_state)
+            color_state.pop("cmap", None)
+            state = dict(state)
+            state["color"] = color_state
+            ds = ds.copy(deep=False)
+            ds.attrs["itool_state"] = json.dumps(state)
+            self._record_missing_workspace_colormap(cmap, node_path)
+        return ds
+
+    def _show_missing_workspace_colormap_warning(self) -> None:
+        if not self._missing_workspace_colormaps:
+            return
+        affected = "\n".join(
+            f"- {node_label}: {cmap}"
+            for node_label, cmap in self._missing_workspace_colormaps
+        )
+        dialog = erlab.interactive.utils.MessageDialog(
+            self._manager,
+            title="Unavailable Colormap",
+            text="Some saved colormaps are unavailable.",
+            informative_text=(
+                "ImageTool Manager used the default colormap for these windows:\n"
+                f"{affected}"
+            ),
+            buttons=QtWidgets.QDialogButtonBox.StandardButton.Ok,
+            icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning,
+        )
+        dialog.exec()
+
+    def _finish_workspace_file_load(self, loaded: bool) -> bool:
+        if loaded:
+            self._show_missing_workspace_colormap_warning()
+        return loaded
 
     @staticmethod
     def _normalize_recent_workspace_paths(
@@ -811,6 +875,7 @@ class _WorkspaceIOController:
         elif "itool_name" not in ds.attrs:
             ds = ds.copy(deep=False)
             ds.attrs["itool_name"] = ""
+        ds = self._dataset_without_missing_workspace_colormap(ds, node_path)
         tool = ImageTool.from_dataset(ds, **tool_kwargs)
         if parent_target is not None:
             target = self._manager.add_imagetool_child(
@@ -2459,65 +2524,70 @@ class _WorkspaceIOController:
         select: bool,
         native: bool = True,
     ) -> bool:
-        with self._manager._workspace_document_access_context(fname) as access:
-            _manager_workspace._recover_workspace_transactions(access.path)
-            if not select and replace:
-                try:
-                    root_attrs = _manager_workspace._read_workspace_root_attrs_h5py(
-                        access.path
-                    )
-                    schema_version, delta_save_count, manifest = (
-                        _manager_workspace._workspace_file_metadata_from_attrs(
-                            root_attrs
+        previous_missing_colormaps = self._missing_workspace_colormaps
+        self._missing_workspace_colormaps = []
+        try:
+            with self._manager._workspace_document_access_context(fname) as access:
+                _manager_workspace._recover_workspace_transactions(access.path)
+                if not select and replace:
+                    try:
+                        root_attrs = _manager_workspace._read_workspace_root_attrs_h5py(
+                            access.path
                         )
-                    )
-                    if (
-                        schema_version
-                        == _manager_workspace._current_workspace_schema_version()
-                        and manifest is not None
-                    ):
-                        loaded = self._manager._from_h5py_workspace_file(
-                            access.path,
-                            manifest,
-                            replace=replace,
-                            mark_dirty=mark_dirty,
-                        )
-                        if loaded and associate:
-                            self._manager._associate_loaded_workspace_file(
-                                access.path,
-                                schema_version,
-                                native=native,
-                                delta_save_count=delta_save_count,
-                                workspace_access=access,
-                                rebind_data=False,
+                        schema_version, delta_save_count, manifest = (
+                            _manager_workspace._workspace_file_metadata_from_attrs(
+                                root_attrs
                             )
-                        return loaded
-                except Exception:
-                    logger.debug(
-                        "Failed h5py workspace load path; falling back to DataTree",
-                        exc_info=True,
-                    )
-            tree = _manager_xarray.open_workspace_datatree(access.path, chunks=None)
-            schema_version, delta_save_count, _manifest = (
-                _manager_workspace._workspace_file_metadata_from_attrs(tree.attrs)
-            )
-            loaded = self._manager._from_datatree(
-                tree,
-                replace=replace,
-                mark_dirty=mark_dirty,
-                select=select,
-                workspace_file_path=access.path,
-            )
-            if loaded and associate:
-                self._manager._associate_loaded_workspace_file(
-                    access.path,
-                    schema_version,
-                    native=native,
-                    delta_save_count=delta_save_count,
-                    workspace_access=access,
-                    rebind_data=False,
+                        )
+                        if (
+                            schema_version
+                            == _manager_workspace._current_workspace_schema_version()
+                            and manifest is not None
+                        ):
+                            loaded = self._manager._from_h5py_workspace_file(
+                                access.path,
+                                manifest,
+                                replace=replace,
+                                mark_dirty=mark_dirty,
+                            )
+                            if loaded and associate:
+                                self._manager._associate_loaded_workspace_file(
+                                    access.path,
+                                    schema_version,
+                                    native=native,
+                                    delta_save_count=delta_save_count,
+                                    workspace_access=access,
+                                    rebind_data=False,
+                                )
+                            return self._finish_workspace_file_load(loaded)
+                    except Exception:
+                        logger.debug(
+                            "Failed h5py workspace load path; falling back to DataTree",
+                            exc_info=True,
+                        )
+                tree = _manager_xarray.open_workspace_datatree(access.path, chunks=None)
+                schema_version, delta_save_count, _manifest = (
+                    _manager_workspace._workspace_file_metadata_from_attrs(tree.attrs)
                 )
-            return loaded
+                loaded = self._manager._from_datatree(
+                    tree,
+                    replace=replace,
+                    mark_dirty=mark_dirty,
+                    select=select,
+                    workspace_file_path=access.path,
+                )
+                if loaded and associate:
+                    self._manager._associate_loaded_workspace_file(
+                        access.path,
+                        schema_version,
+                        native=native,
+                        delta_save_count=delta_save_count,
+                        workspace_access=access,
+                        rebind_data=False,
+                    )
+                return self._finish_workspace_file_load(loaded)
+        finally:
+            self._missing_workspace_colormaps = previous_missing_colormaps
 
     def load(self, *, native: bool = True) -> bool:
         """Replace this manager with a workspace file."""

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -2702,10 +2702,16 @@ class ImageSlicerArea(QtWidgets.QWidget):
         update: bool = True,
     ) -> None:
         action_values = gamma is None and levels_locked is None and levels is None
-        if cmap is not None:
-            self._colormap_properties["cmap"] = cmap
-        if gamma is not None:
-            self._colormap_properties["gamma"] = float(gamma)
+        next_cmap = (
+            cmap
+            if cmap is not None
+            else typing.cast("str | pg.ColorMap", self._colormap_properties["cmap"])
+        )
+        next_gamma = (
+            float(gamma)
+            if gamma is not None
+            else float(self._colormap_properties["gamma"])
+        )
 
         reverse_value = (
             self.reverse_act.isChecked()
@@ -2723,19 +2729,40 @@ class ImageSlicerArea(QtWidgets.QWidget):
             else zero_centered
         )
 
+        next_reverse = bool(self._colormap_properties["reverse"])
+        next_high_contrast = bool(self._colormap_properties["high_contrast"])
+        next_zero_centered = bool(self._colormap_properties["zero_centered"])
+        if reverse_value is not None:
+            next_reverse = bool(reverse_value)
+        if high_contrast_value is not None:
+            next_high_contrast = bool(high_contrast_value)
+        if zero_centered_value is not None:
+            next_zero_centered = bool(zero_centered_value)
+
+        pg_colormap = erlab.interactive.colors._pg_colormap_powernorm_lut(
+            next_cmap,
+            next_gamma,
+            next_reverse,
+            high_contrast=next_high_contrast,
+            zero_centered=next_zero_centered,
+        )
+
+        self._colormap_properties.update(
+            {
+                "cmap": next_cmap,
+                "gamma": next_gamma,
+                "reverse": next_reverse,
+                "high_contrast": next_high_contrast,
+                "zero_centered": next_zero_centered,
+            }
+        )
         reverse_blocker = QtCore.QSignalBlocker(self.reverse_act)
         high_contrast_blocker = QtCore.QSignalBlocker(self.high_contrast_act)
         zero_centered_blocker = QtCore.QSignalBlocker(self.zero_centered_act)
         try:
-            if reverse_value is not None:
-                self._colormap_properties["reverse"] = bool(reverse_value)
-                self.reverse_act.setChecked(bool(reverse_value))
-            if high_contrast_value is not None:
-                self._colormap_properties["high_contrast"] = bool(high_contrast_value)
-                self.high_contrast_act.setChecked(bool(high_contrast_value))
-            if zero_centered_value is not None:
-                self._colormap_properties["zero_centered"] = bool(zero_centered_value)
-                self.zero_centered_act.setChecked(bool(zero_centered_value))
+            self.reverse_act.setChecked(next_reverse)
+            self.high_contrast_act.setChecked(next_high_contrast)
+            self.zero_centered_act.setChecked(next_zero_centered)
         finally:
             del reverse_blocker
             del high_contrast_blocker
@@ -2746,14 +2773,6 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if levels is not None:
             self.levels = levels
 
-        properties = self.colormap_properties
-        pg_colormap = erlab.interactive.colors._pg_colormap_powernorm_lut(
-            properties["cmap"],
-            properties["gamma"],
-            properties["reverse"],
-            high_contrast=properties["high_contrast"],
-            zero_centered=properties["zero_centered"],
-        )
         for im in self._imageitems:
             im.set_pg_colormap(pg_colormap, update=update)
         self.sigViewOptionChanged.emit()

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -300,6 +300,138 @@ def test_manager_workspace_load_preserves_added_time(
         assert manager._child_node(tool_uid).created_time == tool_added
 
 
+def test_manager_workspace_load_warns_for_unavailable_colormap(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    missing = "__erlab_missing_colormap__"
+    dialogs: list[typing.Any] = []
+
+    class _DummySignal:
+        def connect(self, *args, **kwargs) -> None:
+            pass
+
+    class _DummyButtonBox:
+        def addButton(self, *args, **kwargs) -> None:
+            pass
+
+    class _RecordingMessageDialog:
+        def __init__(self, parent=None, **kwargs) -> None:
+            self.parent = parent
+            self.kwargs = kwargs
+            self._button_box = _DummyButtonBox()
+            self.finished = _DummySignal()
+            dialogs.append(self)
+
+        def exec(self):
+            return QtWidgets.QDialog.DialogCode.Accepted
+
+        def setModal(self, value: bool) -> None:
+            pass
+
+        def windowFlags(self):
+            return QtCore.Qt.WindowType.Widget
+
+        def setWindowFlags(self, flags) -> None:
+            pass
+
+        def text(self) -> str:
+            return str(self.kwargs.get("text", ""))
+
+        def close(self) -> None:
+            pass
+
+        def show(self) -> None:
+            pass
+
+        def raise_(self) -> None:
+            pass
+
+        def activateWindow(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
+    )
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        tool = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        tool.slicer_area.set_colormap("viridis", gamma=1.5, reverse=True)
+        manager.add_imagetool(tool, show=False)
+
+        fname = tmp_path / "missing-cmap.itws"
+        manager._save_workspace_document(fname, force_full=True)
+
+        with h5py.File(fname, "a") as h5_file:
+            state = json.loads(h5_file["0/imagetool"].attrs["itool_state"])
+            state["color"]["cmap"] = missing
+            h5_file["0/imagetool"].attrs["itool_state"] = json.dumps(state)
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+
+        props = manager.get_imagetool(0).slicer_area.colormap_properties
+        assert props["cmap"] == erlab.interactive.options.model.colors.cmap.name
+        assert props["gamma"] == pytest.approx(1.5)
+        assert props["reverse"] is True
+
+        colormap_dialogs = [
+            dialog
+            for dialog in dialogs
+            if dialog.kwargs.get("title") == "Unavailable Colormap"
+        ]
+        assert len(colormap_dialogs) == 1
+        assert colormap_dialogs[0].parent is manager
+        assert missing in colormap_dialogs[0].kwargs["informative_text"]
+        assert "0" in colormap_dialogs[0].kwargs["informative_text"]
+
+
+def test_standalone_imagetool_restore_unavailable_colormap_has_no_manager_dialog(
+    qtbot,
+    test_data,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing = "__erlab_missing_colormap__"
+    dialogs: list[typing.Any] = []
+
+    class _RecordingMessageDialog:
+        def __init__(self, *args, **kwargs) -> None:
+            dialogs.append((args, kwargs))
+
+        def exec(self):
+            return QtWidgets.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
+    )
+
+    tool = erlab.interactive.imagetool.ImageTool(test_data)
+    qtbot.addWidget(tool)
+    ds = tool.to_dataset()
+    state = json.loads(ds.attrs["itool_state"])
+    state["color"]["cmap"] = missing
+    ds.attrs["itool_state"] = json.dumps(state)
+
+    with pytest.warns(UserWarning, match="Failed to restore colormap settings"):
+        restored = erlab.interactive.imagetool.ImageTool.from_dataset(ds)
+    qtbot.addWidget(restored)
+
+    assert dialogs == []
+
+
 def test_manager_added_time_display_uses_zone_name_and_offset(
     qtbot,
     test_data,

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -315,6 +315,38 @@ def test_colormap_combobox_populates_on_show(qtbot):
     assert combo.currentText() == default
 
 
+def test_colormap_combobox_ignores_unavailable_text(qtbot):
+    names = pg_colormap_names("matplotlib", exclude_local=True)
+    assert names
+    valid = names[0]
+    missing = "__erlab_missing_colormap__"
+
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+    combo.setDefaultCmap(valid)
+    combo.show()
+
+    qtbot.wait_until(lambda: combo.count() > 0, timeout=2000)
+    combo.setCurrentText(valid)
+    combo.setCurrentText(missing)
+
+    assert combo.currentText() == valid
+
+
+def test_colormap_combobox_missing_default_load_all_falls_back(qtbot):
+    missing = "__erlab_missing_colormap__"
+
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+    combo.setDefaultCmap(missing)
+    combo.show()
+
+    qtbot.wait_until(lambda: combo.count() > 0, timeout=2000)
+    combo.load_all()
+
+    assert combo.currentText() != missing
+
+
 def test_pg_colormap_names_respects_runtime_exclude():
     names = pg_colormap_names("matplotlib", exclude_local=True)
     assert names


### PR DESCRIPTION
## Summary
- Prevented colormap restore from recursing indefinitely when a saved cmap is unavailable.
- Added manager-side workspace load handling that strips only the missing saved cmap, keeps the rest of the restored color state, and shows one warning dialog after load.
- Left standalone `ImageTool.from_dataset()` restore behavior unchanged apart from the existing warning fallback.

## Testing
- Added unit regressions for `ColorMapComboBox` to cover unavailable text and fallback behavior.
- Added manager workspace regressions to verify load succeeds, fallback colormap state is valid, and the warning dialog is shown once from the manager path.
- Verified locally with `pytest` on the targeted colormap tests, plus `ruff check`, `ruff format --check`, and `mypy src`.