### PR TITLE
Suppress harmless lmfit restore warnings during fit restore

### DIFF
--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -9,10 +9,13 @@ import functools
 import gc
 import importlib
 import logging
+import re
 import threading
 import time
 import traceback
 import typing
+import warnings
+from collections.abc import Callable, Iterable
 
 import numpy as np
 import pydantic
@@ -23,7 +26,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab.interactive.utils
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Iterable, Mapping
+    from collections.abc import Hashable, Mapping
 
     import lmfit
     import varname
@@ -35,11 +38,119 @@ else:
 
 _P = typing.ParamSpec("_P")
 _R = typing.TypeVar("_R")
+_T = typing.TypeVar("_T")
 logger = logging.getLogger(__name__)
+_LMFIT_CALLABLE_WARNING_RE = re.compile(
+    r"^Could not unpack dill-encoded callable '([^']+)', saved with Python version .+$"
+)
 
 _fit_worker_gc_lock = threading.Lock()
 _fit_worker_gc_depth = 0
 _fit_worker_gc_restore_enabled = False
+
+
+def _load_lmfit_for_ftool_restore(
+    load: Callable[[], _T], *, params: object | None = None
+) -> _T:
+    caught: list[warnings.WarningMessage] = []
+
+    def _warn_again(
+        warning_message: warnings.WarningMessage, suppressed_names: set[str]
+    ) -> None:
+        match = _LMFIT_CALLABLE_WARNING_RE.match(str(warning_message.message))
+        if match is not None and match.group(1) in suppressed_names:
+            return
+        warnings.warn_explicit(
+            warning_message.message,
+            warning_message.category,
+            warning_message.filename,
+            warning_message.lineno,
+            registry=None,
+            source=warning_message.source,
+        )
+
+    def _model_from_loaded(value: object) -> object | None:
+        if hasattr(value, "func"):
+            return value
+        if isinstance(value, xr.Dataset) and "modelfit_results" in value:
+            results = value["modelfit_results"].compute().values
+            if results.size:
+                return getattr(results.flat[0], "model", None)
+        return None
+
+    def _erlab_callable_names(model: object | None) -> set[str]:
+        if model is None:
+            raise TypeError("Restored lmfit model is missing.")
+        names: set[str] = set()
+        stack = [model]
+        while stack:
+            submodel = stack.pop()
+            func = getattr(submodel, "func", None)
+            if not callable(func):
+                raise TypeError(
+                    "Restored lmfit model contains a non-callable function."
+                )
+            wrapped = getattr(func, "__func__", None)
+            bound_self = getattr(func, "__self__", None)
+            modules = (
+                getattr(func, "__module__", None),
+                getattr(type(func), "__module__", None),
+                getattr(type(bound_self), "__module__", None)
+                if bound_self is not None
+                else None,
+                getattr(wrapped, "__module__", None) if wrapped is not None else None,
+            )
+            if any(
+                isinstance(module, str)
+                and (module == "erlab" or module.startswith("erlab."))
+                for module in modules
+            ):
+                for name_source in (func, wrapped, type(func)):
+                    name = getattr(name_source, "__name__", None)
+                    if isinstance(name, str) and name:
+                        names.add(name)
+            stack.extend(
+                child
+                for child in (
+                    getattr(submodel, "left", None),
+                    getattr(submodel, "right", None),
+                )
+                if child is not None
+            )
+        return names
+
+    def _validate_params(model: object) -> None:
+        if params is None:
+            return
+        if not isinstance(params, Iterable):
+            raise TypeError("Restored lmfit parameters are not iterable.")
+        param_names = set(params)
+        missing = [
+            name
+            for name in list(getattr(model, "param_names", ()))
+            if name not in param_names
+        ]
+        if missing:
+            raise ValueError(
+                "Restored lmfit model is missing saved parameters: "
+                + ", ".join(map(str, missing))
+            )
+
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = load()
+            model = _model_from_loaded(loaded)
+            suppressed_names = _erlab_callable_names(model)
+            _validate_params(model)
+    except Exception:
+        for warning_message in caught:
+            _warn_again(warning_message, set())
+        raise
+
+    for warning_message in caught:
+        _warn_again(warning_message, suppressed_names)
+    return loaded
 
 
 @contextlib.contextmanager
@@ -2010,10 +2121,16 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         with self._history_suppressed():
             self._data_name = status.data_name
             self._model_name = status.model_name
+            restored_params = (
+                self._deserialize_params(status.params) if status.params else None
+            )
             try:
                 model = lmfit.model.Model(lambda x: x)
                 cls_info, model_state = status.model_state
-                model = model.loads(model_state)
+                model = _load_lmfit_for_ftool_restore(
+                    lambda: model.loads(model_state),
+                    params=restored_params,
+                )
                 mod_name, qual = cls_info.split(":")
             except Exception:  # pragma: no cover
                 self._show_error("Model restore failed", "Failed to restore model.")
@@ -2026,9 +2143,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                         cls_obj = getattr(cls_obj, attr)
                     model.__class__ = cls_obj
 
-            restored_params = (
-                self._deserialize_params(status.params) if status.params else None
-            )
             if restored_params is None or len(restored_params) == 0:
                 self.set_model(model, model_load_path=status.model_load_path)
             else:
@@ -2760,8 +2874,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
         if self._PERSISTED_FIT_RESULT_VAR not in ds:
             return
-        self._last_result_ds = erlab.interactive.utils._deserialize_fit_dataset_blob(
-            ds[self._PERSISTED_FIT_RESULT_VAR].values
+        self._last_result_ds = _load_lmfit_for_ftool_restore(
+            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(
+                ds[self._PERSISTED_FIT_RESULT_VAR].values
+            )
         )
         result = self._last_result_ds.modelfit_results.compute().item()
         self._set_fit_stats(result)

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -19,6 +19,7 @@ import erlab.interactive.utils
 from erlab.interactive._fit1d import (
     Fit1DTool,
     _FitRestoreState,
+    _load_lmfit_for_ftool_restore,
     _SnapCursorLine,
     _State2D,
 )
@@ -1271,8 +1272,10 @@ class Fit2DTool(Fit1DTool):
     def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
         if self._PERSISTED_FIT_RESULT_VAR not in ds:
             return
-        sparse = erlab.interactive.utils._deserialize_fit_dataset_blob(
-            ds[self._PERSISTED_FIT_RESULT_VAR].values
+        sparse = _load_lmfit_for_ftool_restore(
+            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(
+                ds[self._PERSISTED_FIT_RESULT_VAR].values
+            )
         )
         y_size = int(self._data_full.sizes[self._y_dim_name])
         self._result_ds_full = [None] * y_size

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -57,6 +57,49 @@ def _fit_result_dataset(params: lmfit.Parameters, *, nfev: int = 1) -> xr.Datase
     return xr.Dataset({"modelfit_results": xr.DataArray(_Result(), dims=())})
 
 
+@pytest.mark.parametrize(
+    "load",
+    [
+        pytest.param(lambda: object(), id="no-model"),
+        pytest.param(
+            lambda: xr.Dataset(
+                {
+                    "modelfit_results": xr.DataArray(
+                        np.empty((0,), dtype=object), dims=("empty",)
+                    )
+                }
+            ),
+            id="empty-result",
+        ),
+    ],
+)
+def test_lmfit_ftool_restore_rejects_missing_restored_model(load) -> None:
+    with pytest.raises(TypeError, match="Restored lmfit model is missing"):
+        fit1d._load_lmfit_for_ftool_restore(load)
+
+
+def test_lmfit_ftool_restore_rejects_non_callable_model_func() -> None:
+    class BadModel:
+        func = None
+
+    with pytest.raises(TypeError, match="non-callable function"):
+        fit1d._load_lmfit_for_ftool_restore(BadModel)
+
+
+def test_lmfit_ftool_restore_rejects_non_iterable_params() -> None:
+    model = lmfit.models.LinearModel()
+
+    with pytest.raises(TypeError, match="parameters are not iterable"):
+        fit1d._load_lmfit_for_ftool_restore(lambda: model, params=object())
+
+
+def test_lmfit_ftool_restore_rejects_incompatible_params() -> None:
+    model = lmfit.models.LinearModel()
+
+    with pytest.raises(ValueError, match="missing saved parameters"):
+        fit1d._load_lmfit_for_ftool_restore(lambda: model, params=[])
+
+
 def test_fit1d_fit_domain_descending_coords(qtbot) -> None:
     x = np.linspace(1.0, -1.0, 21)
     data = xr.DataArray(np.exp(-(x**2)), dims=("x",), coords={"x": x})

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import os
 import re
 import types
@@ -94,6 +95,113 @@ def _configure_fit2d_for_tests(
     monkeypatch.setattr(win, "_show_warning", _warn)
     monkeypatch.setattr(win, "_show_error", _error)
     return warnings, errors
+
+
+def _lmfit_json_with_callable_pyversion(
+    payload: str, callable_name: str, pyversion: str = "3.13"
+) -> str:
+    decoded = json.loads(payload)
+
+    def _set_pyversion(value: object) -> bool:
+        changed = False
+        if isinstance(value, dict):
+            if (
+                value.get("__class__") == "Callable"
+                and value.get("__name__") == callable_name
+            ):
+                value["pyversion"] = pyversion
+                changed = True
+            for item in value.values():
+                changed = _set_pyversion(item) or changed
+        elif isinstance(value, list):
+            for item in value:
+                changed = _set_pyversion(item) or changed
+        return changed
+
+    assert _set_pyversion(decoded)
+    return json.dumps(decoded)
+
+
+def _saved_ftool_dataset_with_callable_pyversion(
+    ds: xr.Dataset, callable_name: str, pyversion: str = "3.13"
+) -> xr.Dataset:
+    ds = ds.copy()
+    state = json.loads(ds.attrs["tool_state"])
+    state["model_state"][1] = _lmfit_json_with_callable_pyversion(
+        state["model_state"][1], callable_name, pyversion
+    )
+    ds.attrs["tool_state"] = json.dumps(state)
+
+    result_var = Fit2DTool._PERSISTED_FIT_RESULT_VAR
+    if result_var not in ds:
+        return ds
+    sparse = xr.load_dataset(
+        memoryview(np.asarray(ds[result_var].values, dtype=np.uint8).tobytes()),
+        engine="h5netcdf",
+    )
+    for var in sparse.data_vars:
+        if str(var).endswith("modelfit_results"):
+            attrs = sparse[var].attrs.copy()
+            patched = xr.apply_ufunc(
+                lambda text: _lmfit_json_with_callable_pyversion(
+                    str(text), callable_name, pyversion
+                ),
+                sparse[var],
+                vectorize=True,
+                output_dtypes=[str],
+            )
+            patched.attrs = attrs
+            sparse[var] = patched
+    blob = sparse.to_netcdf(path=None, engine="h5netcdf", invalid_netcdf=True)
+    ds[result_var] = xr.DataArray(
+        np.frombuffer(blob, dtype=np.uint8).copy(),
+        dims=(Fit2DTool._PERSISTED_FIT_RESULT_DIM,),
+    )
+    return ds
+
+
+def _assert_modelresult_params_equivalent(actual, expected) -> None:
+    assert list(actual.params.keys()) == list(expected.params.keys())
+    for name, expected_param in expected.params.items():
+        actual_param = actual.params[name]
+        assert actual_param.value == pytest.approx(expected_param.value)
+        assert actual_param.expr == expected_param.expr
+        assert actual_param.vary == expected_param.vary
+    np.testing.assert_allclose(actual.best_fit, expected.best_fit)
+
+
+def _make_erlab_callable_case(
+    name: str,
+) -> tuple[str, object, xr.DataArray, object]:
+    x = np.linspace(-1.0, 1.0, 25)
+    y = np.arange(2)
+    match name:
+        case "multipeak":
+            model = erlab.analysis.fit.models.MultiPeakModel(
+                fd=False,
+                background="none",
+                convolve=False,
+            )
+            params = model.make_params(
+                p0_center=0.0,
+                p0_width=0.35,
+                p0_height=1.2,
+            )
+            callable_name = "MultiPeakFunction"
+        case "polynomial":
+            model = erlab.analysis.fit.models.PolynomialModel(degree=2)
+            params = model.make_params(c0=1.0, c1=0.25, c2=-0.15)
+            callable_name = "PolynomialFunction"
+        case _:
+            raise ValueError(name)
+    rows = [model.eval(params, x=x) * (1.0 + 0.05 * idx) for idx in y]
+    data = xr.DataArray(
+        np.stack(rows, axis=0),
+        dims=("y", "x"),
+        coords={"y": y, "x": x},
+        name=f"{name}_map",
+    )
+    return callable_name, model, data, params
 
 
 def test_ftool_2d_fill_and_transpose(qtbot, accept_dialog) -> None:
@@ -218,6 +326,53 @@ def test_fit2d_restore_uses_saved_voigt_params_before_defaults(qtbot) -> None:
     assert win_roundtripped.tool_status.params == status.params
     win_roundtripped.param_plot_combo.setCurrentText("p0_width")
     assert win_roundtripped.param_plot_overlay_check.isChecked()
+
+
+@pytest.mark.parametrize("case_name", ["multipeak", "polynomial"])
+def test_fit2d_persistence_suppresses_successful_erlab_callable_warning(
+    qtbot, case_name: str
+) -> None:
+    callable_name, model, data, params = _make_erlab_callable_case(case_name)
+    win = erlab.interactive.ftool(data, model=model, params=params, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    fit_ds = win._data.xlm.modelfit(
+        win._coord_name,
+        model=model,
+        params=params,
+        max_nfev=10,
+    ).load()
+    expected_result = fit_ds.modelfit_results.compute().item()
+    win._last_result_ds = fit_ds
+    win._result_ds_full[win._current_idx] = fit_ds
+    win._params = expected_result.params.copy()
+    win._params_full[win._current_idx] = win._params.copy()
+    win._fit_is_current = True
+    expected_params = win.tool_status.params
+
+    saved = _saved_ftool_dataset_with_callable_pyversion(
+        win.to_dataset(), callable_name
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit2DTool)
+
+    assert [
+        warning
+        for warning in caught
+        if "Could not unpack dill-encoded callable" in str(warning.message)
+    ] == []
+    assert type(restored._model.func) is type(model.func)
+    assert restored.tool_status.params == expected_params
+
+    restored_result_ds = restored._result_ds_full[restored._current_idx]
+    assert restored_result_ds is not None
+    restored_result = restored_result_ds.modelfit_results.compute().item()
+    assert type(restored_result.model.func) is type(model.func)
+    _assert_modelresult_params_equivalent(restored_result, expected_result)
 
 
 def test_fit2d_status_and_persistence_preserve_transpose_orientation(qtbot) -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import types
 import typing
+import warnings
 
 import lmfit
 import numpy as np
@@ -346,6 +347,47 @@ def test_empty_fit_dataset_blob_roundtrip_has_no_private_coord_data() -> None:
     restored = utils._deserialize_fit_dataset_blob(blob)
 
     xr.testing.assert_identical(restored, empty)
+
+
+def test_lmfit_erlab_callable_warning_filter_reemits_unrelated_warning() -> None:
+    import erlab.analysis.fit.models
+    from erlab.interactive._fit1d import _load_lmfit_for_ftool_restore
+
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        fd=False, background="none", convolve=False
+    )
+    message = (
+        "Could not unpack dill-encoded callable 'NotErlab', saved with Python "
+        "version 3.13"
+    )
+
+    def _load():
+        warnings.warn(message, UserWarning, stacklevel=2)
+        return model
+
+    with pytest.warns(UserWarning, match="NotErlab"):
+        restored = _load_lmfit_for_ftool_restore(_load)
+
+    assert restored is model
+
+
+def test_lmfit_erlab_callable_warning_filter_reemits_when_load_fails() -> None:
+    from erlab.interactive._fit1d import _load_lmfit_for_ftool_restore
+
+    message = (
+        "Could not unpack dill-encoded callable 'MultiPeakFunction', saved with Python "
+        "version 3.13"
+    )
+
+    def _load():
+        warnings.warn(message, UserWarning, stacklevel=2)
+        raise RuntimeError("load failed")
+
+    with (
+        pytest.warns(UserWarning, match="MultiPeakFunction"),
+        pytest.raises(RuntimeError, match="load failed"),
+    ):
+        _load_lmfit_for_ftool_restore(_load)
 
 
 def test_load_ui_temporarily_disables_autoconnect(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Wrap lmfit restore and persisted-result loads so erlab callable warnings are re-emitted only when they are not part of a successful restore
- Keep unrelated warnings visible and still surface failures when loading or validation fails
- Add regression coverage for 1D/2D fit restore paths and warning re-emission behavior

## Testing
- Added unit tests covering unrelated-warning passthrough and failure-path re-emission
- Added 2D persistence roundtrip coverage for erlab callable restores