### PR TITLE
Show a warning dialog when replay code cannot be copied

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -252,6 +252,43 @@ class _DetailsPanelController:
         if code:
             erlab.interactive.utils.copy_to_clipboard(code)
 
+    def _unavailable_replay_code_details(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> str:
+        unavailable_labels: list[str] = []
+        for entry in node.derivation_entries[1:]:
+            if entry.code is not None:
+                continue
+            label = " ".join(entry.label.split())
+            if label and label not in unavailable_labels:
+                unavailable_labels.append(label)
+
+        if unavailable_labels:
+            return "\n".join(
+                (
+                    "The following recorded inputs or steps are not available as "
+                    "replayable code:",
+                    *(f"- {label}" for label in unavailable_labels),
+                )
+            )
+        return "The replay graph could not be emitted as Python code."
+
+    def _show_unavailable_replay_code_dialog(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> None:
+        msg_box = QtWidgets.QMessageBox(self._manager)
+        msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        msg_box.setWindowTitle("Replay Code Unavailable")
+        msg_box.setText("Replay code cannot be copied for the selected result.")
+        msg_box.setInformativeText(
+            "The result has provenance, but at least one recorded input or step "
+            "cannot be converted to replayable Python, so nothing was copied."
+        )
+        msg_box.setDetailedText(self._unavailable_replay_code_details(node))
+        msg_box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
+        msg_box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Ok)
+        msg_box.exec()
+
     def _copy_full_derivation_code(self) -> None:
         node = (
             None
@@ -262,9 +299,7 @@ class _DetailsPanelController:
             return
         code = node.derivation_code
         if not code:
-            self._manager._status_bar.showMessage(
-                "Replay code is unavailable for this result", 5000
-            )
+            self._show_unavailable_replay_code_dialog(node)
             return
         if provenance.uses_default_replay_input(code):
             load_source = self._manager._load_source_for_replay(node)

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -17,6 +17,7 @@ import erlab.interactive.utils
 from erlab.interactive.imagetool import _provenance_framework, itool, provenance
 from erlab.interactive.imagetool.manager import fetch
 from erlab.interactive.imagetool.manager._console import ToolNamespace
+from erlab.interactive.imagetool.manager._details_panel import _DetailsPanelController
 from erlab.interactive.imagetool.manager._dialogs import _ConcatDialog
 from erlab.interactive.imagetool.manager._tool_graph import _ManagerToolGraph
 
@@ -2961,6 +2962,24 @@ def test_manager_reload_raw_self_replacement_unavailable(
 
         manager.console._console_widget.shutdown_kernel()
         InteractiveShell.clear_instance()
+
+
+def test_unavailable_replay_code_details_lists_unique_labels_and_fallback() -> None:
+    controller = object.__new__(_DetailsPanelController)
+    start_entry = provenance.DerivationEntry("Start from data", None, False)
+    unavailable_entry = provenance.DerivationEntry("Opaque step", None, False)
+
+    details = controller._unavailable_replay_code_details(
+        types.SimpleNamespace(
+            derivation_entries=(start_entry, unavailable_entry, unavailable_entry)
+        )
+    )
+    assert details.count("Opaque step") == 1
+
+    fallback = controller._unavailable_replay_code_details(
+        types.SimpleNamespace(derivation_entries=(start_entry,))
+    )
+    assert fallback
 
 
 def test_manager_reload_data_hidden_for_non_replayable_script_provenance(

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -2975,6 +2975,15 @@ def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
         dims=("x", "y"),
         coords={"x": np.arange(2), "y": np.arange(2)},
     )
+    dialogs: list[QtWidgets.QMessageBox] = []
+
+    def _record_dialog(
+        dialog: QtWidgets.QMessageBox,
+    ) -> QtWidgets.QMessageBox.StandardButton:
+        dialogs.append(dialog)
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "exec", _record_dialog)
 
     with manager_context() as manager:
         manager.show()
@@ -3004,7 +3013,12 @@ def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
         manager._set_metadata_node(wrapper)
         manager._copy_full_derivation_code()
         assert not copied
-        assert manager._status_bar.currentMessage()
+        assert len(dialogs) == 1
+        assert dialogs[0].icon() == QtWidgets.QMessageBox.Icon.Warning
+        assert dialogs[0].text()
+        assert dialogs[0].informativeText()
+        assert dialogs[0].detailedText()
+        assert "Run opaque code" in dialogs[0].detailedText()
 
 
 def test_manager_console_replacement_updates_provenance_and_descendants(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -15218,6 +15218,16 @@ def test_manager_copy_full_code_for_memory_figure_reports_unavailable(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    dialogs: list[QtWidgets.QMessageBox] = []
+
+    def _record_dialog(
+        dialog: QtWidgets.QMessageBox,
+    ) -> QtWidgets.QMessageBox.StandardButton:
+        dialogs.append(dialog)
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "exec", _record_dialog)
+
     with manager_context() as manager:
         manager.show()
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -15245,7 +15255,11 @@ def test_manager_copy_full_code_for_memory_figure_reports_unavailable(
         assert menu is not None
         trigger_menu_action(menu, manager._metadata_copy_full_action)
         assert not copied
-        assert manager._status_bar.currentMessage()
+        assert len(dialogs) == 1
+        assert dialogs[0].icon() == QtWidgets.QMessageBox.Icon.Warning
+        assert dialogs[0].text()
+        assert dialogs[0].informativeText()
+        assert dialogs[0].detailedText()
 
 
 def test_manager_figure_action_new_target_creates_second_figure(


### PR DESCRIPTION
## Summary
- Replace the status-bar message for non-replayable provenance with a warning dialog.
- Include a detailed explanation of which recorded inputs or steps cannot be emitted as replayable code.
- Add test coverage for the dialog contents and warning state.

## Testing
- Unit test coverage updated for the manager console path that handles unavailable replay code.