### PR TITLE
Avoid splitter expansion for wrapped metadata labels

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -115,13 +115,14 @@ class _DetailsPanelController:
                 value_label.setAlignment(
                     QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
                 )
-                if field.wrap:
-                    size_policy = QtWidgets.QSizePolicy(
-                        QtWidgets.QSizePolicy.Policy.Expanding,
-                        QtWidgets.QSizePolicy.Policy.Preferred,
-                    )
-                    size_policy.setHeightForWidth(True)
-                    value_label.setSizePolicy(size_policy)
+                size_policy = QtWidgets.QSizePolicy(
+                    QtWidgets.QSizePolicy.Policy.Expanding
+                    if field.wrap
+                    else QtWidgets.QSizePolicy.Policy.Ignored,
+                    QtWidgets.QSizePolicy.Policy.Preferred,
+                )
+                size_policy.setHeightForWidth(field.wrap)
+                value_label.setSizePolicy(size_policy)
             if field.monospace:
                 value_label.setFont(self._manager._metadata_monospace_font)
             self._manager.metadata_details_layout.addWidget(key_label, row, 0)

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -119,6 +119,44 @@ def test_elided_interactive_label_keeps_full_text_during_resize(qtbot) -> None:
     assert clicks == [None]
 
 
+def test_manager_metadata_added_label_does_not_force_splitter_width(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    long_time = "2024-01-02 03:04:05 Pacific Daylight Time (-0700)"
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager._set_metadata_fields(
+            [
+                manager_wrapper._MetadataField(
+                    "Added",
+                    long_time,
+                    monospace=True,
+                )
+            ]
+        )
+        manager._update_metadata_pane()
+
+        label = manager._metadata_detail_labels["Added"]
+        assert label.text() == long_time
+        assert label.toolTip() == long_time
+        assert label.textInteractionFlags() == (
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        assert (
+            label.sizePolicy().horizontalPolicy()
+            == QtWidgets.QSizePolicy.Policy.Ignored
+        )
+        assert manager.metadata_details_widget.minimumSizeHint().width() < (
+            label.fontMetrics().horizontalAdvance(long_time)
+        )
+
+
 def test_manager_file_label_helpers_and_file_replay_rename_update(tmp_path) -> None:
     paths = [
         tmp_path / "scan_a.h5",


### PR DESCRIPTION
## Summary
- Keep wrapped metadata values size-policy aware without forcing the details splitter to widen
- Preserve full text, tooltip, and selectable behavior for long added metadata labels
- Add a regression test covering the metadata pane width behavior

## Testing
- Not run (not requested)