### PR TITLE
Tie Fit2D ImageTool outputs to parameter names

### DIFF
--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -128,7 +128,10 @@ A real example is `Fit2DTool`:
 
 - `Fit2DTool.Output.PARAMETER_VALUES` and `Fit2DTool.Output.PARAMETER_STDERR` are
   declared in `IMAGE_TOOL_OUTPUTS`, so those parameter plots become ImageTool
-  windows as child rows of the fit tool, with persisted `output_id`s.
+  windows as child rows of the fit tool. Each persisted `output_id` records both
+  the output kind and the selected parameter, so refreshing the child window keeps it
+  tied to that parameter even if the fit tool's parameter plot later shows another
+  parameter.
 - `Fit2DTool._show_dataarray_in_itool()` also has a generic path for arbitrary
   `DataArray`s that are not declared outputs. In the manager, that path opens a fresh
   independent top-level ImageTool window each time. Outside the manager, it opens a

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -7,6 +7,7 @@ import enum
 import functools
 import os
 import typing
+import urllib.parse
 
 import numpy as np
 import pyqtgraph as pg
@@ -124,7 +125,9 @@ class _Fit2DParameterPlotItem(pg.PlotItem):
         )
         show_stderr_action.triggered.connect(self._show_parameter_stderr)
 
-    def _current_param_dataarray(self, *, stderr: bool) -> xr.DataArray | None:
+    def _current_param_dataarray(
+        self, *, stderr: bool
+    ) -> tuple[str, xr.DataArray] | None:
         param_name = self._tool.param_plot_combo.currentText().strip()
         if not param_name:
             self._tool._show_warning(
@@ -142,7 +145,7 @@ class _Fit2DParameterPlotItem(pg.PlotItem):
                 "current y-range.",
             )
             return None
-        return da
+        return param_name, da
 
     def _save_dataarray_as_hdf5(self, data: xr.DataArray) -> None:
         if isinstance(data.name, str):
@@ -175,32 +178,40 @@ class _Fit2DParameterPlotItem(pg.PlotItem):
 
     @QtCore.Slot()
     def _save_parameter_values(self) -> None:
-        da = self._current_param_dataarray(stderr=False)
-        if da is not None:
+        current = self._current_param_dataarray(stderr=False)
+        if current is not None:
+            _, da = current
             self._save_dataarray_as_hdf5(da)
 
     @QtCore.Slot()
     def _show_parameter_values(self) -> None:
-        da = self._current_param_dataarray(stderr=False)
-        if da is not None:
+        current = self._current_param_dataarray(stderr=False)
+        if current is not None:
+            param_name, da = current
             self._tool._show_dataarray_in_itool(
                 da,
-                output_id=Fit2DTool.Output.PARAMETER_VALUES,
+                output_id=self._tool._parameter_output_id(
+                    Fit2DTool.Output.PARAMETER_VALUES, param_name
+                ),
             )
 
     @QtCore.Slot()
     def _save_parameter_stderr(self) -> None:
-        da = self._current_param_dataarray(stderr=True)
-        if da is not None:
+        current = self._current_param_dataarray(stderr=True)
+        if current is not None:
+            _, da = current
             self._save_dataarray_as_hdf5(da)
 
     @QtCore.Slot()
     def _show_parameter_stderr(self) -> None:
-        da = self._current_param_dataarray(stderr=True)
-        if da is not None:
+        current = self._current_param_dataarray(stderr=True)
+        if current is not None:
+            param_name, da = current
             self._tool._show_dataarray_in_itool(
                 da,
-                output_id=Fit2DTool.Output.PARAMETER_STDERR,
+                output_id=self._tool._parameter_output_id(
+                    Fit2DTool.Output.PARAMETER_STDERR, param_name
+                ),
             )
 
 
@@ -230,6 +241,7 @@ class Fit2DTool(Fit1DTool):
     _PERSISTED_FIT_RESULT_DIM: typing.ClassVar[str] = "__ftool_fit_results_bytes__"
     _PERSISTED_FIT_INDEX_DIM: typing.ClassVar[str] = "__ftool_fit_result_index__"
     _PERSISTED_FIT_CURRENT_ATTR: typing.ClassVar[str] = "__ftool_fit_is_current__"
+    _PARAMETER_OUTPUT_SEPARATOR: typing.ClassVar[str] = ":"
 
     class Output(enum.StrEnum):
         PARAMETER_VALUES = "fit2d.param_plot.values"
@@ -257,6 +269,39 @@ class Fit2DTool(Fit1DTool):
             ),
         ),
     }
+
+    @classmethod
+    def _parameter_output_id(cls, output: Output, param_name: str) -> str:
+        if output not in (cls.Output.PARAMETER_VALUES, cls.Output.PARAMETER_STDERR):
+            raise ValueError("output must be a Fit2DTool parameter output")
+        return (
+            f"{output.value}{cls._PARAMETER_OUTPUT_SEPARATOR}"
+            f"{urllib.parse.quote(param_name, safe='')}"
+        )
+
+    @classmethod
+    def _parameter_output_parts(
+        cls, output_id: str | enum.Enum
+    ) -> tuple[Output, str | None] | None:
+        normalized = erlab.interactive.utils._normalize_tool_output_id(output_id)
+        for output in (cls.Output.PARAMETER_VALUES, cls.Output.PARAMETER_STDERR):
+            if normalized == output.value:
+                return output, None
+            prefix = f"{output.value}{cls._PARAMETER_OUTPUT_SEPARATOR}"
+            if normalized.startswith(prefix):
+                return output, urllib.parse.unquote(normalized.removeprefix(prefix))
+        return None
+
+    def _image_output_definition(
+        self, output_id: str | enum.Enum
+    ) -> tuple[str, erlab.interactive.utils.ToolImageOutputDefinition]:
+        normalized = erlab.interactive.utils._normalize_tool_output_id(output_id)
+        parts = self._parameter_output_parts(normalized)
+        if parts is None:
+            return super()._image_output_definition(normalized)
+        output, _ = parts
+        _, definition = super()._image_output_definition(output)
+        return normalized, definition
 
     @property
     def tool_data(self) -> xr.DataArray:
@@ -1949,6 +1994,47 @@ class Fit2DTool(Fit1DTool):
             return None
         return param_name, self._param_plot_dataarray(param_name, stderr=stderr)
 
+    def _resolve_parameter_output(
+        self, parts: tuple[Output, str | None]
+    ) -> tuple[str, bool] | None:
+        output, param_name = parts
+        stderr = output == self.Output.PARAMETER_STDERR
+        if param_name is None:
+            current = self._current_param_output(stderr=stderr)
+            if current is None:
+                return None
+            param_name = current[0]
+        elif not param_name or all(
+            self.param_plot_combo.itemText(i) != param_name
+            for i in range(self.param_plot_combo.count())
+        ):
+            return None
+        return param_name, stderr
+
+    def output_imagetool_data(self, output_id: str | enum.Enum) -> xr.DataArray | None:
+        parts = self._parameter_output_parts(output_id)
+        if parts is None:
+            return super().output_imagetool_data(output_id)
+
+        request = self._resolve_parameter_output(parts)
+        if request is None:
+            return None
+        param_name, stderr = request
+        return self._param_plot_dataarray(param_name, stderr=stderr)
+
+    def output_imagetool_provenance(
+        self, output_id: str | enum.Enum, data: xr.DataArray
+    ) -> provenance.ToolProvenanceSpec | None:
+        parts = self._parameter_output_parts(output_id)
+        if parts is None:
+            return super().output_imagetool_provenance(output_id, data)
+
+        request = self._resolve_parameter_output(parts)
+        if request is None:
+            return None
+        param_name, stderr = request
+        return self._parameter_output_provenance(param_name, stderr=stderr, data=data)
+
     def _parameter_output_prelude(
         self,
         *,
@@ -1960,6 +2046,64 @@ class Fit2DTool(Fit1DTool):
         if not prelude or not expression:
             return None
         return "\n".join((prelude, f"result = {expression}"))
+
+    def _parameter_output_expression(self, param_name: str, *, stderr: bool) -> str:
+        if stderr:
+            return (
+                f'result.modelfit_stderr.sel(param={param_name!r}).drop_vars("param")'
+            )
+        return (
+            f'result.modelfit_coefficients.sel(param={param_name!r}).drop_vars("param")'
+        )
+
+    def _parameter_output_provenance(
+        self,
+        param_name: str,
+        *,
+        stderr: bool,
+        data: xr.DataArray,
+    ) -> provenance.ToolProvenanceSpec | None:
+        from erlab.interactive.imagetool import provenance
+
+        input_provenance = self._effective_input_provenance_spec()
+        input_name = provenance.replay_input_name(input_provenance)
+        prelude = self._parameter_output_prelude(
+            input_name=input_name if input_provenance is not None else None,
+            data=data,
+        )
+        if not prelude:
+            return None
+
+        assign = "parameter_stderr" if stderr else "parameter_values"
+        label = (
+            "Extract current parameter standard errors"
+            if stderr
+            else "Extract current parameter values"
+        )
+        local_spec = provenance.script(
+            provenance.ScriptCodeOperation(
+                label=label,
+                code=(
+                    f"{prelude}\n"
+                    f"{assign} = "
+                    f"{self._parameter_output_expression(param_name, stderr=stderr)}"
+                ),
+            ),
+            start_label="Start from current fit-tool input data",
+            active_name=assign,
+        )
+
+        if (
+            input_provenance is not None
+            and provenance.direct_replay_input_name(input_provenance) is not None
+        ):
+            replay_spec = provenance.to_replay_provenance_spec(local_spec)
+            if replay_spec is None:
+                raise RuntimeError("Could not convert local provenance to replay spec.")
+            return replay_spec.model_copy(
+                update={"start_label": typing.cast("str", input_provenance.start_label)}
+            )
+        return provenance.compose_full_provenance(input_provenance, local_spec)
 
     def _parameter_values_output_data(self) -> xr.DataArray | None:
         current = self._current_param_output(stderr=False)
@@ -1983,9 +2127,7 @@ class Fit2DTool(Fit1DTool):
         if current is None:
             return ""
         param_name, _ = current
-        return (
-            f'result.modelfit_coefficients.sel(param={param_name!r}).drop_vars("param")'
-        )
+        return self._parameter_output_expression(param_name, stderr=False)
 
     def _parameter_stderr_output_expression(
         self,
@@ -1997,7 +2139,7 @@ class Fit2DTool(Fit1DTool):
         if current is None:
             return ""
         param_name, _ = current
-        return f'result.modelfit_stderr.sel(param={param_name!r}).drop_vars("param")'
+        return self._parameter_output_expression(param_name, stderr=True)
 
 
 def ftool(

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -1995,16 +1995,10 @@ class Fit2DTool(Fit1DTool):
         return param_name, self._param_plot_dataarray(param_name, stderr=stderr)
 
     def _resolve_parameter_output(
-        self, parts: tuple[Output, str | None]
+        self, output: Output, param_name: str
     ) -> tuple[str, bool] | None:
-        output, param_name = parts
         stderr = output == self.Output.PARAMETER_STDERR
-        if param_name is None:
-            current = self._current_param_output(stderr=stderr)
-            if current is None:
-                return None
-            param_name = current[0]
-        elif not param_name or all(
+        if not param_name or all(
             self.param_plot_combo.itemText(i) != param_name
             for i in range(self.param_plot_combo.count())
         ):
@@ -2015,8 +2009,11 @@ class Fit2DTool(Fit1DTool):
         parts = self._parameter_output_parts(output_id)
         if parts is None:
             return super().output_imagetool_data(output_id)
+        output, param_name = parts
+        if param_name is None:
+            return super().output_imagetool_data(output)
 
-        request = self._resolve_parameter_output(parts)
+        request = self._resolve_parameter_output(output, param_name)
         if request is None:
             return None
         param_name, stderr = request
@@ -2028,8 +2025,11 @@ class Fit2DTool(Fit1DTool):
         parts = self._parameter_output_parts(output_id)
         if parts is None:
             return super().output_imagetool_provenance(output_id, data)
+        output, param_name = parts
+        if param_name is None:
+            return super().output_imagetool_provenance(output, data)
 
-        request = self._resolve_parameter_output(parts)
+        request = self._resolve_parameter_output(output, param_name)
         if request is None:
             return None
         param_name, stderr = request

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1543,40 +1543,81 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
         )
 
         child.param_plot_combo.setCurrentIndex(0)
-        param_name = child.param_plot_combo.currentText()
-        assert param_name
+        first_param_name = child.param_plot_combo.currentText()
+        assert first_param_name
+        first_values = child._param_plot_dataarray(first_param_name, stderr=False)
+        second_param_name = ""
+        second_values = None
+        for index in range(1, child.param_plot_combo.count()):
+            candidate = child.param_plot_combo.itemText(index)
+            candidate_values = child._param_plot_dataarray(candidate, stderr=False)
+            if not candidate_values.identical(first_values):
+                second_param_name = candidate
+                second_values = candidate_values
+                break
+        assert second_param_name
+        assert second_values is not None
 
         child.param_plot._show_parameter_values()
         child_node = manager._child_node(child_uid)
         qtbot.wait_until(lambda: len(child_node._childtool_indices) == 1, timeout=5000)
 
-        child.param_plot._show_parameter_stderr()
+        child.param_plot_combo.setCurrentText(second_param_name)
+        child.param_plot._show_parameter_values()
         qtbot.wait_until(lambda: len(child_node._childtool_indices) == 2, timeout=5000)
 
-        values_uid, stderr_uid = child_node._childtool_indices
-        values_node = manager._child_node(values_uid)
+        child.param_plot_combo.setCurrentText(first_param_name)
+        child.param_plot._show_parameter_stderr()
+        qtbot.wait_until(lambda: len(child_node._childtool_indices) == 3, timeout=5000)
+
+        first_values_uid, second_values_uid, stderr_uid = child_node._childtool_indices
+        first_values_node = manager._child_node(first_values_uid)
+        second_values_node = manager._child_node(second_values_uid)
         stderr_node = manager._child_node(stderr_uid)
         assert manager.ntools == 1
-        assert values_node.parent_uid == child_uid
+        assert first_values_node.parent_uid == child_uid
+        assert second_values_node.parent_uid == child_uid
         assert stderr_node.parent_uid == child_uid
-        assert values_node.output_id == "fit2d.param_plot.values"
-        assert stderr_node.output_id == "fit2d.param_plot.stderr"
-        assert values_node.source_spec is None
-        assert values_node.provenance_spec is not None
+        assert first_values_node.output_id == Fit2DTool._parameter_output_id(
+            Fit2DTool.Output.PARAMETER_VALUES, first_param_name
+        )
+        assert second_values_node.output_id == Fit2DTool._parameter_output_id(
+            Fit2DTool.Output.PARAMETER_VALUES, second_param_name
+        )
+        assert stderr_node.output_id == Fit2DTool._parameter_output_id(
+            Fit2DTool.Output.PARAMETER_STDERR, first_param_name
+        )
+        assert first_values_node.source_spec is None
+        assert first_values_node.provenance_spec is not None
+        assert second_values_node.source_spec is None
+        assert second_values_node.provenance_spec is not None
         assert stderr_node.source_spec is None
         assert stderr_node.provenance_spec is not None
+        xr.testing.assert_identical(fetch(first_values_uid), first_values)
+        xr.testing.assert_identical(fetch(second_values_uid), second_values)
         xr.testing.assert_identical(
-            fetch(values_uid), child._param_plot_dataarray(param_name, stderr=False)
+            fetch(stderr_uid),
+            child._param_plot_dataarray(first_param_name, stderr=True),
         )
-        xr.testing.assert_identical(
-            fetch(stderr_uid), child._param_plot_dataarray(param_name, stderr=True)
+        child.param_plot_combo.setCurrentText(second_param_name)
+        assert first_values_node._update_from_parent_source()
+        xr.testing.assert_identical(fetch(first_values_uid), first_values)
+        assert not fetch(first_values_uid).identical(second_values)
+
+        values_code = copy_full_code_for_uid(monkeypatch, manager, first_values_uid)
+        second_values_code = copy_full_code_for_uid(
+            monkeypatch, manager, second_values_uid
         )
-        values_code = copy_full_code_for_uid(monkeypatch, manager, values_uid)
         stderr_code = copy_full_code_for_uid(monkeypatch, manager, stderr_uid)
         assert "prepared_parent = data + 1" in values_code
+        assert "prepared_parent = data + 1" in second_values_code
         assert "prepared_parent = data + 1" in stderr_code
-        assert ".modelfit_coefficients.sel(param=" in values_code
-        assert ".modelfit_stderr.sel(param=" in stderr_code
+        assert f".modelfit_coefficients.sel(param={first_param_name!r})" in values_code
+        assert (
+            f".modelfit_coefficients.sel(param={second_param_name!r})"
+            in second_values_code
+        )
+        assert f".modelfit_stderr.sel(param={first_param_name!r})" in stderr_code
 
 
 def test_manager_output_refresh_updates_stale_parent_source(

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -12,6 +12,7 @@ from qtpy import QtCore, QtWidgets
 
 import erlab
 from erlab.interactive._fit2d import Fit2DTool
+from erlab.interactive.imagetool import provenance
 from tests._qt_helpers import signal_receiver_count
 
 
@@ -1498,6 +1499,69 @@ def test_fit2d_parameter_output_provenance_uses_distinct_active_names(qtbot) -> 
     assert win.output_imagetool_data(missing_id) is None
     assert win.output_imagetool_provenance(malformed_id, values) is None
     assert win.output_imagetool_provenance(missing_id, values) is None
+
+
+def test_fit2d_parameter_output_resolution_edges(qtbot, monkeypatch) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    center_name = "p0_center"
+    params = win._params.copy()
+    params[center_name].set(value=0.1)
+    params[center_name].stderr = 0.01
+    win._params_full = [params.copy() for _ in range(len(win._params_full))]
+    win._result_ds_full = [xr.Dataset() for _ in range(len(win._result_ds_full))]
+    win.param_plot_combo.setCurrentText(center_name)
+
+    with pytest.raises(ValueError, match="Fit2DTool parameter output"):
+        Fit2DTool._parameter_output_id("not-an-output", center_name)  # type: ignore[arg-type]
+    assert Fit2DTool._parameter_output_parts("other.output") is None
+    with pytest.raises(ValueError, match="does not define ImageTool output"):
+        win._image_output_definition("other.output")
+
+    values = win.output_imagetool_data(Fit2DTool.Output.PARAMETER_VALUES)
+    assert values is not None
+    values_output_id = Fit2DTool._parameter_output_id(
+        Fit2DTool.Output.PARAMETER_VALUES, center_name
+    )
+
+    with pytest.raises(ValueError, match="does not define ImageTool output"):
+        win.output_imagetool_data("other.output")
+    with pytest.raises(ValueError, match="does not define ImageTool output"):
+        win.output_imagetool_provenance("other.output", values)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(win, "_full_fit_expression", lambda **_kwargs: "")
+        assert win.output_imagetool_provenance(values_output_id, values) is None
+
+    direct_input = provenance.script(
+        start_label="Start from watched data",
+        seed_code="derived = watched_data",
+        active_name="derived",
+    )
+    win.set_input_provenance_spec(direct_input)
+    direct_spec = win.output_imagetool_provenance(values_output_id, values)
+    assert direct_spec is not None
+    assert direct_spec.start_label == "Start from watched data"
+
+    with monkeypatch.context() as patch:
+        patch.setattr(provenance, "to_replay_provenance_spec", lambda _spec: None)
+        with pytest.raises(RuntimeError, match="Could not convert local provenance"):
+            win.output_imagetool_provenance(values_output_id, values)
+
+    win.param_plot_combo.clear()
+    assert win.output_imagetool_data(Fit2DTool.Output.PARAMETER_VALUES) is None
+    assert win.output_imagetool_data(Fit2DTool.Output.PARAMETER_STDERR) is None
+    assert (
+        win.output_imagetool_provenance(Fit2DTool.Output.PARAMETER_VALUES, values)
+        is None
+    )
+    assert (
+        win.output_imagetool_provenance(Fit2DTool.Output.PARAMETER_STDERR, values)
+        is None
+    )
 
 
 def test_fit2d_show_dataarray_in_itool_uses_detached_launcher(

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1418,8 +1418,8 @@ def test_fit2d_param_plot_dataarray_context_actions(qtbot, monkeypatch) -> None:
         f"{center_name}_stderr",
     ]
     assert [output_id for _, output_id in shown] == [
-        Fit2DTool.Output.PARAMETER_VALUES,
-        Fit2DTool.Output.PARAMETER_STDERR,
+        Fit2DTool._parameter_output_id(Fit2DTool.Output.PARAMETER_VALUES, center_name),
+        Fit2DTool._parameter_output_id(Fit2DTool.Output.PARAMETER_STDERR, center_name),
     ]
 
 
@@ -1447,6 +1447,12 @@ def test_fit2d_parameter_output_provenance_uses_distinct_active_names(qtbot) -> 
     stderr = win.output_imagetool_data(Fit2DTool.Output.PARAMETER_STDERR)
     assert values is not None
     assert stderr is not None
+    values_output_id = Fit2DTool._parameter_output_id(
+        Fit2DTool.Output.PARAMETER_VALUES, center_name
+    )
+    stderr_output_id = Fit2DTool._parameter_output_id(
+        Fit2DTool.Output.PARAMETER_STDERR, center_name
+    )
 
     values_spec = win.output_imagetool_provenance(
         Fit2DTool.Output.PARAMETER_VALUES, values
@@ -1468,6 +1474,30 @@ def test_fit2d_parameter_output_provenance_uses_distinct_active_names(qtbot) -> 
     assert ".modelfit_stderr.sel(param='p0_center')" in stderr_code
     assert ".rename(" not in values_code
     assert ".rename(" not in stderr_code
+
+    win.param_plot_combo.setCurrentText("p0_width")
+    bound_values = win.output_imagetool_data(values_output_id)
+    bound_stderr = win.output_imagetool_data(stderr_output_id)
+    assert bound_values is not None
+    assert bound_stderr is not None
+    xr.testing.assert_identical(bound_values, values)
+    xr.testing.assert_identical(bound_stderr, stderr)
+
+    bound_values_spec = win.output_imagetool_provenance(values_output_id, bound_values)
+    assert bound_values_spec is not None
+    bound_values_code = bound_values_spec.display_code()
+    assert bound_values_code is not None
+    assert ".modelfit_coefficients.sel(param='p0_center')" in bound_values_code
+    assert ".modelfit_coefficients.sel(param='p0_width')" not in bound_values_code
+
+    malformed_id = f"{Fit2DTool.Output.PARAMETER_VALUES.value}:"
+    missing_id = Fit2DTool._parameter_output_id(
+        Fit2DTool.Output.PARAMETER_VALUES, "does_not_exist"
+    )
+    assert win.output_imagetool_data(malformed_id) is None
+    assert win.output_imagetool_data(missing_id) is None
+    assert win.output_imagetool_provenance(malformed_id, values) is None
+    assert win.output_imagetool_provenance(missing_id, values) is None
 
 
 def test_fit2d_show_dataarray_in_itool_uses_detached_launcher(


### PR DESCRIPTION
## Summary
- Persist Fit2D parameter ImageTool outputs with parameter-specific output IDs so refreshes stay bound to the selected parameter
- Generate provenance and replay code from the bound parameter rather than the current combo selection
- Update the tool authoring docs to describe the new output ID behavior

## Testing
- Added unit and manager integration tests covering distinct parameter output IDs, refresh behavior, malformed IDs, and provenance generation