### PR TITLE
Ignore autorange startup limits when creating figures

### DIFF
--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -1757,12 +1757,16 @@ class ItoolPlotItem(pg.PlotItem):
 
     def _sync_figure_composer_view_limits(self) -> None:
         """Snapshot visible plot limits before seeding a Figure Composer step."""
-        for dim, rng in zip(
+        for dim, auto, rng in zip(
             self.axis_dims_uniform,
+            self.vb.state["autoRange"],
             self.vb.state["viewRange"],
             strict=True,
         ):
             if dim is None:
+                continue
+            if auto:
+                self.slicer_area.manual_limits.pop(dim, None)
                 continue
             try:
                 axis = self.slicer_area.data.dims.index(dim)

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -15599,6 +15599,46 @@ def test_manager_create_figure_uses_first_selected_main_image_state(
         assert styles[(1, 0)].norm_gamma == pytest.approx(0.25)
 
 
+def test_manager_create_figure_from_2d_data_ignores_autorange_startup_limits(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("eV", "alpha"),
+        coords={
+            "eV": np.linspace(10.0, 14.0, 5),
+            "alpha": np.linspace(20.0, 24.0, 5),
+        },
+        name="map",
+    )
+
+    with manager_context() as manager:
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = typing.cast(
+            "FigureComposerTool", manager._child_node(figure_uid).tool_window
+        )
+        operation = figure_tool.tool_status.operations[0]
+        assert operation.xlim is None
+        assert operation.ylim is None
+
+        figure = plt.figure()
+        try:
+            figurecomposer_rendering._render_into_figure(
+                figure_tool, figure, sync_visible=False
+            )
+            assert figure_tool._operation_render_errors == {}
+            assert any(axis.images for axis in figure.axes)
+        finally:
+            plt.close(figure)
+
+
 def test_manager_workspace_figure_sources_save_as_references(
     qtbot,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Stop seeding Figure Composer view limits from transient autorange startup state
- Clear stored manual limits when an axis is still autoranging so new figures use the live data range
- Add a regression test covering 2D data in the manager flow

## Testing
- Added a manager integration test that creates a figure from 2D data and verifies the operation has no startup x/y limits
- Verified the figure still renders successfully after the change