### PR TITLE
Restore fit tools from saved parameters before model defaults

### DIFF
--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -2026,7 +2026,20 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                         cls_obj = getattr(cls_obj, attr)
                     model.__class__ = cls_obj
 
-            self.set_model(model, model_load_path=status.model_load_path)
+            restored_params = (
+                self._deserialize_params(status.params) if status.params else None
+            )
+            if restored_params is None or len(restored_params) == 0:
+                self.set_model(model, model_load_path=status.model_load_path)
+            else:
+                # Saved params are authoritative during restore; generating model
+                # defaults here can evaluate incomplete deserialized model state.
+                self._model = model
+                self._model_load_path = status.model_load_path
+                self._params = restored_params
+                self._initial_params = self._params.copy()
+                self._sync_model_display()
+                self._sync_model_specific_controls()
 
             self.components_check.setChecked(status.show_components)
             self.refit_on_source_update_check.setChecked(status.refit_on_source_update)
@@ -2038,9 +2051,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
             self._slider_widths = dict(status.slider_widths)
 
-            if status.params:
-                self._params = self._deserialize_params(status.params)
-                self._initial_params = self._params.copy()
             self._params_from_coord = self._sanitize_params_from_coord(
                 status.params_from_coord
             )

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -732,6 +732,7 @@ class Fit2DTool(Fit1DTool):
         super(Fit2DTool, self.__class__).tool_status.__set__(  # type: ignore[attr-defined]
             self, status
         )
+        self._update_param_plot_options()
         if state2d is not None:  # pragma: no branch
             y_size = int(self._data_full.sizes[self._y_dim_name])
             self._data_name_full = state2d.data_name_full
@@ -863,7 +864,7 @@ class Fit2DTool(Fit1DTool):
         with QtCore.QSignalBlocker(self.param_plot_combo):
             prev_param = self.param_plot_combo.currentText()
             self.param_plot_combo.clear()
-            updated_names = list(self._model.param_names)
+            updated_names = list(self._params.keys())
             self.param_plot_combo.addItems(updated_names)
             if set(self._param_plot_overlay_states) != set(updated_names):
                 self._reset_param_plot_overlay_states(updated_names)
@@ -876,7 +877,7 @@ class Fit2DTool(Fit1DTool):
 
     def _apply_param_plot_overlay_states(self, states: dict[str, bool]) -> None:
         """Apply saved overlay states and refresh overlay UI."""
-        param_names = list(self._model.param_names)
+        param_names = list(self._params.keys())
         if set(states) != set(param_names):
             self._reset_param_plot_overlay_states(param_names)
             return

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -107,6 +107,26 @@ def test_ftool_1d_param_edit_and_state(qtbot) -> None:
     assert "fit_data" not in code
 
 
+def test_fit1d_tool_status_without_saved_params_uses_model_defaults(
+    qtbot, exp_decay_model
+) -> None:
+    t = np.linspace(0.0, 2.0, 11)
+    data = xr.DataArray(np.exp(-t), dims=("t",), coords={"t": t}, name="decay")
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        data, model=exp_decay_model, params=params, execute=False
+    )
+    qtbot.addWidget(win)
+
+    status = win.tool_status.model_copy(update={"params": []})
+    win_restored = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win_restored)
+    win_restored.tool_status = status
+
+    assert list(win_restored._params) == ["n0", "tau"]
+    assert win_restored.tool_status.params
+
+
 def test_fit1d_undo_redo(qtbot, exp_decay_model) -> None:
     t = np.linspace(0.0, 2.0, 11)
     data = xr.DataArray(np.exp(-t), dims=("t",), coords={"t": t}, name="decay")

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -167,6 +167,59 @@ def test_fit2d_tool_status_restore(qtbot, exp_decay_model) -> None:
     assert win_restored.param_model.param_at(0).value == pytest.approx(3.0)
 
 
+def test_fit2d_restore_uses_saved_voigt_params_before_defaults(qtbot) -> None:
+    data = _make_2d_data()
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        peak_shapes="voigt",
+        fd=False,
+        background="linear",
+        convolve=False,
+    )
+    params = model.make_params(
+        const_bkg=0.0,
+        lin_bkg=0.0,
+        p0_center=0.1,
+        p0_sigma=0.15,
+        p0_gamma=0.2,
+        p0_amplitude=1.3,
+    )
+    win = erlab.interactive.ftool(data, model=model, params=params, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    win.param_plot_combo.setCurrentText("p0_width")
+    win.param_plot_overlay_check.setChecked(True)
+
+    status = win.tool_status
+    expected_param_names = list(win._params.keys())
+
+    win_restored = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win_restored)
+    assert isinstance(win_restored, Fit2DTool)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        win_restored.tool_status = status
+
+    assert win_restored.tool_status.params == status.params
+    assert [
+        win_restored.param_plot_combo.itemText(i)
+        for i in range(win_restored.param_plot_combo.count())
+    ] == expected_param_names
+    win_restored.param_plot_combo.setCurrentText("p0_width")
+    assert win_restored.param_plot_overlay_check.isChecked()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        win_roundtripped = erlab.interactive.utils.ToolWindow.from_dataset(
+            win.to_dataset()
+        )
+    qtbot.addWidget(win_roundtripped)
+    assert isinstance(win_roundtripped, Fit2DTool)
+    assert win_roundtripped.tool_status.params == status.params
+    win_roundtripped.param_plot_combo.setCurrentText("p0_width")
+    assert win_roundtripped.param_plot_overlay_check.isChecked()
+
+
 def test_fit2d_status_and_persistence_preserve_transpose_orientation(qtbot) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)


### PR DESCRIPTION
## Summary
- Restore `Fit1DTool` state from saved parameters before rebuilding model defaults when serialized params are present
- Keep 2D parameter plot options and overlay state aligned with restored parameter names instead of model defaults
- Add coverage for restoring a saved Voigt model without triggering runtime warnings

## Testing
- Added a regression test covering 2D fit state restore and dataset round-trip behavior
- Not run (not requested)