### PR TITLE
Handle missing Data Explorer roots in workspaces

### DIFF
--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -81,6 +81,7 @@ class _FileSystem:
     def __init__(self, path: str | os.PathLike, show_hidden: bool = False) -> None:
         self._path = pathlib.Path(path)
         self._children: list[_FileSystem] | None = None
+        self._children_error: OSError | None = None
 
         self._show_hidden = show_hidden
 
@@ -93,6 +94,7 @@ class _FileSystem:
     def path(self, path: str | os.PathLike) -> None:
         self._path = pathlib.Path(path)
         self._children = None
+        self._children_error = None
 
     @property
     def show_hidden(self) -> bool:
@@ -103,6 +105,7 @@ class _FileSystem:
     def show_hidden(self, show: bool) -> None:
         self._show_hidden = show
         self._children = None
+        self._children_error = None
 
     @property
     def has_children(self) -> bool:
@@ -117,11 +120,16 @@ class _FileSystem:
     def children(self) -> list[_FileSystem]:
         """List of children of the file system.
 
-        This property is undefined if the file system has no children.
+        Returns an empty list when the path is not a readable directory.
         """
         if self._children is None:
             self.reload()
         return typing.cast("list[_FileSystem]", self._children)
+
+    @property
+    def children_error(self) -> OSError | None:
+        """Error raised while loading children, if any."""
+        return self._children_error
 
     @property
     def can_fetch_children(self) -> bool:
@@ -130,12 +138,21 @@ class _FileSystem:
 
     def reload(self) -> None:
         """Reload the children of the file system."""
-        if self.has_children:
-            self._children = []
-            for p in self.path.iterdir():
+        self._children = []
+        self._children_error = None
+        if not self.has_children:
+            return
+        children: list[_FileSystem] = []
+        try:
+            paths = self.path.iterdir()
+            for p in paths:
                 if not self.show_hidden and p.name.startswith("."):
                     continue
-                self._children.append(_FileSystem(p))
+                children.append(_FileSystem(p))
+        except OSError as exc:
+            self._children_error = exc
+        else:
+            self._children = children
 
     def __getitem__(self, key: str) -> _FileSystem:
         """Get a child of the file system by its name."""
@@ -828,6 +845,17 @@ class _DataExplorer(QtWidgets.QMainWindow):
     )
     TEXT_MULTIPLE_SELECTED: str = "Multiple files selected"
     TEXT_LOADING: str = "Loading..."
+    TEXT_DIRECTORY_UNAVAILABLE: str = (
+        "The current folder is not available:\n"
+        "{path}\n\n"
+        "Reconnect the drive or choose another folder."
+    )
+    TEXT_DIRECTORY_UNREADABLE: str = (
+        "The current folder cannot be read:\n"
+        "{path}\n\n"
+        "{error}\n\n"
+        "Check permissions or choose another folder."
+    )
 
     sigDirectoryChanged = QtCore.Signal(str)
     sigCloseRequested = QtCore.Signal(object)
@@ -1207,6 +1235,8 @@ class _DataExplorer(QtWidgets.QMainWindow):
             dir_name = dir_path.name or str(dir_path)
             self.setWindowTitle(f"Data Explorer — {dir_name}")
         self.sigDirectoryChanged.emit(str(dir_path))
+        if not self._current_selection:
+            self._show_empty_selection_state()
         self._emit_workspace_state_changed()
 
     @QtCore.Slot()
@@ -1241,6 +1271,25 @@ class _DataExplorer(QtWidgets.QMainWindow):
     def _up_to_date(self) -> bool:
         """Whether the displayed file info is up to date."""
         return set(self._displayed_selection) == set(self._current_selection)
+
+    def _current_directory_notice(self) -> str | None:
+        file_system = self._fs_model.file_system
+        dir_path = file_system.path
+        if dir_path.is_dir():
+            _ = file_system.children
+            if file_system.children_error is None:
+                return None
+            return self.TEXT_DIRECTORY_UNREADABLE.format(
+                path=dir_path, error=file_system.children_error
+            )
+        return self.TEXT_DIRECTORY_UNAVAILABLE.format(path=dir_path)
+
+    def _show_empty_selection_state(self) -> None:
+        self._preview.setVisible(False)
+        self._text_edit.setText(
+            self._current_directory_notice() or self.TEXT_NONE_SELECTED
+        )
+        self._displayed_selection = []
 
     @QtCore.Slot()
     def _choose_directory(self) -> None:
@@ -1320,11 +1369,12 @@ class _DataExplorer(QtWidgets.QMainWindow):
             self._threadpool.start(worker)
 
         else:
-            self._preview.setVisible(False)
-            self._text_edit.setText(
-                self.TEXT_NONE_SELECTED if n_sel == 0 else self.TEXT_MULTIPLE_SELECTED
-            )
-            self._displayed_selection = selected_files
+            if n_sel == 0:
+                self._show_empty_selection_state()
+            else:
+                self._preview.setVisible(False)
+                self._text_edit.setText(self.TEXT_MULTIPLE_SELECTED)
+                self._displayed_selection = selected_files
 
     @QtCore.Slot()
     def _show_loading_text_if_needed(self) -> None:

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import stat
 import sys
 import time
 import traceback
@@ -232,27 +233,40 @@ class _DataExplorerModel(QtCore.QAbstractItemModel):
 
     def file_info(self, index: QtCore.QModelIndex) -> QtCore.QFileInfo:
         """Get the :class:`QtCore.QFileInfo` of the file at given index."""
-        return QtCore.QFileInfo(self.file_path(index))
+        return self._file_info_for_path(self.get_fs(index).path)
 
     def mime_type(self, index: QtCore.QModelIndex) -> str:
-        file_info = self.file_info(index)
-        if file_info.suffix() in _IGOR_PRO_MIME_TYPES:
-            mime: str = _IGOR_PRO_MIME_TYPES[file_info.suffix()]
+        return self._mime_type_for_path(self.get_fs(index).path)
 
+    @staticmethod
+    def _file_info_for_path(path: pathlib.Path) -> QtCore.QFileInfo:
+        return QtCore.QFileInfo(str(path))
+
+    def _mime_type_for_path(self, path: pathlib.Path) -> str:
+        suffix = path.suffix.removeprefix(".")
+        if suffix in _IGOR_PRO_MIME_TYPES:
+            mime: str = _IGOR_PRO_MIME_TYPES[suffix]
         else:
             mime = self._mime_database.mimeTypeForFile(
-                file_info, QtCore.QMimeDatabase.MatchMode.MatchExtension
+                self._file_info_for_path(path),
+                QtCore.QMimeDatabase.MatchMode.MatchExtension,
             ).comment()
-
         return _TRANSLATE_MIME_TYPES.get(mime, mime)
+
+    @staticmethod
+    def _stat_path(path: pathlib.Path) -> os.stat_result | None:
+        try:
+            return path.stat()
+        except OSError:
+            return None
 
     def date_modified(self, index: QtCore.QModelIndex) -> str:
         """Get the date modified of the file at the index."""
-        path: pathlib.Path = index.internalPointer().path
-        if path.exists():
+        stat_result = self._stat_path(self.get_fs(index).path)
+        if stat_result is not None:
             return time.strftime(
                 "%Y-%m-%d %H:%M:%S",
-                time.localtime(os.path.getmtime(path)),
+                time.localtime(stat_result.st_mtime),
             )
         return ""
 
@@ -366,11 +380,10 @@ class _DataExplorerModel(QtCore.QAbstractItemModel):
                 case 0:
                     return item.path.name
                 case 1:
-                    if item.path.is_dir() or not item.path.exists():
+                    stat_result = self._stat_path(item.path)
+                    if stat_result is None or stat.S_ISDIR(stat_result.st_mode):
                         return "--"
-                    return erlab.utils.formatting.format_nbytes(
-                        os.path.getsize(item.path)
-                    )
+                    return erlab.utils.formatting.format_nbytes(stat_result.st_size)
                 case 2:
                     return self.mime_type(index)
                 case 3:
@@ -437,13 +450,19 @@ class _DataExplorerModel(QtCore.QAbstractItemModel):
             return item.path.name.casefold()
 
         def size_key(item: _FileSystem) -> int:
-            return os.path.getsize(item.path) if item.path.is_file() else -1
+            stat_result = self._stat_path(item.path)
+            if stat_result is None or not stat.S_ISREG(stat_result.st_mode):
+                return -1
+            return stat_result.st_size
 
         def type_key(item: _FileSystem) -> str:
-            return self.mime_type(self._find_index(item)).casefold()
+            return self._mime_type_for_path(item.path).casefold()
 
         def date_key(item: _FileSystem) -> float:
-            return os.path.getmtime(item.path) if item.path.exists() else 0
+            stat_result = self._stat_path(item.path)
+            if stat_result is None:
+                return 0
+            return stat_result.st_mtime
 
         return [name_key, size_key, type_key, date_key][column]
 

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -290,6 +290,32 @@ def test_explorer_workspace_state_restores_selection(
     assert not explorer._model_index_for_path(missing_path).isValid()
 
 
+def test_explorer_workspace_state_missing_root_is_empty(
+    qtbot,
+    example_loader,
+    tmp_path: pathlib.Path,
+) -> None:
+    explorer = _DataExplorer(root_path=tmp_path, loader_name="example")
+    qtbot.addWidget(explorer)
+
+    missing_root = tmp_path / "disconnected-share"
+    missing_path = missing_root / "data_001.h5"
+    explorer.restore_workspace_state(
+        DataExplorerTabState(
+            root_path=str(missing_root),
+            loader_name="example",
+            selected_paths=(str(missing_path),),
+        )
+    )
+    qtbot.wait(10)
+
+    assert explorer.current_directory == missing_root
+    assert explorer._tree_view.model().rowCount() == 0
+    assert explorer.workspace_state_payload()["root_path"] == str(missing_root)
+    assert explorer._current_selection == []
+    assert not explorer._model_index_for_path(missing_path).isValid()
+
+
 def test_explorer_loader_options_dialog_updates_kwargs(
     qtbot,
     monkeypatch,

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -316,6 +316,24 @@ def test_explorer_workspace_state_missing_root_is_empty(
     assert not explorer._model_index_for_path(missing_path).isValid()
 
 
+def test_explorer_type_sort_uses_file_paths(
+    qtbot,
+    monkeypatch,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    qtbot.wait_until(lambda: explorer._tree_view.model().rowCount() > 0)
+
+    def _fail_find_index(_item):
+        raise AssertionError("type sorting should not walk model indexes")
+
+    monkeypatch.setattr(explorer._fs_model, "_find_index", _fail_find_index)
+
+    explorer._tree_view.sortByColumn(2, QtCore.Qt.SortOrder.AscendingOrder)
+
+
 def test_explorer_loader_options_dialog_updates_kwargs(
     qtbot,
     monkeypatch,

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -6,8 +6,10 @@ from qtpy import QtCore, QtGui
 
 import erlab
 from erlab.interactive.explorer._base_explorer import (
+    _IGOR_PRO_MIME_TYPES,
     DataExplorerTabState,
     _DataExplorer,
+    _FileSystem,
     _ReprFetcher,
 )
 from erlab.interactive.explorer._tabbed_explorer import (
@@ -314,6 +316,54 @@ def test_explorer_workspace_state_missing_root_is_empty(
     assert explorer.workspace_state_payload()["root_path"] == str(missing_root)
     assert explorer._current_selection == []
     assert not explorer._model_index_for_path(missing_path).isValid()
+
+
+def test_explorer_filesystem_read_error_stays_empty(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    read_error = OSError("network drive unavailable")
+    original_iterdir = pathlib.Path.iterdir
+
+    def _iterdir(path: pathlib.Path):
+        if path == tmp_path:
+            raise read_error
+        return original_iterdir(path)
+
+    monkeypatch.setattr(pathlib.Path, "iterdir", _iterdir)
+
+    file_system = _FileSystem(tmp_path)
+    file_system.reload()
+
+    assert file_system.children == []
+    assert file_system.children_error is read_error
+
+
+def test_explorer_metadata_helpers_handle_edge_paths(
+    qtbot,
+    example_loader,
+    tmp_path: pathlib.Path,
+) -> None:
+    explorer = _DataExplorer(root_path=tmp_path, loader_name="example")
+    qtbot.addWidget(explorer)
+    model = explorer._fs_model
+
+    missing_path = tmp_path / "missing.h5"
+    missing_item = _FileSystem(missing_path)
+
+    assert model._stat_path(missing_path) is None
+    assert model.data(model.createIndex(0, 1, missing_item)) == "--"
+    assert model.date_modified(model.createIndex(0, 3, missing_item)) == ""
+    assert model._get_sort_key_func(1)(missing_item) == -1
+    assert model._get_sort_key_func(3)(missing_item) == 0
+    assert (
+        model._mime_type_for_path(tmp_path / "packed.pxt")
+        == _IGOR_PRO_MIME_TYPES["pxt"]
+    )
+
+    model.file_system._children = []
+    model.file_system._children_error = OSError("permission denied")
+    assert explorer._current_directory_notice() is not None
 
 
 def test_explorer_type_sort_uses_file_paths(


### PR DESCRIPTION
## Summary

- Treat missing or unreadable Data Explorer root directories as empty, recoverable tabs.
- Preserve the saved workspace path so users can reconnect a drive or choose a replacement folder without losing context.
- Show an inline unavailable-folder state instead of surfacing an uncaught model error.

## Root Cause

Workspace restore could point a Data Explorer tab at a directory that no longer exists on the current machine. The explorer model then exposed `_FileSystem.children` while it was still `None`, which raised during Qt row-count requests.

## Validation

- `uv run ruff format src/erlab/interactive/explorer/_base_explorer.py tests/interactive/test_explorer.py`
- `uv run ruff check .`
- `uv run pytest tests/interactive/test_explorer.py`
- Commit hooks passed; `prek` reported one unhealthy installed hook environment and skipped it.