### PR TITLE
refactor(manager): persist workspace loader and app state

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Interactive windows support dark mode.
   <img alt="Data explorer window." src="https://github.com/kmnhan/erlabpy/blob/main/docs/source/images/explorer_light.png?raw=true">
 </picture>
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/kmnhan/erlabpy/blob/main/docs/source/images/ptable_dark.png?raw=true">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/kmnhan/erlabpy/blob/main/docs/source/images/ptable_light.png?raw=true">
+  <img alt="Periodic table window." src="https://github.com/kmnhan/erlabpy/blob/main/docs/source/images/ptable_light.png?raw=true">
+</picture>
+
 ## Contributing
 
 We welcome contributions. Report issues to the [issue tracker](https://github.com/kmnhan/erlabpy/issues). For questions, visit the [Discussions page](https://github.com/kmnhan/erlabpy/discussions). To contribute, fork the repository and submit a pull request. See our [Contributing page](https://erlabpy.readthedocs.io/en/stable/contributing.html) for more information.

--- a/src/erlab/interactive/_qt_state.py
+++ b/src/erlab/interactive/_qt_state.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import typing
+
+import pydantic
+from qtpy import QtCore, QtWidgets
+
+__all__ = [
+    "QtWindowState",
+    "parse_qt_window_state",
+    "qt_bytearray_from_base64",
+    "qt_bytearray_to_base64",
+    "qt_window_state",
+    "qt_window_state_json",
+    "qt_window_state_payload",
+    "restore_qt_window_state",
+]
+
+
+class QtWindowState(pydantic.BaseModel):
+    """JSON-safe Qt top-level window state."""
+
+    # Native Qt geometry preserves frame/window-manager state when Qt can restore it.
+    geometry: str | None = None
+    # Rect is a portable fallback when native Qt geometry cannot be restored.
+    rect: tuple[int, int, int, int] | None = None
+    # Visibility is tracked separately so hidden restored windows can stay hidden.
+    visible: bool = False
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    @pydantic.field_validator("rect", mode="before")
+    @classmethod
+    def _validate_rect(cls, value: object) -> object:
+        if value is None:
+            return None
+        if not isinstance(value, (list, tuple)) or len(value) != 4:
+            raise ValueError("window rect must contain four integers")
+        return tuple(int(item) for item in value)
+
+
+def qt_bytearray_to_base64(value: QtCore.QByteArray) -> str:
+    return base64.b64encode(value.data()).decode("ascii")
+
+
+def qt_bytearray_from_base64(value: object) -> QtCore.QByteArray | None:
+    if isinstance(value, bytes):
+        try:
+            text = value.decode("ascii")
+        except UnicodeDecodeError:
+            return None
+    elif isinstance(value, str):
+        text = value
+    else:
+        return None
+
+    try:
+        raw = base64.b64decode(text.encode("ascii"), validate=True)
+    except (binascii.Error, ValueError, UnicodeEncodeError):
+        return None
+    if not raw:
+        return None
+    return QtCore.QByteArray(raw)
+
+
+def qt_window_state(widget: QtWidgets.QWidget) -> QtWindowState:
+    return QtWindowState(
+        geometry=qt_bytearray_to_base64(widget.saveGeometry()),
+        rect=widget.geometry().getRect(),
+        visible=bool(widget.isVisible()),
+    )
+
+
+def qt_window_state_payload(widget: QtWidgets.QWidget) -> dict[str, typing.Any]:
+    return qt_window_state(widget).model_dump(mode="json", exclude_none=True)
+
+
+def qt_window_state_json(widget: QtWidgets.QWidget) -> str:
+    return qt_window_state(widget).model_dump_json(exclude_none=True)
+
+
+def parse_qt_window_state(value: object) -> QtWindowState | None:
+    if isinstance(value, QtWindowState):
+        return value
+    if isinstance(value, bytes):
+        try:
+            value = value.decode()
+        except UnicodeDecodeError:
+            return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(value, dict):
+        return None
+    try:
+        return QtWindowState.model_validate(value)
+    except pydantic.ValidationError:
+        return None
+
+
+def restore_qt_window_state(
+    widget: QtWidgets.QWidget, state: QtWindowState | object
+) -> bool:
+    parsed = parse_qt_window_state(state)
+    if parsed is None:
+        return False
+
+    restored = False
+    geometry = qt_bytearray_from_base64(parsed.geometry)
+    if geometry is not None:
+        restored = bool(widget.restoreGeometry(geometry))
+    if not restored and parsed.rect is not None:
+        widget.setGeometry(*parsed.rect)
+        restored = True
+    return restored

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -16,6 +16,7 @@ import traceback
 import typing
 import weakref
 
+import pydantic
 import pyqtgraph as pg
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -37,6 +38,33 @@ _TRANSLATE_MIME_TYPES = {
     "application/octet-stream": "Unknown",
     "text/csv": "CSV Document",
 }
+
+
+class DataExplorerTabState(pydantic.BaseModel):
+    root_path: str
+    loader_name: str | None = None
+    preview: bool = False
+    # Absolute file paths selected in the tree after the folder model is restored.
+    selected_paths: tuple[str, ...] = ()
+    sort_column: int = 0
+    sort_order: typing.Literal["ascending", "descending"] = "ascending"
+    # Splitter sizes are enough to restore the tab layout without QWidget state.
+    splitter_sizes: tuple[int, ...] = ()
+    preview_splitter_sizes: tuple[int, ...] = ()
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    @pydantic.field_validator(
+        "selected_paths",
+        "splitter_sizes",
+        "preview_splitter_sizes",
+        mode="before",
+    )
+    @classmethod
+    def _tuple_field(cls, value: object) -> object:
+        if value is None:
+            return ()
+        return tuple(value) if isinstance(value, (list, tuple)) else value
 
 
 class _FileSystem:
@@ -803,6 +831,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
 
     sigDirectoryChanged = QtCore.Signal(str)
     sigCloseRequested = QtCore.Signal(object)
+    sigStateChanged = QtCore.Signal()
 
     def __init__(
         self,
@@ -818,6 +847,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
         self._fs_model.modelReset.connect(
             lambda: erlab.interactive.utils.single_shot(self, 1, self._dir_loaded)
         )
+        self._fs_model.layoutChanged.connect(self._emit_workspace_state_changed)
 
         self.menu_bar: QtWidgets.QMenuBar = typing.cast(
             "QtWidgets.QMenuBar", self.menuBar()
@@ -826,6 +856,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
         self._slider_value: int | None = None
         self._loader_kwargs_by_name: dict[str, dict[str, typing.Any]] = {}
         self._loader_extensions_by_name: dict[str, dict[str, typing.Any]] = {}
+        self._workspace_state_restoring = False
 
         self._setup_actions()
         self._setup_ui()
@@ -850,6 +881,116 @@ class _DataExplorer(QtWidgets.QMainWindow):
     def current_directory(self) -> pathlib.Path:
         """Current directory being displayed."""
         return self._fs_model.file_system.path
+
+    def _emit_workspace_state_changed(self, *_args: object) -> None:
+        if not self._workspace_state_restoring:
+            self.sigStateChanged.emit()
+
+    def loader_kwargs_by_name(self) -> dict[str, dict[str, typing.Any]]:
+        return {
+            name: kwargs.copy() for name, kwargs in self._loader_kwargs_by_name.items()
+        }
+
+    def loader_extensions_by_name(self) -> dict[str, dict[str, typing.Any]]:
+        return {
+            name: extensions.copy()
+            for name, extensions in self._loader_extensions_by_name.items()
+        }
+
+    def apply_loader_state(
+        self,
+        *,
+        kwargs_by_name: dict[str, dict[str, typing.Any]],
+        extensions_by_name: dict[str, dict[str, typing.Any]],
+    ) -> None:
+        self._loader_kwargs_by_name = {
+            name: kwargs.copy() for name, kwargs in kwargs_by_name.items()
+        }
+        self._loader_extensions_by_name = {
+            name: extensions.copy() for name, extensions in extensions_by_name.items()
+        }
+
+    def workspace_state_payload(self) -> dict[str, typing.Any]:
+        sort_order: typing.Literal["ascending", "descending"] = (
+            "descending"
+            if self._fs_model._sort_order == QtCore.Qt.SortOrder.DescendingOrder
+            else "ascending"
+        )
+        return DataExplorerTabState(
+            root_path=str(self.current_directory),
+            loader_name=self.loader_name,
+            preview=bool(self._preview_check.isChecked()),
+            selected_paths=tuple(str(path) for path in self._current_selection),
+            sort_column=int(self._fs_model._sort_column),
+            sort_order=sort_order,
+            splitter_sizes=tuple(int(value) for value in self._main_splitter.sizes()),
+            preview_splitter_sizes=tuple(
+                int(value) for value in self._preview_splitter.sizes()
+            ),
+        ).model_dump(mode="json", exclude_none=True)
+
+    def restore_workspace_state(self, state: DataExplorerTabState) -> None:
+        state = DataExplorerTabState.model_validate(state)
+        self._workspace_state_restoring = True
+        try:
+            if state.loader_name is not None and state.loader_name in erlab.io.loaders:
+                self._loader_combo.setCurrentText(state.loader_name)
+
+            self._preview_check.setChecked(state.preview)
+
+            if state.root_path:
+                self._fs_model.set_root_path(state.root_path)
+
+            sort_order = (
+                QtCore.Qt.SortOrder.DescendingOrder
+                if state.sort_order == "descending"
+                else QtCore.Qt.SortOrder.AscendingOrder
+            )
+            self._tree_view.sortByColumn(state.sort_column, sort_order)
+
+            if state.splitter_sizes:
+                self._main_splitter.setSizes(list(state.splitter_sizes))
+
+            if state.preview_splitter_sizes:
+                self._preview_splitter.setSizes(list(state.preview_splitter_sizes))
+
+            if state.selected_paths:
+                restore_paths = tuple(str(path) for path in state.selected_paths)
+
+                def restore_selection() -> None:
+                    self._restore_workspace_selection(restore_paths)
+
+                erlab.interactive.utils.single_shot(
+                    self,
+                    0,
+                    restore_selection,
+                )
+        finally:
+            self._workspace_state_restoring = False
+        self._emit_workspace_state_changed()
+
+    def _restore_workspace_selection(self, paths: tuple[str, ...]) -> None:
+        selection_model = self._tree_view.selectionModel()
+        selection_model.clearSelection()
+        for path in paths:
+            index = self._model_index_for_path(path)
+            if not index.isValid():
+                continue
+            last_column = self._tree_view.model().columnCount() - 1
+            idx_end = self._tree_view.model().index(
+                index.row(), last_column, index.parent()
+            )
+            selection_model.select(
+                QtCore.QItemSelection(index, idx_end),
+                QtCore.QItemSelectionModel.SelectionFlag.Select,
+            )
+
+    def _model_index_for_path(self, path: str | os.PathLike[str]) -> QtCore.QModelIndex:
+        try:
+            item = self._fs_model.file_system.child_from_path(pathlib.Path(path))
+        except (KeyError, ValueError):
+            return QtCore.QModelIndex()
+        return self._fs_model._find_index(item)
 
     @QtCore.Slot()
     def try_close(self) -> None:
@@ -943,15 +1084,15 @@ class _DataExplorer(QtWidgets.QMainWindow):
         layout = QtWidgets.QVBoxLayout(main_widget)
         main_widget.setLayout(layout)
 
-        splitter = QtWidgets.QSplitter(main_widget)
-        splitter.setOrientation(QtCore.Qt.Orientation.Horizontal)
-        layout.addWidget(splitter)
+        self._main_splitter = QtWidgets.QSplitter(main_widget)
+        self._main_splitter.setOrientation(QtCore.Qt.Orientation.Horizontal)
+        layout.addWidget(self._main_splitter)
 
         left_widget = QtWidgets.QWidget()
         left_layout = QtWidgets.QVBoxLayout(left_widget)
         left_layout.setContentsMargins(0, 0, 0, 0)
         left_widget.setLayout(left_layout)
-        splitter.addWidget(left_widget)
+        self._main_splitter.addWidget(left_widget)
 
         left_header = QtWidgets.QWidget()
         left_header_layout = QtWidgets.QHBoxLayout(left_header)
@@ -989,6 +1130,9 @@ class _DataExplorer(QtWidgets.QMainWindow):
         self._tree_view.selectionModel().selectionChanged.connect(
             self._on_selection_changed
         )
+        self._tree_view.selectionModel().selectionChanged.connect(
+            self._emit_workspace_state_changed
+        )
         self._tree_view.doubleClicked.connect(self.double_clicked)
         self._tree_view.sortByColumn(0, QtCore.Qt.SortOrder.AscendingOrder)
         left_layout.addWidget(self._tree_view)
@@ -997,11 +1141,11 @@ class _DataExplorer(QtWidgets.QMainWindow):
         right_layout = QtWidgets.QVBoxLayout(right_widget)
         right_layout.setContentsMargins(0, 0, 0, 0)
         right_widget.setLayout(right_layout)
-        splitter.addWidget(right_widget)
+        self._main_splitter.addWidget(right_widget)
 
-        preview_splitter = QtWidgets.QSplitter()
-        preview_splitter.setOrientation(QtCore.Qt.Orientation.Vertical)
-        right_layout.addWidget(preview_splitter)
+        self._preview_splitter = QtWidgets.QSplitter()
+        self._preview_splitter.setOrientation(QtCore.Qt.Orientation.Vertical)
+        right_layout.addWidget(self._preview_splitter)
 
         right_footer = QtWidgets.QWidget()
         right_footer_layout = QtWidgets.QHBoxLayout(right_footer)
@@ -1013,6 +1157,9 @@ class _DataExplorer(QtWidgets.QMainWindow):
         self._loader_combo = _LoaderWidget()
         self._loader_combo.currentIndexChanged.connect(self._on_selection_changed)
         self._loader_combo.currentIndexChanged.connect(self._loader_changed)
+        self._loader_combo.currentIndexChanged.connect(
+            self._emit_workspace_state_changed
+        )
         right_footer_layout.addWidget(self._loader_combo)
         right_footer_layout.addWidget(
             erlab.interactive.utils.IconActionButton(
@@ -1028,6 +1175,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
         )
         self._preview_check.setChecked(False)
         self._preview_check.toggled.connect(self._on_selection_changed)
+        self._preview_check.toggled.connect(self._emit_workspace_state_changed)
         right_footer_layout.addWidget(self._preview_check)
 
         self._text_edit = QtWidgets.QTextEdit()
@@ -1037,13 +1185,13 @@ class _DataExplorer(QtWidgets.QMainWindow):
         typing.cast("QtWidgets.QScrollBar", scroll_bar).valueChanged.connect(
             self._save_slider_pos
         )
-        preview_splitter.addWidget(self._text_edit)
+        self._preview_splitter.addWidget(self._text_edit)
 
         self._preview = _DataPreviewWidget()
         self._preview.setVisible(False)
-        preview_splitter.addWidget(self._preview)
+        self._preview_splitter.addWidget(self._preview)
 
-        preview_splitter.setSizes([200, 200])
+        self._preview_splitter.setSizes([200, 200])
 
         self.setMinimumWidth(487)
         self.setMinimumHeight(301)
@@ -1059,6 +1207,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
             dir_name = dir_path.name or str(dir_path)
             self.setWindowTitle(f"Data Explorer — {dir_name}")
         self.sigDirectoryChanged.emit(str(dir_path))
+        self._emit_workspace_state_changed()
 
     @QtCore.Slot()
     def _save_slider_pos(self) -> None:
@@ -1131,6 +1280,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
         selected_extensions = selected_kwargs.pop("loader_extensions", {})
         self._loader_kwargs_by_name[loader_name] = selected_kwargs
         self._loader_extensions_by_name[loader_name] = selected_extensions
+        self._emit_workspace_state_changed()
 
     def _manager_load_kwargs(
         self, kwargs: dict[str, typing.Any]

--- a/src/erlab/interactive/explorer/_tabbed_explorer.py
+++ b/src/erlab/interactive/explorer/_tabbed_explorer.py
@@ -6,15 +6,46 @@ import sys
 import typing
 import weakref
 
+import pydantic
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
-from erlab.interactive.explorer._base_explorer import _DataExplorer
+from erlab.interactive import _qt_state
+from erlab.interactive.explorer._base_explorer import (
+    DataExplorerTabState,
+    _DataExplorer,
+)
+
+
+class DataExplorerState(pydantic.BaseModel):
+    # The tabbed Data Explorer top-level window uses the shared Qt window schema.
+    window_state: _qt_state.QtWindowState | None = None
+    tabs: tuple[DataExplorerTabState, ...] = ()
+    active_tab: int = 0
+    # Shared loader options for tabs in this Data Explorer window.
+    loader_kwargs_by_name: dict[str, dict[str, typing.Any]] = pydantic.Field(
+        default_factory=dict
+    )
+    loader_extensions_by_name: dict[str, dict[str, typing.Any]] = pydantic.Field(
+        default_factory=dict
+    )
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    @pydantic.field_validator("tabs", mode="before")
+    @classmethod
+    def _tabs_tuple(cls, value: object) -> object:
+        if value is None:
+            return ()
+        return tuple(value) if isinstance(value, (list, tuple)) else value
 
 
 class _TabbedExplorer(QtWidgets.QMainWindow):
+    sigStateChanged = QtCore.Signal()
+
     def __init__(self, parent: QtWidgets.QWidget | None = None, **kwargs) -> None:
         super().__init__(parent=parent)
+        self._workspace_state_restoring = False
         self._setup_actions()
         self._setup_ui(**kwargs)
 
@@ -27,6 +58,7 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
 
         self.tab_widget.tabCloseRequested.connect(self.close_tab)
         self.tab_widget.currentChanged.connect(self.update_menubar)
+        self.tab_widget.currentChanged.connect(self._emit_workspace_state_changed)
 
         add_btn = erlab.interactive.utils.IconActionButton(
             self._addtab_act, "mdi6.plus", icon_kw={"scale_factor": 1.2}
@@ -106,6 +138,101 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
             return typing.cast("_DataExplorer", current_tab._explorer)
         return None
 
+    def _emit_workspace_state_changed(self, *_args: object) -> None:
+        if not self._workspace_state_restoring:
+            self.sigStateChanged.emit()
+
+    def loader_kwargs_by_name(self) -> dict[str, dict[str, typing.Any]]:
+        loader_kwargs: dict[str, dict[str, typing.Any]] = {}
+        for index in range(self.tab_widget.count()):
+            explorer = self.get_explorer(index)
+            if explorer is not None:
+                loader_kwargs.update(explorer.loader_kwargs_by_name())
+        return loader_kwargs
+
+    def loader_extensions_by_name(self) -> dict[str, dict[str, typing.Any]]:
+        loader_extensions: dict[str, dict[str, typing.Any]] = {}
+        for index in range(self.tab_widget.count()):
+            explorer = self.get_explorer(index)
+            if explorer is not None:
+                loader_extensions.update(explorer.loader_extensions_by_name())
+        return loader_extensions
+
+    def apply_loader_state(
+        self,
+        *,
+        kwargs_by_name: dict[str, dict[str, typing.Any]],
+        extensions_by_name: dict[str, dict[str, typing.Any]],
+    ) -> None:
+        for index in range(self.tab_widget.count()):
+            explorer = self.get_explorer(index)
+            if explorer is not None:
+                explorer.apply_loader_state(
+                    kwargs_by_name=kwargs_by_name,
+                    extensions_by_name=extensions_by_name,
+                )
+
+    def workspace_state_payload(self) -> dict[str, typing.Any]:
+        return DataExplorerState(
+            window_state=_qt_state.qt_window_state(self),
+            tabs=tuple(
+                DataExplorerTabState.model_validate(explorer.workspace_state_payload())
+                for index in range(self.tab_widget.count())
+                if (explorer := self.get_explorer(index)) is not None
+            ),
+            active_tab=int(self.tab_widget.currentIndex()),
+            loader_kwargs_by_name=self.loader_kwargs_by_name(),
+            loader_extensions_by_name=self.loader_extensions_by_name(),
+        ).model_dump(mode="json", exclude_none=True)
+
+    def restore_workspace_state(self, state: DataExplorerState) -> None:
+        state = DataExplorerState.model_validate(state)
+        self._workspace_state_restoring = True
+        try:
+            loader_kwargs_by_name = {
+                str(name): dict(value)
+                for name, value in state.loader_kwargs_by_name.items()
+            }
+            loader_extensions_by_name = {
+                str(name): dict(value)
+                for name, value in state.loader_extensions_by_name.items()
+            }
+
+            if state.tabs:
+                self._clear_tabs()
+                for tab_state in state.tabs:
+                    self.add_tab(
+                        root_path=tab_state.root_path,
+                        loader_name=tab_state.loader_name,
+                    )
+                    explorer = self.current_explorer
+                    if explorer is not None:
+                        explorer.restore_workspace_state(tab_state)
+            self.apply_loader_state(
+                kwargs_by_name=loader_kwargs_by_name,
+                extensions_by_name=loader_extensions_by_name,
+            )
+
+            if self.tab_widget.count() > 0:
+                self.tab_widget.setCurrentIndex(
+                    max(0, min(state.active_tab, self.tab_widget.count() - 1))
+                )
+
+            _qt_state.restore_qt_window_state(self, state.window_state)
+        finally:
+            self._workspace_state_restoring = False
+        self._emit_workspace_state_changed()
+
+    def _clear_tabs(self) -> None:
+        while self.tab_widget.count() > 0:
+            tab = self.tab_widget.widget(0)
+            explorer = self.get_explorer(0)
+            self.tab_widget.removeTab(0)
+            if explorer is not None:
+                explorer.deleteLater()
+            if tab is not None:
+                tab.deleteLater()
+
     @QtCore.Slot()
     def add_tab(self, **kwargs) -> None:
         """Add a new tab with a DataExplorer instance.
@@ -122,7 +249,13 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
             kwargs.setdefault("root_path", self.current_explorer.current_directory)
             kwargs.setdefault("loader_name", self.current_explorer.loader_name)
 
+        loader_kwargs = self.loader_kwargs_by_name()
+        loader_extensions = self.loader_extensions_by_name()
         new_explorer: _DataExplorer = _DataExplorer(self, **kwargs)
+        new_explorer.apply_loader_state(
+            kwargs_by_name=loader_kwargs,
+            extensions_by_name=loader_extensions,
+        )
         tab_idx: int = self.tab_widget.addTab(
             QtWidgets.QWidget(), str(new_explorer.current_directory.name)
         )
@@ -144,7 +277,9 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
 
         new_explorer.sigDirectoryChanged.connect(self.update_title)
         new_explorer.sigCloseRequested.connect(self.close_tab)
+        new_explorer.sigStateChanged.connect(self._emit_workspace_state_changed)
         self.update_menubar()
+        self._emit_workspace_state_changed()
 
     @QtCore.Slot()
     def update_menubar(self) -> None:
@@ -226,6 +361,7 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
                 self.tab_widget.currentIndex() if index < 0 else index
             )
         self.update_menubar()
+        self._emit_workspace_state_changed()
 
     def dragEnterEvent(
         self, event: QtGui.QDragEnterEvent | None

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -19,6 +19,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+from erlab.interactive import _qt_state
 from erlab.interactive.imagetool import _serialization, provenance
 from erlab.interactive.imagetool._load_source import _load_provenance_from_file_details
 from erlab.interactive.imagetool.viewer_state import _select_input_dataarrays
@@ -193,11 +194,7 @@ class BaseImageTool(QtWidgets.QMainWindow):
             "itool_state": json.dumps(state),
             "itool_title": self.windowTitle(),
             "itool_name": str(name),
-            "itool_qt_geometry": (
-                erlab.interactive.utils._qt_bytearray_to_base64(self.saveGeometry())
-            ),
-            "itool_rect": self.geometry().getRect(),
-            "itool_visible": bool(self.isVisible()),
+            "itool_window_state": _qt_state.qt_window_state_json(self),
             "erlab_version": erlab.__version__,
         }
         if self._provenance_spec is not None:
@@ -260,13 +257,12 @@ class BaseImageTool(QtWidgets.QMainWindow):
                     "Ignoring invalid saved ImageTool provenance metadata.",
                 )
         tool.setWindowTitle(ds.attrs["itool_title"])
-        restored_geometry = False
-        geometry = erlab.interactive.utils._qt_bytearray_from_base64(
-            ds.attrs.get("itool_qt_geometry")
-        )
-        if geometry is not None:
-            restored_geometry = tool.restoreGeometry(geometry)
-        if not restored_geometry and "itool_rect" in ds.attrs:
+        if (
+            not _qt_state.restore_qt_window_state(
+                tool, ds.attrs.get("itool_window_state")
+            )
+            and "itool_rect" in ds.attrs
+        ):
             tool.setGeometry(*ds.attrs["itool_rect"])
         return tool
 

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -10,6 +10,7 @@ import typing
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+from erlab.interactive import _qt_state
 from erlab.interactive.imagetool.manager._dialogs import _NameFilterDialog
 
 if typing.TYPE_CHECKING:
@@ -57,6 +58,29 @@ if typing.TYPE_CHECKING:
         _ManagedWindowNode,
     )
     from erlab.interactive.ptable import PeriodicTableWindow
+
+
+class _StandaloneAppEventFilter(QtCore.QObject):
+    _STATE_EVENT_TYPES = frozenset(
+        {
+            QtCore.QEvent.Type.Hide,
+            QtCore.QEvent.Type.Move,
+            QtCore.QEvent.Type.Resize,
+            QtCore.QEvent.Type.Show,
+            QtCore.QEvent.Type.WindowStateChange,
+        }
+    )
+
+    def __init__(self, manager: _ImageToolManagerBase) -> None:
+        super().__init__(manager)
+        self._manager = manager
+
+    def eventFilter(
+        self, obj: QtCore.QObject | None, event: QtCore.QEvent | None
+    ) -> bool:
+        if event is not None and event.type() in self._STATE_EVENT_TYPES:
+            self._manager._mark_standalone_app_state_dirty()
+        return super().eventFilter(obj, event)
 
 
 class _ImageToolManagerBase(QtWidgets.QMainWindow):
@@ -124,6 +148,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     ]
     _progress_bars: dict[int, QtWidgets.QProgressDialog]
     _recent_directory: str | None
+    _recent_loader_kwargs_by_filter: dict[str, dict[str, typing.Any]]
     _recent_loader_extensions_by_filter: dict[str, dict[str, typing.Any]]
     _recent_name_filter: str | None
     _registry_heartbeat_timer: QtCore.QTimer
@@ -132,6 +157,8 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     _sigReplyData: QtCore.SignalInstance
     _sigWatchedDataEdited: QtCore.SignalInstance
     _standalone_app_actions: dict[str, QtGui.QAction]
+    _standalone_app_event_filters: dict[str, QtCore.QObject]
+    _standalone_app_pending_states: dict[str, dict[str, typing.Any]]
     _standalone_app_specs: dict[str, _StandaloneAppSpec]
     _standalone_app_windows: dict[str, QtWidgets.QWidget]
     _tool_graph: _ManagerToolGraph
@@ -156,6 +183,9 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
             )
             msg_box.setIconPixmap(self.windowIcon().pixmap(icon_size, icon_size))
         return msg_box
+
+    def _mark_workspace_layout_dirty(self) -> None:
+        self._workspace_controller._mark_workspace_layout_dirty()
 
     def _node_for_target(
         self, target: int | str
@@ -253,9 +283,17 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     def _create_explorer_window(self) -> QtWidgets.QWidget:
         from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
 
-        return _TabbedExplorer(
+        explorer = _TabbedExplorer(
             root_path=self._recent_directory, loader_name=self._recent_loader_name
         )
+        loader_kwargs, loader_extensions = (
+            self._workspace_controller._explorer_loader_state()
+        )
+        explorer.apply_loader_state(
+            kwargs_by_name=loader_kwargs,
+            extensions_by_name=loader_extensions,
+        )
+        return explorer
 
     def _create_ptable_window(self) -> QtWidgets.QWidget:
         from erlab.interactive.ptable import PeriodicTableWindow
@@ -299,13 +337,21 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         *,
         sample_paths: Iterable[str | pathlib.Path] | None = None,
     ) -> tuple[str, Callable, dict[str, typing.Any]] | None:
+        dialog_loaders: dict[str, tuple[Callable, dict[str, typing.Any]]] = {}
+        for current_filter, (func, kwargs) in valid_loaders.items():
+            dialog_kwargs = kwargs.copy()
+            dialog_kwargs.update(
+                self._recent_loader_kwargs_by_filter.get(current_filter, {})
+            )
+            dialog_loaders[current_filter] = (func, dialog_kwargs)
+
         dialog = _NameFilterDialog(
             self,
-            valid_loaders,
+            dialog_loaders,
             loader_extensions=self._recent_loader_extensions_by_filter,
             sample_paths=sample_paths,
         )
-        dialog.check_filter(name_filter or self._preferred_name_filter(valid_loaders))
+        dialog.check_filter(name_filter or self._preferred_name_filter(dialog_loaders))
 
         if not dialog.exec():
             return None
@@ -313,9 +359,13 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         selected_filter, func, kwargs = dialog.checked_filter()
         self._recent_name_filter = selected_filter
         loader_extensions = kwargs.get("loader_extensions", {})
+        selected_kwargs = kwargs.copy()
+        selected_kwargs.pop("loader_extensions", None)
+        self._recent_loader_kwargs_by_filter[selected_filter] = selected_kwargs
         self._recent_loader_extensions_by_filter[selected_filter] = (
             loader_extensions.copy() if isinstance(loader_extensions, dict) else {}
         )
+        self._mark_workspace_layout_dirty()
         return selected_filter, func, kwargs
 
     def _create_standalone_app_action(self, key: str) -> QtGui.QAction:
@@ -335,10 +385,22 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
 
     def _create_standalone_app_window(self, key: str) -> QtWidgets.QWidget:
         widget = self._standalone_app_specs[key].factory()
-        widget.destroyed.connect(
-            lambda _=None, app_key=key: self._standalone_app_windows.pop(app_key, None)
-        )
+        event_filter = _StandaloneAppEventFilter(self)
+        widget.installEventFilter(event_filter)
+        self._standalone_app_event_filters[key] = event_filter
+        signal = getattr(widget, "sigStateChanged", None)
+        if signal is not None:
+            signal.connect(self._mark_standalone_app_state_dirty)
+
+        def cleanup(_obj: QtCore.QObject | None = None) -> None:
+            self._standalone_app_windows.pop(key, None)
+            self._standalone_app_event_filters.pop(key, None)
+
+        widget.destroyed.connect(cleanup)
         self._standalone_app_windows[key] = widget
+        pending_state = self._standalone_app_pending_states.get(key)
+        if pending_state is not None:
+            self._apply_standalone_app_state(key, widget, pending_state)
         return widget
 
     def _ensure_standalone_app(self, key: str) -> QtWidgets.QWidget:
@@ -354,9 +416,40 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         widget.raise_()
         return widget
 
+    def _mark_standalone_app_state_dirty(self) -> None:
+        self._mark_workspace_layout_dirty()
+
+    def _apply_standalone_app_state(
+        self,
+        key: str,
+        widget: QtWidgets.QWidget,
+        state: dict[str, typing.Any],
+    ) -> None:
+        restore_state = getattr(widget, "restore_workspace_state", None)
+        if callable(restore_state):
+            restore_state(state)
+
+        window_state = _qt_state.parse_qt_window_state(state.get("window_state"))
+        if window_state is None:
+            return
+        if window_state.visible:
+            widget.show()
+        else:
+            widget.hide()
+        self._standalone_app_pending_states[key] = state
+
+    def _close_standalone_app(self, key: str) -> None:
+        widget = self._standalone_app_windows.pop(key, None)
+        event_filter = self._standalone_app_event_filters.pop(key, None)
+        if widget is None or not erlab.interactive.utils.qt_is_valid(widget):
+            self._standalone_app_pending_states.pop(key, None)
+            return
+        if event_filter is not None:
+            widget.removeEventFilter(event_filter)
+        widget.close()
+        widget.deleteLater()
+        self._standalone_app_pending_states.pop(key, None)
+
     def _close_standalone_apps(self) -> None:
-        for widget in tuple(self._standalone_app_windows.values()):
-            if erlab.interactive.utils.qt_is_valid(widget):
-                widget.close()
-                widget.deleteLater()
-        self._standalone_app_windows.clear()
+        for key in tuple(self._standalone_app_windows):
+            self._close_standalone_app(key)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -179,6 +179,8 @@ class ImageToolManager(_ImageToolManagerBase):
         # Stores additional analysis tools opened from child ImageTool windows
         self._additional_windows: dict[str, QtWidgets.QWidget] = {}
         self._standalone_app_windows: dict[str, QtWidgets.QWidget] = {}
+        self._standalone_app_event_filters: dict[str, QtCore.QObject] = {}
+        self._standalone_app_pending_states: dict[str, dict[str, typing.Any]] = {}
         self._standalone_app_specs: dict[str, _StandaloneAppSpec] = {
             "explorer": _StandaloneAppSpec(
                 key="explorer",
@@ -643,6 +645,7 @@ class ImageToolManager(_ImageToolManagerBase):
         # Store most recent name filter and directory for new windows
         self._recent_name_filter: str | None = None
         self._recent_directory: str | None = None
+        self._recent_loader_kwargs_by_filter: dict[str, dict[str, typing.Any]] = {}
         self._recent_loader_extensions_by_filter: dict[str, dict[str, typing.Any]] = {}
         self._metadata_full_code_available = False
         self._metadata_node_uid: str | None = None
@@ -1210,9 +1213,6 @@ class ImageToolManager(_ImageToolManagerBase):
     def _mark_workspace_structure_dirty(self, reason: str) -> None:
         self._workspace_controller._mark_workspace_structure_dirty(reason)
 
-    def _mark_workspace_layout_dirty(self) -> None:
-        self._workspace_controller._mark_workspace_layout_dirty()
-
     def _mark_workspace_clean(self) -> None:
         self._workspace_controller._mark_workspace_clean()
 
@@ -1424,7 +1424,7 @@ class ImageToolManager(_ImageToolManagerBase):
             delta_save_count=delta_save_count
         )
 
-    def _workspace_layout_snapshot(self) -> dict[str, str]:
+    def _workspace_layout_snapshot(self) -> dict[str, typing.Any]:
         return self._workspace_controller._workspace_layout_snapshot()
 
     def _restore_workspace_layout(

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -1,3 +1,43 @@
+"""ImageTool Manager workspace file format internals.
+
+Workspace files use the ``.itws`` suffix and are HDF5 files written through
+``xarray.DataTree``/``h5netcdf``. Runtime code should treat the root attributes as the
+authoritative manifest for ordering and manager-level state; HDF5 group names are
+payload locations, not the complete schema.
+
+Current file layout
+-------------------
+
+::
+
+    /
+      attrs:
+        imagetool_workspace_schema_version
+        imagetool_workspace_manifest
+        erlab_version
+      <root index>/
+        imagetool/
+        childtools/
+          <child uid>/
+            imagetool/ or tool/
+      __itws_txn_<id>/, __itws_pending_<id>/, __itws_backup_<id>/
+
+Schema ownership
+----------------
+
+The root manifest envelope is assembled by :func:`_workspace_root_attrs_payload`;
+non-obvious manifest entries are commented where they are built. Manager-level loader
+state and the standalone app envelope are validated in this module. Data Explorer
+and Periodic Table state schemas live with the app code that snapshots and restores
+them. Shared Qt geometry/visibility state is implemented in
+:mod:`erlab.interactive._qt_state`.
+
+ImageTool and ToolWindow payload attrs live with the serializers that write them:
+``BaseImageTool.to_dataset`` and ``ToolWindow._saved_tool_attrs``. New writers use
+``*_window_state`` attrs; readers only fall back to released legacy ``itool_rect`` and
+``tool_rect`` attrs for older workspace files.
+"""
+
 from __future__ import annotations
 
 import contextlib
@@ -13,6 +53,7 @@ import typing
 import uuid
 from dataclasses import dataclass
 
+import pydantic
 from qtpy import QtCore
 
 import erlab
@@ -31,6 +72,37 @@ _WORKSPACE_TRANSACTION_PROTOCOL = "recoverable-delta-v1"
 _WORKSPACE_PENDING_GROUP_PREFIX = "__itws_pending_"
 _WORKSPACE_BACKUP_GROUP_PREFIX = "__itws_backup_"
 _WORKSPACE_TRANSACTION_GROUP_PREFIX = "__itws_txn_"
+
+
+class WorkspaceLoaderState(pydantic.BaseModel):
+    recent_directory: str | None = None
+    # QFileDialog name filter selected in manager file-open flows.
+    recent_name_filter: str | None = None
+    # Manager file-open options are keyed by name filter, not loader name.
+    manager_loader_kwargs_by_filter: dict[str, dict[str, typing.Any]] = pydantic.Field(
+        default_factory=dict
+    )
+    # Loader extensions are saved separately because extend_loader applies them later.
+    manager_loader_extensions_by_filter: dict[str, dict[str, typing.Any]] = (
+        pydantic.Field(default_factory=dict)
+    )
+    # Data Explorer tabs select loaders by name, so their options use loader names.
+    explorer_loader_kwargs_by_name: dict[str, dict[str, typing.Any]] = pydantic.Field(
+        default_factory=dict
+    )
+    explorer_loader_extensions_by_name: dict[str, dict[str, typing.Any]] = (
+        pydantic.Field(default_factory=dict)
+    )
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+
+class StandaloneAppsState(pydantic.BaseModel):
+    schema_version: int = 1
+    # Keys are manager standalone app ids such as "explorer" and "ptable".
+    apps: dict[str, dict[str, typing.Any]] = pydantic.Field(default_factory=dict)
+
+    model_config = pydantic.ConfigDict(extra="ignore")
 
 
 @dataclass
@@ -311,18 +383,31 @@ def _workspace_root_attrs_payload(
     erlab_version: str,
     workspace_link_id: str | None = None,
     manager_layout: Mapping[str, typing.Any] | None = None,
+    loader_state: Mapping[str, typing.Any] | None = None,
+    standalone_apps: Mapping[str, typing.Any] | None = None,
 ) -> dict[str, typing.Any]:
     manifest: dict[str, typing.Any] = {
         "schema_version": _WORKSPACE_SCHEMA_VERSION,
         "erlab_version": erlab_version,
+        # HDF5 group order is not the manager's authoritative top-level order.
         "root_order": list(root_order),
+        # Stable manager UIDs map to payload groups and link/data metadata here.
         "nodes": list(nodes),
     }
     if workspace_link_id is not None:
+        # Scopes watched-variable/source links to this workspace document.
         manifest["workspace_link_id"] = workspace_link_id
     if manager_layout is not None:
+        # Stored at root so layout-only saves can avoid rewriting tool payloads.
         manifest["manager_layout"] = dict(manager_layout)
+    if loader_state is not None:
+        # Manager loader choices are independent of standalone Data Explorer state.
+        manifest["loader_state"] = dict(loader_state)
+    if standalone_apps is not None:
+        # Restored on full workspace open; imports intentionally ignore app windows.
+        manifest["standalone_apps"] = dict(standalone_apps)
     if delta_save_count > 0:
+        # Marks files written through the recoverable in-place delta-save protocol.
         manifest["transaction_protocol"] = _WORKSPACE_TRANSACTION_PROTOCOL
         manifest["delta_save_count"] = int(delta_save_count)
     return {

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -15,6 +15,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.slicer
+from erlab.interactive import _qt_state
 from erlab.interactive.imagetool import provenance
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME, ImageTool
 from erlab.interactive.imagetool.manager import _desktop
@@ -60,6 +61,15 @@ if typing.TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+
+def _workspace_dataset_window_visible(
+    ds: xr.Dataset, prefix: str, *, default: bool = True
+) -> bool:
+    state = _qt_state.parse_qt_window_state(ds.attrs.get(f"{prefix}_window_state"))
+    if state is not None:
+        return state.visible
+    return bool(ds.attrs.get(f"{prefix}_visible", default))
 
 
 def _workspace_provenance_file_stems(
@@ -124,6 +134,7 @@ class _WorkspaceIOController:
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager = manager
         self._missing_workspace_colormaps: list[tuple[str, str]] = []
+        self._loader_state = _manager_workspace.WorkspaceLoaderState()
 
     def _record_missing_workspace_colormap(
         self, cmap: str, node_path: str | None
@@ -899,7 +910,7 @@ class _WorkspaceIOController:
             target = self._manager.add_imagetool_child(
                 tool,
                 parent_target,
-                show=ds.attrs.get("itool_visible", True),
+                show=_workspace_dataset_window_visible(ds, "itool"),
                 **kwargs,
             )
             self._manager._record_workspace_loaded_imagetool_target(
@@ -942,7 +953,7 @@ class _WorkspaceIOController:
                 preferred_index = None
         target = self._manager.add_imagetool(
             tool,
-            show=ds.attrs.get("itool_visible", True),
+            show=_workspace_dataset_window_visible(ds, "itool"),
             index=preferred_index,
             **kwargs,
         )
@@ -959,7 +970,7 @@ class _WorkspaceIOController:
         return self._manager.add_childtool(
             erlab.interactive.utils.ToolWindow.from_dataset(ds),
             parent_target,
-            show=ds.attrs.get("tool_visible", True),
+            show=_workspace_dataset_window_visible(ds, "tool"),
             uid=ds.attrs.get("manager_node_uid"),
             snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
             created_time=ds.attrs.get("manager_node_added_at"),
@@ -1319,6 +1330,8 @@ class _WorkspaceIOController:
                 )
                 if replace:
                     self._manager._restore_workspace_layout(manifest)
+                    self._restore_workspace_loader_state(manifest)
+                    self._restore_standalone_apps_state(manifest)
                 if not mark_dirty:
                     self._manager._drain_workspace_deferred_events()
             except Exception:
@@ -1443,6 +1456,8 @@ class _WorkspaceIOController:
                     )
                     if replace:
                         self._manager._restore_workspace_layout(manifest)
+                        self._restore_workspace_loader_state(manifest)
+                        self._restore_standalone_apps_state(manifest)
                     if not mark_dirty:
                         self._manager._drain_workspace_deferred_events()
                 except Exception:
@@ -1543,16 +1558,20 @@ class _WorkspaceIOController:
             node = self._manager._tool_graph.nodes[uid]
             entry: dict[str, typing.Any] = {
                 "uid": uid,
+                # Payload group path relative to the workspace root HDF5 group.
                 "path": self._manager._workspace_node_path(uid),
+                # Restores graph node type without probing payload attrs first.
                 "kind": "imagetool" if node.is_imagetool else "tool",
                 "parent_uid": node.parent_uid,
                 "display_name": node.display_text,
             }
             if node.is_imagetool and node.imagetool is not None:
                 persistence = node.persistence_view()
+                # Distinguishes embedded data from lazy file-backed/dask payloads.
                 entry["data_backing"] = persistence.data_backing
                 link_info = link_metadata.get(uid)
                 if link_info is not None:
+                    # link_group is an ordinal within this manifest, not a stable id.
                     entry["link_group"], entry["link_colors"] = link_info
             entries.append(entry)
             for child_uid in node._childtool_indices:
@@ -1590,13 +1609,14 @@ class _WorkspaceIOController:
             erlab_version=str(erlab.__version__),
             workspace_link_id=self._manager._workspace_state.link_id,
             manager_layout=self._manager._workspace_layout_snapshot(),
+            loader_state=self._workspace_loader_state_snapshot(),
+            standalone_apps=self._workspace_standalone_apps_snapshot(),
         )
 
-    def _workspace_layout_snapshot(self) -> dict[str, str]:
+    def _workspace_layout_snapshot(self) -> dict[str, typing.Any]:
         return {
-            "geometry": erlab.interactive.utils._qt_bytearray_to_base64(
-                self._manager.saveGeometry()
-            ),
+            "window_state": _qt_state.qt_window_state_payload(self._manager),
+            # QSplitter state preserves pane sizes and collapsed/expanded handles.
             "main_splitter": erlab.interactive.utils._qt_bytearray_to_base64(
                 self._manager.main_splitter.saveState()
             ),
@@ -1614,11 +1634,7 @@ class _WorkspaceIOController:
         if not isinstance(layout, dict):
             return
 
-        geometry = erlab.interactive.utils._qt_bytearray_from_base64(
-            layout.get("geometry")
-        )
-        if geometry is not None:
-            self._manager.restoreGeometry(geometry)
+        _qt_state.restore_qt_window_state(self._manager, layout.get("window_state"))
 
         main_splitter = erlab.interactive.utils._qt_bytearray_from_base64(
             layout.get("main_splitter")
@@ -1631,6 +1647,188 @@ class _WorkspaceIOController:
         )
         if right_splitter is not None:
             self._manager.right_splitter.restoreState(right_splitter)
+
+    def _workspace_loader_state_snapshot(self) -> dict[str, typing.Any]:
+        manager_loader_kwargs = self._manager._recent_loader_kwargs_by_filter
+        manager_loader_extensions = self._manager._recent_loader_extensions_by_filter
+        explorer_kwargs = self._loader_state.explorer_loader_kwargs_by_name
+        explorer_extensions = self._loader_state.explorer_loader_extensions_by_name
+        explorer = self._manager._standalone_app_windows.get("explorer")
+        if explorer is not None and erlab.interactive.utils.qt_is_valid(explorer):
+            kwargs_getter = getattr(explorer, "loader_kwargs_by_name", None)
+            if callable(kwargs_getter):
+                explorer_kwargs = kwargs_getter()
+            extensions_getter = getattr(explorer, "loader_extensions_by_name", None)
+            if callable(extensions_getter):
+                explorer_extensions = extensions_getter()
+        state = _manager_workspace.WorkspaceLoaderState(
+            recent_directory=self._manager._recent_directory,
+            recent_name_filter=self._manager._recent_name_filter,
+            manager_loader_kwargs_by_filter={
+                str(name): dict(kwargs)
+                for name, kwargs in manager_loader_kwargs.items()
+            },
+            manager_loader_extensions_by_filter={
+                str(name): dict(extensions)
+                for name, extensions in manager_loader_extensions.items()
+            },
+            explorer_loader_kwargs_by_name={
+                str(name): dict(kwargs) for name, kwargs in explorer_kwargs.items()
+            },
+            explorer_loader_extensions_by_name={
+                str(name): dict(extensions)
+                for name, extensions in explorer_extensions.items()
+            },
+        )
+        self._loader_state = state
+        return state.model_dump(mode="json", exclude_none=True)
+
+    def _explorer_loader_state(
+        self,
+    ) -> tuple[dict[str, dict[str, typing.Any]], dict[str, dict[str, typing.Any]]]:
+        loader_kwargs = self._loader_state.explorer_loader_kwargs_by_name
+        loader_extensions = self._loader_state.explorer_loader_extensions_by_name
+        return (
+            {str(name): dict(kwargs) for name, kwargs in loader_kwargs.items()},
+            {
+                str(name): dict(extensions)
+                for name, extensions in loader_extensions.items()
+            },
+        )
+
+    def _restore_workspace_loader_state(
+        self,
+        manifest: Mapping[str, typing.Any] | None,
+        *,
+        apply_explorer: bool = True,
+    ) -> None:
+        if manifest is None:
+            return
+        payload = manifest.get("loader_state")
+        if not isinstance(payload, dict):
+            return
+        try:
+            state = _manager_workspace.WorkspaceLoaderState.model_validate(payload)
+        except Exception:
+            logger.warning("Ignoring invalid workspace loader state", exc_info=True)
+            return
+
+        self._loader_state = state
+        self._manager._recent_directory = state.recent_directory
+        self._manager._recent_name_filter = state.recent_name_filter
+        self._manager._recent_loader_kwargs_by_filter = {
+            str(name): dict(kwargs)
+            for name, kwargs in state.manager_loader_kwargs_by_filter.items()
+        }
+        self._manager._recent_loader_extensions_by_filter = {
+            str(name): dict(extensions)
+            for name, extensions in state.manager_loader_extensions_by_filter.items()
+        }
+        explorer_kwargs = {
+            str(name): dict(kwargs)
+            for name, kwargs in state.explorer_loader_kwargs_by_name.items()
+        }
+        explorer_extensions = {
+            str(name): dict(extensions)
+            for name, extensions in state.explorer_loader_extensions_by_name.items()
+        }
+        if not apply_explorer:
+            return
+        explorer = self._manager._standalone_app_windows.get("explorer")
+        if explorer is not None and erlab.interactive.utils.qt_is_valid(explorer):
+            apply_loader_state = getattr(explorer, "apply_loader_state", None)
+            if callable(apply_loader_state):
+                apply_loader_state(
+                    kwargs_by_name=explorer_kwargs,
+                    extensions_by_name=explorer_extensions,
+                )
+
+    @staticmethod
+    def _validated_standalone_app_state(
+        key: str, state: Mapping[str, typing.Any]
+    ) -> dict[str, typing.Any] | None:
+        model_type: typing.Any
+        if key == "explorer":
+            from erlab.interactive.explorer._tabbed_explorer import DataExplorerState
+
+            model_type = DataExplorerState
+        elif key == "ptable":
+            from erlab.interactive.ptable._window import PeriodicTableState
+
+            model_type = PeriodicTableState
+        else:
+            return None
+        try:
+            return typing.cast(
+                "dict[str, typing.Any]",
+                model_type.model_validate(state).model_dump(
+                    mode="json", exclude_none=True
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Ignoring invalid %s standalone app state", key, exc_info=True
+            )
+            return None
+
+    def _workspace_standalone_apps_snapshot(self) -> dict[str, typing.Any]:
+        app_states: dict[str, dict[str, typing.Any]] = {}
+        for key in self._manager._standalone_app_specs:
+            widget = self._manager._standalone_app_windows.get(key)
+            state: dict[str, typing.Any] | None = None
+            if widget is not None and erlab.interactive.utils.qt_is_valid(widget):
+                state_getter = getattr(widget, "workspace_state_payload", None)
+                if callable(state_getter):
+                    state = typing.cast("dict[str, typing.Any]", state_getter())
+            elif key in self._manager._standalone_app_pending_states:
+                state = self._manager._standalone_app_pending_states[key]
+            if state is None:
+                continue
+            validated = self._validated_standalone_app_state(key, state)
+            if validated is not None:
+                app_states[key] = validated
+        return _manager_workspace.StandaloneAppsState(apps=app_states).model_dump(
+            mode="json", exclude_none=True
+        )
+
+    def _restore_standalone_apps_state(
+        self, manifest: Mapping[str, typing.Any] | None
+    ) -> None:
+        if manifest is None:
+            return
+        payload = manifest.get("standalone_apps")
+        if not isinstance(payload, dict):
+            return
+        try:
+            state = _manager_workspace.StandaloneAppsState.model_validate(payload)
+        except Exception:
+            logger.warning("Ignoring invalid standalone app state", exc_info=True)
+            return
+
+        restored_states: dict[str, dict[str, typing.Any]] = {}
+        for key, app_state in state.apps.items():
+            if key not in self._manager._standalone_app_specs:
+                continue
+            validated = self._validated_standalone_app_state(key, app_state)
+            if validated is not None:
+                restored_states[key] = validated
+
+        for key in set(self._manager._standalone_app_specs) - set(restored_states):
+            self._manager._close_standalone_app(key)
+
+        for key, app_state in restored_states.items():
+            window_state = _qt_state.parse_qt_window_state(
+                app_state.get("window_state")
+            )
+            if window_state is not None and window_state.visible:
+                widget = self._manager._ensure_standalone_app(key)
+                self._manager._apply_standalone_app_state(key, widget, app_state)
+            else:
+                widget = self._manager._standalone_app_windows.get(key)
+                if widget is not None and erlab.interactive.utils.qt_is_valid(widget):
+                    self._manager._apply_standalone_app_state(key, widget, app_state)
+                else:
+                    self._manager._standalone_app_pending_states[key] = app_state
 
     def _write_full_workspace_file(self, fname: str | os.PathLike[str]) -> None:
         tree: xr.DataTree = self._manager._to_datatree()
@@ -2646,6 +2844,10 @@ class _WorkspaceIOController:
                                     workspace_access=access,
                                     rebind_data=False,
                                 )
+                                if replace:
+                                    self._restore_workspace_loader_state(
+                                        manifest, apply_explorer=False
+                                    )
                             return self._finish_workspace_file_load(loaded)
                     except Exception:
                         logger.debug(
@@ -2653,7 +2855,7 @@ class _WorkspaceIOController:
                             exc_info=True,
                         )
                 tree = _manager_xarray.open_workspace_datatree(access.path, chunks=None)
-                schema_version, delta_save_count, _manifest = (
+                schema_version, delta_save_count, manifest = (
                     _manager_workspace._workspace_file_metadata_from_attrs(tree.attrs)
                 )
                 loaded = self._manager._from_datatree(
@@ -2672,6 +2874,10 @@ class _WorkspaceIOController:
                         workspace_access=access,
                         rebind_data=False,
                     )
+                    if replace:
+                        self._restore_workspace_loader_state(
+                            manifest, apply_explorer=False
+                        )
                 return self._finish_workspace_file_load(loaded)
         finally:
             self._missing_workspace_colormaps = previous_missing_colormaps

--- a/src/erlab/interactive/ptable/_window.py
+++ b/src/erlab/interactive/ptable/_window.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import contextlib
+import typing
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
+import pydantic
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+from erlab.interactive import _qt_state
 from erlab.interactive.ptable._inspector import ElementInspector
 from erlab.interactive.ptable._shared import (
     ElementRecord,
@@ -34,8 +36,42 @@ from erlab.interactive.ptable._table import (
 
 __all__ = ["PeriodicTableWindow", "ptable"]
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from collections.abc import Callable
+
+
+class PeriodicTableState(pydantic.BaseModel):
+    # The Periodic Table top-level window uses the shared Qt window schema.
+    window_state: _qt_state.QtWindowState | None = None
+    selected_atomic_numbers: tuple[int, ...] = ()
+    current_atomic_number: int | None = None
+    anchor_atomic_number: int | None = None
+    # Plot target may differ from the current item when multiple elements are selected.
+    plot_atomic_number: int | None = None
+    plot_target_user_selected: bool = False
+    # Line-edit text is preserved exactly, including temporarily invalid input.
+    photon_energy: str = ""
+    work_function: str = ""
+    max_harmonic: int = 1
+    notation: typing.Literal["orbital", "iupac"] = "orbital"
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    @pydantic.field_validator("selected_atomic_numbers", mode="before")
+    @classmethod
+    def _selected_tuple(cls, value: object) -> object:
+        if value is None:
+            return ()
+        return tuple(value) if isinstance(value, (list, tuple)) else value
+
+    @pydantic.field_validator("photon_energy", "work_function", mode="before")
+    @classmethod
+    def _line_edit_text(cls, value: object) -> object:
+        if value is None:
+            return ""
+        if isinstance(value, (int, float, str)) and not isinstance(value, bool):
+            return str(value)
+        return value
 
 
 class _SearchLineEdit(QtWidgets.QLineEdit):
@@ -349,7 +385,7 @@ class _SearchCompletion:
 
 
 _NOTATION_VALUES = frozenset({"orbital", "iupac"})
-_DEFAULT_NOTATION = "orbital"
+_DEFAULT_NOTATION: typing.Literal["orbital", "iupac"] = "orbital"
 _NOTATION_SETTINGS_KEY = "notation"
 _ENERGY_RELATION_TOOLTIP = (
     "<i>E</i><sub>kin</sub> = <i>h\u03bd</i> \u2212 <i>E</i><sub>edge</sub> "
@@ -386,6 +422,8 @@ def _resolve_notation(notation: str | None) -> str:
 
 
 class PeriodicTableWindow(QtWidgets.QMainWindow):
+    sigStateChanged = QtCore.Signal()
+
     _MAX_HARMONIC = 10
     _LEGACY_MINIMUM_WINDOW_SIZE = QtCore.QSize(1180, 760)
     _LEGACY_TOP_SPLITTER_RATIO = 560 / (560 + 340)
@@ -413,6 +451,7 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         self._search_matches: set[int] = set()
         self._search_completions: tuple[_SearchCompletion, ...] = ()
         self._search_completion_row: int | None = None
+        self._workspace_state_restoring = False
 
         self.setWindowTitle("Periodic Table of the Elements")
         self.resize(1600, 920)
@@ -615,10 +654,10 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         return tuple(self._selected_atomic_numbers)
 
     @property
-    def current_notation(self) -> str:
+    def current_notation(self) -> typing.Literal["orbital", "iupac"]:
         current_data = self.notation_combo.currentData()
         if isinstance(current_data, str) and current_data in _NOTATION_VALUES:
-            return current_data
+            return typing.cast("typing.Literal['orbital', 'iupac']", current_data)
         return _DEFAULT_NOTATION
 
     @property
@@ -646,6 +685,83 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         except ValueError:
             return 0.0
         return max(value, 0.0)
+
+    def workspace_state_payload(self) -> dict[str, typing.Any]:
+        return PeriodicTableState(
+            window_state=_qt_state.qt_window_state(self),
+            selected_atomic_numbers=tuple(self._selected_atomic_numbers),
+            current_atomic_number=self._current_atomic_number,
+            anchor_atomic_number=self._selection_anchor_atomic_number,
+            plot_atomic_number=self._plot_atomic_number,
+            plot_target_user_selected=self._plot_target_user_selected,
+            photon_energy=self.hv_edit.text(),
+            work_function=self.workfunction_edit.text(),
+            max_harmonic=self.max_harmonic,
+            notation=self.current_notation,
+        ).model_dump(mode="json", exclude_none=True)
+
+    def restore_workspace_state(self, state: PeriodicTableState) -> None:
+        state = PeriodicTableState.model_validate(state)
+        self._workspace_state_restoring = True
+        try:
+            notation_index = self.notation_combo.findData(state.notation)
+            if notation_index >= 0:
+                self.notation_combo.setCurrentIndex(notation_index)
+
+            self.hv_edit.setText(state.photon_energy)
+            self.workfunction_edit.setText(state.work_function)
+
+            self.max_harmonic_spin.setValue(
+                max(1, min(int(state.max_harmonic), self._MAX_HARMONIC))
+            )
+
+            selected_numbers = [
+                atomic_number
+                for value in state.selected_atomic_numbers
+                if (atomic_number := self._atomic_number_from_state(value)) is not None
+            ]
+            current_atomic_number = self._atomic_number_from_state(
+                state.current_atomic_number
+            )
+            anchor_atomic_number = self._atomic_number_from_state(
+                state.anchor_atomic_number
+            )
+            self._set_selection_state(
+                selected_numbers,
+                current_atomic_number=current_atomic_number,
+                anchor_atomic_number=anchor_atomic_number,
+            )
+
+            plot_atomic_number = self._atomic_number_from_state(
+                state.plot_atomic_number
+            )
+            if plot_atomic_number in self._selected_atomic_numbers:
+                self._plot_atomic_number = plot_atomic_number
+                self._plot_target_user_selected = (
+                    state.plot_target_user_selected
+                    and len(self._selected_atomic_numbers) > 1
+                )
+
+            _qt_state.restore_qt_window_state(self, state.window_state)
+        finally:
+            self._workspace_state_restoring = False
+        self._refresh_inputs()
+        self._refresh_window_state(ensure_visible=False)
+        self._emit_workspace_state_changed()
+
+    @staticmethod
+    def _atomic_number_from_state(value: object) -> int | None:
+        if isinstance(value, bool):
+            return None
+        with contextlib.suppress(TypeError, ValueError):
+            atomic_number = int(typing.cast("typing.Any", value))
+            if 1 <= atomic_number <= 118:
+                return atomic_number
+        return None
+
+    def _emit_workspace_state_changed(self) -> None:
+        if not self._workspace_state_restoring:
+            self.sigStateChanged.emit()
 
     def _set_line_edit_invalid_state(
         self, widget: QtWidgets.QLineEdit, invalid: bool
@@ -1213,15 +1329,18 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         self.table_view.setFocus()
         self._clear_hover_preview()
         self._refresh_window_state(ensure_visible=False)
+        self._emit_workspace_state_changed()
 
     def _handle_background_clicked(self, _: object) -> None:
         self._clear_hover_preview()
         self._clear_selection()
         self._refresh_window_state(ensure_visible=False)
+        self._emit_workspace_state_changed()
 
     def _handle_clear_requested(self) -> None:
         self._clear_selection()
         self._refresh_window_state(ensure_visible=False)
+        self._emit_workspace_state_changed()
 
     def _handle_navigation_requested(self, key: int, modifiers: object) -> None:
         navigation = _navigation_atomic_numbers()
@@ -1246,6 +1365,7 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
             self._select_single_atomic_number(target_atomic_number)
         self._clear_hover_preview()
         self._refresh_window_state(ensure_visible=True)
+        self._emit_workspace_state_changed()
 
     def _handle_search_changed(self, text: str) -> None:
         if text.strip() == "":
@@ -1358,6 +1478,7 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
             )
         self.table_view.setFocus()
         self._refresh_window_state(ensure_visible=True)
+        self._emit_workspace_state_changed()
 
     def _handle_plot_target_changed(self, atomic_number: int) -> None:
         if (
@@ -1368,19 +1489,24 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         self._plot_atomic_number = atomic_number
         self._plot_target_user_selected = len(self._selected_atomic_numbers) > 1
         self._refresh_window_state(ensure_visible=False)
+        self._emit_workspace_state_changed()
 
     def _handle_energy_inputs_changed(self, _: str) -> None:
         self._refresh_inputs()
         self._refresh_window_state(ensure_visible=False)
+        self._emit_workspace_state_changed()
 
     def _handle_max_harmonic_changed(self, _: int) -> None:
         self._refresh_window_state(ensure_visible=False)
+        self._emit_workspace_state_changed()
 
     def _handle_notation_changed(self, _: int) -> None:
-        settings = _get_ptable_settings()
-        settings.setValue(_NOTATION_SETTINGS_KEY, self.current_notation)
-        settings.sync()
+        if not self._workspace_state_restoring:
+            settings = _get_ptable_settings()
+            settings.setValue(_NOTATION_SETTINGS_KEY, self.current_notation)
+            settings.sync()
         self._refresh_window_state(ensure_visible=False)
+        self._emit_workspace_state_changed()
 
 
 def ptable(

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -7,8 +7,6 @@ of pyqtgraph and Qt.
 from __future__ import annotations
 
 import ast
-import base64
-import binascii
 import bisect
 import contextlib
 import enum
@@ -42,6 +40,7 @@ import xarray as xr
 from qtpy import PYQT6, PYSIDE6, QtCore, QtGui, QtWidgets, uic
 
 import erlab
+from erlab.interactive import _qt_state
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Collection, Hashable, Iterator, Mapping
@@ -100,27 +99,11 @@ logger = logging.getLogger(__name__)
 
 
 def _qt_bytearray_to_base64(value: QtCore.QByteArray) -> str:
-    return base64.b64encode(value.data()).decode("ascii")
+    return _qt_state.qt_bytearray_to_base64(value)
 
 
 def _qt_bytearray_from_base64(value: object) -> QtCore.QByteArray | None:
-    if isinstance(value, bytes):
-        try:
-            text = value.decode("ascii")
-        except UnicodeDecodeError:
-            return None
-    elif isinstance(value, str):
-        text = value
-    else:
-        return None
-
-    try:
-        raw = base64.b64decode(text.encode("ascii"), validate=True)
-    except (binascii.Error, ValueError, UnicodeEncodeError):
-        return None
-    if not raw:
-        return None
-    return QtCore.QByteArray(raw)
+    return _qt_state.qt_bytearray_from_base64(value)
 
 
 def _qt_object_is_valid_fallback(arg__1: object) -> bool:
@@ -4287,15 +4270,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         data_name = self.tool_data.name
         if data_name is None:
             data_name = "<none-value>"
-        attrs = {
+        attrs: dict[str, typing.Any] = {
             "tool_state": self.tool_status.model_dump_json(),
             "tool_data_name": str(data_name),
             "tool_title": self.windowTitle(),
             "tool_cls_qualname": self._qual_name(),
             "tool_display_name": self._tool_display_name,
-            "tool_qt_geometry": _qt_bytearray_to_base64(self.saveGeometry()),
-            "tool_rect": self.geometry().getRect(),
-            "tool_visible": bool(self.isVisible()),
+            "tool_window_state": _qt_state.qt_window_state_json(self),
             "erlab_version": erlab.__version__,
         }
         if self._source_spec is not None:
@@ -4450,11 +4431,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 )
         tool._restore_persistence_payload(ds)
         tool.setWindowTitle(ds.attrs["tool_title"])
-        restored_geometry = False
-        geometry = _qt_bytearray_from_base64(ds.attrs.get("tool_qt_geometry"))
-        if geometry is not None:
-            restored_geometry = tool.restoreGeometry(geometry)
-        if not restored_geometry and "tool_rect" in ds.attrs:
+        if (
+            not _qt_state.restore_qt_window_state(
+                tool, ds.attrs.get("tool_window_state")
+            )
+            and "tool_rect" in ds.attrs
+        ):
             tool.setGeometry(*ds.attrs["tool_rect"])
         return tool
 

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -609,6 +609,7 @@ def test_select_loader_options_cancel_keeps_recent_filter(
 
     monkeypatch.setattr(manager_base, "_NameFilterDialog", _CancelNameFilterDialog)
     manager = types.SimpleNamespace(
+        _recent_loader_kwargs_by_filter={},
         _recent_loader_extensions_by_filter={"Example Raw Data (*.h5)": {}},
         _recent_name_filter="Previous",
     )
@@ -710,6 +711,7 @@ def test_open_multiple_files_preselects_default_loader_filter(
             return False
 
     manager = types.SimpleNamespace(
+        _recent_loader_kwargs_by_filter={},
         _recent_loader_extensions_by_filter={},
         _recent_name_filter=None,
         _add_from_multiple_files=lambda *_args, **_kwargs: None,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -22,6 +22,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive._qt_state as qt_state
 import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager as manager_module
 import erlab.interactive.imagetool.manager._desktop as manager_desktop
@@ -533,6 +534,24 @@ def test_qt_bytearray_base64_helpers_reject_invalid_values() -> None:
     assert erlab.interactive.utils._qt_bytearray_from_base64(b"\xff") is None
     assert erlab.interactive.utils._qt_bytearray_from_base64("%%not-base64%%") is None
     assert erlab.interactive.utils._qt_bytearray_from_base64("") is None
+
+
+def test_qt_window_state_helpers_parse_invalid_and_restore_rect(qtbot) -> None:
+    assert qt_state.QtWindowState.model_validate({"rect": None}).rect is None
+    with pytest.raises(pydantic.ValidationError):
+        qt_state.QtWindowState.model_validate({"rect": [1, 2, 3]})
+
+    assert qt_state.qt_bytearray_from_base64(object()) is None
+    assert qt_state.parse_qt_window_state(b"\xff") is None
+    assert qt_state.parse_qt_window_state("{") is None
+    assert qt_state.parse_qt_window_state({"rect": [1, 2, 3]}) is None
+
+    widget = QtWidgets.QWidget()
+    qtbot.addWidget(widget)
+    assert qt_state.restore_qt_window_state(
+        widget, {"geometry": "", "rect": [10, 20, 123, 45]}
+    )
+    assert widget.geometry().getRect() == (10, 20, 123, 45)
 
 
 def test_imagetool_dataset_uses_window_state_and_keeps_rect_fallback(
@@ -1276,6 +1295,89 @@ def test_manager_workspace_loader_state_does_not_create_explorer_app_state(
             explorer.loader_extensions_by_name()[loader_name]
             == explorer_extensions[loader_name]
         )
+
+
+def test_workspace_loader_and_standalone_app_state_edge_cases(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        controller = manager._workspace_controller
+
+        controller._restore_workspace_loader_state({"loader_state": []})
+        controller._restore_workspace_loader_state(
+            {"loader_state": {"manager_loader_kwargs_by_filter": []}}
+        )
+
+        loader_calls: list[
+            tuple[dict[str, dict[str, typing.Any]], dict[str, dict[str, typing.Any]]]
+        ] = []
+
+        class _LoaderStateExplorer(QtWidgets.QWidget):
+            def apply_loader_state(
+                self,
+                *,
+                kwargs_by_name: dict[str, dict[str, typing.Any]],
+                extensions_by_name: dict[str, dict[str, typing.Any]],
+            ) -> None:
+                loader_calls.append((kwargs_by_name, extensions_by_name))
+
+        explorer = _LoaderStateExplorer()
+        qtbot.addWidget(explorer)
+        manager._standalone_app_windows["explorer"] = explorer
+        controller._restore_workspace_loader_state(
+            {
+                "loader_state": {
+                    "explorer_loader_kwargs_by_name": {"example": {"single": True}},
+                    "explorer_loader_extensions_by_name": {
+                        "example": {"coordinate_attrs": ["sample"]}
+                    },
+                }
+            }
+        )
+        assert loader_calls == [
+            (
+                {"example": {"single": True}},
+                {"example": {"coordinate_attrs": ["sample"]}},
+            )
+        ]
+        manager._standalone_app_windows.pop("explorer")
+
+        assert controller._validated_standalone_app_state("missing", {}) is None
+        assert (
+            controller._validated_standalone_app_state("explorer", {"tabs": "bad"})
+            is None
+        )
+
+        manager._standalone_app_pending_states["ptable"] = {
+            "window_state": {"visible": False},
+            "selected_atomic_numbers": [1],
+        }
+        snapshot = controller._workspace_standalone_apps_snapshot()
+        assert snapshot["apps"]["ptable"]["selected_atomic_numbers"] == [1]
+
+        controller._restore_standalone_apps_state({"standalone_apps": []})
+        controller._restore_standalone_apps_state({"standalone_apps": {"apps": []}})
+        controller._restore_standalone_apps_state(
+            {"standalone_apps": {"apps": {"missing": {}}}}
+        )
+
+        manager.show_ptable()
+        ptable = manager.ptable_window
+        assert ptable.isVisible()
+        hidden_ptable_state = ptable.workspace_state_payload()
+        hidden_ptable_state["window_state"]["visible"] = False
+        controller._restore_standalone_apps_state(
+            {"standalone_apps": {"apps": {"ptable": hidden_ptable_state}}}
+        )
+        assert not ptable.isVisible()
+
+        widget = QtWidgets.QWidget()
+        qtbot.addWidget(widget)
+        manager._apply_standalone_app_state("missing", widget, {})
 
 
 def test_manager_workspace_import_does_not_restore_standalone_apps(

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -535,55 +535,69 @@ def test_qt_bytearray_base64_helpers_reject_invalid_values() -> None:
     assert erlab.interactive.utils._qt_bytearray_from_base64("") is None
 
 
-def test_imagetool_dataset_prefers_qt_geometry_and_keeps_rect_fallback(
+def test_imagetool_dataset_uses_window_state_and_keeps_rect_fallback(
     qtbot, test_data
 ) -> None:
     tool = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
     qtbot.addWidget(tool)
     tool.resize(533, 477)
     ds = tool.to_dataset()
-    assert ds.attrs["itool_qt_geometry"]
-
-    qt_geometry_ds = ds.copy(deep=False)
-    del qt_geometry_ds.attrs["itool_rect"]
-    restored = erlab.interactive.imagetool.ImageTool.from_dataset(
-        qt_geometry_ds, _in_manager=True
+    window_state = json.loads(ds.attrs["itool_window_state"])
+    assert window_state["geometry"]
+    assert tuple(window_state["rect"]) == tuple(
+        int(value) for value in tool.geometry().getRect()
     )
+    assert "itool_qt_geometry" not in ds.attrs
+    assert "itool_rect" not in ds.attrs
+
+    restored = erlab.interactive.imagetool.ImageTool.from_dataset(ds, _in_manager=True)
     qtbot.addWidget(restored)
     assert restored.size() == tool.size()
 
     legacy_ds = ds.copy(deep=False)
-    del legacy_ds.attrs["itool_qt_geometry"]
+    del legacy_ds.attrs["itool_window_state"]
+    legacy_ds.attrs["itool_rect"] = tuple(
+        int(value) for value in tool.geometry().getRect()
+    )
+    legacy_ds.attrs["itool_visible"] = True
     legacy = erlab.interactive.imagetool.ImageTool.from_dataset(
         legacy_ds, _in_manager=True
     )
     qtbot.addWidget(legacy)
     assert tuple(legacy.geometry().getRect()) == tuple(
-        int(value) for value in ds.attrs["itool_rect"]
+        int(value) for value in legacy_ds.attrs["itool_rect"]
     )
 
 
-def test_toolwindow_dataset_prefers_qt_geometry_and_keeps_rect_fallback(
+def test_toolwindow_dataset_uses_window_state_and_keeps_rect_fallback(
     qtbot, test_data
 ) -> None:
     tool = _AddedTimeChildTool(test_data)
     qtbot.addWidget(tool)
     tool.resize(421, 333)
     ds = tool.to_dataset()
-    assert ds.attrs["tool_qt_geometry"]
+    window_state = json.loads(ds.attrs["tool_window_state"])
+    assert window_state["geometry"]
+    assert tuple(window_state["rect"]) == tuple(
+        int(value) for value in tool.geometry().getRect()
+    )
+    assert "tool_qt_geometry" not in ds.attrs
+    assert "tool_rect" not in ds.attrs
 
-    qt_geometry_ds = ds.copy(deep=False)
-    del qt_geometry_ds.attrs["tool_rect"]
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(qt_geometry_ds)
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(ds)
     qtbot.addWidget(restored)
     assert restored.size() == tool.size()
 
     legacy_ds = ds.copy(deep=False)
-    del legacy_ds.attrs["tool_qt_geometry"]
+    del legacy_ds.attrs["tool_window_state"]
+    legacy_ds.attrs["tool_rect"] = tuple(
+        int(value) for value in tool.geometry().getRect()
+    )
+    legacy_ds.attrs["tool_visible"] = True
     legacy = erlab.interactive.utils.ToolWindow.from_dataset(legacy_ds)
     qtbot.addWidget(legacy)
     assert tuple(legacy.geometry().getRect()) == tuple(
-        int(value) for value in ds.attrs["tool_rect"]
+        int(value) for value in legacy_ds.attrs["tool_rect"]
     )
 
 
@@ -856,6 +870,9 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
         manager.main_splitter.setSizes([220, 420])
         manager.right_splitter.setSizes([300, 160])
         expected_layout = manager._workspace_layout_snapshot()
+        assert "window_state" in expected_layout
+        assert "geometry" not in expected_layout
+        assert expected_layout["window_state"]["geometry"]
         expected_size = manager.size()
         expected_main_sizes = manager.main_splitter.sizes()
         expected_right_sizes = manager.right_splitter.sizes()
@@ -942,6 +959,60 @@ def test_manager_workspace_layout_only_save_updates_root_manifest_only(
         assert manifest["manager_layout"] == manager._workspace_layout_snapshot()
 
 
+def test_manager_workspace_standalone_app_only_save_updates_root_manifest_only(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        root = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "standalone-only.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+        delta_save_count = manager._workspace_state.delta_save_count
+
+        manager.show_ptable()
+        ptable = manager.ptable_window
+        ptable.hv_edit.setText("150")
+        qtbot.wait_until(lambda: manager.is_workspace_modified, timeout=5000)
+        assert manager._workspace_state.layout_modified
+
+        def _forbid_node_serialization(*_args, **_kwargs):
+            raise AssertionError("standalone-only save serialized a node")
+
+        def _forbid_full_save(*_args, **_kwargs):
+            raise AssertionError(
+                "standalone-only save requested a full workspace write"
+            )
+
+        monkeypatch.setattr(
+            manager, "_serialize_workspace_node", _forbid_node_serialization
+        )
+        monkeypatch.setattr(
+            manager_workspace, "_write_full_workspace_tree_file", _forbid_full_save
+        )
+
+        assert manager.save()
+        assert manager._workspace_state.delta_save_count == delta_save_count
+        assert not manager.is_workspace_modified
+
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert "delta_save_count" not in manifest
+        assert manifest["standalone_apps"]["apps"]["ptable"]["photon_energy"] == "150"
+
+
 def test_manager_workspace_import_does_not_restore_manager_layout(
     qtbot,
     tmp_path: pathlib.Path,
@@ -987,6 +1058,278 @@ def test_manager_workspace_import_does_not_restore_manager_layout(
         assert manager._workspace_layout_snapshot() == current_layout
 
 
+def test_manager_workspace_roundtrip_restores_loader_and_standalone_apps(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    example_data_dir: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    loader_name = next(
+        name for name in erlab.io.loaders if erlab.io.loaders[name].file_dialog_methods
+    )
+    name_filter = next(iter(erlab.io.loaders[loader_name].file_dialog_methods))
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        root = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        manager.add_imagetool(root, show=False)
+
+        manager._recent_directory = str(example_data_dir)
+        manager._recent_name_filter = name_filter
+        manager._recent_loader_kwargs_by_filter[name_filter] = {"single": True}
+        manager._recent_loader_extensions_by_filter[name_filter] = {
+            "coordinate_attrs": ["manager"]
+        }
+
+        manager.show_explorer()
+        explorer = manager.explorer
+        explorer.resize(682, 444)
+        explorer.add_tab(root_path=example_data_dir, loader_name=loader_name)
+        qtbot.wait_until(lambda: explorer.tab_widget.count() == 2, timeout=5000)
+        explorer.tab_widget.setCurrentIndex(1)
+        explorer.current_explorer._preview_check.setChecked(True)
+        explorer.current_explorer._tree_view.sortByColumn(
+            0, QtCore.Qt.SortOrder.DescendingOrder
+        )
+        explorer.current_explorer._loader_kwargs_by_name[loader_name] = {
+            "single": False
+        }
+        explorer.current_explorer._loader_extensions_by_name[loader_name] = {
+            "coordinate_attrs": ["explorer"]
+        }
+        expected_explorer_size = explorer.size()
+        explorer.hide()
+        qtbot.wait_until(lambda: not explorer.isVisible(), timeout=5000)
+
+        manager.show_ptable()
+        ptable = manager.ptable_window
+        ptable.resize(825, 650)
+        ptable._set_selection_state(
+            [6, 8], current_atomic_number=8, anchor_atomic_number=6
+        )
+        ptable._plot_atomic_number = 6
+        ptable._plot_target_user_selected = True
+        ptable.hv_edit.setText("80")
+        ptable.workfunction_edit.setText("4.5")
+        ptable.max_harmonic_spin.setValue(3)
+        ptable.notation_combo.setCurrentIndex(ptable.notation_combo.findData("iupac"))
+        ptable._refresh_window_state(ensure_visible=False)
+
+        fname = tmp_path / "loader-standalone.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        expected_ptable_size = ptable.size()
+
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert manifest["loader_state"]["recent_directory"] == str(example_data_dir)
+        assert manifest["loader_state"]["recent_name_filter"] == name_filter
+        assert manifest["loader_state"]["manager_loader_kwargs_by_filter"][
+            name_filter
+        ] == {"single": True}
+        app_state = manifest["standalone_apps"]["apps"]
+        assert not app_state["explorer"]["window_state"]["visible"]
+        assert app_state["explorer"]["active_tab"] == 1
+        assert app_state["explorer"]["loader_kwargs_by_name"][loader_name] == {
+            "single": False
+        }
+        assert app_state["ptable"]["window_state"]["visible"]
+        assert app_state["ptable"]["window_state"]["rect"][2:] == [
+            expected_ptable_size.width(),
+            expected_ptable_size.height(),
+        ]
+        assert app_state["ptable"]["selected_atomic_numbers"] == [6, 8]
+
+        manager._close_standalone_app("explorer")
+        manager._close_standalone_app("ptable")
+        manager._recent_directory = None
+        manager._recent_name_filter = None
+        manager._recent_loader_kwargs_by_filter.clear()
+        manager._recent_loader_extensions_by_filter.clear()
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+
+        assert manager._recent_directory == str(example_data_dir)
+        assert manager._recent_name_filter == name_filter
+        assert manager._recent_loader_kwargs_by_filter[name_filter] == {"single": True}
+        assert manager._recent_loader_extensions_by_filter[name_filter] == {
+            "coordinate_attrs": ["manager"]
+        }
+
+        assert "explorer" not in manager._standalone_app_windows
+        assert manager._standalone_app_pending_states["explorer"]["active_tab"] == 1
+        restored_ptable = manager.ptable_window
+        assert restored_ptable.isVisible()
+        assert restored_ptable.size().width() >= expected_ptable_size.width()
+        assert restored_ptable.size().height() == expected_ptable_size.height()
+        assert restored_ptable.selected_atomic_numbers == (6, 8)
+        assert restored_ptable._plot_atomic_number == 6
+        assert restored_ptable.hv_edit.text() == "80"
+        assert restored_ptable.workfunction_edit.text() == "4.5"
+        assert restored_ptable.max_harmonic == 3
+        assert restored_ptable.current_notation == "iupac"
+
+        manager.show_explorer()
+        restored_explorer = manager.explorer
+        qtbot.wait_until(restored_explorer.isVisible, timeout=5000)
+        assert restored_explorer.size() == expected_explorer_size
+        assert restored_explorer.tab_widget.count() == 2
+        assert restored_explorer.tab_widget.currentIndex() == 1
+        restored_tab = restored_explorer.current_explorer
+        assert restored_tab is not None
+        assert restored_tab.current_directory == example_data_dir
+        assert restored_tab.loader_name == loader_name
+        assert restored_tab._preview_check.isChecked()
+        assert restored_tab._fs_model._sort_order == QtCore.Qt.SortOrder.DescendingOrder
+        assert restored_explorer.loader_kwargs_by_name()[loader_name] == {
+            "single": False
+        }
+        assert restored_explorer.loader_extensions_by_name()[loader_name] == {
+            "coordinate_attrs": ["explorer"]
+        }
+
+
+def test_manager_workspace_loader_state_does_not_create_explorer_app_state(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    example_data_dir: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    loader_name = next(
+        name for name in erlab.io.loaders if erlab.io.loaders[name].file_dialog_methods
+    )
+    name_filter = next(iter(erlab.io.loaders[loader_name].file_dialog_methods))
+    explorer_kwargs = {loader_name: {"single": False}}
+    explorer_extensions = {loader_name: {"coordinate_attrs": ["explorer"]}}
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        root = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        manager.add_imagetool(root, show=False)
+        manager._recent_directory = str(example_data_dir)
+        manager._recent_name_filter = name_filter
+        manager._recent_loader_kwargs_by_filter[name_filter] = {"single": True}
+        manager._workspace_controller._loader_state = (
+            manager_workspace.WorkspaceLoaderState(
+                explorer_loader_kwargs_by_name=explorer_kwargs,
+                explorer_loader_extensions_by_name=explorer_extensions,
+            )
+        )
+
+        fname = tmp_path / "loader-no-explorer.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert manifest["loader_state"]["explorer_loader_kwargs_by_name"] == (
+            explorer_kwargs
+        )
+        assert "explorer" not in manifest["standalone_apps"]["apps"]
+
+        manager._workspace_controller._loader_state = (
+            manager_workspace.WorkspaceLoaderState()
+        )
+        manager._recent_directory = None
+        manager._recent_name_filter = None
+        manager._recent_loader_kwargs_by_filter.clear()
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        assert "explorer" not in manager._standalone_app_pending_states
+
+        manager._mark_workspace_layout_dirty()
+        assert manager.save()
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert "explorer" not in manifest["standalone_apps"]["apps"]
+        assert manifest["loader_state"]["explorer_loader_kwargs_by_name"] == (
+            explorer_kwargs
+        )
+
+        manager.show_explorer()
+        explorer = manager.explorer
+        assert (
+            explorer.loader_kwargs_by_name()[loader_name]
+            == explorer_kwargs[loader_name]
+        )
+        assert (
+            explorer.loader_extensions_by_name()[loader_name]
+            == explorer_extensions[loader_name]
+        )
+
+
+def test_manager_workspace_import_does_not_restore_standalone_apps(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        root = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        manager.add_imagetool(root, show=False)
+        manager.show_ptable()
+        ptable = manager.ptable_window
+        ptable.hv_edit.setText("120")
+        ptable._set_selection_state(
+            [8], current_atomic_number=8, anchor_atomic_number=8
+        )
+        ptable._refresh_window_state(ensure_visible=False)
+
+        fname = tmp_path / "import-standalone.itws"
+        manager._save_workspace_document(fname, force_full=True)
+
+        ptable.hv_edit.setText("30")
+        ptable._set_selection_state(
+            [1], current_atomic_number=1, anchor_atomic_number=1
+        )
+        ptable._refresh_window_state(ensure_visible=False)
+
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert manager._from_h5py_workspace_file(
+            fname, manifest, replace=False, mark_dirty=True
+        )
+        assert ptable.hv_edit.text() == "30"
+        assert ptable.selected_atomic_numbers == (1,)
+
+        tree = manager_xarray.open_workspace_datatree(fname, chunks=None)
+        assert manager._from_datatree(
+            tree,
+            replace=False,
+            mark_dirty=True,
+            select=False,
+            workspace_file_path=fname,
+        )
+        assert ptable.hv_edit.text() == "30"
+        assert ptable.selected_atomic_numbers == (1,)
+
+
 def test_manager_workspace_restore_layout_ignores_missing_or_invalid_values(
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -1001,7 +1344,7 @@ def test_manager_workspace_restore_layout_ignores_missing_or_invalid_values(
         manager._restore_workspace_layout(
             {
                 "manager_layout": {
-                    "geometry": "",
+                    "window_state": {"geometry": ""},
                     "main_splitter": "",
                     "right_splitter": "",
                 }
@@ -7276,9 +7619,8 @@ def test_manager_workspace_delta_save_persists_geometry_changes(
 
         assert manager.save()
         with h5py.File(fname, "r") as h5_file:
-            saved_rect = tuple(
-                int(value) for value in h5_file["0/imagetool"].attrs["itool_rect"]
-            )
+            saved_state = json.loads(h5_file["0/imagetool"].attrs["itool_window_state"])
+            saved_rect = tuple(int(value) for value in saved_state["rect"])
         assert saved_rect == expected_rect
 
 

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -5,8 +5,15 @@ from collections.abc import Callable
 from qtpy import QtCore, QtGui
 
 import erlab
-from erlab.interactive.explorer._base_explorer import _DataExplorer, _ReprFetcher
-from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
+from erlab.interactive.explorer._base_explorer import (
+    DataExplorerTabState,
+    _DataExplorer,
+    _ReprFetcher,
+)
+from erlab.interactive.explorer._tabbed_explorer import (
+    DataExplorerState,
+    _TabbedExplorer,
+)
 from erlab.interactive.imagetool.manager import _dialogs
 
 
@@ -237,6 +244,50 @@ def test_explorer_loader_extensions_apply_only_to_manager_loads(
     worker = _ReprFetcher(file_path, _preview_loader, include_values=False)
     worker.run()
     assert preview_calls == [{"single": True, "load_kwargs": {"without_values": True}}]
+
+
+def test_explorer_workspace_state_restores_selection(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    qtbot.wait_until(lambda: explorer._tree_view.model().rowCount() > 0)
+
+    assert (
+        DataExplorerTabState.model_validate(
+            {
+                "root_path": str(example_data_dir),
+                "selected_paths": None,
+                "splitter_sizes": None,
+                "preview_splitter_sizes": None,
+            }
+        ).selected_paths
+        == ()
+    )
+    assert DataExplorerState.model_validate({"tabs": None}).tabs == ()
+
+    explorer._tree_view.selectionModel().selectionChanged.disconnect(
+        explorer._on_selection_changed
+    )
+    file_paths = (
+        example_data_dir / "data_002.h5",
+        example_data_dir / "data_003.h5",
+    )
+    missing_path = example_data_dir / "missing.h5"
+    explorer.restore_workspace_state(
+        DataExplorerTabState(
+            root_path=str(example_data_dir),
+            loader_name="example",
+            selected_paths=(*map(str, file_paths), str(missing_path)),
+        )
+    )
+
+    qtbot.wait_until(lambda: set(file_paths).issubset(explorer._current_selection))
+    assert set(file_paths).issubset(explorer._current_selection)
+    assert missing_path not in explorer._current_selection
+    assert not explorer._model_index_for_path(missing_path).isValid()
 
 
 def test_explorer_loader_options_dialog_updates_kwargs(

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from dataclasses import replace
 
 import numpy as np
+import pydantic
 import pyqtgraph as pg
 import pytest
 import xarray as xr
@@ -30,12 +31,33 @@ from erlab.interactive.ptable._shared import (
     _effective_point_size,
     _format_mass,
 )
+from erlab.interactive.ptable._window import PeriodicTableState
 
 
 def _show_window(qtbot, win: PeriodicTableWindow) -> None:
     qtbot.addWidget(win)
     with qtbot.waitExposed(win):
         win.show()
+
+
+def test_ptable_workspace_state_validators() -> None:
+    state = PeriodicTableState.model_validate(
+        {
+            "selected_atomic_numbers": None,
+            "photon_energy": None,
+            "work_function": 4.5,
+        }
+    )
+    assert state.selected_atomic_numbers == ()
+    assert state.photon_energy == ""
+    assert state.work_function == "4.5"
+
+    with pytest.raises(pydantic.ValidationError):
+        PeriodicTableState.model_validate({"photon_energy": object()})
+
+    assert PeriodicTableWindow._atomic_number_from_state(True) is None
+    assert PeriodicTableWindow._atomic_number_from_state("not an element") is None
+    assert PeriodicTableWindow._atomic_number_from_state(119) is None
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Persist ImageTool workspace loader defaults and standalone app state in separate root-manifest payloads. Add a shared Qt window-state schema for ImageTool, ToolWindow, manager layout, Data Explorer, and Periodic Table geometry/visibility.

Data Explorer workspaces now restore tabs, active tab, loader options, preview/sort/selection state, and splitters. Periodic Table workspaces now restore selection, plotted element, energy/work-function inputs, harmonics, notation, visibility, and geometry. Workspace imports continue to ignore standalone app state.

## Validation

- `git diff --cached --check`
- `uv run ruff check src/erlab/interactive/_qt_state.py src/erlab/interactive/explorer/_base_explorer.py src/erlab/interactive/explorer/_tabbed_explorer.py src/erlab/interactive/imagetool/_mainwindow.py src/erlab/interactive/imagetool/manager/_base.py src/erlab/interactive/imagetool/manager/_mainwindow.py src/erlab/interactive/imagetool/manager/_workspace.py src/erlab/interactive/imagetool/manager/_workspace_io.py src/erlab/interactive/ptable/_window.py src/erlab/interactive/utils.py tests/interactive/imagetool/manager/test_workspace.py`
- `uv run ruff format --check src/erlab/interactive/_qt_state.py src/erlab/interactive/explorer/_base_explorer.py src/erlab/interactive/explorer/_tabbed_explorer.py src/erlab/interactive/imagetool/_mainwindow.py src/erlab/interactive/imagetool/manager/_base.py src/erlab/interactive/imagetool/manager/_mainwindow.py src/erlab/interactive/imagetool/manager/_workspace.py src/erlab/interactive/imagetool/manager/_workspace_io.py src/erlab/interactive/ptable/_window.py src/erlab/interactive/utils.py tests/interactive/imagetool/manager/test_workspace.py`
- `uv run mypy src`
- `uv run pytest tests/interactive/imagetool/manager/test_workspace.py tests/interactive/test_explorer.py tests/interactive/test_ptable.py`