### PR TITLE
Add provenance step paste to ImageTool manager

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -396,7 +396,7 @@ window created from another row, the panel can show:
 
 Right-click on the steps list to copy code that rebuilds the data shown in the selected
 ImageTool window. You can also copy selected steps, select another ImageTool in the
-manager, and choose {guilabel}`Paste Steps` to apply those steps to that ImageTool's
+manager, and choose {guilabel}`Paste` to apply those steps to that ImageTool's
 current data.
 
 For [watched variables](working-with-notebooks), copied code contains the watched

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -395,7 +395,9 @@ window created from another row, the panel can show:
 - Code that can be pasted into a notebook or script to repeat those steps
 
 Right-click on the steps list to copy code that rebuilds the data shown in the selected
-ImageTool window.
+ImageTool window. You can also copy selected steps, select another ImageTool in the
+manager, and choose {guilabel}`Paste Steps` to apply those steps to that ImageTool's
+current data.
 
 For [watched variables](working-with-notebooks), copied code contains the watched
 variable name. File-backed workflows also include a snippet that loads the data in the

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -148,6 +148,7 @@ class _FigureComposerStepMimeData(QtCore.QMimeData):
     def __init__(
         self,
         payload_text: str,
+        step_code_text: str,
         source_data: Mapping[str, xr.DataArray],
         *,
         cut_source_tool_id: str | None = None,
@@ -156,7 +157,7 @@ class _FigureComposerStepMimeData(QtCore.QMimeData):
         self.figure_composer_source_data: dict[str, xr.DataArray] = dict(source_data)
         self.figure_composer_cut_source_tool_id = cut_source_tool_id
         self.setData(_STEPS_CLIPBOARD_MIME, payload_text.encode("utf-8"))
-        self.setText(payload_text)
+        self.setText(step_code_text)
 
 
 class _FigureComposerOperationList(QtWidgets.QListWidget):
@@ -202,6 +203,24 @@ def _step_clipboard_payload_text(
         },
         indent=2,
     )
+
+
+def _step_clipboard_code_text(
+    tool: FigureComposerTool,
+    operations: Sequence[FigureOperationState],
+) -> str:
+    lines: list[str] = []
+    for operation in operations:
+        if not operation.enabled:
+            continue
+        try:
+            lines.extend(_registry.spec_for(operation.kind).code_lines(tool, operation))
+        except Exception as exc:
+            return (
+                "# Could not generate Python code for the copied "
+                f"Figure Composer steps: {exc}"
+            )
+    return "\n".join(lines)
 
 
 def _step_clipboard_payload(
@@ -3516,6 +3535,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         clipboard.setMimeData(
             _FigureComposerStepMimeData(
                 _step_clipboard_payload_text(operations, sources),
+                _step_clipboard_code_text(self, operations),
                 source_data,
                 cut_source_tool_id=self._step_clipboard_tool_id if cut else None,
             )

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -1841,6 +1841,44 @@ class ScriptInput(pydantic.BaseModel):
         return parse_tool_provenance_spec(self.provenance_spec)
 
 
+class _ScriptContextBinding(pydantic.BaseModel):
+    """Hidden binding from the current script output to names used by later code."""
+
+    operation_index: int
+    names: tuple[str, ...]
+
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        extra="forbid",
+    )
+
+    @pydantic.field_validator("operation_index", mode="before")
+    @classmethod
+    def _validate_operation_index(cls, value: typing.Any) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("script context operation index must be an integer")
+        if value < 0:
+            raise ValueError("script context operation index must be non-negative")
+        return value
+
+    @pydantic.field_validator("names", mode="before")
+    @classmethod
+    def _validate_names(cls, value: typing.Any) -> tuple[str, ...]:
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise TypeError("script context names must be a sequence")
+        names: list[str] = []
+        for item in value:
+            name = _validate_active_name(item)
+            if name is None:
+                raise ValueError("script context names must not be None")
+            if name not in names:
+                names.append(name)
+        if not names:
+            raise ValueError("script context names must not be empty")
+        return tuple(names)
+
+
 class ToolProvenanceSpec(pydantic.BaseModel):
     """Saved provenance recipe for ImageTool data.
 
@@ -1865,6 +1903,10 @@ class ToolProvenanceSpec(pydantic.BaseModel):
     file_load_source: FileLoadSource | None = None
     replay_stages: tuple[ReplayStage, ...] = ()
     script_inputs: tuple[ScriptInput, ...] = ()
+    script_context_bindings: tuple[_ScriptContextBinding, ...] = pydantic.Field(
+        default=(),
+        exclude_if=lambda value: not value,
+    )
 
     model_config = pydantic.ConfigDict(
         frozen=True,
@@ -1928,6 +1970,22 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             for item in value
         )
 
+    @pydantic.field_validator("script_context_bindings", mode="before")
+    @classmethod
+    def _validate_script_context_bindings(
+        cls, value: typing.Any
+    ) -> tuple[_ScriptContextBinding, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise TypeError("Serialized script context bindings must be a sequence")
+        return tuple(
+            item
+            if isinstance(item, _ScriptContextBinding)
+            else _ScriptContextBinding.model_validate(item)
+            for item in value
+        )
+
     @pydantic.model_validator(mode="after")
     def _validate_kind_fields(self) -> typing.Self:
         if self.kind == "script":
@@ -1935,6 +1993,11 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 raise ValueError("script provenance specs must define `start_label`")
             if self.replay_stages:
                 raise ValueError("script provenance specs cannot define replay stages")
+            for binding in self.script_context_bindings:
+                if binding.operation_index >= len(self.operations):
+                    raise ValueError(
+                        "script context binding must target an operation boundary"
+                    )
             return self
         if self.kind == "file":
             if self.start_label is None:
@@ -1949,6 +2012,8 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 raise ValueError("file provenance specs must define `replay_call`")
             if self.operations:
                 raise ValueError("file provenance specs cannot define operations")
+            if self.script_context_bindings:
+                raise ValueError("file provenance specs cannot define script context")
             return self
         if (
             self.start_label is not None
@@ -1957,11 +2022,12 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             or self.file_load_source is not None
             or self.replay_stages
             or self.script_inputs
+            or self.script_context_bindings
         ):
             raise ValueError(
                 "Only script or file provenance specs may define `start_label`, "
                 "`seed_code`, `active_name`, `file_load_source`, `replay_stages`, "
-                "or `script_inputs`"
+                "`script_inputs`, or `script_context_bindings`"
             )
         return self
 
@@ -2047,7 +2113,22 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         if ref.stage_index is None:
             operations = list(self.operations)
             operations[ref.operation_index : ref.operation_index + 1] = replacement_ops
-            return self.model_copy(update={"operations": tuple(operations)})
+            updates: dict[str, typing.Any] = {"operations": tuple(operations)}
+            if self.kind == "script" and self.script_context_bindings:
+                operation_count_delta = len(replacement_ops) - 1
+                script_context_bindings: list[_ScriptContextBinding] = []
+                for binding in self.script_context_bindings:
+                    operation_index = binding.operation_index
+                    if operation_index > ref.operation_index:
+                        operation_index += operation_count_delta
+                    if operation_index < len(operations):
+                        script_context_bindings.append(
+                            binding.model_copy(
+                                update={"operation_index": operation_index}
+                            )
+                        )
+                updates["script_context_bindings"] = tuple(script_context_bindings)
+            return self.model_copy(update=updates)
 
         stages = list(self.replay_stages)
         stage = stages[ref.stage_index]
@@ -2065,14 +2146,23 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 return self.model_copy(update={"replay_stages": ()})
             if self.kind in {"full_data", "public_data", "selection"}:
                 return self.model_copy(update={"operations": ()})
-            return self.model_copy(update={"operations": ()})
+            return self.model_copy(
+                update={"operations": (), "script_context_bindings": ()}
+            )
 
         if ref.kind != "operation" or ref.operation_index is None:
             raise ValueError("This provenance row cannot be replayed as a prefix")
 
         end = ref.operation_index + 1
         if ref.stage_index is None:
-            return self.model_copy(update={"operations": self.operations[:end]})
+            updates: dict[str, typing.Any] = {"operations": self.operations[:end]}
+            if self.kind == "script" and self.script_context_bindings:
+                updates["script_context_bindings"] = tuple(
+                    binding
+                    for binding in self.script_context_bindings
+                    if binding.operation_index < end
+                )
+            return self.model_copy(update=updates)
 
         stages = list(self.replay_stages[: ref.stage_index])
         stage = self.replay_stages[ref.stage_index]
@@ -2085,9 +2175,16 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             return self._prefix_through_ref(ref)
 
         if ref.stage_index is None:
-            return self.model_copy(
-                update={"operations": self.operations[: ref.operation_index]}
-            )
+            updates: dict[str, typing.Any] = {
+                "operations": self.operations[: ref.operation_index]
+            }
+            if self.kind == "script" and self.script_context_bindings:
+                updates["script_context_bindings"] = tuple(
+                    binding
+                    for binding in self.script_context_bindings
+                    if binding.operation_index < ref.operation_index
+                )
+            return self.model_copy(update=updates)
 
         stages = list(self.replay_stages[: ref.stage_index])
         stage = self.replay_stages[ref.stage_index]
@@ -2319,6 +2416,8 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         return entries
 
     def _script_graph_code(self, *, display: bool) -> str | None:
+        if not self.operations:
+            return None
         try:
             graph = _replay_graph.compile_replay_graph(self, display=display)
             return _replay_graph.emit_replay_code(
@@ -2480,7 +2579,11 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         if self.kind == "script" and (
             graph_code := self._script_graph_code(display=True)
         ):
-            return graph_code
+            inline_targets = {"derived"} if self.active_name != "derived" else None
+            return _simplify_display_code(
+                graph_code,
+                inline_targets=inline_targets,
+            )
         if self.kind in {"script", "file"}:
             prefix = self.seed_code
 
@@ -2765,6 +2868,8 @@ def _as_script_replay_spec(spec: ToolProvenanceSpec) -> ToolProvenanceSpec:
 def compose_full_provenance(
     parent: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
     local: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
+    *,
+    script_context_names: Sequence[str] = (),
 ) -> ToolProvenanceSpec | None:
     """Compose canonical full provenance from parent and local provenance.
 
@@ -2795,7 +2900,17 @@ def compose_full_provenance(
     parent_spec = _as_script_replay_spec(parent_replay)
     local_spec = _as_script_replay_spec(local_value.to_replay_spec())
 
+    normalized_context_names: list[str] = []
+    for item in script_context_names:
+        name = _validate_active_name(item)
+        if name is None:
+            raise ValueError("script context names must not be None")
+        if name not in normalized_context_names:
+            normalized_context_names.append(name)
+
     local_operations = list(local_spec.operations)
+    local_operation_offset = len(parent_spec.operations)
+    inserted_local_operations = 0
     if local_spec.seed_code:
         seed_code: str | None = local_spec.seed_code
         if seed_code == _DEFAULT_REPLAY_SEED_CODE:
@@ -2813,6 +2928,7 @@ def compose_full_provenance(
                     code=seed_code,
                 ),
             )
+            inserted_local_operations = 1
     elif local_spec.active_name == "derived":
         parent_input = replay_input_name(parent_spec)
         if (
@@ -2829,6 +2945,28 @@ def compose_full_provenance(
                     code=f"derived = {parent_input}",
                 ),
             )
+            inserted_local_operations = 1
+
+    script_context_bindings = list(parent_spec.script_context_bindings)
+    if normalized_context_names and local_value.kind == "script" and local_operations:
+        script_context_bindings.append(
+            _ScriptContextBinding(
+                operation_index=local_operation_offset,
+                names=tuple(normalized_context_names),
+            )
+        )
+    script_context_bindings.extend(
+        binding.model_copy(
+            update={
+                "operation_index": (
+                    local_operation_offset
+                    + inserted_local_operations
+                    + binding.operation_index
+                )
+            }
+        )
+        for binding in local_spec.script_context_bindings
+    )
 
     return ToolProvenanceSpec(
         kind="script",
@@ -2838,6 +2976,7 @@ def compose_full_provenance(
         file_load_source=parent_spec.file_load_source or local_spec.file_load_source,
         script_inputs=(*parent_spec.script_inputs, *local_spec.script_inputs),
         operations=(*parent_spec.operations, *local_operations),
+        script_context_bindings=tuple(script_context_bindings),
     )
 
 

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -2319,9 +2319,6 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         return entries
 
     def _script_graph_code(self, *, display: bool) -> str | None:
-        if not self.script_inputs:
-            return None
-
         try:
             graph = _replay_graph.compile_replay_graph(self, display=display)
             return _replay_graph.emit_replay_code(
@@ -2343,8 +2340,10 @@ class ToolProvenanceSpec(pydantic.BaseModel):
 
     def derivation_code(self) -> str | None:
         prefix: str | None = None
-        if self.kind == "script" and self.script_inputs:
-            return self._script_graph_code(display=True)
+        if self.kind == "script" and (
+            graph_code := self._script_graph_code(display=True)
+        ):
+            return graph_code
         if self.kind in {"script", "file"}:
             prefix = self.seed_code
         step_codes = self._code_lines_from_entries(self.display_entries()[1:])
@@ -2478,8 +2477,10 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         no-op and normalization steps from copied provenance code.
         """
         prefix: str | None = None
-        if self.kind == "script" and self.script_inputs:
-            return self._script_graph_code(display=True)
+        if self.kind == "script" and (
+            graph_code := self._script_graph_code(display=True)
+        ):
+            return graph_code
         if self.kind in {"script", "file"}:
             prefix = self.seed_code
 

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -144,6 +144,8 @@ def _reserved_names_from_spec(spec: typing.Any) -> set[str]:
         nested = script_input.parsed_provenance_spec()
         if nested is not None:
             names.update(_reserved_names_from_spec(nested))
+    for binding in getattr(spec, "script_context_bindings", ()):
+        names.update(binding.names)
     return names
 
 
@@ -323,6 +325,22 @@ def _simple_assignment_source_name(code: str, target_name: str) -> str | None:
     return None
 
 
+def _script_codes_output_name(
+    codes: Sequence[str],
+    *,
+    active_name: str,
+    current_name: str | None,
+) -> str | None:
+    candidates = [active_name]
+    for name in (current_name, "derived"):
+        if name is not None and name not in candidates:
+            candidates.append(name)
+    for name in candidates:
+        if any(_provenance_framework._code_stores_name(code, name) for code in codes):
+            return name
+    return current_name
+
+
 def _validate_script_provenance(
     spec: typing.Any,
     *,
@@ -352,6 +370,7 @@ def _validate_script_provenance(
     function_dependencies: dict[str, set[str]] = {}
     has_replay_step = False
     active_available = spec.active_name in available_names
+    current_name: str | None = spec.active_name if active_available else None
     if spec.seed_code:
         has_replay_step = True
         try:
@@ -374,7 +393,21 @@ def _validate_script_provenance(
         active_available = active_available or _provenance_framework._code_stores_name(
             spec.seed_code, spec.active_name
         )
-    for operation in spec.operations:
+        current_name = _script_codes_output_name(
+            (spec.seed_code,),
+            active_name=spec.active_name,
+            current_name=current_name,
+        )
+    context_bindings_by_index: dict[int, list[str]] = {}
+    for binding in spec.script_context_bindings:
+        context_bindings_by_index.setdefault(binding.operation_index, []).extend(
+            binding.names
+        )
+    for index, operation in enumerate(spec.operations):
+        if context_names := context_bindings_by_index.get(index):
+            if current_name is None:
+                raise ReplayGraphError("Script provenance has no replay code")
+            available_names.update(context_names)
         if getattr(operation, "op", None) == "script_code":
             if not operation.copyable or operation.code is None:
                 raise ReplayGraphError("Script provenance contains non-replayable code")
@@ -394,19 +427,24 @@ def _validate_script_provenance(
                     operation.code, spec.active_name
                 )
             )
+            current_name = _script_codes_output_name(
+                (operation.code,),
+                active_name=spec.active_name,
+                current_name=current_name,
+            )
             continue
-        if not active_available:
+        if current_name is None:
             raise ReplayGraphError("Script provenance has no replay code")
         if not operation.live_applicable:
             raise ReplayGraphError(
                 "Script provenance contains non-replayable operation"
             )
         has_replay_step = True
-        available_names.add(spec.active_name)
-        active_available = True
+        available_names.add(current_name)
+        active_available = active_available or current_name == spec.active_name
     if not has_replay_step:
         raise ReplayGraphError("Script provenance has no replay code")
-    if not active_available:
+    if not active_available and current_name != spec.active_name:
         raise ReplayGraphError("Script provenance has no replay code")
 
 
@@ -632,6 +670,7 @@ def _compile_spec(
 
         active_name = typing.cast("str", parsed.active_name)
         script_current_key: str | None = None
+        current_name: str | None = None
         current_bindings = tuple(bindings)
         pending_codes: list[str] = []
 
@@ -663,28 +702,38 @@ def _compile_spec(
             return tuple(output)
 
         def apply_simple_alias(code: str) -> bool:
-            nonlocal current_bindings, script_current_key
+            nonlocal current_bindings, current_name, script_current_key
             if pending_codes:
                 return False
-            source_name = _simple_assignment_source_name(code, active_name)
-            if source_name is None:
-                return False
-            source_key = binding_key(source_name)
-            if source_key is None:
-                return False
-            script_current_key = relay_key(source_key)
-            current_bindings = bind_name(active_name, script_current_key)
-            return True
+            for target_name in dict.fromkeys((active_name, "derived")):
+                source_name = _simple_assignment_source_name(code, target_name)
+                if source_name is None:
+                    continue
+                source_key = binding_key(source_name)
+                if source_key is None:
+                    continue
+                script_current_key = relay_key(source_key)
+                current_name = target_name
+                current_bindings = bind_name(target_name, script_current_key)
+                return True
+            return False
 
         def flush_script() -> None:
-            nonlocal current_bindings, pending_codes, script_current_key
+            nonlocal current_bindings, current_name, pending_codes, script_current_key
             if not pending_codes:
                 return
+            output_name = _script_codes_output_name(
+                pending_codes,
+                active_name=active_name,
+                current_name=current_name,
+            )
+            if output_name is None:  # pragma: no cover - rejected by validation.
+                raise ReplayGraphError("Script provenance has no replay code")
             script_current_key = graph.add_node(
                 _canonical_key(
                     "script",
                     {
-                        "active_name": active_name,
+                        "active_name": output_name,
                         "bindings": current_bindings,
                         "codes": tuple(pending_codes),
                     },
@@ -693,18 +742,48 @@ def _compile_spec(
                 parents=tuple(key for _name, key in current_bindings),
                 cacheable=False,
                 payload={
-                    "active_name": active_name,
+                    "active_name": output_name,
                     "bindings": current_bindings,
                     "codes": tuple(pending_codes),
                 },
             )
-            current_bindings = bind_name(active_name, script_current_key)
+            current_name = output_name
+            current_bindings = bind_name(output_name, script_current_key)
             pending_codes = []
+
+        def apply_context_binding(names: Sequence[str]) -> None:
+            nonlocal current_bindings, current_name, script_current_key
+            flush_script()
+            if script_current_key is None:
+                current_names = tuple(
+                    name for name in (current_name, active_name, "derived") if name
+                )
+                matching_inputs = list(
+                    dict.fromkeys(
+                        key for name, key in current_bindings if name in current_names
+                    )
+                )
+                if len(matching_inputs) != 1:  # pragma: no cover - validation guard.
+                    raise ReplayGraphError("Script provenance has no replay code")
+                script_current_key = relay_key(matching_inputs[0])
+            if display:
+                for name in (current_name, active_name):
+                    if name is not None:
+                        graph.add_alias(name, script_current_key)
+            for name in names:
+                current_bindings = bind_name(name, script_current_key)
 
         if parsed.seed_code and not apply_simple_alias(parsed.seed_code):
             pending_codes.append(parsed.seed_code)
         operations = tuple(parsed.operations)
+        context_bindings_by_index: dict[int, list[str]] = {}
+        for binding in parsed.script_context_bindings:
+            context_bindings_by_index.setdefault(binding.operation_index, []).extend(
+                binding.names
+            )
         for index, operation in enumerate(operations):
+            if context_names := context_bindings_by_index.get(index):
+                apply_context_binding(context_names)
             if display:
                 if getattr(operation, "op", None) == "rename" and not any(
                     getattr(later_operation, "op", None) == "script_code"
@@ -738,21 +817,37 @@ def _compile_spec(
                 continue
 
             if pending_codes:
+                pending_output_name = _script_codes_output_name(
+                    pending_codes,
+                    active_name=active_name,
+                    current_name=current_name,
+                )
+                if pending_output_name is None:  # pragma: no cover - validation guard.
+                    raise ReplayGraphError("Script provenance has no replay code")
                 pending_codes.append(
                     _operation_replay_code(
                         operation,
-                        active_name=active_name,
-                        context_name=active_name,
+                        active_name=pending_output_name,
+                        context_name=pending_output_name,
                     )
                 )
                 continue
 
             flush_script()
             if script_current_key is None:
-                matching_inputs = [key for name, key in bindings if name == active_name]
+                current_names = tuple(
+                    name for name in (current_name, active_name, "derived") if name
+                )
+                matching_inputs = list(
+                    dict.fromkeys(
+                        key for name, key in current_bindings if name in current_names
+                    )
+                )
                 if len(matching_inputs) != 1:
                     raise ReplayGraphError("Script provenance has no replay code")
                 script_current_key = relay_key(matching_inputs[0])
+                current_name = current_names[0]
+            operation_name = current_name or active_name
             script_current_key = graph.add_node(
                 _canonical_key(
                     "operation",
@@ -766,14 +861,24 @@ def _compile_spec(
                 parents=(script_current_key, script_current_key),
                 payload={"operation": operation},
             )
-            current_bindings = bind_name(active_name, script_current_key)
+            current_name = operation_name
+            current_bindings = bind_name(operation_name, script_current_key)
 
         flush_script()
         if script_current_key is None:
-            matching_inputs = [key for name, key in bindings if name == active_name]
+            matching_inputs = [
+                key for name, key in current_bindings if name == active_name
+            ]
             if len(matching_inputs) != 1:
                 raise ReplayGraphError("Script provenance has no replay code")
             script_current_key = relay_key(matching_inputs[0])
+            current_name = active_name
+        if current_name != active_name:
+            active_key = binding_key(active_name)
+            if active_key is None:  # pragma: no cover - validation guard.
+                raise ReplayGraphError("Script provenance has no replay code")
+            script_current_key = relay_key(active_key)
+            current_name = active_name
         if display:
             graph.add_alias(active_name, script_current_key)
         return script_current_key
@@ -1017,6 +1122,28 @@ def _inline_single_use_replay_expressions(code: str) -> str:
     return ast.unparse(ast.fix_missing_locations(module))
 
 
+def _remove_noop_assignments(code: str) -> str:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return code
+    original_count = len(module.body)
+    module.body = [
+        stmt
+        for stmt in module.body
+        if not (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and isinstance(stmt.value, ast.Name)
+            and stmt.targets[0].id == stmt.value.id
+        )
+    ]
+    if len(module.body) == original_count:
+        return code
+    return ast.unparse(ast.fix_missing_locations(module))
+
+
 def _compact_replay_temp_names(code: str) -> str:
     try:
         module = ast.parse(code, mode="exec")
@@ -1076,6 +1203,7 @@ def _code_has_scoped_definition(code: str) -> bool:
 def _cleanup_emitted_replay_code(code: str) -> str:
     code = _inline_adjacent_replay_assignments(code)
     code = _inline_single_use_replay_expressions(code)
+    code = _remove_noop_assignments(code)
     return _compact_replay_temp_names(code)
 
 
@@ -1134,9 +1262,11 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
             codes = list(typing.cast("tuple[str, ...]", node.payload["codes"]))
             active_name = typing.cast("str", node.payload["active_name"])
             input_replacements: dict[str, str] = {}
+            input_names: set[str] = set()
             for input_name, input_key in typing.cast(
                 "tuple[tuple[str, str], ...]", node.payload["bindings"]
             ):
+                input_names.add(input_name)
                 input_value_name = names[input_key]
                 if input_name == input_value_name:
                     continue
@@ -1164,7 +1294,12 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
                     raise ReplayGraphError(
                         "Script replay code is not valid Python"
                     ) from exc
-            if graph.display and active_name != name:
+            if (
+                graph.display
+                and active_name != name
+                and active_name not in input_names
+                and active_name not in input_replacements.values()
+            ):
                 try:
                     codes = [
                         _provenance_framework._replace_code_identifiers(
@@ -1188,7 +1323,9 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
     if output_name is not None:
         if graph.output_key is None:
             raise ReplayGraphError("Replay graph has no output")
-        aliases = [*aliases, (output_name, graph.output_key)]
+        output_alias = (output_name, graph.output_key)
+        if output_alias not in aliases:
+            aliases = [*aliases, output_alias]
     for public_name, key in aliases:
         planned_name = names[key]
         if public_name != planned_name:

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -156,6 +156,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     _manager_layout_tracking_enabled: bool
     _metadata_copy_full_action: QtGui.QAction
     _metadata_copy_selected_action: QtGui.QAction
+    _metadata_delete_step_action: QtGui.QAction
     _metadata_edit_step_action: QtGui.QAction
     _metadata_paste_steps_action: QtGui.QAction
     _metadata_revert_step_action: QtGui.QAction

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -157,6 +157,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     _metadata_copy_full_action: QtGui.QAction
     _metadata_copy_selected_action: QtGui.QAction
     _metadata_edit_step_action: QtGui.QAction
+    _metadata_paste_steps_action: QtGui.QAction
     _metadata_revert_step_action: QtGui.QAction
     _metadata_detail_labels: dict[str, QtWidgets.QLabel]
     _metadata_full_code_available: bool

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -48,9 +48,9 @@ def _provenance_step_clipboard_payload(
     payload_text: str | None = None
     if mime_data.hasFormat(_PROVENANCE_STEPS_CLIPBOARD_MIME):
         try:
-            payload_text = bytes(
-                mime_data.data(_PROVENANCE_STEPS_CLIPBOARD_MIME)
-            ).decode("utf-8")
+            payload_text = (
+                mime_data.data(_PROVENANCE_STEPS_CLIPBOARD_MIME).data().decode("utf-8")
+            )
         except UnicodeDecodeError:
             return None
     elif mime_data.hasText():
@@ -514,8 +514,9 @@ class _DetailsPanelController:
         if self._manager._metadata_full_code_available:
             self._manager._metadata_copy_full_action.setEnabled(True)
             menu.addAction(self._manager._metadata_copy_full_action)
+        clipboard = QtWidgets.QApplication.clipboard()
         paste_payload = _provenance_step_clipboard_payload(
-            QtWidgets.QApplication.clipboard().mimeData()
+            None if clipboard is None else clipboard.mimeData()
         )
         paste_enabled, paste_reason = (
             self._manager._provenance_edit_controller.can_paste_steps(
@@ -563,11 +564,15 @@ class _DetailsPanelController:
             _PROVENANCE_STEPS_CLIPBOARD_MIME, payload_text.encode("utf-8")
         )
         mime_data.setText(code)
-        QtWidgets.QApplication.clipboard().setMimeData(mime_data)
+        clipboard = QtWidgets.QApplication.clipboard()
+        if clipboard is None:
+            return
+        clipboard.setMimeData(mime_data)
 
     def _paste_provenance_steps_from_clipboard(self) -> None:
+        clipboard = QtWidgets.QApplication.clipboard()
         payload = _provenance_step_clipboard_payload(
-            QtWidgets.QApplication.clipboard().mimeData()
+            None if clipboard is None else clipboard.mimeData()
         )
         if payload is None:
             self._manager._provenance_edit_controller._show_unavailable(

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -498,10 +498,15 @@ class _DetailsPanelController:
         revert_enabled, revert_reason = (
             self._manager._provenance_edit_controller.can_revert_row(row)
         )
+        delete_enabled, delete_reason = (
+            self._manager._provenance_edit_controller.can_delete_row(row)
+        )
         self._manager._metadata_edit_step_action.setEnabled(edit_enabled)
         self._manager._metadata_edit_step_action.setToolTip(edit_reason)
         self._manager._metadata_revert_step_action.setEnabled(revert_enabled)
         self._manager._metadata_revert_step_action.setToolTip(revert_reason)
+        self._manager._metadata_delete_step_action.setEnabled(delete_enabled)
+        self._manager._metadata_delete_step_action.setToolTip(delete_reason)
         menu.addAction(self._manager._metadata_edit_step_action)
         if edit_enabled:
             menu.setDefaultAction(self._manager._metadata_edit_step_action)
@@ -511,9 +516,6 @@ class _DetailsPanelController:
         selected_code = self._manager._selected_derivation_code()
         self._manager._metadata_copy_selected_action.setEnabled(bool(selected_code))
         menu.addAction(self._manager._metadata_copy_selected_action)
-        if self._manager._metadata_full_code_available:
-            self._manager._metadata_copy_full_action.setEnabled(True)
-            menu.addAction(self._manager._metadata_copy_full_action)
         clipboard = QtWidgets.QApplication.clipboard()
         paste_payload = _provenance_step_clipboard_payload(
             None if clipboard is None else clipboard.mimeData()
@@ -526,10 +528,16 @@ class _DetailsPanelController:
         self._manager._metadata_paste_steps_action.setEnabled(paste_enabled)
         self._manager._metadata_paste_steps_action.setToolTip(paste_reason)
         menu.addAction(self._manager._metadata_paste_steps_action)
+        if self._manager._metadata_full_code_available:
+            self._manager._metadata_copy_full_action.setEnabled(True)
+            menu.addAction(self._manager._metadata_copy_full_action)
+        menu.addSeparator()
+        menu.addAction(self._manager._metadata_delete_step_action)
         return menu
 
     def _show_metadata_derivation_menu(self, pos: QtCore.QPoint) -> None:
-        if self._manager.metadata_derivation_list.itemAt(pos) is None:
+        item = self._manager.metadata_derivation_list.itemAt(pos)
+        if item is None:
             return
         menu = self._manager._build_metadata_derivation_menu()
         if menu is None:
@@ -662,6 +670,11 @@ class _DetailsPanelController:
 
     def _revert_selected_derivation_step(self) -> None:
         self._manager._provenance_edit_controller.revert_row(
+            self._manager._selected_derivation_row()
+        )
+
+    def _delete_selected_derivation_step(self) -> None:
+        self._manager._provenance_edit_controller.delete_row(
             self._manager._selected_derivation_row()
         )
 

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import typing
 
@@ -34,6 +35,59 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _TOOL_PREVIEW_UPDATE_DELAY_MS = 250
+_PROVENANCE_STEPS_CLIPBOARD_MIME = "application/x-erlab-imagetool-provenance-steps+json"
+_PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.imagetool.provenance.steps"
+_PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
+
+
+def _provenance_step_clipboard_payload(
+    mime_data: QtCore.QMimeData | None,
+) -> tuple[tuple[provenance.ToolProvenanceOperation, ...], str, bool] | None:
+    if mime_data is None:
+        return None
+    payload_text: str | None = None
+    if mime_data.hasFormat(_PROVENANCE_STEPS_CLIPBOARD_MIME):
+        try:
+            payload_text = bytes(
+                mime_data.data(_PROVENANCE_STEPS_CLIPBOARD_MIME)
+            ).decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    elif mime_data.hasText():
+        text = mime_data.text().strip()
+        if text.startswith("{"):
+            payload_text = text
+    if payload_text is None:
+        return None
+    try:
+        payload = json.loads(payload_text)
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("type") != _PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_TYPE:
+            return None
+        if payload.get("version") != _PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_VERSION:
+            return None
+        operations_payload = payload.get("operations")
+        if not isinstance(operations_payload, list):
+            return None
+        operations = tuple(
+            provenance.parse_tool_provenance_operation(operation)
+            for operation in operations_payload
+        )
+    except (
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        return None
+    active_name = payload.get("active_name")
+    if not isinstance(active_name, str) or not active_name:
+        active_name = "derived"
+    return (
+        operations,
+        active_name,
+        any(not operation.live_applicable for operation in operations),
+    )
 
 
 class _DetailsPanelController:
@@ -367,6 +421,60 @@ class _DetailsPanelController:
             return None
         return "\n".join(codes)
 
+    def _selected_derivation_step_payload(
+        self,
+    ) -> tuple[tuple[provenance.ToolProvenanceOperation, ...], str, bool] | None:
+        if self._manager._metadata_node_uid is None:
+            return None
+        node = self._manager._tool_graph.nodes.get(self._manager._metadata_node_uid)
+        if node is None:
+            return None
+
+        operations: list[provenance.ToolProvenanceOperation] = []
+        script_active_names: list[str] = []
+        for item in self._manager._selected_derivation_items():
+            row = item.data(_METADATA_DERIVATION_ROW_ROLE)
+            if not isinstance(row, provenance._ProvenanceDisplayRow):
+                continue
+            ref = row.replay_ref
+            if ref is None or ref.kind != "operation":
+                continue
+            if not bool(item.data(_METADATA_DERIVATION_COPYABLE_ROLE)):
+                continue
+            if not item.data(_METADATA_DERIVATION_CODE_ROLE):
+                continue
+            spec = self._manager._provenance_edit_controller._display_spec_for_row(
+                node,
+                row,
+            )
+            if spec is None:
+                continue
+            operation = spec._operation_for_ref(ref)
+            if operation is None:
+                continue
+            if isinstance(operation, provenance.ScriptCodeOperation):
+                if operation.copyable and operation.code:
+                    operations.append(operation)
+                    script_active_names.append(spec.active_name or "derived")
+                continue
+            if operation.live_applicable:
+                operations.append(operation)
+
+        if not operations:
+            return None
+        script_active_name = (
+            script_active_names[0] if script_active_names else "derived"
+        )
+        if any(
+            active_name != script_active_name for active_name in script_active_names
+        ):
+            return None
+        return (
+            tuple(operations),
+            script_active_name,
+            any(not operation.live_applicable for operation in operations),
+        )
+
     def _selected_derivation_row(
         self,
     ) -> provenance._ProvenanceDisplayRow | None:
@@ -406,6 +514,17 @@ class _DetailsPanelController:
         if self._manager._metadata_full_code_available:
             self._manager._metadata_copy_full_action.setEnabled(True)
             menu.addAction(self._manager._metadata_copy_full_action)
+        paste_payload = _provenance_step_clipboard_payload(
+            QtWidgets.QApplication.clipboard().mimeData()
+        )
+        paste_enabled, paste_reason = (
+            self._manager._provenance_edit_controller.can_paste_steps(
+                None if paste_payload is None else paste_payload[0]
+            )
+        )
+        self._manager._metadata_paste_steps_action.setEnabled(paste_enabled)
+        self._manager._metadata_paste_steps_action.setToolTip(paste_reason)
+        menu.addAction(self._manager._metadata_paste_steps_action)
         return menu
 
     def _show_metadata_derivation_menu(self, pos: QtCore.QPoint) -> None:
@@ -421,8 +540,46 @@ class _DetailsPanelController:
 
     def _copy_selected_derivation_code(self) -> None:
         code = self._manager._selected_derivation_code()
-        if code:
+        if not code:
+            return
+        payload = self._selected_derivation_step_payload()
+        if payload is None:
             erlab.interactive.utils.copy_to_clipboard(code)
+            return
+        operations, active_name, _contains_script = payload
+        payload_text = json.dumps(
+            {
+                "type": _PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_TYPE,
+                "version": _PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_VERSION,
+                "active_name": active_name,
+                "operations": [
+                    operation.model_dump(mode="json") for operation in operations
+                ],
+            },
+            separators=(",", ":"),
+        )
+        mime_data = QtCore.QMimeData()
+        mime_data.setData(
+            _PROVENANCE_STEPS_CLIPBOARD_MIME, payload_text.encode("utf-8")
+        )
+        mime_data.setText(code)
+        QtWidgets.QApplication.clipboard().setMimeData(mime_data)
+
+    def _paste_provenance_steps_from_clipboard(self) -> None:
+        payload = _provenance_step_clipboard_payload(
+            QtWidgets.QApplication.clipboard().mimeData()
+        )
+        if payload is None:
+            self._manager._provenance_edit_controller._show_unavailable(
+                "The clipboard does not contain copied ImageTool provenance steps."
+            )
+            return
+        operations, active_name, contains_script = payload
+        self._manager._provenance_edit_controller.paste_steps(
+            operations,
+            active_name=active_name,
+            contains_script=contains_script,
+        )
 
     def _unavailable_replay_code_details(
         self, node: _ImageToolWrapper | _ManagedWindowNode

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -997,7 +997,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self._metadata_full_code_available = False
         self._metadata_node_uid: str | None = None
         self._refreshing_figure_list = False
-        self._metadata_copy_selected_action = QtGui.QAction("Copy Selected Code", self)
+        self._metadata_copy_selected_action = QtGui.QAction("Copy", self)
         self._metadata_copy_selected_action.setObjectName(
             "manager_copy_selected_code_action"
         )
@@ -1009,7 +1009,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self._metadata_copy_full_action.triggered.connect(
             self._copy_full_derivation_code
         )
-        self._metadata_paste_steps_action = QtGui.QAction("Paste Steps", self)
+        self._metadata_paste_steps_action = QtGui.QAction("Paste", self)
         self._metadata_paste_steps_action.setObjectName(
             "manager_paste_provenance_steps_action"
         )
@@ -1029,6 +1029,13 @@ class ImageToolManager(_ImageToolManagerBase):
         )
         self._metadata_revert_step_action.triggered.connect(
             self._revert_selected_derivation_step
+        )
+        self._metadata_delete_step_action = QtGui.QAction("Delete", self)
+        self._metadata_delete_step_action.setObjectName(
+            "manager_delete_provenance_step_action"
+        )
+        self._metadata_delete_step_action.triggered.connect(
+            self._delete_selected_derivation_step
         )
 
         self.sigLinkersChanged.connect(self._update_actions)
@@ -2418,6 +2425,9 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def _revert_selected_derivation_step(self) -> None:
         self._details_panel._revert_selected_derivation_step()
+
+    def _delete_selected_derivation_step(self) -> None:
+        self._details_panel._delete_selected_derivation_step()
 
     def _update_info(self, *, uid: str | None = None) -> None:
         self._details_panel._update_info(uid=uid)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -972,6 +972,9 @@ class ImageToolManager(_ImageToolManagerBase):
         self.metadata_derivation_list.copy_requested.connect(
             self._copy_selected_derivation_code
         )
+        self.metadata_derivation_list.paste_requested.connect(
+            self._paste_provenance_steps_from_clipboard
+        )
         self.metadata_derivation_list.context_menu_requested.connect(
             self._show_metadata_derivation_menu
         )
@@ -1005,6 +1008,13 @@ class ImageToolManager(_ImageToolManagerBase):
         self._metadata_copy_full_action.setObjectName("manager_copy_full_code_action")
         self._metadata_copy_full_action.triggered.connect(
             self._copy_full_derivation_code
+        )
+        self._metadata_paste_steps_action = QtGui.QAction("Paste Steps", self)
+        self._metadata_paste_steps_action.setObjectName(
+            "manager_paste_provenance_steps_action"
+        )
+        self._metadata_paste_steps_action.triggered.connect(
+            self._paste_provenance_steps_from_clipboard
         )
         self._metadata_edit_step_action = QtGui.QAction("Edit Step…", self)
         self._metadata_edit_step_action.setObjectName(
@@ -2394,6 +2404,9 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def _copy_full_derivation_code(self) -> None:
         self._details_panel._copy_full_derivation_code()
+
+    def _paste_provenance_steps_from_clipboard(self) -> None:
+        self._details_panel._paste_provenance_steps_from_clipboard()
 
     def _edit_selected_derivation_step(self) -> None:
         self._details_panel._edit_selected_derivation_step()

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -10,6 +10,7 @@ import warnings
 from qtpy import QtCore, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.slicer
 from erlab.interactive.imagetool import dialogs, provenance
 from erlab.interactive.imagetool._load_source import (
     _load_provenance_from_file_details,
@@ -453,6 +454,127 @@ def _dialog_class_for_operation(
 class _ProvenanceEditController:
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager = manager
+
+    def can_paste_steps(
+        self,
+        operations: Sequence[provenance.ToolProvenanceOperation] | None,
+    ) -> tuple[bool, str]:
+        if not operations:
+            return False, "The clipboard does not contain copied ImageTool steps."
+        node = self._metadata_node()
+        if not self._node_editable(node):
+            return False, "Select an available ImageTool row to paste provenance."
+        return True, ""
+
+    def paste_steps(
+        self,
+        operations: Sequence[provenance.ToolProvenanceOperation],
+        *,
+        active_name: str,
+        contains_script: bool,
+    ) -> None:
+        paste_enabled, paste_reason = self.can_paste_steps(operations)
+        if not paste_enabled:
+            self._show_unavailable(paste_reason)
+            return
+        node = typing.cast(
+            "_ImageToolWrapper | _ManagedWindowNode",
+            self._metadata_node(),
+        )
+        steps = tuple(operations)
+        try:
+            if contains_script or any(
+                not operation.live_applicable for operation in steps
+            ):
+                self._paste_detached_steps(
+                    node,
+                    provenance.script(
+                        *steps,
+                        start_label="Paste provenance steps",
+                        seed_code="derived = data",
+                        active_name=active_name or "derived",
+                    ),
+                    where="validating the pasted script provenance steps",
+                )
+            else:
+                self._paste_structured_steps(node, steps)
+        except Exception as exc:
+            self._show_failed("Could Not Paste Provenance Steps", exc)
+
+    def _paste_structured_steps(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        operations: tuple[provenance.ToolProvenanceOperation, ...],
+    ) -> None:
+        for operation in operations:
+            if not operation.live_applicable:
+                raise TypeError("Only live provenance operations can be pasted here")
+
+        if node.parent_uid is not None and node.displayed_source_spec is not None:
+            candidate = node.displayed_source_spec.append_replacement_operations(
+                *operations
+            )
+            try:
+                data, candidate = self._replay_candidate_result(
+                    node,
+                    "source",
+                    candidate,
+                )
+                data = erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
+                    data,
+                    copy_values=False,
+                )
+            except Exception as exc:
+                raise _ProvenanceReplayFailure(
+                    "validating the pasted provenance steps: "
+                    "replaying the requested provenance",
+                    exc,
+                ) from exc
+            self._replace_node_data(node, "source", data, candidate, None)
+            self._manager._update_info(uid=node.uid)
+            return
+
+        local = provenance.full_data(*operations)
+        self._paste_detached_steps(
+            node,
+            local,
+            where="validating the pasted provenance steps",
+        )
+
+    def _paste_detached_steps(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        local: provenance.ToolProvenanceSpec,
+        *,
+        where: str,
+    ) -> None:
+        current_data = node.current_source_data()
+        try:
+            if local.kind == "script":
+                data = provenance.replay_script_provenance(
+                    local,
+                    {"data": current_data},
+                )
+            else:
+                data = local.apply(current_data)
+            data = erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
+                data,
+                copy_values=False,
+            )
+        except Exception as exc:
+            raise _ProvenanceReplayFailure(
+                f"{where}: replaying the requested provenance",
+                exc,
+            ) from exc
+
+        spec = provenance.compose_full_provenance(
+            node.displayed_provenance_spec,
+            local,
+        )
+        if spec is None:
+            spec = local.to_replay_spec()
+        node.replace_with_detached_data(data, spec, preserve_filter=False)
+        self._manager._update_info(uid=node.uid)
 
     def can_edit_row(
         self,

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -490,8 +490,7 @@ class _ProvenanceEditController:
                     node,
                     provenance.script(
                         *steps,
-                        start_label="Paste provenance steps",
-                        seed_code="derived = data",
+                        start_label="Start from current ImageTool data",
                         active_name=active_name or "derived",
                     ),
                     where="validating the pasted script provenance steps",
@@ -563,7 +562,10 @@ class _ProvenanceEditController:
             if local.kind == "script":
                 data = provenance.replay_script_provenance(
                     local,
-                    {"data": current_data},
+                    {
+                        "data": current_data,
+                        "derived": current_data,
+                    },
                 )
             else:
                 data = local.apply(current_data)
@@ -585,6 +587,38 @@ class _ProvenanceEditController:
             spec = local.to_replay_spec()
         node.replace_with_detached_data(data, spec, preserve_filter=False)
         self._manager._update_info(uid=node.uid)
+
+    def can_delete_row(
+        self,
+        row: provenance._ProvenanceDisplayRow | None,
+    ) -> tuple[bool, str]:
+        node = self._metadata_node()
+        if row is None or row.replay_ref is None:
+            return False, "This row cannot be deleted."
+        if row.replay_ref.kind != "operation":
+            return False, "Only operation rows can be deleted."
+        if not self._node_editable(node):
+            return False, "Select an available ImageTool row to delete provenance."
+        node = typing.cast("_ImageToolWrapper | _ManagedWindowNode", node)
+        if self._source_child_parent_row(node, row):
+            return False, "Delete the parent ImageTool row directly."
+        spec = self._display_spec_for_row(node, row)
+        if spec is None:
+            return False, "This row does not have replayable provenance."
+        if spec._operation_for_ref(row.replay_ref) is None:
+            return False, "This operation is not available."
+        if spec.kind == "script":
+            try:
+                candidate = spec._replace_operation_ref(row.replay_ref, ())
+            except (IndexError, ValueError):
+                return False, "This script row is not a replayable step."
+            if not provenance.script_provenance_replayable(candidate):
+                return False, "Deleting this script step would make replay invalid."
+        if spec.kind in {"full_data", "public_data", "selection"}:
+            if row.scope == "source" and node.parent_uid is not None:
+                return True, ""
+            return False, "This live row needs a parent source to replay."
+        return True, ""
 
     def can_edit_row(
         self,
@@ -734,6 +768,54 @@ class _ProvenanceEditController:
             ):
                 return
             self._show_failed("Could Not Revert Provenance Step", exc)
+
+    def delete_row(self, row: provenance._ProvenanceDisplayRow | None) -> None:
+        deletable, reason = self.can_delete_row(row)
+        if not deletable:
+            self._show_unavailable(reason)
+            return
+        node = typing.cast(
+            "_ImageToolWrapper | _ManagedWindowNode",
+            self._metadata_node(),
+        )
+        row = typing.cast("provenance._ProvenanceDisplayRow", row)
+        ref = typing.cast("provenance._ProvenanceStepRef", row.replay_ref)
+        spec = self._display_spec_for_row(node, row)
+        if spec is None:
+            self._show_failed(
+                "Could Not Delete Provenance Step",
+                RuntimeError("No provenance spec is available"),
+            )
+            return
+        candidate: provenance.ToolProvenanceSpec | None = None
+        try:
+            candidate = spec._replace_operation_ref(ref, ())
+            if candidate.kind == "file":
+                candidate = candidate.model_copy(
+                    update={
+                        "replay_stages": tuple(
+                            stage
+                            for stage in candidate.replay_stages
+                            if stage.operations
+                        )
+                    }
+                )
+            self._validate_and_replace(
+                node,
+                row.scope,
+                candidate,
+                where="validating the provenance delete target",
+            )
+        except Exception as exc:
+            if self._handle_missing_source_file(
+                node,
+                row,
+                title="Could Not Delete Provenance Step",
+                exc=exc,
+                repair_spec=candidate,
+            ):
+                return
+            self._show_failed("Could Not Delete Provenance Step", exc)
 
     def _metadata_node(self) -> _ImageToolWrapper | _ManagedWindowNode | None:
         uid = self._manager._metadata_node_uid

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -579,10 +579,17 @@ class _ProvenanceEditController:
                 exc,
             ) from exc
 
-        spec = provenance.compose_full_provenance(
-            node.displayed_provenance_spec,
-            local,
-        )
+        if local.kind == "script":
+            spec = provenance.compose_full_provenance(
+                node.displayed_provenance_spec,
+                local,
+                script_context_names=("data", "derived"),
+            )
+        else:
+            spec = provenance.compose_full_provenance(
+                node.displayed_provenance_spec,
+                local,
+            )
         if spec is None:
             spec = local.to_replay_spec()
         node.replace_with_detached_data(data, spec, preserve_filter=False)

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -499,7 +499,17 @@ class _ProvenanceEditController:
             else:
                 self._paste_structured_steps(node, steps)
         except Exception as exc:
-            self._show_failed("Could Not Paste Provenance Steps", exc)
+            self._show_failed(
+                "Could Not Paste Provenance Steps",
+                exc,
+                text="The copied provenance steps could not be applied.",
+                unchanged_reason=(
+                    "The copied steps could not be replayed on the selected "
+                    "ImageTool's current data, so nothing was changed. Check that "
+                    "the destination data has the dimensions, coordinates, and "
+                    "inputs expected by the copied steps."
+                ),
+            )
 
     def _paste_structured_steps(
         self,
@@ -1297,24 +1307,32 @@ class _ProvenanceEditController:
             reason,
         )
 
-    def _show_failed(self, title: str, exc: Exception) -> None:
+    def _show_failed(
+        self,
+        title: str,
+        exc: Exception,
+        *,
+        text: str = "The provenance change could not be applied.",
+        unchanged_reason: str | None = None,
+    ) -> None:
         exc_text = "".join(traceback.TracebackException.from_exception(exc).format())
         where = (
             exc.where
             if isinstance(exc, _ProvenanceReplayFailure)
             else "replaying the requested provenance"
         )
-        dialog = erlab.interactive.utils.MessageDialog(
-            self._manager,
-            title=title,
-            text="The provenance change could not be applied.",
-            informative_text=(
-                f"Failed while: {where}\n\n"
+        if unchanged_reason is None:
+            unchanged_reason = (
                 "The current ImageTool data was left unchanged because the requested "
                 "provenance could not be replayed. Use Revert to This Step to drop "
                 "later provenance, or adjust the earlier steps so the full chain is "
                 "valid again."
-            ),
+            )
+        dialog = erlab.interactive.utils.MessageDialog(
+            self._manager,
+            title=title,
+            text=text,
+            informative_text=f"Failed while: {where}\n\n{unchanged_reason}",
             detailed_text=erlab.interactive.utils._format_traceback(exc_text),
             buttons=QtWidgets.QDialogButtonBox.StandardButton.Ok,
             icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning,

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -113,6 +113,7 @@ class _WarningEmitter(QtCore.QObject):
 
 class _MetadataDerivationListWidget(QtWidgets.QListWidget):
     copy_requested = QtCore.Signal()
+    paste_requested = QtCore.Signal()
     context_menu_requested = QtCore.Signal(QtCore.QPoint)
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
@@ -125,6 +126,10 @@ class _MetadataDerivationListWidget(QtWidgets.QListWidget):
             return
         if event.matches(QtGui.QKeySequence.StandardKey.Copy):
             self.copy_requested.emit()
+            event.accept()
+            return
+        if event.matches(QtGui.QKeySequence.StandardKey.Paste):
+            self.paste_requested.emit()
             event.accept()
             return
         if event.key() in {QtCore.Qt.Key.Key_Return, QtCore.Qt.Key.Key_Enter}:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -5904,10 +5904,19 @@ def test_figure_composer_cut_paste_steps_preserves_order_and_history(qtbot) -> N
     ]
     assert _selected_operation_rows(tool) == (1,)
     assert tool.operation_list.currentRow() == 1
+    mime = clipboard.mimeData()
+    payload_text = bytes(
+        mime.data(figurecomposer_tool_module._STEPS_CLIPBOARD_MIME).data()
+    ).decode("utf-8")
     assert [
-        operation["label"]
-        for operation in json.loads(clipboard.mimeData().text())["operations"]
+        operation["label"] for operation in json.loads(payload_text)["operations"]
     ] == ["b", "d"]
+    assert clipboard.text().splitlines() == [
+        "fig.__dict__['_order'] = fig.__dict__.get('_order', []) + ['b']",
+        "fig.__dict__['_order'] = fig.__dict__.get('_order', []) + ['d']",
+    ]
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(clipboard.text())
 
     tool.paste_operation_button.click()
 
@@ -6197,7 +6206,7 @@ def test_figure_composer_copy_paste_steps_renames_source_conflicts(qtbot) -> Non
     xr.testing.assert_identical(destination.source_data()["profile_copy"], profile)
 
 
-def test_figure_composer_copy_paste_steps_plain_payload_has_missing_source(
+def test_figure_composer_copy_paste_steps_typed_payload_has_missing_source(
     qtbot,
 ) -> None:
     remote_data = xr.DataArray(
@@ -6241,17 +6250,24 @@ def test_figure_composer_copy_paste_steps_plain_payload_has_missing_source(
 
     _select_operation_rows(source_tool, (0,))
     source_tool.copy_operation_button.click()
-    payload_text = clipboard.mimeData().text()
+    copied_mime = clipboard.mimeData()
+    payload_text = bytes(
+        copied_mime.data(figurecomposer_tool_module._STEPS_CLIPBOARD_MIME).data()
+    ).decode("utf-8")
     assert payload_text.startswith(
         '{\n  "type": "erlab.figure_composer.steps",\n  "version": 1,'
     )
     assert json.loads(payload_text)["type"] == "erlab.figure_composer.steps"
+    assert copied_mime.text()
+    assert not copied_mime.text().lstrip().startswith("{")
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(copied_mime.text())
     mime = QtCore.QMimeData()
     mime.setData(
         figurecomposer_tool_module._STEPS_CLIPBOARD_MIME,
         payload_text.encode("utf-8"),
     )
-    mime.setText(payload_text)
+    mime.setText(copied_mime.text())
     clipboard.setMimeData(mime)
     destination._paste_operations_from_clipboard()
 
@@ -6261,6 +6277,65 @@ def test_figure_composer_copy_paste_steps_plain_payload_has_missing_source(
     ]
     assert destination.tool_status.operations[-1].sources == ("remote",)
     assert "remote" not in destination.source_data()
+
+
+def test_figure_composer_copy_steps_keeps_payload_when_code_text_fails(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(_custom_order_step("a"),),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    clipboard = _clear_clipboard()
+    disabled = tool.tool_status.operations[0].model_copy(update={"enabled": False})
+    assert figurecomposer_tool_module._step_clipboard_code_text(tool, (disabled,)) == ""
+
+    class BrokenSpec:
+        @staticmethod
+        def code_lines(
+            _tool: FigureComposerTool,
+            _operation: FigureOperationState,
+        ) -> list[str]:
+            raise ValueError("bad axes")
+
+    _select_operation_rows(tool, (0,))
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            figurecomposer_tool_module._registry,
+            "spec_for",
+            lambda _kind: BrokenSpec(),
+        )
+        failure_text = figurecomposer_tool_module._step_clipboard_code_text(
+            tool,
+            tool.tool_status.operations,
+        )
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            figurecomposer_tool_module,
+            "_step_clipboard_code_text",
+            lambda _tool, _operations: failure_text,
+        )
+        tool._write_selected_operations_to_clipboard()
+
+    copied_mime = clipboard.mimeData()
+    payload_text = bytes(
+        copied_mime.data(figurecomposer_tool_module._STEPS_CLIPBOARD_MIME).data()
+    ).decode("utf-8")
+    assert [
+        operation["label"] for operation in json.loads(payload_text)["operations"]
+    ] == ["a"]
+    assert failure_text.startswith(
+        "# Could not generate Python code for the copied Figure Composer steps:"
+    )
+    assert copied_mime.text() == failure_text
+    assert not copied_mime.text().lstrip().startswith("{")
 
 
 def test_figure_composer_copy_paste_steps_ignores_invalid_payload(qtbot) -> None:
@@ -6278,6 +6353,12 @@ def test_figure_composer_copy_paste_steps_ignores_invalid_payload(qtbot) -> None
     clipboard.setText("{not valid json")
     before = tool.tool_status
 
+    tool._update_step_action_buttons()
+    assert not tool.paste_operation_button.isEnabled()
+    tool._paste_operations_from_clipboard()
+    assert tool.tool_status == before
+
+    clipboard.setText("fig.suptitle('Copied step code')")
     tool._update_step_action_buttons()
     assert not tool.paste_operation_button.isEnabled()
     tool._paste_operations_from_clipboard()

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -6320,6 +6320,22 @@ def test_manager_copy_selected_derivation_code_fallbacks(
     controller._copy_selected_derivation_code()
 
 
+def test_manager_derivation_context_menu_ignores_empty_space(
+    qtbot,
+) -> None:
+    list_widget = QtWidgets.QListWidget()
+    qtbot.addWidget(list_widget)
+    manager = types.SimpleNamespace(
+        metadata_derivation_list=list_widget,
+        _build_metadata_derivation_menu=lambda: pytest.fail("unexpected menu"),
+    )
+    controller = manager_details_panel._DetailsPanelController(
+        typing.cast("typing.Any", manager)
+    )
+
+    controller._show_metadata_derivation_menu(QtCore.QPoint(10, 10))
+
+
 def test_manager_paste_steps_validation_error_branches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -6455,6 +6471,25 @@ def test_manager_can_delete_row_reports_unavailable_branches(
     assert not deletable
     assert reason
 
+    valid_script_spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Offset",
+            code="derived = derived + 1",
+        ),
+        provenance.ScriptCodeOperation(
+            label="Scale",
+            code="derived = derived * 2",
+        ),
+        start_label="Start from data",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(provenance.ScriptInput(name="data_0", label="Input"),),
+    )
+    controller = _fake_edit_controller(_fake_edit_node(valid_script_spec))
+    deletable, reason = controller.can_delete_row(valid_script_spec.display_rows()[2])
+    assert deletable
+    assert reason == ""
+
     source_live_spec = provenance.full_data(provenance.AverageOperation(dims=("x",)))
     live_row = source_live_spec.display_rows(scope="source")[1]
     source_bound = _fake_edit_node(
@@ -6527,6 +6562,33 @@ def test_manager_delete_row_error_branches(
     )
     controller.delete_row(row)
     assert failures == []
+
+    live_row = provenance.full_data(
+        provenance.AverageOperation(dims=("x",))
+    ).display_rows()[1]
+    replaced: list[
+        tuple[
+            object,
+            typing.Literal["display", "source"],
+            provenance.ToolProvenanceSpec,
+        ]
+    ] = []
+    monkeypatch.setattr(controller, "can_delete_row", lambda _row: (True, ""))
+    monkeypatch.setattr(
+        controller,
+        "_display_spec_for_row",
+        lambda *_args: provenance.full_data(provenance.AverageOperation(dims=("x",))),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_validate_and_replace",
+        lambda edit_node, scope, candidate, **_kwargs: replaced.append(
+            (edit_node, scope, candidate)
+        ),
+    )
+    controller.delete_row(live_row)
+    assert len(replaced) == 1
+    assert replaced[0][2].operations == ()
 
 
 def test_manager_delete_provenance_step_preserves_later_operations(
@@ -6724,6 +6786,7 @@ def test_manager_copy_paste_structured_provenance_steps(
 
         dest_node = manager._tool_graph.root_wrappers[dest_index]
         assert dest_node.displayed_provenance_spec is not None
+        assert dest_node.displayed_provenance_spec.script_context_bindings == ()
         replay_namespace = _exec_generated_code(
             dest_node.displayed_provenance_spec.derivation_code(),
             {"data": dest_base.copy(deep=True)},
@@ -6889,10 +6952,14 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
         assert child_node.source_spec is None
         assert child_node.source_auto_update is False
         pasted_code = child_node.displayed_provenance_spec.derivation_code()
-        source_code = script_spec.derivation_code()
         assert pasted_code is not None
-        assert source_code is not None
-        assert pasted_code.splitlines()[-2:] == source_code.splitlines()[-2:]
+        replay_namespace = _exec_generated_code(
+            pasted_code,
+            {"data": data.copy(deep=True)},
+        )
+        replayed = replay_namespace["result"]
+        assert isinstance(replayed, xr.DataArray)
+        xr.testing.assert_identical(replayed, expected)
         derivation = metadata_derivation_texts(manager)
         assert script_operations[0].derivation_entry().label in derivation
         assert script_operations[1].derivation_entry().label in derivation
@@ -6948,6 +7015,96 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
         xr.testing.assert_identical(child_tool.slicer_area._data, before)
         assert child_node.provenance_spec == before_spec
         assert child_node.source_spec is None
+
+
+def test_manager_paste_script_steps_replays_from_current_output_name(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = _provenance_paste_test_data("scan")
+    dest_base_spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Compute destination result",
+            code="result = derived + 1.0",
+        ),
+        start_label="Start from destination data",
+        seed_code="derived = data",
+        active_name="result",
+    )
+    dest_data = provenance.replay_script_provenance(dest_base_spec, {"data": data})
+    copied_operation = provenance.ScriptCodeOperation(
+        label="Offset copied result",
+        code="result = derived + 2.0",
+    )
+    source_spec = provenance.script(
+        copied_operation,
+        start_label="Run copied script",
+        seed_code="derived = data",
+        active_name="result",
+    )
+    source_data = provenance.replay_script_provenance(source_spec, {"data": data})
+
+    with manager_context() as manager:
+        dest_tool = itool(dest_data, manager=False, execute=False)
+        assert isinstance(dest_tool, erlab.interactive.imagetool.ImageTool)
+        dest_index = manager.add_imagetool(
+            dest_tool,
+            show=False,
+            provenance_spec=dest_base_spec,
+        )
+        source_tool = itool(source_data, manager=False, execute=False)
+        assert isinstance(source_tool, erlab.interactive.imagetool.ImageTool)
+        source_index = manager.add_imagetool(
+            source_tool,
+            show=False,
+            provenance_spec=source_spec,
+        )
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [source_index])
+        manager._update_info()
+        select_metadata_rows(manager, [1])
+        manager._copy_selected_derivation_code()
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [dest_index])
+        manager._update_info()
+        manager._paste_provenance_steps_from_clipboard()
+
+        expected = dest_data + 2.0
+        displayed_expected = (
+            erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
+                expected,
+                copy_values=False,
+            )
+        )
+        xr.testing.assert_identical(dest_tool.slicer_area._data, displayed_expected)
+        dest_node = manager._tool_graph.root_wrappers[dest_index]
+        assert dest_node.displayed_provenance_spec is not None
+        assert [
+            operation.derivation_entry().label
+            for operation in dest_node.displayed_provenance_spec.operations
+        ] == [
+            "Compute destination result",
+            "Offset copied result",
+        ]
+        assert [
+            binding.model_dump(mode="json")
+            for binding in dest_node.displayed_provenance_spec.script_context_bindings
+        ] == [{"operation_index": 1, "names": ["data", "derived"]}]
+
+        code = dest_node.displayed_provenance_spec.derivation_code()
+        assert code is not None
+        assert "Start from current ImageTool data" not in code
+        assert "derived = derived" not in code
+        replay_namespace = _exec_generated_code(
+            code,
+            {"data": data.copy(deep=True)},
+        )
+        replayed = replay_namespace["result"]
+        assert isinstance(replayed, xr.DataArray)
+        xr.testing.assert_identical(replayed, expected)
 
 
 def test_manager_divide_by_coord_child_refresh_and_code(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -14,6 +14,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
 import erlab.interactive.imagetool.manager._provenance_edit as manager_provenance_edit
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
@@ -108,6 +109,15 @@ def _add_file_replay_tool(
     assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
     manager.add_imagetool(tool, show=False, provenance_spec=spec)
     return tool
+
+
+def _provenance_paste_test_data(name: str = "data") -> xr.DataArray:
+    return xr.DataArray(
+        np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5),
+        dims=("x", "y", "z"),
+        coords={"x": [0.0, 1.0, 2.0], "y": [0.0, 1.0, 2.0, 3.0]},
+        name=name,
+    )
 
 
 def test_file_load_edit_dialog_uses_loader_options_widget(qtbot) -> None:
@@ -5868,13 +5878,16 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert "Aggregate" in derivation[2]
         assert "dims=" in derivation[2]
         manager.metadata_derivation_list.setFocus()
+        clipboard = QtWidgets.QApplication.clipboard()
         select_metadata_rows(manager, [0])
+        clipboard.clear()
         qtbot.keyClick(
             manager.metadata_derivation_list,
             QtCore.Qt.Key.Key_C,
             QtCore.Qt.KeyboardModifier.ControlModifier,
         )
         assert copied == []
+        assert clipboard.text() == ""
 
         select_metadata_rows(manager, [1, 2])
         qtbot.keyClick(
@@ -5883,8 +5896,11 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
             QtCore.Qt.KeyboardModifier.ControlModifier,
         )
         selected_namespace = _exec_generated_code(
-            copied[-1],
+            clipboard.text(),
             {"derived": data.copy(deep=True)},
+        )
+        assert clipboard.mimeData().hasFormat(
+            manager_details_panel._PROVENANCE_STEPS_CLIPBOARD_MIME
         )
         selected_result = selected_namespace["derived"]
         assert isinstance(selected_result, xr.DataArray)
@@ -5897,7 +5913,7 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert menu is not None
         trigger_menu_action(menu, manager._metadata_copy_selected_action)
         selected_namespace = _exec_generated_code(
-            copied[-1],
+            clipboard.text(),
             {"derived": data.copy(deep=True)},
         )
         selected_result = selected_namespace["derived"]
@@ -6032,6 +6048,307 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert metadata_detail_map(manager) == {}
         assert metadata_derivation_texts(manager) == []
         assert manager._build_metadata_derivation_menu() is None
+
+
+def test_manager_copy_paste_structured_provenance_steps(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source_base = _provenance_paste_test_data("source")
+    source_operations = (
+        provenance.AssignAttrsOperation(attrs={"copied": "yes"}),
+        provenance.AverageOperation(dims=("z",)),
+    )
+    source_spec = provenance.full_data(*source_operations)
+    source_data = source_spec.apply(source_base)
+
+    dest_base = _provenance_paste_test_data("dest") + 100.0
+    dest_seed_op = provenance.ScriptCodeOperation(
+        label="Keep existing destination provenance",
+        code="derived = derived.assign_attrs({'existing': 'yes'})",
+    )
+    dest_spec = provenance.script(
+        dest_seed_op,
+        start_label="Start from destination data",
+        seed_code="derived = data",
+        active_name="derived",
+    )
+    dest_data = provenance.replay_script_provenance(dest_spec, {"data": dest_base})
+
+    with manager_context() as manager:
+        source_tool = itool(source_data, manager=False, execute=False)
+        assert isinstance(source_tool, erlab.interactive.imagetool.ImageTool)
+        source_index = manager.add_imagetool(
+            source_tool,
+            show=False,
+            provenance_spec=source_spec,
+        )
+        dest_tool = itool(dest_data, manager=False, execute=False)
+        assert isinstance(dest_tool, erlab.interactive.imagetool.ImageTool)
+        dest_index = manager.add_imagetool(
+            dest_tool,
+            show=False,
+            provenance_spec=dest_spec,
+        )
+
+        clipboard = QtWidgets.QApplication.clipboard()
+        clipboard.clear()
+        manager.tree_view.clearSelection()
+        select_tools(manager, [source_index])
+        manager._update_info()
+        select_metadata_rows(manager, [1, 2])
+        qtbot.keyClick(
+            manager.metadata_derivation_list,
+            QtCore.Qt.Key.Key_C,
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+        )
+
+        payload = manager_details_panel._provenance_step_clipboard_payload(
+            clipboard.mimeData()
+        )
+        assert payload is not None
+        payload_operations, _active_name, contains_script = payload
+        assert payload_operations == source_operations
+        assert not contains_script
+        assert clipboard.mimeData().hasFormat(
+            manager_details_panel._PROVENANCE_STEPS_CLIPBOARD_MIME
+        )
+        copied_namespace = _exec_generated_code(
+            clipboard.text(),
+            {"derived": dest_data.copy(deep=True)},
+        )
+        copied_result = copied_namespace["derived"]
+        assert isinstance(copied_result, xr.DataArray)
+        expected = source_spec.apply(dest_data)
+        xr.testing.assert_identical(copied_result, expected)
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [dest_index])
+        manager._update_info()
+        select_metadata_rows(manager, [0])
+        menu = manager._build_metadata_derivation_menu()
+        assert menu is not None
+        assert manager._metadata_paste_steps_action in menu.actions()
+        assert manager._metadata_paste_steps_action.isEnabled()
+
+        manager.metadata_derivation_list.setFocus()
+        qtbot.keyClick(
+            manager.metadata_derivation_list,
+            QtCore.Qt.Key.Key_V,
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+        )
+        xr.testing.assert_identical(dest_tool.slicer_area._data, expected)
+
+        dest_node = manager._tool_graph.root_wrappers[dest_index]
+        assert dest_node.displayed_provenance_spec is not None
+        replay_namespace = _exec_generated_code(
+            dest_node.displayed_provenance_spec.derivation_code(),
+            {"data": dest_base.copy(deep=True)},
+        )
+        replayed = replay_namespace["derived"]
+        assert isinstance(replayed, xr.DataArray)
+        xr.testing.assert_identical(replayed, expected)
+
+        bad_mime = QtCore.QMimeData()
+        bad_mime.setData(
+            manager_details_panel._PROVENANCE_STEPS_CLIPBOARD_MIME,
+            b"{not-json",
+        )
+        clipboard.setMimeData(bad_mime)
+        failures: list[str] = []
+        monkeypatch.setattr(
+            manager._provenance_edit_controller,
+            "_show_unavailable",
+            lambda reason: failures.append(reason),
+        )
+        before = dest_tool.slicer_area._data.copy(deep=True)
+        manager._paste_provenance_steps_from_clipboard()
+        assert failures
+        xr.testing.assert_identical(dest_tool.slicer_area._data, before)
+
+
+def test_manager_paste_structured_steps_preserves_source_binding(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    parent_data = _provenance_paste_test_data("parent")
+    copied_operation = provenance.AverageOperation(dims=("z",))
+    source_spec = provenance.full_data(copied_operation)
+    source_data = source_spec.apply(parent_data)
+    child_base_spec = provenance.full_data(
+        provenance.AssignAttrsOperation(attrs={"child": "bound"})
+    )
+    child_data = child_base_spec.apply(parent_data)
+
+    with manager_context() as manager:
+        parent_tool = itool(parent_data, manager=False, execute=False)
+        assert isinstance(parent_tool, erlab.interactive.imagetool.ImageTool)
+        parent_index = manager.add_imagetool(parent_tool, show=False)
+        child_tool = itool(child_data, manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            parent_index,
+            show=False,
+            source_spec=child_base_spec,
+            source_auto_update=True,
+        )
+        child_node = manager._child_node(child_uid)
+        filter_operation = provenance.GaussianFilterOperation(sigma={"z": 1.0})
+        child_tool.slicer_area.apply_filter_operation(filter_operation)
+        displayed_child_source = child_node.displayed_source_spec
+        assert displayed_child_source is not None
+        source_tool = itool(source_data, manager=False, execute=False)
+        assert isinstance(source_tool, erlab.interactive.imagetool.ImageTool)
+        source_index = manager.add_imagetool(
+            source_tool,
+            show=False,
+            provenance_spec=source_spec,
+        )
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [source_index])
+        manager._update_info()
+        select_metadata_rows(manager, [1])
+        manager._copy_selected_derivation_code()
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        manager._update_info()
+        manager._paste_provenance_steps_from_clipboard()
+
+        child_node = manager._child_node(child_uid)
+        assert (
+            child_node.parent_uid == manager._tool_graph.root_wrappers[parent_index].uid
+        )
+        assert child_node.source_auto_update is True
+        expected_source_spec = displayed_child_source.append_replacement_operations(
+            copied_operation
+        )
+        assert child_node.source_spec == expected_source_spec
+        assert child_tool.slicer_area._accepted_filter_provenance_operation is None
+        expected = child_node.source_spec.apply(parent_data)
+        xr.testing.assert_identical(child_tool.slicer_area._data, expected)
+
+
+def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = _provenance_paste_test_data("scan")
+    child_source_spec = provenance.full_data(
+        provenance.AssignAttrsOperation(attrs={"before": "script paste"})
+    )
+    child_data = child_source_spec.apply(data)
+    script_operations = (
+        provenance.ScriptCodeOperation(
+            label="Offset data",
+            code="result = derived + 2.0",
+        ),
+        provenance.AverageOperation(dims=("z",)),
+    )
+    script_spec = provenance.script(
+        *script_operations,
+        start_label="Run copied script",
+        seed_code="derived = data",
+        active_name="result",
+    )
+    script_data = provenance.replay_script_provenance(script_spec, {"data": data})
+
+    with manager_context() as manager:
+        parent_tool = itool(data, manager=False, execute=False)
+        assert isinstance(parent_tool, erlab.interactive.imagetool.ImageTool)
+        parent_index = manager.add_imagetool(parent_tool, show=False)
+        child_tool = itool(child_data, manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            parent_index,
+            show=False,
+            source_spec=child_source_spec,
+            source_auto_update=True,
+        )
+        source_tool = itool(script_data, manager=False, execute=False)
+        assert isinstance(source_tool, erlab.interactive.imagetool.ImageTool)
+        source_index = manager.add_imagetool(
+            source_tool,
+            show=False,
+            provenance_spec=script_spec,
+        )
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [source_index])
+        manager._update_info()
+        select_metadata_rows(manager, [1, 2])
+        manager._copy_selected_derivation_code()
+        payload = manager_details_panel._provenance_step_clipboard_payload(
+            QtWidgets.QApplication.clipboard().mimeData()
+        )
+        assert payload is not None
+        payload_operations, _active_name, contains_script = payload
+        assert payload_operations == script_operations
+        assert contains_script
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        manager._update_info()
+        manager._paste_provenance_steps_from_clipboard()
+
+        child_node = manager._child_node(child_uid)
+        expected = provenance.replay_script_provenance(
+            script_spec,
+            {"data": child_data},
+        )
+        xr.testing.assert_identical(child_tool.slicer_area._data, expected)
+        assert child_node.source_spec is None
+        assert child_node.source_auto_update is False
+
+        bad_operation = provenance.ScriptCodeOperation(
+            label="Use unavailable scratch value",
+            code="result = scratch + 1.0",
+        )
+        bad_spec = provenance.script(
+            bad_operation,
+            start_label="Run invalid copied script",
+            seed_code="derived = data",
+            active_name="result",
+        )
+        bad_tool = itool(data, manager=False, execute=False)
+        assert isinstance(bad_tool, erlab.interactive.imagetool.ImageTool)
+        bad_index = manager.add_imagetool(
+            bad_tool,
+            show=False,
+            provenance_spec=bad_spec,
+        )
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [bad_index])
+        manager._update_info()
+        select_metadata_rows(manager, [1])
+        manager._copy_selected_derivation_code()
+
+        failures: list[tuple[str, Exception]] = []
+        monkeypatch.setattr(
+            manager._provenance_edit_controller,
+            "_show_failed",
+            lambda title, exc: failures.append((title, exc)),
+        )
+        before = child_tool.slicer_area._data.copy(deep=True)
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        manager._update_info()
+        manager._paste_provenance_steps_from_clipboard()
+
+        assert failures
+        assert failures[0][0] == "Could Not Paste Provenance Steps"
+        xr.testing.assert_identical(child_tool.slicer_area._data, before)
+        assert child_node.source_spec is None
 
 
 def test_manager_divide_by_coord_child_refresh_and_code(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -5102,6 +5102,7 @@ def test_manager_provenance_context_menu_preserves_extended_selection(
         assert menu is not None
         assert not manager._metadata_edit_step_action.isEnabled()
         assert not manager._metadata_revert_step_action.isEnabled()
+        assert not manager._metadata_delete_step_action.isEnabled()
 
         captured_selection: list[list[int]] = []
 
@@ -5134,6 +5135,51 @@ def test_manager_provenance_context_menu_preserves_extended_selection(
         assert not manager._metadata_edit_step_action.isEnabled()
         assert not manager._metadata_revert_step_action.isEnabled()
         assert not manager._metadata_copy_selected_action.isEnabled()
+        assert not manager._metadata_delete_step_action.isEnabled()
+
+
+def test_manager_provenance_context_menu_groups_row_commands(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    file_path = tmp_path / "scan.h5"
+    test_data.to_netcdf(file_path, engine="h5netcdf")
+    spec = _manager_replay_file_spec(
+        file_path,
+        provenance.QSelAggregationOperation(dims=("alpha",), func="mean"),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        _add_file_replay_tool(manager, test_data.qsel.mean("alpha"), spec)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        select_tools(manager, [0])
+        manager._update_info()
+        select_metadata_rows(manager, [1])
+        menu = manager._build_metadata_derivation_menu()
+        assert menu is not None
+
+        assert manager._metadata_delete_step_action.isEnabled()
+
+        actions = menu.actions()
+        assert actions[0] is manager._metadata_edit_step_action
+        assert actions[1] is manager._metadata_revert_step_action
+        assert actions[2].isSeparator()
+        assert actions[3] is manager._metadata_copy_selected_action
+        assert actions[4] is manager._metadata_paste_steps_action
+        if manager._metadata_copy_full_action in actions:
+            assert actions[5] is manager._metadata_copy_full_action
+            separator_index = 6
+        else:
+            separator_index = 5
+        assert actions[separator_index].isSeparator()
+        assert actions[separator_index + 1] is manager._metadata_delete_step_action
 
 
 def test_manager_provenance_script_operation_rows_are_not_editable_v1(
@@ -6344,6 +6390,246 @@ def test_manager_paste_detached_steps_uses_replay_spec_fallback(
     assert replaced[0][2] is False
 
 
+def test_manager_can_delete_row_reports_unavailable_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_ref = provenance._ProvenanceStepRef(
+        "operation",
+        operation_index=0,
+        stage_index=0,
+    )
+    row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("Average", None),
+        replay_ref=operation_ref,
+    )
+
+    controller = _fake_edit_controller(None, metadata_uid=None)
+    deletable, reason = controller.can_delete_row(row)
+    assert not deletable
+    assert reason
+
+    source_child = _fake_edit_node(
+        provenance.full_data(provenance.AverageOperation(dims=("x",))),
+        parent_uid="parent",
+        source_spec=provenance.full_data(),
+    )
+    controller = _fake_edit_controller(source_child)
+    deletable, reason = controller.can_delete_row(row)
+    assert not deletable
+    assert reason
+
+    controller = _fake_edit_controller(_fake_edit_node(None))
+    deletable, reason = controller.can_delete_row(row)
+    assert not deletable
+    assert reason
+
+    missing_ref_row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("Missing", None),
+        replay_ref=provenance._ProvenanceStepRef(
+            "operation",
+            operation_index=99,
+            stage_index=0,
+        ),
+    )
+    controller = _fake_edit_controller(
+        _fake_edit_node(provenance.full_data(provenance.AverageOperation(dims=("x",))))
+    )
+    deletable, reason = controller.can_delete_row(missing_ref_row)
+    assert not deletable
+    assert reason
+
+    broken_script_spec = types.SimpleNamespace(
+        kind="script",
+        _operation_for_ref=lambda _ref: provenance.ScriptCodeOperation(
+            label="Broken",
+            code="derived = data",
+        ),
+        _replace_operation_ref=lambda *_args: (_ for _ in ()).throw(
+            ValueError("bad ref")
+        ),
+    )
+    controller = _fake_edit_controller(
+        _fake_edit_node(typing.cast("typing.Any", broken_script_spec))
+    )
+    deletable, reason = controller.can_delete_row(row)
+    assert not deletable
+    assert reason
+
+    source_live_spec = provenance.full_data(provenance.AverageOperation(dims=("x",)))
+    live_row = source_live_spec.display_rows(scope="source")[1]
+    source_bound = _fake_edit_node(
+        provenance.full_data(),
+        parent_uid="parent",
+        source_display_spec=source_live_spec,
+    )
+    controller = _fake_edit_controller(source_bound)
+    deletable, reason = controller.can_delete_row(live_row)
+    assert deletable
+    assert reason == ""
+
+    controller = _fake_edit_controller(_fake_edit_node(source_live_spec))
+    deletable, reason = controller.can_delete_row(source_live_spec.display_rows()[1])
+    assert not deletable
+    assert reason
+
+
+def test_manager_delete_row_error_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("Average", None),
+        replay_ref=provenance._ProvenanceStepRef(
+            "operation",
+            operation_index=0,
+            stage_index=0,
+        ),
+    )
+    node = _fake_edit_node(
+        provenance.full_data(provenance.AverageOperation(dims=("x",)))
+    )
+    controller = _fake_edit_controller(node)
+    monkeypatch.setattr(controller, "can_delete_row", lambda _row: (True, ""))
+
+    failures: list[tuple[str, Exception]] = []
+    monkeypatch.setattr(
+        controller,
+        "_show_failed",
+        lambda title, exc: failures.append((title, exc)),
+    )
+    monkeypatch.setattr(controller, "_display_spec_for_row", lambda *_args: None)
+    controller.delete_row(row)
+    assert failures
+
+    failures.clear()
+    monkeypatch.setattr(
+        controller,
+        "_display_spec_for_row",
+        lambda *_args: provenance.full_data(provenance.AverageOperation(dims=("x",))),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_validate_and_replace",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad replay")),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_handle_missing_source_file",
+        lambda *_args, **_kwargs: False,
+    )
+    controller.delete_row(row)
+    assert failures
+
+    failures.clear()
+    monkeypatch.setattr(
+        controller,
+        "_handle_missing_source_file",
+        lambda *_args, **_kwargs: True,
+    )
+    controller.delete_row(row)
+    assert failures == []
+
+
+def test_manager_delete_provenance_step_preserves_later_operations(
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = _provenance_paste_test_data("scan")
+    file_path = tmp_path / "scan.h5"
+    data.to_netcdf(file_path, engine="h5netcdf")
+    operations = (
+        provenance.AverageOperation(dims=("z",)),
+        provenance.IselOperation(kwargs={"y": 1}),
+    )
+    spec = _manager_replay_file_spec(file_path, *operations)
+    displayed = provenance.replay_file_provenance(spec)
+
+    with manager_context() as manager:
+        tool = _add_file_replay_tool(manager, displayed, spec)
+        index = 0
+
+        select_tools(manager, [index])
+        manager._update_info()
+        select_metadata_rows(manager, [1])
+        row = manager._selected_derivation_row()
+        deletable, reason = manager._provenance_edit_controller.can_delete_row(row)
+        assert deletable, reason
+        menu = manager._build_metadata_derivation_menu()
+        assert menu is not None
+        trigger_menu_action(menu, manager._metadata_delete_step_action)
+
+        expected_spec = spec._replace_operation_ref(
+            provenance._ProvenanceStepRef(
+                "operation",
+                operation_index=0,
+                stage_index=0,
+            ),
+            (),
+        )
+        expected = provenance.replay_file_provenance(expected_spec)
+        xr.testing.assert_identical(tool.slicer_area._data, expected)
+        root = manager._tool_graph.root_wrappers[index]
+        assert root.provenance_spec == expected_spec
+        assert metadata_derivation_texts(manager) == [
+            f"Load data from file {file_path.name!r}",
+            operations[1].derivation_entry().label,
+        ]
+
+
+def test_manager_delete_invalid_script_step_rolls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = _provenance_paste_test_data("scan")
+    operations = (
+        provenance.ScriptCodeOperation(
+            label="Create result",
+            code="result = derived + 1.0",
+        ),
+        provenance.ScriptCodeOperation(
+            label="Use result",
+            code="result = result * 2.0",
+        ),
+    )
+    spec = provenance.script(
+        *operations,
+        start_label="Start from data",
+        seed_code="derived = data",
+        active_name="result",
+    )
+    displayed = provenance.replay_script_provenance(spec, {"data": data})
+
+    with manager_context() as manager:
+        tool = itool(displayed, manager=False, execute=False)
+        assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+        index = manager.add_imagetool(tool, show=False, provenance_spec=spec)
+
+        select_tools(manager, [index])
+        manager._update_info()
+        select_metadata_rows(manager, [1])
+        row = manager._selected_derivation_row()
+        deletable, reason = manager._provenance_edit_controller.can_delete_row(row)
+        assert not deletable
+        assert reason
+
+        unavailable: list[str] = []
+        monkeypatch.setattr(
+            manager._provenance_edit_controller,
+            "_show_unavailable",
+            unavailable.append,
+        )
+        before = tool.slicer_area._data.copy(deep=True)
+        before_spec = manager._tool_graph.root_wrappers[index].provenance_spec
+        manager._delete_selected_derivation_step()
+
+        assert unavailable
+        xr.testing.assert_identical(tool.slicer_area._data, before)
+        assert manager._tool_graph.root_wrappers[index].provenance_spec == before_spec
+
+
 def test_manager_copy_paste_structured_provenance_steps(
     qtbot,
     monkeypatch: pytest.MonkeyPatch,
@@ -6602,6 +6888,16 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
         xr.testing.assert_identical(child_tool.slicer_area._data, expected)
         assert child_node.source_spec is None
         assert child_node.source_auto_update is False
+        pasted_code = child_node.displayed_provenance_spec.derivation_code()
+        source_code = script_spec.derivation_code()
+        assert pasted_code is not None
+        assert source_code is not None
+        assert pasted_code.splitlines()[-2:] == source_code.splitlines()[-2:]
+        derivation = metadata_derivation_texts(manager)
+        assert script_operations[0].derivation_entry().label in derivation
+        assert script_operations[1].derivation_entry().label in derivation
+        assert not any("Paste provenance steps" in label for label in derivation)
+        assert not any("derived = data" in label for label in derivation)
 
         bad_operation = provenance.ScriptCodeOperation(
             label="Use unavailable scratch value",
@@ -6634,6 +6930,7 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
             lambda title, exc, **kwargs: failures.append((title, exc, kwargs)),
         )
         before = child_tool.slicer_area._data.copy(deep=True)
+        before_spec = child_node.provenance_spec
         manager.tree_view.clearSelection()
         select_child_tool(manager, child_uid)
         manager._update_info()
@@ -6649,6 +6946,7 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
         )
         assert "Revert to This Step" not in failures[0][2]["unchanged_reason"]
         xr.testing.assert_identical(child_tool.slicer_area._data, before)
+        assert child_node.provenance_spec == before_spec
         assert child_node.source_spec is None
 
 

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1544,6 +1544,7 @@ def test_manager_provenance_file_load_batch_failure_confirmation_dialog(
         dialogs[0]["icon_pixmap"]
         == QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning
     )
+
     assert "RuntimeError" in dialogs[0]["detailed_text"]
     assert "peer failed" in dialogs[0]["detailed_text"]
 
@@ -1633,6 +1634,17 @@ def test_manager_provenance_edit_controller_failed_dialog_uses_message_dialog(
         dialogs[0]["icon_pixmap"]
         == QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning
     )
+
+    controller._show_failed(
+        "Could Not Paste Provenance Steps",
+        failure,
+        text="The copied provenance steps could not be applied.",
+        unchanged_reason="The copied steps could not be replayed.",
+    )
+
+    assert len(dialogs) == 2
+    assert dialogs[1]["text"] == "The copied provenance steps could not be applied."
+    assert "The copied steps could not be replayed." in dialogs[1]["informative_text"]
 
 
 @pytest.mark.parametrize(
@@ -6050,6 +6062,288 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
         assert manager._build_metadata_derivation_menu() is None
 
 
+def test_manager_provenance_step_clipboard_payload_validation() -> None:
+    operation_payload = provenance.AverageOperation(dims=("z",)).model_dump(mode="json")
+    valid_payload = {
+        "type": manager_details_panel._PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_TYPE,
+        "version": manager_details_panel._PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_VERSION,
+        "operations": [operation_payload],
+    }
+
+    mime_data = QtCore.QMimeData()
+    mime_data.setData(
+        manager_details_panel._PROVENANCE_STEPS_CLIPBOARD_MIME,
+        json.dumps(valid_payload).encode("utf-8"),
+    )
+    payload = manager_details_panel._provenance_step_clipboard_payload(mime_data)
+    assert payload is not None
+    assert payload[0] == (provenance.AverageOperation(dims=("z",)),)
+    assert payload[1] == "derived"
+    assert not payload[2]
+
+    text_mime_data = QtCore.QMimeData()
+    text_mime_data.setText(json.dumps({**valid_payload, "active_name": "result"}))
+    payload = manager_details_panel._provenance_step_clipboard_payload(text_mime_data)
+    assert payload is not None
+    assert payload[1] == "result"
+
+    plain_text_mime_data = QtCore.QMimeData()
+    plain_text_mime_data.setText("derived = data")
+    assert (
+        manager_details_panel._provenance_step_clipboard_payload(plain_text_mime_data)
+        is None
+    )
+    assert (
+        manager_details_panel._provenance_step_clipboard_payload(QtCore.QMimeData())
+        is None
+    )
+
+    invalid_utf8_mime_data = QtCore.QMimeData()
+    invalid_utf8_mime_data.setData(
+        manager_details_panel._PROVENANCE_STEPS_CLIPBOARD_MIME,
+        b"\xff",
+    )
+    assert (
+        manager_details_panel._provenance_step_clipboard_payload(invalid_utf8_mime_data)
+        is None
+    )
+
+    for malformed_payload in (
+        [],
+        {**valid_payload, "type": "other"},
+        {**valid_payload, "version": -1},
+        {**valid_payload, "operations": {}},
+        {**valid_payload, "operations": [{"op": "unknown"}]},
+    ):
+        malformed_mime_data = QtCore.QMimeData()
+        malformed_mime_data.setData(
+            manager_details_panel._PROVENANCE_STEPS_CLIPBOARD_MIME,
+            json.dumps(malformed_payload).encode("utf-8"),
+        )
+        assert (
+            manager_details_panel._provenance_step_clipboard_payload(
+                malformed_mime_data
+            )
+            is None
+        )
+
+
+def test_manager_selected_derivation_step_payload_filters_rows() -> None:
+    def item(
+        row: provenance._ProvenanceDisplayRow | str,
+        *,
+        copyable: bool = True,
+        code: str | None = "derived = data",
+    ) -> QtWidgets.QListWidgetItem:
+        list_item = QtWidgets.QListWidgetItem()
+        list_item.setData(manager_details_panel._METADATA_DERIVATION_ROW_ROLE, row)
+        list_item.setData(
+            manager_details_panel._METADATA_DERIVATION_COPYABLE_ROLE,
+            copyable,
+        )
+        list_item.setData(manager_details_panel._METADATA_DERIVATION_CODE_ROLE, code)
+        return list_item
+
+    operation_ref = provenance._ProvenanceStepRef("operation", operation_index=0)
+    script_row_a = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("script a", None),
+        replay_ref=operation_ref,
+    )
+    script_row_b = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("script b", None),
+        replay_ref=operation_ref,
+    )
+    missing_operation_row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("missing op", None),
+        replay_ref=provenance._ProvenanceStepRef(
+            "operation",
+            operation_index=10,
+        ),
+    )
+    non_copyable_script_row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("non-copyable script", None),
+        replay_ref=operation_ref,
+    )
+    non_live_row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("non-live", None),
+        replay_ref=operation_ref,
+    )
+    row_to_spec = {
+        script_row_a: provenance.script(
+            provenance.ScriptCodeOperation(label="script a", code="a = data"),
+            start_label="Start script a",
+            active_name="a",
+        ),
+        script_row_b: provenance.script(
+            provenance.ScriptCodeOperation(label="script b", code="b = data"),
+            start_label="Start script b",
+            active_name="b",
+        ),
+        missing_operation_row: provenance.full_data(
+            provenance.AverageOperation(dims=("x",))
+        ),
+        non_copyable_script_row: types.SimpleNamespace(
+            _operation_for_ref=lambda _ref: provenance.ScriptCodeOperation(
+                label="hidden script",
+                code="derived = data",
+                copyable=False,
+            )
+        ),
+        non_live_row: types.SimpleNamespace(
+            _operation_for_ref=lambda _ref: types.SimpleNamespace(live_applicable=False)
+        ),
+    }
+    edit_controller = types.SimpleNamespace(
+        _display_spec_for_row=lambda _node, row: row_to_spec.get(row)
+    )
+    selected_items: list[QtWidgets.QListWidgetItem] = []
+    manager = types.SimpleNamespace(
+        _metadata_node_uid="node",
+        _tool_graph=types.SimpleNamespace(nodes={"node": object()}),
+        _selected_derivation_items=lambda: selected_items,
+        _provenance_edit_controller=edit_controller,
+    )
+    controller = manager_details_panel._DetailsPanelController(
+        typing.cast("typing.Any", manager)
+    )
+
+    manager._metadata_node_uid = None
+    assert controller._selected_derivation_step_payload() is None
+
+    manager._metadata_node_uid = "missing"
+    assert controller._selected_derivation_step_payload() is None
+
+    manager._metadata_node_uid = "node"
+    selected_items = [
+        item("not a row"),
+        item(
+            provenance._ProvenanceDisplayRow(provenance.DerivationEntry("start", None))
+        ),
+        item(
+            provenance._ProvenanceDisplayRow(
+                provenance.DerivationEntry("file", None),
+                replay_ref=provenance._ProvenanceStepRef("file_load"),
+            )
+        ),
+        item(script_row_a, copyable=False),
+        item(script_row_a, code=None),
+        item(
+            provenance._ProvenanceDisplayRow(
+                provenance.DerivationEntry("no spec", None),
+                replay_ref=operation_ref,
+            )
+        ),
+        item(missing_operation_row),
+        item(non_copyable_script_row),
+        item(non_live_row),
+    ]
+    assert controller._selected_derivation_step_payload() is None
+
+    selected_items = [item(script_row_a), item(script_row_b)]
+    assert controller._selected_derivation_step_payload() is None
+
+
+def test_manager_copy_selected_derivation_code_fallbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = types.SimpleNamespace(_selected_derivation_code=lambda: "derived = data")
+    controller = manager_details_panel._DetailsPanelController(
+        typing.cast("typing.Any", manager)
+    )
+
+    copied: list[str] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "copy_to_clipboard",
+        lambda text: copied.append(text) or text,
+    )
+    monkeypatch.setattr(
+        controller,
+        "_selected_derivation_step_payload",
+        lambda: None,
+    )
+    controller._copy_selected_derivation_code()
+    assert copied == ["derived = data"]
+
+    monkeypatch.setattr(
+        controller,
+        "_selected_derivation_step_payload",
+        lambda: ((provenance.AverageOperation(dims=("x",)),), "derived", False),
+    )
+    monkeypatch.setattr(QtWidgets.QApplication, "clipboard", lambda: None)
+    controller._copy_selected_derivation_code()
+
+
+def test_manager_paste_steps_validation_error_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _fake_edit_controller(None, metadata_uid=None)
+    unavailable: list[str] = []
+    monkeypatch.setattr(controller, "_show_unavailable", unavailable.append)
+    controller.paste_steps(
+        (provenance.AverageOperation(dims=("x",)),),
+        active_name="derived",
+        contains_script=False,
+    )
+    assert unavailable
+
+    node = _fake_edit_node(
+        provenance.full_data(),
+        parent_uid="parent",
+        source_display_spec=provenance.full_data(),
+    )
+    with pytest.raises(TypeError, match="Only live provenance operations"):
+        controller._paste_structured_steps(
+            node,
+            (provenance.ScriptCodeOperation(label="script", code="derived = data"),),
+        )
+
+    monkeypatch.setattr(
+        controller,
+        "_replay_candidate_result",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad replay")),
+    )
+    with pytest.raises(manager_provenance_edit._ProvenanceReplayFailure) as exc_info:
+        controller._paste_structured_steps(
+            node,
+            (provenance.AverageOperation(dims=("x",)),),
+        )
+    assert "pasted provenance steps" in exc_info.value.where
+
+
+def test_manager_paste_detached_steps_uses_replay_spec_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _provenance_paste_test_data()
+    local = provenance.full_data(provenance.AverageOperation(dims=("z",)))
+    controller = _fake_edit_controller(None, metadata_uid=None)
+    replaced: list[tuple[xr.DataArray, provenance.ToolProvenanceSpec, bool]] = []
+    node = types.SimpleNamespace(
+        uid="node",
+        displayed_provenance_spec=provenance.full_data(),
+        current_source_data=lambda: data,
+        replace_with_detached_data=lambda data, spec, preserve_filter: replaced.append(
+            (data, spec, preserve_filter)
+        ),
+    )
+    monkeypatch.setattr(
+        provenance,
+        "compose_full_provenance",
+        lambda _parent, _local: None,
+    )
+
+    controller._paste_detached_steps(
+        typing.cast("typing.Any", node),
+        local,
+        where="testing fallback",
+    )
+
+    assert len(replaced) == 1
+    xr.testing.assert_identical(replaced[0][0], local.apply(data))
+    assert replaced[0][1] == local.to_replay_spec()
+    assert replaced[0][2] is False
+
+
 def test_manager_copy_paste_structured_provenance_steps(
     qtbot,
     monkeypatch: pytest.MonkeyPatch,
@@ -6333,11 +6627,11 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
         select_metadata_rows(manager, [1])
         manager._copy_selected_derivation_code()
 
-        failures: list[tuple[str, Exception]] = []
+        failures: list[tuple[str, Exception, dict[str, str]]] = []
         monkeypatch.setattr(
             manager._provenance_edit_controller,
             "_show_failed",
-            lambda title, exc: failures.append((title, exc)),
+            lambda title, exc, **kwargs: failures.append((title, exc, kwargs)),
         )
         before = child_tool.slicer_area._data.copy(deep=True)
         manager.tree_view.clearSelection()
@@ -6347,6 +6641,13 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
 
         assert failures
         assert failures[0][0] == "Could Not Paste Provenance Steps"
+        assert failures[0][2]["text"] == (
+            "The copied provenance steps could not be applied."
+        )
+        assert (
+            "dimensions, coordinates, and inputs" in failures[0][2]["unchanged_reason"]
+        )
+        assert "Revert to This Step" not in failures[0][2]["unchanged_reason"]
         xr.testing.assert_identical(child_tool.slicer_area._data, before)
         assert child_node.source_spec is None
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -2125,6 +2125,259 @@ def test_tool_provenance_compose_full_uses_parent_active_name_for_live_local() -
     xr.testing.assert_identical(derived, (data + 1).qsel.mean("x"))
 
 
+def test_tool_provenance_script_context_binding_replays_current_output() -> None:
+    data = _base_data()
+    parent = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Compute intermediate result",
+            code="result = derived + 1",
+        ),
+        start_label="Start from current tool input data",
+        seed_code="derived = data",
+        active_name="result",
+    )
+    local = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Offset copied result",
+            code="result = derived + 2",
+        ),
+        start_label="Start from current ImageTool data",
+        active_name="result",
+    )
+    current = provenance.replay_script_provenance(parent, {"data": data})
+    expected = provenance.replay_script_provenance(
+        local,
+        {"data": current, "derived": current},
+    )
+
+    composed = provenance.compose_full_provenance(
+        parent,
+        local,
+        script_context_names=("data", "derived", "data"),
+    )
+
+    assert composed is not None
+    assert [entry.label for entry in composed.derivation_entries()] == [
+        "Start from current tool input data",
+        "Compute intermediate result",
+        "Offset copied result",
+    ]
+    assert [
+        operation.derivation_entry().label for operation in composed.operations
+    ] == [
+        "Compute intermediate result",
+        "Offset copied result",
+    ]
+    assert [
+        binding.model_dump(mode="json") for binding in composed.script_context_bindings
+    ] == [{"operation_index": 1, "names": ["data", "derived"]}]
+
+    replayed = provenance.replay_script_provenance(composed, {"data": data})
+    xr.testing.assert_identical(replayed, expected)
+    code = typing.cast("str", composed.derivation_code())
+    assert "Start from current ImageTool data" not in code
+    assert "derived = derived" not in code
+    namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
+    result = namespace["result"]
+    assert isinstance(result, xr.DataArray)
+    xr.testing.assert_identical(result, expected)
+
+
+def test_tool_provenance_script_context_binding_validation() -> None:
+    operation = provenance.ScriptCodeOperation(
+        label="Offset copied result",
+        code="result = derived + 2",
+    )
+
+    spec = provenance.ToolProvenanceSpec(
+        kind="script",
+        start_label="Run script",
+        seed_code="derived = data",
+        active_name="result",
+        operations=(operation,),
+        script_context_bindings=[
+            {"operation_index": 0, "names": ["data", "derived", "data"]},
+        ],
+    )
+    assert [
+        binding.model_dump(mode="json") for binding in spec.script_context_bindings
+    ] == [{"operation_index": 0, "names": ["data", "derived"]}]
+    assert (
+        provenance.ToolProvenanceSpec(
+            kind="script",
+            start_label="Run script",
+            active_name="result",
+            operations=(operation,),
+            script_context_bindings=None,
+        ).script_context_bindings
+        == ()
+    )
+
+    invalid_payloads: tuple[tuple[typing.Any, type[BaseException], str], ...] = (
+        (
+            [{"operation_index": True, "names": ["data"]}],
+            TypeError,
+            "operation index",
+        ),
+        (
+            [{"operation_index": -1, "names": ["data"]}],
+            ValidationError,
+            "non-negative",
+        ),
+        (
+            [{"operation_index": 0, "names": "data"}],
+            TypeError,
+            "names must be a sequence",
+        ),
+        (
+            [{"operation_index": 0, "names": [None]}],
+            ValidationError,
+            "must not be None",
+        ),
+        (
+            [{"operation_index": 0, "names": []}],
+            ValidationError,
+            "must not be empty",
+        ),
+        ("bad", TypeError, "must be a sequence"),
+    )
+    for bindings, exc_type, message in invalid_payloads:
+        with pytest.raises(exc_type, match=message):
+            provenance.ToolProvenanceSpec(
+                kind="script",
+                start_label="Run script",
+                active_name="result",
+                operations=(operation,),
+                script_context_bindings=bindings,
+            )
+
+    with pytest.raises(ValidationError, match="operation boundary"):
+        provenance.ToolProvenanceSpec(
+            kind="script",
+            start_label="Run script",
+            active_name="result",
+            operations=(operation,),
+            script_context_bindings=[
+                {"operation_index": 1, "names": ["data"]},
+            ],
+        )
+    with pytest.raises(ValidationError, match="file provenance specs"):
+        provenance.ToolProvenanceSpec(
+            kind="file",
+            start_label="Load source",
+            seed_code="derived = data",
+            active_name="derived",
+            file_load_source=_file_replay_source(),
+            script_context_bindings=[
+                {"operation_index": 0, "names": ["data"]},
+            ],
+        )
+    with pytest.raises(ValidationError, match="Only script or file provenance specs"):
+        provenance.ToolProvenanceSpec(
+            kind="full_data",
+            script_context_bindings=[
+                {"operation_index": 0, "names": ["data"]},
+            ],
+        )
+
+
+def test_tool_provenance_script_context_bindings_follow_operation_edits() -> None:
+    first = provenance.ScriptCodeOperation(
+        label="Compute intermediate result",
+        code="result = derived + 1",
+    )
+    second = provenance.ScriptCodeOperation(
+        label="Offset copied result",
+        code="result = derived + 2",
+    )
+    average = provenance.AverageOperation(dims=("x",))
+    spec = provenance.ToolProvenanceSpec(
+        kind="script",
+        start_label="Run script",
+        seed_code="derived = data",
+        active_name="result",
+        operations=(first, second, average),
+        script_context_bindings=[
+            {"operation_index": 1, "names": ["data", "derived"]},
+            {"operation_index": 2, "names": ["data"]},
+        ],
+    )
+
+    def binding_payloads(
+        value: provenance.ToolProvenanceSpec,
+    ) -> list[dict[str, typing.Any]]:
+        return [
+            binding.model_dump(mode="json") for binding in value.script_context_bindings
+        ]
+
+    expanded = spec._replace_operation_ref(
+        provenance._ProvenanceStepRef("operation", operation_index=0),
+        (first, provenance.SqueezeOperation()),
+    )
+    assert binding_payloads(expanded) == [
+        {"operation_index": 2, "names": ["data", "derived"]},
+        {"operation_index": 3, "names": ["data"]},
+    ]
+
+    deleted_last = spec._replace_operation_ref(
+        provenance._ProvenanceStepRef("operation", operation_index=2),
+        (),
+    )
+    assert binding_payloads(deleted_last) == [
+        {"operation_index": 1, "names": ["data", "derived"]},
+    ]
+
+    through_second = spec._prefix_through_ref(
+        provenance._ProvenanceStepRef("operation", operation_index=1)
+    )
+    assert binding_payloads(through_second) == [
+        {"operation_index": 1, "names": ["data", "derived"]},
+    ]
+    before_second = spec._prefix_before_ref(
+        provenance._ProvenanceStepRef("operation", operation_index=1)
+    )
+    assert binding_payloads(before_second) == []
+    start_only = spec._prefix_through_ref(provenance._ProvenanceStepRef("start"))
+    assert start_only.operations == ()
+    assert start_only.script_context_bindings == ()
+
+
+def test_tool_provenance_script_context_names_are_validation_only() -> None:
+    parent = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Compute intermediate result",
+            code="result = derived + 1",
+        ),
+        start_label="Start from current tool input data",
+        seed_code="derived = data",
+        active_name="result",
+    )
+    local_script = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Offset copied result",
+            code="result = derived + 2",
+        ),
+        start_label="Run pasted script",
+        active_name="result",
+    )
+    local_structured = provenance.full_data(provenance.AverageOperation(dims=("x",)))
+
+    with pytest.raises(ValueError, match="script context names"):
+        provenance.compose_full_provenance(
+            parent,
+            local_script,
+            script_context_names=(typing.cast("str", None),),
+        )
+    composed = provenance.compose_full_provenance(
+        parent,
+        local_structured,
+        script_context_names=("data", "derived"),
+    )
+
+    assert composed is not None
+    assert composed.script_context_bindings == ()
+
+
 def test_file_load_source_replay_call_round_trips() -> None:
 
     xarray_source = provenance.FileLoadSource(

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -203,6 +203,80 @@ class Child(Base, metaclass=data_5):
     assert not _replay_graph.script_provenance_replayable(None)
 
 
+def test_replay_graph_script_context_binding_error_paths() -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+    invalid_context = provenance.ToolProvenanceSpec(
+        kind="script",
+        start_label="Run script",
+        active_name="result",
+        operations=(
+            provenance.ScriptCodeOperation(
+                label="Use pasted context",
+                code="result = data + 1",
+            ),
+        ),
+        script_context_bindings=[
+            {"operation_index": 0, "names": ["data"]},
+        ],
+    )
+
+    with pytest.raises(_replay_graph.ReplayGraphError, match="no replay code"):
+        _replay_graph._validate_script_provenance(invalid_context)
+
+    rebound_input = provenance.ToolProvenanceSpec(
+        kind="script",
+        start_label="Run script",
+        active_name="data_0",
+        script_inputs=(provenance.ScriptInput(name="data_0", label="Input"),),
+        operations=(
+            provenance.ScriptCodeOperation(
+                label="Offset rebound input",
+                code="data_0 = derived + 1",
+            ),
+        ),
+        script_context_bindings=[
+            {"operation_index": 0, "names": ["derived"]},
+        ],
+    )
+    rebound_graph = _replay_graph.compile_replay_graph(
+        rebound_input,
+        external_inputs={"data_0": data},
+    )
+    rebound_display_graph = _replay_graph.compile_replay_graph(
+        rebound_input,
+        display=True,
+        external_inputs={"data_0": data},
+    )
+    xr.testing.assert_identical(
+        _replay_graph.execute_replay_graph(rebound_graph),
+        data + 1,
+    )
+    assert rebound_display_graph.output_key is not None
+
+    active_relay = provenance.ToolProvenanceSpec(
+        kind="script",
+        start_label="Run script",
+        seed_code="result = data",
+        active_name="result",
+        operations=(
+            provenance.ScriptCodeOperation(
+                label="Write alternate output",
+                code="derived = result + 1",
+            ),
+        ),
+    )
+    active_graph = _replay_graph.compile_replay_graph(
+        active_relay,
+        external_inputs={"data": data},
+    )
+
+    xr.testing.assert_identical(
+        _replay_graph.execute_replay_graph(active_graph),
+        data,
+    )
+    assert _replay_graph._remove_noop_assignments("derived =") == "derived ="
+
+
 def test_replay_graph_manual_error_and_cache_paths() -> None:
     data = xr.DataArray(np.arange(3.0), dims=("x",))
 


### PR DESCRIPTION
## Summary
- Add a Paste Steps action and keyboard shortcut handling in the ImageTool manager details panel
- Preserve copied provenance step payloads on the clipboard so selected steps can be pasted into another ImageTool
- Support pasting structured steps into bound tools and detached script-based steps with rollback on failure
- Update the manager user guide to describe the new copy/paste flow
- Add tests for structured paste, source-binding preservation, and detached/script failure handling

## Testing
- Added unit and UI-style manager tests covering copy, paste, and error paths
- Not run (not requested)