### PR TITLE
Add undo and redo support to interactive tools

### DIFF
--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -351,7 +351,7 @@ Some models have additional options that appear below the model selector that ar
      generate initial parameter values based on the data in the fit window. This
      overwrites all current parameter values.
 
-   - Any adjustment can be undone & redone with standard keyboard shortcuts.
+   - Adjustments can be undone and redone with standard keyboard shortcuts.
 
    - You can right-click parameters in the table to assign/remove expressions.
 

--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -29,6 +29,7 @@ In practice, `ToolWindow` enables several things:
 - save/restore support through `to_dataset()`, `from_dataset()`, `to_file()`, and
   `from_file()`, using `tool_data`, `StateModel`, `tool_status`, and optional
   save-only payload hooks for persisted data that should stay out of undo/redo history;
+- standard undo/redo actions for the lightweight UI state stored in `tool_status`;
 - integration with the ImageTool manager, including tool naming, preview images, rich
   info text, and manager refresh notifications through `sigInfoChanged`;
 - remembering which ImageTool data and selection opened the tool, including saved
@@ -195,6 +196,7 @@ class MinimalScaleTool(erlab.interactive.utils.ToolWindow):
 
         # Paint the first frame after all widgets exist.
         self._refresh()
+        self._reset_history_stack()
 
     def _coerce_data(self, data: xr.DataArray) -> xr.DataArray:
         # Minimal tools can validate inline instead of overriding validate_update_data().
@@ -226,7 +228,9 @@ class MinimalScaleTool(erlab.interactive.utils.ToolWindow):
     def update_data(self, new_data: xr.DataArray) -> bool:
         # This is the minimal refresh path: replace the data and repaint.
         self._data = self._coerce_data(new_data)
-        self._refresh()
+        with self._history_suppressed():
+            self._refresh()
+        self._reset_history_stack()
         return True
 
     def _display_data(self) -> xr.DataArray:
@@ -234,6 +238,7 @@ class MinimalScaleTool(erlab.interactive.utils.ToolWindow):
 
     def _refresh(self) -> None:
         self.image.setDataArray(self._display_data())
+        self._write_state()
 ```
 
 That is the minimum `ToolWindow` surface to keep in your head:
@@ -459,6 +464,11 @@ Some implementation details matter:
   and is stored separately in workspace files. If you need to persist expensive
   calculated arrays, use the explicit persistence hooks instead of `tool_status` so
   ordinary history snapshots stay cheap.
+- Record undo/redo checkpoints after user-visible state changes by calling
+  `_write_state()`. Call `_reset_history_stack()` after construction, file restore,
+  duplication, or source-data replacement so a restored or refreshed tool starts from
+  the current state with no previous history. Use `_replace_last_state()` when an
+  asynchronous result updates the current step instead of creating a new undo step.
 - Make the `tool_status` getter and setter fully describe and restore the current UI
   state. A restored tool should look the same as one configured interactively.
 - Keep provenance and output declarations declarative. Prefer method names in
@@ -570,11 +580,13 @@ def update_data(self, new_data: xr.DataArray) -> bool:
     old_geom = self.saveGeometry()
 
     def _apply_update(validated: xr.DataArray) -> bool:
-        self._data = validated
-        self._rebuild_ui()
-        self.tool_status = status
-        self.restoreGeometry(old_geom)
-        self._notify_data_changed()
+        with self._history_suppressed():
+            self._data = validated
+            self._rebuild_ui()
+            self.tool_status = status
+            self.restoreGeometry(old_geom)
+            self._notify_data_changed()
+        self._reset_history_stack()
         return True
 
     return self._perform_source_update(new_data, apply_update=_apply_update)

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -136,6 +136,8 @@ _MISSING = object()
 _PLOT_SLICES_PANEL_LINE = "line"
 _PLOT_SLICES_PANEL_IMAGE = "image"
 _PLOT_SLICES_PANEL_MIXED = "mixed"
+_PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR = "_figure_composer_operation_id"
+_PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR = "_figure_composer_panel_key"
 
 
 class _PlotSlicesPanelKey(typing.NamedTuple):
@@ -3167,11 +3169,55 @@ def _render_plot_slices(
         maps,
         _axes_from_selection(tool, operation.axes, axs, for_plot_slices=True),
     )
+    axes_tuple = _iter_axes(axes)
+    panel_keys = _plot_slices_panel_keys(tool, operation)
+    mappable_ids_before = _axis_mappable_ids(axes_tuple)
     eplt.plot_slices(
         maps,
         axes=typing.cast("Iterable[matplotlib.axes.Axes]", axes),
         **kwargs,
     )
+    _tag_plot_slices_mappables(
+        operation,
+        axes_tuple,
+        panel_keys,
+        mappable_ids_before,
+    )
+
+
+def _axis_mappables(axis: object) -> tuple[object, ...]:
+    images = tuple(getattr(axis, "images", ()))
+    collections = tuple(getattr(axis, "collections", ()))
+    return (*images, *collections)
+
+
+def _axis_mappable_ids(axes: Sequence[object]) -> dict[object, set[int]]:
+    return {axis: {id(mappable) for mappable in _axis_mappables(axis)} for axis in axes}
+
+
+def _tag_plot_slices_mappables(
+    operation: FigureOperationState,
+    axes: Sequence[object],
+    panel_keys: Sequence[_PlotSlicesPanelKey],
+    mappable_ids_before: Mapping[object, set[int]],
+) -> None:
+    if len(axes) != len(panel_keys):
+        return
+    for axis, panel_key in zip(axes, panel_keys, strict=True):
+        previous_ids = mappable_ids_before.get(axis, set())
+        for mappable in _axis_mappables(axis):
+            if id(mappable) in previous_ids:
+                continue
+            setattr(
+                mappable,
+                _PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
+                operation.operation_id,
+            )
+            setattr(
+                mappable,
+                _PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
+                (panel_key.map_index, panel_key.slice_index),
+            )
 
 
 def _plot_slices_axes(

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -70,6 +70,11 @@ from erlab.interactive._figurecomposer._operations._base import (
     COMMON_SOURCE_SECTION_TOOLTIP,
     StepSection,
 )
+from erlab.interactive._figurecomposer._operations._plot_slices import (
+    _PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
+    _PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
+    _plot_slices_panel_keys,
+)
 from erlab.interactive._figurecomposer._rendering import (
     _live_layout_axes,
     _render_into_figure,
@@ -94,6 +99,7 @@ from erlab.interactive._figurecomposer._state import (
     FigureMethodFamily,
     FigureOperationKind,
     FigureOperationState,
+    FigurePlotSlicesPanelStyleState,
     FigureRecipeState,
     FigureSourceState,
     FigureSubplotsState,
@@ -281,6 +287,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 axes_customize_callback=lambda: self._show_axes_customize_dialog(),
                 show_composer_callback=lambda: self._show_composer_from_figure_window(),
                 navigation_callback=self._figure_window_navigation_changed,
+                colorbar_callback=self._figure_window_colorbar_changed,
                 undo_callback=self.undo,
                 redo_callback=self.redo,
                 undoable_callback=lambda: self.undoable,
@@ -433,6 +440,37 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if not changed:
             return
 
+        self._apply_live_figure_operation_updates(operations, changed_operation_ids)
+
+    def _figure_window_colorbar_changed(
+        self, changes: Mapping[object, tuple[float, float]]
+    ) -> None:
+        if self._updating_controls or self._rendering:
+            return
+        operations = list(self._recipe.operations)
+        changed_operation_ids: set[str] = set()
+        changed = False
+        for mappable, clim in changes.items():
+            target = self._plot_slices_mappable_target(mappable, operations)
+            if target is None:
+                continue
+            index, operation, panel_key = target
+            updated = self._operation_with_colorbar_clim(operation, panel_key, clim)
+            if operation.model_dump() == updated.model_dump():
+                continue
+            operations[index] = updated
+            changed_operation_ids.add(updated.operation_id)
+            changed = True
+        if not changed:
+            return
+
+        self._apply_live_figure_operation_updates(operations, changed_operation_ids)
+
+    def _apply_live_figure_operation_updates(
+        self,
+        operations: Sequence[FigureOperationState],
+        changed_operation_ids: set[str],
+    ) -> None:
         current = self._current_operation()
         self._recipe = self._recipe.model_copy(update={"operations": tuple(operations)})
         self._refresh_operation_list()
@@ -450,6 +488,69 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._mark_preview_pixmap_stale()
         self.sigInfoChanged.emit()
         self._write_state()
+
+    def _plot_slices_mappable_target(
+        self,
+        mappable: object,
+        operations: Sequence[FigureOperationState],
+    ) -> tuple[int, FigureOperationState, tuple[int, int]] | None:
+        operation_id = getattr(mappable, _PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR, None)
+        panel_key = getattr(mappable, _PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR, None)
+        if not isinstance(operation_id, str):
+            return None
+        if (
+            not isinstance(panel_key, tuple)
+            or len(panel_key) != 2
+            or not all(isinstance(value, int) for value in panel_key)
+        ):
+            return None
+        for index, operation in enumerate(operations):
+            if (
+                operation.operation_id == operation_id
+                and operation.kind == FigureOperationKind.PLOT_SLICES
+            ):
+                return index, operation, typing.cast("tuple[int, int]", panel_key)
+        return None
+
+    def _operation_with_colorbar_clim(
+        self,
+        operation: FigureOperationState,
+        panel_key: tuple[int, int],
+        clim: tuple[float, float],
+    ) -> FigureOperationState:
+        panel_keys = _plot_slices_panel_keys(self, operation)
+        valid_keys = {(key.map_index, key.slice_index) for key in panel_keys}
+        if panel_key not in valid_keys:
+            return operation
+        vmin, vmax = clim
+        if len(panel_keys) == 1 or (
+            operation.same_limits is not False and not operation.panel_styles_enabled
+        ):
+            return operation.model_copy(update={"vmin": vmin, "vmax": vmax})
+
+        styles = {
+            (style.map_index, style.slice_index): style
+            for style in operation.panel_styles
+            if (style.map_index, style.slice_index) in valid_keys
+        }
+        current_style = styles.get(
+            panel_key,
+            FigurePlotSlicesPanelStyleState(
+                map_index=panel_key[0],
+                slice_index=panel_key[1],
+            ),
+        )
+        styles[panel_key] = current_style.model_copy(
+            update={"vmin": vmin, "vmax": vmax}
+        )
+        panel_styles = tuple(
+            sorted(
+                styles.values(), key=lambda style: (style.map_index, style.slice_index)
+            )
+        )
+        return operation.model_copy(
+            update={"panel_styles_enabled": True, "panel_styles": panel_styles}
+        )
 
     def _navigation_axis_selection(
         self,

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -71,6 +71,7 @@ from erlab.interactive._figurecomposer._operations._base import (
     StepSection,
 )
 from erlab.interactive._figurecomposer._rendering import (
+    _live_layout_axes,
     _render_into_figure,
     _render_preview,
     _rendered_output_figure,
@@ -90,6 +91,8 @@ from erlab.interactive._figurecomposer._state import (
     FigureGridSpecAxesState,
     FigureGridSpecGridState,
     FigureGridSpecSpanState,
+    FigureMethodFamily,
+    FigureOperationKind,
     FigureOperationState,
     FigureRecipeState,
     FigureSourceState,
@@ -276,6 +279,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 export_callback=lambda: self.export_figure(),
                 subplot_adjust_callback=lambda: self._show_subplot_adjust_dialog(),
                 axes_customize_callback=lambda: self._show_axes_customize_dialog(),
+                show_composer_callback=lambda: self._show_composer_from_figure_window(),
+                navigation_callback=self._figure_window_navigation_changed,
+                undo_callback=self.undo,
+                redo_callback=self.redo,
+                undoable_callback=lambda: self.undoable,
+                redoable_callback=lambda: self.redoable,
             )
             window_ref = weakref.ref(self._figure_window)
             tool_ref = weakref.ref(self)
@@ -304,6 +313,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if window is not None and self._figure_window is window:
             self._figure_window = None
 
+    def _update_history_actions(self) -> None:
+        super()._update_history_actions()
+        window = getattr(self, "_figure_window", None)
+        if window is not None and erlab.interactive.utils.qt_is_valid(window):
+            window.toolbar.set_history_buttons()
+
     def _disconnect_figure_window(self, window: _FigureComposerDisplayWindow) -> None:
         with contextlib.suppress(TypeError, RuntimeError):
             window.sigCanvasSizeChanged.disconnect(
@@ -320,6 +335,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     @QtCore.Slot()
     def _show_figure_window_requested(self) -> None:
         self._request_show_figure_window(activate=True)
+
+    def _show_composer_from_figure_window(self) -> None:
+        if not erlab.interactive.utils.qt_is_valid(self):
+            return
+        if self.isMinimized():
+            self.showNormal()
+        else:
+            self.show()
+        self.raise_()
+        self.activateWindow()
 
     def show_figure_window(self, *, activate: bool = True) -> None:
         self.figure_window.show_for_setup(
@@ -364,6 +389,117 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             width_inches, height_inches, draw=False, emit_info=False
         ):
             self._queue_figure_resize_render()
+
+    def _figure_window_navigation_changed(
+        self, changes: Mapping[object, tuple[bool, bool]]
+    ) -> None:
+        if self._updating_controls or self._rendering:
+            return
+        layout_axes = _live_layout_axes(self)
+        if layout_axes is None:
+            return
+
+        operations = list(self._recipe.operations)
+        changed_operation_ids: set[str] = set()
+        changed = False
+        for axis, (x_changed, y_changed) in changes.items():
+            selection = self._navigation_axis_selection(layout_axes, axis)
+            if selection is None:
+                continue
+            for method_name, limits in self._navigation_axis_limit_updates(
+                axis, x_changed=x_changed, y_changed=y_changed
+            ):
+                index = self._matching_navigation_limit_operation_index(
+                    operations, method_name, selection
+                )
+                updated = FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name=method_name,
+                    axes=selection,
+                    args=limits,
+                )
+                if index is None:
+                    operations.append(updated)
+                    changed_operation_ids.add(updated.operation_id)
+                    changed = True
+                    continue
+                previous = operations[index]
+                updated = previous.model_copy(update={"method_args": limits})
+                if previous.model_dump() == updated.model_dump():
+                    continue
+                operations[index] = updated
+                changed_operation_ids.add(updated.operation_id)
+                changed = True
+        if not changed:
+            return
+
+        current = self._current_operation()
+        self._recipe = self._recipe.model_copy(update={"operations": tuple(operations)})
+        self._refresh_operation_list()
+        if current is not None and current[0] < len(operations):
+            self._set_current_operation_row_silent(current[0])
+        current_operation = self._current_operation()
+        self._sync_axes_selector()
+        self._update_step_action_buttons()
+        self._refresh_step_section_button_texts()
+        self._update_source_status(current_operation[1] if current_operation else None)
+        if current_operation is not None and (
+            current_operation[1].operation_id in changed_operation_ids
+        ):
+            self._update_operation_editor_safely()
+        self._mark_preview_pixmap_stale()
+        self.sigInfoChanged.emit()
+        self._write_state()
+
+    def _navigation_axis_selection(
+        self,
+        layout_axes: object,
+        axis: object,
+    ) -> FigureAxesSelectionState | None:
+        if isinstance(layout_axes, dict):
+            for axes_id, candidate in layout_axes.items():
+                if candidate is axis:
+                    return FigureAxesSelectionState(axes_ids=(str(axes_id),))
+            return None
+        shape = getattr(layout_axes, "shape", ())
+        if len(shape) != 2:
+            return None
+        for row in range(shape[0]):
+            for col in range(shape[1]):
+                if layout_axes[row, col] is axis:
+                    return FigureAxesSelectionState(axes=((row, col),))
+        return None
+
+    @staticmethod
+    def _navigation_axis_limit_updates(
+        axis: object, *, x_changed: bool, y_changed: bool
+    ) -> tuple[tuple[str, tuple[float, float]], ...]:
+        updates: list[tuple[str, tuple[float, float]]] = []
+        if x_changed and hasattr(axis, "get_xlim"):
+            xlim = typing.cast("typing.Any", axis).get_xlim()
+            updates.append(("set_xlim", (float(xlim[0]), float(xlim[1]))))
+        if y_changed and hasattr(axis, "get_ylim"):
+            ylim = typing.cast("typing.Any", axis).get_ylim()
+            updates.append(("set_ylim", (float(ylim[0]), float(ylim[1]))))
+        return tuple(updates)
+
+    @staticmethod
+    def _matching_navigation_limit_operation_index(
+        operations: Sequence[FigureOperationState],
+        method_name: str,
+        selection: FigureAxesSelectionState,
+    ) -> int | None:
+        selection_payload = selection.model_dump()
+        for index in range(len(operations) - 1, -1, -1):
+            operation = operations[index]
+            if (
+                operation.kind == FigureOperationKind.METHOD
+                and operation.method_family == FigureMethodFamily.AXES
+                and operation.method_name == method_name
+                and operation.axes.model_dump() == selection_payload
+            ):
+                return index
+        return None
 
     def _queue_figure_resize_render(self) -> None:
         self._figure_resize_render_generation += 1

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -563,11 +563,13 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                     return FigureAxesSelectionState(axes_ids=(str(axes_id),))
             return None
         shape = getattr(layout_axes, "shape", ())
-        if len(shape) != 2:
+        if not isinstance(shape, tuple) or len(shape) != 2:
             return None
-        for row in range(shape[0]):
-            for col in range(shape[1]):
-                if layout_axes[row, col] is axis:
+        row_count, column_count = typing.cast("tuple[int, int]", shape)
+        layout_array = typing.cast("typing.Any", layout_axes)
+        for row in range(row_count):
+            for col in range(column_count):
+                if layout_array[row, col] is axis:
                     return FigureAxesSelectionState(axes=((row, col),))
         return None
 

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -214,6 +214,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._current_step_section_key = "sources"
         self._build_ui()
         self._apply_recipe_to_controls()
+        self._write_state()
 
     @staticmethod
     def _default_recipe(data: xr.DataArray) -> FigureRecipeState:
@@ -441,6 +442,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self.canvas.draw()
         if emit_info:
             self.sigInfoChanged.emit()
+        self._write_state()
         return True
 
     def _show_subplot_adjust_dialog(self) -> None:
@@ -1995,6 +1997,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if render:
             _render_preview(self)
             self.sigInfoChanged.emit()
+        self._write_state()
 
     def _replace_operation(
         self,
@@ -2028,6 +2031,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if render:
             _render_preview(self)
             self.sigInfoChanged.emit()
+        self._write_state()
 
     def _update_current_operation(self, **updates: typing.Any) -> None:
         if self._updating_controls:
@@ -2168,6 +2172,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._update_operation_editor()
         _render_preview(self)
         self.sigInfoChanged.emit()
+        self._write_state()
 
     @QtCore.Slot()
     def _add_subplot_row(self) -> None:
@@ -2283,6 +2288,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._update_operation_editor()
         _render_preview(self)
         self.sigInfoChanged.emit()
+        self._write_state()
 
     @staticmethod
     def _combo_bool_or_text(
@@ -2573,6 +2579,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 self._refresh_step_section_button_texts()
                 _render_preview(self)
                 self.sigInfoChanged.emit()
+                self._write_state()
                 return
 
     @QtCore.Slot()
@@ -2880,6 +2887,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._update_operation_editor()
         _render_preview(self)
         self.sigInfoChanged.emit()
+        self._write_state()
 
     @QtCore.Slot()
     def _show_add_step_menu(self) -> None:
@@ -2897,6 +2905,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.operation_list.setCurrentRow(len(operations) - 1)
         _render_preview(self)
         self.sigInfoChanged.emit()
+        self._write_state()
 
     @QtCore.Slot()
     def _remove_current_operation(self) -> None:
@@ -2997,6 +3006,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._update_operation_editor()
         _render_preview(self)
         self.sigInfoChanged.emit()
+        self._write_state()
 
     @QtCore.Slot()
     def _move_current_operation_up(self) -> None:
@@ -3015,6 +3025,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.operation_list.setCurrentRow(len(self._recipe.operations) - 1)
         _render_preview(self)
         self.sigInfoChanged.emit()
+        self._write_state()
 
     def add_sources(
         self,
@@ -3032,6 +3043,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._update_source_section()
         _render_preview(self)
         self.sigInfoChanged.emit()
+        self._write_state()
 
     @staticmethod
     def _remove_posted_events_recursive(widget: QtWidgets.QWidget) -> None:

--- a/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
+++ b/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
@@ -88,6 +88,7 @@ if typing.TYPE_CHECKING:
 _LAYOUT_ENGINE_OPTIONS = ("default", "none", "tight", "constrained", "compressed")
 _STYLE_TARGET_PLOT_SLICES = "plot_slices"
 _STYLE_TARGET_LINE = "line"
+_STYLE_TARGET_COMBO_MINIMUM_CONTENTS = 28
 
 
 class _StyleTarget(typing.NamedTuple):
@@ -96,12 +97,31 @@ class _StyleTarget(typing.NamedTuple):
     target_kind: str
     label: str
     panel_keys: tuple[_PlotSlicesPanelKey, ...] = ()
+    tooltip: str = ""
 
 
 class _AxisValueState(typing.NamedTuple):
     value: typing.Any = None
     mixed: bool = False
     available: bool = False
+
+
+class _ElidingComboBox(QtWidgets.QComboBox):
+    """Combo box whose closed label elides instead of driving dialog width."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setMinimumContentsLength(_STYLE_TARGET_COMBO_MINIMUM_CONTENTS)
+        self.setSizeAdjustPolicy(
+            QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+        )
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+        view = self.view()
+        if view is not None:  # pragma: no branch - Qt creates the popup view.
+            view.setTextElideMode(QtCore.Qt.TextElideMode.ElideMiddle)
 
 
 def _add_axis_form_row(
@@ -955,9 +975,12 @@ def _style_tab_page(
 ) -> tuple[QtWidgets.QWidget, QtWidgets.QComboBox, QtWidgets.QVBoxLayout]:
     page = QtWidgets.QWidget(parent)
     layout = QtWidgets.QVBoxLayout(page)
-    combo = QtWidgets.QComboBox(page)
+    combo = _ElidingComboBox(page)
     combo.setObjectName(combo_object_name)
     combo.setToolTip("Choose the plotted item to customize.")
+    combo.currentIndexChanged.connect(
+        lambda _index, combo=combo: _update_style_target_combo_tooltip(combo)
+    )
     layout.addWidget(combo)
     editor_layout = QtWidgets.QVBoxLayout()
     editor_layout.setContentsMargins(0, 0, 0, 0)
@@ -1011,7 +1034,22 @@ def _populate_style_target_combo(
         combo.clear()
         for index, target in enumerate(targets):
             combo.addItem(target.label, index)
+            combo.setItemData(
+                index,
+                target.tooltip or target.label,
+                QtCore.Qt.ItemDataRole.ToolTipRole,
+            )
         combo.setEnabled(bool(targets))
+        _update_style_target_combo_tooltip(combo)
+
+
+def _update_style_target_combo_tooltip(combo: QtWidgets.QComboBox) -> None:
+    tooltip = combo.itemData(combo.currentIndex(), QtCore.Qt.ItemDataRole.ToolTipRole)
+    combo.setToolTip(
+        tooltip
+        if isinstance(tooltip, str) and tooltip
+        else "Choose the plotted item to customize."
+    )
 
 
 def _current_style_target(
@@ -1085,13 +1123,15 @@ def _image_style_targets(
             tool, operation, selected_axis_ids
         )
         if panel_keys:
+            full_label = _style_target_label(tool, operation, panel_keys)
             targets.append(
                 _StyleTarget(
                     operation.operation_id,
                     index,
                     _STYLE_TARGET_PLOT_SLICES,
-                    _style_target_label(tool, operation, panel_keys),
+                    _image_style_target_label(index, operation, panel_keys),
                     panel_keys,
+                    full_label,
                 )
             )
     return targets
@@ -1141,6 +1181,26 @@ def _style_target_label(
     text = tool._operation_display_text(operation)
     if len(panel_keys) == 1:
         return f"{text}: {panel_keys[0].label}"
+    return f"{text}: {len(panel_keys)} panels"
+
+
+def _image_style_target_label(
+    operation_index: int,
+    operation: FigureOperationState,
+    panel_keys: Sequence[_PlotSlicesPanelKey],
+) -> str:
+    label = operation.label.strip() or "Image slices"
+    if label == "plot_slices":
+        label = "Image slices"
+    text = f"Step {operation_index + 1}: {label}"
+    if len(panel_keys) == 1:
+        key = panel_keys[0]
+        panel_text = (
+            f"panel {key.map_index + 1}"
+            if key.slice_index == 0
+            else f"panel {key.map_index + 1}.{key.slice_index + 1}"
+        )
+        return f"{text}: {panel_text}"
     return f"{text}: {len(panel_keys)} panels"
 
 

--- a/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
+++ b/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
@@ -1388,6 +1388,7 @@ def _set_operations(
         tool._update_operation_editor_safely()
     _render_preview(tool)
     tool.sigInfoChanged.emit()
+    tool._write_state()
 
 
 def _layout_axes(tool: FigureComposerTool) -> np.ndarray | dict[str, Axes] | None:

--- a/src/erlab/interactive/_figurecomposer/_widgets.py
+++ b/src/erlab/interactive/_figurecomposer/_widgets.py
@@ -727,6 +727,10 @@ def _noop_navigation_callback(_changes: Mapping[object, tuple[bool, bool]]) -> N
     return
 
 
+def _noop_colorbar_callback(_changes: Mapping[object, tuple[float, float]]) -> None:
+    return
+
+
 def _false_toolbar_state() -> bool:
     return False
 
@@ -758,6 +762,29 @@ def _is_colorbar_axis(axis: object) -> bool:
     return hasattr(axis, "_colorbar")
 
 
+def _colorbar_mappable(axis: object) -> object | None:
+    colorbar = getattr(axis, "_colorbar", None)
+    if colorbar is None:
+        return None
+    return getattr(colorbar, "mappable", None)
+
+
+def _mappable_clim(mappable: object) -> tuple[float, float] | None:
+    get_clim = getattr(mappable, "get_clim", None)
+    if get_clim is None:
+        return None
+    try:
+        first, second = get_clim()
+    except (TypeError, ValueError):
+        return None
+    if first is None or second is None:
+        return None
+    try:
+        return float(first), float(second)
+    except (TypeError, ValueError):
+        return None
+
+
 class _FigureComposerNavigationToolbar(NavigationToolbar):
     """Navigation toolbar that routes composer actions through recipe edits."""
 
@@ -778,6 +805,9 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         navigation_callback: Callable[
             [Mapping[object, tuple[bool, bool]]], None
         ] = _noop_navigation_callback,
+        colorbar_callback: Callable[
+            [Mapping[object, tuple[float, float]]], None
+        ] = _noop_colorbar_callback,
         undo_callback: Callable[[], None] = _noop_toolbar_callback,
         redo_callback: Callable[[], None] = _noop_toolbar_callback,
         undoable_callback: Callable[[], bool] = _false_toolbar_state,
@@ -788,6 +818,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         self._axes_customize_callback = axes_customize_callback
         self._show_composer_callback = show_composer_callback
         self._navigation_callback = navigation_callback
+        self._colorbar_callback = colorbar_callback
         self._undo_callback = undo_callback
         self._redo_callback = redo_callback
         self._undoable_callback = undoable_callback
@@ -795,6 +826,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         self._navigation_press_views: dict[
             object, tuple[tuple[float, float], tuple[float, float]]
         ] = {}
+        self._colorbar_press_clims: dict[object, tuple[float, float]] = {}
         super().__init__(canvas, parent)
         self.setObjectName("figureComposerNavigationToolbar")
         for action_id, action in self._actions.items():
@@ -897,6 +929,19 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
                 views[axis] = view
         return views
 
+    def _capture_colorbar_clims(
+        self, axes: typing.Iterable[object]
+    ) -> dict[object, tuple[float, float]]:
+        clims: dict[object, tuple[float, float]] = {}
+        for axis in axes:
+            mappable = _colorbar_mappable(axis)
+            if mappable is None:
+                continue
+            clim = _mappable_clim(mappable)
+            if clim is not None:
+                clims[mappable] = clim
+        return clims
+
     def _commit_navigation_views(
         self,
         before: Mapping[object, tuple[tuple[float, float], tuple[float, float]]],
@@ -914,18 +959,39 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
             self._navigation_callback(changes)
         self.set_history_buttons()
 
+    def _commit_colorbar_clims(
+        self,
+        before: Mapping[object, tuple[float, float]],
+    ) -> None:
+        if not before:
+            return
+        changes: dict[object, tuple[float, float]] = {}
+        for mappable, previous in before.items():
+            current = _mappable_clim(mappable)
+            if current is not None and not _same_axis_limits(previous, current):
+                changes[mappable] = current
+        if changes:
+            self._colorbar_callback(changes)
+        self.set_history_buttons()
+
     def press_pan(self, event: object) -> None:
         super().press_pan(event)
         pan_info = getattr(self, "_pan_info", None)
         self._navigation_press_views = (
             {} if pan_info is None else self._capture_navigation_views(pan_info.axes)
         )
+        self._colorbar_press_clims = (
+            {} if pan_info is None else self._capture_colorbar_clims(pan_info.axes)
+        )
 
     def release_pan(self, event: object) -> None:
         before = dict(self._navigation_press_views)
+        colorbar_before = dict(self._colorbar_press_clims)
         self._navigation_press_views = {}
+        self._colorbar_press_clims = {}
         super().release_pan(event)
         self._commit_navigation_views(before)
+        self._commit_colorbar_clims(colorbar_before)
 
     def press_zoom(self, event: object) -> None:
         super().press_zoom(event)
@@ -933,12 +999,18 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         self._navigation_press_views = (
             {} if zoom_info is None else self._capture_navigation_views(zoom_info.axes)
         )
+        self._colorbar_press_clims = (
+            {} if zoom_info is None else self._capture_colorbar_clims(zoom_info.axes)
+        )
 
     def release_zoom(self, event: object) -> None:
         before = dict(self._navigation_press_views)
+        colorbar_before = dict(self._colorbar_press_clims)
         self._navigation_press_views = {}
+        self._colorbar_press_clims = {}
         super().release_zoom(event)
         self._commit_navigation_views(before)
+        self._commit_colorbar_clims(colorbar_before)
 
     def changeEvent(self, event: QtCore.QEvent | None) -> None:
         if event is not None and event.type() == QtCore.QEvent.Type.PaletteChange:
@@ -972,6 +1044,9 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
         navigation_callback: Callable[
             [Mapping[object, tuple[bool, bool]]], None
         ] = _noop_navigation_callback,
+        colorbar_callback: Callable[
+            [Mapping[object, tuple[float, float]]], None
+        ] = _noop_colorbar_callback,
         undo_callback: Callable[[], None] = _noop_toolbar_callback,
         redo_callback: Callable[[], None] = _noop_toolbar_callback,
         undoable_callback: Callable[[], bool] = _false_toolbar_state,
@@ -1000,6 +1075,7 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
             axes_customize_callback=axes_customize_callback,
             show_composer_callback=show_composer_callback,
             navigation_callback=navigation_callback,
+            colorbar_callback=colorbar_callback,
             undo_callback=undo_callback,
             redo_callback=redo_callback,
             undoable_callback=undoable_callback,

--- a/src/erlab/interactive/_figurecomposer/_widgets.py
+++ b/src/erlab/interactive/_figurecomposer/_widgets.py
@@ -700,9 +700,9 @@ class _StyledFigureCanvas(FigureCanvas):
 
 
 _TOOLBAR_ICON_NAMES = {
-    "home": "mdi6.home",
-    "back": "mdi6.arrow-left",
-    "forward": "mdi6.arrow-right",
+    "figure_composer": "mdi6.application-edit-outline",
+    "back": "mdi6.undo",
+    "forward": "mdi6.redo",
     "move": "mdi6.arrow-all",
     "zoom_to_rect": "mdi6.magnify-plus",
     "subplots": "mdi6.view-grid-outline",
@@ -711,13 +711,60 @@ _TOOLBAR_ICON_NAMES = {
     "filesave": "mdi6.export",
 }
 
+_SHOW_COMPOSER_TOOLITEM = (
+    "Composer",
+    "Show the corresponding Figure Composer window",
+    "figure_composer",
+    "show_composer",
+)
+
 
 def _noop_toolbar_callback() -> None:
     return
 
 
+def _noop_navigation_callback(_changes: Mapping[object, tuple[bool, bool]]) -> None:
+    return
+
+
+def _false_toolbar_state() -> bool:
+    return False
+
+
+def _axis_limit_pair(axis: object, getter_name: str) -> tuple[float, float] | None:
+    getter = getattr(axis, getter_name, None)
+    if getter is None:
+        return None
+    try:
+        first, second = getter()
+    except (TypeError, ValueError):
+        return None
+    return float(first), float(second)
+
+
+def _axis_view(axis: object) -> tuple[tuple[float, float], tuple[float, float]] | None:
+    xlim = _axis_limit_pair(axis, "get_xlim")
+    ylim = _axis_limit_pair(axis, "get_ylim")
+    if xlim is None or ylim is None:
+        return None
+    return xlim, ylim
+
+
+def _same_axis_limits(first: tuple[float, float], second: tuple[float, float]) -> bool:
+    return math.isclose(first[0], second[0]) and math.isclose(first[1], second[1])
+
+
+def _is_colorbar_axis(axis: object) -> bool:
+    return hasattr(axis, "_colorbar")
+
+
 class _FigureComposerNavigationToolbar(NavigationToolbar):
     """Navigation toolbar that routes composer actions through recipe edits."""
+
+    toolitems = tuple(
+        _SHOW_COMPOSER_TOOLITEM if item[3] == "home" else item
+        for item in NavigationToolbar.toolitems
+    )
 
     def __init__(
         self,
@@ -727,15 +774,35 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         export_callback: Callable[[], None],
         subplot_adjust_callback: Callable[[], None],
         axes_customize_callback: Callable[[], None],
+        show_composer_callback: Callable[[], None] = _noop_toolbar_callback,
+        navigation_callback: Callable[
+            [Mapping[object, tuple[bool, bool]]], None
+        ] = _noop_navigation_callback,
+        undo_callback: Callable[[], None] = _noop_toolbar_callback,
+        redo_callback: Callable[[], None] = _noop_toolbar_callback,
+        undoable_callback: Callable[[], bool] = _false_toolbar_state,
+        redoable_callback: Callable[[], bool] = _false_toolbar_state,
     ) -> None:
         self._export_callback = export_callback
         self._subplot_adjust_callback = subplot_adjust_callback
         self._axes_customize_callback = axes_customize_callback
+        self._show_composer_callback = show_composer_callback
+        self._navigation_callback = navigation_callback
+        self._undo_callback = undo_callback
+        self._redo_callback = redo_callback
+        self._undoable_callback = undoable_callback
+        self._redoable_callback = redoable_callback
+        self._navigation_press_views: dict[
+            object, tuple[tuple[float, float], tuple[float, float]]
+        ] = {}
         super().__init__(canvas, parent)
         self.setObjectName("figureComposerNavigationToolbar")
         for action_id, action in self._actions.items():
             action.setObjectName(f"figureComposerToolbar_{action_id}")
         tooltips = {
+            "show_composer": "Show the corresponding Figure Composer window.",
+            "back": "Undo the last Figure Composer recipe change.",
+            "forward": "Redo the last undone Figure Composer recipe change.",
             "save_figure": "Export the composer figure using recipe export settings.",
             "copy_figure_to_clipboard": "Copy the current figure image.",
             "configure_subplots": (
@@ -747,6 +814,15 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         for action_id, tooltip in tooltips.items():
             if action := self._actions.get(action_id):
                 action.setToolTip(tooltip)
+        if action := self._actions.get("back"):
+            action.setText("Undo")
+            action.setShortcut(QtGui.QKeySequence.StandardKey.Undo)
+            action.setShortcutContext(QtCore.Qt.ShortcutContext.WindowShortcut)
+        if action := self._actions.get("forward"):
+            action.setText("Redo")
+            action.setShortcut(QtGui.QKeySequence.StandardKey.Redo)
+            action.setShortcutContext(QtCore.Qt.ShortcutContext.WindowShortcut)
+        self.set_history_buttons()
 
     def _add_copy_action(self) -> None:
         action_id = "copy_figure_to_clipboard"
@@ -773,6 +849,9 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
     def edit_parameters(self) -> None:
         self._axes_customize_callback()
 
+    def show_composer(self) -> None:
+        self._show_composer_callback()
+
     def save_figure(self, *args: object) -> None:
         self._export_callback()
 
@@ -792,6 +871,75 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         ):
             clipboard.setPixmap(pixmap)
 
+    def set_history_buttons(self) -> None:
+        if "back" in self._actions:
+            self._actions["back"].setEnabled(self._undoable_callback())
+        if "forward" in self._actions:
+            self._actions["forward"].setEnabled(self._redoable_callback())
+
+    def back(self, *args: object) -> None:
+        self._undo_callback()
+        self.set_history_buttons()
+
+    def forward(self, *args: object) -> None:
+        self._redo_callback()
+        self.set_history_buttons()
+
+    def _capture_navigation_views(
+        self, axes: typing.Iterable[object]
+    ) -> dict[object, tuple[tuple[float, float], tuple[float, float]]]:
+        views: dict[object, tuple[tuple[float, float], tuple[float, float]]] = {}
+        for axis in axes:
+            if _is_colorbar_axis(axis):
+                continue
+            view = _axis_view(axis)
+            if view is not None:
+                views[axis] = view
+        return views
+
+    def _commit_navigation_views(
+        self,
+        before: Mapping[object, tuple[tuple[float, float], tuple[float, float]]],
+    ) -> None:
+        changes: dict[object, tuple[bool, bool]] = {}
+        for axis, previous in before.items():
+            current = _axis_view(axis)
+            if current is None:
+                continue
+            x_changed = not _same_axis_limits(previous[0], current[0])
+            y_changed = not _same_axis_limits(previous[1], current[1])
+            if x_changed or y_changed:
+                changes[axis] = (x_changed, y_changed)
+        if changes:
+            self._navigation_callback(changes)
+        self.set_history_buttons()
+
+    def press_pan(self, event: object) -> None:
+        super().press_pan(event)
+        pan_info = getattr(self, "_pan_info", None)
+        self._navigation_press_views = (
+            {} if pan_info is None else self._capture_navigation_views(pan_info.axes)
+        )
+
+    def release_pan(self, event: object) -> None:
+        before = dict(self._navigation_press_views)
+        self._navigation_press_views = {}
+        super().release_pan(event)
+        self._commit_navigation_views(before)
+
+    def press_zoom(self, event: object) -> None:
+        super().press_zoom(event)
+        zoom_info = getattr(self, "_zoom_info", None)
+        self._navigation_press_views = (
+            {} if zoom_info is None else self._capture_navigation_views(zoom_info.axes)
+        )
+
+    def release_zoom(self, event: object) -> None:
+        before = dict(self._navigation_press_views)
+        self._navigation_press_views = {}
+        super().release_zoom(event)
+        self._commit_navigation_views(before)
+
     def changeEvent(self, event: QtCore.QEvent | None) -> None:
         if event is not None and event.type() == QtCore.QEvent.Type.PaletteChange:
             erlab.interactive.utils.qtawesome.reset_cache()
@@ -799,6 +947,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
                 icon_name = {
                     "zoom": "zoom_to_rect",
                     "pan": "move",
+                    "show_composer": "figure_composer",
                     "configure_subplots": "subplots",
                     "edit_parameters": "qt4_editor_options",
                     "save_figure": "filesave",
@@ -819,6 +968,14 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
         export_callback: Callable[[], None] = _noop_toolbar_callback,
         subplot_adjust_callback: Callable[[], None] = _noop_toolbar_callback,
         axes_customize_callback: Callable[[], None] = _noop_toolbar_callback,
+        show_composer_callback: Callable[[], None] = _noop_toolbar_callback,
+        navigation_callback: Callable[
+            [Mapping[object, tuple[bool, bool]]], None
+        ] = _noop_navigation_callback,
+        undo_callback: Callable[[], None] = _noop_toolbar_callback,
+        redo_callback: Callable[[], None] = _noop_toolbar_callback,
+        undoable_callback: Callable[[], bool] = _false_toolbar_state,
+        redoable_callback: Callable[[], bool] = _false_toolbar_state,
     ) -> None:
         super().__init__(None)
         erlab.interactive.utils.patch_macos_matplotlib_qt_cursor()
@@ -841,6 +998,12 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
             export_callback=export_callback,
             subplot_adjust_callback=subplot_adjust_callback,
             axes_customize_callback=axes_customize_callback,
+            show_composer_callback=show_composer_callback,
+            navigation_callback=navigation_callback,
+            undo_callback=undo_callback,
+            redo_callback=redo_callback,
+            undoable_callback=undoable_callback,
+            redoable_callback=redoable_callback,
         )
 
         root = QtWidgets.QWidget(self)

--- a/src/erlab/interactive/_figurecomposer/_widgets.py
+++ b/src/erlab/interactive/_figurecomposer/_widgets.py
@@ -32,7 +32,9 @@ from erlab.interactive._figurecomposer._state import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Iterable, Mapping, Sequence
+
+    from matplotlib.backend_bases import Event
 
     from erlab.interactive._figurecomposer._state import FigureSubplotsState
 
@@ -788,10 +790,10 @@ def _mappable_clim(mappable: object) -> tuple[float, float] | None:
 class _FigureComposerNavigationToolbar(NavigationToolbar):
     """Navigation toolbar that routes composer actions through recipe edits."""
 
-    toolitems = tuple(
+    toolitems = [  # noqa: RUF012 - Matplotlib expects toolbar items on the class.
         _SHOW_COMPOSER_TOOLITEM if item[3] == "home" else item
         for item in NavigationToolbar.toolitems
-    )
+    ]
 
     def __init__(
         self,
@@ -918,7 +920,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         self.set_history_buttons()
 
     def _capture_navigation_views(
-        self, axes: typing.Iterable[object]
+        self, axes: Iterable[object]
     ) -> dict[object, tuple[tuple[float, float], tuple[float, float]]]:
         views: dict[object, tuple[tuple[float, float], tuple[float, float]]] = {}
         for axis in axes:
@@ -930,7 +932,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         return views
 
     def _capture_colorbar_clims(
-        self, axes: typing.Iterable[object]
+        self, axes: Iterable[object]
     ) -> dict[object, tuple[float, float]]:
         clims: dict[object, tuple[float, float]] = {}
         for axis in axes:
@@ -974,7 +976,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
             self._colorbar_callback(changes)
         self.set_history_buttons()
 
-    def press_pan(self, event: object) -> None:
+    def press_pan(self, event: Event) -> None:
         super().press_pan(event)
         pan_info = getattr(self, "_pan_info", None)
         self._navigation_press_views = (
@@ -984,7 +986,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
             {} if pan_info is None else self._capture_colorbar_clims(pan_info.axes)
         )
 
-    def release_pan(self, event: object) -> None:
+    def release_pan(self, event: Event) -> None:
         before = dict(self._navigation_press_views)
         colorbar_before = dict(self._colorbar_press_clims)
         self._navigation_press_views = {}
@@ -993,7 +995,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
         self._commit_navigation_views(before)
         self._commit_colorbar_clims(colorbar_before)
 
-    def press_zoom(self, event: object) -> None:
+    def press_zoom(self, event: Event) -> None:
         super().press_zoom(event)
         zoom_info = getattr(self, "_zoom_info", None)
         self._navigation_press_views = (
@@ -1003,7 +1005,7 @@ class _FigureComposerNavigationToolbar(NavigationToolbar):
             {} if zoom_info is None else self._capture_colorbar_clims(zoom_info.axes)
         )
 
-    def release_zoom(self, event: object) -> None:
+    def release_zoom(self, event: Event) -> None:
         before = dict(self._navigation_press_views)
         colorbar_before = dict(self._colorbar_press_clims)
         self._navigation_press_views = {}

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import collections
 import contextlib
 import dataclasses
 import functools
@@ -835,20 +834,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         )
 
         self._build_ui()
-        self._undo_shortcut = QtWidgets.QShortcut(
-            QtGui.QKeySequence.StandardKey.Undo, self
-        )
-        self._undo_shortcut.setContext(
-            QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
-        )
-        self._undo_shortcut.activated.connect(self.undo)
-        self._redo_shortcut = QtWidgets.QShortcut(
-            QtGui.QKeySequence.StandardKey.Redo, self
-        )
-        self._redo_shortcut.setContext(
-            QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
-        )
-        self._redo_shortcut.activated.connect(self.redo)
         self._update_fit_curve()
         self._write_history: bool = True
         self._write_state()
@@ -1004,12 +989,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_multi_step: int = 0
         self._fit_multi_fit_data: xr.DataArray | None = None
         self._fit_multi_params: lmfit.Parameters | None = None
-        self._prev_states: collections.deque[Fit1DTool.StateModel] = collections.deque(
-            maxlen=5000
-        )
-        self._next_states: collections.deque[Fit1DTool.StateModel] = collections.deque(
-            maxlen=5000
-        )
         self._write_history = False
 
     def _fit_finished_connection_key(
@@ -1880,12 +1859,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         if self.param_model.rowCount() > 0:
             self.param_view.selectRow(0)
 
-    def _reset_history_stack(self) -> None:
-        self._prev_states.clear()
-        self._next_states.clear()
-        self._prev_states.append(self.tool_status)
-        self._update_history_actions()
-
     @QtCore.Slot(int)
     def _on_model_choice_changed(self, _index: int) -> None:
         label = self.model_combo.currentData(role=QtCore.Qt.ItemDataRole.UserRole)
@@ -1919,68 +1892,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self._sync_model_display()
             return
         self.set_model(model, **set_model_kw)
-
-    @property
-    def undoable(self) -> bool:
-        return len(self._prev_states) > 1
-
-    @property
-    def redoable(self) -> bool:
-        return len(self._next_states) > 0
-
-    @contextlib.contextmanager
-    def _history_suppressed(self):
-        original = bool(self._write_history)
-        self._write_history = False
-        try:
-            yield
-        finally:
-            self._write_history = original
-
-    @QtCore.Slot()
-    def _write_state(self) -> None:
-        if not self._write_history:
-            return
-        curr_state = self.tool_status
-        last_state = self._prev_states[-1] if self._prev_states else None
-        if last_state is None or last_state.model_dump() != curr_state.model_dump():
-            self._prev_states.append(curr_state)
-            self._next_states.clear()
-            self._update_history_actions()
-
-    @QtCore.Slot()
-    def _replace_last_state(self) -> None:
-        if not self._write_history:
-            return
-        curr_state = self.tool_status
-        if self._prev_states:
-            self._prev_states[-1] = curr_state
-            self._update_history_actions()
-
-    def _update_history_actions(self) -> None:
-        if hasattr(self, "_undo_shortcut"):
-            self._undo_shortcut.setEnabled(self.undoable)
-        if hasattr(self, "_redo_shortcut"):
-            self._redo_shortcut.setEnabled(self.redoable)
-
-    @QtCore.Slot()
-    def undo(self) -> None:
-        if not self.undoable:
-            return
-        with self._history_suppressed():
-            self._next_states.append(self._prev_states.pop())
-            self.tool_status = self._prev_states[-1]
-        self._update_history_actions()
-
-    @QtCore.Slot()
-    def redo(self) -> None:
-        if not self.redoable:
-            return
-        with self._history_suppressed():
-            next_state = self._next_states.pop()
-            self._prev_states.append(next_state)
-            self.tool_status = next_state
-        self._update_history_actions()
 
     @property
     def tool_status(self) -> StateModel:

--- a/src/erlab/interactive/_mesh.py
+++ b/src/erlab/interactive/_mesh.py
@@ -62,6 +62,7 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
 
     def _emit_info_changed(self, *_args: typing.Any) -> None:
         self.sigInfoChanged.emit()
+        self._write_state()
 
     class StateModel(pydantic.BaseModel):
         first_order_peaks: list[list[int]]
@@ -291,6 +292,7 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
                 plot.hideAxis("bottom")
             plot.vb.autoRange()
         self._connect_signals()
+        self._reset_history_stack()
 
     def _connect_signals(self) -> None:
         self.auto_btn.clicked.connect(self.auto_find_peaks)
@@ -451,10 +453,12 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
                 return
             raise
 
-        self.p0_spin0.setValue(int(peaks[1, 0]))
-        self.p0_spin1.setValue(int(peaks[1, 1]))
-        self.p1_spin0.setValue(int(peaks[2, 0]))
-        self.p1_spin1.setValue(int(peaks[2, 1]))
+        with self._history_suppressed():
+            self.p0_spin0.setValue(int(peaks[1, 0]))
+            self.p0_spin1.setValue(int(peaks[1, 1]))
+            self.p1_spin0.setValue(int(peaks[2, 0]))
+            self.p1_spin1.setValue(int(peaks[2, 1]))
+        self._write_state()
 
     @QtCore.Slot()
     def update(self) -> None:
@@ -518,10 +522,12 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
         ):
             spin.setMaximum(maximum)
 
-        self.tool_status = status
-        self.set_data_beforecalc(initial=True)
-        self._update_target_pos()
-        self._notify_data_changed()
+        with self._history_suppressed():
+            self.tool_status = status
+            self.set_data_beforecalc(initial=True)
+            self._update_target_pos()
+            self._notify_data_changed()
+        self._reset_history_stack()
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
         data = erlab.interactive.utils.parse_data(new_data)

--- a/src/erlab/interactive/derivative.py
+++ b/src/erlab/interactive/derivative.py
@@ -294,6 +294,7 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
         self.plots[0].autoRange()
 
         self.update_result()
+        self._write_state()
 
     @QtCore.Slot()
     def reset_smooth(self) -> None:
@@ -394,6 +395,7 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
             self.images[1].setDataArray(
                 self.result, levels=self.get_levels(self.result.values)
             )
+            self._write_state()
 
     def get_levels(self, data) -> tuple[float, float]:
         cutoff = (self.lo_spin.value(), self.hi_spin.value())
@@ -460,6 +462,7 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
         if not self._pause_update:
             self.result = self.process_func(self.processed_data, **self.process_kwargs)
             self._notify_data_changed()
+            self._write_state()
 
     @QtCore.Slot()
     def open_itool(self) -> None:
@@ -483,8 +486,10 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
         self.xdim = self.data.dims[1]
         self.ydim = self.data.dims[0]
         self.__dict__.pop("processed_data", None)
-        self.tool_status = status
-        self.update_preprocess()
+        with self._history_suppressed():
+            self.tool_status = status
+            self.update_preprocess()
+        self._reset_history_stack()
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
         data = erlab.interactive.utils.parse_data(new_data)

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -507,6 +507,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
         # Initialize fit result
         self.result: scipy.interpolate.BSpline | xr.Dataset | None = None
+        self._reset_history_stack()
 
     @property
     def data_name(self) -> str:
@@ -576,6 +577,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     def _emit_info_changed(self, *_args: typing.Any) -> None:
         self.sigInfoChanged.emit()
+        self._write_state()
 
     @staticmethod
     def _bool_text(value: bool) -> str:
@@ -810,50 +812,58 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         )
 
     def _apply_update_request(self, request: _GoldUpdateRequest) -> bool:
-        self._clear_edge_fit_results()
-        self.data = request.data
-        self._along_dim = str(self.data.dims[1])
-        self.aw.set_input(self.data)
-        self.aw.axes[0].autoRange()
+        with self._history_suppressed():
+            self._clear_edge_fit_results()
+            self.data = request.data
+            self._along_dim = str(self.data.dims[1])
+            self.aw.set_input(self.data)
+            self.aw.axes[0].autoRange()
 
-        roi_rect = self.aw.axes[0].getViewBox().itemBoundingRect(self.aw.images[0])
-        self.params_roi.roi.maxBounds = roi_rect
-        self.params_roi._x_decimals = erlab.utils.array.effective_decimals(
-            self.data[self._along_dim].values
-        )
-        self.params_roi._y_decimals = erlab.utils.array.effective_decimals(
-            self.data.eV.values
-        )
-        xm, ym, xM, yM = self.params_roi.max_bounds
-        for name in ("x0", "x1"):
-            spin = typing.cast(
-                "QtWidgets.QDoubleSpinBox", self.params_roi.widgets[name]
+            roi_rect = self.aw.axes[0].getViewBox().itemBoundingRect(self.aw.images[0])
+            self.params_roi.roi.maxBounds = roi_rect
+            self.params_roi._x_decimals = erlab.utils.array.effective_decimals(
+                self.data[self._along_dim].values
             )
-            spin.setRange(xm, xM)
-            spin.setDecimals(self.params_roi._x_decimals)
-        for name in ("y0", "y1"):
-            spin = typing.cast(
-                "QtWidgets.QDoubleSpinBox", self.params_roi.widgets[name]
+            self.params_roi._y_decimals = erlab.utils.array.effective_decimals(
+                self.data.eV.values
             )
-            spin.setRange(ym, yM)
-            spin.setDecimals(self.params_roi._y_decimals)
-        self.params_roi.modify_roi(
-            *self._clamp_roi_limits_to_bounds(request.roi_limits)
-        )
-        self.params_roi.update_pos()
+            xm, ym, xM, yM = self.params_roi.max_bounds
+            for name in ("x0", "x1"):
+                spin = typing.cast(
+                    "QtWidgets.QDoubleSpinBox", self.params_roi.widgets[name]
+                )
+                spin.setRange(xm, xM)
+                spin.setDecimals(self.params_roi._x_decimals)
+            for name in ("y0", "y1"):
+                spin = typing.cast(
+                    "QtWidgets.QDoubleSpinBox", self.params_roi.widgets[name]
+                )
+                spin.setRange(ym, yM)
+                spin.setDecimals(self.params_roi._y_decimals)
+            self.params_roi.modify_roi(
+                *self._clamp_roi_limits_to_bounds(request.roi_limits)
+            )
+            self.params_roi.update_pos()
 
-        with (
-            QtCore.QSignalBlocker(self.params_edge),
-            QtCore.QSignalBlocker(self.params_poly),
-            QtCore.QSignalBlocker(self.params_spl),
-            QtCore.QSignalBlocker(self.params_tab),
-        ):
-            self._restore_parameter_group_values(self.params_edge, request.edge_values)
-            self._restore_parameter_group_values(self.params_poly, request.poly_values)
-            self._restore_parameter_group_values(self.params_spl, request.spline_values)
-            self.params_tab.setCurrentIndex(request.tab_index)
-        self._toggle_fast()
-        self._sync_spline_lambda_enabled()
+            with (
+                QtCore.QSignalBlocker(self.params_edge),
+                QtCore.QSignalBlocker(self.params_poly),
+                QtCore.QSignalBlocker(self.params_spl),
+                QtCore.QSignalBlocker(self.params_tab),
+            ):
+                self._restore_parameter_group_values(
+                    self.params_edge, request.edge_values
+                )
+                self._restore_parameter_group_values(
+                    self.params_poly, request.poly_values
+                )
+                self._restore_parameter_group_values(
+                    self.params_spl, request.spline_values
+                )
+                self.params_tab.setCurrentIndex(request.tab_index)
+            self._toggle_fast()
+            self._sync_spline_lambda_enabled()
+        self._reset_history_stack()
 
         if request.had_fit and request.refit:
             self._source_refresh_deferred = self.has_source_binding
@@ -986,6 +996,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         self.params_spl.setDisabled(False)
         self.params_tab.setDisabled(False)
         self.perform_fit()
+        self._replace_last_state()
 
     @QtCore.Slot()
     def _abort_fit_task(self) -> None:
@@ -1664,6 +1675,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self._pending_fit_action: Callable[[], None] | None = None
         self._fit_signature_current: tuple[typing.Any, ...] | None = None
         self._fit_signature_displayed: tuple[typing.Any, ...] | None = None
+        self._reset_history_stack()
 
     def _configure_data(self, data: xr.DataArray) -> None:
         if (data.ndim != 2) or ("eV" not in data.dims):
@@ -1789,11 +1801,13 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         )
 
         def _apply_update(validated: xr.DataArray) -> bool:
-            self._configure_data(validated)
-            self._clear_fit_outputs()
-            self.tool_status = status
-            self._update_edc()
-            self._notify_data_changed()
+            with self._history_suppressed():
+                self._configure_data(validated)
+                self._clear_fit_outputs()
+                self.tool_status = status
+                self._update_edc()
+                self._notify_data_changed()
+            self._reset_history_stack()
 
             if had_fit and self.refit_on_source_update_check.isChecked():
                 self._source_refresh_deferred = self.has_source_binding
@@ -1978,9 +1992,11 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
             return
         self._result_ds = None
         self._fit_signature_displayed = None
-        self.live_check.setChecked(False)
-        self._fit_failed(f"Fit timed out in {elapsed:.2f} seconds")
-        self.edc_fit.setData(x=[], y=[])
+        with self._history_suppressed():
+            self.live_check.setChecked(False)
+            self._fit_failed(f"Fit timed out in {elapsed:.2f} seconds")
+            self.edc_fit.setData(x=[], y=[])
+        self._replace_last_state()
 
     def _handle_fit_error(
         self, message: str, fit_signature: tuple[typing.Any, ...]
@@ -1989,9 +2005,11 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
             return
         self._result_ds = None
         self._fit_signature_displayed = None
-        self.live_check.setChecked(False)
-        self.edc_fit.setData(x=[], y=[])
-        self._fit_failed("Fit failed")
+        with self._history_suppressed():
+            self.live_check.setChecked(False)
+            self.edc_fit.setData(x=[], y=[])
+            self._fit_failed("Fit failed")
+        self._replace_last_state()
         logger.error("Error while fitting resolution tool data:\n%s", message)
 
     def _handle_fit_success(
@@ -2043,7 +2061,9 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
             textedit.setText(_get_param_text(param))
         redchi: float | None = modelresult.redchi
         self.redchi_val.setText(f"{redchi:.4f}" if redchi is not None else "—")
-        self._emit_info_changed()
+        with self._history_suppressed():
+            self._emit_info_changed()
+        self._replace_last_state()
         if self._source_refresh_deferred:
             self.finalize_source_refresh()
 
@@ -2073,6 +2093,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
 
         self.x_region.sigRegionChanged.connect(self._emit_info_changed)
         self.y_region.sigRegionChanged.connect(self._emit_info_changed)
+        self.live_check.toggled.connect(self._emit_info_changed)
         self.refit_on_source_update_check.toggled.connect(self._emit_info_changed)
         self.temp_spin.valueChanged.connect(self._emit_info_changed)
         self.fix_temp_check.toggled.connect(self._emit_info_changed)
@@ -2085,6 +2106,24 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self.timeout_spin.valueChanged.connect(self._emit_info_changed)
         self.nfev_spin.valueChanged.connect(self._emit_info_changed)
         self.mev_check.toggled.connect(self._emit_info_changed)
+        for signal in (
+            self.x_region.sigRegionChanged,
+            self.y_region.sigRegionChanged,
+            self.live_check.toggled,
+            self.refit_on_source_update_check.toggled,
+            self.temp_spin.valueChanged,
+            self.fix_temp_check.toggled,
+            self.center_spin.valueChanged,
+            self.fix_center_check.toggled,
+            self.res_spin.valueChanged,
+            self.fix_res_check.toggled,
+            self.slope_check.toggled,
+            self.method_combo.currentTextChanged,
+            self.timeout_spin.valueChanged,
+            self.nfev_spin.valueChanged,
+            self.mev_check.toggled,
+        ):
+            signal.connect(self._write_state)
 
     def _copy_expression(
         self,

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -241,6 +241,7 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
         self.angle_plot_check.stateChanged.connect(
             lambda: self.plotitems[0].setVisible(self.angle_plot_check.isChecked())
         )
+        self.angle_plot_check.stateChanged.connect(self._write_state_if_ready)
 
         self._roi_list: list[_MovableCircleROI] = []
         self.add_circle_btn.clicked.connect(self._add_circle)
@@ -334,8 +335,11 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
         def _remove_roi():
             self.plotitems[1].removeItem(roi)
             self._roi_list.remove(roi)
+            self._write_state_if_ready()
 
         roi.sigRemoveRequested.connect(_remove_roi)
+        roi.sigRegionChangeFinished.connect(self._write_state_if_ready)
+        self._write_state_if_ready()
 
     def update_cmap(self) -> None:
         name = self.cmap_combo.currentText()
@@ -347,6 +351,7 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
                 high_contrast=self.contrast_check.isChecked(),
                 update=True,
             )
+        self._write_state_if_ready()
 
     def get_bz_lines(self):
         raise NotImplementedError
@@ -354,6 +359,7 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
     def update_bz(self) -> None:
         self.plotitems[1].clearPlots()
         if not self.bz_group.isChecked():
+            self._write_state_if_ready()
             return
 
         lines, vertices, midpoints = self.get_bz_lines()
@@ -379,6 +385,11 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
                 symbolBrush=pg.mkColor("m"),
                 symbolSize=8,
             )
+        self._write_state_if_ready()
+
+    def _write_state_if_ready(self, *_args: typing.Any) -> None:
+        if hasattr(self, "data"):
+            self._write_state()
 
 
 class KspaceTool(KspaceToolGUI):
@@ -856,6 +867,7 @@ class KspaceTool(KspaceToolGUI):
 
         if avec is not None and self.bz_group.isEnabled():
             self.bz_group.setChecked(True)
+        self._reset_history_stack()
 
     def _ensure_energy_control_connections(self) -> None:
         if self._energy_controls_connected:
@@ -892,8 +904,10 @@ class KspaceTool(KspaceToolGUI):
                 self.center_spin.setValue(fixed_energy)
             self.energy_group.setDisabled(True)
 
-        self.tool_status = status
+        with self._history_suppressed():
+            self.tool_status = status
         self._notify_data_changed()
+        self._reset_history_stack()
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
         data = erlab.interactive.utils.parse_data(new_data)
@@ -1298,6 +1312,7 @@ class KspaceTool(KspaceToolGUI):
         self._notify_data_changed()
         if bz_available and self.bz_group.isChecked():
             self.update_bz()
+        self._write_state()
 
     @staticmethod
     def _bz_digest_array(values: npt.ArrayLike) -> bytes:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ast
 import bisect
+import collections
 import contextlib
 import enum
 import fnmatch
@@ -3200,6 +3201,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._output_imagetool_targets: dict[str, str | QtWidgets.QWidget] = {}
         self._save_tool_data_references = False
         self._save_tool_data_reference_node_uids: frozenset[str] | None = None
+        self._prev_states: collections.deque[M] = collections.deque(maxlen=5000)
+        self._next_states: collections.deque[M] = collections.deque(maxlen=5000)
+        self._write_history = True
 
         menu_bar = typing.cast("QtWidgets.QMenuBar", self.menuBar())
         self._tool_file_menu = typing.cast("QtWidgets.QMenu", menu_bar.addMenu("&File"))
@@ -3218,6 +3222,30 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._tool_file_menu.aboutToShow.connect(self._refresh_reload_data_action)
         self._refresh_reload_data_action()
 
+        self._tool_edit_menu = typing.cast("QtWidgets.QMenu", menu_bar.addMenu("&Edit"))
+        self._tool_edit_menu.setObjectName("tool_edit_menu")
+        self.undo_action = QtWidgets.QAction("&Undo", self)
+        self.undo_action.setObjectName("tool_undo_action")
+        self.undo_action.setShortcut(QtGui.QKeySequence.StandardKey.Undo)
+        self.undo_action.setShortcutContext(
+            QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
+        self.undo_action.setIcon(QtGui.QIcon.fromTheme("edit-undo"))
+        self.undo_action.setEnabled(False)
+        self.undo_action.triggered.connect(self.undo)
+        self._tool_edit_menu.addAction(self.undo_action)
+        self.redo_action = QtWidgets.QAction("&Redo", self)
+        self.redo_action.setObjectName("tool_redo_action")
+        self.redo_action.setShortcut(QtGui.QKeySequence.StandardKey.Redo)
+        self.redo_action.setShortcutContext(
+            QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
+        self.redo_action.setIcon(QtGui.QIcon.fromTheme("edit-redo"))
+        self.redo_action.setEnabled(False)
+        self.redo_action.triggered.connect(self.redo)
+        self._tool_edit_menu.addAction(self.redo_action)
+        self._update_history_actions()
+
         # Enable closing with keyboard shortcut
         self.__close_shortcut = QtWidgets.QShortcut("Ctrl+W", self, self._hide_or_close)
         self.__close_shortcut.setContext(
@@ -3231,6 +3259,86 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self.__remove_shortcut.setContext(
             QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
         )
+
+    @staticmethod
+    def _history_state_equal(left: M | None, right: M | None) -> bool:
+        if left is None or right is None:
+            return left is right
+        return left.model_dump() == right.model_dump()
+
+    @property
+    def undoable(self) -> bool:
+        """Return whether a previous tool state is available."""
+        return len(self._prev_states) > 1
+
+    @property
+    def redoable(self) -> bool:
+        """Return whether an undone tool state is available."""
+        return len(self._next_states) > 0
+
+    @contextlib.contextmanager
+    def _history_suppressed(self):
+        original = bool(self._write_history)
+        self._write_history = False
+        try:
+            yield
+        finally:
+            self._write_history = original
+
+    def _reset_history_stack(self) -> None:
+        self._prev_states.clear()
+        self._next_states.clear()
+        self._prev_states.append(self.tool_status)
+        self._update_history_actions()
+
+    @QtCore.Slot()
+    def _write_state(self, *_args: typing.Any) -> None:
+        if not self._write_history:
+            return
+        curr_state = self.tool_status
+        last_state = self._prev_states[-1] if self._prev_states else None
+        if not self._history_state_equal(last_state, curr_state):
+            self._prev_states.append(curr_state)
+            self._next_states.clear()
+            self._update_history_actions()
+
+    @QtCore.Slot()
+    def _replace_last_state(self, *_args: typing.Any) -> None:
+        if not self._write_history:
+            return
+        curr_state = self.tool_status
+        if self._prev_states:
+            self._prev_states[-1] = curr_state
+        else:
+            self._prev_states.append(curr_state)
+        self._update_history_actions()
+
+    def _update_history_actions(self) -> None:
+        if hasattr(self, "undo_action") and qt_is_valid(self.undo_action):
+            self.undo_action.setEnabled(self.undoable)
+        if hasattr(self, "redo_action") and qt_is_valid(self.redo_action):
+            self.redo_action.setEnabled(self.redoable)
+
+    @QtCore.Slot()
+    def undo(self) -> None:
+        """Undo the most recent recorded tool state change."""
+        if not self.undoable:
+            return
+        with self._history_suppressed():
+            self._next_states.append(self._prev_states.pop())
+            self.tool_status = self._prev_states[-1]
+        self._update_history_actions()
+
+    @QtCore.Slot()
+    def redo(self) -> None:
+        """Redo the most recently undone tool state change."""
+        if not self.redoable:
+            return
+        with self._history_suppressed():
+            next_state = self._next_states.pop()
+            self._prev_states.append(next_state)
+            self.tool_status = next_state
+        self._update_history_actions()
 
     def centralWidget(self) -> QtWidgets.QWidget | None:
         """Return the content widget shown below the source-status banner."""
@@ -4743,9 +4851,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         tool = cls_obj(
             data_items[_SAVED_TOOL_DATA_NAME].rename(tool_data_name), **kwargs
         )
-        tool.tool_status = cls_obj.StateModel.model_validate_json(
-            ds.attrs["tool_state"]
-        )
+        with tool._history_suppressed():
+            tool.tool_status = cls_obj.StateModel.model_validate_json(
+                ds.attrs["tool_state"]
+            )
         tool._tool_display_name = ds.attrs.get("tool_display_name", "")
         source_spec = None
         if _TOOL_SOURCE_SPEC_ATTR in ds.attrs:
@@ -4815,6 +4924,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             and "tool_rect" in ds.attrs
         ):
             tool.setGeometry(*ds.attrs["tool_rect"])
+        tool._reset_history_stack()
         return tool
 
     def to_file(self, filename: str | os.PathLike) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -8085,6 +8085,7 @@ def test_figure_composer_toolbar_operation_helpers_update_recipe(qtbot) -> None:
     assert new_index == 2
     assert not tool.tool_status.operations[new_index].enabled
 
+    tool._reset_history_stack()
     figurecomposer_toolbar_dialogs._set_method_operation_enabled(
         tool,
         FigureMethodFamily.AXES,
@@ -8092,6 +8093,14 @@ def test_figure_composer_toolbar_operation_helpers_update_recipe(qtbot) -> None:
         axes=FigureAxesSelectionState(axes=((0, 1),)),
         enabled=True,
     )
+    assert tool.tool_status.operations[new_index].enabled
+    assert tool.undoable
+
+    tool.undo()
+    assert not tool.tool_status.operations[new_index].enabled
+    assert tool.redoable
+
+    tool.redo()
     assert tool.tool_status.operations[new_index].enabled
 
     slices_id = slices.operation_id

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -4540,6 +4540,24 @@ def test_figure_composer_recipe_codegen_and_loaded_custom_code_trust(qtbot) -> N
     assert loaded.tool_status.operations[0].trusted is False
 
 
+def test_figure_composer_undo_redo_setup_state(qtbot) -> None:
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+    initial = tool.tool_status
+
+    tool.nrows_spin.setValue(initial.setup.nrows + 1)
+
+    assert tool.undoable
+    assert tool.tool_status.setup.nrows == initial.setup.nrows + 1
+
+    tool.undo()
+    assert tool.tool_status.model_dump(mode="json") == initial.model_dump(mode="json")
+    assert tool.redoable
+
+    tool.redo()
+    assert tool.tool_status.setup.nrows == initial.setup.nrows + 1
+
+
 def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0),

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -4654,6 +4654,103 @@ def test_figure_composer_navigation_ignores_colorbar_axes(qtbot) -> None:
     assert not tool.undoable
 
 
+def test_figure_composer_colorbar_drag_updates_recipe_limits(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("y", "x"),
+        coords={"y": np.arange(3), "x": np.arange(4)},
+        name="data",
+    )
+    operation = FigureOperationState.plot_slices(
+        label="data",
+        sources=("data",),
+    ).model_copy(update={"colorbar": "right"})
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    qtbot.addWidget(tool.figure_window)
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+    tool.canvas.draw()
+    tool._reset_history_stack()
+
+    colorbar_axis = next(
+        axis for axis in tool.figure.axes if hasattr(axis, "_colorbar")
+    )
+    mappable = typing.cast("typing.Any", colorbar_axis)._colorbar.mappable
+    previous_clim = mappable.get_clim()
+
+    mappable.set_clim(1.0, 5.0)
+    tool.figure_window.toolbar._commit_colorbar_clims({mappable: previous_clim})
+
+    updated = tool.tool_status.operations[0]
+    assert updated.vmin == pytest.approx(1.0)
+    assert updated.vmax == pytest.approx(5.0)
+    assert tool.undoable
+
+    tool.figure_window.toolbar.back()
+
+    assert tool.tool_status.operations[0].vmin is None
+    assert tool.tool_status.operations[0].vmax is None
+    assert tool.redoable
+
+    tool.figure_window.toolbar.forward()
+
+    assert tool.tool_status.operations[0].vmin == pytest.approx(1.0)
+    assert tool.tool_status.operations[0].vmax == pytest.approx(5.0)
+
+
+def test_figure_composer_colorbar_drag_updates_panel_style_limits(qtbot) -> None:
+    data = _figure_composer_image_source("data")
+    operation = FigureOperationState.plot_slices(
+        label="data",
+        sources=("data",),
+        slice_dim="eV",
+        slice_values=(-0.5, 0.0),
+        axes=FigureAxesSelectionState(expression="axs[0, :]"),
+    ).model_copy(update={"colorbar": "right"})
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(ncols=2),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    qtbot.addWidget(tool.figure_window)
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+    tool.canvas.draw()
+    tool._reset_history_stack()
+
+    colorbar_axis = next(
+        axis for axis in tool.figure.axes if hasattr(axis, "_colorbar")
+    )
+    mappable = typing.cast("typing.Any", colorbar_axis)._colorbar.mappable
+    previous_clim = mappable.get_clim()
+
+    mappable.set_clim(0.25, 0.75)
+    tool.figure_window.toolbar._commit_colorbar_clims({mappable: previous_clim})
+
+    updated = tool.tool_status.operations[0]
+    assert updated.vmin is None
+    assert updated.vmax is None
+    assert updated.panel_styles_enabled
+    assert len(updated.panel_styles) == 1
+    style = updated.panel_styles[0]
+    assert style.map_index == 0
+    assert style.slice_index == 0
+    assert style.vmin == pytest.approx(0.25)
+    assert style.vmax == pytest.approx(0.75)
+
+
 def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0),

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -4084,6 +4084,29 @@ def test_figure_composer_hide_cancels_deferred_figure_window(
     assert calls == []
 
 
+def test_figure_composer_show_composer_from_figure_window(qtbot, monkeypatch) -> None:
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+
+    calls: list[str] = []
+    monkeypatch.setattr(tool, "isMinimized", lambda: False)
+    monkeypatch.setattr(tool, "show", lambda: calls.append("show"))
+    monkeypatch.setattr(tool, "raise_", lambda: calls.append("raise"))
+    monkeypatch.setattr(tool, "activateWindow", lambda: calls.append("activate"))
+
+    tool._show_composer_from_figure_window()
+
+    assert calls == ["show", "raise", "activate"]
+
+    calls.clear()
+    monkeypatch.setattr(tool, "isMinimized", lambda: True)
+    monkeypatch.setattr(tool, "showNormal", lambda: calls.append("showNormal"))
+
+    tool._show_composer_from_figure_window()
+
+    assert calls == ["showNormal", "raise", "activate"]
+
+
 def test_figure_composer_tool_edge_state_contracts(qtbot, monkeypatch) -> None:
     monkeypatch.setattr(
         "erlab.interactive._figurecomposer._tool._render_preview",
@@ -4556,6 +4579,79 @@ def test_figure_composer_undo_redo_setup_state(qtbot) -> None:
 
     tool.redo()
     assert tool.tool_status.setup.nrows == initial.setup.nrows + 1
+
+
+def test_figure_composer_navigation_updates_recipe_limits(qtbot) -> None:
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+    qtbot.addWidget(tool.figure_window)
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+    tool.canvas.draw()
+    tool._reset_history_stack()
+
+    initial = tool.tool_status
+    layout_axes = figurecomposer_rendering._live_layout_axes(tool)
+    assert layout_axes is not None
+    axis = figurecomposer_rendering._iter_axes(layout_axes)[0]
+    axis.set_xlim(0.25, 0.75)
+
+    tool._figure_window_navigation_changed({axis: (True, False)})
+
+    operation = tool.tool_status.operations[-1]
+    assert operation.kind == FigureOperationKind.METHOD
+    assert operation.method_family == FigureMethodFamily.AXES
+    assert operation.method_name == "set_xlim"
+    assert operation.method_args == pytest.approx((0.25, 0.75))
+    assert operation.axes == FigureAxesSelectionState(axes=((0, 0),))
+
+    toolbar = tool.figure_window.toolbar
+    assert toolbar._actions["back"].isEnabled()
+    assert not toolbar._actions["forward"].isEnabled()
+
+    toolbar.back()
+
+    assert tool.tool_status == initial
+    assert not toolbar._actions["back"].isEnabled()
+    assert toolbar._actions["forward"].isEnabled()
+
+    toolbar.forward()
+
+    assert tool.tool_status.operations[-1].method_name == "set_xlim"
+    assert tool.tool_status.operations[-1].method_args == pytest.approx((0.25, 0.75))
+
+
+def test_figure_composer_navigation_ignores_colorbar_axes(qtbot) -> None:
+    data = _figure_composer_image_source("data")
+    operation = FigureOperationState.plot_slices(
+        label="data",
+        sources=("data",),
+        slice_dim="eV",
+        slice_values=(0.0,),
+    ).model_copy(update={"colorbar": "right"})
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    qtbot.addWidget(tool.figure_window)
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+    tool.canvas.draw()
+    tool._reset_history_stack()
+
+    colorbar_axes = [axis for axis in tool.figure.axes if hasattr(axis, "_colorbar")]
+    assert colorbar_axes
+
+    initial = tool.tool_status
+    colorbar_axes[0].set_ylim(0.2, 0.8)
+    tool._figure_window_navigation_changed({colorbar_axes[0]: (False, True)})
+
+    assert tool.tool_status == initial
+    assert not tool.undoable
 
 
 def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
@@ -7359,8 +7455,9 @@ def test_figure_composer_toolbar_uses_composer_actions(qtbot, monkeypatch) -> No
     toolbar = tool.figure_window.toolbar
 
     assert toolbar.objectName() == "figureComposerNavigationToolbar"
+    assert "home" not in toolbar._actions
     for action_id in (
-        "home",
+        "show_composer",
         "back",
         "forward",
         "pan",
@@ -7374,6 +7471,17 @@ def test_figure_composer_toolbar_uses_composer_actions(qtbot, monkeypatch) -> No
         assert action.objectName() == f"figureComposerToolbar_{action_id}"
         assert not action.icon().isNull()
 
+    undo_action = toolbar._actions["back"]
+    redo_action = toolbar._actions["forward"]
+    assert undo_action.shortcut() in QtGui.QKeySequence.keyBindings(
+        QtGui.QKeySequence.StandardKey.Undo
+    )
+    assert redo_action.shortcut() in QtGui.QKeySequence.keyBindings(
+        QtGui.QKeySequence.StandardKey.Redo
+    )
+    assert undo_action.shortcutContext() == QtCore.Qt.ShortcutContext.WindowShortcut
+    assert redo_action.shortcutContext() == QtCore.Qt.ShortcutContext.WindowShortcut
+
     calls: list[str] = []
     monkeypatch.setattr(tool, "export_figure", lambda: calls.append("export"))
     monkeypatch.setattr(
@@ -7382,15 +7490,21 @@ def test_figure_composer_toolbar_uses_composer_actions(qtbot, monkeypatch) -> No
     monkeypatch.setattr(
         tool, "_show_axes_customize_dialog", lambda: calls.append("axes")
     )
+    monkeypatch.setattr(
+        tool,
+        "_show_composer_from_figure_window",
+        lambda: calls.append("composer"),
+    )
 
+    toolbar._actions["show_composer"].trigger()
     toolbar._actions["save_figure"].trigger()
     toolbar._actions["configure_subplots"].trigger()
     toolbar._actions["edit_parameters"].trigger()
 
-    assert calls == ["export", "subplots", "axes"]
+    assert calls == ["composer", "export", "subplots", "axes"]
     assert figurecomposer_widgets._noop_toolbar_callback() is None
     toolbar.changeEvent(QtCore.QEvent(QtCore.QEvent.Type.PaletteChange))
-    for action_id in ("pan", "zoom", "copy_figure_to_clipboard"):
+    for action_id in ("show_composer", "pan", "zoom", "copy_figure_to_clipboard"):
         assert not toolbar._actions[action_id].icon().isNull()
 
 

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -4106,6 +4106,12 @@ def test_figure_composer_show_composer_from_figure_window(qtbot, monkeypatch) ->
 
     assert calls == ["showNormal", "raise", "activate"]
 
+    calls.clear()
+    with monkeypatch.context() as context:
+        context.setattr(erlab.interactive.utils, "qt_is_valid", lambda *_args: False)
+        tool._show_composer_from_figure_window()
+    assert calls == []
+
 
 def test_figure_composer_tool_edge_state_contracts(qtbot, monkeypatch) -> None:
     monkeypatch.setattr(
@@ -4619,6 +4625,94 @@ def test_figure_composer_navigation_updates_recipe_limits(qtbot) -> None:
     assert tool.tool_status.operations[-1].method_name == "set_xlim"
     assert tool.tool_status.operations[-1].method_args == pytest.approx((0.25, 0.75))
 
+    axis.set_xlim(0.25, 0.75)
+    unchanged_status = tool.tool_status
+    tool._figure_window_navigation_changed({axis: (True, False)})
+    assert tool.tool_status == unchanged_status
+
+    axis.set_xlim(0.1, 0.9)
+    tool._figure_window_navigation_changed({axis: (True, False)})
+    assert tool.tool_status.operations[-1].method_name == "set_xlim"
+    assert tool.tool_status.operations[-1].method_args == pytest.approx((0.1, 0.9))
+
+    axis.set_ylim(0.2, 0.8)
+    tool._figure_window_navigation_changed({axis: (False, True)})
+    assert tool.tool_status.operations[-1].method_name == "set_ylim"
+    assert tool.tool_status.operations[-1].method_args == pytest.approx((0.2, 0.8))
+
+    status = tool.tool_status
+    tool._updating_controls = True
+    try:
+        tool._figure_window_navigation_changed({axis: (True, True)})
+    finally:
+        tool._updating_controls = False
+    assert tool.tool_status == status
+
+    with pytest.MonkeyPatch.context() as context:
+        context.setattr(
+            figurecomposer_tool_module, "_live_layout_axes", lambda _tool: None
+        )
+        tool._figure_window_navigation_changed({axis: (True, True)})
+    assert tool.tool_status == status
+
+
+def test_figure_composer_navigation_helper_edges(qtbot) -> None:
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+
+    axis = object()
+    assert tool._navigation_axis_selection({"main": axis}, axis) == (
+        FigureAxesSelectionState(axes_ids=("main",))
+    )
+    assert tool._navigation_axis_selection({"main": object()}, axis) is None
+    assert tool._navigation_axis_selection(object(), axis) is None
+
+    layout_axes = np.empty((1, 2), dtype=object)
+    layout_axes[0, 0] = object()
+    layout_axes[0, 1] = axis
+    assert tool._navigation_axis_selection(layout_axes, axis) == (
+        FigureAxesSelectionState(axes=((0, 1),))
+    )
+
+    class AxisWithLimits:
+        def get_xlim(self) -> tuple[float, float]:
+            return (0.1, 0.9)
+
+        def get_ylim(self) -> tuple[float, float]:
+            return (0.2, 0.8)
+
+    assert tool._navigation_axis_limit_updates(
+        AxisWithLimits(), x_changed=True, y_changed=True
+    ) == (("set_xlim", (0.1, 0.9)), ("set_ylim", (0.2, 0.8)))
+    assert (
+        tool._navigation_axis_limit_updates(object(), x_changed=True, y_changed=True)
+        == ()
+    )
+
+    matching_operation = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="set_xlim",
+        axes=FigureAxesSelectionState(axes_ids=("main",)),
+    )
+    assert (
+        tool._matching_navigation_limit_operation_index(
+            (matching_operation,),
+            "set_xlim",
+            FigureAxesSelectionState(axes_ids=("main",)),
+        )
+        == 0
+    )
+    assert (
+        tool._matching_navigation_limit_operation_index(
+            (matching_operation,),
+            "set_ylim",
+            FigureAxesSelectionState(axes_ids=("main",)),
+        )
+        is None
+    )
+    tool._apply_live_figure_operation_updates((), set())
+    assert tool.tool_status.operations == ()
+
 
 def test_figure_composer_navigation_ignores_colorbar_axes(qtbot) -> None:
     data = _figure_composer_image_source("data")
@@ -4686,6 +4780,49 @@ def test_figure_composer_colorbar_drag_updates_recipe_limits(qtbot) -> None:
     mappable = typing.cast("typing.Any", colorbar_axis)._colorbar.mappable
     previous_clim = mappable.get_clim()
 
+    operations = tool.tool_status.operations
+    assert tool._plot_slices_mappable_target(object(), operations) is None
+    bad_panel_mappable = type("BadPanelMappable", (), {})()
+    setattr(
+        bad_panel_mappable,
+        figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
+        operation.operation_id,
+    )
+    setattr(
+        bad_panel_mappable,
+        figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
+        ("bad", 0),
+    )
+    assert tool._plot_slices_mappable_target(bad_panel_mappable, operations) is None
+    missing_operation_mappable = type("MissingOperationMappable", (), {})()
+    setattr(
+        missing_operation_mappable,
+        figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
+        "missing",
+    )
+    setattr(
+        missing_operation_mappable,
+        figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
+        (0, 0),
+    )
+    assert (
+        tool._plot_slices_mappable_target(missing_operation_mappable, operations)
+        is None
+    )
+    assert (
+        tool._operation_with_colorbar_clim(operation, (99, 99), (1.0, 5.0)) == operation
+    )
+
+    initial = tool.tool_status
+    tool._figure_window_colorbar_changed({object(): (0.0, 1.0)})
+    assert tool.tool_status == initial
+    tool._updating_controls = True
+    try:
+        tool._figure_window_colorbar_changed({mappable: (1.0, 5.0)})
+    finally:
+        tool._updating_controls = False
+    assert tool.tool_status == initial
+
     mappable.set_clim(1.0, 5.0)
     tool.figure_window.toolbar._commit_colorbar_clims({mappable: previous_clim})
 
@@ -4693,6 +4830,10 @@ def test_figure_composer_colorbar_drag_updates_recipe_limits(qtbot) -> None:
     assert updated.vmin == pytest.approx(1.0)
     assert updated.vmax == pytest.approx(5.0)
     assert tool.undoable
+
+    unchanged = tool.tool_status
+    tool._figure_window_colorbar_changed({mappable: (1.0, 5.0)})
+    assert tool.tool_status == unchanged
 
     tool.figure_window.toolbar.back()
 
@@ -4749,6 +4890,51 @@ def test_figure_composer_colorbar_drag_updates_panel_style_limits(qtbot) -> None
     assert style.slice_index == 0
     assert style.vmin == pytest.approx(0.25)
     assert style.vmax == pytest.approx(0.75)
+
+
+def test_figure_composer_plot_slices_mappable_tagging_edges() -> None:
+    operation = FigureOperationState.plot_slices(label="data", sources=("data",))
+    key = figurecomposer_plot_slices._PlotSlicesPanelKey(0, 0, "panel")
+    figure = Figure()
+    axis = figure.subplots()
+    old_mappable = axis.imshow(np.arange(4.0).reshape(2, 2))
+    old_ids = figurecomposer_plot_slices._axis_mappable_ids((axis,))
+
+    figurecomposer_plot_slices._tag_plot_slices_mappables(
+        operation,
+        (axis,),
+        (key, figurecomposer_plot_slices._PlotSlicesPanelKey(0, 1, "extra")),
+        old_ids,
+    )
+
+    assert not hasattr(
+        old_mappable,
+        figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
+    )
+
+    new_mappable = axis.imshow(np.arange(4.0).reshape(2, 2))
+    figurecomposer_plot_slices._tag_plot_slices_mappables(
+        operation,
+        (axis,),
+        (key,),
+        old_ids,
+    )
+
+    assert not hasattr(
+        old_mappable,
+        figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
+    )
+    assert (
+        getattr(
+            new_mappable,
+            figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
+        )
+        == operation.operation_id
+    )
+    assert getattr(
+        new_mappable,
+        figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
+    ) == (0, 0)
 
 
 def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
@@ -7605,6 +7791,193 @@ def test_figure_composer_toolbar_uses_composer_actions(qtbot, monkeypatch) -> No
         assert not toolbar._actions[action_id].icon().isNull()
 
 
+def test_figure_composer_toolbar_navigation_helper_edges(qtbot, monkeypatch) -> None:
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+    toolbar = tool.figure_window.toolbar
+
+    limited_toolitems = [
+        item
+        for item in figurecomposer_widgets._FigureComposerNavigationToolbar.toolitems
+        if item[3] not in {"back", "forward"}
+    ]
+    with monkeypatch.context() as context:
+        context.setattr(
+            figurecomposer_widgets._FigureComposerNavigationToolbar,
+            "toolitems",
+            limited_toolitems,
+        )
+        limited_window = figurecomposer_widgets._FigureComposerDisplayWindow(
+            FigureSubplotsState()
+        )
+        qtbot.addWidget(limited_window)
+    assert "back" not in limited_window.toolbar._actions
+    assert "forward" not in limited_window.toolbar._actions
+
+    assert (
+        figurecomposer_widgets._noop_navigation_callback({object(): (True, False)})
+        is None
+    )
+    assert (
+        figurecomposer_widgets._noop_colorbar_callback({object(): (0.0, 1.0)}) is None
+    )
+
+    class Axis:
+        def __init__(
+            self,
+            xlim: tuple[float, float] = (0.0, 1.0),
+            ylim: tuple[float, float] = (0.0, 1.0),
+        ) -> None:
+            self.xlim = xlim
+            self.ylim = ylim
+
+        def get_xlim(self) -> tuple[float, float]:
+            return self.xlim
+
+        def get_ylim(self) -> tuple[float, float]:
+            return self.ylim
+
+    class RaisingAxis:
+        def get_xlim(self) -> tuple[float, float]:
+            raise ValueError
+
+        def get_ylim(self) -> tuple[float, float]:
+            raise TypeError
+
+    class Mappable:
+        def __init__(self, clim: tuple[float | None, float | None]) -> None:
+            self.clim = clim
+
+        def get_clim(self) -> tuple[float | None, float | None]:
+            return self.clim
+
+    class RaisingMappable:
+        def get_clim(self) -> tuple[float, float]:
+            raise ValueError
+
+    axis = Axis()
+    assert figurecomposer_widgets._axis_limit_pair(axis, "get_xlim") == (0.0, 1.0)
+    assert figurecomposer_widgets._axis_limit_pair(object(), "get_xlim") is None
+    assert figurecomposer_widgets._axis_limit_pair(RaisingAxis(), "get_xlim") is None
+    assert figurecomposer_widgets._axis_view(axis) == ((0.0, 1.0), (0.0, 1.0))
+    assert figurecomposer_widgets._axis_view(object()) is None
+
+    mappable = Mappable((0.0, 1.0))
+    colorbar_axis = Axis()
+    colorbar_axis._colorbar = type("Colorbar", (), {"mappable": mappable})()
+    colorbar_without_mappable = Axis()
+    colorbar_without_mappable._colorbar = None
+    invalid_clim_axis = Axis()
+    invalid_clim_axis._colorbar = type(
+        "InvalidColorbar",
+        (),
+        {"mappable": Mappable((None, 1.0))},
+    )()
+
+    assert figurecomposer_widgets._is_colorbar_axis(colorbar_axis)
+    assert not figurecomposer_widgets._is_colorbar_axis(axis)
+    assert figurecomposer_widgets._colorbar_mappable(colorbar_axis) is mappable
+    assert figurecomposer_widgets._colorbar_mappable(colorbar_without_mappable) is None
+    assert figurecomposer_widgets._mappable_clim(mappable) == (0.0, 1.0)
+    assert figurecomposer_widgets._mappable_clim(object()) is None
+    assert figurecomposer_widgets._mappable_clim(RaisingMappable()) is None
+    assert figurecomposer_widgets._mappable_clim(Mappable((None, 1.0))) is None
+    assert figurecomposer_widgets._mappable_clim(Mappable(("bad", 1.0))) is None
+
+    navigation_views = toolbar._capture_navigation_views(
+        (axis, colorbar_axis, object(), RaisingAxis())
+    )
+    assert navigation_views == {axis: ((0.0, 1.0), (0.0, 1.0))}
+    assert toolbar._capture_colorbar_clims(
+        (
+            axis,
+            colorbar_axis,
+            colorbar_without_mappable,
+            invalid_clim_axis,
+            object(),
+            RaisingAxis(),
+        )
+    ) == {mappable: (0.0, 1.0)}
+
+    navigation_calls: list[dict[object, tuple[bool, bool]]] = []
+    colorbar_calls: list[dict[object, tuple[float, float]]] = []
+    toolbar._navigation_callback = navigation_calls.append
+    toolbar._colorbar_callback = colorbar_calls.append
+
+    axis.xlim = (0.2, 0.8)
+    toolbar._commit_navigation_views(
+        {
+            axis: ((0.0, 1.0), (0.0, 1.0)),
+            object(): ((0.0, 1.0), (0.0, 1.0)),
+        }
+    )
+    assert navigation_calls == [{axis: (True, False)}]
+
+    toolbar._commit_navigation_views({axis: ((0.2, 0.8), (0.0, 1.0))})
+    assert navigation_calls == [{axis: (True, False)}]
+
+    toolbar._commit_colorbar_clims({})
+    mappable.clim = (0.25, 0.75)
+    toolbar._commit_colorbar_clims({mappable: (0.0, 1.0), object(): (0.0, 1.0)})
+    assert colorbar_calls == [{mappable: (0.25, 0.75)}]
+    toolbar._commit_colorbar_clims({mappable: (0.25, 0.75)})
+    assert colorbar_calls == [{mappable: (0.25, 0.75)}]
+
+    back_action = toolbar._actions.pop("back")
+    forward_action = toolbar._actions.pop("forward")
+    try:
+        toolbar.set_history_buttons()
+    finally:
+        toolbar._actions["back"] = back_action
+        toolbar._actions["forward"] = forward_action
+
+    pan_axis = Axis()
+    zoom_axis = Axis()
+
+    class ToolbarInfo:
+        def __init__(self, axes: tuple[object, ...]) -> None:
+            self.axes = axes
+
+    def fake_press_pan(self, _event):
+        self._pan_info = ToolbarInfo((pan_axis, colorbar_axis))
+
+    def fake_press_zoom(self, _event):
+        self._zoom_info = ToolbarInfo((zoom_axis, colorbar_axis))
+
+    monkeypatch.setattr(
+        figurecomposer_widgets.NavigationToolbar, "press_pan", fake_press_pan
+    )
+    monkeypatch.setattr(
+        figurecomposer_widgets.NavigationToolbar,
+        "release_pan",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        figurecomposer_widgets.NavigationToolbar,
+        "press_zoom",
+        fake_press_zoom,
+    )
+    monkeypatch.setattr(
+        figurecomposer_widgets.NavigationToolbar,
+        "release_zoom",
+        lambda *_args: None,
+    )
+
+    toolbar.press_pan(object())
+    assert pan_axis in toolbar._navigation_press_views
+    assert mappable in toolbar._colorbar_press_clims
+    toolbar.release_pan(object())
+    assert toolbar._navigation_press_views == {}
+    assert toolbar._colorbar_press_clims == {}
+
+    toolbar.press_zoom(object())
+    assert zoom_axis in toolbar._navigation_press_views
+    assert mappable in toolbar._colorbar_press_clims
+    toolbar.release_zoom(object())
+    assert toolbar._navigation_press_views == {}
+    assert toolbar._colorbar_press_clims == {}
+
+
 def test_figure_composer_toolbar_copies_canvas_to_clipboard(qtbot, monkeypatch) -> None:
     tool = FigureComposerTool(_figure_composer_image_source("data"))
     qtbot.addWidget(tool)
@@ -9073,6 +9446,81 @@ def test_figure_composer_toolbar_axes_dialog_updates_image_style(qtbot) -> None:
     )
     assert main_panel_styles_check is not None
     assert main_panel_styles_check.checkState() == QtCore.Qt.CheckState.Checked
+
+
+def test_figure_composer_toolbar_image_target_combo_elides_long_sources(qtbot) -> None:
+    source_count = 6
+    source_names = tuple(
+        f"source_{index}_with_an_intentionally_long_alias_name"
+        for index in range(source_count)
+    )
+    source_labels = tuple(
+        f"Long data label {index} with additional descriptive text"
+        for index in range(source_count)
+    )
+    source_data = {name: _figure_composer_image_source(name) for name in source_names}
+    operation = FigureOperationState.plot_slices(
+        label="plot_slices",
+        sources=source_names,
+        axes=FigureAxesSelectionState(
+            axes=tuple((0, index) for index in range(source_count))
+        ),
+    )
+    tool = FigureComposerTool(
+        source_data[source_names[0]],
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(ncols=source_count),
+            sources=tuple(
+                FigureSourceState(name=name, label=label)
+                for name, label in zip(source_names, source_labels, strict=True)
+            ),
+            operations=(operation,),
+            primary_source=source_names[0],
+        ),
+        source_data=source_data,
+    )
+    qtbot.addWidget(tool)
+    tool.show_figure_window(activate=False)
+
+    tool._show_axes_customize_dialog()
+    dialog = tool._axes_customize_dialog
+    assert isinstance(dialog, QtWidgets.QDialog)
+    selector = dialog.findChild(figurecomposer_widgets._AxesSelectorWidget)
+    target_combo = dialog.findChild(
+        QtWidgets.QComboBox, "figureComposerToolbarImageTargetCombo"
+    )
+    assert selector is not None
+    assert target_combo is not None
+    selector.set_selected_axes(
+        tuple((0, index) for index in range(source_count)), emit=True
+    )
+
+    assert target_combo.count() == 1
+    visible_text = target_combo.itemText(0)
+    assert "Image slices" in visible_text
+    assert f"{source_count} panels" in visible_text
+    for text in (*source_names, *source_labels):
+        assert text not in visible_text
+
+    tooltip = target_combo.itemData(0, QtCore.Qt.ItemDataRole.ToolTipRole)
+    assert isinstance(tooltip, str)
+    assert all(label in tooltip for label in source_labels)
+    assert target_combo.toolTip() == tooltip
+    assert target_combo.view().textElideMode() == QtCore.Qt.TextElideMode.ElideMiddle
+    assert (
+        target_combo.sizeAdjustPolicy()
+        == QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+    )
+    assert (
+        target_combo.sizeHint().width()
+        < target_combo.fontMetrics().horizontalAdvance(tooltip)
+    )
+    custom_label = figurecomposer_toolbar_dialogs._image_style_target_label(
+        1,
+        operation.model_copy(update={"label": "Custom image step"}),
+        (figurecomposer_plot_slices._PlotSlicesPanelKey(0, 1, "ignored"),),
+    )
+    assert custom_label == "Step 2: Custom image step: panel 1.2"
 
 
 def test_figure_composer_toolbar_axes_dialog_keeps_cleared_image_styles_on_close(

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -177,6 +177,27 @@ def test_dtool_update_data_preserves_state(qtbot) -> None:
     assert win.result.shape == win.processed_data.shape
 
 
+def test_dtool_undo_redo_state_change(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    win: DerivativeTool = dtool(data, execute=False)
+    qtbot.addWidget(win)
+    initial = win.tool_status
+
+    win.nx_spin.setValue(initial.nx_value + 2)
+
+    assert win.undoable
+    assert win.tool_status.nx_value == initial.nx_value + 2
+
+    win.undo()
+    assert win.tool_status == initial
+    assert win.redoable
+
+    win.redo()
+    assert win.tool_status.nx_value == initial.nx_value + 2
+
+
 def test_dtool_open_itool_uses_output_launcher(qtbot, monkeypatch) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -513,6 +513,26 @@ def test_goldtool_validate_update_data_transposes_and_rejects_invalid(
         win.validate_update_data(xr.DataArray(np.arange(5), dims=("alpha",)))
 
 
+def test_goldtool_undo_redo_state_change(qtbot, gold) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    initial = win.tool_status
+    win.refit_on_source_update_check.setChecked(not initial.refit_on_source_update)
+
+    assert win.undoable is True
+    assert win.tool_status.refit_on_source_update is not initial.refit_on_source_update
+
+    win.undo()
+
+    assert win.tool_status == initial
+    assert win.redoable is True
+
+    win.redo()
+
+    assert win.tool_status.refit_on_source_update is not initial.refit_on_source_update
+
+
 def test_restool(qtbot) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
@@ -567,6 +587,29 @@ def test_restool(qtbot) -> None:
     assert str(win_restored.info_text) == str(win.info_text)
 
     tmp_dir.cleanup()
+
+
+def test_restool_undo_redo_state_change(qtbot) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    initial = win.tool_status
+    win.temp_spin.setValue(initial.temp + 1.0)
+
+    assert win.undoable is True
+    assert win.tool_status.temp == initial.temp + 1.0
+
+    win.undo()
+
+    assert win.tool_status == initial
+    assert win.redoable is True
+
+    win.redo()
+
+    assert win.tool_status.temp == initial.temp + 1.0
 
 
 def test_restool_timeout_cleans_up_worker(qtbot, monkeypatch) -> None:

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -1033,6 +1033,24 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
     assert win.images[1].data_array is not None
 
 
+def test_ktool_undo_redo_colormap_state(qtbot, anglemap) -> None:
+    win = ktool(anglemap.qsel(eV=-0.1), execute=False)
+    qtbot.addWidget(win)
+    initial = win.tool_status
+
+    win.gamma_widget.setValue(initial.cmap_gamma + 0.1)
+
+    assert win.undoable
+    assert win.tool_status.cmap_gamma == initial.cmap_gamma + 0.1
+
+    win.undo()
+    assert win.tool_status == initial
+    assert win.redoable
+
+    win.redo()
+    assert win.tool_status.cmap_gamma == initial.cmap_gamma + 0.1
+
+
 def test_ktool_update_data_with_single_energy_disables_energy_group(
     qtbot, anglemap
 ) -> None:

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -199,6 +199,8 @@ def test_ktool(qtbot, anglemap, wf, kind, assignment) -> None:
     roi_control_widget.y_spin.setValue(0.2)
     roi_control_widget.r_spin.setValue(0.3)
     assert roi.get_position() == (0.0, 0.2, 0.3)
+    roi.sigRemoveRequested.emit(roi)
+    assert win._roi_list == []
 
     assert win.preview_symmetry_group.isEnabled()
     win.preview_symmetry_fold_spin.setValue(4)

--- a/tests/interactive/test_mesh.py
+++ b/tests/interactive/test_mesh.py
@@ -285,3 +285,23 @@ def test_meshtool_update_data_preserves_state(qtbot, meshy_data) -> None:
     assert win._corrected is None
     assert win._mesh is None
     assert win.main_image.data_array is not None
+
+
+def test_meshtool_undo_redo_state_change(qtbot, meshy_data) -> None:
+    win: MeshTool = meshtool(meshy_data, execute=False)
+    qtbot.addWidget(win)
+
+    initial = win.tool_status
+    win.roi_hw_spin.setValue(initial.roi_hw + 1)
+
+    assert win.undoable is True
+    assert win.tool_status.roi_hw == initial.roi_hw + 1
+
+    win.undo()
+
+    assert win.tool_status == initial
+    assert win.redoable is True
+
+    win.redo()
+
+    assert win.tool_status.roi_hw == initial.roi_hw + 1

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -81,6 +81,76 @@ class _PersistentTool(erlab.interactive.utils.ToolWindow[_PersistentToolState]):
         self._data = new_data
 
 
+def test_tool_window_history_actions_undo_redo(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    win = _PersistentTool(data)
+    qtbot.addWidget(win)
+    win._reset_history_stack()
+
+    undo_action = win.findChild(QtGui.QAction, "tool_undo_action")
+    redo_action = win.findChild(QtGui.QAction, "tool_redo_action")
+    assert undo_action is not None
+    assert redo_action is not None
+    assert not win.undoable
+    assert not win.redoable
+    assert not undo_action.isEnabled()
+    assert not redo_action.isEnabled()
+    assert undo_action.shortcut() in QtGui.QKeySequence.keyBindings(
+        QtGui.QKeySequence.StandardKey.Undo
+    )
+    assert redo_action.shortcut() in QtGui.QKeySequence.keyBindings(
+        QtGui.QKeySequence.StandardKey.Redo
+    )
+    assert (
+        undo_action.shortcutContext()
+        == QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+    )
+    assert (
+        redo_action.shortcutContext()
+        == QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+    )
+
+    win.tool_status = _PersistentToolState(value=1)
+    win._write_state()
+
+    assert win.undoable
+    assert undo_action.isEnabled()
+
+    win.undo()
+    assert win.tool_status == _PersistentToolState(value=0)
+    assert not win.undoable
+    assert win.redoable
+    assert redo_action.isEnabled()
+
+    win.redo()
+    assert win.tool_status == _PersistentToolState(value=1)
+    assert win.undoable
+    assert not win.redoable
+
+
+def test_tool_window_from_dataset_starts_with_clean_history(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    win = _PersistentTool(data)
+    qtbot.addWidget(win)
+    win._reset_history_stack()
+    win.tool_status = _PersistentToolState(value=1)
+    win._write_state()
+    assert win.undoable
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _PersistentTool)
+    assert restored.tool_status == _PersistentToolState(value=1)
+    assert not restored.undoable
+    assert not restored.redoable
+
+    duplicated = win.duplicate()
+    qtbot.addWidget(duplicated)
+    assert duplicated.tool_status == _PersistentToolState(value=1)
+    assert not duplicated.undoable
+    assert not duplicated.redoable
+
+
 @pytest.fixture
 def action():
     action = QtGui.QAction("Test Action")

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -128,6 +128,30 @@ def test_tool_window_history_actions_undo_redo(qtbot) -> None:
     assert not win.redoable
 
 
+def test_tool_window_history_guard_edges(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    win = _PersistentTool(data)
+    qtbot.addWidget(win)
+    win._reset_history_stack()
+
+    initial = win.tool_status
+    win.undo()
+    win.redo()
+    assert win.tool_status == initial
+
+    win._prev_states.clear()
+    win.tool_status = _PersistentToolState(value=2)
+    win._replace_last_state()
+
+    assert tuple(win._prev_states) == (_PersistentToolState(value=2),)
+    assert not win.undoable
+    assert not win.redoable
+
+    monkeypatch.delattr(win, "undo_action")
+    monkeypatch.delattr(win, "redo_action")
+    win._update_history_actions()
+
+
 def test_tool_window_from_dataset_starts_with_clean_history(qtbot) -> None:
     data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
     win = _PersistentTool(data)


### PR DESCRIPTION
## Summary
- Add undo and redo actions to interactive interactive tools and shared utility plumbing
- Update the figure composer, fit, mesh, derivative, fermiedge, and k-space tools to participate in the new history flow
- Refresh interactive tool authoring docs to describe the behavior
- Extend tests to cover the new undo and redo paths

## Testing
- Added and updated unit coverage for the affected interactive tools and shared utilities
- Updated figure composer manager tests for the new interaction flow