### PR TITLE
Add Sort By support to ImageTool

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -323,6 +323,9 @@ script or notebook for reproducibility.
 - {guilabel}`Edit → Interpolate…` opens the {guilabel}`Interpolate` dialog. Choose one
   dimension, enter the target coordinate values, and interpolate with
   {meth}`xarray.DataArray.interp` using `linear` or `nearest`.
+- {guilabel}`Edit → Sort By…` opens the {guilabel}`Sort By` dialog. Choose one or
+  more dimension or 1D coordinate keys, order them by priority, and sort with
+  {meth}`xarray.DataArray.sortby`.
 - {guilabel}`Edit → Leading Edge…` opens the {guilabel}`Leading Edge` dialog. Choose the
   dimension to extract the leading edge from, set the fraction of the curve maximum, and
   choose whether the edge is searched toward larger or smaller coordinate values with

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -49,8 +49,8 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
 - Search `erlab.io.load`, `loader_context`, `set_loader`, `set_data_dir`,
   `plugins`, or `data explorer` for loading and plugin questions.
 - Search `xarray.DataArray.qsel`, `qsel.mean`, `qsel.min`,
-  `qsel.max`, `qsel.sum`, `qsel.around`, `Aggregate`, or `workflow-bridge` for
-  slicing and indexing questions.
+  `qsel.max`, `qsel.sum`, `qsel.around`, `xarray.DataArray.sortby`, `Sort By`,
+  `Aggregate`, or `workflow-bridge` for slicing and indexing questions.
 - Search `kspace.convert`, `kspace.convert_coords`, `ktool`, `work function`,
   `inner potential`, or `offsets` for momentum-conversion questions.
 - Search `xlm.modelfit`, `MultiPeakModel`, `FermiEdgeModel`, `gold`, `ftool`,

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -693,6 +693,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                         "text": "Interpolate…",
                         "triggered": self._interpolate,
                     },
+                    "sortByAct": {
+                        "text": "Sort By…",
+                        "triggered": self._sort_by,
+                    },
                     "leadingEdgeAct": {
                         "text": "Leading Edge…",
                         "triggered": self._leading_edge,
@@ -920,6 +924,10 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     @QtCore.Slot()
     def _interpolate(self) -> None:
         self.execute_dialog(erlab.interactive.imagetool.dialogs.InterpolationDialog)
+
+    @QtCore.Slot()
+    def _sort_by(self) -> None:
+        self.execute_dialog(erlab.interactive.imagetool.dialogs.SortByDialog)
 
     @QtCore.Slot()
     def _leading_edge(self) -> None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -1525,7 +1525,8 @@ class SortByDialog(DataTransformDialog):
             item.setCheckState(QtCore.Qt.CheckState.Unchecked)
             item.setData(QtCore.Qt.ItemDataRole.UserRole, key)
             self.key_table.setItem(row, 0, item)
-        if self.key_table.rowCount() != 0:
+        # ImageTool data always contributes at least one dimension-backed sort key.
+        if self.key_table.rowCount() != 0:  # pragma: no branch
             self.key_table.selectRow(0)
 
         header = typing.cast("QtWidgets.QHeaderView", self.key_table.horizontalHeader())

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -40,6 +40,7 @@ __all__ = [
     "RenameDimsCoordsDialog",
     "RotationDialog",
     "SelectionDialog",
+    "SortByDialog",
     "SwapDimsDialog",
     "SymmetrizeDialog",
     "SymmetrizeNfoldDialog",
@@ -1458,6 +1459,152 @@ class InterpolationDialog(DataTransformDialog):
             )
             return
 
+        super().accept()
+
+
+class SortByDialog(DataTransformDialog):
+    title = "Sort By"
+    enable_copy = True
+    apply_on_nonuniform_data = True
+    operation_types = (provenance.SortByOperation,)
+
+    def setup_widgets(self) -> None:
+        source_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+            self.slicer_area.data
+        )
+        public_dims = tuple(
+            dim.removesuffix("_idx")
+            if isinstance(dim, str) and dim.endswith("_idx")
+            else dim
+            for dim in self.slicer_area.data.dims
+        )
+        if tuple(source_data.dims) != public_dims and set(source_data.dims) == set(
+            public_dims
+        ):
+            source_data = source_data.transpose(*public_dims)
+
+        sort_keys: list[Hashable] = list(source_data.dims)
+        for name, coord in source_data.coords.items():
+            if name in sort_keys:
+                continue
+            if (
+                coord.ndim == 1
+                and len(coord.dims) == 1
+                and coord.dims[0] in source_data.dims
+            ):
+                sort_keys.append(name)
+
+        key_group = QtWidgets.QGroupBox("Sort Keys")
+        key_layout = QtWidgets.QVBoxLayout()
+        key_group.setLayout(key_layout)
+
+        self.key_table = QtWidgets.QTableWidget()
+        self.key_table.setObjectName("sortby_key_table")
+        self.key_table.setColumnCount(1)
+        self.key_table.setHorizontalHeaderLabels(["Coordinate"])
+        self.key_table.setRowCount(len(sort_keys))
+        self.key_table.setAlternatingRowColors(True)
+        self.key_table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.key_table.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        )
+        self.key_table.setEditTriggers(
+            QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
+        )
+
+        item_flags = (
+            QtCore.Qt.ItemFlag.ItemIsUserCheckable
+            | QtCore.Qt.ItemFlag.ItemIsSelectable
+            | QtCore.Qt.ItemFlag.ItemIsEnabled
+        )
+        for row, key in enumerate(sort_keys):
+            item = QtWidgets.QTableWidgetItem(str(key))
+            item.setFlags(item_flags)
+            item.setCheckState(QtCore.Qt.CheckState.Unchecked)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, key)
+            self.key_table.setItem(row, 0, item)
+        if self.key_table.rowCount() != 0:
+            self.key_table.selectRow(0)
+
+        header = typing.cast("QtWidgets.QHeaderView", self.key_table.horizontalHeader())
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        self.key_table.resizeRowsToContents()
+
+        move_layout = QtWidgets.QHBoxLayout()
+        self.move_up_button = QtWidgets.QPushButton("Move Up")
+        self.move_up_button.setObjectName("sortby_move_up_button")
+        self.move_down_button = QtWidgets.QPushButton("Move Down")
+        self.move_down_button.setObjectName("sortby_move_down_button")
+        self.move_up_button.clicked.connect(lambda: self._move_selected_row(-1))
+        self.move_down_button.clicked.connect(lambda: self._move_selected_row(1))
+        move_layout.addWidget(self.move_up_button)
+        move_layout.addWidget(self.move_down_button)
+
+        key_layout.addWidget(self.key_table)
+        key_layout.addLayout(move_layout)
+
+        self.ascending_combo = QtWidgets.QComboBox()
+        self.ascending_combo.setObjectName("sortby_direction_combo")
+        self.ascending_combo.addItem("Ascending", userData=True)
+        self.ascending_combo.addItem("Descending", userData=False)
+
+        self.layout_.addRow(key_group)
+        self.layout_.addRow("Direction", self.ascending_combo)
+
+    @property
+    def _sort_keys(self) -> tuple[Hashable, ...]:
+        keys: list[Hashable] = []
+        for row in range(self.key_table.rowCount()):
+            item = self.key_table.item(row, 0)
+            if item is None:
+                continue
+            if item.checkState() == QtCore.Qt.CheckState.Checked:
+                keys.append(
+                    typing.cast(
+                        "Hashable",
+                        item.data(QtCore.Qt.ItemDataRole.UserRole),
+                    )
+                )
+        return tuple(keys)
+
+    @QtCore.Slot()
+    def _move_selected_row(self, offset: int) -> None:
+        row = self.key_table.currentRow()
+        target_row = row + offset
+        if row < 0 or target_row < 0 or target_row >= self.key_table.rowCount():
+            return
+        item = self.key_table.takeItem(row, 0)
+        target_item = self.key_table.takeItem(target_row, 0)
+        if item is None or target_item is None:
+            return
+        self.key_table.setItem(row, 0, target_item)
+        self.key_table.setItem(target_row, 0, item)
+        self.key_table.selectRow(target_row)
+
+    def source_transform_operation(
+        self,
+    ) -> provenance.SortByOperation:
+        sort_keys = self._sort_keys
+        if not sort_keys:
+            raise ValueError("No sort keys selected")
+        return provenance.SortByOperation(
+            variables=sort_keys,
+            ascending=bool(
+                self.ascending_combo.currentData(QtCore.Qt.ItemDataRole.UserRole)
+            ),
+        )
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        if not self._sort_keys:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Sort Keys Selected",
+                "Choose at least one coordinate to sort by.",
+            )
+            return
         super().accept()
 
 

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -49,6 +49,7 @@ _BATCH_OPERATION_CATEGORIES: tuple[tuple[str, tuple[_BatchDialogType, ...]], ...
             imagetool_dialogs.RotationDialog,
             imagetool_dialogs.AggregateDialog,
             imagetool_dialogs.InterpolationDialog,
+            imagetool_dialogs.SortByDialog,
             imagetool_dialogs.LeadingEdgeDialog,
             imagetool_dialogs.DivideByCoordDialog,
             imagetool_dialogs.CoarsenDialog,

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -38,6 +38,7 @@ __all__ = [
     "SelOperation",
     "SelectCoordOperation",
     "SliceAlongPathOperation",
+    "SortByOperation",
     "SortCoordOrderOperation",
     "SqueezeOperation",
     "SwapDimsOperation",
@@ -391,6 +392,76 @@ class SortCoordOrderOperation(ToolProvenanceOperation):
             "erlab.utils.array.sort_coord_order("
             f"{input_name}, {source_name}.coords.keys())"
         )
+
+
+class SortByOperation(ToolProvenanceOperation):
+    op: typing.Literal["sortby"] = "sortby"
+    batch_available: typing.ClassVar[bool] = True
+    variables: ProvenanceHashableTuple
+    ascending: bool = True
+
+    @classmethod
+    def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:
+        if (
+            call.has_extra_tracked_inputs
+            or call.dataarray_method != "sortby"
+            or call.accessor_path
+            or len(call.args) > 1
+        ):
+            return None
+        kwargs = dict(call.kwargs)
+        ascending = kwargs.pop("ascending", True)
+        if not isinstance(ascending, bool):
+            return None
+        if call.args:
+            if "variables" in kwargs:
+                return None
+            variables = call.args[0]
+        else:
+            variables = kwargs.pop("variables", None)
+        if kwargs or variables is None:
+            return None
+        variables = tuple(variables) if isinstance(variables, list) else (variables,)
+        with contextlib.suppress(TypeError, ValueError, pydantic.ValidationError):
+            return cls(variables=variables, ascending=ascending)
+        return None
+
+    @pydantic.field_validator("variables", mode="before")
+    @classmethod
+    def _validate_variables(cls, value: typing.Any) -> tuple[Hashable, ...]:
+        value = decode_provenance_value(value)
+        if callable(value) or isinstance(value, xr.DataArray):
+            raise TypeError("sortby variables must be coordinate names")
+        if isinstance(value, str) or not isinstance(value, Sequence):
+            values = (value,)
+        else:
+            values = tuple(value)
+        if not values:
+            raise ValueError("sortby requires at least one variable")
+        if any(callable(item) or isinstance(item, xr.DataArray) for item in values):
+            raise TypeError("sortby variables must be coordinate names")
+        return typing.cast("tuple[Hashable, ...]", values)
+
+    def apply(self, data: xr.DataArray, *, parent_data: xr.DataArray) -> xr.DataArray:
+        variables: Hashable | list[Hashable] = (
+            self.variables[0] if len(self.variables) == 1 else list(self.variables)
+        )
+        return data.sortby(variables, ascending=self.ascending)
+
+    def derivation_label(self) -> str:
+        label_kwargs = {"variables": self.variables, "ascending": self.ascending}
+        return f"Sort By({_format_derivation_value(label_kwargs)})"
+
+    def expression_code(
+        self, input_name: str, *, source_name: str | None = None
+    ) -> str:
+        variables: Hashable | list[Hashable] = (
+            self.variables[0] if len(self.variables) == 1 else list(self.variables)
+        )
+        args = erlab.interactive.utils._parse_single_arg(variables)
+        if self.ascending:
+            return f"{input_name}.sortby({args})"
+        return f"{input_name}.sortby({args}, ascending=False)"
 
 
 class SelectCoordOperation(ToolProvenanceOperation):

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -465,7 +465,8 @@ class ArraySlicer(QtCore.QObject):
         if (obj_original is not None) and reset:
             # If same coords, keep cursors
             if check_cursors_compatible(obj_original, self._obj):
-                self._obj = self._obj.transpose(*obj_original.dims)
+                if set(self._obj.dims) == set(obj_original.dims):
+                    self._obj = self._obj.transpose(*obj_original.dims)
                 reset = False
             del obj_original
 

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -813,6 +813,51 @@ def test_batch_transform_placements(
                 )
 
 
+def test_batch_sortby_transform_replace(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = _batch_data("scan0").assign_coords(temperature=("x", [20.0, 10.0, 30.0]))
+    data1 = _batch_data("scan1", offset=100.0).assign_coords(
+        temperature=("x", [25.0, 5.0, 15.0])
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, data0, data1)
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.SortByDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        for row in range(dialog.key_table.rowCount()):
+            item = dialog.key_table.item(row, 0)
+            if (
+                item is not None
+                and item.data(QtCore.Qt.ItemDataRole.UserRole) == "temperature"
+            ):
+                item.setCheckState(QtCore.Qt.CheckState.Checked)
+        dialog.ascending_combo.setCurrentIndex(
+            dialog.ascending_combo.findData(False, QtCore.Qt.ItemDataRole.UserRole)
+        )
+
+        assert manager.apply_batch_transform_dialog(dialog, "replace")
+        assert manager.ntools == 2
+        for index, expected_data in enumerate(
+            (
+                data0.sortby("temperature", ascending=False),
+                data1.sortby("temperature", ascending=False),
+            )
+        ):
+            xarray.testing.assert_identical(
+                manager.get_imagetool(index).slicer_area._data.rename(None),
+                expected_data.rename(None),
+            )
+
+
 def test_batch_filter_applies_in_place_only(
     qtbot,
     manager_context: Callable[
@@ -865,6 +910,46 @@ def test_batch_transform_preflight_failure_leaves_all_targets_unchanged(
             batch_manager=manager,
         )
         dialog.dim_checks["y"].setChecked(True)
+
+        assert not manager.apply_batch_transform_dialog(dialog, "replace")
+        assert messages
+        xarray.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area._data.rename(None),
+            data0.rename(None),
+        )
+        xarray.testing.assert_identical(
+            manager.get_imagetool(1).slicer_area._data.rename(None),
+            data1.rename(None),
+        )
+
+
+def test_batch_sortby_preflight_failure_leaves_all_targets_unchanged(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    messages = _block_message_dialog(monkeypatch)
+    data0 = _batch_data("scan0").assign_coords(temperature=("x", [20.0, 10.0, 30.0]))
+    data1 = _batch_data("scan1", offset=100.0)
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, data0, data1)
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.SortByDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        for row in range(dialog.key_table.rowCount()):
+            item = dialog.key_table.item(row, 0)
+            if (
+                item is not None
+                and item.data(QtCore.Qt.ItemDataRole.UserRole) == "temperature"
+            ):
+                item.setCheckState(QtCore.Qt.CheckState.Checked)
 
         assert not manager.apply_batch_transform_dialog(dialog, "replace")
         assert messages

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -7027,6 +7027,117 @@ def test_itool_sortby_nonuniform_public_dims(qtbot, accept_dialog) -> None:
     win.close()
 
 
+def test_sortby_dialog_public_dim_order_and_coord_filters(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(12).reshape((4, 3)).astype(float),
+        dims=("x", "y"),
+        coords={
+            "x": np.array([2.0, 0.0, 1.0, 3.0]),
+            "y": np.arange(3),
+            "temperature": ("x", [20.0, 10.0, 15.0, 5.0]),
+            "sample_id": 1,
+            "mesh": (("x", "y"), np.ones((4, 3))),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    restore_nonuniform_dims = erlab.interactive.imagetool.slicer.restore_nonuniform_dims
+
+    def restore_transposed(source: xr.DataArray) -> xr.DataArray:
+        return restore_nonuniform_dims(source).transpose("y", "x")
+
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.slicer,
+        "restore_nonuniform_dims",
+        restore_transposed,
+    )
+
+    dialog = SortByDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+    keys = [
+        item.data(QtCore.Qt.ItemDataRole.UserRole)
+        for row in range(dialog.key_table.rowCount())
+        if (item := dialog.key_table.item(row, 0)) is not None
+    ]
+
+    assert keys[:2] == ["x", "y"]
+    assert "temperature" in keys
+    assert "sample_id" not in keys
+    assert "mesh" not in keys
+
+    dialog.close()
+    win.close()
+
+
+def test_sortby_dialog_key_table_order_and_empty_items(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(12).reshape((4, 3)).astype(float),
+        dims=("x", "y"),
+        coords={
+            "x": [0.0, 1.0, 2.0, 3.0],
+            "y": [0.0, 1.0, 2.0],
+            "temperature": ("x", [20.0, 10.0, 15.0, 5.0]),
+            "pressure": ("x", [3.0, 1.0, 2.0, 4.0]),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = SortByDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    def table_keys() -> list[collections.abc.Hashable]:
+        return [
+            item.data(QtCore.Qt.ItemDataRole.UserRole)
+            for row in range(dialog.key_table.rowCount())
+            if (item := dialog.key_table.item(row, 0)) is not None
+        ]
+
+    initial_keys = table_keys()
+    assert initial_keys[:4] == ["x", "y", "temperature", "pressure"]
+    with pytest.raises(ValueError, match="No sort keys selected"):
+        dialog.source_transform_operation()
+
+    removed_item = dialog.key_table.takeItem(0, 0)
+    assert removed_item is not None
+    assert dialog._sort_keys == ()
+    dialog.key_table.setItem(0, 0, removed_item)
+
+    dialog.key_table.selectRow(0)
+    dialog._move_selected_row(-1)
+    assert table_keys() == initial_keys
+
+    dialog.key_table.selectRow(initial_keys.index("temperature"))
+    dialog._move_selected_row(-1)
+    assert table_keys()[:4] == ["x", "temperature", "y", "pressure"]
+    dialog._move_selected_row(1)
+    assert table_keys() == initial_keys
+
+    dialog.key_table.selectRow(dialog.key_table.rowCount() - 1)
+    dialog._move_selected_row(1)
+    assert table_keys() == initial_keys
+
+    for key in ("y", "temperature"):
+        item = dialog.key_table.item(table_keys().index(key), 0)
+        assert item is not None
+        item.setCheckState(QtCore.Qt.CheckState.Checked)
+    dialog.key_table.selectRow(table_keys().index("temperature"))
+    dialog._move_selected_row(-1)
+    operation = dialog.source_transform_operation()
+    assert operation.variables == ("temperature", "y")
+
+    empty_item_dialog = SortByDialog(win.slicer_area)
+    qtbot.addWidget(empty_item_dialog)
+    empty_item_dialog.key_table.selectRow(1)
+    assert empty_item_dialog.key_table.takeItem(1, 0) is not None
+    empty_item_dialog._move_selected_row(-1)
+
+    empty_item_dialog.close()
+    dialog.close()
+    win.close()
+
+
 def test_sortby_dialog_accept_requires_key(qtbot, monkeypatch) -> None:
     data = xr.DataArray(
         np.arange(6).reshape((2, 3)).astype(float),
@@ -7048,6 +7159,8 @@ def test_sortby_dialog_accept_requires_key(qtbot, monkeypatch) -> None:
 
     monkeypatch.setattr(QtWidgets.QMessageBox, "warning", record_warning)
 
+    with pytest.raises(ValueError, match="No sort keys selected"):
+        dialog.source_transform_operation()
     dialog.accept()
 
     assert warnings_shown

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -56,6 +56,7 @@ from erlab.interactive.imagetool.dialogs import (
     ROIPathDialog,
     RotationDialog,
     SelectionDialog,
+    SortByDialog,
     SwapDimsDialog,
     SymmetrizeDialog,
     SymmetrizeNfoldDialog,
@@ -6920,6 +6921,139 @@ def test_itool_interpolate_nonuniform_public_dims(qtbot, accept_dialog) -> None:
     assert isinstance(derived, xr.DataArray)
     xarray.testing.assert_identical(derived.rename(None), expected.rename(None))
 
+    win.close()
+
+
+def test_itool_sortby(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(12).reshape((4, 3)).astype(float),
+        dims=("x", "y"),
+        coords={
+            "x": [2.0, 0.0, 1.0, 3.0],
+            "y": [0.0, 1.0, 2.0],
+            "temperature": ("x", [20.0, 10.0, 15.0, 5.0]),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _check_key(dialog: SortByDialog, key: str) -> None:
+        for row in range(dialog.key_table.rowCount()):
+            item = dialog.key_table.item(row, 0)
+            if item is not None and item.data(QtCore.Qt.ItemDataRole.UserRole) == key:
+                item.setCheckState(QtCore.Qt.CheckState.Checked)
+                dialog.key_table.selectRow(row)
+                return
+        raise AssertionError(f"Missing sort key {key!r}")
+
+    def _set_dialog_params(dialog: SortByDialog) -> None:
+        _check_key(dialog, "temperature")
+        dialog.ascending_combo.setCurrentIndex(
+            dialog.ascending_combo.findData(False, QtCore.Qt.ItemDataRole.UserRole)
+        )
+        with qtbot.wait_signal(dialog._sigCodeCopied):
+            dialog.copy_button.click()
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._sort_by, pre_call=_set_dialog_params)
+
+    expected = data.sortby("temperature", ascending=False)
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None), expected.rename(None)
+    )
+    assert win.slicer_area._data.name == "scan"
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, pyperclip.paste()), expected
+    )
+
+    assert win.provenance_spec is not None
+    display_code = win.provenance_spec.display_code()
+    assert display_code is not None
+    namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
+    derived = namespace["derived"]
+    assert isinstance(derived, xr.DataArray)
+    xarray.testing.assert_identical(derived.rename(None), expected.rename(None))
+
+    win.close()
+
+
+def test_itool_sortby_nonuniform_public_dims(qtbot, accept_dialog) -> None:
+    data = xr.DataArray(
+        np.arange(12).reshape((4, 3)).astype(float),
+        dims=("x", "y"),
+        coords={
+            "x": np.array([2.0, 0.0, 1.0, 3.0]),
+            "y": np.arange(3),
+        },
+        name="scan",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    assert win.slicer_area.data.dims == ("x_idx", "y")
+
+    def _set_dialog_params(dialog: SortByDialog) -> None:
+        keys = [
+            dialog.key_table.item(row, 0).data(QtCore.Qt.ItemDataRole.UserRole)
+            for row in range(dialog.key_table.rowCount())
+            if dialog.key_table.item(row, 0) is not None
+        ]
+        assert "x" in keys
+        assert "x_idx" not in keys
+        for row, key in enumerate(keys):
+            if key == "x":
+                item = dialog.key_table.item(row, 0)
+                assert item is not None
+                item.setCheckState(QtCore.Qt.CheckState.Checked)
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._sort_by, pre_call=_set_dialog_params)
+
+    expected = data.sortby("x")
+    xarray.testing.assert_identical(
+        win.slicer_area._data.rename(None), expected.rename(None)
+    )
+    assert win.provenance_spec is not None
+    display_code = win.provenance_spec.display_code()
+    assert display_code is not None
+    assert ".sortby(" in display_code
+    assert "x_idx" not in display_code
+    namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
+    derived = namespace["derived"]
+    assert isinstance(derived, xr.DataArray)
+    xarray.testing.assert_identical(derived.rename(None), expected.rename(None))
+
+    win.close()
+
+
+def test_sortby_dialog_accept_requires_key(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(6).reshape((2, 3)).astype(float),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0, 2.0]},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = SortByDialog(win.slicer_area)
+    warnings_shown: list[tuple[QtWidgets.QWidget | None, str, str]] = []
+
+    def record_warning(
+        parent: QtWidgets.QWidget | None,
+        title: str,
+        text: str,
+    ) -> QtWidgets.QMessageBox.StandardButton:
+        warnings_shown.append((parent, title, text))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", record_warning)
+
+    dialog.accept()
+
+    assert warnings_shown
+    assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
+
+    dialog.close()
     win.close()
 
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -3236,6 +3236,157 @@ def test_console_pattern_matches_new_replayable_operations() -> None:
     )
 
 
+def test_sortby_operation_apply_code_and_console_calls() -> None:
+    tuple_key = ("beta", 0)
+    data = xr.DataArray(
+        np.arange(12.0).reshape(4, 3),
+        dims=("x", "y"),
+        coords={
+            "x": [2.0, 1.0, 2.0, 0.0],
+            "y": [0.0, 1.0, 2.0],
+            "sample temp": ("x", [20.0, 10.0, 15.0, 30.0]),
+        },
+        name="scan",
+    )
+    tuple_key_data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={
+            "x": [0.0, 1.0, 2.0, 3.0],
+            tuple_key: ("x", [20.0, 10.0, 15.0, 30.0]),
+        },
+        name="tuple_coord_scan",
+    )
+
+    single = provenance.SortByOperation(variables=("x",))
+    multi = provenance.SortByOperation(
+        variables=("x", "sample temp"),
+        ascending=False,
+    )
+    non_identifier = provenance.SortByOperation(variables=("sample temp",))
+    tuple_key_operation = provenance.SortByOperation(variables=(tuple_key,))
+
+    assert provenance.SortByOperation(variables="x") == single
+    with pytest.raises(TypeError, match="sortby variables must be coordinate names"):
+        provenance.SortByOperation(variables=lambda darr: darr.x)
+    assert multi.derivation_label().startswith("Sort By(")
+    for operation in (single, multi, tuple_key_operation):
+        assert (
+            provenance.parse_tool_provenance_operation(
+                operation.model_dump(mode="json")
+            )
+            == operation
+        )
+
+    xr.testing.assert_identical(single.apply(data, parent_data=data), data.sortby("x"))
+    xr.testing.assert_identical(
+        multi.apply(data, parent_data=data),
+        data.sortby(["x", "sample temp"], ascending=False),
+    )
+    xr.testing.assert_identical(
+        non_identifier.apply(data, parent_data=data),
+        data.sortby("sample temp"),
+    )
+    xr.testing.assert_identical(
+        tuple_key_operation.apply(tuple_key_data, parent_data=tuple_key_data),
+        tuple_key_data.sortby(tuple_key),
+    )
+
+    code = f"derived = {multi.expression_code('data')}"
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    xr.testing.assert_identical(
+        namespace["derived"],
+        data.sortby(["x", "sample temp"], ascending=False),
+    )
+    code = f"derived = {tuple_key_operation.expression_code('data')}"
+    namespace = _exec_generated_code(code, {"data": tuple_key_data.copy(deep=True)})
+    xr.testing.assert_identical(namespace["derived"], tuple_key_data.sortby(tuple_key))
+
+    assert (
+        provenance.operation_from_console_call(
+            provenance.ConsoleCall(
+                dataarray_method="sortby",
+                args=("x",),
+                display_code='data.sortby("x")',
+                has_extra_tracked_inputs=False,
+                receiver_data=data,
+            )
+        )
+        == single
+    )
+    assert (
+        provenance.operation_from_console_call(
+            provenance.ConsoleCall(
+                dataarray_method="sortby",
+                kwargs={"variables": ["x", "sample temp"], "ascending": False},
+                display_code=(
+                    'data.sortby(variables=["x", "sample temp"], ascending=False)'
+                ),
+                has_extra_tracked_inputs=False,
+                receiver_data=data,
+            )
+        )
+        == multi
+    )
+    assert (
+        provenance.operation_from_console_call(
+            provenance.ConsoleCall(
+                dataarray_method="sortby",
+                args=(tuple_key,),
+                display_code="data.sortby(('beta', 0))",
+                has_extra_tracked_inputs=False,
+                receiver_data=tuple_key_data,
+            )
+        )
+        == tuple_key_operation
+    )
+
+    for args, kwargs in (
+        ((), {"variables": "x", "ascending": "false"}),
+        (("x",), {"variables": "y"}),
+        ((), {}),
+    ):
+        assert (
+            provenance.SortByOperation.from_console_call(
+                provenance.ConsoleCall(
+                    dataarray_method="sortby",
+                    args=args,
+                    kwargs=kwargs,
+                    display_code="data.sortby(...)",
+                    has_extra_tracked_inputs=False,
+                    receiver_data=data,
+                )
+            )
+            is None
+        )
+
+    for variables in (lambda darr: darr.x, data.x, [lambda darr: darr.x], [data.x], []):
+        assert (
+            provenance.SortByOperation.from_console_call(
+                provenance.ConsoleCall(
+                    dataarray_method="sortby",
+                    args=(variables,),
+                    display_code="data.sortby(...)",
+                    has_extra_tracked_inputs=False,
+                    receiver_data=data,
+                )
+            )
+            is None
+        )
+    assert (
+        provenance.SortByOperation.from_console_call(
+            provenance.ConsoleCall(
+                dataarray_method="sortby",
+                args=("x",),
+                display_code='data.sortby("x")',
+                has_extra_tracked_inputs=True,
+                receiver_data=data,
+            )
+        )
+        is None
+    )
+
+
 def test_console_pattern_rejects_ambiguous_calls_and_expands_defaults() -> None:
 
     assert provenance._console_values_equal(np.nan, np.nan)


### PR DESCRIPTION
## Summary
- Add a new ImageTool `Sort By` dialog and menu action for sorting data by one or more coordinates
- Record `sortby` operations in provenance and replay code
- Update batch manager support, documentation, and indexing guidance for the new workflow

## Testing
- Added unit coverage for provenance parsing, replay code generation, and dialog validation
- Added UI/integration tests for single-tool and batch `Sort By` flows, including nonuniform data and preflight failure handling