### PR TITLE
Preserve rich workspace attributes through save and load

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -713,6 +713,7 @@ class ImageToolManager(_ImageToolManagerBase):
         logger.debug("Closing ImageTool Manager...")
         previous_closing_workspace_document = self._workspace_state.closing_document
         self._workspace_state.closing_document = True
+        close_confirmed = False
         try:
             if not self._confirm_save_dirty_workspace(
                 "Closing this manager will discard unsaved workspace changes."
@@ -720,6 +721,9 @@ class ImageToolManager(_ImageToolManagerBase):
                 if event:
                     event.ignore()
                 return
+
+            close_confirmed = True
+            self._workspace_controller._cancel_macos_workspace_window_file_path_update()
 
             logger.debug("Waiting for file handlers to finish...")
             if len(self._file_handlers) > 0:  # pragma: no cover
@@ -788,6 +792,8 @@ class ImageToolManager(_ImageToolManagerBase):
             super().closeEvent(event)
         finally:
             self._workspace_state.closing_document = previous_closing_workspace_document
+            if not close_confirmed:
+                self._workspace_controller._schedule_macos_workspace_window_file_path_update()
 
     @property
     def ntools(self) -> int:

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -40,9 +40,14 @@ ImageTool and ToolWindow payload attrs live with the serializers that write them
 
 from __future__ import annotations
 
+import base64
+import collections.abc
 import contextlib
 import errno
 import json
+import logging
+import math
+import numbers
 import os
 import pathlib
 import sys
@@ -60,6 +65,8 @@ import erlab
 from erlab.interactive.imagetool import _serialization
 from erlab.interactive.imagetool.manager import _xarray
 
+logger = logging.getLogger(__name__)
+
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, MutableMapping
 
@@ -72,6 +79,8 @@ _WORKSPACE_TRANSACTION_PROTOCOL = "recoverable-delta-v1"
 _WORKSPACE_PENDING_GROUP_PREFIX = "__itws_pending_"
 _WORKSPACE_BACKUP_GROUP_PREFIX = "__itws_backup_"
 _WORKSPACE_TRANSACTION_GROUP_PREFIX = "__itws_txn_"
+_WORKSPACE_ENCODED_ATTRS_ATTR = "_erlab_workspace_encoded_attrs"
+_WORKSPACE_ENCODED_ATTRS_VERSION = 1
 
 
 class WorkspaceLoaderState(pydantic.BaseModel):
@@ -553,7 +562,312 @@ def _ensure_h5_parent_group(h5_file, path: str):
 def _workspace_serializable_attrs(
     attrs: Mapping[typing.Any, typing.Any],
 ) -> dict[str, typing.Any]:
-    return {key: value for key, value in attrs.items() if isinstance(key, str) and key}
+    serializable: dict[str, typing.Any] = {}
+    encoded_entries: list[list[typing.Any]] = []
+    for key, value in attrs.items():
+        if not isinstance(key, str) or not key:
+            continue
+        if key == _WORKSPACE_ENCODED_ATTRS_ATTR:
+            existing_entries = _workspace_encoded_attr_entries(value)
+            if existing_entries is not None:
+                encoded_entries.extend(existing_entries)
+                continue
+        if (
+            key != _WORKSPACE_ENCODED_ATTRS_ATTR
+            and _workspace_attr_value_writes_natively(value)
+        ):
+            serializable[key] = value
+            continue
+        try:
+            encoded_entries.append(
+                [_workspace_encode_attr_key(key), _workspace_encode_attr_value(value)]
+            )
+        except TypeError:
+            logger.warning(
+                "Dropping workspace attribute %r with unsupported value type %s",
+                key,
+                type(value).__name__,
+            )
+    if encoded_entries:
+        serializable[_WORKSPACE_ENCODED_ATTRS_ATTR] = json.dumps(
+            {
+                "version": _WORKSPACE_ENCODED_ATTRS_VERSION,
+                "attrs": encoded_entries,
+            },
+            separators=(",", ":"),
+        )
+    return serializable
+
+
+def _workspace_attr_value_writes_natively(value: typing.Any) -> bool:
+    import numpy as np
+
+    if isinstance(value, str):
+        return True
+    if isinstance(value, bytes):
+        return b"\x00" not in value and _workspace_bytes_are_utf8(value)
+    if isinstance(value, np.ndarray):
+        return value.dtype.kind in "biufcSU"
+    if isinstance(value, np.generic):
+        return isinstance(value, (np.number, np.bool_))
+    if isinstance(value, bool | int | float | complex):
+        return True
+    if isinstance(value, list | tuple):
+        return all(_workspace_attr_scalar_writes_natively(item) for item in value)
+    return False
+
+
+def _workspace_attr_scalar_writes_natively(value: typing.Any) -> bool:
+    import numpy as np
+
+    if isinstance(value, str):
+        return True
+    if isinstance(value, bytes):
+        return b"\x00" not in value and _workspace_bytes_are_utf8(value)
+    if isinstance(value, np.generic):
+        return isinstance(value, (np.number, np.bool_))
+    return isinstance(value, bool | int | float | complex)
+
+
+def _workspace_bytes_are_utf8(value: bytes) -> bool:
+    try:
+        value.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _workspace_encode_attr_key(value: typing.Any) -> dict[str, typing.Any]:
+    import numpy as np
+
+    if isinstance(value, np.generic):
+        value = value.item()
+    if value is None:
+        return {"kind": "none"}
+    if isinstance(value, bool):
+        return {"kind": "bool", "value": value}
+    if isinstance(value, int):
+        return {"kind": "int", "value": value}
+    if isinstance(value, float):
+        return {"kind": "float", **_workspace_encode_float(value)}
+    if isinstance(value, complex):
+        return {
+            "kind": "complex",
+            "real": _workspace_encode_float(value.real),
+            "imag": _workspace_encode_float(value.imag),
+        }
+    if isinstance(value, str):
+        return {"kind": "str", "value": value}
+    if isinstance(value, bytes):
+        return {
+            "kind": "bytes",
+            "value": base64.b64encode(value).decode("ascii"),
+        }
+    if isinstance(value, tuple):
+        return {
+            "kind": "tuple",
+            "items": [_workspace_encode_attr_key(item) for item in value],
+        }
+    raise TypeError(f"unsupported attr key type {type(value).__name__!r}")
+
+
+def _workspace_decode_attr_key(value: typing.Any) -> typing.Hashable:
+    decoded = _workspace_decode_attr_value(value)
+    if not isinstance(decoded, collections.abc.Hashable):
+        raise TypeError(f"decoded attr key is not hashable: {type(decoded).__name__!r}")
+    return decoded
+
+
+def _workspace_encode_attr_value(value: typing.Any) -> dict[str, typing.Any]:
+    import numpy as np
+
+    if isinstance(value, np.ndarray):
+        return _workspace_encode_array(value, kind="ndarray")
+    if isinstance(value, np.generic):
+        return _workspace_encode_array(np.asarray(value), kind="numpy_scalar")
+    if value is None:
+        return {"kind": "none"}
+    if isinstance(value, bool):
+        return {"kind": "bool", "value": value}
+    if isinstance(value, int):
+        return {"kind": "int", "value": value}
+    if isinstance(value, float):
+        return {"kind": "float", **_workspace_encode_float(value)}
+    if isinstance(value, complex):
+        return {
+            "kind": "complex",
+            "real": _workspace_encode_float(value.real),
+            "imag": _workspace_encode_float(value.imag),
+        }
+    if isinstance(value, str):
+        return {"kind": "str", "value": value}
+    if isinstance(value, bytes):
+        return {
+            "kind": "bytes",
+            "value": base64.b64encode(value).decode("ascii"),
+        }
+    if isinstance(value, list):
+        return {
+            "kind": "list",
+            "items": [_workspace_encode_attr_value(item) for item in value],
+        }
+    if isinstance(value, tuple):
+        return {
+            "kind": "tuple",
+            "items": [_workspace_encode_attr_value(item) for item in value],
+        }
+    if isinstance(value, collections.abc.Mapping):
+        return {
+            "kind": "dict",
+            "items": [
+                [_workspace_encode_attr_key(key), _workspace_encode_attr_value(item)]
+                for key, item in value.items()
+            ],
+        }
+    if isinstance(value, numbers.Number):
+        raise TypeError(f"unsupported numeric attr type {type(value).__name__!r}")
+    raise TypeError(f"unsupported attr value type {type(value).__name__!r}")
+
+
+def _workspace_decode_attr_value(value: typing.Any) -> typing.Any:
+    if not isinstance(value, collections.abc.Mapping):
+        raise TypeError("encoded workspace attr value must be a mapping")
+    kind = value.get("kind")
+    match kind:
+        case "none":
+            return None
+        case "bool":
+            return bool(value["value"])
+        case "int":
+            return int(value["value"])
+        case "float":
+            return _workspace_decode_float(value)
+        case "complex":
+            return complex(
+                _workspace_decode_float(value["real"]),
+                _workspace_decode_float(value["imag"]),
+            )
+        case "str":
+            return str(value["value"])
+        case "bytes":
+            return base64.b64decode(str(value["value"]).encode("ascii"))
+        case "list":
+            return [_workspace_decode_attr_value(item) for item in value["items"]]
+        case "tuple":
+            return tuple(_workspace_decode_attr_value(item) for item in value["items"])
+        case "dict":
+            return {
+                _workspace_decode_attr_key(key): _workspace_decode_attr_value(item)
+                for key, item in value["items"]
+            }
+        case "ndarray":
+            return _workspace_decode_array(value)
+        case "numpy_scalar":
+            return _workspace_decode_array(value)[()]
+        case _:
+            raise TypeError(f"unknown workspace attr value kind {kind!r}")
+
+
+def _workspace_encode_float(value: float) -> dict[str, typing.Any]:
+    if math.isnan(value):
+        return {"special": "nan"}
+    if math.isinf(value):
+        return {"special": "inf" if value > 0 else "-inf"}
+    return {"value": value}
+
+
+def _workspace_decode_float(value: Mapping[str, typing.Any]) -> float:
+    special = value.get("special")
+    if special == "nan":
+        return math.nan
+    if special == "inf":
+        return math.inf
+    if special == "-inf":
+        return -math.inf
+    return float(value["value"])
+
+
+def _workspace_encode_array(value, *, kind: str) -> dict[str, typing.Any]:
+    import numpy as np
+
+    array = np.asarray(value)
+    payload: dict[str, typing.Any] = {
+        "kind": kind,
+        "dtype": array.dtype.str,
+        "shape": list(array.shape),
+    }
+    if array.dtype.kind == "O":
+        payload["items"] = _workspace_encode_attr_value(array.tolist())
+        return payload
+    contiguous = np.ascontiguousarray(array)
+    payload["data"] = base64.b64encode(contiguous.tobytes()).decode("ascii")
+    return payload
+
+
+def _workspace_decode_array(value: Mapping[str, typing.Any]):
+    import numpy as np
+
+    dtype = np.dtype(typing.cast("str", value["dtype"]))
+    shape = tuple(int(size) for size in typing.cast("list[typing.Any]", value["shape"]))
+    if "items" in value:
+        items = _workspace_decode_attr_value(value["items"])
+        return np.asarray(items, dtype=object).reshape(shape)
+    data = base64.b64decode(str(value["data"]).encode("ascii"))
+    return np.frombuffer(data, dtype=dtype).copy().reshape(shape)
+
+
+def _workspace_encoded_attr_entries(value: typing.Any) -> list[list[typing.Any]] | None:
+    if isinstance(value, bytes):
+        try:
+            value = value.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    if not isinstance(value, str):
+        return None
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("version") != _WORKSPACE_ENCODED_ATTRS_VERSION
+        or not isinstance(payload.get("attrs"), list)
+    ):
+        return None
+    entries = payload["attrs"]
+    if not all(
+        isinstance(entry, list) and len(entry) == 2
+        for entry in typing.cast("list[typing.Any]", entries)
+    ):
+        return None
+    return typing.cast("list[list[typing.Any]]", entries)
+
+
+def _restore_workspace_serialized_attrs(
+    attrs: Mapping[typing.Any, typing.Any],
+) -> dict[typing.Any, typing.Any]:
+    encoded_entries = _workspace_encoded_attr_entries(
+        attrs.get(_WORKSPACE_ENCODED_ATTRS_ATTR)
+    )
+    if encoded_entries is None:
+        return dict(attrs)
+    restored = {
+        key: value
+        for key, value in attrs.items()
+        if key != _WORKSPACE_ENCODED_ATTRS_ATTR
+    }
+    for key_payload, value_payload in encoded_entries:
+        try:
+            key = _workspace_decode_attr_key(key_payload)
+            value = _workspace_decode_attr_value(value_payload)
+        except (KeyError, TypeError, ValueError):
+            logger.warning(
+                "Ignoring invalid encoded workspace attribute", exc_info=True
+            )
+            continue
+        if isinstance(key, str) and key:
+            restored[key] = value
+    return restored
 
 
 def _sanitize_workspace_attr_names(ds: xr.Dataset) -> xr.Dataset:
@@ -562,6 +876,14 @@ def _sanitize_workspace_attr_names(ds: xr.Dataset) -> xr.Dataset:
     for variable in sanitized.variables.values():
         variable.attrs = _workspace_serializable_attrs(variable.attrs)
     return sanitized
+
+
+def _restore_workspace_dataset_attrs(ds: xr.Dataset) -> xr.Dataset:
+    restored = ds.copy(deep=False)
+    restored.attrs = _restore_workspace_serialized_attrs(restored.attrs)
+    for variable in restored.variables.values():
+        variable.attrs = _restore_workspace_serialized_attrs(variable.attrs)
+    return restored
 
 
 def _replace_h5_attrs(target_attrs, attrs: Mapping[typing.Any, typing.Any]) -> None:
@@ -755,7 +1077,7 @@ def _h5py_attrs_to_dict(
         if isinstance(value, bytes):
             value = value.decode()
         out[key] = value
-    return out
+    return _restore_workspace_serialized_attrs(out)
 
 
 def _read_workspace_root_attrs_h5py(
@@ -1143,6 +1465,7 @@ def _write_workspace_dataset_group_h5py(
 
     if not _workspace_dataset_can_write_h5py(ds):
         return False
+    ds = _sanitize_workspace_attr_names(ds)
     data_name = _workspace_h5py_data_name(ds)
     if data_name is None:
         return False

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -1091,12 +1091,17 @@ class _WorkspaceIOController:
                                 chunks={},
                             )
                             try:
-                                ds = opened.copy(deep=False)
+                                opened_ds = opened.copy(deep=False)
+                                ds = (
+                                    _manager_workspace._restore_workspace_dataset_attrs(
+                                        opened_ds
+                                    )
+                                )
                             finally:
                                 opened.close()
                             break
             if ds is None:
-                ds = (
+                ds = _manager_workspace._restore_workspace_dataset_attrs(
                     typing.cast("xr.DataTree", node_tree["imagetool"])
                     .to_dataset(inherit=False)
                     .load()
@@ -1108,7 +1113,7 @@ class _WorkspaceIOController:
                 loaded_targets_by_uid=loaded_targets_by_uid,
             )
         elif "tool" in node_tree:
-            ds = (
+            ds = _manager_workspace._restore_workspace_dataset_attrs(
                 typing.cast("xr.DataTree", node_tree["tool"])
                 .to_dataset(inherit=False)
                 .load()
@@ -1246,8 +1251,12 @@ class _WorkspaceIOController:
             )
             try:
                 if load:
-                    return opened.load()
-                return opened.copy(deep=False)
+                    return _manager_workspace._restore_workspace_dataset_attrs(
+                        opened.load()
+                    )
+                return _manager_workspace._restore_workspace_dataset_attrs(
+                    opened.copy(deep=False)
+                )
             finally:
                 opened.close()
 
@@ -2790,6 +2799,12 @@ class _WorkspaceIOController:
             with erlab.interactive.utils.wait_dialog(
                 self._manager, "Saving workspace..."
             ):
+                for node in tree.subtree:
+                    ds = node.to_dataset(inherit=False)
+                    if ds.variables or ds.attrs:
+                        node.dataset = (
+                            _manager_workspace._sanitize_workspace_attr_names(ds)
+                        )
                 tree.to_netcdf(
                     fname,
                     engine="h5netcdf",

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -135,6 +135,14 @@ class _WorkspaceIOController:
         self._manager = manager
         self._missing_workspace_colormaps: list[tuple[str, str]] = []
         self._loader_state = _manager_workspace.WorkspaceLoaderState()
+        self._pending_workspace_window_file_path: str | None = None
+        self._workspace_window_file_path_defer_depth = 0
+        self._workspace_window_file_path_timer = QtCore.QTimer(manager)
+        self._workspace_window_file_path_timer.setSingleShot(True)
+        self._workspace_window_file_path_timer.setInterval(0)
+        self._workspace_window_file_path_timer.timeout.connect(
+            self._apply_macos_workspace_window_file_path
+        )
 
     def _record_missing_workspace_colormap(
         self, cmap: str, node_path: str | None
@@ -395,13 +403,9 @@ class _WorkspaceIOController:
             window_file_path = ""
         else:
             window_file_path = typing.cast("str", self._manager.workspace_path)
-        # Work around a macOS Qt/Cocoa crash observed during close-time workspace
-        # saves in QWidget.setWindowFilePath() -> QImage.toCGImage(). The window is
-        # closing, so the document proxy icon update is unnecessary here. Add the
-        # QTBUG ID once a reproducible report exists and remove this guard once fixed.
-        if not (
-            sys.platform == "darwin" and self._manager._workspace_state.closing_document
-        ):
+        if sys.platform == "darwin":
+            self._defer_macos_workspace_window_file_path_update(window_file_path)
+        else:
             self._manager.setWindowFilePath(window_file_path)
         workspace_display_name = (
             "Untitled"
@@ -413,6 +417,71 @@ class _WorkspaceIOController:
             f" - ImageTool Manager #{self._manager.manager_index}"
         )
         self._manager.setWindowModified(self._manager.is_workspace_modified)
+
+    def _defer_macos_workspace_window_file_path_update(
+        self, window_file_path: str
+    ) -> None:
+        # Work around a macOS Qt/Cocoa crash observed while opening and closing
+        # workspaces in QWidget.setWindowFilePath() -> QImage.toCGImage(). The
+        # represented-file/proxy-icon update is queued until workspace load/save
+        # boundaries are no longer active, while closing windows skip it entirely.
+        if self._manager._workspace_state.closing_document:
+            self._cancel_macos_workspace_window_file_path_update()
+            return
+        if (
+            self._pending_workspace_window_file_path is None
+            and self._manager.windowFilePath() == window_file_path
+        ):
+            return
+        self._pending_workspace_window_file_path = window_file_path
+        self._schedule_macos_workspace_window_file_path_update()
+
+    @contextlib.contextmanager
+    def _macos_workspace_window_file_path_update_context(self) -> Iterator[None]:
+        self._workspace_window_file_path_defer_depth += 1
+        try:
+            yield
+        finally:
+            self._workspace_window_file_path_defer_depth -= 1
+            self._schedule_macos_workspace_window_file_path_update()
+
+    def _schedule_macos_workspace_window_file_path_update(self) -> None:
+        if (
+            self._pending_workspace_window_file_path is None
+            or self._manager._workspace_state.closing_document
+            or self._macos_workspace_window_file_path_update_deferred()
+            or self._workspace_window_file_path_timer.isActive()
+        ):
+            return
+        self._workspace_window_file_path_timer.start()
+
+    def _macos_workspace_window_file_path_update_deferred(self) -> bool:
+        return (
+            self._workspace_window_file_path_defer_depth > 0
+            or self._manager._workspace_state.loading_depth > 0
+            or self._manager._workspace_state.saving_depth > 0
+            or self._manager._workspace_state.save_in_progress
+        )
+
+    def _cancel_macos_workspace_window_file_path_update(self) -> None:
+        self._pending_workspace_window_file_path = None
+        self._workspace_window_file_path_timer.stop()
+
+    def _apply_macos_workspace_window_file_path(self) -> None:
+        window_file_path = self._pending_workspace_window_file_path
+        if window_file_path is None or not erlab.interactive.utils.qt_is_valid(
+            self._manager
+        ):
+            self._pending_workspace_window_file_path = None
+            return
+        if self._manager._workspace_state.closing_document:
+            return
+        if self._macos_workspace_window_file_path_update_deferred():
+            return
+        self._pending_workspace_window_file_path = None
+        if self._manager.windowFilePath() == window_file_path:
+            return
+        self._manager.setWindowFilePath(window_file_path)
 
     def _release_workspace_lock(self) -> None:
         if self._manager._workspace_state.lock is None:
@@ -662,7 +731,10 @@ class _WorkspaceIOController:
     @contextlib.contextmanager
     def _workspace_load_context(self) -> Iterator[None]:
         with self._manager._workspace_state.load_context():
-            yield
+            try:
+                yield
+            finally:
+                self._schedule_macos_workspace_window_file_path_update()
 
     def _drain_workspace_deferred_events(self) -> None:
         for _ in range(3):
@@ -2044,38 +2116,39 @@ class _WorkspaceIOController:
         workspace_access: _WorkspaceDocumentAccess | None = None,
         rebind_data: bool = True,
     ) -> None:
-        associated_fname = fname
-        associated_lock: QtCore.QLockFile | None = None
-        if _manager_workspace._workspace_schema_requires_conversion(schema_version):
-            converted = self._manager._save_legacy_workspace_as_v4(
-                fname, native=native, existing_access=workspace_access
-            )
-            if converted is None:
-                self._manager._set_workspace_path(None)
-                self._manager._workspace_state.needs_full_save = True
-                self._manager._mark_workspace_structure_dirty(
-                    "Legacy workspace needs conversion"
+        with self._macos_workspace_window_file_path_update_context():
+            associated_fname = fname
+            associated_lock: QtCore.QLockFile | None = None
+            if _manager_workspace._workspace_schema_requires_conversion(schema_version):
+                converted = self._manager._save_legacy_workspace_as_v4(
+                    fname, native=native, existing_access=workspace_access
                 )
-                return
-            associated_fname, associated_lock = converted
-            delta_save_count = 0
-            schema_version = _manager_workspace._current_workspace_schema_version()
-        elif workspace_access is not None:
-            associated_lock = workspace_access.take_lock()
+                if converted is None:
+                    self._manager._set_workspace_path(None)
+                    self._manager._workspace_state.needs_full_save = True
+                    self._manager._mark_workspace_structure_dirty(
+                        "Legacy workspace needs conversion"
+                    )
+                    return
+                associated_fname, associated_lock = converted
+                delta_save_count = 0
+                schema_version = _manager_workspace._current_workspace_schema_version()
+            elif workspace_access is not None:
+                associated_lock = workspace_access.take_lock()
 
-        self._manager._set_workspace_path(
-            associated_fname, workspace_lock=associated_lock
-        )
-        self._manager._workspace_state.delta_save_count = delta_save_count
-        self._manager._workspace_state.schema_version = schema_version
-        self._manager._workspace_state.needs_full_save = (
-            _manager_workspace._workspace_schema_requires_full_save(schema_version)
-        )
-        if rebind_data:
-            self._manager._rebind_workspace_backed_imagetools(associated_fname)
-        self._manager._drain_workspace_deferred_events()
-        self._manager._mark_workspace_clean()
-        self._manager._record_recent_workspace(associated_fname)
+            self._manager._set_workspace_path(
+                associated_fname, workspace_lock=associated_lock
+            )
+            self._manager._workspace_state.delta_save_count = delta_save_count
+            self._manager._workspace_state.schema_version = schema_version
+            self._manager._workspace_state.needs_full_save = (
+                _manager_workspace._workspace_schema_requires_full_save(schema_version)
+            )
+            if rebind_data:
+                self._manager._rebind_workspace_backed_imagetools(associated_fname)
+            self._manager._drain_workspace_deferred_events()
+            self._manager._mark_workspace_clean()
+            self._manager._record_recent_workspace(associated_fname)
 
     def _workspace_rebind_data_for_uid(
         self,
@@ -2628,37 +2701,38 @@ class _WorkspaceIOController:
         )
         if fname is None:
             return False
-        old_workspace_path = self._manager._workspace_state.path
-        backing_snapshot = self._manager._workspace_data_backing_snapshot()
-        try:
-            dialog_parent = origin or self._manager
-            with self._manager._workspace_document_access_context(fname) as access:
-                with erlab.interactive.utils.wait_dialog(
-                    dialog_parent, "Saving workspace..."
-                ):
-                    self._manager._save_workspace_document(
-                        access.path,
-                        force_full=True,
-                        document_access=access,
+        with self._macos_workspace_window_file_path_update_context():
+            old_workspace_path = self._manager._workspace_state.path
+            backing_snapshot = self._manager._workspace_data_backing_snapshot()
+            try:
+                dialog_parent = origin or self._manager
+                with self._manager._workspace_document_access_context(fname) as access:
+                    with erlab.interactive.utils.wait_dialog(
+                        dialog_parent, "Saving workspace..."
+                    ):
+                        self._manager._save_workspace_document(
+                            access.path,
+                            force_full=True,
+                            document_access=access,
+                        )
+                        self._manager._rebind_workspace_backed_imagetools(
+                            access.path,
+                            backing_snapshot=backing_snapshot,
+                            old_workspace_path=old_workspace_path,
+                        )
+                    self._manager._set_workspace_path(
+                        access.path, workspace_lock=access.take_lock()
                     )
-                    self._manager._rebind_workspace_backed_imagetools(
-                        access.path,
-                        backing_snapshot=backing_snapshot,
-                        old_workspace_path=old_workspace_path,
-                    )
-                self._manager._set_workspace_path(
-                    access.path, workspace_lock=access.take_lock()
+                self._manager._workspace_state.needs_full_save = False
+                self._manager._drain_workspace_deferred_events()
+                self._manager._mark_workspace_clean()
+                self._manager._record_recent_workspace(access.path)
+            except Exception:
+                self._manager._show_operation_error(
+                    "Error while saving workspace",
+                    "An error occurred while saving the workspace file.",
                 )
-            self._manager._workspace_state.needs_full_save = False
-            self._manager._drain_workspace_deferred_events()
-            self._manager._mark_workspace_clean()
-            self._manager._record_recent_workspace(access.path)
-        except Exception:
-            self._manager._show_operation_error(
-                "Error while saving workspace",
-                "An error occurred while saving the workspace file.",
-            )
-            return False
+                return False
         self._manager._restore_focus_after_workspace_save(origin)
         return True
 

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -773,7 +773,13 @@ def test_manager_open_preselects_default_loader_filter(
         def exec(self) -> bool:
             return False
 
-    manager = types.SimpleNamespace(_recent_name_filter=None, _recent_directory=None)
+    class _FakeManager(QtCore.QObject):
+        def __init__(self) -> None:
+            super().__init__()
+            self._recent_name_filter = None
+            self._recent_directory = None
+
+    manager = _FakeManager()
     manager._preferred_name_filter = types.MethodType(
         ImageToolManager._preferred_name_filter, manager
     )
@@ -1094,14 +1100,17 @@ def test_manager_open_loader_selection_branches(
     def _select_loader_options(*args, **kwargs):
         select_calls.append((*args, kwargs))
 
-    manager = types.SimpleNamespace(
-        _recent_name_filter=None,
-        _recent_directory=None,
-        _select_loader_options=_select_loader_options,
-        _add_from_multiple_files=lambda *args, **kwargs: add_calls.append(
-            (args, kwargs)
-        ),
-    )
+    class _FakeManager(QtCore.QObject):
+        def __init__(self) -> None:
+            super().__init__()
+            self._recent_name_filter = None
+            self._recent_directory = None
+            self._select_loader_options = _select_loader_options
+            self._add_from_multiple_files = lambda *args, **kwargs: add_calls.append(
+                (args, kwargs)
+            )
+
+    manager = _FakeManager()
     manager._preferred_name_filter = types.MethodType(
         ImageToolManager._preferred_name_filter, manager
     )

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -4042,7 +4042,7 @@ def test_workspace_window_title_placeholder_non_macos(monkeypatch) -> None:
     )
 
 
-def test_manager_workspace_window_title_sets_file_path_normally(
+def test_manager_workspace_window_title_sets_file_path_on_non_macos(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -4056,6 +4056,7 @@ def test_manager_workspace_window_title_sets_file_path_normally(
         file_path_calls: list[str] = []
 
         with monkeypatch.context() as patch:
+            patch.setattr(manager_mainwindow.sys, "platform", "linux")
             patch.setattr(
                 ImageToolManager,
                 "setWindowFilePath",
@@ -4064,6 +4065,35 @@ def test_manager_workspace_window_title_sets_file_path_normally(
             manager._update_workspace_window_title()
 
         assert file_path_calls == [str(workspace)]
+        assert workspace.name in manager.windowTitle()
+        assert manager.isWindowModified()
+
+
+def test_manager_workspace_window_title_defers_file_path_on_macos(
+    monkeypatch,
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        workspace = tmp_path / "macos-workspace.itws"
+        manager._workspace_state.path = workspace
+        manager._workspace_state.structure_modified = True
+        file_path_calls: list[str] = []
+
+        with monkeypatch.context() as patch:
+            patch.setattr(manager_mainwindow.sys, "platform", "darwin")
+            patch.setattr(
+                ImageToolManager,
+                "setWindowFilePath",
+                lambda _manager, path: file_path_calls.append(path),
+            )
+            manager._update_workspace_window_title()
+            assert file_path_calls == []
+            qtbot.wait_until(lambda: file_path_calls == [str(workspace)])
+
         assert workspace.name in manager.windowTitle()
         assert manager.isWindowModified()
 
@@ -4093,8 +4123,89 @@ def test_manager_workspace_window_title_skips_file_path_during_macos_close(
         finally:
             manager._workspace_state.closing_document = previous_closing
 
+        assert not (
+            manager._workspace_controller._workspace_window_file_path_timer.isActive()
+        )
+        assert manager._workspace_controller._pending_workspace_window_file_path is None
         assert workspace.name in manager.windowTitle()
         assert manager.isWindowModified()
+
+
+def test_manager_workspace_window_file_path_waits_for_load_on_macos(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        workspace = tmp_path / "loading.itws"
+        manager._workspace_state.path = workspace
+        manager._workspace_state.loading_depth = 1
+        file_path_calls: list[str] = []
+
+        try:
+            with monkeypatch.context() as patch:
+                patch.setattr(manager_mainwindow.sys, "platform", "darwin")
+                patch.setattr(
+                    ImageToolManager,
+                    "setWindowFilePath",
+                    lambda _manager, path: file_path_calls.append(path),
+                )
+                manager._update_workspace_window_title()
+                controller._workspace_window_file_path_timer.stop()
+                controller._apply_macos_workspace_window_file_path()
+
+                assert file_path_calls == []
+                assert controller._pending_workspace_window_file_path == str(workspace)
+                assert not controller._workspace_window_file_path_timer.isActive()
+
+                manager._workspace_state.loading_depth = 0
+                controller._schedule_macos_workspace_window_file_path_update()
+                assert controller._workspace_window_file_path_timer.isActive()
+                controller._workspace_window_file_path_timer.stop()
+                controller._apply_macos_workspace_window_file_path()
+
+            assert file_path_calls == [str(workspace)]
+        finally:
+            manager._workspace_state.loading_depth = 0
+            controller._workspace_window_file_path_timer.stop()
+
+
+def test_manager_loaded_workspace_association_defers_macos_file_path_update(
+    monkeypatch,
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        workspace = tmp_path / "loaded.itws"
+        workspace.touch()
+        file_path_calls: list[str] = []
+
+        with monkeypatch.context() as patch:
+            patch.setattr(manager_mainwindow.sys, "platform", "darwin")
+            patch.setattr(
+                ImageToolManager,
+                "setWindowFilePath",
+                lambda _manager, path: file_path_calls.append(path),
+            )
+            with manager._workspace_document_access_context(workspace) as access:
+                manager._associate_loaded_workspace_file(
+                    access.path,
+                    manager_workspace._current_workspace_schema_version(),
+                    workspace_access=access,
+                    rebind_data=False,
+                )
+            assert file_path_calls == []
+            qtbot.wait_until(lambda: file_path_calls == [str(workspace.resolve())])
+
+        assert manager.workspace_path == str(workspace.resolve())
+        assert workspace.name in manager.windowTitle()
+        assert not manager.isWindowModified()
 
 
 def test_manager_workspace_window_title_sets_file_path_for_non_macos_close(
@@ -4128,19 +4239,35 @@ def test_manager_workspace_window_title_sets_file_path_for_non_macos_close(
 
 def test_manager_close_cancel_restores_workspace_document_closing_state(
     monkeypatch,
+    qtbot,
+    tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
     with manager_context() as manager:
+        workspace = tmp_path / "cancel-close.itws"
+        manager._workspace_state.path = workspace
         manager._workspace_state.structure_modified = True
         manager._workspace_state.closing_document = False
+        file_path_calls: list[str] = []
         event = QtGui.QCloseEvent()
         with monkeypatch.context() as patch:
+            patch.setattr(manager_mainwindow.sys, "platform", "darwin")
+            patch.setattr(
+                ImageToolManager,
+                "setWindowFilePath",
+                lambda _manager, path: file_path_calls.append(path),
+            )
             patch.setattr(
                 manager, "_confirm_save_dirty_workspace", lambda _message: False
             )
+            manager._update_workspace_window_title()
+            manager._workspace_controller._workspace_window_file_path_timer.stop()
             manager.closeEvent(event)
+            assert file_path_calls == []
+            assert manager._workspace_controller._workspace_window_file_path_timer.isActive()
+            qtbot.wait_until(lambda: file_path_calls == [str(workspace)])
 
         assert not event.isAccepted()
         assert not manager._workspace_state.closing_document

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -1587,6 +1587,57 @@ def test_manager_workspace_save_selection_cancel_does_not_write(
             assert len(closed_trees) == 1
 
 
+def test_manager_workspace_save_selection_encodes_rich_attrs(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    class _AcceptedChooseDialog:
+        def __init__(self, _manager, tree: xr.DataTree, *, mode: str) -> None:
+            assert mode == "save"
+            self._tree_widget = QtWidgets.QTreeWidget()
+            root_item = self._tree_widget.invisibleRootItem()
+            for key in tree:
+                item = QtWidgets.QTreeWidgetItem(root_item)
+                item.setData(0, QtCore.Qt.ItemDataRole.UserRole, key)
+                item.setCheckState(0, QtCore.Qt.CheckState.Checked)
+
+        def exec(self) -> QtWidgets.QDialog.DialogCode:
+            return QtWidgets.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager._workspace_io,
+        "_ChooseFromDataTreeDialog",
+        _AcceptedChooseDialog,
+    )
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        rich_attr = _rich_workspace_attr_value()
+        data = xr.DataArray(
+            np.arange(4).reshape((2, 2)),
+            dims=("x", "y"),
+            attrs={"Single Motor Scan": rich_attr},
+        )
+        root = itool(data, link=False, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "selected-rich.itws"
+        manager._save_to_file(str(fname))
+
+    with h5py.File(fname, "r") as h5_file:
+        saved_data = h5_file["0/imagetool"][manager_workspace_io._ITOOL_DATA_NAME]
+        assert "Single Motor Scan" not in saved_data.attrs
+        decoded = manager_workspace._h5py_attrs_to_dict(saved_data.attrs)
+    _assert_rich_workspace_attr(decoded["Single Motor Scan"])
+
+
 def test_manager_workspace_load_selection_skips_unchecked_children(
     qtbot,
     monkeypatch,
@@ -2221,6 +2272,108 @@ def _assert_rich_workspace_attr(value: typing.Any) -> None:
     assert value["raw"] == b"\xff"
     np.testing.assert_array_equal(value["points"], np.array([1, 2, 3], dtype=np.int16))
     assert value["window"] == (None, complex(1.0, -2.0))
+
+
+def test_workspace_attr_native_detection_handles_edge_types() -> None:
+    assert manager_workspace._workspace_attr_value_writes_natively(b"ok")
+    assert not manager_workspace._workspace_attr_value_writes_natively(b"\xff")
+    assert not manager_workspace._workspace_attr_value_writes_natively(b"a\x00")
+    assert manager_workspace._workspace_attr_value_writes_natively(
+        np.array([1, 2], dtype=np.int16)
+    )
+    assert not manager_workspace._workspace_attr_value_writes_natively(
+        np.array([object()], dtype=object)
+    )
+    assert manager_workspace._workspace_attr_value_writes_natively(np.float64(1.0))
+    assert not manager_workspace._workspace_attr_value_writes_natively(
+        np.datetime64("2024-01-01")
+    )
+    assert manager_workspace._workspace_attr_value_writes_natively(
+        ("text", b"bytes", np.bool_(True), complex(1.0, 2.0))
+    )
+    assert not manager_workspace._workspace_attr_value_writes_natively(([1],))
+
+
+def test_workspace_attr_typed_encoding_roundtrips_safe_values(caplog) -> None:
+    import decimal
+    import math
+
+    value = {
+        None: None,
+        False: True,
+        np.int64(3): 5,
+        7: np.float64(2.5),
+        1.5: math.inf,
+        complex(1.0, -2.0): -math.inf,
+        "nan": math.nan,
+        b"\xff": b"\x00\xff",
+        ("tuple", 2): [
+            np.array([[1, 2], [3, 4]], dtype=np.int16),
+            np.array([{"nested": (None, complex(3.0, 4.0))}], dtype=object),
+        ],
+    }
+
+    decoded = manager_workspace._workspace_decode_attr_value(
+        manager_workspace._workspace_encode_attr_value(value)
+    )
+
+    assert decoded[None] is None
+    assert decoded[False] is True
+    assert decoded[3] == 5
+    assert decoded[7] == np.float64(2.5)
+    assert decoded[1.5] == math.inf
+    assert decoded[complex(1.0, -2.0)] == -math.inf
+    assert math.isnan(decoded["nan"])
+    assert decoded[b"\xff"] == b"\x00\xff"
+    np.testing.assert_array_equal(
+        decoded[("tuple", 2)][0], np.array([[1, 2], [3, 4]], dtype=np.int16)
+    )
+    assert decoded[("tuple", 2)][1][0]["nested"] == (None, complex(3.0, 4.0))
+
+    with pytest.raises(TypeError, match="unsupported attr key type"):
+        manager_workspace._workspace_encode_attr_key(["bad"])
+    with pytest.raises(TypeError, match="unsupported numeric attr type"):
+        manager_workspace._workspace_encode_attr_value(decimal.Decimal("1.0"))
+    with pytest.raises(TypeError, match="must be a mapping"):
+        manager_workspace._workspace_decode_attr_value([])
+    with pytest.raises(TypeError, match="unknown workspace attr value kind"):
+        manager_workspace._workspace_decode_attr_value({"kind": "unknown"})
+    with pytest.raises(TypeError, match="not hashable"):
+        manager_workspace._workspace_decode_attr_key({"kind": "list", "items": []})
+
+    assert manager_workspace._workspace_encoded_attr_entries(b"\xff") is None
+    assert manager_workspace._workspace_encoded_attr_entries(1) is None
+    assert manager_workspace._workspace_encoded_attr_entries("{bad-json") is None
+    assert (
+        manager_workspace._workspace_encoded_attr_entries(
+            json.dumps({"version": -1, "attrs": []})
+        )
+        is None
+    )
+    assert (
+        manager_workspace._workspace_encoded_attr_entries(
+            json.dumps(
+                {
+                    "version": manager_workspace._WORKSPACE_ENCODED_ATTRS_VERSION,
+                    "attrs": [["too-short"]],
+                }
+            )
+        )
+        is None
+    )
+
+    invalid_payload = json.dumps(
+        {
+            "version": manager_workspace._WORKSPACE_ENCODED_ATTRS_VERSION,
+            "attrs": [[{"kind": "list", "items": []}, {"kind": "str", "value": "x"}]],
+        }
+    )
+    with caplog.at_level(logging.WARNING):
+        restored = manager_workspace._restore_workspace_serialized_attrs(
+            {manager_workspace._WORKSPACE_ENCODED_ATTRS_ATTR: invalid_payload}
+        )
+    assert restored == {}
+    assert "Ignoring invalid encoded workspace attribute" in caplog.text
 
 
 def test_replace_h5_attrs_drops_invalid_attr_names(tmp_path) -> None:
@@ -4173,6 +4326,44 @@ def test_manager_workspace_window_file_path_waits_for_load_on_macos(
             controller._workspace_window_file_path_timer.stop()
 
 
+def test_manager_workspace_window_file_path_apply_guard_paths(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        file_path_calls: list[str] = []
+        workspace = str(tmp_path / "same.itws")
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                ImageToolManager,
+                "setWindowFilePath",
+                lambda _manager, path: file_path_calls.append(path),
+            )
+
+            controller._pending_workspace_window_file_path = None
+            controller._apply_macos_workspace_window_file_path()
+            assert controller._pending_workspace_window_file_path is None
+
+            manager._workspace_state.closing_document = True
+            controller._pending_workspace_window_file_path = workspace
+            controller._apply_macos_workspace_window_file_path()
+            assert file_path_calls == []
+            assert controller._pending_workspace_window_file_path == workspace
+
+            manager._workspace_state.closing_document = False
+            patch.setattr(
+                ImageToolManager, "windowFilePath", lambda _manager: workspace
+            )
+            controller._apply_macos_workspace_window_file_path()
+            assert file_path_calls == []
+            assert controller._pending_workspace_window_file_path is None
+
+
 def test_manager_loaded_workspace_association_defers_macos_file_path_update(
     monkeypatch,
     qtbot,
@@ -4206,6 +4397,34 @@ def test_manager_loaded_workspace_association_defers_macos_file_path_update(
         assert manager.workspace_path == str(workspace.resolve())
         assert workspace.name in manager.windowTitle()
         assert not manager.isWindowModified()
+
+
+def test_manager_loaded_workspace_association_rebinds_data_after_path_update_context(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        workspace = tmp_path / "loaded-rebind.itws"
+        workspace.touch()
+        rebind_paths: list[pathlib.Path] = []
+
+        monkeypatch.setattr(
+            manager,
+            "_rebind_workspace_backed_imagetools",
+            lambda path: rebind_paths.append(pathlib.Path(path)),
+        )
+        with manager._workspace_document_access_context(workspace) as access:
+            manager._associate_loaded_workspace_file(
+                access.path,
+                manager_workspace._current_workspace_schema_version(),
+                workspace_access=access,
+                rebind_data=True,
+            )
+
+        assert rebind_paths == [workspace.resolve()]
 
 
 def test_manager_workspace_window_title_sets_file_path_for_non_macos_close(
@@ -4246,6 +4465,7 @@ def test_manager_close_cancel_restores_workspace_document_closing_state(
     ],
 ) -> None:
     with manager_context() as manager:
+        controller = manager._workspace_controller
         workspace = tmp_path / "cancel-close.itws"
         manager._workspace_state.path = workspace
         manager._workspace_state.structure_modified = True
@@ -4263,10 +4483,10 @@ def test_manager_close_cancel_restores_workspace_document_closing_state(
                 manager, "_confirm_save_dirty_workspace", lambda _message: False
             )
             manager._update_workspace_window_title()
-            manager._workspace_controller._workspace_window_file_path_timer.stop()
+            controller._workspace_window_file_path_timer.stop()
             manager.closeEvent(event)
             assert file_path_calls == []
-            assert manager._workspace_controller._workspace_window_file_path_timer.isActive()
+            assert controller._workspace_window_file_path_timer.isActive()
             qtbot.wait_until(lambda: file_path_calls == [str(workspace)])
 
         assert not event.isAccepted()
@@ -4460,6 +4680,41 @@ def test_manager_workspace_save_as_locked_target_does_not_write(
         lock.unlock()
 
     assert operation_errors
+
+
+def test_manager_workspace_save_as_reports_document_write_error(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    fname = tmp_path / "write-error.itws"
+    operation_errors: list[tuple[typing.Any, ...]] = []
+
+    with manager_context() as manager:
+        monkeypatch.setattr(
+            manager, "_workspace_save_dialog", lambda *args, **kwargs: str(fname)
+        )
+        monkeypatch.setattr(
+            manager,
+            "_save_workspace_document",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        monkeypatch.setattr(
+            manager,
+            "_show_operation_error",
+            lambda *args, **kwargs: operation_errors.append(args),
+        )
+
+        assert not manager.save_as(native=False)
+
+    assert operation_errors == [
+        (
+            "Error while saving workspace",
+            "An error occurred while saving the workspace file.",
+        )
+    ]
 
 
 def test_manager_workspace_load_locks_before_recovery(

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -2202,6 +2202,27 @@ def test_workspace_h5py_attrs_and_root_validation(tmp_path) -> None:
         manager_workspace._read_workspace_root_attrs_h5py(fname)
 
 
+def _rich_workspace_attr_value() -> dict[str, typing.Any]:
+    return {
+        "X Motor": "EPU Gap",
+        "Start": np.float64(20.0),
+        "Bidirect": False,
+        "raw": b"\xff",
+        "points": np.array([1, 2, 3], dtype=np.int16),
+        "window": (None, complex(1.0, -2.0)),
+    }
+
+
+def _assert_rich_workspace_attr(value: typing.Any) -> None:
+    assert isinstance(value, dict)
+    assert value["X Motor"] == "EPU Gap"
+    assert value["Start"] == np.float64(20.0)
+    assert value["Bidirect"] is False
+    assert value["raw"] == b"\xff"
+    np.testing.assert_array_equal(value["points"], np.array([1, 2, 3], dtype=np.int16))
+    assert value["window"] == (None, complex(1.0, -2.0))
+
+
 def test_replace_h5_attrs_drops_invalid_attr_names(tmp_path) -> None:
     import h5py
 
@@ -2219,6 +2240,26 @@ def test_replace_h5_attrs_drops_invalid_attr_names(tmp_path) -> None:
         assert "" not in list(group.attrs)
         assert group.attrs["note"] == ""
         assert group.attrs["valid"] == "kept"
+
+
+def test_replace_h5_attrs_encodes_non_native_attr_values(tmp_path) -> None:
+    import h5py
+
+    fname = tmp_path / "replace-rich-attrs.itws"
+    rich_attr = _rich_workspace_attr_value()
+    with h5py.File(fname, "w") as h5_file:
+        group = h5_file.create_group("0/imagetool")
+
+        manager_workspace._replace_h5_attrs(
+            group.attrs,
+            {"Single Motor Scan": rich_attr, "valid": "kept"},
+        )
+
+        assert "Single Motor Scan" not in group.attrs
+        assert manager_workspace._WORKSPACE_ENCODED_ATTRS_ATTR in group.attrs
+        decoded = manager_workspace._h5py_attrs_to_dict(group.attrs)
+        assert decoded["valid"] == "kept"
+        _assert_rich_workspace_attr(decoded["Single Motor Scan"])
 
 
 def _assert_workspace_h5py_roundtrip(
@@ -2445,6 +2486,66 @@ def test_workspace_h5py_fast_path_keeps_numeric_since_units(tmp_path) -> None:
     assert loaded.coords["elapsed"].attrs["units"] == "seconds since start"
 
 
+def test_workspace_writer_roundtrips_non_native_attr_values_from_fast_path(
+    tmp_path,
+) -> None:
+    import h5py
+
+    data_name = manager_workspace_io._ITOOL_DATA_NAME
+    fname = tmp_path / "rich-attrs-fast-path.itws"
+    rich_attr = _rich_workspace_attr_value()
+    data = xr.DataArray(
+        np.arange(2.0),
+        dims=("x",),
+        coords={
+            "x": xr.DataArray(
+                [0.0, 1.0],
+                dims=("x",),
+                attrs={"axis_config": rich_attr},
+            ),
+            "temperature": xr.DataArray(
+                [20.0, 21.0],
+                dims=("x",),
+                attrs={"scan_config": rich_attr},
+            ),
+        },
+        attrs={"Single Motor Scan": rich_attr},
+        name=data_name,
+    )
+    ds = data.to_dataset()
+    ds.attrs["dataset_config"] = rich_attr
+
+    manager_workspace._write_workspace_dataset_group_to_file(fname, "0/imagetool", ds)
+
+    assert ds.attrs["dataset_config"] is rich_attr
+    assert ds[data_name].attrs["Single Motor Scan"] is rich_attr
+    with h5py.File(fname, "r") as h5_file:
+        group = h5_file["0/imagetool"]
+        saved_data = group[data_name]
+        assert "dataset_config" not in group.attrs
+        assert "Single Motor Scan" not in saved_data.attrs
+        assert manager_workspace._WORKSPACE_ENCODED_ATTRS_ATTR in group.attrs
+        assert manager_workspace._WORKSPACE_ENCODED_ATTRS_ATTR in saved_data.attrs
+
+    loaded = manager_workspace._read_workspace_dataset_group_h5py(
+        fname, "0/imagetool", preferred_data_name=data_name
+    )
+    assert loaded is not None
+    _assert_rich_workspace_attr(loaded.attrs["dataset_config"])
+    _assert_rich_workspace_attr(loaded[data_name].attrs["Single Motor Scan"])
+    _assert_rich_workspace_attr(loaded.coords["x"].attrs["axis_config"])
+    _assert_rich_workspace_attr(loaded.coords["temperature"].attrs["scan_config"])
+
+    opened = manager_xarray.open_workspace_dataset(fname, "0/imagetool", chunks=None)
+    try:
+        restored = manager_workspace._restore_workspace_dataset_attrs(opened.load())
+    finally:
+        opened.close()
+    _assert_rich_workspace_attr(restored.attrs["dataset_config"])
+    _assert_rich_workspace_attr(restored[data_name].attrs["Single Motor Scan"])
+    _assert_rich_workspace_attr(restored.coords["x"].attrs["axis_config"])
+
+
 def test_workspace_writer_drops_invalid_attr_names_from_fast_path(tmp_path) -> None:
     import h5py
 
@@ -2502,12 +2603,17 @@ def test_workspace_writer_drops_invalid_attr_names_from_fast_path(tmp_path) -> N
 
 def test_workspace_writer_drops_invalid_attr_names_from_fallback(tmp_path) -> None:
     fname = tmp_path / "invalid-attrs-fallback.itws"
+    rich_attr = _rich_workspace_attr_value()
     ds = xr.Dataset(
         {
             "left": xr.DataArray(
                 [1.0, 2.0],
                 dims=("x",),
-                attrs={"": "dropped", "left_note": ""},
+                attrs={
+                    "": "dropped",
+                    "left_note": "",
+                    "Single Motor Scan": rich_attr,
+                },
             ),
             "right": ("x", [3.0, 4.0]),
         },
@@ -2515,17 +2621,17 @@ def test_workspace_writer_drops_invalid_attr_names_from_fallback(tmp_path) -> No
             "x": xr.DataArray(
                 [0.0, 1.0],
                 dims=("x",),
-                attrs={None: "dropped", "axis_note": ""},
+                attrs={None: "dropped", "axis_note": "", "axis_config": rich_attr},
             )
         },
-        attrs={"": "dropped", "dataset_note": ""},
+        attrs={"": "dropped", "dataset_note": "", "dataset_config": rich_attr},
     )
 
     manager_workspace._write_workspace_dataset_group_to_file(fname, "0/tool", ds)
 
     opened = xr.open_dataset(fname, group="/0/tool", engine="h5netcdf")
     try:
-        loaded = opened.load()
+        loaded = manager_workspace._restore_workspace_dataset_attrs(opened.load())
     finally:
         opened.close()
 
@@ -2535,12 +2641,15 @@ def test_workspace_writer_drops_invalid_attr_names_from_fallback(tmp_path) -> No
     assert loaded.attrs["dataset_note"] == ""
     assert "" not in loaded["left"].attrs
     assert loaded["left"].attrs["left_note"] == ""
+    _assert_rich_workspace_attr(loaded["left"].attrs["Single Motor Scan"])
     assert "" not in loaded.coords["x"].attrs
     assert loaded.coords["x"].attrs["axis_note"] == ""
+    _assert_rich_workspace_attr(loaded.coords["x"].attrs["axis_config"])
+    _assert_rich_workspace_attr(loaded.attrs["dataset_config"])
 
 
 def test_workspace_h5py_fast_path_rejects_invalid_payloads(
-    monkeypatch, tmp_path
+    caplog, monkeypatch, tmp_path
 ) -> None:
     data_name = manager_workspace_io._ITOOL_DATA_NAME
     private_attr = imagetool_serialization._PRIVATE_COORDS_ATTR
@@ -2607,13 +2716,16 @@ def test_workspace_h5py_fast_path_rejects_invalid_payloads(
     bad_attrs = xr.Dataset({data_name: ("x", [1.0])}, coords={"x": [0.0]})
     bad_attrs.attrs["bad"] = object()
     fname = tmp_path / "bad-attrs.itws"
-    assert not manager_workspace._write_workspace_dataset_group_h5py(
-        fname, "0/imagetool", bad_attrs
-    )
+    with caplog.at_level(logging.WARNING, logger=manager_workspace.logger.name):
+        assert manager_workspace._write_workspace_dataset_group_h5py(
+            fname, "0/imagetool", bad_attrs
+        )
+    assert "unsupported value type object" in caplog.text
     import h5py
 
     with h5py.File(fname, "r") as h5_file:
-        assert "0/imagetool" not in h5_file
+        assert "0/imagetool" in h5_file
+        assert "bad" not in h5_file["0/imagetool"].attrs
 
 
 def test_workspace_h5py_reader_rejects_malformed_groups(tmp_path) -> None:
@@ -3327,6 +3439,7 @@ def test_write_full_workspace_tree_file_copies_unchanged_payload_groups(
             "itool_title": "new",
             "manager_node_uid": "n0",
             "manager_node_kind": "imagetool",
+            "Single Motor Scan": _rich_workspace_attr_value(),
         }
     )
     tree = xr.DataTree.from_dict({"0/imagetool": rewritten})
@@ -3349,6 +3462,8 @@ def test_write_full_workspace_tree_file_copies_unchanged_payload_groups(
     with h5py.File(fname, "r") as h5_file:
         group = h5_file["0/imagetool"]
         assert group.attrs["itool_title"] == "new"
+        decoded_attrs = manager_workspace._h5py_attrs_to_dict(group.attrs)
+        _assert_rich_workspace_attr(decoded_attrs["Single Motor Scan"])
         np.testing.assert_array_equal(
             group[manager_workspace_io._ITOOL_DATA_NAME][...],
             np.arange(12, dtype=np.float64).reshape(3, 4),
@@ -3716,6 +3831,41 @@ def test_workspace_recovery_rolls_back_attr_only_transaction(tmp_path) -> None:
         assert h5_file["0/imagetool"].attrs["itool_title"] == "old"
         assert (
             manager_workspace._workspace_delta_save_count_from_attrs(h5_file.attrs) == 0
+        )
+    _assert_no_workspace_internal_groups(fname)
+
+
+def test_workspace_transaction_attr_update_encodes_non_native_values(tmp_path) -> None:
+    import h5py
+
+    fname = tmp_path / "rich-attrs-transaction.itws"
+    _write_transaction_test_workspace(fname)
+    fallback = (
+        "0",
+        {"0/imagetool": _transaction_test_dataset(2.0, title="fallback")},
+    )
+    rich_attr = _rich_workspace_attr_value()
+    manager_workspace._write_workspace_transaction_file(
+        fname,
+        (),
+        (
+            (
+                "0/imagetool",
+                {"itool_title": "new", "Single Motor Scan": rich_attr},
+                fallback,
+            ),
+        ),
+        _transaction_test_root_attrs(delta_save_count=1),
+    )
+
+    with h5py.File(fname, "r") as h5_file:
+        decoded_attrs = manager_workspace._h5py_attrs_to_dict(
+            h5_file["0/imagetool"].attrs
+        )
+        assert decoded_attrs["itool_title"] == "new"
+        _assert_rich_workspace_attr(decoded_attrs["Single Motor Scan"])
+        assert (
+            manager_workspace._workspace_delta_save_count_from_attrs(h5_file.attrs) == 1
         )
     _assert_no_workspace_internal_groups(fname)
 
@@ -6930,6 +7080,83 @@ def test_manager_workspace_full_save_drops_empty_attr_name(
             ].attrs
             assert "" not in list(saved_attrs)
             assert saved_attrs["note"] == ""
+
+
+def test_manager_workspace_full_save_roundtrips_non_native_data_attrs(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    rich_attr = _rich_workspace_attr_value()
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25).reshape((5, 5)),
+            dims=["x", "y"],
+            coords={
+                "x": xr.DataArray(
+                    np.arange(5),
+                    dims=("x",),
+                    attrs={"axis_config": rich_attr},
+                ),
+                "y": np.arange(5),
+            },
+            attrs={"Single Motor Scan": rich_attr},
+            name="data",
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        live_rich_attr = root.slicer_area._data.attrs["Single Motor Scan"]
+        live_axis_attr = root.slicer_area._data.coords["x"].attrs["axis_config"]
+
+        fname = tmp_path / "rich-data-attrs.itws"
+        manager._save_workspace_document(fname, force_full=True)
+
+        assert root.slicer_area._data.attrs["Single Motor Scan"] is live_rich_attr
+        assert root.slicer_area._data.coords["x"].attrs["axis_config"] is live_axis_attr
+        assert (
+            manager_workspace._WORKSPACE_ENCODED_ATTRS_ATTR
+            not in root.slicer_area._data.attrs
+        )
+        with h5py.File(fname, "r") as h5_file:
+            saved_data = h5_file["0/imagetool"][manager_workspace_io._ITOOL_DATA_NAME]
+            assert "Single Motor Scan" not in saved_data.attrs
+            assert manager_workspace._WORKSPACE_ENCODED_ATTRS_ATTR in saved_data.attrs
+
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        loaded = manager.get_imagetool(0).slicer_area._data
+        _assert_rich_workspace_attr(loaded.attrs["Single Motor Scan"])
+        _assert_rich_workspace_attr(loaded.coords["x"].attrs["axis_config"])
+
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+        tree = manager_xarray.open_workspace_datatree(fname, chunks=None)
+        try:
+            assert manager._from_datatree(
+                tree,
+                replace=True,
+                mark_dirty=False,
+                select=False,
+                workspace_file_path=fname,
+            )
+        finally:
+            tree.close()
+        loaded = manager.get_imagetool(0).slicer_area._data
+        _assert_rich_workspace_attr(loaded.attrs["Single Motor Scan"])
+        _assert_rich_workspace_attr(loaded.coords["x"].attrs["axis_config"])
 
 
 def test_manager_workspace_save_preserves_reordered_roots(


### PR DESCRIPTION
## Summary
- Encode workspace attributes that h5py cannot write natively, including nested values, arrays, bytes, and non-string keys
- Restore encoded attributes when reading workspace files so ImageTool datasets keep their original metadata
- Sanitize workspace attributes before full saves and transaction writes so invalid names are dropped cleanly while supported values round-trip
- Add regression coverage for fast-path saves, fallback saves, transaction updates, and manager full-save/load flows

## Testing
- Added unit and integration-style tests covering attribute encoding/decoding and workspace round-trips
- Validated that unsupported attribute values are logged and skipped instead of aborting the save path
- Not run (not requested)