### PR TITLE
Restore platform-native manager selection shortcuts

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1298,7 +1298,7 @@ class ImageToolManager(_ImageToolManagerBase):
             shortcut.setContext(QtCore.Qt.ShortcutContext.WidgetShortcut)
             shortcut.activated.connect(callback)
 
-        if sys.platform == "darwin":  # pragma: no cover
+        if sys.platform == "darwin":
             add_shortcut("Return", self.rename_selected)
             add_shortcut("Enter", self.rename_selected)
             add_shortcut("Ctrl+Down", self.show_selected)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -527,11 +527,6 @@ class ImageToolManager(_ImageToolManagerBase):
 
         self.show_action = QtWidgets.QAction("Show", self)
         self.show_action.triggered.connect(self.show_selected)
-        self.show_action.setShortcut(
-            "Return"
-            if sys.platform == "darwin"
-            else QtGui.QKeySequence.StandardKey.InsertParagraphSeparator
-        )
         self.show_action.setToolTip("Show selected windows")
 
         self.hide_action = QtWidgets.QAction("Hide", self)
@@ -883,6 +878,7 @@ class ImageToolManager(_ImageToolManagerBase):
 
         self.tree_view = _ImageToolWrapperTreeView(self)
         self.tree_view.setObjectName("manager_data_tree_view")
+        self._install_selection_shortcuts(self.tree_view)
         self.tree_view._selection_model.selectionChanged.connect(self._update_actions)
         self.tree_view._selection_model.selectionChanged.connect(self._update_info)
         self.tree_view._selection_model.selectionChanged.connect(
@@ -1288,9 +1284,28 @@ class ImageToolManager(_ImageToolManagerBase):
         self.figure_list.itemChanged.connect(self._figure_item_changed)
         self.figure_list.itemDoubleClicked.connect(self._show_figure_item)
         self.figure_list.customContextMenuRequested.connect(self._show_figure_menu)
+        self._install_selection_shortcuts(self.figure_list)
         figure_layout.addWidget(self.figure_list)
         self._apply_figure_view_controls()
         self._apply_figure_list_view_configuration()
+
+    def _install_selection_shortcuts(self, widget: QtWidgets.QWidget) -> None:
+        def add_shortcut(
+            sequence: str,
+            callback: Callable[[], None],
+        ) -> None:
+            shortcut = QtWidgets.QShortcut(QtGui.QKeySequence(sequence), widget)
+            shortcut.setContext(QtCore.Qt.ShortcutContext.WidgetShortcut)
+            shortcut.activated.connect(callback)
+
+        if sys.platform == "darwin":  # pragma: no cover
+            add_shortcut("Return", self.rename_selected)
+            add_shortcut("Enter", self.rename_selected)
+            add_shortcut("Ctrl+Down", self.show_selected)
+        else:
+            add_shortcut("F2", self.rename_selected)
+            add_shortcut("Return", self.show_selected)
+            add_shortcut("Enter", self.show_selected)
 
     def _destroy_figures_ui(self) -> None:
         figure_tab = getattr(self, "figure_tab", None)

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -15572,6 +15572,87 @@ def test_manager_figures_tab_does_not_set_empty_minimum_width(
         manager._show_figure_menu(QtCore.QPoint())
 
 
+def _selection_shortcut_sequences(widget: QtWidgets.QWidget) -> set[str]:
+    return {
+        shortcut.key().toString(QtGui.QKeySequence.SequenceFormat.PortableText)
+        for shortcut in widget.findChildren(QtWidgets.QShortcut)
+        if shortcut.parent() is widget
+    }
+
+
+@pytest.mark.parametrize(
+    ("platform", "rename_key", "show_key", "show_modifier", "expected_shortcuts"),
+    [
+        (
+            "darwin",
+            QtCore.Qt.Key.Key_Return,
+            QtCore.Qt.Key.Key_Down,
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+            {"Return", "Enter", "Ctrl+Down"},
+        ),
+        (
+            "linux",
+            QtCore.Qt.Key.Key_F2,
+            QtCore.Qt.Key.Key_Return,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+            {"F2", "Return", "Enter"},
+        ),
+    ],
+)
+def test_manager_figure_list_selection_shortcuts_are_platform_native(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    platform: str,
+    rename_key: QtCore.Qt.Key,
+    show_key: QtCore.Qt.Key,
+    show_modifier: QtCore.Qt.KeyboardModifier,
+    expected_shortcuts: set[str],
+) -> None:
+    monkeypatch.setattr(manager_mainwindow.sys, "platform", platform)
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="line",
+    )
+
+    with manager_context() as manager:
+        figure_uid = manager.add_figuretool(FigureComposerTool(data), show=False)
+        manager._select_figure_uid(figure_uid)
+
+        assert manager.show_action.shortcut().isEmpty()
+        assert _selection_shortcut_sequences(manager.figure_list) == expected_shortcuts
+
+        manager.figure_list.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+        qtbot.wait_until(manager.figure_list.hasFocus, timeout=5000)
+        qtbot.keyClick(manager.figure_list, rename_key)
+        qtbot.wait_until(
+            lambda: (
+                manager.figure_list.state()
+                == QtWidgets.QAbstractItemView.State.EditingState
+            ),
+            timeout=5000,
+        )
+        editor = manager.figure_list.findChild(QtWidgets.QLineEdit)
+        assert editor is not None
+        editor.setText(f"{platform}_figure")
+        qtbot.keyClick(editor, QtCore.Qt.Key.Key_Return)
+        qtbot.wait_until(
+            lambda: manager._child_node(figure_uid).name == f"{platform}_figure",
+            timeout=5000,
+        )
+
+        shown: list[str] = []
+        monkeypatch.setattr(manager, "show_childtool", shown.append)
+        manager.figure_list.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+        qtbot.wait_until(manager.figure_list.hasFocus, timeout=5000)
+        qtbot.keyClick(manager.figure_list, show_key, show_modifier)
+        qtbot.wait_until(lambda: shown == [figure_uid], timeout=5000)
+
+
 def test_manager_figures_gallery_view_preserves_selection_and_persists(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -114,6 +114,93 @@ def _add_batch_tools(
     )
 
 
+def _selection_shortcut_sequences(
+    widget: QtWidgets.QWidget,
+) -> set[str]:
+    return {
+        shortcut.key().toString(QtGui.QKeySequence.SequenceFormat.PortableText)
+        for shortcut in widget.findChildren(QtWidgets.QShortcut)
+        if shortcut.parent() is widget
+    }
+
+
+@pytest.mark.parametrize(
+    ("platform", "rename_key", "show_key", "show_modifier", "expected_shortcuts"),
+    [
+        (
+            "darwin",
+            QtCore.Qt.Key.Key_Return,
+            QtCore.Qt.Key.Key_Down,
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+            {"Return", "Enter", "Ctrl+Down"},
+        ),
+        (
+            "linux",
+            QtCore.Qt.Key.Key_F2,
+            QtCore.Qt.Key.Key_Return,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+            {"F2", "Return", "Enter"},
+        ),
+    ],
+)
+def test_manager_tree_view_selection_shortcuts_are_platform_native(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    test_data: xr.DataArray,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    platform: str,
+    rename_key: QtCore.Qt.Key,
+    show_key: QtCore.Qt.Key,
+    show_modifier: QtCore.Qt.KeyboardModifier,
+    expected_shortcuts: set[str],
+) -> None:
+    monkeypatch.setattr(manager_mainwindow.sys, "platform", platform)
+
+    with manager_context() as manager:
+        manager.show()
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        select_tools(manager, [0])
+        manager._update_actions()
+
+        assert manager.show_action.shortcut().isEmpty()
+        assert _selection_shortcut_sequences(manager.tree_view) == expected_shortcuts
+
+        tool = manager.get_imagetool(0)
+        tool.hide()
+        bring_manager_to_top(qtbot, manager)
+        manager.tree_view.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+        qtbot.wait_until(manager.tree_view.hasFocus, timeout=5000)
+
+        qtbot.keyClick(manager.tree_view, rename_key)
+        qtbot.wait_until(
+            lambda: (
+                manager.tree_view.state()
+                == QtWidgets.QAbstractItemView.State.EditingState
+            ),
+            timeout=5000,
+        )
+        delegate = manager.tree_view.itemDelegate()
+        assert isinstance(delegate, _ImageToolWrapperItemDelegate)
+        assert isinstance(delegate._current_editor, QtWidgets.QLineEdit)
+        delegate._current_editor.setText(f"{platform}_shortcut_name")
+        qtbot.keyClick(delegate._current_editor, QtCore.Qt.Key.Key_Return)
+        qtbot.wait_until(
+            lambda: (
+                manager._tool_graph.root_wrappers[0].name == f"{platform}_shortcut_name"
+            ),
+            timeout=5000,
+        )
+        assert not tool.isVisible()
+
+        manager.tree_view.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+        qtbot.wait_until(manager.tree_view.hasFocus, timeout=5000)
+        qtbot.keyClick(manager.tree_view, show_key, show_modifier)
+        qtbot.wait_until(tool.isVisible, timeout=5000)
+
+
 def _block_message_dialog(monkeypatch: pytest.MonkeyPatch) -> list[tuple[tuple, dict]]:
     calls: list[tuple[tuple, dict]] = []
 


### PR DESCRIPTION
## Summary
- Move ImageTool manager selection shortcuts onto the tree and figure list widgets instead of the global Show action shortcut.
- Use platform-specific bindings for rename and show actions so selection behavior stays native on macOS and Linux.
- Add regression tests that verify both shortcut registration and end-to-end rename/show interaction for the manager tree and figure list.

## Testing
- Added platform-specific Qt interaction coverage for the manager tree view.
- Added platform-specific Qt interaction coverage for the figure list.
- Validated shortcut registration, inline rename, and show behavior through focused GUI tests.