### PR TITLE
Add batch ImageTool operations to the manager

### DIFF
--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -1101,6 +1101,7 @@ class ToolProvenanceOperation(pydantic.BaseModel):
     """
 
     live_applicable: typing.ClassVar[bool] = True
+    batch_available: typing.ClassVar[bool] = False
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = ()
 
     model_config = pydantic.ConfigDict(

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -51,6 +51,7 @@ if typing.TYPE_CHECKING:
 
     import xarray as xr
 
+    from erlab.interactive.imagetool.manager import ImageToolManager
     from erlab.interactive.imagetool.plot_items import ItoolPolyLineROI
     from erlab.interactive.imagetool.slicer import ArraySlicer
     from erlab.interactive.imagetool.viewer import ImageSlicerArea
@@ -78,14 +79,27 @@ class _DataManipulationDialog(QtWidgets.QDialog):
     overridden to provide the code to be copied.
     """
 
+    operation_types: typing.ClassVar[
+        tuple[type[provenance.ToolProvenanceOperation], ...]
+    ] = ()
+    """Operation classes this dialog can emit directly."""
+
     _sigCodeCopied = QtCore.Signal(str)
 
-    def __init__(self, slicer_area: ImageSlicerArea) -> None:
+    def __init__(
+        self,
+        slicer_area: ImageSlicerArea,
+        *,
+        batch_manager: ImageToolManager | None = None,
+    ) -> None:
         super().__init__(slicer_area)
         if self.title is not None:
             self.setWindowTitle(self.title)
 
         self.slicer_area = slicer_area
+        self._batch_manager = (
+            None if batch_manager is None else weakref.ref(batch_manager)
+        )
 
         self._layout = QtWidgets.QFormLayout()
         self.setLayout(self._layout)
@@ -131,6 +145,16 @@ class _DataManipulationDialog(QtWidgets.QDialog):
     @property
     def array_slicer(self) -> ArraySlicer:
         return self.slicer_area.array_slicer
+
+    @property
+    def batch_manager(self) -> ImageToolManager | None:
+        if self._batch_manager is None:
+            return None
+        return self._batch_manager()
+
+    @property
+    def is_batch_mode(self) -> bool:
+        return self.batch_manager is not None
 
     @QtCore.Slot()
     def _copy(self) -> None:
@@ -241,8 +265,31 @@ class DataTransformDialog(_DataManipulationDialog):
         ),
     )
 
-    def __init__(self, slicer_area: ImageSlicerArea) -> None:
-        super().__init__(slicer_area)
+    _BATCH_LAUNCH_MODES: typing.ClassVar[tuple[tuple[str, str, str], ...]] = (
+        (
+            "replace",
+            "Replace Selected",
+            "Replace the data in each selected ImageTool.",
+        ),
+        (
+            "nest",
+            "Open Child Window Under Each",
+            "Create one child ImageTool under each selected ImageTool.",
+        ),
+        (
+            "detach",
+            "Open Top-Level Copies",
+            "Create one detached top-level ImageTool for each selected ImageTool.",
+        ),
+    )
+
+    def __init__(
+        self,
+        slicer_area: ImageSlicerArea,
+        *,
+        batch_manager: ImageToolManager | None = None,
+    ) -> None:
+        super().__init__(slicer_area, batch_manager=batch_manager)
         self.launch_mode_combo = QtWidgets.QComboBox()
         for value, label, tooltip in self._available_launch_modes():
             self.launch_mode_combo.addItem(label, userData=value)
@@ -269,11 +316,15 @@ class DataTransformDialog(_DataManipulationDialog):
         )
 
     def _available_launch_modes(self) -> tuple[tuple[str, str, str], ...]:
+        if self.is_batch_mode:
+            return self._BATCH_LAUNCH_MODES
         if self._manager_target()[1] is not None:
             return self._LAUNCH_MODES
         return tuple(mode for mode in self._LAUNCH_MODES if mode[0] != "nest")
 
     def _default_launch_mode(self) -> typing.Literal["replace", "detach", "nest"]:
+        if self.is_batch_mode:
+            return "replace"
         if any(mode[0] == "nest" for mode in self._available_launch_modes()):
             return "replace"
         return "detach"
@@ -303,7 +354,11 @@ class DataTransformDialog(_DataManipulationDialog):
     ) -> provenance.ToolProvenanceOperation | None:
         return None
 
-    def source_spec(self, new_name: str | None = None) -> provenance.ToolProvenanceSpec:
+    def source_spec_for_data(
+        self,
+        data: xr.DataArray,
+        new_name: str | None = None,
+    ) -> provenance.ToolProvenanceSpec:
         del new_name
         operations = self.source_operations()
         builder = (
@@ -312,12 +367,14 @@ class DataTransformDialog(_DataManipulationDialog):
             else provenance.full_data
         )
         if not self.apply_on_nonuniform_data and any(
-            str(dim).endswith("_idx")
-            and str(dim).removesuffix("_idx") in self.slicer_area.data.coords
-            for dim in self.slicer_area.data.dims
+            str(dim).endswith("_idx") and str(dim).removesuffix("_idx") in data.coords
+            for dim in data.dims
         ):
             operations.append(provenance.RestoreNonuniformDimsOperation())
         return builder(*operations)
+
+    def source_spec(self, new_name: str | None = None) -> provenance.ToolProvenanceSpec:
+        return self.source_spec_for_data(self.slicer_area.data, new_name)
 
     def _detached_provenance_spec(
         self,
@@ -420,14 +477,20 @@ class DataTransformDialog(_DataManipulationDialog):
         except Exception:
             return ""
 
-    def _itool_kwargs(self, processed) -> dict[str, typing.Any]:
+    def _itool_kwargs(
+        self,
+        processed,
+        slicer_area: ImageSlicerArea | None = None,
+    ) -> dict[str, typing.Any]:
         itool_kw: dict[str, typing.Any] = {
             "data": processed,
             "execute": False,
         }
 
         if self.keep_colors:
-            color_props: ColorMapState = self.slicer_area.colormap_properties
+            if slicer_area is None:
+                slicer_area = self.slicer_area
+            color_props: ColorMapState = slicer_area.colormap_properties
 
             itool_kw["cmap"] = color_props["cmap"]
             itool_kw["gamma"] = color_props["gamma"]
@@ -461,6 +524,19 @@ class DataTransformDialog(_DataManipulationDialog):
 
     @QtCore.Slot()
     def accept(self) -> None:
+        manager = self.batch_manager
+        if manager is not None:
+            try:
+                if not manager.apply_batch_transform_dialog(self, self.launch_mode):
+                    return
+            except Exception:
+                erlab.interactive.utils.MessageDialog.critical(
+                    self, "Error", "An error occurred while processing data."
+                )
+                return
+            super().accept()
+            return
+
         input_name = self.slicer_area.data.name
         new_name = ""
         if input_name is not None:
@@ -581,15 +657,20 @@ class DataFilterDialog(_DataManipulationDialog):
     enable_preview: bool = True
     """Whether to show a preview button."""
 
-    def __init__(self, slicer_area: ImageSlicerArea) -> None:
-        super().__init__(slicer_area)
+    def __init__(
+        self,
+        slicer_area: ImageSlicerArea,
+        *,
+        batch_manager: ImageToolManager | None = None,
+    ) -> None:
+        super().__init__(slicer_area, batch_manager=batch_manager)
         self._previewed: bool = False
         self._starting_applied_func = self.slicer_area._applied_func
         self._starting_filter_operation = (
             self.slicer_area._accepted_filter_provenance_operation
         )
 
-        if self.enable_preview:
+        if self.enable_preview and not self.is_batch_mode:
             self.preview_button = QtWidgets.QPushButton("Preview")
             self.preview_button.clicked.connect(self._preview)
             self.buttonBox.addButton(
@@ -665,6 +746,19 @@ class DataFilterDialog(_DataManipulationDialog):
 
     @QtCore.Slot()
     def accept(self) -> None:
+        manager = self.batch_manager
+        if manager is not None:
+            try:
+                if not manager.apply_batch_filter_dialog(self):
+                    return
+            except Exception:
+                erlab.interactive.utils.MessageDialog.critical(
+                    self, "Error", "An error occurred while processing data."
+                )
+                return
+            super().accept()
+            return
+
         try:
             operation = self.filter_operation()
             emit_edited = (
@@ -707,6 +801,7 @@ class DataFilterDialog(_DataManipulationDialog):
 
 class RotationDialog(DataTransformDialog):
     enable_copy = True
+    operation_types = (provenance.RotateOperation,)
 
     @property
     def _rotate_params(self) -> dict[str, typing.Any]:
@@ -775,6 +870,7 @@ class RotationDialog(DataTransformDialog):
 class AggregateDialog(DataTransformDialog):
     title = "Aggregate Over Dimensions"
     enable_copy = True
+    operation_types = (provenance.QSelAggregationOperation,)
 
     _REDUCERS: typing.ClassVar[dict[str, str]] = {
         "mean": "Mean",
@@ -1062,6 +1158,11 @@ class SelectionDialog(DataTransformDialog):
     title = "Select Data"
     enable_copy = True
     apply_on_nonuniform_data = True
+    operation_types = (
+        provenance.IselOperation,
+        provenance.SelOperation,
+        provenance.QSelOperation,
+    )
 
     def setup_widgets(self) -> None:
         self.public_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -1228,6 +1329,7 @@ class InterpolationDialog(DataTransformDialog):
     title = "Interpolate"
     enable_copy = True
     apply_on_nonuniform_data = True
+    operation_types = (provenance.InterpolationOperation,)
 
     def setup_widgets(self) -> None:
         self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -1363,6 +1465,7 @@ class LeadingEdgeDialog(DataTransformDialog):
     title = "Leading Edge"
     enable_copy = True
     apply_on_nonuniform_data = True
+    operation_types = (provenance.LeadingEdgeOperation,)
 
     def setup_widgets(self) -> None:
         self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -1460,6 +1563,7 @@ class CoarsenDialog(DataTransformDialog):
     title = "Coarsen"
     enable_copy = True
     apply_on_nonuniform_data = True
+    operation_types = (provenance.CoarsenOperation,)
 
     _REDUCERS: tuple[str, ...] = (
         "all",
@@ -1609,6 +1713,7 @@ class ThinDialog(DataTransformDialog):
     title = "Thin Data"
     enable_copy = True
     apply_on_nonuniform_data = True
+    operation_types = (provenance.ThinOperation,)
 
     def setup_widgets(self) -> None:
         self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -1739,6 +1844,7 @@ class ThinDialog(DataTransformDialog):
 class SymmetrizeDialog(DataTransformDialog):
     title = "Symmetrize"
     enable_copy = True
+    operation_types = (provenance.SymmetrizeOperation,)
 
     def setup_widgets(self) -> None:
         dim_group = QtWidgets.QGroupBox("Mirror plane")
@@ -1832,6 +1938,7 @@ class SymmetrizeDialog(DataTransformDialog):
 class SymmetrizeNfoldDialog(DataTransformDialog):
     title = "Rotational Symmetrize"
     enable_copy = True
+    operation_types = (provenance.SymmetrizeNfoldOperation,)
 
     @property
     def _params(self) -> dict[str, typing.Any]:
@@ -1945,6 +2052,7 @@ class EdgeCorrectionDialog(DataTransformDialog):
 
 class _BaseCropDialog(DataTransformDialog):
     enable_copy = True
+    operation_types = (provenance.SelOperation, provenance.IselOperation)
 
     @property
     def _slice_kwargs(self) -> dict[Hashable, slice]:
@@ -2127,6 +2235,7 @@ class CropDialog(_BaseCropDialog):
 class NormalizeDialog(DataFilterDialog):
     title = "Normalize"
     enable_copy = True
+    operation_types = (provenance.NormalizeOperation,)
     denominator_rtol: float = 1e-12
     _MODES: typing.ClassVar[
         tuple[typing.Literal["area", "minmax", "min", "min_area"], ...]
@@ -2210,6 +2319,7 @@ class DivideByCoordDialog(DataTransformDialog):
     title = "Divide by Coordinate"
     enable_copy = True
     apply_on_nonuniform_data = True
+    operation_types = (provenance.DivideByCoordOperation,)
 
     def setup_widgets(self) -> None:
         self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -2299,6 +2409,7 @@ class DivideByCoordDialog(DataTransformDialog):
 class GaussianFilterDialog(DataFilterDialog):
     title = "Gaussian Filter"
     enable_copy = True
+    operation_types = (provenance.GaussianFilterOperation,)
 
     def setup_widgets(self) -> None:
         self._source_data = self.slicer_area._data
@@ -2503,6 +2614,7 @@ class SwapDimsDialog(DataTransformDialog):
     title = "Swap Dimensions"
     enable_copy = True
     apply_on_nonuniform_data = True
+    operation_types = (provenance.SwapDimsOperation,)
 
     def setup_widgets(self) -> None:
         self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -2608,6 +2720,7 @@ class RenameDimsCoordsDialog(DataTransformDialog):
     title = "Rename Coordinates and Dimensions"
     enable_copy = True
     apply_on_nonuniform_data = True
+    operation_types = (provenance.RenameDimsCoordsOperation,)
 
     def setup_widgets(self) -> None:
         self._source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
@@ -2737,6 +2850,12 @@ class RenameDimsCoordsDialog(DataTransformDialog):
 
 class AssignCoordsDialog(DataTransformDialog):
     title = "Coordinate Editor"
+    operation_types = (
+        provenance.AffineCoordOperation,
+        provenance.AssignCoordsOperation,
+        provenance.AssignScalarCoordOperation,
+        provenance.AssignCoord1DOperation,
+    )
 
     def setup_widgets(self) -> None:
         self._mode_tabs = QtWidgets.QTabWidget(self)
@@ -3016,6 +3135,7 @@ def _attr_values_equal(left: typing.Any, right: typing.Any) -> bool:
 
 class AssignAttrsDialog(DataTransformDialog):
     title = "Attribute Editor"
+    operation_types = (provenance.AssignAttrsOperation,)
 
     def setup_widgets(self) -> None:
         self._original_attrs = dict(self.slicer_area.data.attrs)

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -16,6 +16,7 @@ from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool.manager import _workspace as _manager_workspace
 from erlab.interactive.imagetool.manager import _xarray as _manager_xarray
 from erlab.interactive.imagetool.manager._dialogs import (
+    _BatchOperationDialog,
     _ConcatDialog,
     _is_loader_func,
     _RenameDialog,
@@ -33,12 +34,13 @@ from erlab.interactive.imagetool.manager._wrapper import (
 
 if typing.TYPE_CHECKING:
     import datetime
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
 
     import xarray as xr
 
     from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
     from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
+    from erlab.interactive.imagetool.viewer import ImageSlicerArea
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +50,7 @@ class _ActionsController:
         self._manager = manager
         self.__rename_dialog: _RenameDialog | None = None
         self.__concat_dialog: _ConcatDialog | None = None
+        self.__batch_dialog: _BatchOperationDialog | None = None
 
     @property
     def _rename_dialog(self) -> _RenameDialog:
@@ -243,6 +246,331 @@ class _ActionsController:
         """Concatenate the selected data using :func:`xarray.concat`."""
         dlg = self._concat_dialog
         dlg.open()
+
+    @property
+    def _batch_dialog(self) -> _BatchOperationDialog:
+        if self.__batch_dialog is None:
+            self.__batch_dialog = _BatchOperationDialog(self._manager)
+        return self.__batch_dialog
+
+    def batch_target_count(self) -> int:
+        return sum(
+            1
+            for node in self._manager._tool_graph.nodes.values()
+            if node.is_imagetool and node.imagetool is not None
+        )
+
+    def show_batch_operations(self) -> None:
+        if self._manager.batch_target_count() < 2:
+            return
+        dialog = self._batch_dialog
+        dialog.open()
+        dialog.raise_()
+        dialog.activateWindow()
+
+    def _selected_batch_targets(self) -> list[int | str]:
+        targets = list(self._manager._selected_imagetool_targets())
+        if len(targets) < 2:
+            raise ValueError("Select at least two ImageTool targets.")
+        for target in targets:
+            if not self._manager._is_imagetool_target(target):
+                raise TypeError(f"Target {target!r} is not an ImageTool.")
+        return targets
+
+    def _target_display_text(self, target: int | str) -> str:
+        return self._manager._node_for_target(target).display_text
+
+    def _validate_batch_operations(
+        self,
+        dialog: typing.Any,
+        operations: Iterable[provenance.ToolProvenanceOperation],
+        *,
+        extra_types: tuple[type[provenance.ToolProvenanceOperation], ...] = (),
+    ) -> None:
+        declared_types = tuple(dialog.operation_types)
+        accepted_types = declared_types + extra_types
+        for operation in operations:
+            if accepted_types and not isinstance(operation, accepted_types):
+                raise TypeError(
+                    f"{type(dialog).__name__} produced unsupported batch operation "
+                    f"{type(operation).__name__}."
+                )
+            if not type(operation).batch_available:
+                raise TypeError(
+                    f"{type(operation).__name__} is not available for batch use."
+                )
+
+    def _validate_batch_target_operations(
+        self,
+        operations: Iterable[provenance.ToolProvenanceOperation],
+        data: xr.DataArray,
+    ) -> None:
+        for operation in operations:
+            if not isinstance(
+                operation,
+                (
+                    provenance.AssignScalarCoordOperation,
+                    provenance.AssignCoord1DOperation,
+                ),
+            ):
+                continue
+            if operation.coord_name in data.dims or operation.coord_name in data.coords:
+                raise ValueError(
+                    f"Coordinate or dimension {operation.coord_name!r} already exists."
+                )
+
+    def _show_batch_error(
+        self,
+        text: str,
+        *,
+        target: int | str | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        details = ""
+        if target is not None:
+            details = f"Target: {self._target_display_text(target)}"
+        if error is not None:
+            details = "\n".join(part for part in (details, str(error)) if part)
+        traceback_text = traceback.format_exc()
+        detailed_text = (
+            ""
+            if traceback_text == "NoneType: None\n"
+            else erlab.interactive.utils._format_traceback(traceback_text)
+        )
+        erlab.interactive.utils.MessageDialog.critical(
+            self._manager,
+            "Error",
+            text,
+            informative_text=details,
+            detailed_text=detailed_text,
+        )
+
+    def apply_batch_transform_dialog(
+        self,
+        dialog: typing.Any,
+        launch_mode: typing.Literal["replace", "detach", "nest"],
+    ) -> bool:
+        try:
+            targets = self._selected_batch_targets()
+            operations = dialog.source_operations()
+        except Exception as exc:
+            self._show_batch_error("Batch operation could not be started.", error=exc)
+            return False
+        if not operations:
+            self._show_batch_error(
+                "Batch operation could not be started.",
+                error=ValueError("The dialog did not produce an operation."),
+            )
+            return False
+        try:
+            self._validate_batch_operations(dialog, operations)
+        except Exception as exc:
+            self._show_batch_error("Batch operation could not be started.", error=exc)
+            return False
+
+        plan: list[tuple[typing.Any, ...]] = []
+        for target in targets:
+            try:
+                node = self._manager._node_for_target(target)
+                slicer_area = self._manager.get_imagetool(target).slicer_area
+                input_name = slicer_area.data.name
+                new_name = "" if input_name is None else str(input_name)
+                source_spec = dialog.source_spec_for_data(slicer_area.data, new_name)
+                self._validate_batch_operations(
+                    dialog,
+                    source_spec.operations,
+                    extra_types=(provenance.RestoreNonuniformDimsOperation,),
+                )
+                source_data = slicer_area.data
+                if source_spec.kind == "public_data":
+                    source_data = (
+                        erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+                            source_data
+                        )
+                    )
+                self._validate_batch_target_operations(
+                    source_spec.operations,
+                    source_data,
+                )
+                processed = source_spec.apply(slicer_area.data).rename(input_name)
+                erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
+                    processed,
+                    copy_values=False,
+                )
+
+                parent_provenance = node.displayed_provenance_spec
+                if parent_provenance is None:
+                    parent_provenance = slicer_area.displayed_provenance_spec()
+                nested_provenance = provenance.compose_full_provenance(
+                    parent_provenance,
+                    source_spec,
+                )
+                detached_provenance = dialog._detached_provenance_spec(
+                    parent_provenance,
+                    source_spec,
+                    new_name,
+                )
+
+                replace_kind = ""
+                replace_provenance = None
+                if launch_mode == "replace":
+                    displayed_source = node.displayed_source_spec
+                    if displayed_source is not None:
+                        replace_kind = "source"
+                        replace_provenance = dialog._compose_transform_provenance(
+                            displayed_source,
+                            source_spec,
+                            new_name,
+                        )
+                    elif node.displayed_provenance_spec is not None:
+                        replace_kind = "detached"
+                        replace_provenance = dialog._compose_transform_provenance(
+                            node.displayed_provenance_spec,
+                            source_spec,
+                            new_name,
+                        )
+                    else:
+                        replace_kind = "detached"
+                        replace_provenance = detached_provenance
+
+                plan.append(
+                    (
+                        target,
+                        node,
+                        slicer_area,
+                        processed,
+                        source_spec,
+                        nested_provenance,
+                        detached_provenance,
+                        replace_kind,
+                        replace_provenance,
+                    )
+                )
+            except Exception as exc:
+                self._show_batch_error(
+                    "Batch operation failed before changing data.",
+                    target=target,
+                    error=exc,
+                )
+                return False
+
+        try:
+            for (
+                target,
+                node,
+                slicer_area,
+                processed,
+                source_spec,
+                nested_provenance,
+                detached_provenance,
+                replace_kind,
+                replace_provenance,
+            ) in plan:
+                if launch_mode == "replace":
+                    if replace_provenance is not None:
+                        if replace_kind == "source":
+                            node.set_source_binding(
+                                replace_provenance,
+                                auto_update=node.source_auto_update,
+                                state=node.source_state,
+                            )
+                        else:
+                            node.set_detached_provenance(replace_provenance)
+                    slicer_area.replace_source_data(processed, emit_edited=True)
+                    continue
+
+                itool_kw = dialog._itool_kwargs(processed, slicer_area)
+                tool = typing.cast(
+                    "ImageTool | None",
+                    erlab.interactive.itool(manager=False, **itool_kw),
+                )
+                if tool is None:
+                    self._show_batch_error(
+                        "An error occurred while applying batch data.",
+                        error=RuntimeError("Could not create the ImageTool window."),
+                    )
+                    return False
+
+                if launch_mode == "nest":
+                    tool.set_provenance_spec(nested_provenance)
+                    self._manager.add_imagetool_child(
+                        tool,
+                        target,
+                        source_spec=source_spec,
+                    )
+                else:
+                    tool.set_provenance_spec(detached_provenance)
+                    self._manager.add_imagetool(
+                        tool,
+                        activate=True,
+                        provenance_spec=detached_provenance,
+                    )
+            if launch_mode == "replace":
+                self._manager._sigDataReplaced.emit()
+        except Exception as exc:
+            self._show_batch_error(
+                "An error occurred while applying batch data.",
+                error=exc,
+            )
+            return False
+        return True
+
+    def apply_batch_filter_dialog(self, dialog: typing.Any) -> bool:
+        try:
+            targets = self._selected_batch_targets()
+            operation = dialog.filter_operation()
+            if operation is not None:
+                self._validate_batch_operations(dialog, (operation,))
+        except Exception as exc:
+            self._show_batch_error("Batch filter could not be started.", error=exc)
+            return False
+
+        for target in targets:
+            try:
+                slicer_area = self._manager.get_imagetool(target).slicer_area
+                if operation is not None:
+                    slicer_area._filter_operation_result_for_data(
+                        slicer_area._data,
+                        operation,
+                        tuple(slicer_area.data.dims),
+                    )
+            except Exception as exc:
+                self._show_batch_error(
+                    "Batch filter failed before changing data.",
+                    target=target,
+                    error=exc,
+                )
+                return False
+
+        try:
+            for target in targets:
+                slicer_area = self._manager.get_imagetool(target).slicer_area
+                emit_edited = (
+                    operation is not None
+                    or slicer_area._accepted_filter_provenance_operation is not None
+                    or slicer_area._applied_func is not None
+                    or slicer_area.has_active_filter
+                )
+
+                def _apply_filter(
+                    *,
+                    area: ImageSlicerArea = slicer_area,
+                    op: provenance.ToolProvenanceOperation | None = operation,
+                    edited: bool = emit_edited,
+                ) -> None:
+                    area.apply_filter_operation(op, emit_edited=edited)
+
+                slicer_area.record_history_mutation(
+                    None,
+                    _apply_filter,
+                )
+        except Exception as exc:
+            self._show_batch_error(
+                "An error occurred while applying batch filter.",
+                error=exc,
+            )
+            return False
+        return True
 
     def store_selected(self) -> None:
         self._manager.ensure_console_initialized()
@@ -1049,6 +1377,7 @@ class _ActionsController:
             )
         self._manager.tree_view.childtool_added(node.uid, parent)
         self._manager._mark_node_added(node.uid)
+        self._manager._update_actions()
         if show:
             node.show()
         if activate and node.window is not None:
@@ -1166,6 +1495,7 @@ class _ActionsController:
         self._manager._mark_removed_subtree_dirty(uid)
         self._manager.tree_view.childtool_removed(uid)
         self._manager._remove_uid_target(uid)
+        self._manager._update_actions()
 
     def eventFilter(
         self, obj: QtCore.QObject | None = None, event: QtCore.QEvent | None = None

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -402,6 +402,7 @@ class _DetailsPanelController:
         self._manager.concat_action.setEnabled(
             multiple_selected and len(selection_children) == 0
         )
+        self._manager.batch_action.setEnabled(self._manager.batch_target_count() >= 2)
         self._manager.store_action.setEnabled(
             bool(self._manager.tree_view.selected_imagetool_indices)
         )

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -13,6 +13,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
@@ -20,6 +21,295 @@ if typing.TYPE_CHECKING:
     import xarray
 
     from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
+
+
+_BatchDialogType = type[imagetool_dialogs._DataManipulationDialog]
+
+_BATCH_OPERATION_CATEGORIES: tuple[tuple[str, tuple[_BatchDialogType, ...]], ...] = (
+    (
+        "Coordinates",
+        (
+            imagetool_dialogs.AssignCoordsDialog,
+            imagetool_dialogs.AssignAttrsDialog,
+            imagetool_dialogs.RenameDimsCoordsDialog,
+            imagetool_dialogs.SwapDimsDialog,
+        ),
+    ),
+    (
+        "Selection",
+        (
+            imagetool_dialogs.SelectionDialog,
+            imagetool_dialogs.CropDialog,
+            imagetool_dialogs.CropToViewDialog,
+        ),
+    ),
+    (
+        "Transforms",
+        (
+            imagetool_dialogs.RotationDialog,
+            imagetool_dialogs.AggregateDialog,
+            imagetool_dialogs.InterpolationDialog,
+            imagetool_dialogs.LeadingEdgeDialog,
+            imagetool_dialogs.DivideByCoordDialog,
+            imagetool_dialogs.CoarsenDialog,
+            imagetool_dialogs.ThinDialog,
+            imagetool_dialogs.SymmetrizeDialog,
+            imagetool_dialogs.SymmetrizeNfoldDialog,
+        ),
+    ),
+    (
+        "Filters",
+        (
+            imagetool_dialogs.NormalizeDialog,
+            imagetool_dialogs.GaussianFilterDialog,
+        ),
+    ),
+)
+
+
+def _dialog_batch_available(dialog_cls: _BatchDialogType) -> bool:
+    return bool(dialog_cls.operation_types) and all(
+        operation_type.batch_available for operation_type in dialog_cls.operation_types
+    )
+
+
+def _batch_operation_dialog_classes() -> tuple[_BatchDialogType, ...]:
+    return tuple(
+        dialog_cls
+        for _category, dialog_classes in _BATCH_OPERATION_CATEGORIES
+        for dialog_cls in dialog_classes
+        if _dialog_batch_available(dialog_cls)
+    )
+
+
+class _BatchOperationDialog(QtWidgets.QDialog):
+    def __init__(self, manager: ImageToolManager) -> None:
+        super().__init__(manager)
+        self.setWindowTitle("Batch Operation")
+        self.setModal(True)
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, False)
+        self._manager = weakref.ref(manager)
+        self._syncing_targets = False
+        self._target_items: dict[int | str, QtWidgets.QTreeWidgetItem] = {}
+
+        layout = QtWidgets.QVBoxLayout(self)
+        self.setLayout(layout)
+
+        panes = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal, self)
+        layout.addWidget(panes)
+
+        target_group = QtWidgets.QGroupBox("Targets", self)
+        target_layout = QtWidgets.QVBoxLayout(target_group)
+        self._target_tree = QtWidgets.QTreeWidget(target_group)
+        self._target_tree.setObjectName("manager_batch_target_tree")
+        self._target_tree.setHeaderHidden(True)
+        self._target_tree.itemChanged.connect(self._target_item_changed)
+        target_layout.addWidget(self._target_tree)
+        panes.addWidget(target_group)
+
+        operation_group = QtWidgets.QGroupBox("Operations", self)
+        operation_layout = QtWidgets.QVBoxLayout(operation_group)
+        self._operation_tree = QtWidgets.QTreeWidget(operation_group)
+        self._operation_tree.setObjectName("manager_batch_operation_tree")
+        self._operation_tree.setHeaderHidden(True)
+        self._operation_tree.itemSelectionChanged.connect(self._update_launch_enabled)
+        operation_layout.addWidget(self._operation_tree)
+        panes.addWidget(operation_group)
+
+        panes.setSizes([220, 280])
+
+        self._button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        self._launch_button = self._button_box.button(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
+        if self._launch_button is not None:  # pragma: no branch
+            self._launch_button.setObjectName("manager_batch_launch_button")
+            self._launch_button.setText("Open")
+        self._button_box.accepted.connect(self._launch_selected_operation)
+        self._button_box.rejected.connect(self.reject)
+        layout.addWidget(self._button_box)
+
+        selection_model = manager.tree_view.selectionModel()
+        if selection_model is not None:  # pragma: no branch
+            selection_model.selectionChanged.connect(self._sync_target_checks)
+            selection_model.selectionChanged.connect(self._update_launch_enabled)
+
+        self._populate_operations()
+        self._populate_targets()
+        self._update_launch_enabled()
+
+    def _manager_instance(self) -> ImageToolManager | None:
+        return self._manager()
+
+    def _populate_operations(self) -> None:
+        self._operation_tree.clear()
+        for category, dialog_classes in _BATCH_OPERATION_CATEGORIES:
+            visible_dialogs = [
+                dialog_cls
+                for dialog_cls in dialog_classes
+                if _dialog_batch_available(dialog_cls)
+            ]
+            if not visible_dialogs:
+                continue
+            category_item = QtWidgets.QTreeWidgetItem([category])
+            category_item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
+            self._operation_tree.addTopLevelItem(category_item)
+            for dialog_cls in visible_dialogs:
+                item = QtWidgets.QTreeWidgetItem(
+                    [dialog_cls.title or dialog_cls.__name__]
+                )
+                item.setData(0, QtCore.Qt.ItemDataRole.UserRole, dialog_cls)
+                category_item.addChild(item)
+        self._operation_tree.expandAll()
+
+    def _populate_targets(self) -> None:
+        manager = self._manager_instance()
+        if manager is None:
+            return
+        self._syncing_targets = True
+        try:
+            self._target_tree.clear()
+            self._target_items.clear()
+            for target in manager._tool_graph.displayed_indices:
+                self._add_target_item(target)
+            self._target_tree.expandAll()
+        finally:
+            self._syncing_targets = False
+        self._sync_target_checks()
+
+    def _add_target_item(
+        self,
+        target: int | str,
+        parent: QtWidgets.QTreeWidgetItem | None = None,
+    ) -> None:
+        manager = self._manager_instance()
+        if manager is None:
+            return
+        node = manager._node_for_target(target)
+        item: QtWidgets.QTreeWidgetItem | None = None
+        if node.is_imagetool:
+            item = QtWidgets.QTreeWidgetItem([node.display_text])
+            item.setData(0, QtCore.Qt.ItemDataRole.UserRole, target)
+            item.setFlags(
+                item.flags()
+                | QtCore.Qt.ItemFlag.ItemIsUserCheckable
+                | QtCore.Qt.ItemFlag.ItemIsSelectable
+            )
+            item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
+            self._target_items[target] = item
+            if parent is None:
+                self._target_tree.addTopLevelItem(item)
+            else:
+                parent.addChild(item)
+        child_parent = item if item is not None else parent
+        for child_uid in node._childtool_indices:
+            self._add_target_item(child_uid, child_parent)
+
+    @QtCore.Slot()
+    def _sync_target_checks(self) -> None:
+        manager = self._manager_instance()
+        if manager is None:
+            return
+        selected = set(manager._selected_imagetool_targets())
+        self._syncing_targets = True
+        try:
+            for target, item in self._target_items.items():
+                checked = target in selected
+                item.setCheckState(
+                    0,
+                    QtCore.Qt.CheckState.Checked
+                    if checked
+                    else QtCore.Qt.CheckState.Unchecked,
+                )
+        finally:
+            self._syncing_targets = False
+        self._update_launch_enabled()
+
+    @QtCore.Slot(QtWidgets.QTreeWidgetItem, int)
+    def _target_item_changed(
+        self, item: QtWidgets.QTreeWidgetItem, column: int
+    ) -> None:
+        if self._syncing_targets or column != 0:
+            return
+        manager = self._manager_instance()
+        if manager is None:
+            return
+        target = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        if not isinstance(target, (int, str)):
+            return
+        qmodelindex = manager.tree_view._model._row_index(target)
+        if not qmodelindex.isValid():
+            return
+        selection_model = manager.tree_view.selectionModel()
+        if selection_model is None:
+            return
+        flag = (
+            QtCore.QItemSelectionModel.SelectionFlag.Select
+            if item.checkState(0) == QtCore.Qt.CheckState.Checked
+            else QtCore.QItemSelectionModel.SelectionFlag.Deselect
+        )
+        selection_model.select(QtCore.QItemSelection(qmodelindex, qmodelindex), flag)
+        self._update_launch_enabled()
+
+    def _selected_dialog_cls(self) -> _BatchDialogType | None:
+        items = self._operation_tree.selectedItems()
+        if not items:
+            return None
+        dialog_cls = items[0].data(0, QtCore.Qt.ItemDataRole.UserRole)
+        if isinstance(dialog_cls, type) and issubclass(
+            dialog_cls, imagetool_dialogs._DataManipulationDialog
+        ):
+            return dialog_cls
+        return None
+
+    @QtCore.Slot()
+    def _update_launch_enabled(self) -> None:
+        if self._launch_button is None:
+            return
+        manager = self._manager_instance()
+        selected_targets = (
+            [] if manager is None else manager._selected_imagetool_targets()
+        )
+        self._launch_button.setEnabled(
+            self._selected_dialog_cls() is not None and len(selected_targets) >= 2
+        )
+
+    @QtCore.Slot()
+    def _launch_selected_operation(self) -> None:
+        manager = self._manager_instance()
+        dialog_cls = self._selected_dialog_cls()
+        if manager is None or dialog_cls is None:
+            return
+        targets = manager._selected_imagetool_targets()
+        if len(targets) < 2:
+            erlab.interactive.utils.MessageDialog.critical(
+                self,
+                "Error",
+                "Select at least two ImageTool targets.",
+            )
+            return
+        anchor_tool = manager.get_imagetool(targets[0])
+        dialog = dialog_cls(anchor_tool.slicer_area, batch_manager=manager)
+        dialog.setModal(True)
+        anchor_tool.slicer_area.add_tool_window(
+            dialog,
+            update_title=False,
+            transfer_to_manager=False,
+        )
+        super().accept()
+
+    def show(self) -> None:
+        self._populate_targets()
+        super().show()
+
+    def open(self) -> None:
+        self._populate_targets()
+        super().open()
 
 
 class _ConcatDialog(QtWidgets.QDialog):

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -383,6 +383,11 @@ class ImageToolManager(_ImageToolManagerBase):
         self.concat_action.triggered.connect(self.concat_selected)
         self.concat_action.setToolTip("Concatenate data in selected windows")
 
+        self.batch_action = QtWidgets.QAction("Batch Operation…", self)
+        self.batch_action.setObjectName("manager_batch_operation_action")
+        self.batch_action.triggered.connect(self.show_batch_operations)
+        self.batch_action.setToolTip("Apply an operation to multiple ImageTools")
+
         self.reload_action = QtWidgets.QAction("Reload Data", self)
         self.reload_action.triggered.connect(self.reload_selected)
         self.reload_action.setToolTip(
@@ -466,6 +471,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self.edit_menu.addAction(self.reindex_action)
         self.edit_menu.addSeparator()
         self.edit_menu.addAction(self.concat_action)
+        self.edit_menu.addAction(self.batch_action)
         self.edit_menu.addAction(self.duplicate_action)
         self.edit_menu.addAction(self.promote_action)
         self.edit_menu.addSeparator()
@@ -518,6 +524,9 @@ class ImageToolManager(_ImageToolManagerBase):
         self.rename_button = erlab.interactive.utils.IconActionButton(
             self.rename_action, "mdi6.rename"
         )
+        self.batch_button = erlab.interactive.utils.IconActionButton(
+            self.batch_action, "mdi6.table-edit"
+        )
         self.link_button = erlab.interactive.utils.IconActionButton(
             self.link_action, "mdi6.link-variant"
         )
@@ -548,6 +557,7 @@ class ImageToolManager(_ImageToolManagerBase):
         titlebar_layout.addWidget(self.open_button)
         titlebar_layout.addWidget(self.remove_button)
         titlebar_layout.addWidget(self.rename_button)
+        titlebar_layout.addWidget(self.batch_button)
         titlebar_layout.addWidget(self.link_button)
         titlebar_layout.addWidget(self.unlink_button)
         titlebar_layout.addStretch()
@@ -1922,6 +1932,25 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def concat_selected(self) -> None:
         self._actions_controller.concat_selected()
+
+    def batch_target_count(self) -> int:
+        return self._actions_controller.batch_target_count()
+
+    def show_batch_operations(self) -> None:
+        self._actions_controller.show_batch_operations()
+
+    def apply_batch_transform_dialog(
+        self,
+        dialog: typing.Any,
+        launch_mode: typing.Literal["replace", "detach", "nest"],
+    ) -> bool:
+        return self._actions_controller.apply_batch_transform_dialog(
+            dialog,
+            launch_mode,
+        )
+
+    def apply_batch_filter_dialog(self, dialog: typing.Any) -> bool:
+        return self._actions_controller.apply_batch_filter_dialog(dialog)
 
     def store_selected(self) -> None:
         self._actions_controller.store_selected()

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -1630,6 +1630,7 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
         self._menu.addAction(manager.reindex_action)
         self._menu.addSeparator()
         self._menu.addAction(manager.concat_action)
+        self._menu.addAction(manager.batch_action)
         self._menu.addAction(manager.duplicate_action)
         self._menu.addAction(manager.promote_action)
         self._menu.addSeparator()

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -290,6 +290,7 @@ class ScriptCodeOperation(ToolProvenanceOperation):
 
 class QSelOperation(ToolProvenanceOperation):
     op: typing.Literal["qsel"] = "qsel"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             accessor_path=("qsel",),
@@ -317,6 +318,7 @@ class QSelOperation(ToolProvenanceOperation):
 
 class IselOperation(ToolProvenanceOperation):
     op: typing.Literal["isel"] = "isel"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             dataarray_method="isel",
@@ -345,6 +347,7 @@ class IselOperation(ToolProvenanceOperation):
 
 class SelOperation(ToolProvenanceOperation):
     op: typing.Literal["sel"] = "sel"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             dataarray_method="sel",
@@ -523,6 +526,7 @@ class RenameOperation(ToolProvenanceOperation):
 
 class RestoreNonuniformDimsOperation(ToolProvenanceOperation):
     op: typing.Literal["restore_nonuniform_dims"] = "restore_nonuniform_dims"
+    batch_available: typing.ClassVar[bool] = True
 
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
         return erlab.interactive.imagetool.slicer.restore_nonuniform_dims(data)
@@ -540,6 +544,7 @@ class RestoreNonuniformDimsOperation(ToolProvenanceOperation):
 
 class RotateOperation(ToolProvenanceOperation):
     op: typing.Literal["rotate"] = "rotate"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             target="erlab.analysis.transform.rotate",
@@ -647,6 +652,7 @@ class AverageOperation(ToolProvenanceOperation):
 
 class QSelAggregationOperation(ToolProvenanceOperation):
     op: typing.Literal["qsel_aggregate"] = "qsel_aggregate"
+    batch_available: typing.ClassVar[bool] = True
     dims: ProvenanceHashableTuple
     func: typing.Literal["mean", "min", "max", "sum"] = "mean"
 
@@ -696,6 +702,7 @@ class QSelAggregationOperation(ToolProvenanceOperation):
 
 class InterpolationOperation(ToolProvenanceOperation):
     op: typing.Literal["interpolate"] = "interpolate"
+    batch_available: typing.ClassVar[bool] = True
     dim: ProvenanceHashable
     values: typing.Any
     method: typing.Literal["linear", "nearest"] = "linear"
@@ -785,6 +792,7 @@ class InterpolationOperation(ToolProvenanceOperation):
 
 class LeadingEdgeOperation(ToolProvenanceOperation):
     op: typing.Literal["leading_edge"] = "leading_edge"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             target="erlab.analysis.interpolate.leading_edge",
@@ -827,6 +835,7 @@ class LeadingEdgeOperation(ToolProvenanceOperation):
 
 class DivideByCoordOperation(ToolProvenanceOperation):
     op: typing.Literal["divide_by_coord"] = "divide_by_coord"
+    batch_available: typing.ClassVar[bool] = True
     coord_name: ProvenanceHashable
 
     @staticmethod
@@ -863,6 +872,7 @@ class DivideByCoordOperation(ToolProvenanceOperation):
 
 class GaussianFilterOperation(ToolProvenanceOperation):
     op: typing.Literal["gaussian_filter"] = "gaussian_filter"
+    batch_available: typing.ClassVar[bool] = True
     sigma: ProvenanceFloatMapping = pydantic.Field(default_factory=dict)
 
     def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
@@ -885,6 +895,7 @@ class GaussianFilterOperation(ToolProvenanceOperation):
 
 class NormalizeOperation(ToolProvenanceOperation):
     op: typing.Literal["normalize"] = "normalize"
+    batch_available: typing.ClassVar[bool] = True
     dims: ProvenanceHashableTuple = ()
     mode: typing.Literal["area", "minmax", "min", "min_area"] = "area"
     denominator_rtol: float = 1e-12
@@ -978,6 +989,7 @@ class NormalizeOperation(ToolProvenanceOperation):
 
 class CoarsenOperation(ToolProvenanceOperation):
     op: typing.Literal["coarsen"] = "coarsen"
+    batch_available: typing.ClassVar[bool] = True
     dim: ProvenanceIntMapping = pydantic.Field(default_factory=dict)
     boundary: str
     side: str
@@ -1067,6 +1079,7 @@ class CoarsenOperation(ToolProvenanceOperation):
 
 class ThinOperation(ToolProvenanceOperation):
     op: typing.Literal["thin"] = "thin"
+    batch_available: typing.ClassVar[bool] = True
     mode: typing.Literal["global", "per_dim"]
     factor: int | None = None
     factors: ProvenanceIntMapping = pydantic.Field(default_factory=dict)
@@ -1136,6 +1149,7 @@ class ThinOperation(ToolProvenanceOperation):
 
 class SymmetrizeOperation(ToolProvenanceOperation):
     op: typing.Literal["symmetrize"] = "symmetrize"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             target="erlab.analysis.transform.symmetrize",
@@ -1184,6 +1198,7 @@ class SymmetrizeOperation(ToolProvenanceOperation):
 
 class SymmetrizeNfoldOperation(ToolProvenanceOperation):
     op: typing.Literal["symmetrize_nfold"] = "symmetrize_nfold"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             target="erlab.analysis.transform.symmetrize_nfold",
@@ -1310,6 +1325,7 @@ class CorrectWithEdgeOperation(ToolProvenanceOperation):
 
 class SwapDimsOperation(ToolProvenanceOperation):
     op: typing.Literal["swap_dims"] = "swap_dims"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             dataarray_method="swap_dims",
@@ -1336,6 +1352,7 @@ class SwapDimsOperation(ToolProvenanceOperation):
 
 class RenameDimsCoordsOperation(ToolProvenanceOperation):
     op: typing.Literal["rename_dims_coords"] = "rename_dims_coords"
+    batch_available: typing.ClassVar[bool] = True
     mapping: ProvenanceHashableMapping = pydantic.Field(default_factory=dict)
 
     @classmethod
@@ -1375,6 +1392,7 @@ class RenameDimsCoordsOperation(ToolProvenanceOperation):
 
 class AffineCoordOperation(ToolProvenanceOperation):
     op: typing.Literal["affine_coord"] = "affine_coord"
+    batch_available: typing.ClassVar[bool] = True
     coord_name: str
     scale: float
     offset: float
@@ -1433,6 +1451,7 @@ class AffineCoordOperation(ToolProvenanceOperation):
 
 class AssignCoordsOperation(ToolProvenanceOperation):
     op: typing.Literal["assign_coords"] = "assign_coords"
+    batch_available: typing.ClassVar[bool] = True
     coord_name: str
     values: typing.Any
 
@@ -1506,6 +1525,7 @@ class AssignCoordsOperation(ToolProvenanceOperation):
 
 class AssignScalarCoordOperation(ToolProvenanceOperation):
     op: typing.Literal["assign_scalar_coord"] = "assign_scalar_coord"
+    batch_available: typing.ClassVar[bool] = True
     coord_name: ProvenanceHashable
     value: typing.Any
 
@@ -1558,6 +1578,7 @@ class AssignScalarCoordOperation(ToolProvenanceOperation):
 
 class AssignCoord1DOperation(ToolProvenanceOperation):
     op: typing.Literal["assign_coord_1d"] = "assign_coord_1d"
+    batch_available: typing.ClassVar[bool] = True
     coord_name: ProvenanceHashable
     dim: ProvenanceHashable
     values: typing.Any
@@ -1639,6 +1660,7 @@ class AssignCoord1DOperation(ToolProvenanceOperation):
 
 class AssignAttrsOperation(ToolProvenanceOperation):
     op: typing.Literal["assign_attrs"] = "assign_attrs"
+    batch_available: typing.ClassVar[bool] = True
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(dataarray_method="assign_attrs", kwargs_field="attrs"),
     )

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -12,6 +12,8 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.dialogs as imagetool_dialogs
+import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
@@ -20,7 +22,12 @@ from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import itool, provenance
 from erlab.interactive.imagetool._load_source import _LoadSourceDetails
 from erlab.interactive.imagetool.manager import fetch, replace_data
-from erlab.interactive.imagetool.manager._dialogs import _ConcatDialog, _RenameDialog
+from erlab.interactive.imagetool.manager._dialogs import (
+    _batch_operation_dialog_classes,
+    _BatchOperationDialog,
+    _ConcatDialog,
+    _RenameDialog,
+)
 from erlab.interactive.imagetool.manager._modelview import (
     _TOOL_TYPE_ROLE,
     _ImageToolWrapperItemDelegate,
@@ -52,6 +59,850 @@ if typing.TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+
+def _batch_data(
+    name: str,
+    *,
+    dims: tuple[str, str] = ("x", "y"),
+    offset: float = 0.0,
+    first_coord: list[float] | None = None,
+) -> xr.DataArray:
+    coords = {
+        dims[0]: np.arange(3, dtype=float) if first_coord is None else first_coord,
+        dims[1]: np.arange(4, dtype=float),
+    }
+    return xr.DataArray(
+        np.arange(12, dtype=float).reshape(3, 4) + offset,
+        dims=dims,
+        coords=coords,
+        name=name,
+    )
+
+
+def _batch_volume(
+    name: str,
+    *,
+    dims: tuple[str, str, str] = ("x", "y", "z"),
+    offset: float = 0.0,
+    first_coord: list[float] | None = None,
+) -> xr.DataArray:
+    coords = {
+        dims[0]: np.arange(3, dtype=float) if first_coord is None else first_coord,
+        dims[1]: np.arange(3, dtype=float),
+        dims[2]: np.arange(4, dtype=float),
+    }
+    return xr.DataArray(
+        np.arange(36, dtype=float).reshape(3, 3, 4) + offset,
+        dims=dims,
+        coords=coords,
+        name=name,
+    )
+
+
+def _add_batch_tools(
+    qtbot,
+    manager: erlab.interactive.imagetool.manager.ImageToolManager,
+    *data_arrays: xr.DataArray,
+) -> None:
+    initial_count = manager.ntools
+    for data in data_arrays:
+        itool(data, manager=True)
+    qtbot.wait_until(
+        lambda: manager.ntools == initial_count + len(data_arrays),
+        timeout=5000,
+    )
+
+
+def _block_message_dialog(monkeypatch: pytest.MonkeyPatch) -> list[tuple[tuple, dict]]:
+    calls: list[tuple[tuple, dict]] = []
+
+    def _critical(*args, **kwargs) -> int:
+        calls.append((args, kwargs))
+        return int(QtWidgets.QDialog.DialogCode.Accepted)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        staticmethod(_critical),
+    )
+    return calls
+
+
+def _select_batch_operation(
+    dialog: _BatchOperationDialog,
+    dialog_cls: type[imagetool_dialogs._DataManipulationDialog],
+) -> None:
+    for top_index in range(dialog._operation_tree.topLevelItemCount()):
+        top_item = dialog._operation_tree.topLevelItem(top_index)
+        for child_index in range(top_item.childCount()):
+            child_item = top_item.child(child_index)
+            if child_item.data(0, QtCore.Qt.ItemDataRole.UserRole) is dialog_cls:
+                dialog._operation_tree.setCurrentItem(child_item)
+                return
+    raise AssertionError(f"{dialog_cls.__name__} was not rendered")
+
+
+class _BatchTransformStub:
+    operation_types = (provenance.AssignAttrsOperation,)
+
+    def __init__(
+        self,
+        operations: list[provenance.ToolProvenanceOperation] | None = None,
+        *,
+        source_error: Exception | None = None,
+        public_source: bool = False,
+    ) -> None:
+        self._operations = operations
+        self._source_error = source_error
+        self._public_source = public_source
+        self.keep_colors = False
+
+    def source_operations(self) -> list[provenance.ToolProvenanceOperation]:
+        if self._source_error is not None:
+            raise self._source_error
+        if self._operations is not None:
+            return list(self._operations)
+        return [provenance.AssignAttrsOperation(attrs={"batch": True})]
+
+    def source_spec_for_data(
+        self,
+        data: xr.DataArray,
+        new_name: str | None = None,
+    ) -> provenance.ToolProvenanceSpec:
+        del data, new_name
+        builder = (
+            provenance.public_data if self._public_source else provenance.full_data
+        )
+        return builder(*self.source_operations())
+
+    def _detached_provenance_spec(
+        self,
+        parent_provenance: provenance.ToolProvenanceSpec | None,
+        source_spec: provenance.ToolProvenanceSpec,
+        new_name: str,
+    ) -> provenance.ToolProvenanceSpec:
+        del parent_provenance, new_name
+        return source_spec
+
+    def _compose_transform_provenance(
+        self,
+        base_spec: provenance.ToolProvenanceSpec | None,
+        source_spec: provenance.ToolProvenanceSpec,
+        new_name: str,
+    ) -> provenance.ToolProvenanceSpec:
+        del base_spec, new_name
+        return source_spec
+
+    def _itool_kwargs(
+        self,
+        processed: xr.DataArray,
+        slicer_area=None,
+    ) -> dict[str, typing.Any]:
+        del slicer_area
+        return {"data": processed, "execute": False}
+
+
+class _BatchFilterStub:
+    operation_types = (provenance.NormalizeOperation,)
+
+    def __init__(
+        self,
+        operation: provenance.ToolProvenanceOperation | None,
+    ) -> None:
+        self._operation = operation
+
+    def filter_operation(self) -> provenance.ToolProvenanceOperation | None:
+        return self._operation
+
+
+def test_batch_operation_metadata_matches_launcher() -> None:
+    dialog_classes = _batch_operation_dialog_classes()
+    assert dialog_classes
+    assert imagetool_dialogs.EdgeCorrectionDialog not in dialog_classes
+    assert imagetool_dialogs.ROIPathDialog not in dialog_classes
+    assert imagetool_dialogs.ROIMaskDialog not in dialog_classes
+    assert [
+        dialog_cls for dialog_cls in dialog_classes if not dialog_cls.operation_types
+    ] == []
+    assert [
+        operation_type
+        for dialog_cls in dialog_classes
+        for operation_type in dialog_cls.operation_types
+        if not operation_type.batch_available
+    ] == []
+    assert provenance.RestoreNonuniformDimsOperation.batch_available
+
+
+def test_batch_dialog_defensive_paths_and_launch(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    messages = _block_message_dialog(monkeypatch)
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(
+            qtbot,
+            manager,
+            _batch_data("scan0"),
+            _batch_data("scan1", offset=100.0),
+        )
+        select_tools(manager, [0, 1])
+        dialog = _BatchOperationDialog(manager)
+        qtbot.addWidget(dialog)
+
+        with monkeypatch.context() as mp:
+            mp.setattr(
+                manager_dialogs,
+                "_BATCH_OPERATION_CATEGORIES",
+                (("Hidden", (imagetool_dialogs.EdgeCorrectionDialog,)),),
+            )
+            dialog._populate_operations()
+            assert dialog._operation_tree.topLevelItemCount() == 0
+        dialog._populate_operations()
+
+        dialog.show()
+        qtbot.wait_until(lambda: dialog.isVisible(), timeout=1000)
+        dialog.close()
+
+        _select_batch_operation(dialog, imagetool_dialogs.NormalizeDialog)
+        manager.tree_view.deselect_all()
+        select_tools(manager, [0])
+        dialog._launch_selected_operation()
+        assert messages
+
+        launched_dialogs = []
+
+        def _capture_tool_window(widget, **kwargs) -> None:
+            launched_dialogs.append((widget, kwargs))
+
+        select_tools(manager, [0, 1])
+        monkeypatch.setattr(
+            manager.get_imagetool(0).slicer_area,
+            "add_tool_window",
+            _capture_tool_window,
+        )
+        dialog._launch_selected_operation()
+        assert isinstance(
+            launched_dialogs[0][0],
+            imagetool_dialogs.NormalizeDialog,
+        )
+        assert launched_dialogs[0][1] == {
+            "update_title": False,
+            "transfer_to_manager": False,
+        }
+
+        invalid_item = QtWidgets.QTreeWidgetItem(["invalid"])
+        invalid_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, object())
+        dialog._target_item_changed(invalid_item, 0)
+
+        missing_item = QtWidgets.QTreeWidgetItem(["missing"])
+        missing_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, "missing")
+        dialog._target_item_changed(missing_item, 0)
+
+        valid_item = dialog._target_items[0]
+        monkeypatch.setattr(manager.tree_view, "selectionModel", lambda: None)
+        dialog._target_item_changed(valid_item, 0)
+
+        invalid_operation_item = QtWidgets.QTreeWidgetItem(["invalid"])
+        invalid_operation_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, object())
+        dialog._operation_tree.addTopLevelItem(invalid_operation_item)
+        dialog._operation_tree.setCurrentItem(invalid_operation_item)
+        assert dialog._selected_dialog_cls() is None
+
+        old_launch_button = dialog._launch_button
+        dialog._launch_button = None
+        dialog._update_launch_enabled()
+        dialog._launch_button = old_launch_button
+
+        dialog._manager = lambda: None
+        dialog._populate_targets()
+        dialog._add_target_item(0)
+        dialog._sync_target_checks()
+        dialog._target_item_changed(valid_item, 0)
+        dialog._launch_selected_operation()
+
+
+def test_batch_action_transform_error_paths(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    messages = _block_message_dialog(monkeypatch)
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, _batch_data("scan0"))
+        manager.show_batch_operations()
+        assert manager._actions_controller._ActionsController__batch_dialog is None
+
+        _add_batch_tools(qtbot, manager, _batch_data("scan1", offset=100.0))
+        select_tools(manager, [0, 1])
+
+        with monkeypatch.context() as mp:
+            mp.setattr(manager, "_selected_imagetool_targets", lambda: [0])
+            assert not manager.apply_batch_transform_dialog(
+                _BatchTransformStub(),
+                "replace",
+            )
+            mp.setattr(manager, "_selected_imagetool_targets", lambda: [0, "tool"])
+            mp.setattr(
+                manager,
+                "_is_imagetool_target",
+                lambda target: target == 0,
+            )
+            assert not manager.apply_batch_transform_dialog(
+                _BatchTransformStub(),
+                "replace",
+            )
+        select_tools(manager, [0, 1])
+
+        assert not manager.apply_batch_transform_dialog(
+            _BatchTransformStub(source_error=RuntimeError("source failed")),
+            "replace",
+        )
+        assert not manager.apply_batch_transform_dialog(
+            _BatchTransformStub([]),
+            "replace",
+        )
+        assert not manager.apply_batch_transform_dialog(
+            _BatchTransformStub([provenance.NormalizeOperation(dims=("x",))]),
+            "replace",
+        )
+
+        class _ScriptTransformStub(_BatchTransformStub):
+            operation_types = (provenance.ScriptCodeOperation,)
+
+        assert not manager.apply_batch_transform_dialog(
+            _ScriptTransformStub(
+                [provenance.ScriptCodeOperation(label="Custom", code=None)]
+            ),
+            "replace",
+        )
+
+        manager._node_for_target(0).set_source_binding(provenance.full_data())
+        manager._node_for_target(1).set_detached_provenance(provenance.full_data())
+        assert manager.apply_batch_transform_dialog(
+            _BatchTransformStub(public_source=True),
+            "replace",
+        )
+
+        monkeypatch.setattr(erlab.interactive, "itool", lambda **kwargs: None)
+        assert not manager.apply_batch_transform_dialog(
+            _BatchTransformStub(),
+            "detach",
+        )
+
+        def _raise_replace(*args, **kwargs) -> None:
+            raise RuntimeError("replace failed")
+
+        monkeypatch.setattr(
+            manager.get_imagetool(0).slicer_area,
+            "replace_source_data",
+            _raise_replace,
+        )
+        assert not manager.apply_batch_transform_dialog(
+            _BatchTransformStub(),
+            "replace",
+        )
+        assert len(messages) >= 6
+
+
+def test_batch_filter_error_paths(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    messages = _block_message_dialog(monkeypatch)
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(
+            qtbot,
+            manager,
+            _batch_data("scan0"),
+            _batch_data("scan1", offset=100.0),
+        )
+        select_tools(manager, [0, 1])
+
+        class _ScriptFilterStub(_BatchFilterStub):
+            operation_types = (provenance.ScriptCodeOperation,)
+
+        assert not manager.apply_batch_filter_dialog(
+            _ScriptFilterStub(provenance.ScriptCodeOperation(label="Custom", code=None))
+        )
+        assert not manager.apply_batch_filter_dialog(
+            _BatchFilterStub(provenance.NormalizeOperation(dims=("missing",)))
+        )
+
+        real_get_imagetool = manager.get_imagetool
+        get_imagetool_calls = 0
+
+        def _raise_during_commit(target):
+            nonlocal get_imagetool_calls
+            get_imagetool_calls += 1
+            if get_imagetool_calls > 2:
+                raise RuntimeError("commit failed")
+            return real_get_imagetool(target)
+
+        monkeypatch.setattr(manager, "get_imagetool", _raise_during_commit)
+        assert not manager.apply_batch_filter_dialog(
+            _BatchFilterStub(provenance.NormalizeOperation(dims=("x",)))
+        )
+        assert len(messages) >= 3
+
+
+def test_batch_dialog_accept_wrappers(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    messages = _block_message_dialog(monkeypatch)
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(
+            qtbot,
+            manager,
+            _batch_volume("scan0"),
+            _batch_volume("scan1", offset=100.0),
+        )
+        area = manager.get_imagetool(0).slicer_area
+
+        single_dialog = imagetool_dialogs.RotationDialog(area)
+        qtbot.addWidget(single_dialog)
+        assert single_dialog.batch_manager is None
+        assert single_dialog.source_spec().kind == "full_data"
+        assert single_dialog._itool_kwargs(area.data)["data"] is area.data
+
+        transform_dialog = imagetool_dialogs.RotationDialog(
+            area,
+            batch_manager=manager,
+        )
+        monkeypatch.setattr(
+            manager,
+            "apply_batch_transform_dialog",
+            lambda dialog, launch_mode: False,
+        )
+        transform_dialog.accept()
+        assert transform_dialog.result() == int(QtWidgets.QDialog.DialogCode.Rejected)
+
+        transform_dialog = imagetool_dialogs.RotationDialog(
+            area,
+            batch_manager=manager,
+        )
+        monkeypatch.setattr(
+            manager,
+            "apply_batch_transform_dialog",
+            lambda dialog, launch_mode: True,
+        )
+        transform_dialog.accept()
+        assert transform_dialog.result() == int(QtWidgets.QDialog.DialogCode.Accepted)
+
+        transform_dialog = imagetool_dialogs.RotationDialog(
+            area,
+            batch_manager=manager,
+        )
+
+        def _raise_transform(dialog, launch_mode) -> bool:
+            raise RuntimeError("batch failed")
+
+        monkeypatch.setattr(
+            manager,
+            "apply_batch_transform_dialog",
+            _raise_transform,
+        )
+        transform_dialog.accept()
+
+        filter_dialog = imagetool_dialogs.NormalizeDialog(area, batch_manager=manager)
+        monkeypatch.setattr(
+            manager,
+            "apply_batch_filter_dialog",
+            lambda dialog: False,
+        )
+        filter_dialog.accept()
+        assert filter_dialog.result() == int(QtWidgets.QDialog.DialogCode.Rejected)
+
+        filter_dialog = imagetool_dialogs.NormalizeDialog(area, batch_manager=manager)
+        monkeypatch.setattr(
+            manager,
+            "apply_batch_filter_dialog",
+            lambda dialog: True,
+        )
+        filter_dialog.accept()
+        assert filter_dialog.result() == int(QtWidgets.QDialog.DialogCode.Accepted)
+
+        filter_dialog = imagetool_dialogs.NormalizeDialog(area, batch_manager=manager)
+
+        def _raise_filter(dialog) -> bool:
+            raise RuntimeError("batch failed")
+
+        monkeypatch.setattr(manager, "apply_batch_filter_dialog", _raise_filter)
+        filter_dialog.accept()
+        assert messages
+
+
+def test_batch_dialog_categories_and_target_checks_update_manager_selection(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(
+            qtbot,
+            manager,
+            _batch_data("scan0"),
+            _batch_data("scan1", offset=100.0),
+        )
+        manager.tree_view.deselect_all()
+        manager._update_actions()
+        assert manager.batch_action.isEnabled()
+
+        select_tools(manager, [0, 1])
+        dialog = _BatchOperationDialog(manager)
+        qtbot.addWidget(dialog)
+
+        assert dialog._operation_tree.topLevelItemCount() == 4
+        rendered_dialogs = []
+        for top_index in range(dialog._operation_tree.topLevelItemCount()):
+            top_item = dialog._operation_tree.topLevelItem(top_index)
+            assert top_item.childCount() > 0
+            rendered_dialogs.extend(
+                top_item.child(child_index).data(0, QtCore.Qt.ItemDataRole.UserRole)
+                for child_index in range(top_item.childCount())
+            )
+        assert set(_batch_operation_dialog_classes()) == set(rendered_dialogs)
+
+        assert dialog._launch_button is not None
+        assert not dialog._launch_button.isEnabled()
+        _select_batch_operation(dialog, imagetool_dialogs.NormalizeDialog)
+        assert dialog._launch_button.isEnabled()
+
+        dialog._target_items[1].setCheckState(0, QtCore.Qt.CheckState.Unchecked)
+        qtbot.wait_until(
+            lambda: manager._selected_imagetool_targets() == [0],
+            timeout=1000,
+        )
+        assert not dialog._launch_button.isEnabled()
+
+        dialog._target_items[1].setCheckState(0, QtCore.Qt.CheckState.Checked)
+        qtbot.wait_until(
+            lambda: manager._selected_imagetool_targets() == [0, 1],
+            timeout=1000,
+        )
+        assert dialog._launch_button.isEnabled()
+
+
+def test_batch_dialog_open_refreshes_cached_targets(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(
+            qtbot,
+            manager,
+            _batch_data("scan0"),
+            _batch_data("scan1", offset=100.0),
+        )
+
+        manager.show_batch_operations()
+        dialog = manager._actions_controller._batch_dialog
+        qtbot.addWidget(dialog)
+        qtbot.wait_until(lambda: dialog.isVisible(), timeout=1000)
+        assert set(dialog._target_items) == {0, 1}
+
+        dialog.close()
+        _add_batch_tools(qtbot, manager, _batch_data("scan2", offset=200.0))
+
+        manager.show_batch_operations()
+        qtbot.wait_until(lambda: dialog.isVisible(), timeout=1000)
+        assert set(dialog._target_items) == {0, 1, 2}
+
+
+def test_batch_action_updates_when_child_imagetool_count_changes(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, _batch_data("scan0"))
+        assert manager.batch_target_count() == 1
+        assert not manager.batch_action.isEnabled()
+
+        child_tool = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(_batch_data("child"), manager=False, execute=False),
+        )
+        child_uid = manager.add_imagetool_child(child_tool, 0, show=False)
+        assert manager.batch_target_count() == 2
+        assert manager.batch_action.isEnabled()
+
+        manager._remove_childtool(child_uid)
+        assert manager.batch_target_count() == 1
+        assert not manager.batch_action.isEnabled()
+
+
+def test_batch_dialog_expands_child_targets(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, _batch_data("scan0"))
+
+        child_tool = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(_batch_data("child"), manager=False, execute=False),
+        )
+        child_uid = manager.add_imagetool_child(child_tool, 0, show=False)
+
+        manager.show_batch_operations()
+        dialog = manager._actions_controller._batch_dialog
+        qtbot.addWidget(dialog)
+        qtbot.wait_until(lambda: dialog.isVisible(), timeout=1000)
+
+        parent_item = dialog._target_tree.topLevelItem(0)
+        assert parent_item is dialog._target_items[0]
+        assert dialog._target_items[child_uid].parent() is parent_item
+        assert parent_item.isExpanded()
+
+
+def test_batch_action_updates_when_tool_child_subtree_removes_imagetool(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, _batch_data("scan0"))
+
+        tool_uid = manager.add_childtool(
+            erlab.interactive.utils.ToolWindow(),
+            0,
+            show=False,
+        )
+        child_tool = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(_batch_data("child"), manager=False, execute=False),
+        )
+        manager.add_imagetool_child(child_tool, tool_uid, show=False)
+        assert manager.batch_target_count() == 2
+        assert manager.batch_action.isEnabled()
+
+        manager._remove_childtool(tool_uid)
+        assert manager.batch_target_count() == 1
+        assert not manager.batch_action.isEnabled()
+
+
+@pytest.mark.parametrize("launch_mode", ["replace", "nest", "detach"])
+def test_batch_transform_placements(
+    qtbot,
+    launch_mode: str,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = _batch_volume("scan0")
+    data1 = _batch_volume("scan1", offset=100.0)
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, data0, data1)
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.AggregateDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        dialog.dim_checks["y"].setChecked(True)
+
+        assert manager.apply_batch_transform_dialog(
+            dialog,
+            typing.cast("typing.Literal['replace', 'detach', 'nest']", launch_mode),
+        )
+
+        expected = [data0.qsel.mean("y"), data1.qsel.mean("y")]
+        if launch_mode == "replace":
+            assert manager.ntools == 2
+            for index, expected_data in enumerate(expected):
+                xarray.testing.assert_identical(
+                    manager.get_imagetool(index).slicer_area._data.rename(None),
+                    expected_data.rename(None),
+                )
+        elif launch_mode == "nest":
+            assert manager.ntools == 2
+            for index, expected_data in enumerate(expected):
+                child_uids = manager._tool_graph.root_wrappers[index]._childtool_indices
+                assert len(child_uids) == 1
+                child_tool = manager.get_imagetool(child_uids[0])
+                xarray.testing.assert_identical(
+                    child_tool.slicer_area._data.rename(None),
+                    expected_data.rename(None),
+                )
+        else:
+            assert manager.ntools == 4
+            for index, expected_data in zip((2, 3), expected, strict=True):
+                xarray.testing.assert_identical(
+                    manager.get_imagetool(index).slicer_area._data.rename(None),
+                    expected_data.rename(None),
+                )
+
+
+def test_batch_filter_applies_in_place_only(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(
+            qtbot,
+            manager,
+            _batch_data("scan0"),
+            _batch_data("scan1", offset=100.0),
+        )
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.NormalizeDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        dialog.dim_checks["y"].setChecked(True)
+
+        assert manager.apply_batch_filter_dialog(dialog)
+        assert manager.ntools == 2
+        for index in (0, 1):
+            operation = manager.get_imagetool(
+                index
+            ).slicer_area._accepted_filter_provenance_operation
+            assert isinstance(operation, provenance.NormalizeOperation)
+
+
+def test_batch_transform_preflight_failure_leaves_all_targets_unchanged(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    messages = _block_message_dialog(monkeypatch)
+    data0 = _batch_volume("scan0")
+    data1 = _batch_volume("scan1", dims=("x", "other", "z"), offset=100.0)
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, data0, data1)
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.AggregateDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        dialog.dim_checks["y"].setChecked(True)
+
+        assert not manager.apply_batch_transform_dialog(dialog, "replace")
+        assert messages
+        xarray.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area._data.rename(None),
+            data0.rename(None),
+        )
+        xarray.testing.assert_identical(
+            manager.get_imagetool(1).slicer_area._data.rename(None),
+            data1.rename(None),
+        )
+
+
+def test_batch_add_coord_duplicate_target_aborts_all_unchanged(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    messages = _block_message_dialog(monkeypatch)
+    data0 = _batch_data("scan0")
+    data1 = _batch_data("scan1", offset=100.0).assign_coords(foo=5.0)
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, data0, data1)
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.AssignCoordsDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        dialog._mode_tabs.setCurrentIndex(1)
+        dialog._add_name_edit.setText("foo")
+
+        assert not manager.apply_batch_transform_dialog(dialog, "replace")
+        assert messages
+        xarray.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area._data.rename(None),
+            data0.rename(None),
+        )
+        xarray.testing.assert_identical(
+            manager.get_imagetool(1).slicer_area._data.rename(None),
+            data1.rename(None),
+        )
+
+
+def test_batch_nonuniform_restore_is_target_specific(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    uniform = _batch_volume("uniform")
+    nonuniform = _batch_volume(
+        "nonuniform",
+        offset=100.0,
+        first_coord=[0.0, 0.4, 1.1],
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, uniform, nonuniform)
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.AggregateDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        dialog.dim_checks["y"].setChecked(True)
+
+        assert manager.apply_batch_transform_dialog(dialog, "nest")
+
+        uniform_child_uid = manager._tool_graph.root_wrappers[0]._childtool_indices[0]
+        nonuniform_child_uid = manager._tool_graph.root_wrappers[1]._childtool_indices[
+            0
+        ]
+        uniform_source_spec = manager._child_node(uniform_child_uid).source_spec
+        nonuniform_source_spec = manager._child_node(nonuniform_child_uid).source_spec
+        assert uniform_source_spec is not None
+        assert nonuniform_source_spec is not None
+        assert [op.op for op in uniform_source_spec.operations] == ["qsel_aggregate"]
+        assert [op.op for op in nonuniform_source_spec.operations] == [
+            "qsel_aggregate",
+            "restore_nonuniform_dims",
+        ]
 
 
 def test_manager_metadata_full_code_generated_only_when_copied(


### PR DESCRIPTION
## Summary
- Add a manager-owned batch operation dialog and launcher button for applying ImageTool operations to multiple selected tools.
- Teach transformation and filter dialogs how to run in batch mode while preserving per-target provenance and placement behavior.
- Add operation metadata and manager selection wiring so batch targets stay tied to the real tree selection.
- Expand manager tests to cover batch dialog population, execution modes, failure rollback, and nonuniform-data handling.

## Testing
- Added unit/integration tests for batch dialog behavior and batch transform/filter execution paths.
- Verified the new batch-specific tests pass locally.