### PR TITLE
Raise image tool guidelines above cursor overlays

### DIFF
--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -47,6 +47,10 @@ else:
 
 logger = logging.getLogger(__name__)
 
+_CURSOR_SPAN_Z_VALUE = 9
+_CURSOR_LINE_Z_VALUE = 10
+_GUIDELINE_Z_VALUE = 11
+
 
 class ItoolGraphicsLayoutWidget(pg.PlotWidget):
     # Unsure of whether to subclass GraphicsLayoutWidget or PlotWidget at the moment
@@ -1324,6 +1328,7 @@ class ItoolPlotItem(pg.PlotItem):
         angle: float | None = None,
     ) -> None:
         for item in erlab.interactive.utils.make_crosshairs(n):
+            item.setZValue(_GUIDELINE_Z_VALUE)
             self.addItem(item)
             self._guidelines_items.append(item)
 
@@ -2844,9 +2849,9 @@ class ItoolPlotItem(pg.PlotItem):
             self.cursor_lines[-1][ax] = c
             self.cursor_spans[-1][ax] = s
             self.addItem(c)
-            c.setZValue(10)
+            c.setZValue(_CURSOR_LINE_Z_VALUE)
             self.addItem(s)
-            s.setZValue(9)
+            s.setZValue(_CURSOR_SPAN_Z_VALUE)
             c.sigDragged.connect(
                 lambda v, *, line=c, axis=ax: self.line_drag(line, v.temp_value, axis)
             )

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5038,6 +5038,37 @@ def test_itool_guidelines_start_at_active_cursor(qtbot) -> None:
     win.close()
 
 
+def test_itool_guidelines_draw_above_all_cursors(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    area = win.slicer_area
+    plot_item = area.main_image
+
+    area.add_cursor()
+    plot_item.set_guidelines(2)
+    area.add_cursor()
+
+    cursor_z_values = [
+        item.zValue()
+        for item_dict in (*plot_item.cursor_lines, *plot_item.cursor_spans)
+        for item in item_dict.values()
+    ]
+
+    assert cursor_z_values
+    assert all(
+        guideline_item.zValue() > max(cursor_z_values)
+        for guideline_item in plot_item._guidelines_items
+    )
+
+    win.close()
+
+
 def test_itool_guidelines_follow_active_cursor(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)).astype(float),


### PR DESCRIPTION
## Summary
- Move guideline crosshairs above cursor spans and lines by assigning explicit z-order constants
- Keep cursor overlay ordering stable with named z-values instead of inline literals
- Add a regression test that verifies guidelines render above all cursors

## Testing
- Added a UI-level regression test for guideline and cursor z-order in ImageTool