### PR TITLE
Normalize slicer cursor state during axis swaps

### DIFF
--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -495,7 +495,7 @@ class ArraySlicer(QtCore.QObject):
         else:
             # Preserve cursor bin widths when the array is replaced, but rebuild the
             # derived boolean cache against the current axis order.
-            self._binned = [tuple(b != 1 for b in bins) for bins in self._bins]
+            self._normalize_cursor_axis_state()
         return reset
 
     @functools.cached_property
@@ -912,6 +912,48 @@ class ArraySlicer(QtCore.QObject):
         """Refresh the cached binned-state tuple after mutating bin widths."""
         self._binned[cursor] = tuple(b != 1 for b in self._bins[cursor])
 
+    def _normalize_cursor_axis_state(self) -> None:
+        center_indices = [s // 2 - (1 if s % 2 == 0 else 0) for s in self._obj.shape]
+        if not self._bins:
+            self._bins.append([1] * self._obj.ndim)
+        cursor_count = len(self._bins)
+        del self._indices[cursor_count:]
+        del self._values[cursor_count:]
+        while len(self._indices) < cursor_count:
+            self._indices.append(list(center_indices))
+        while len(self._values) < cursor_count:
+            self._values.append(
+                [
+                    coord[index]
+                    for coord, index in zip(self.coords, center_indices, strict=True)
+                ]
+            )
+
+        for cursor in range(cursor_count):
+            bins = self._bins[cursor]
+            indices = self._indices[cursor]
+            values = self._values[cursor]
+            normalized_bins: list[int] = []
+            normalized_indices: list[int] = []
+            normalized_values: list[np.floating] = []
+            for axis in self._all_axes:
+                normalized_bins.append(int(bins[axis]) if axis < len(bins) else 1)
+                index_missing = axis >= len(indices)
+                index = center_indices[axis] if index_missing else int(indices[axis])
+                index_clamped = not 0 <= index < self._obj.shape[axis]
+                if index_clamped:
+                    index = center_indices[axis]
+                normalized_indices.append(index)
+                if index_missing or index_clamped or axis >= len(values):
+                    normalized_values.append(self.coords[axis][index])
+                else:
+                    normalized_values.append(values[axis])
+            self._bins[cursor] = normalized_bins
+            self._indices[cursor] = normalized_indices
+            self._values[cursor] = normalized_values
+
+        self._binned = [tuple(b != 1 for b in bins) for bins in self._bins]
+
     def _hidden_axes_for_disp(self, disp: Sequence[int]) -> tuple[int, ...]:
         """Return cached hidden axes for a given displayed-axis selection."""
         key = tuple(disp)
@@ -1162,6 +1204,7 @@ class ArraySlicer(QtCore.QObject):
                 f"axis indices {ax1} and {ax2} are incompatible with "
                 f"{self._obj.ndim}-dimensional data"
             )
+        self._normalize_cursor_axis_state()
         for i in range(self.n_cursors):
             self._bins[i][ax1], self._bins[i][ax2] = (
                 self._bins[i][ax2],

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -371,6 +371,30 @@ def test_swap_axes_rejects_axes_outside_data_dimensions(qtbot) -> None:
         slicer.swap_axes(0, 2)
 
 
+def test_swap_axes_normalizes_legacy_short_cursor_state(qtbot) -> None:
+    data = xr.DataArray(
+        np.zeros((3, 4), dtype=np.float32),
+        dims=("a", "b"),
+        coords={"a": np.arange(3), "b": np.arange(4)},
+    )
+    parent = QtCore.QObject()
+    slicer = ArraySlicer(data, parent=parent)
+    slicer.set_bin(0, 0, 3, update=False)
+    slicer.set_index(0, 0, 2, update=False)
+    slicer._bins[0] = slicer._bins[0][:1]
+    slicer._indices[0][1] = 99
+    slicer._values[0][1] = np.float64(99.0)
+    slicer._binned[0] = slicer._binned[0][:1]
+
+    slicer.swap_axes(0, 1)
+
+    assert slicer._obj.dims == ("b", "a")
+    assert slicer.get_bins(0) == [1, 3]
+    assert slicer.get_indices(0) == [1, 2]
+    assert slicer.get_values(0) == [1, 2]
+    assert slicer.get_binned(0) == (False, True)
+
+
 def test_clear_dim_cache_resets_dimension_memos(qtbot) -> None:
     data = xr.DataArray(
         np.zeros((3, 4, 5), dtype=np.float32),
@@ -421,6 +445,27 @@ def test_state_restore_rebuilds_layout_caches_before_cursor_restore(qtbot) -> No
     assert slicer._nonuniform_axes == [0]
     assert slicer._nonuniform_axes_set == {0}
     assert slicer._dim_indices[slicer._obj.dims[0]] == 0
+    assert slicer.get_indices(0) == saved_state["indices"][0]
+    np.testing.assert_allclose(slicer.get_values(0), saved_state["values"][0])
+
+
+def test_state_restore_preserves_valid_off_grid_cursor_values(qtbot) -> None:
+    data = xr.DataArray(
+        np.zeros((3, 4), dtype=np.float32),
+        dims=("x", "y"),
+        coords={
+            "x": np.arange(3, dtype=np.float32),
+            "y": np.arange(4, dtype=np.float32),
+        },
+    )
+    parent = QtCore.QObject()
+    slicer = ArraySlicer(data, parent=parent)
+    slicer.set_value(0, 1, 1.2, update=False)
+    saved_state = slicer.state
+
+    slicer.swap_axes(0, 1)
+    slicer.state = saved_state
+
     assert slicer.get_indices(0) == saved_state["indices"][0]
     np.testing.assert_allclose(slicer.get_values(0), saved_state["values"][0])
 

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -395,6 +395,27 @@ def test_swap_axes_normalizes_legacy_short_cursor_state(qtbot) -> None:
     assert slicer.get_binned(0) == (False, True)
 
 
+def test_set_array_normalizes_missing_cursor_state(qtbot) -> None:
+    data = xr.DataArray(
+        np.zeros((3, 4), dtype=np.float32),
+        dims=("a", "b"),
+        coords={"a": np.arange(3), "b": np.arange(4)},
+    )
+    parent = QtCore.QObject()
+    slicer = ArraySlicer(data, parent=parent)
+    slicer._bins.clear()
+    slicer._indices.clear()
+    slicer._values.clear()
+    slicer._binned.clear()
+
+    slicer.set_array(data.copy(deep=False), validate=False)
+
+    assert slicer.get_bins(0) == [1, 1]
+    assert slicer.get_indices(0) == [1, 1]
+    assert slicer.get_values(0) == [1, 1]
+    assert slicer.get_binned(0) == (False, False)
+
+
 def test_clear_dim_cache_resets_dimension_memos(qtbot) -> None:
     data = xr.DataArray(
         np.zeros((3, 4, 5), dtype=np.float32),


### PR DESCRIPTION
## Summary
- normalize legacy or truncated cursor state before axis swaps and array replacement in `ArraySlicer`
- preserve valid cursor values while rebuilding missing or out-of-range bin, index, and value state
- add regression coverage for short legacy cursor state and state restore after transpose

## Testing
- Added unit tests covering legacy short cursor normalization during `swap_axes`
- Added unit tests covering state restore after axis swaps with valid off-grid cursor values