### PR TITLE
Show delete action for child ImageTools

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -400,6 +400,7 @@ class _ManagedWindowNode(QtCore.QObject):
                 self._handle_source_data_replaced
             )
             value.slicer_area._in_manager = True
+            value.remove_act.setVisible(True)
             for plot in value.slicer_area.axes:
                 plot.ensure_manager_figure_actions()
             return

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -2828,15 +2828,22 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if self._in_manager:
             manager = self._manager_instance
             if manager:  # pragma: no branch
-                index = manager.index_from_slicer_area(self)
-                if index is not None:  # pragma: no branch
+                target = manager.target_from_slicer_area(self)
+                if target is not None:  # pragma: no branch
                     msg_box = QtWidgets.QMessageBox(self)
                     msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
                     msg_box.setText("Remove window?")
-                    msg_box.setInformativeText(
-                        f"The ImageTool window at index {index} will be removed. "
-                        "This cannot be undone."
-                    )
+                    if isinstance(target, int):
+                        informative_text = (
+                            f"The ImageTool window at index {target} will be removed. "
+                            "This cannot be undone."
+                        )
+                    else:
+                        informative_text = (
+                            "The current ImageTool window will be removed. "
+                            "This cannot be undone."
+                        )
+                    msg_box.setInformativeText(informative_text)
                     msg_box.setStandardButtons(
                         QtWidgets.QMessageBox.StandardButton.Yes
                         | QtWidgets.QMessageBox.StandardButton.Cancel
@@ -2844,9 +2851,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
                     msg_box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Yes)
 
                     if msg_box.exec() == QtWidgets.QMessageBox.StandardButton.Yes:
-                        erlab.interactive.utils.single_shot(
-                            manager, 0, lambda: manager.remove_imagetool(index)
-                        )
+                        if isinstance(target, int):
+                            erlab.interactive.utils.single_shot(
+                                manager, 0, lambda: manager.remove_imagetool(target)
+                            )
+                        else:
+                            erlab.interactive.utils.single_shot(
+                                manager, 0, lambda: manager._remove_childtool(target)
+                            )
 
     def add_tool_window(
         self,

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -1553,6 +1553,41 @@ def test_remove_childtool_delete_shortcut(
         qtbot.wait_until(lambda: uid not in wrapper._childtools, timeout=5000)
 
 
+def test_remove_child_imagetool_delete_shortcut(
+    qtbot,
+    accept_dialog,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        test_data.qshow(manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child_tool = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(_batch_data("child"), manager=False, execute=False),
+        )
+        child_uid = manager.add_imagetool_child(child_tool, 0, show=True, activate=True)
+        child = manager.get_imagetool(child_uid)
+
+        with qtbot.waitExposed(child):
+            child.activateWindow()
+            child.raise_()
+            child.setFocus()
+
+        assert child.remove_act.isVisible()
+
+        accept_dialog(lambda: qtbot.keyClick(child, QtCore.Qt.Key.Key_Delete))
+        qtbot.wait_until(
+            lambda: child_uid not in manager._tool_graph.nodes, timeout=5000
+        )
+
+
 def test_manager_childtool_type_badge_only_for_tool_windows(
     qtbot,
     monkeypatch,


### PR DESCRIPTION
## Summary
- make the delete action visible for child ImageTool windows managed by the main window
- route delete requests through the manager target so child tools prompt and remove correctly
- add a UI test that covers deleting a child ImageTool with the Delete shortcut

## Testing
- Added UI coverage for the child ImageTool delete flow in the manager test suite
- Not run (not requested)