### PR TITLE
Persist manager layout and Qt geometry in workspaces

### DIFF
--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -193,6 +193,9 @@ class BaseImageTool(QtWidgets.QMainWindow):
             "itool_state": json.dumps(state),
             "itool_title": self.windowTitle(),
             "itool_name": str(name),
+            "itool_qt_geometry": (
+                erlab.interactive.utils._qt_bytearray_to_base64(self.saveGeometry())
+            ),
             "itool_rect": self.geometry().getRect(),
             "itool_visible": bool(self.isVisible()),
             "erlab_version": erlab.__version__,
@@ -257,7 +260,14 @@ class BaseImageTool(QtWidgets.QMainWindow):
                     "Ignoring invalid saved ImageTool provenance metadata.",
                 )
         tool.setWindowTitle(ds.attrs["itool_title"])
-        tool.setGeometry(*ds.attrs["itool_rect"])
+        restored_geometry = False
+        geometry = erlab.interactive.utils._qt_bytearray_from_base64(
+            ds.attrs.get("itool_qt_geometry")
+        )
+        if geometry is not None:
+            restored_geometry = tool.restoreGeometry(geometry)
+        if not restored_geometry and "itool_rect" in ds.attrs:
+            tool.setGeometry(*ds.attrs["itool_rect"])
         return tool
 
     @classmethod

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -69,6 +69,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     duplicate_action: QtGui.QAction
     hide_action: QtGui.QAction
     link_action: QtGui.QAction
+    main_splitter: QtWidgets.QSplitter
     metadata_derivation_list: QtWidgets.QListWidget
     metadata_details_layout: QtWidgets.QGridLayout
     metadata_details_widget: _HeightForWidthFrame
@@ -85,6 +86,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     show_action: QtGui.QAction
     source_update_action: QtGui.QAction
     store_action: QtGui.QAction
+    right_splitter: QtWidgets.QSplitter
     text_box: QtWidgets.QTextEdit
     tree_view: _ImageToolWrapperTreeView
     unlink_action: QtGui.QAction
@@ -110,6 +112,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     _link_registry: _ManagerLinkRegistry
     _lineage_controller: _LineageController
     _manager_record: _ManagerRecord
+    _manager_layout_tracking_enabled: bool
     _metadata_copy_full_action: QtGui.QAction
     _metadata_copy_selected_action: QtGui.QAction
     _metadata_detail_labels: dict[str, QtWidgets.QLabel]

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -205,6 +205,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self._progress_bars: dict[int, QtWidgets.QProgressDialog] = {}
 
         self._bulk_remove_depth: int = 0
+        self._manager_layout_tracking_enabled = False
 
         # Initialize actions
         self.settings_action = QtWidgets.QAction("Settings", self)
@@ -526,15 +527,18 @@ class ImageToolManager(_ImageToolManagerBase):
         )
 
         # Initialize GUI
-        main_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
-        self.setCentralWidget(main_splitter)
+        self.main_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        self.main_splitter.splitterMoved.connect(
+            lambda _pos, _index: self._mark_workspace_layout_dirty()
+        )
+        self.setCentralWidget(self.main_splitter)
 
         # Construct left side of splitter
         left_container = QtWidgets.QWidget()
         left_layout = QtWidgets.QHBoxLayout(left_container)
         left_layout.setContentsMargins(0, 0, 0, 0)
         left_layout.setSpacing(0)
-        main_splitter.addWidget(left_container)
+        self.main_splitter.addWidget(left_container)
 
         titlebar = QtWidgets.QWidget()
         titlebar_layout = QtWidgets.QVBoxLayout()
@@ -558,17 +562,20 @@ class ImageToolManager(_ImageToolManagerBase):
         right_layout = QtWidgets.QVBoxLayout(right_panel)
         right_layout.setContentsMargins(0, 0, 0, 0)
         right_layout.setSpacing(0)
-        main_splitter.addWidget(right_panel)
+        self.main_splitter.addWidget(right_panel)
 
-        right_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
-        right_layout.addWidget(right_splitter, 1)
+        self.right_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        self.right_splitter.splitterMoved.connect(
+            lambda _pos, _index: self._mark_workspace_layout_dirty()
+        )
+        right_layout.addWidget(self.right_splitter, 1)
 
         self.text_box = QtWidgets.QTextEdit(self)
         self.text_box.setReadOnly(True)
-        right_splitter.addWidget(self.text_box)
+        self.right_splitter.addWidget(self.text_box)
 
         self.preview_widget = _SingleImagePreview(self)
-        right_splitter.addWidget(self.preview_widget)
+        self.right_splitter.addWidget(self.preview_widget)
 
         self.metadata_group = _HeightForWidthFrame(self)
         self.metadata_group.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
@@ -630,8 +637,8 @@ class ImageToolManager(_ImageToolManagerBase):
         right_layout.addWidget(self.metadata_group, 0)
 
         # Set initial splitter sizes
-        right_splitter.setSizes([280, 140])
-        main_splitter.setSizes([100, 150])
+        self.right_splitter.setSizes([280, 140])
+        self.main_splitter.setSizes([100, 150])
 
         # Store most recent name filter and directory for new windows
         self._recent_name_filter: str | None = None
@@ -676,6 +683,17 @@ class ImageToolManager(_ImageToolManagerBase):
 
         # Initialize status bar
         self._status_bar.showMessage("")
+        self._manager_layout_tracking_enabled = True
+
+    def event(self, event: QtCore.QEvent | None) -> bool:
+        handled = super().event(event)
+        if event is not None and event.type() in (
+            QtCore.QEvent.Type.Move,
+            QtCore.QEvent.Type.Resize,
+            QtCore.QEvent.Type.WindowStateChange,
+        ):
+            self._mark_workspace_layout_dirty()
+        return handled
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """Handle proper termination of resources before closing the application."""
@@ -1192,6 +1210,9 @@ class ImageToolManager(_ImageToolManagerBase):
     def _mark_workspace_structure_dirty(self, reason: str) -> None:
         self._workspace_controller._mark_workspace_structure_dirty(reason)
 
+    def _mark_workspace_layout_dirty(self) -> None:
+        self._workspace_controller._mark_workspace_layout_dirty()
+
     def _mark_workspace_clean(self) -> None:
         self._workspace_controller._mark_workspace_clean()
 
@@ -1402,6 +1423,14 @@ class ImageToolManager(_ImageToolManagerBase):
         return self._workspace_controller._workspace_root_attrs_payload(
             delta_save_count=delta_save_count
         )
+
+    def _workspace_layout_snapshot(self) -> dict[str, str]:
+        return self._workspace_controller._workspace_layout_snapshot()
+
+    def _restore_workspace_layout(
+        self, manifest: Mapping[str, typing.Any] | None
+    ) -> None:
+        self._workspace_controller._restore_workspace_layout(manifest)
 
     def _write_full_workspace_file(self, fname: str | os.PathLike[str]) -> None:
         self._workspace_controller._write_full_workspace_file(fname)

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -310,6 +310,7 @@ def _workspace_root_attrs_payload(
     delta_save_count: int,
     erlab_version: str,
     workspace_link_id: str | None = None,
+    manager_layout: Mapping[str, typing.Any] | None = None,
 ) -> dict[str, typing.Any]:
     manifest: dict[str, typing.Any] = {
         "schema_version": _WORKSPACE_SCHEMA_VERSION,
@@ -319,6 +320,8 @@ def _workspace_root_attrs_payload(
     }
     if workspace_link_id is not None:
         manifest["workspace_link_id"] = workspace_link_id
+    if manager_layout is not None:
+        manifest["manager_layout"] = dict(manager_layout)
     if delta_save_count > 0:
         manifest["transaction_protocol"] = _WORKSPACE_TRANSACTION_PROTOCOL
         manifest["delta_save_count"] = int(delta_save_count)

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -466,6 +466,12 @@ class _WorkspaceIOController:
                 "Structure modified",
                 tuple(dict.fromkeys(self._manager._workspace_state.structure_reasons)),
             ),
+            (
+                "Layout modified",
+                ("Manager window layout",)
+                if self._manager._workspace_state.layout_modified
+                else (),
+            ),
         )
         blocks: list[str] = []
         for label, items in sections:
@@ -547,6 +553,18 @@ class _WorkspaceIOController:
 
     def _mark_workspace_structure_dirty(self, reason: str) -> None:
         self._manager._mark_workspace_dirty(structure=reason)
+
+    def _mark_workspace_layout_dirty(self) -> None:
+        if (
+            not getattr(self._manager, "_manager_layout_tracking_enabled", False)
+            or self._manager._workspace_state.path is None
+            or self._manager._workspace_state.loading_depth > 0
+            or self._manager._workspace_state.saving_depth > 0
+            or self._manager._workspace_state.closing_document
+        ):
+            return
+        if self._manager._workspace_state.mark_layout_dirty():
+            self._manager._update_workspace_window_title()
 
     def _mark_workspace_clean(self) -> None:
         self._manager._workspace_state.mark_clean()
@@ -1234,6 +1252,8 @@ class _WorkspaceIOController:
                 self._manager._restore_workspace_link_groups(
                     manifest, loaded_targets_by_uid
                 )
+                if replace:
+                    self._manager._restore_workspace_layout(manifest)
                 if not mark_dirty:
                     self._manager._drain_workspace_deferred_events()
             except Exception:
@@ -1356,6 +1376,8 @@ class _WorkspaceIOController:
                     self._manager._restore_workspace_link_groups(
                         manifest, loaded_targets_by_uid
                     )
+                    if replace:
+                        self._manager._restore_workspace_layout(manifest)
                     if not mark_dirty:
                         self._manager._drain_workspace_deferred_events()
                 except Exception:
@@ -1502,7 +1524,48 @@ class _WorkspaceIOController:
             delta_save_count=delta_save_count,
             erlab_version=str(erlab.__version__),
             workspace_link_id=self._manager._workspace_state.link_id,
+            manager_layout=self._manager._workspace_layout_snapshot(),
         )
+
+    def _workspace_layout_snapshot(self) -> dict[str, str]:
+        return {
+            "geometry": erlab.interactive.utils._qt_bytearray_to_base64(
+                self._manager.saveGeometry()
+            ),
+            "main_splitter": erlab.interactive.utils._qt_bytearray_to_base64(
+                self._manager.main_splitter.saveState()
+            ),
+            "right_splitter": erlab.interactive.utils._qt_bytearray_to_base64(
+                self._manager.right_splitter.saveState()
+            ),
+        }
+
+    def _restore_workspace_layout(
+        self, manifest: Mapping[str, typing.Any] | None
+    ) -> None:
+        if manifest is None:
+            return
+        layout = manifest.get("manager_layout")
+        if not isinstance(layout, dict):
+            return
+
+        geometry = erlab.interactive.utils._qt_bytearray_from_base64(
+            layout.get("geometry")
+        )
+        if geometry is not None:
+            self._manager.restoreGeometry(geometry)
+
+        main_splitter = erlab.interactive.utils._qt_bytearray_from_base64(
+            layout.get("main_splitter")
+        )
+        if main_splitter is not None:
+            self._manager.main_splitter.restoreState(main_splitter)
+
+        right_splitter = erlab.interactive.utils._qt_bytearray_from_base64(
+            layout.get("right_splitter")
+        )
+        if right_splitter is not None:
+            self._manager.right_splitter.restoreState(right_splitter)
 
     def _write_full_workspace_file(self, fname: str | os.PathLike[str]) -> None:
         tree: xr.DataTree = self._manager._to_datatree()
@@ -1923,6 +1986,22 @@ class _WorkspaceIOController:
             has_dirty_removed=bool(self._manager._workspace_state.dirty_removed),
         )
 
+    def _workspace_has_non_layout_modifications(self) -> bool:
+        state = self._manager._workspace_state
+        return (
+            state.structure_modified
+            or bool(state.dirty_added)
+            or bool(state.dirty_data)
+            or bool(state.dirty_state)
+            or bool(state.dirty_removed)
+        )
+
+    def _workspace_layout_only_modified(self) -> bool:
+        return (
+            self._manager._workspace_state.layout_modified
+            and not self._workspace_has_non_layout_modifications()
+        )
+
     def _workspace_rewrite_group_snapshot(
         self, uid: str
     ) -> tuple[str, dict[str, xr.Dataset]]:
@@ -1989,6 +2068,14 @@ class _WorkspaceIOController:
         try:
             if self._manager._workspace_requires_full_save(fname):
                 return self._manager._workspace_full_save_snapshot(generation)
+            if self._workspace_layout_only_modified():
+                delta_save_count = self._manager._workspace_state.delta_save_count
+                root_attrs = self._manager._workspace_root_attrs_payload(
+                    delta_save_count=delta_save_count
+                )
+                return self._manager._workspace_delta_save_snapshot(
+                    generation, root_attrs, delta_save_count
+                )
             delta_save_count = self._manager._workspace_state.delta_save_count + 1
             root_attrs = self._manager._workspace_root_attrs_payload(
                 delta_save_count=delta_save_count

--- a/src/erlab/interactive/imagetool/manager/_workspace_state.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_state.py
@@ -28,6 +28,7 @@ class _WorkspaceStateSnapshot(typing.TypedDict):
     dirty_state: frozenset[str]
     dirty_removed: tuple[str, ...]
     structure_reasons: tuple[str, ...]
+    layout_modified: bool
     dirty_generation: int
     dirty_events: tuple[_manager_workspace._WorkspaceDirtyEvent, ...]
     delta_save_count: int
@@ -48,6 +49,7 @@ class _ManagerWorkspaceState:
         self.dirty_state: set[str] = set()
         self.dirty_removed: list[str] = []
         self.structure_reasons: list[str] = []
+        self.layout_modified: bool = False
         self.needs_full_save: bool = False
         self.dirty_generation: int = 0
         self.dirty_events: list[_manager_workspace._WorkspaceDirtyEvent] = []
@@ -64,6 +66,7 @@ class _ManagerWorkspaceState:
             return False
         return (
             self.structure_modified
+            or self.layout_modified
             or bool(self.dirty_added)
             or bool(self.dirty_data)
             or bool(self.dirty_state)
@@ -98,8 +101,16 @@ class _ManagerWorkspaceState:
             return True
         return False
 
+    def mark_layout_dirty(self) -> bool:
+        if self.layout_modified:
+            return False
+        self.layout_modified = True
+        self.dirty_generation += 1
+        return True
+
     def mark_clean(self) -> None:
         self.structure_modified = False
+        self.layout_modified = False
         self.dirty_added.clear()
         self.dirty_data.clear()
         self.dirty_state.clear()
@@ -135,6 +146,7 @@ class _ManagerWorkspaceState:
             "dirty_state": frozenset(self.dirty_state),
             "dirty_removed": tuple(self.dirty_removed),
             "structure_reasons": tuple(self.structure_reasons),
+            "layout_modified": self.layout_modified,
             "dirty_generation": self.dirty_generation,
             "dirty_events": tuple(self.dirty_events),
             "delta_save_count": self.delta_save_count,
@@ -151,6 +163,7 @@ class _ManagerWorkspaceState:
         self.dirty_state = set(snapshot["dirty_state"])
         self.dirty_removed = list(snapshot["dirty_removed"])
         self.structure_reasons = list(snapshot["structure_reasons"])
+        self.layout_modified = snapshot["layout_modified"]
         self.dirty_generation = snapshot["dirty_generation"]
         self.dirty_events = list(snapshot["dirty_events"])
         self.delta_save_count = snapshot["delta_save_count"]

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -7,6 +7,8 @@ of pyqtgraph and Qt.
 from __future__ import annotations
 
 import ast
+import base64
+import binascii
 import bisect
 import contextlib
 import enum
@@ -95,6 +97,30 @@ __all__ = [
 
 _LOAD_UI_LOCK = threading.RLock()
 logger = logging.getLogger(__name__)
+
+
+def _qt_bytearray_to_base64(value: QtCore.QByteArray) -> str:
+    return base64.b64encode(value.data()).decode("ascii")
+
+
+def _qt_bytearray_from_base64(value: object) -> QtCore.QByteArray | None:
+    if isinstance(value, bytes):
+        try:
+            text = value.decode("ascii")
+        except UnicodeDecodeError:
+            return None
+    elif isinstance(value, str):
+        text = value
+    else:
+        return None
+
+    try:
+        raw = base64.b64decode(text.encode("ascii"), validate=True)
+    except (binascii.Error, ValueError, UnicodeEncodeError):
+        return None
+    if not raw:
+        return None
+    return QtCore.QByteArray(raw)
 
 
 def _qt_object_is_valid_fallback(arg__1: object) -> bool:
@@ -4267,6 +4293,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             "tool_title": self.windowTitle(),
             "tool_cls_qualname": self._qual_name(),
             "tool_display_name": self._tool_display_name,
+            "tool_qt_geometry": _qt_bytearray_to_base64(self.saveGeometry()),
             "tool_rect": self.geometry().getRect(),
             "tool_visible": bool(self.isVisible()),
             "erlab_version": erlab.__version__,
@@ -4423,7 +4450,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 )
         tool._restore_persistence_payload(ds)
         tool.setWindowTitle(ds.attrs["tool_title"])
-        tool.setGeometry(*ds.attrs["tool_rect"])
+        restored_geometry = False
+        geometry = _qt_bytearray_from_base64(ds.attrs.get("tool_qt_geometry"))
+        if geometry is not None:
+            restored_geometry = tool.restoreGeometry(geometry)
+        if not restored_geometry and "tool_rect" in ds.attrs:
+            tool.setGeometry(*ds.attrs["tool_rect"])
         return tool
 
     def to_file(self, filename: str | os.PathLike) -> None:

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -391,6 +391,70 @@ def test_manager_workspace_load_falls_back_for_legacy_or_invalid_added_time(
         assert loaded.utcoffset() is not None
 
 
+def test_qt_bytearray_base64_helpers_reject_invalid_values() -> None:
+    value = QtCore.QByteArray(b"layout-state")
+    encoded = erlab.interactive.utils._qt_bytearray_to_base64(value)
+
+    decoded = erlab.interactive.utils._qt_bytearray_from_base64(encoded)
+    assert decoded == value
+
+    assert erlab.interactive.utils._qt_bytearray_from_base64(b"\xff") is None
+    assert erlab.interactive.utils._qt_bytearray_from_base64("%%not-base64%%") is None
+    assert erlab.interactive.utils._qt_bytearray_from_base64("") is None
+
+
+def test_imagetool_dataset_prefers_qt_geometry_and_keeps_rect_fallback(
+    qtbot, test_data
+) -> None:
+    tool = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+    qtbot.addWidget(tool)
+    tool.resize(533, 477)
+    ds = tool.to_dataset()
+    assert ds.attrs["itool_qt_geometry"]
+
+    qt_geometry_ds = ds.copy(deep=False)
+    del qt_geometry_ds.attrs["itool_rect"]
+    restored = erlab.interactive.imagetool.ImageTool.from_dataset(
+        qt_geometry_ds, _in_manager=True
+    )
+    qtbot.addWidget(restored)
+    assert restored.size() == tool.size()
+
+    legacy_ds = ds.copy(deep=False)
+    del legacy_ds.attrs["itool_qt_geometry"]
+    legacy = erlab.interactive.imagetool.ImageTool.from_dataset(
+        legacy_ds, _in_manager=True
+    )
+    qtbot.addWidget(legacy)
+    assert tuple(legacy.geometry().getRect()) == tuple(
+        int(value) for value in ds.attrs["itool_rect"]
+    )
+
+
+def test_toolwindow_dataset_prefers_qt_geometry_and_keeps_rect_fallback(
+    qtbot, test_data
+) -> None:
+    tool = _AddedTimeChildTool(test_data)
+    qtbot.addWidget(tool)
+    tool.resize(421, 333)
+    ds = tool.to_dataset()
+    assert ds.attrs["tool_qt_geometry"]
+
+    qt_geometry_ds = ds.copy(deep=False)
+    del qt_geometry_ds.attrs["tool_rect"]
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(qt_geometry_ds)
+    qtbot.addWidget(restored)
+    assert restored.size() == tool.size()
+
+    legacy_ds = ds.copy(deep=False)
+    del legacy_ds.attrs["tool_qt_geometry"]
+    legacy = erlab.interactive.utils.ToolWindow.from_dataset(legacy_ds)
+    qtbot.addWidget(legacy)
+    assert tuple(legacy.geometry().getRect()) == tuple(
+        int(value) for value in ds.attrs["tool_rect"]
+    )
+
+
 def test_workspace_backing_uses_persistence_data_for_filtered_file_data(
     qtbot,
     tmp_path: pathlib.Path,
@@ -638,6 +702,180 @@ def test_manager_workspace_io(
             select_tools(manager, list(manager._tool_graph.root_wrappers.keys()))
             accept_dialog(manager.remove_action.trigger)
             qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+
+def test_manager_workspace_roundtrip_restores_manager_layout(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        root = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        manager.add_imagetool(root, show=False)
+
+        manager.resize(640, 520)
+        manager.main_splitter.setSizes([220, 420])
+        manager.right_splitter.setSizes([300, 160])
+        expected_layout = manager._workspace_layout_snapshot()
+        expected_size = manager.size()
+        expected_main_sizes = manager.main_splitter.sizes()
+        expected_right_sizes = manager.right_splitter.sizes()
+
+        fname = tmp_path / "manager-layout.itws"
+        manager._save_workspace_document(fname, force_full=True)
+
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert manifest["manager_layout"] == expected_layout
+
+        manager.resize(480, 500)
+        manager.main_splitter.setSizes([120, 360])
+        manager.right_splitter.setSizes([120, 280])
+        assert manager._workspace_layout_snapshot() != expected_layout
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(
+            lambda: (
+                manager.size() == expected_size
+                and manager.main_splitter.sizes() == expected_main_sizes
+                and manager.right_splitter.sizes() == expected_right_sizes
+            ),
+            timeout=5000,
+        )
+        assert not manager.is_workspace_modified
+
+
+def test_manager_workspace_layout_only_save_updates_root_manifest_only(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        root = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "layout-only.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+        delta_save_count = manager._workspace_state.delta_save_count
+
+        manager.resize(manager.width() + 40, manager.height() + 30)
+        qtbot.wait_until(lambda: manager.is_workspace_modified, timeout=5000)
+        assert manager._workspace_state.layout_modified
+        assert manager._dirty_details_text()
+        manager._mark_workspace_layout_dirty()
+
+        def _forbid_node_serialization(*_args, **_kwargs):
+            raise AssertionError("layout-only save serialized a node")
+
+        def _forbid_full_save(*_args, **_kwargs):
+            raise AssertionError("layout-only save requested a full workspace write")
+
+        monkeypatch.setattr(
+            manager, "_serialize_workspace_node", _forbid_node_serialization
+        )
+        monkeypatch.setattr(
+            manager_workspace, "_write_full_workspace_tree_file", _forbid_full_save
+        )
+
+        assert manager.save()
+        assert manager._workspace_state.delta_save_count == delta_save_count
+        assert not manager.is_workspace_modified
+
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert "delta_save_count" not in manifest
+        assert manifest["manager_layout"] == manager._workspace_layout_snapshot()
+
+
+def test_manager_workspace_import_does_not_restore_manager_layout(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        root = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        manager.add_imagetool(root, show=False)
+
+        manager.resize(640, 520)
+        manager.main_splitter.setSizes([220, 420])
+        manager.right_splitter.setSizes([300, 160])
+        import_fname = tmp_path / "import-layout.itws"
+        manager._save_workspace_document(import_fname, force_full=True)
+
+        manager.resize(480, 500)
+        manager.main_splitter.setSizes([120, 360])
+        manager.right_splitter.setSizes([120, 280])
+        current_layout = manager._workspace_layout_snapshot()
+
+        import h5py
+
+        with h5py.File(import_fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert manager._from_h5py_workspace_file(
+            import_fname, manifest, replace=False, mark_dirty=True
+        )
+        assert manager._workspace_layout_snapshot() == current_layout
+
+        tree = manager_xarray.open_workspace_datatree(import_fname, chunks=None)
+        assert manager._from_datatree(
+            tree,
+            replace=False,
+            mark_dirty=True,
+            select=False,
+            workspace_file_path=import_fname,
+        )
+        assert manager._workspace_layout_snapshot() == current_layout
+
+
+def test_manager_workspace_restore_layout_ignores_missing_or_invalid_values(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        layout = manager._workspace_layout_snapshot()
+
+        manager._restore_workspace_layout(None)
+        manager._restore_workspace_layout({})
+        manager._restore_workspace_layout({"manager_layout": "invalid"})
+        manager._restore_workspace_layout(
+            {
+                "manager_layout": {
+                    "geometry": "",
+                    "main_splitter": "",
+                    "right_splitter": "",
+                }
+            }
+        )
+        assert manager._workspace_layout_snapshot() == layout
 
 
 def test_manager_workspace_preserves_link_groups(


### PR DESCRIPTION
## Summary
- Persist ImageTool and ToolWindow geometry as Qt geometry blobs, with legacy rect fallback.
- Store manager window geometry plus both splitter states in the workspace manifest.
- Track layout-only changes as workspace dirtiness and keep layout-only saves root-manifest-only.
- Restore manager layout only for replace/open loads, not imports.

## Testing
- Added unit tests for Qt geometry round-tripping, legacy rect fallback, manager layout restore, import behavior, and layout-only save behavior.
- Ran focused manager workspace tests plus the existing delta-save and geometry regression slice; all passed.