### PR TITLE
Fix colorbar handle scaling for large data ranges

### DIFF
--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -421,15 +421,15 @@ class _ColorBarLimitWidget(QtWidgets.QWidget):
 
     @QtCore.Slot()
     def region_changed(self):
-        mn, mx = self.cb._span.getRegion()
+        mn, mx = self.cb.spanRegion()
         self._set_spin_values(mn, mx)
 
     @QtCore.Slot()
     def center_zero(self):
-        old_min, old_max = self.cb._span.getRegion()
+        old_min, old_max = self.cb.spanRegion()
         self.reset()
 
-        mn, mx = self.cb._span.getRegion()
+        mn, mx = self.cb.spanRegion()
         if mn < 0 < mx:
             half_len = min(abs(mn), abs(mx))
             self._set_spin_values(-half_len, half_len)
@@ -610,6 +610,77 @@ class BetterColorBarItem(pg.PlotItem):
             return self._fixedlimits
         return self.primary_image().quickMinMax(targetSize=2**16)
 
+    def _normalized_transform(self) -> QtGui.QTransform:
+        mn, mx = self.limits
+        span = mx - mn
+        if not np.isfinite(mn):
+            mn = 0.0
+        if not np.isfinite(span) or span <= 0.0:
+            span = 1.0
+        tr = QtGui.QTransform()
+        tr.translate(0.0, mn)
+        tr.scale(1.0, span)
+        return tr
+
+    def _colorbar_image_transform(self) -> QtGui.QTransform:
+        mn, mx = self.limits
+        span = mx - mn
+        if not np.isfinite(mn):
+            mn = 0.0
+        if not np.isfinite(span) or span <= 0.0:
+            span = 1.0
+
+        width = self._colorbar.width()
+        height = self._colorbar.height()
+        if width is None or width <= 0:
+            width = 1.0
+        if height is None or height <= 0:
+            height = 1.0
+
+        tr = QtGui.QTransform()
+        tr.translate(0.0, mn)
+        tr.scale(1.0 / width, span / height)
+        return tr
+
+    def _level_to_span_unit(self, value: float) -> float:
+        mn, mx = self.limits
+        span = mx - mn
+        if value == -np.inf:
+            return 0.0
+        if value == np.inf:
+            return 1.0
+        if not np.isfinite(value):
+            return 0.0
+        if not np.isfinite(span) or span <= 0.0:
+            return 0.0
+        return float(np.clip((value - mn) / span, 0.0, 1.0))
+
+    def _levels_to_span_units(self, levels: Sequence[float]) -> tuple[float, float]:
+        return (
+            self._level_to_span_unit(float(levels[0])),
+            self._level_to_span_unit(float(levels[1])),
+        )
+
+    def _span_unit_to_level(self, value: float) -> float:
+        mn, mx = self.limits
+        span = mx - mn
+        if not np.isfinite(span) or span <= 0.0:
+            return float(mn)
+        return float(mn + value * span)
+
+    def _span_units_to_levels(self, levels: Sequence[float]) -> tuple[float, float]:
+        return (
+            self._span_unit_to_level(float(levels[0])),
+            self._span_unit_to_level(float(levels[1])),
+        )
+
+    def _set_span_region(self, levels: Sequence[float]) -> None:
+        self._span.setRegion(self._levels_to_span_units(levels))
+
+    def _set_span_region_blocked(self, levels: Sequence[float]) -> None:
+        with QtCore.QSignalBlocker(self._span):
+            self._set_span_region(levels)
+
     def set_width(self, width: int) -> None:
         self.layout.setColumnFixedWidth(1, width)
 
@@ -646,17 +717,25 @@ class BetterColorBarItem(pg.PlotItem):
         pass
 
     def spanRegion(self) -> tuple[float, float]:
-        return self._span.getRegion()
+        return self._span_units_to_levels(self._span.getRegion())
 
     def setSpanRegion(self, levels: tuple[float, float]) -> None:
         # Trigger region change start and finish signals to simulate drag
         self._span.sigRegionChangeStarted.emit(self._span)
-        self._span.setRegion(levels)
+        self._set_span_region(levels)
         self._span.sigRegionChangeFinished.emit(self._span)
 
     def setLimits(self, limits: tuple[float, float] | None) -> None:
+        levels = None
+        if self._primary_image is not None:
+            levels = self.levels
+            if levels is None:
+                levels = self.spanRegion()
+
         self._fixedlimits = limits
         if self._primary_image is not None:
+            if levels is not None:
+                self._set_span_region_blocked(levels)
             self.limit_changed()
 
     def addImage(self, image: Iterable[BetterImageItem] | BetterImageItem) -> None:
@@ -709,7 +788,7 @@ class BetterColorBarItem(pg.PlotItem):
 
         self._span.blockSignals(True)
         if hasattr(self, "limits"):
-            self._span.setRegion(self.limits)
+            self._set_span_region(self.limits)
         self._span.blockSignals(False)
 
         self._span.sigRegionChanged.connect(self.level_change)
@@ -721,15 +800,19 @@ class BetterColorBarItem(pg.PlotItem):
     def image_level_changed(self) -> None:
         levels = self.primary_image().getLevels()
         if levels is not None:
-            self._span.setRegion(levels)
+            self._set_span_region(levels)
 
     def image_changed(self) -> None:
-        self.level_change()
+        if self.levels is None:
+            self.level_change()
+        else:
+            self._set_span_region_blocked(self.levels)
+            self.limit_changed()
         if self._auto_levels:
             self.reset_levels()
 
     def reset_levels(self) -> None:
-        self._span.setRegion(self.limits)
+        self._set_span_region(self.limits)
 
     def setAutoLevels(self, value) -> None:
         self._auto_levels = bool(value)
@@ -776,12 +859,12 @@ class BetterColorBarItem(pg.PlotItem):
         self.color_changed()
         # if (self._fixedlimits is not None) or (mn is None):
         mn, mx = self.limits
-        self._colorbar.setRect(0.0, mn, 1.0, mx - mn)
+        self._colorbar.setTransform(self._colorbar_image_transform())
+        self._span.setTransform(self._normalized_transform())
         if self.levels is not None:
-            self._colorbar.setLevels(
-                (np.asarray(self.levels) - mn) / max(mx - mn, 1e-15)
-            )
-        self._span.setBounds((mn, mx))
+            self._colorbar.setLevels(self._levels_to_span_units(self.levels))
+        self._span.setBounds((0.0, 1.0))
+        self.vb.setRange(xRange=(0.0, 1.0), yRange=(mn, mx), padding=0.0)
 
     # def cmap_changed(self):
     #     cmap = self.imageItem()._colorMap

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -3262,7 +3262,7 @@ class ItoolColorBarItem(erlab.interactive.colors.BetterColorBarItem):
         self.slicer_area.sigViewOptionChanged.connect(self.limit_changed)
 
         self._span.blockSignals(True)
-        self._span.setRegion(self.limits)
+        self._set_span_region(self.limits)
         self._span.blockSignals(False)
         self._span.sigRegionChangeStarted.connect(
             lambda *_: self.slicer_area.begin_history_group()

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -365,6 +365,62 @@ def test_colorbar_limit_change_preserves_data_levels(qtbot):
     assert image.getLevels() == pytest.approx((2.0, 8.0))
 
 
+def test_colorbar_normalized_helpers_handle_invalid_limits(qtbot, monkeypatch):
+    image = BetterImageItem(np.array([[0.0, 1.0]], dtype=float))
+    image.set_colormap("viridis", gamma=1.0)
+    colorbar = BetterColorBarItem(image=image)
+    widget = pg.PlotWidget(plotItem=colorbar)
+    qtbot.addWidget(widget)
+
+    colorbar._fixedlimits = (np.inf, np.inf)
+    monkeypatch.setattr(colorbar._colorbar, "width", lambda: 0)
+    monkeypatch.setattr(colorbar._colorbar, "height", lambda: 0)
+
+    normalized = colorbar._normalized_transform()
+    colorbar_image = colorbar._colorbar_image_transform()
+
+    assert normalized.map(QtCore.QPointF(0.0, 0.0)).y() == pytest.approx(0.0)
+    assert normalized.map(QtCore.QPointF(0.0, 1.0)).y() == pytest.approx(1.0)
+    assert colorbar_image.mapRect(QtCore.QRectF(0.0, 0.0, 1.0, 1.0)) == (
+        QtCore.QRectF(0.0, 0.0, 1.0, 1.0)
+    )
+
+    colorbar._fixedlimits = (5.0, 5.0)
+
+    assert colorbar._level_to_span_unit(np.nan) == 0.0
+    assert colorbar._level_to_span_unit(6.0) == 0.0
+    assert colorbar._span_unit_to_level(0.5) == 5.0
+
+
+def test_colorbar_syncs_unset_levels_and_reset_paths(qtbot):
+    image = BetterImageItem(np.arange(100, dtype=float).reshape(10, 10))
+    image.set_colormap("viridis", gamma=1.0)
+    colorbar = BetterColorBarItem(image=image, limits=(0.0, 10.0))
+    widget = pg.PlotWidget(plotItem=colorbar)
+    qtbot.addWidget(widget)
+    widget.show()
+    QtWidgets.QApplication.processEvents()
+
+    colorbar.setSpanRegion((2.0, 8.0))
+    image.setLevels(None)
+    colorbar.setLimits((0.0, 20.0))
+
+    assert colorbar.spanRegion() == pytest.approx((2.0, 8.0))
+    assert image.getLevels() is None
+
+    colorbar.image_changed()
+    assert image.getLevels() == pytest.approx((2.0, 8.0))
+
+    colorbar.reset_levels()
+    assert colorbar.spanRegion() == pytest.approx((0.0, 20.0))
+    assert image.getLevels() == pytest.approx((0.0, 20.0))
+
+    image.setLevels((4.0, 12.0))
+    colorbar.image_level_changed()
+
+    assert colorbar.spanRegion() == pytest.approx((4.0, 12.0))
+
+
 def test_colormap_combobox_populates_on_show(qtbot):
     names = pg_colormap_names("matplotlib", exclude_local=True)
     assert names

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pyqtgraph as pg
 import pytest
-from qtpy import QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive._options import options
@@ -297,6 +297,72 @@ def test_colorbar_edit_widget_applies_changes_to_images(qtbot):
         assert attrs["gamma"] == pytest.approx(0.4)
         assert attrs["reverse"] is True
         assert attrs["high_contrast"] is True
+
+
+def test_colorbar_handle_drag_updates_large_data_levels(qtbot):
+    mn, mx = 1e11, 1e15
+    image = BetterImageItem(np.array([[mn, mx]], dtype=float))
+    image.set_colormap("viridis", gamma=1.0)
+    colorbar = BetterColorBarItem(image=image)
+    widget = pg.PlotWidget(plotItem=colorbar)
+    qtbot.addWidget(widget)
+    widget.resize(100, 400)
+    widget.show()
+    QtWidgets.QApplication.processEvents()
+
+    colorbar.setSpanRegion((mn, mx))
+    QtWidgets.QApplication.processEvents()
+
+    start = widget.mapFromScene(colorbar.vb.mapViewToScene(pg.Point(0.5, mn)))
+    start += QtCore.QPoint(0, -3)
+    end = QtCore.QPoint(start.x(), start.y() - 30)
+
+    qtbot.mousePress(widget.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=start)
+    qtbot.mouseMove(widget.viewport(), pos=end)
+    qtbot.mouseRelease(widget.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=end)
+    QtWidgets.QApplication.processEvents()
+
+    lower, upper = colorbar.spanRegion()
+    assert lower > mn
+    assert upper == pytest.approx(mx)
+    assert image.getLevels() == pytest.approx((lower, upper))
+
+
+def test_colorbar_image_maps_to_large_data_limits(qtbot):
+    mn, mx = 1e11, 1e15
+    image = BetterImageItem(np.array([[mn, mx]], dtype=float))
+    image.set_colormap("viridis", gamma=1.0)
+    colorbar = BetterColorBarItem(image=image)
+    widget = pg.PlotWidget(plotItem=colorbar)
+    qtbot.addWidget(widget)
+    widget.resize(100, 400)
+    widget.show()
+    QtWidgets.QApplication.processEvents()
+
+    mapped_rect = colorbar._colorbar.mapRectToParent(colorbar._colorbar.boundingRect())
+
+    assert mapped_rect.left() == pytest.approx(0.0)
+    assert mapped_rect.width() == pytest.approx(1.0)
+    assert mapped_rect.top() == pytest.approx(mn)
+    assert mapped_rect.bottom() == pytest.approx(mx)
+
+
+def test_colorbar_limit_change_preserves_data_levels(qtbot):
+    image = BetterImageItem(np.arange(100, dtype=float).reshape(10, 10))
+    image.set_colormap("viridis", gamma=1.0)
+    image.setLevels((2.0, 8.0))
+    colorbar = BetterColorBarItem(image=image, limits=(0.0, 10.0))
+    widget = pg.PlotWidget(plotItem=colorbar)
+    qtbot.addWidget(widget)
+    widget.show()
+    QtWidgets.QApplication.processEvents()
+
+    colorbar.setSpanRegion((2.0, 8.0))
+    colorbar.setLimits((0.0, 20.0))
+    QtWidgets.QApplication.processEvents()
+
+    assert colorbar.spanRegion() == pytest.approx((2.0, 8.0))
+    assert image.getLevels() == pytest.approx((2.0, 8.0))
 
 
 def test_colormap_combobox_populates_on_show(qtbot):


### PR DESCRIPTION
## Summary
- Normalize colorbar span handling so handle positions and levels stay in data space even when limits span large values
- Preserve image levels when limits change and keep the colorbar geometry mapped through transforms
- Add Qt-based regression tests for drag behavior, image mapping, and limit changes

## Testing
- Added unit/UI coverage for large-range handle dragging and limit preservation
- Not run (not requested)