### PR TITLE
fix(manager): stabilize Qt lifetime during compatibility tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,25 +52,25 @@ jobs:
             use-xdist: true
           - group: "cov-io"
             timeout-minutes: 25
-            use-xdist: false
+            use-xdist: true
           - group: "cov-qt-imagetool"
             timeout-minutes: 30
-            use-xdist: false
+            use-xdist: true
           - group: "cov-qt-manager-mainwindow"
             timeout-minutes: 25
-            use-xdist: false
+            use-xdist: true
           - group: "cov-qt-manager-workspace"
             timeout-minutes: 25
-            use-xdist: false
+            use-xdist: true
           - group: "cov-qt-manager-provenance-console"
             timeout-minutes: 30
-            use-xdist: false
+            use-xdist: true
           - group: "cov-qt-tools"
             timeout-minutes: 25
-            use-xdist: false
+            use-xdist: true
           - group: "cov-qt-ux"
             timeout-minutes: 25
-            use-xdist: false
+            use-xdist: true
     steps:
       - uses: actions/checkout@v6
         with:
@@ -193,6 +193,8 @@ jobs:
           PYTEST_QT_API=${{ matrix.qt-api }} QT_API=${{ matrix.qt-api }} \
             uv run pytest \
             -m compat \
+            -n auto \
+            --dist=worksteal \
             -o faulthandler_timeout=300 \
             --junitxml "junit-smoke-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
             -o junit_family=legacy \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             -o junit_family=legacy
           )
           if [[ "${{ matrix.use-xdist }}" == "true" ]]; then
-            pytest_args+=(-n auto --dist=worksteal)
+            pytest_args+=(-n auto --dist=loadgroup)
           fi
           uv run pytest "${pytest_args[@]}" "${targets[@]}"
 
@@ -194,7 +194,7 @@ jobs:
             uv run pytest \
             -m compat \
             -n auto \
-            --dist=worksteal \
+            --dist=loadgroup \
             -o faulthandler_timeout=300 \
             --junitxml "junit-smoke-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
             -o junit_family=legacy \

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -122,7 +122,7 @@ jobs:
             uv run pytest \
             -v \
             -n auto \
-            --dist=worksteal \
+            --dist=loadgroup \
             -o faulthandler_timeout=300 \
             --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
             -o junit_family=legacy

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -15,10 +15,63 @@ permissions:
 
 env:
   FORCE_COLOR: 1
+  ERLAB_TEST_DATA_COMMIT: a90b37654184b9bf3378b032646c9c5b6231a0fa
+  ERLAB_TEST_DATA_ARCHIVE_SHA256: de72bfef9cedea535e5502fe55903c526ca500ef1575cd3c63e0aae3f4fb77be
+  ERLAB_TEST_DATA_CACHE_DIR: /home/runner/.cache/erlabpy
+  ERLAB_TEST_DATA_DIR: /home/runner/.cache/erlabpy/kmnhan-erlabpy-data-a90b376
 
 jobs:
+  test-data-cache:
+    name: Cache Test Data
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore test data cache
+        id: restore-test-data
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.ERLAB_TEST_DATA_CACHE_DIR }}
+          key: erlabpy-data-${{ env.ERLAB_TEST_DATA_COMMIT }}
+
+      - name: Populate test data cache
+        if: steps.restore-test-data.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/erlabpy-data.tar.gz"
+          curl \
+            --fail \
+            --location \
+            --retry 4 \
+            --retry-all-errors \
+            --retry-delay 5 \
+            "https://codeload.github.com/kmnhan/erlabpy-data/legacy.tar.gz/${ERLAB_TEST_DATA_COMMIT}" \
+            --output "$archive"
+          echo "${ERLAB_TEST_DATA_ARCHIVE_SHA256}  ${archive}" | sha256sum --check
+          mkdir -p "$ERLAB_TEST_DATA_CACHE_DIR"
+          rm -rf "$ERLAB_TEST_DATA_DIR"
+          tar -xzf "$archive" -C "$ERLAB_TEST_DATA_CACHE_DIR"
+          test -d "$ERLAB_TEST_DATA_DIR/da30"
+          test -d "$ERLAB_TEST_DATA_DIR/erpes"
+          test -d "$ERLAB_TEST_DATA_DIR/merlin"
+
+      - name: Save test data cache
+        if: steps.restore-test-data.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.ERLAB_TEST_DATA_CACHE_DIR }}
+          key: erlabpy-data-${{ env.ERLAB_TEST_DATA_COMMIT }}
+
+      - name: Verify test data cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d "$ERLAB_TEST_DATA_DIR/da30"
+          test -d "$ERLAB_TEST_DATA_DIR/erpes"
+          test -d "$ERLAB_TEST_DATA_DIR/merlin"
+
   compat:
     name: Compat Python ${{ matrix.python-version }} [${{ matrix.qt-api }}]
+    needs: test-data-cache
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -47,6 +100,21 @@ jobs:
 
       - name: Install project with upgraded dependencies
         run: uv sync --all-extras --dev --group ${{ matrix.qt-api }} --upgrade
+
+      - name: Restore test data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.ERLAB_TEST_DATA_CACHE_DIR }}
+          key: erlabpy-data-${{ env.ERLAB_TEST_DATA_COMMIT }}
+          fail-on-cache-miss: true
+
+      - name: Verify test data cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d "$ERLAB_TEST_DATA_DIR/da30"
+          test -d "$ERLAB_TEST_DATA_DIR/erpes"
+          test -d "$ERLAB_TEST_DATA_DIR/merlin"
 
       - name: Run compatibility suite
         run: |

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -117,20 +117,32 @@ jobs:
           test -d "$ERLAB_TEST_DATA_DIR/merlin"
 
       - name: Run compatibility suite
+        shell: bash
+        env:
+          PYTEST_QT_API: ${{ matrix.qt-api }}
+          QT_API: ${{ matrix.qt-api }}
         run: |
-          PYTEST_QT_API=${{ matrix.qt-api }} QT_API=${{ matrix.qt-api }} \
-            uv run pytest \
-            -v \
+          set -euo pipefail
+          common_args=(
+            -v
+            -o faulthandler_timeout=300
+            -o junit_family=legacy
+          )
+          uv run pytest \
+            "${common_args[@]}" \
+            -m "not serial" \
             -n auto \
             --dist=loadgroup \
-            -o faulthandler_timeout=300 \
-            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
-            -o junit_family=legacy
+            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-parallel.xml"
+          uv run pytest \
+            "${common_args[@]}" \
+            -m serial \
+            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-serial.xml"
 
       - name: Upload compatibility JUnit artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: compat-${{ matrix.python-version }}-${{ matrix.qt-api }}
-          path: junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml
+          path: junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-*.xml
           if-no-files-found: error

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -127,17 +127,22 @@ jobs:
             -v
             -o faulthandler_timeout=300
             -o junit_family=legacy
+            -n auto
+            --dist=loadgroup
           )
           uv run pytest \
             "${common_args[@]}" \
-            -n auto \
-            --dist=loadgroup \
-            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml"
+            -m "not gui" \
+            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-non-gui.xml"
+          uv run pytest \
+            "${common_args[@]}" \
+            -m gui \
+            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-gui.xml"
 
       - name: Upload compatibility JUnit artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: compat-${{ matrix.python-version }}-${{ matrix.qt-api }}
-          path: junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml
+          path: junit-${{ matrix.python-version }}-${{ matrix.qt-api }}*.xml
           if-no-files-found: error

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Restore test data cache
         id: restore-test-data
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.ERLAB_TEST_DATA_CACHE_DIR }}
           key: erlabpy-data-${{ env.ERLAB_TEST_DATA_COMMIT }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Save test data cache
         if: steps.restore-test-data.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.ERLAB_TEST_DATA_CACHE_DIR }}
           key: erlabpy-data-${{ env.ERLAB_TEST_DATA_COMMIT }}
@@ -102,7 +102,7 @@ jobs:
         run: uv sync --all-extras --dev --group ${{ matrix.qt-api }} --upgrade
 
       - name: Restore test data cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.ERLAB_TEST_DATA_CACHE_DIR }}
           key: erlabpy-data-${{ env.ERLAB_TEST_DATA_COMMIT }}
@@ -130,19 +130,14 @@ jobs:
           )
           uv run pytest \
             "${common_args[@]}" \
-            -m "not serial" \
             -n auto \
             --dist=loadgroup \
-            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-parallel.xml"
-          uv run pytest \
-            "${common_args[@]}" \
-            -m serial \
-            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-serial.xml"
+            --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml"
 
       - name: Upload compatibility JUnit artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: compat-${{ matrix.python-version }}-${{ matrix.qt-api }}
-          path: junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-*.xml
+          path: junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml
           if-no-files-found: error

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -7,8 +7,8 @@ on:
     - cron: "0 22 * * FRI"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
@@ -53,6 +53,8 @@ jobs:
           PYTEST_QT_API=${{ matrix.qt-api }} QT_API=${{ matrix.qt-api }} \
             uv run pytest \
             -v \
+            -n auto \
+            --dist=worksteal \
             -o faulthandler_timeout=300 \
             --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
             -o junit_family=legacy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,7 @@ qt_log_ignore = [
 markers = [
     "compat: compatibility smoke tests for non-primary CI lanes",
     "gui: tests that require Qt or GUI-related infrastructure",
-    "serial: tests that should not be run under pytest-xdist",
+    "serial: tests with legacy process-isolation risk",
 ]
 
 [tool.pytest_env]

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -107,17 +107,25 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
 GUI_PREFIXES: tuple[str, ...] = ("tests/interactive/",)
 GUI_TARGETS: tuple[str, ...] = ()
 
-SERIAL_PREFIXES: tuple[str, ...] = ("tests/interactive/imagetool/",)
-SERIAL_TARGETS: tuple[str, ...] = ()
-SERIAL_NODEIDS: frozenset[str] = frozenset(
-    {
-        "tests/interactive/test_explorer.py::test_explorer_general",
-        (
-            "tests/interactive/test_utils.py::"
-            "test_tool_window_managed_detached_output_preserves_provenance"
-        ),
-    }
+SERIAL_PREFIX_GROUPS: tuple[tuple[str, str], ...] = (
+    ("tests/interactive/imagetool/", "qt"),
 )
+SERIAL_TARGET_GROUPS: dict[str, str] = {
+    "tests/io/plugins/test_erpes.py": "hdf5-cache",
+    "tests/io/plugins/test_maestro.py": "hdf5-cache",
+}
+SERIAL_NODEID_GROUPS: dict[str, str] = {
+    "tests/interactive/test_explorer.py::test_explorer_general": "qt",
+    (
+        "tests/interactive/test_utils.py::"
+        "test_tool_window_managed_detached_output_preserves_provenance"
+    ): "qt",
+}
+SERIAL_PREFIXES: tuple[str, ...] = tuple(
+    prefix for prefix, _group in SERIAL_PREFIX_GROUPS
+)
+SERIAL_TARGETS: tuple[str, ...] = tuple(SERIAL_TARGET_GROUPS)
+SERIAL_NODEIDS: frozenset[str] = frozenset(SERIAL_NODEID_GROUPS)
 
 COMPAT_NODEIDS: frozenset[str] = frozenset(
     target for target in COMPAT_TARGETS if "::" in target
@@ -227,6 +235,17 @@ def is_serial_path(rel_path: str) -> bool:
 
 def is_serial_nodeid(nodeid: str) -> bool:
     return nodeid in SERIAL_NODEIDS
+
+
+def serial_xdist_group(rel_path: str, nodeid: str) -> str | None:
+    if nodeid in SERIAL_NODEID_GROUPS:
+        return SERIAL_NODEID_GROUPS[nodeid]
+    if rel_path in SERIAL_TARGET_GROUPS:
+        return SERIAL_TARGET_GROUPS[rel_path]
+    for prefix, group in SERIAL_PREFIX_GROUPS:
+        if rel_path.startswith(prefix):
+            return group
+    return None
 
 
 def is_compat_path(rel_path: str) -> bool:

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -107,9 +107,8 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
 GUI_PREFIXES: tuple[str, ...] = ("tests/interactive/",)
 GUI_TARGETS: tuple[str, ...] = ()
 
-QT_MANAGER_XDIST_GROUP = "qt-manager"
 SERIAL_PREFIX_GROUPS: tuple[tuple[str, str | None], ...] = (
-    ("tests/interactive/imagetool/manager/", QT_MANAGER_XDIST_GROUP),
+    ("tests/interactive/imagetool/manager/", None),
     ("tests/interactive/imagetool/", None),
 )
 SERIAL_TARGET_GROUPS: dict[str, str] = {
@@ -118,15 +117,15 @@ SERIAL_TARGET_GROUPS: dict[str, str] = {
 }
 SERIAL_NODEID_GROUPS: dict[str, str] = {
     "tests/interactive/test_explorer.py::test_explorer_general": (
-        QT_MANAGER_XDIST_GROUP
+        "qt-tests-interactive-test_explorer"
     ),
     "tests/interactive/imagetool/test_watcher.py::test_watcher_real": (
-        QT_MANAGER_XDIST_GROUP
+        "qt-tests-interactive-imagetool-test_watcher"
     ),
     (
         "tests/interactive/test_utils.py::"
         "test_tool_window_managed_detached_output_preserves_provenance"
-    ): QT_MANAGER_XDIST_GROUP,
+    ): "qt-tests-interactive-test_utils",
 }
 SERIAL_PREFIXES: tuple[str, ...] = tuple(
     prefix for prefix, _group in SERIAL_PREFIX_GROUPS

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -107,9 +107,7 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
 GUI_PREFIXES: tuple[str, ...] = ("tests/interactive/",)
 GUI_TARGETS: tuple[str, ...] = ()
 
-SERIAL_PREFIX_GROUPS: tuple[tuple[str, str], ...] = (
-    ("tests/interactive/imagetool/", "qt"),
-)
+SERIAL_PREFIX_GROUPS: tuple[str, ...] = ("tests/interactive/imagetool/",)
 SERIAL_TARGET_GROUPS: dict[str, str] = {
     "tests/io/plugins/test_erpes.py": "hdf5-cache",
     "tests/io/plugins/test_maestro.py": "hdf5-cache",
@@ -121,9 +119,7 @@ SERIAL_NODEID_GROUPS: dict[str, str] = {
         "test_tool_window_managed_detached_output_preserves_provenance"
     ): "qt",
 }
-SERIAL_PREFIXES: tuple[str, ...] = tuple(
-    prefix for prefix, _group in SERIAL_PREFIX_GROUPS
-)
+SERIAL_PREFIXES: tuple[str, ...] = SERIAL_PREFIX_GROUPS
 SERIAL_TARGETS: tuple[str, ...] = tuple(SERIAL_TARGET_GROUPS)
 SERIAL_NODEIDS: frozenset[str] = frozenset(SERIAL_NODEID_GROUPS)
 
@@ -242,9 +238,9 @@ def serial_xdist_group(rel_path: str, nodeid: str) -> str | None:
         return SERIAL_NODEID_GROUPS[nodeid]
     if rel_path in SERIAL_TARGET_GROUPS:
         return SERIAL_TARGET_GROUPS[rel_path]
-    for prefix, group in SERIAL_PREFIX_GROUPS:
+    for prefix in SERIAL_PREFIX_GROUPS:
         if rel_path.startswith(prefix):
-            return group
+            return f"qt-{rel_path.removesuffix('.py').replace('/', '-')}"
     return None
 
 

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -109,6 +109,15 @@ GUI_TARGETS: tuple[str, ...] = ()
 
 SERIAL_PREFIXES: tuple[str, ...] = ("tests/interactive/imagetool/",)
 SERIAL_TARGETS: tuple[str, ...] = ()
+SERIAL_NODEIDS: frozenset[str] = frozenset(
+    {
+        "tests/interactive/test_explorer.py::test_explorer_general",
+        (
+            "tests/interactive/test_utils.py::"
+            "test_tool_window_managed_detached_output_preserves_provenance"
+        ),
+    }
+)
 
 COMPAT_NODEIDS: frozenset[str] = frozenset(
     target for target in COMPAT_TARGETS if "::" in target
@@ -214,6 +223,10 @@ def is_gui_path(rel_path: str) -> bool:
 
 def is_serial_path(rel_path: str) -> bool:
     return rel_path in SERIAL_TARGETS or rel_path.startswith(SERIAL_PREFIXES)
+
+
+def is_serial_nodeid(nodeid: str) -> bool:
+    return nodeid in SERIAL_NODEIDS
 
 
 def is_compat_path(rel_path: str) -> bool:

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -107,19 +107,30 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
 GUI_PREFIXES: tuple[str, ...] = ("tests/interactive/",)
 GUI_TARGETS: tuple[str, ...] = ()
 
-SERIAL_PREFIX_GROUPS: tuple[str, ...] = ("tests/interactive/imagetool/",)
+QT_MANAGER_XDIST_GROUP = "qt-manager"
+SERIAL_PREFIX_GROUPS: tuple[tuple[str, str | None], ...] = (
+    ("tests/interactive/imagetool/manager/", QT_MANAGER_XDIST_GROUP),
+    ("tests/interactive/imagetool/", None),
+)
 SERIAL_TARGET_GROUPS: dict[str, str] = {
     "tests/io/plugins/test_erpes.py": "hdf5-cache",
     "tests/io/plugins/test_maestro.py": "hdf5-cache",
 }
 SERIAL_NODEID_GROUPS: dict[str, str] = {
-    "tests/interactive/test_explorer.py::test_explorer_general": "qt",
+    "tests/interactive/test_explorer.py::test_explorer_general": (
+        QT_MANAGER_XDIST_GROUP
+    ),
+    "tests/interactive/imagetool/test_watcher.py::test_watcher_real": (
+        QT_MANAGER_XDIST_GROUP
+    ),
     (
         "tests/interactive/test_utils.py::"
         "test_tool_window_managed_detached_output_preserves_provenance"
-    ): "qt",
+    ): QT_MANAGER_XDIST_GROUP,
 }
-SERIAL_PREFIXES: tuple[str, ...] = SERIAL_PREFIX_GROUPS
+SERIAL_PREFIXES: tuple[str, ...] = tuple(
+    prefix for prefix, _group in SERIAL_PREFIX_GROUPS
+)
 SERIAL_TARGETS: tuple[str, ...] = tuple(SERIAL_TARGET_GROUPS)
 SERIAL_NODEIDS: frozenset[str] = frozenset(SERIAL_NODEID_GROUPS)
 
@@ -238,8 +249,10 @@ def serial_xdist_group(rel_path: str, nodeid: str) -> str | None:
         return SERIAL_NODEID_GROUPS[nodeid]
     if rel_path in SERIAL_TARGET_GROUPS:
         return SERIAL_TARGET_GROUPS[rel_path]
-    for prefix in SERIAL_PREFIX_GROUPS:
+    for prefix, group_name in SERIAL_PREFIX_GROUPS:
         if rel_path.startswith(prefix):
+            if group_name is not None:
+                return group_name
             return f"qt-{rel_path.removesuffix('.py').replace('/', '-')}"
     return None
 

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -560,7 +560,10 @@ class _ReprFetcher(QtCore.QRunnable):
             text = erlab.interactive.utils._format_traceback(traceback.format_exc())
         else:
             text = erlab.utils.formatting.format_darr_html(
-                dat, additional_info=[], show_size=self.include_values
+                dat,
+                additional_info=[],
+                show_size=self.include_values,
+                load_values=self.include_values,
             )
             if not self.include_values:
                 dat = None
@@ -904,6 +907,8 @@ class _DataExplorer(QtWidgets.QMainWindow):
         self._loader_kwargs_by_name: dict[str, dict[str, typing.Any]] = {}
         self._loader_extensions_by_name: dict[str, dict[str, typing.Any]] = {}
         self._workspace_state_restoring = False
+        self._preview_threadpool = QtCore.QThreadPool(self)
+        self._preview_threadpool.setExpiryTimeout(0)
 
         self._setup_actions()
         self._setup_ui()
@@ -1279,7 +1284,15 @@ class _DataExplorer(QtWidgets.QMainWindow):
 
     @property
     def _threadpool(self) -> QtCore.QThreadPool:
-        return typing.cast("QtCore.QThreadPool", QtCore.QThreadPool.globalInstance())
+        return self._preview_threadpool
+
+    def _stop_preview_workers(self) -> None:
+        self._preview_threadpool.clear()
+        self._preview_threadpool.waitForDone()
+
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        self._stop_preview_workers()
+        super().closeEvent(event)
 
     @property
     def _current_selection(self) -> list[pathlib.Path]:

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -12,6 +12,7 @@ import os
 import pathlib
 import stat
 import sys
+import threading
 import time
 import traceback
 import typing
@@ -39,6 +40,7 @@ _TRANSLATE_MIME_TYPES = {
     "application/octet-stream": "Unknown",
     "text/csv": "CSV Document",
 }
+_PREVIEW_WORKER_STOP_TIMEOUT_MS = 5000
 
 
 class DataExplorerTabState(pydantic.BaseModel):
@@ -524,6 +526,7 @@ class _DataExplorerTreeView(QtWidgets.QTreeView):
 
 class _ReprFetcherSignals(QtCore.QObject):
     fetched = QtCore.Signal(str, str, object)
+    finished = QtCore.Signal(object)
 
 
 class _ReprFetcher(QtCore.QRunnable):
@@ -545,11 +548,19 @@ class _ReprFetcher(QtCore.QRunnable):
         self.file_path = pathlib.Path(file_path)
         self.load_method = load_method
         self.include_values = include_values
+        self._aborted = threading.Event()
+
+    def abort(self) -> None:
+        self._aborted.set()
 
     @QtCore.Slot()
     def run(self) -> None:
+        if self._aborted.is_set():
+            self.signals.finished.emit(self)
+            return
         file_path = str(self.file_path)
         dat = None
+        text: str | None = None
         try:
             dat = self.load_method(
                 file_path,
@@ -559,6 +570,8 @@ class _ReprFetcher(QtCore.QRunnable):
         except Exception:
             text = erlab.interactive.utils._format_traceback(traceback.format_exc())
         else:
+            if self._aborted.is_set():
+                return
             text = erlab.utils.formatting.format_darr_html(
                 dat,
                 additional_info=[],
@@ -567,7 +580,10 @@ class _ReprFetcher(QtCore.QRunnable):
             )
             if not self.include_values:
                 dat = None
-        self.signals.fetched.emit(file_path, text, dat)
+        finally:
+            if text is not None and not self._aborted.is_set():
+                self.signals.fetched.emit(file_path, text, dat)
+            self.signals.finished.emit(self)
 
 
 class _LoaderInfoModel(QtCore.QAbstractTableModel):
@@ -909,6 +925,8 @@ class _DataExplorer(QtWidgets.QMainWindow):
         self._workspace_state_restoring = False
         self._preview_threadpool = QtCore.QThreadPool(self)
         self._preview_threadpool.setExpiryTimeout(0)
+        self._preview_workers: set[_ReprFetcher] = set()
+        self._preview_stopping = False
 
         self._setup_actions()
         self._setup_ui()
@@ -1286,9 +1304,29 @@ class _DataExplorer(QtWidgets.QMainWindow):
     def _threadpool(self) -> QtCore.QThreadPool:
         return self._preview_threadpool
 
-    def _stop_preview_workers(self) -> None:
+    def _stop_preview_workers(
+        self, timeout_ms: int = _PREVIEW_WORKER_STOP_TIMEOUT_MS
+    ) -> bool:
+        self._preview_stopping = True
+        for worker in tuple(self._preview_workers):
+            worker.abort()
         self._preview_threadpool.clear()
-        self._preview_threadpool.waitForDone()
+        if self._preview_threadpool.waitForDone(timeout_ms):
+            self._preview_workers.clear()
+            return True
+        return False
+
+    def _delete_when_preview_workers_done(self) -> None:
+        self._preview_threadpool.clear()
+        if self._preview_threadpool.activeThreadCount() > 0:
+            erlab.interactive.utils.single_shot(
+                self,
+                100,
+                self._delete_when_preview_workers_done,
+            )
+            return
+        self._preview_workers.clear()
+        self.deleteLater()
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         self._stop_preview_workers()
@@ -1383,6 +1421,8 @@ class _DataExplorer(QtWidgets.QMainWindow):
 
     @QtCore.Slot()
     def _on_selection_changed(self) -> None:
+        if self._preview_stopping:
+            return
         selected_files: list[pathlib.Path] = self._current_selection
         n_sel = len(selected_files)
         self._to_manager_act.setEnabled(n_sel >= 1)
@@ -1398,6 +1438,8 @@ class _DataExplorer(QtWidgets.QMainWindow):
                 include_values=self._preview_check.isChecked(),
             )
             worker.signals.fetched.connect(self._show_file_info)
+            worker.signals.finished.connect(self._preview_worker_finished)
+            self._preview_workers.add(worker)
             self._threadpool.start(worker)
 
         else:
@@ -1410,14 +1452,21 @@ class _DataExplorer(QtWidgets.QMainWindow):
 
     @QtCore.Slot()
     def _show_loading_text_if_needed(self) -> None:
-        if not self._up_to_date:
+        if not self._preview_stopping and not self._up_to_date:
             self._preview.setVisible(False)
             self._text_edit.setText(self.TEXT_LOADING)
+
+    @QtCore.Slot(object)
+    def _preview_worker_finished(self, worker: object) -> None:
+        if isinstance(worker, _ReprFetcher):
+            self._preview_workers.discard(worker)
 
     @QtCore.Slot(str, str, object)
     def _show_file_info(
         self, file_path: str, text: str, data: xr.DataArray | None
     ) -> None:
+        if self._preview_stopping or not erlab.interactive.utils.qt_is_valid(self):
+            return
         selected_files: list[pathlib.Path] = self._current_selection
         if len(selected_files) == 1 and selected_files[0] == pathlib.Path(file_path):
             # Update text and restore scroll position

--- a/src/erlab/interactive/explorer/_tabbed_explorer.py
+++ b/src/erlab/interactive/explorer/_tabbed_explorer.py
@@ -294,9 +294,9 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
 
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
-        content = new_explorer.centralWidget()
+        content = new_explorer.takeCentralWidget()
         if content:
-            # Embed the DataExplorer's central widget into the tab
+            # Transfer UI ownership from the hidden QMainWindow wrapper to the tab.
             layout.addWidget(content)
         current_tab = typing.cast("QtWidgets.QWidget", self.tab_widget.widget(tab_idx))
         current_tab.setLayout(layout)

--- a/src/erlab/interactive/explorer/_tabbed_explorer.py
+++ b/src/erlab/interactive/explorer/_tabbed_explorer.py
@@ -249,8 +249,10 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
         explorer = self.get_explorer(index)
         self.tab_widget.removeTab(index)
         if explorer is not None:
-            explorer._stop_preview_workers()
-            explorer.deleteLater()
+            if explorer._stop_preview_workers():
+                explorer.deleteLater()
+            else:
+                explorer._delete_when_preview_workers_done()
         if tab is not None:
             tab.deleteLater()
 

--- a/src/erlab/interactive/explorer/_tabbed_explorer.py
+++ b/src/erlab/interactive/explorer/_tabbed_explorer.py
@@ -242,13 +242,27 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
 
     def _clear_tabs(self) -> None:
         while self.tab_widget.count() > 0:
-            tab = self.tab_widget.widget(0)
-            explorer = self.get_explorer(0)
-            self.tab_widget.removeTab(0)
+            self._discard_tab(0)
+
+    def _discard_tab(self, index: int) -> None:
+        tab = self.tab_widget.widget(index)
+        explorer = self.get_explorer(index)
+        self.tab_widget.removeTab(index)
+        if explorer is not None:
+            explorer._stop_preview_workers()
+            explorer.deleteLater()
+        if tab is not None:
+            tab.deleteLater()
+
+    def _stop_preview_workers(self) -> None:
+        for index in range(self.tab_widget.count()):
+            explorer = self.get_explorer(index)
             if explorer is not None:
-                explorer.deleteLater()
-            if tab is not None:
-                tab.deleteLater()
+                explorer._stop_preview_workers()
+
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        self._stop_preview_workers()
+        super().closeEvent(event)
 
     @QtCore.Slot()
     def add_tab(self, **kwargs) -> None:
@@ -374,9 +388,7 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
                     if self.get_explorer(i) is index:
                         index = i
                         break
-            self.tab_widget.removeTab(
-                self.tab_widget.currentIndex() if index < 0 else index
-            )
+            self._discard_tab(self.tab_widget.currentIndex() if index < 0 else index)
         self.update_menubar()
         self._emit_workspace_state_changed()
 

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -10,6 +10,7 @@ import threading
 import time
 import traceback
 import typing
+import warnings
 from collections.abc import Callable, Iterable
 
 import numpy as np
@@ -59,6 +60,17 @@ LMFIT_METHODS = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def _disconnect_signal(signal: typing.Any) -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"libpyside: Failed to disconnect .*",
+            category=RuntimeWarning,
+        )
+        with contextlib.suppress(TypeError, RuntimeError):
+            signal.disconnect()
 
 
 class EdgeFitSignals(QtCore.QObject):
@@ -485,6 +497,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         # This allows the GUI to remain responsive during fitting so it can be aborted
         self._threadpool = QtCore.QThreadPool(self)
         self._fit_task: EdgeFitTask | None = None
+        self._fit_closing = False
         self.sigAbortFitting.connect(self._abort_fit_task)
         self._pending_update_request: _GoldUpdateRequest | None = None
         self._pending_update_timer = QtCore.QTimer(self)
@@ -912,7 +925,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         )
 
     def iterated(self, n: int, *, task: EdgeFitTask | None = None) -> None:
-        if task is not None and task is not self._fit_task:
+        if task is not None and not self._accept_fit_task_result(task):
             return
         if n == 0:
             self.progress.setLabelText("")
@@ -939,7 +952,11 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     @QtCore.Slot()
     def perform_edge_fit(self) -> None:
-        if self._pending_update_request is not None:
+        if (
+            self._pending_update_request is not None
+            or self._fit_closing
+            or not erlab.interactive.utils.qt_is_valid(self)
+        ):
             return
         self.progress.setVisible(True)
         self.params_roi.draw_button.setChecked(False)
@@ -973,6 +990,19 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     def abort_fit(self) -> None:
         self.sigAbortFitting.emit()
 
+    def _accept_fit_task_result(self, task: EdgeFitTask) -> bool:
+        return (
+            task is self._fit_task
+            and not self._fit_closing
+            and erlab.interactive.utils.qt_is_valid(self)
+        )
+
+    @staticmethod
+    def _disconnect_fit_task_signals(task: EdgeFitTask) -> None:
+        _disconnect_signal(task.signals.sigIterated)
+        _disconnect_signal(task.signals.sigFinished)
+        _disconnect_signal(task.signals.sigFailed)
+
     def post_fit(
         self,
         edge_center: xr.DataArray,
@@ -980,9 +1010,15 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         *,
         task: EdgeFitTask | None = None,
     ) -> None:
-        if task is not None and task is not self._fit_task:
+        if task is not None and not self._accept_fit_task_result(task):
+            return
+        if task is None and (
+            self._fit_closing or not erlab.interactive.utils.qt_is_valid(self)
+        ):
             return
         self.progress.reset()
+        if task is not None:
+            self._disconnect_fit_task_signals(task)
         self.edge_center, self.edge_stderr = edge_center, edge_stderr
         self._fit_task = None
 
@@ -1004,6 +1040,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         if task is None:
             return
         self._fit_task = None
+        self._disconnect_fit_task_signals(task)
         task.abort_fit()
         self.progress.reset()
         self._emit_info_changed()
@@ -1011,8 +1048,14 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     def _handle_fit_failed(
         self, message: str, *, task: EdgeFitTask | None = None
     ) -> None:
-        if task is not None and task is not self._fit_task:
+        if task is not None and not self._accept_fit_task_result(task):
             return
+        if task is None and (
+            self._fit_closing or not erlab.interactive.utils.qt_is_valid(self)
+        ):
+            return
+        if task is not None:
+            self._disconnect_fit_task_signals(task)
         self.progress.reset()
         self._fit_task = None
         self._emit_info_changed()
@@ -1321,7 +1364,9 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """Overridden close event to ensure proper cleanup."""
+        self._fit_closing = True
         if not self._stop_server():
+            self._fit_closing = False
             logger.warning(
                 "Gold fit worker did not stop within timeout; aborting window close"
             )
@@ -1670,6 +1715,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
 
         self._result_ds: xr.Dataset | None = None
         self._fit_thread: ResolutionFitThread | None = None
+        self._fit_closing = False
         self._fit_cancel_requested: bool = False
         self._fit_queued: bool = False
         self._pending_fit_action: Callable[[], None] | None = None
@@ -1781,7 +1827,9 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         return True
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        self._fit_closing = True
         if not self._cancel_fit(wait=True):
+            self._fit_closing = False
             logger.warning(
                 "Resolution fit worker did not stop within timeout; "
                 "aborting window close"
@@ -1916,6 +1964,8 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
     ) -> None:
         if self._fit_thread is not thread:
             return
+        if self._fit_closing or not erlab.interactive.utils.qt_is_valid(self):
+            return
         if self._fit_cancel_requested and not allow_when_cancelled:
             return
         self._pending_fit_action = action
@@ -1931,15 +1981,22 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self._fit_thread = None
         was_cancelled = self._fit_cancel_requested
         self._fit_cancel_requested = False
-        if action is not None:
+        closing = self._fit_closing or not erlab.interactive.utils.qt_is_valid(self)
+        if action is not None and not closing:
             action()
-        if self._fit_queued and not was_cancelled:
+        if self._fit_queued and not was_cancelled and not closing:
             self._fit_queued = False
             self._start_fit_worker()
+        elif closing:
+            self._fit_queued = False
         thread.deleteLater()
 
     def _start_fit_worker(self) -> bool:
-        if self._fit_thread is not None:
+        if (
+            self._fit_thread is not None
+            or self._fit_closing
+            or not erlab.interactive.utils.qt_is_valid(self)
+        ):
             return False
 
         fit_signature = self._fit_signature_current

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -99,17 +99,23 @@ class EdgeFitTask(QtCore.QRunnable):
         self.parallel_obj: joblib.Parallel | None = None
         self.signals = EdgeFitSignals()
         self._mutex = QtCore.QMutex()
+        self._aborted = threading.Event()
 
     @QtCore.Slot()
     def abort_fit(self) -> None:
-        if self.parallel_obj is None:
-            return
+        self._aborted.set()
         self._mutex.lock()
-        self.parallel_obj._aborting = True
-        self.parallel_obj._exception = True
-        self._mutex.unlock()
+        try:
+            if self.parallel_obj is None:
+                return
+            self.parallel_obj._aborting = True
+            self.parallel_obj._exception = True
+        finally:
+            self._mutex.unlock()
 
     def run(self) -> None:
+        if self._aborted.is_set():
+            return
         try:
             # https://github.com/joblib/joblib/issues/1002
             backend = (
@@ -117,14 +123,28 @@ class EdgeFitTask(QtCore.QRunnable):
                 if erlab.utils.misc._IS_PACKAGED
                 else joblib.parallel.DEFAULT_BACKEND
             )
-            self.parallel_obj = joblib.Parallel(
+            parallel_obj = joblib.Parallel(
                 n_jobs=self.params["# CPU"],
                 max_nbytes=None,
                 return_as="generator",
                 pre_dispatch="n_jobs",
                 backend=backend,
             )
+            self._mutex.lock()
+            try:
+                self.parallel_obj = parallel_obj
+                if self._aborted.is_set():
+                    self.parallel_obj._aborting = True
+                    self.parallel_obj._exception = True
+                    return
+            finally:
+                self._mutex.unlock()
+            # Race-only guard: abort can arrive just after the mutex is released.
+            if self._aborted.is_set():  # pragma: no cover
+                return
             self.signals.sigIterated.emit(0)
+            if self._aborted.is_set():
+                return
             with erlab.utils.parallel.joblib_progress_qt(self.signals.sigIterated) as _:
                 edge_center, edge_stderr = typing.cast(
                     "tuple[xr.DataArray, xr.DataArray]",
@@ -146,8 +166,12 @@ class EdgeFitTask(QtCore.QRunnable):
                         drop_nans=True,
                     ),
                 )
+            if self._aborted.is_set():
+                return
             self.signals.sigFinished.emit(edge_center, edge_stderr)
         except Exception:  # pragma: no cover - defensive for worker thread
+            if self._aborted.is_set():
+                return
             self.signals.sigFailed.emit(traceback.format_exc())
 
 

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -1371,6 +1371,17 @@ def execute_replay_graph(
     *,
     cache: dict[str, xr.DataArray] | None = None,
 ) -> xr.DataArray:
+    # Replay runs from manager actions; avoid optional native reduction accelerators
+    # that can crash PySide6/Python 3.14 while Qt threads are alive.
+    with xr.set_options(use_numbagg=False):
+        return _execute_replay_graph(graph, cache=cache)
+
+
+def _execute_replay_graph(
+    graph: ReplayGraph,
+    *,
+    cache: dict[str, xr.DataArray] | None = None,
+) -> xr.DataArray:
     replay_cache = {} if cache is None else cache
     values: dict[str, xr.DataArray] = {}
 

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -919,6 +919,7 @@ class _ActionsController:
             self._manager.console.activateWindow()
             self._manager.console.raise_()
             self._manager.console._console_widget._control.setFocus()
+            self._manager.console._initialize_visible_console()
 
     @property
     def _recent_loader_name(self) -> str | None:

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -1817,6 +1817,7 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
         self._namespace = namespace
         self._kernel_banner_default: str = ""
         self._kernel_initializing = False
+        self._kernel_shutdown_requested = False
         self._erlab_loader_name: str | None = None
         self._erlab_data_dir: str | None = None
         self._erlab_io_hooks_registered = False
@@ -1844,6 +1845,8 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
         self._persist_erlab_io_state()
 
     def initialize_kernel(self) -> None:
+        if self._kernel_shutdown_requested:
+            return
         if self.kernel_manager.kernel or self._kernel_initializing:
             return
         self._kernel_initializing = True
@@ -1876,6 +1879,8 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
     def execute(
         self, source: str | None = None, hidden: bool = False, interactive: bool = False
     ) -> None:
+        if self._kernel_shutdown_requested:
+            return
         if not self.kernel_manager.kernel and not self._kernel_initializing:
             self.initialize_kernel()
         super().execute(source, hidden=hidden, interactive=interactive)
@@ -1892,6 +1897,7 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
 
     @QtCore.Slot()
     def shutdown_kernel(self) -> None:
+        self._kernel_shutdown_requested = True
         if self.kernel_manager.kernel:
             if self._tools_namespace is not None:
                 self._tools_namespace.unbind_shell()
@@ -2016,17 +2022,34 @@ class _ImageToolManagerJupyterConsole(QtWidgets.QDockWidget):
         # Start kernel when console is shown
         self._console_widget.installEventFilter(self)
 
+    def _initialize_visible_console(self) -> None:
+        if not erlab.interactive.utils.qt_is_valid(self, self._console_widget):
+            return
+        if self._console_widget._kernel_shutdown_requested:
+            return
+        self._console_widget.initialize_kernel()
+        self._console_widget._update_colors()
+
     def eventFilter(
         self, obj: QtCore.QObject | None = None, event: QtCore.QEvent | None = None
     ) -> bool:
-        if (
-            hasattr(self, "_console_widget")
-            and obj == self._console_widget
-            and event is not None
-            and event.type() == QtCore.QEvent.Type.Show
-        ):
-            self._console_widget.initialize_kernel()
-            self._console_widget._update_colors()
+        if not hasattr(self, "_console_widget") or event is None:
+            return False
+        if obj is not self._console_widget:
+            return super().eventFilter(obj, event)
+        if not erlab.interactive.utils.qt_is_valid(self, self._console_widget, event):
+            return False
+        try:
+            event_type = event.type()
+        except RuntimeError:
+            return False
+        if event_type == QtCore.QEvent.Type.Show:
+            erlab.interactive.utils.single_shot(
+                self._console_widget,
+                0,
+                self._initialize_visible_console,
+                self,
+            )
         return super().eventFilter(obj, event)
 
     def changeEvent(self, evt: QtCore.QEvent | None) -> None:

--- a/src/erlab/interactive/imagetool/manager/_desktop.py
+++ b/src/erlab/interactive/imagetool/manager/_desktop.py
@@ -91,6 +91,21 @@ def install_macos_dock_menu(manager: QtWidgets.QWidget) -> QtWidgets.QMenu | Non
     return dock_menu
 
 
+def uninstall_macos_dock_menu(manager: QtWidgets.QWidget) -> None:
+    """Remove the running-app macOS Dock actions installed for the manager."""
+    dock_menu = typing.cast(
+        "QtWidgets.QMenu | None", getattr(manager, "_macos_dock_menu", None)
+    )
+    if dock_menu is None:
+        return
+    try:
+        dock_menu.close()
+        dock_menu.deleteLater()
+    except RuntimeError:
+        pass
+    typing.cast("typing.Any", manager)._macos_dock_menu = None
+
+
 def set_windows_app_user_model_id(app_id: str = APP_USER_MODEL_ID) -> None:
     """Set the process AppUserModelID used for taskbar grouping."""
     if not sys.platform.startswith("win"):

--- a/src/erlab/interactive/imagetool/manager/_heartbeat.py
+++ b/src/erlab/interactive/imagetool/manager/_heartbeat.py
@@ -142,9 +142,10 @@ class _RegistryHeartbeatController(QtCore.QObject):
         thread = self._thread
         if thread is None:
             return
+        if idle:
+            self._disconnect_worker_signals()
         thread.quit()
         if idle and thread.wait(_HEARTBEAT_THREAD_STOP_TIMEOUT_MS):
-            self._disconnect_worker_signals()
             self._worker = None
             self._thread = None
             return
@@ -266,9 +267,11 @@ class _RegistryHeartbeatController(QtCore.QObject):
         worker = self._worker
         if worker is None:
             return
-        with contextlib.suppress(TypeError, RuntimeError):
+        if not erlab.interactive.utils.qt_is_valid(worker):
+            return
+        with contextlib.suppress(TypeError, RuntimeError, SystemError):
             self._sigRefreshRequested.disconnect(worker.refresh)
-        with contextlib.suppress(TypeError, RuntimeError):
+        with contextlib.suppress(TypeError, RuntimeError, SystemError):
             worker.finished.disconnect(self._refresh_finished)
 
     @staticmethod

--- a/src/erlab/interactive/imagetool/manager/_heartbeat.py
+++ b/src/erlab/interactive/imagetool/manager/_heartbeat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import logging
+import time
 import typing
 
 from qtpy import QtCore
@@ -134,15 +135,16 @@ class _RegistryHeartbeatController(QtCore.QObject):
     def stop(self) -> None:
         if self._stopping:
             return
-        self._stopping = True
         self._pending_workspace_path = _NO_PENDING_WORKSPACE_PATH
+        idle = self._wait_until_idle(_HEARTBEAT_THREAD_STOP_TIMEOUT_MS)
+        self._stopping = True
         self._in_flight_generation = None
-        self._disconnect_worker_signals()
         thread = self._thread
         if thread is None:
             return
         thread.quit()
-        if thread.wait(_HEARTBEAT_THREAD_STOP_TIMEOUT_MS):
+        if idle and thread.wait(_HEARTBEAT_THREAD_STOP_TIMEOUT_MS):
+            self._disconnect_worker_signals()
             self._worker = None
             self._thread = None
             return
@@ -154,6 +156,25 @@ class _RegistryHeartbeatController(QtCore.QObject):
         )
         self._worker = None
         self._thread = None
+
+    def _wait_until_idle(self, timeout_ms: int) -> bool:
+        """Let an in-flight refresh finish before tearing down the worker thread."""
+        deadline = time.monotonic() + max(timeout_ms, 0) / 1000
+        while self._in_flight_generation is not None:
+            remaining_ms = int((deadline - time.monotonic()) * 1000)
+            if remaining_ms <= 0:
+                return False
+            app = QtCore.QCoreApplication.instance()
+            if app is not None:
+                QtCore.QCoreApplication.sendPostedEvents(
+                    None, int(QtCore.QEvent.Type.MetaCall.value)
+                )
+                app.processEvents(
+                    QtCore.QEventLoop.ProcessEventsFlag.AllEvents,
+                    min(10, remaining_ms),
+                )
+            QtCore.QThread.msleep(min(10, remaining_ms))
+        return True
 
     def _start_refresh(self, workspace_path: str | None) -> None:
         thread = self._thread

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -12,6 +12,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 import erlab.interactive.imagetool.slicer
 from erlab.interactive._dask import DaskMenu
+from erlab.interactive.imagetool.manager import _desktop
 from erlab.interactive.imagetool.manager import _server as _manager_server
 from erlab.interactive.imagetool.manager._actions import _ActionsController
 from erlab.interactive.imagetool.manager._base import _ImageToolManagerBase
@@ -1110,14 +1111,7 @@ class ImageToolManager(_ImageToolManagerBase):
             for widget in dict(self._additional_windows).values():
                 widget.close()
                 widget.deleteLater()
-            dock_menu = typing.cast(
-                "QtWidgets.QMenu | None", getattr(self, "_macos_dock_menu", None)
-            )
-            if dock_menu is not None:
-                dock_menu.close()
-                if erlab.interactive.utils.qt_is_valid(dock_menu):
-                    dock_menu.deleteLater()
-                self._macos_dock_menu = None
+            _desktop.uninstall_macos_dock_menu(self)
 
             logger.debug("Removing event filters...")
             qapp = QtWidgets.QApplication.instance()

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -997,6 +997,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self._metadata_full_code_available = False
         self._metadata_node_uid: str | None = None
         self._refreshing_figure_list = False
+        self._figure_menu: QtWidgets.QMenu | None = None
         self._metadata_copy_selected_action = QtGui.QAction("Copy", self)
         self._metadata_copy_selected_action.setObjectName(
             "manager_copy_selected_code_action"
@@ -1346,6 +1347,7 @@ class ImageToolManager(_ImageToolManagerBase):
             add_shortcut("Enter", self.show_selected)
 
     def _destroy_figures_ui(self) -> None:
+        self._close_figure_menu()
         figure_tab = getattr(self, "figure_tab", None)
         if figure_tab is None:
             return
@@ -1752,7 +1754,10 @@ class ImageToolManager(_ImageToolManagerBase):
     def _show_figure_menu(self, position: QtCore.QPoint) -> None:
         if not hasattr(self, "figure_list"):
             return
+        self._close_figure_menu()
         menu = QtWidgets.QMenu("Figures", self.figure_list)
+        self._figure_menu = menu
+        menu.aboutToHide.connect(lambda *, popup=menu: self._release_figure_menu(popup))
         menu.addAction(self.show_action)
         menu.addAction(self.hide_action)
         menu.addSeparator()
@@ -1760,8 +1765,27 @@ class ImageToolManager(_ImageToolManagerBase):
         menu.addAction(self.remove_action)
         menu.addAction(self.rename_action)
         viewport = self.figure_list.viewport()
-        if viewport is not None:  # pragma: no branch
-            menu.popup(viewport.mapToGlobal(position))
+        if viewport is None:  # pragma: no cover
+            self._release_figure_menu(menu)
+            return
+        menu.popup(viewport.mapToGlobal(position))
+
+    def _close_figure_menu(self) -> None:
+        menu = self._figure_menu
+        if menu is None:
+            return
+        if not erlab.interactive.utils.qt_is_valid(menu):
+            self._figure_menu = None
+            return
+        menu.close()
+        if self._figure_menu is menu:
+            self._release_figure_menu(menu)
+
+    def _release_figure_menu(self, menu: QtWidgets.QMenu) -> None:
+        if self._figure_menu is menu:
+            self._figure_menu = None
+        if erlab.interactive.utils.qt_is_valid(menu):
+            menu.deleteLater()
 
     @staticmethod
     def _figure_all_axes(nrows: int, ncols: int) -> tuple[tuple[int, int], ...]:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1110,6 +1110,14 @@ class ImageToolManager(_ImageToolManagerBase):
             for widget in dict(self._additional_windows).values():
                 widget.close()
                 widget.deleteLater()
+            dock_menu = typing.cast(
+                "QtWidgets.QMenu | None", getattr(self, "_macos_dock_menu", None)
+            )
+            if dock_menu is not None:
+                dock_menu.close()
+                if erlab.interactive.utils.qt_is_valid(dock_menu):
+                    dock_menu.deleteLater()
+                self._macos_dock_menu = None
 
             logger.debug("Removing event filters...")
             qapp = QtWidgets.QApplication.instance()

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -1078,7 +1078,6 @@ class _ProvenanceEditController:
         )
         if tool is None:
             raise RuntimeError("Could not create a temporary ImageTool")
-        tool.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
         tool.hide()
         try:
             dialog = dialog_cls(tool.slicer_area)
@@ -1101,8 +1100,10 @@ class _ProvenanceEditController:
                 return None
             return transform_dialog.source_operations()
         finally:
-            tool.close()
-            tool.deleteLater()
+            if erlab.interactive.utils.qt_is_valid(tool):
+                tool.close()
+            if erlab.interactive.utils.qt_is_valid(tool):
+                tool.deleteLater()
 
     def _edit_active_filter(
         self,

--- a/src/erlab/interactive/imagetool/manager/_server.py
+++ b/src/erlab/interactive/imagetool/manager/_server.py
@@ -447,14 +447,12 @@ _UNSET = object()
 
 def _wait_for_qthread_to_stop(thread: QtCore.QThread, timeout_ms: int) -> bool:
     deadline = time.monotonic() + timeout_ms / 1000
-    app = QtCore.QCoreApplication.instance()
     while thread.isRunning():
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return False
-        if app is not None and QtCore.QThread.currentThread() == app.thread():
-            app.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 10)
-        time.sleep(min(0.01, remaining))
+        if thread.wait(min(10, max(1, int(remaining * 1000)))):
+            return True
     return True
 
 

--- a/src/erlab/interactive/imagetool/manager/_server.py
+++ b/src/erlab/interactive/imagetool/manager/_server.py
@@ -589,6 +589,7 @@ class _ManagerServer(QtCore.QThread):
 
     def stop(self, timeout_ms: int = 5000) -> None:
         self.stopped.set()
+        self.requestInterruption()
         with self._condition:
             self._condition.notify_all()
         self._wake_receiver()
@@ -604,7 +605,7 @@ class _ManagerServer(QtCore.QThread):
         sock.setsockopt(zmq.SNDTIMEO, 100)
         sock.setsockopt(zmq.RCVTIMEO, 100)
         try:
-            sock.connect(f"tcp://{HOST_IP}:{self._bound_port}")
+            sock.connect(f"tcp://127.0.0.1:{self._bound_port}")
             _send_multipart(sock, {"packet_type": "command", "command": "ping"})
             with contextlib.suppress(zmq.Again, zmq.ZMQError):
                 sock.recv_multipart()
@@ -631,6 +632,8 @@ class _ManagerServer(QtCore.QThread):
         sock.setsockopt(zmq.SNDHWM, 0)
         sock.setsockopt(zmq.RCVHWM, 0)
         sock.setsockopt(zmq.RCVTIMEO, 100)
+        poller = zmq.Poller()
+        poller.register(sock, zmq.POLLIN)
 
         try:
             try:
@@ -647,9 +650,14 @@ class _ManagerServer(QtCore.QThread):
             self._bound_event.set()
             logger.debug("Server is listening on port %s...", self.port)
 
-            while not self.stopped.is_set():
+            while not self.stopped.is_set() and not self.isInterruptionRequested():
+                events = dict(poller.poll(100))
+                if sock not in events:
+                    continue
                 try:
-                    payload = Packet.validate_python(_recv_multipart(sock))
+                    payload = Packet.validate_python(
+                        _recv_multipart(sock, flags=zmq.NOBLOCK)
+                    )
                 except zmq.Again:
                     continue
                 except Exception:
@@ -757,6 +765,8 @@ class _ManagerServer(QtCore.QThread):
                 self._bound_event.set()
             logger.exception("Server encountered an error")
         finally:
+            with contextlib.suppress(zmq.ZMQError):
+                poller.unregister(sock)
             sock.close()
             logger.debug("Socket closed")
 

--- a/src/erlab/interactive/imagetool/manager/_server.py
+++ b/src/erlab/interactive/imagetool/manager/_server.py
@@ -469,8 +469,7 @@ class _WatcherServer(QtCore.QThread):
         self._bind_error: Exception | None = None
 
         self._ret_val: typing.Any = _UNSET
-        self._mutex = QtCore.QMutex()
-        self._cv = QtCore.QWaitCondition()
+        self._condition = threading.Condition()
 
     def wait_until_bound(self, timeout_ms: int = 5000) -> int:
         if not self._bound_event.wait(timeout_ms / 1000):
@@ -488,9 +487,9 @@ class _WatcherServer(QtCore.QThread):
         uid: str,
         event: typing.Literal["updated", "removed", "shutdown"],
     ) -> None:
-        with QtCore.QMutexLocker(self._mutex):
+        with self._condition:
             self._ret_val = (varname, uid, event)
-            self._cv.wakeAll()
+            self._condition.notify_all()
 
     def stop(self, timeout_ms: int = 5000) -> None:
         self.stopped.set()
@@ -522,11 +521,9 @@ class _WatcherServer(QtCore.QThread):
             logger.debug("Watcher server is listening on port %s...", self.port)
 
             while not self.stopped.is_set():
-                with QtCore.QMutexLocker(self._mutex):
-                    while self._ret_val is _UNSET:
-                        self._cv.wait(self._mutex, 100)
-                        if self.stopped.is_set():
-                            break
+                with self._condition:
+                    while self._ret_val is _UNSET and not self.stopped.is_set():
+                        self._condition.wait(0.1)
                     if self._ret_val is _UNSET:
                         continue
                     varname, uid, event = self._ret_val
@@ -574,8 +571,7 @@ class _ManagerServer(QtCore.QThread):
         self._bind_error: Exception | None = None
 
         self._ret_val: typing.Any = _UNSET
-        self._mutex = QtCore.QMutex()
-        self._cv = QtCore.QWaitCondition()
+        self._condition = threading.Condition()
 
     def wait_until_bound(self, timeout_ms: int = 5000) -> int:
         if not self._bound_event.wait(timeout_ms / 1000):
@@ -588,23 +584,21 @@ class _ManagerServer(QtCore.QThread):
 
     @QtCore.Slot(object)
     def set_return_value(self, value: typing.Any) -> None:
-        with QtCore.QMutexLocker(self._mutex):
+        with self._condition:
             self._ret_val = value
-            self._cv.wakeAll()
+            self._condition.notify_all()
 
     def stop(self, timeout_ms: int = 5000) -> None:
         self.stopped.set()
-        with QtCore.QMutexLocker(self._mutex):
-            self._cv.wakeAll()
+        with self._condition:
+            self._condition.notify_all()
         if self.isRunning() and not _wait_for_qthread_to_stop(self, timeout_ms):
             logger.warning("Manager server did not stop within timeout")
 
     def _wait_for_return_value(self) -> typing.Any:
-        with QtCore.QMutexLocker(self._mutex):
-            while self._ret_val is _UNSET:
-                if self.stopped.is_set():
-                    break
-                self._cv.wait(self._mutex, 100)
+        with self._condition:
+            while self._ret_val is _UNSET and not self.stopped.is_set():
+                self._condition.wait(0.1)
             value = self._ret_val
             self._ret_val = _UNSET
             return value

--- a/src/erlab/interactive/imagetool/manager/_server.py
+++ b/src/erlab/interactive/imagetool/manager/_server.py
@@ -26,6 +26,7 @@ __all__ = [
 ]
 
 
+import contextlib
 import errno
 import html
 import io
@@ -590,8 +591,27 @@ class _ManagerServer(QtCore.QThread):
         self.stopped.set()
         with self._condition:
             self._condition.notify_all()
+        self._wake_receiver()
         if self.isRunning() and not _wait_for_qthread_to_stop(self, timeout_ms):
             logger.warning("Manager server did not stop within timeout")
+
+    def _wake_receiver(self) -> None:
+        if self._bound_port is None:
+            return
+        ctx = zmq.Context.instance()
+        sock: zmq.Socket = ctx.socket(zmq.REQ)
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.setsockopt(zmq.SNDTIMEO, 100)
+        sock.setsockopt(zmq.RCVTIMEO, 100)
+        try:
+            sock.connect(f"tcp://{HOST_IP}:{self._bound_port}")
+            _send_multipart(sock, {"packet_type": "command", "command": "ping"})
+            with contextlib.suppress(zmq.Again, zmq.ZMQError):
+                sock.recv_multipart()
+        except Exception:
+            logger.debug("Failed to wake manager server receive loop", exc_info=True)
+        finally:
+            sock.close()
 
     def _wait_for_return_value(self) -> typing.Any:
         with self._condition:

--- a/src/erlab/interactive/imagetool/manager/_server.py
+++ b/src/erlab/interactive/imagetool/manager/_server.py
@@ -34,6 +34,7 @@ import os
 import pathlib
 import pickle
 import threading
+import time
 import typing
 import warnings
 
@@ -444,6 +445,19 @@ def _load_paths_and_loader(
 _UNSET = object()
 
 
+def _wait_for_qthread_to_stop(thread: QtCore.QThread, timeout_ms: int) -> bool:
+    deadline = time.monotonic() + timeout_ms / 1000
+    app = QtCore.QCoreApplication.instance()
+    while thread.isRunning():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        if app is not None and QtCore.QThread.currentThread() == app.thread():
+            app.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 10)
+        time.sleep(min(0.01, remaining))
+    return True
+
+
 class _WatcherServer(QtCore.QThread):
     def __init__(self, port: int | None = None) -> None:
         super().__init__()
@@ -481,7 +495,7 @@ class _WatcherServer(QtCore.QThread):
     def stop(self, timeout_ms: int = 5000) -> None:
         self.stopped.set()
         self.send_parameters("", "", "shutdown")
-        if self.isRunning() and not self.wait(timeout_ms):
+        if self.isRunning() and not _wait_for_qthread_to_stop(self, timeout_ms):
             logger.warning("Watcher server did not stop within timeout")
 
     def run(self) -> None:
@@ -582,7 +596,7 @@ class _ManagerServer(QtCore.QThread):
         self.stopped.set()
         with QtCore.QMutexLocker(self._mutex):
             self._cv.wakeAll()
-        if self.isRunning() and not self.wait(timeout_ms):
+        if self.isRunning() and not _wait_for_qthread_to_stop(self, timeout_ms):
             logger.warning("Manager server did not stop within timeout")
 
     def _wait_for_return_value(self) -> typing.Any:

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -975,12 +975,18 @@ class _ApplicationQuitFilter(QtCore.QObject):
     ) -> bool:
         if event is None:
             return False
-        if event.type() == QtCore.QEvent.Type.Quit:
+        if not erlab.interactive.utils.qt_is_valid(self, self._manager, obj, event):
+            return False
+        try:
+            event_type = event.type()
+        except RuntimeError:
+            return False
+        if event_type == QtCore.QEvent.Type.Quit:
             event.accept()
             self._close_manager_for_application_quit()
             return True
         if (
-            event.type() == QtCore.QEvent.Type.KeyPress
+            event_type == QtCore.QEvent.Type.KeyPress
             and isinstance(event, QtGui.QKeyEvent)
             and event.matches(QtGui.QKeySequence.StandardKey.Quit)
         ):

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -1458,10 +1458,39 @@ class _WidgetsController:
 
     def _stop_servers(self) -> None:
         """Stop the server thread properly."""
-        if self._manager.server.isRunning():  # pragma: no branch
-            self._manager.server.stop()
-        if self._manager.watcher_server.isRunning():  # pragma: no branch
-            self._manager.watcher_server.stop()
+        server = self._manager.server
+        if erlab.interactive.utils.qt_is_valid(server):
+            if server.isRunning():  # pragma: no branch
+                server.stop()
+            if not server.isRunning():
+                for signal, slot in (
+                    (server.sigReceived, self._manager._data_recv),
+                    (server.sigLoadRequested, self._manager._data_load),
+                    (server.sigReplaceRequested, self._manager._data_replace),
+                    (server.sigDataRequested, self._manager._send_imagetool_data),
+                    (server.sigWatchInfoRequested, self._manager._send_watch_info),
+                    (self._manager._sigReplyData, server.set_return_value),
+                    (server.sigRemoveIndex, self._manager.remove_imagetool),
+                    (server.sigShowIndex, self._manager.show_imagetool),
+                    (server.sigRemoveUID, self._manager._remove_watched),
+                    (server.sigShowUID, self._manager._show_watched),
+                    (server.sigUnwatchUID, self._manager._data_unwatch),
+                    (server.sigWatchedVarChanged, self._manager._data_watched_update),
+                ):
+                    with contextlib.suppress(TypeError, RuntimeError):
+                        signal.disconnect(slot)
+                server.deleteLater()
+
+        watcher_server = self._manager.watcher_server
+        if erlab.interactive.utils.qt_is_valid(watcher_server):
+            if watcher_server.isRunning():  # pragma: no branch
+                watcher_server.stop()
+            if not watcher_server.isRunning():
+                with contextlib.suppress(TypeError, RuntimeError):
+                    self._manager._sigWatchedDataEdited.disconnect(
+                        watcher_server.send_parameters
+                    )
+                watcher_server.deleteLater()
 
     def open_settings(self) -> None:
         """Open the settings dialog for the ImageTool manager."""

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -671,7 +671,6 @@ class _WorkspaceIOController:
 
     def _drain_workspace_deferred_events(self) -> None:
         self._send_workspace_posted_events(QtCore.QEvent.Type.MetaCall)
-        self._send_workspace_posted_events(QtCore.QEvent.Type.DeferredDelete)
         for _ in range(3):
             QtWidgets.QApplication.processEvents()
 

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -666,9 +666,6 @@ class _WorkspaceIOController:
             QtWidgets.QApplication.sendPostedEvents(
                 None, int(QtCore.QEvent.Type.MetaCall.value)
             )
-            QtWidgets.QApplication.sendPostedEvents(
-                None, int(QtCore.QEvent.Type.DeferredDelete.value)
-            )
 
     def _drain_workspace_restore_events(self) -> None:
         self._send_workspace_posted_events()

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -661,17 +661,17 @@ class _WorkspaceIOController:
         with self._manager._workspace_state.load_context():
             yield
 
-    def _send_workspace_posted_events(self) -> None:
+    def _send_workspace_posted_events(self, event_type: QtCore.QEvent.Type) -> None:
         for _ in range(3):
-            QtWidgets.QApplication.sendPostedEvents(
-                None, int(QtCore.QEvent.Type.MetaCall.value)
-            )
+            QtWidgets.QApplication.sendPostedEvents(None, int(event_type.value))
 
     def _drain_workspace_restore_events(self) -> None:
-        self._send_workspace_posted_events()
+        self._send_workspace_posted_events(QtCore.QEvent.Type.MetaCall)
+        self._send_workspace_posted_events(QtCore.QEvent.Type.DeferredDelete)
 
     def _drain_workspace_deferred_events(self) -> None:
-        self._send_workspace_posted_events()
+        self._send_workspace_posted_events(QtCore.QEvent.Type.MetaCall)
+        self._send_workspace_posted_events(QtCore.QEvent.Type.DeferredDelete)
         for _ in range(3):
             QtWidgets.QApplication.processEvents()
 
@@ -1448,6 +1448,7 @@ class _WorkspaceIOController:
                     backup_snapshot = self._manager._workspace_state_snapshot()
                     backup_tree = self._manager._to_datatree()
                     self._manager.remove_all_tools()
+                    self._manager._drain_workspace_restore_events()
                 for root_path in root_paths:
                     _load_path(root_path)
                 for figure_path in figure_paths:
@@ -1485,6 +1486,7 @@ class _WorkspaceIOController:
     ) -> None:
         with self._manager._workspace_load_context():
             self._manager.remove_all_tools()
+            self._manager._drain_workspace_restore_events()
             self._manager._load_workspace_roots(
                 backup_tree, [str(key) for key in backup_tree]
             )
@@ -1566,6 +1568,7 @@ class _WorkspaceIOController:
                         backup_snapshot = self._manager._workspace_state_snapshot()
                         backup_tree = self._manager._to_datatree()
                         self._manager.remove_all_tools()
+                        self._manager._drain_workspace_restore_events()
                     root_item = (
                         None
                         if dialog is None

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -303,6 +303,8 @@ class _CloseShortcutEventFilter(QtCore.QObject):
     ) -> None:
         super().__init__(parent)
         self._widget_ref = weakref.ref(widget)
+        self._callback_ref: weakref.WeakMethod[Callable[[], None]] | None
+        self._callback: Callable[[], None] | None
         try:
             self._callback_ref = weakref.WeakMethod(callback)
         except TypeError:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -296,8 +296,13 @@ def _application_quit_requested() -> bool:
 
 
 class _CloseShortcutEventFilter(QtCore.QObject):
-    def __init__(self, widget: QtWidgets.QWidget, callback: Callable[[], None]) -> None:
-        super().__init__(widget)
+    def __init__(
+        self,
+        widget: QtWidgets.QWidget,
+        callback: Callable[[], None],
+        parent: QtCore.QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
         self._widget = widget
         self._callback = callback
 
@@ -308,6 +313,7 @@ class _CloseShortcutEventFilter(QtCore.QObject):
     ) -> bool:
         if (
             event is None
+            or not qt_is_valid(self._widget)
             or event.type() != QtCore.QEvent.Type.KeyPress
             or not isinstance(event, QtGui.QKeyEvent)
         ):
@@ -362,9 +368,15 @@ def _install_close_shortcut(
 
     application = QtWidgets.QApplication.instance()
     if isinstance(application, QtWidgets.QApplication):
-        shortcut_filter = _CloseShortcutEventFilter(widget, callback)
+        shortcut_filter = _CloseShortcutEventFilter(widget, callback, application)
         application.installEventFilter(shortcut_filter)
-        widget.destroyed.connect(lambda: application.removeEventFilter(shortcut_filter))
+
+        def _remove_shortcut_filter(*_args: object) -> None:
+            if qt_is_valid(application, shortcut_filter):
+                application.removeEventFilter(shortcut_filter)
+                shortcut_filter.deleteLater()
+
+        widget.destroyed.connect(_remove_shortcut_filter)
         widget._erlab_close_shortcut_refs = (shortcut, shortcut_filter)  # type: ignore[attr-defined]
     else:
         widget._erlab_close_shortcut_refs = (shortcut,)  # type: ignore[attr-defined]

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -12,7 +12,6 @@ import collections
 import contextlib
 import enum
 import fnmatch
-import functools
 import importlib
 import inspect
 import itertools
@@ -303,17 +302,30 @@ class _CloseShortcutEventFilter(QtCore.QObject):
         parent: QtCore.QObject | None = None,
     ) -> None:
         super().__init__(parent)
-        self._widget = widget
-        self._callback = callback
+        self._widget_ref = weakref.ref(widget)
+        try:
+            self._callback_ref = weakref.WeakMethod(callback)
+        except TypeError:
+            self._callback_ref = None
+            self._callback = callback
+        else:
+            self._callback = None
+
+    def _callback_or_none(self) -> Callable[[], None] | None:
+        if self._callback_ref is None:
+            return self._callback
+        return self._callback_ref()
 
     def eventFilter(
         self,
         watched: QtCore.QObject | None,
         event: QtCore.QEvent | None,
     ) -> bool:
+        widget = self._widget_ref()
         if (
             event is None
-            or not qt_is_valid(self._widget)
+            or widget is None
+            or not qt_is_valid(widget)
             or event.type() != QtCore.QEvent.Type.KeyPress
             or not isinstance(event, QtGui.QKeyEvent)
         ):
@@ -322,8 +334,8 @@ class _CloseShortcutEventFilter(QtCore.QObject):
         focused = watched if isinstance(watched, QtWidgets.QWidget) else None
         if (
             focused is None
-            or not self._widget.isVisible()
-            or (focused is not self._widget and focused.window() is not self._widget)
+            or not widget.isVisible()
+            or (focused is not widget and focused.window() is not widget)
         ):
             return False
 
@@ -341,7 +353,10 @@ class _CloseShortcutEventFilter(QtCore.QObject):
         if not close_shortcut:
             return False
 
-        self._callback()
+        callback = self._callback_or_none()
+        if callback is None:
+            return False
+        callback()
         event.accept()
         return True
 
@@ -358,7 +373,12 @@ def _install_close_shortcut(
 ) -> QtWidgets.QShortcut:
     """Install robust Ctrl+W handling on a widget and its child widgets."""
     if callback is None:
-        callback = functools.partial(_hide_or_close_with_manager, widget)
+        widget_ref = weakref.ref(widget)
+
+        def callback() -> None:
+            target = widget_ref()
+            if target is not None and qt_is_valid(target):
+                _hide_or_close_with_manager(target)
 
     if isinstance(widget, QtWidgets.QMainWindow):
         widget.menuBar()

--- a/src/erlab/utils/formatting.py
+++ b/src/erlab/utils/formatting.py
@@ -392,6 +392,30 @@ def _format_array_values(val: npt.NDArray) -> str:
     return f"min {mn} max {mx}"
 
 
+def _format_array_metadata(coord: xr.DataArray) -> str:
+    dtype = str(coord.dtype)
+    if coord.shape:
+        shape = " x ".join(str(size) for size in coord.shape)
+        return f"{dtype} [{shape}]"
+    return f"{dtype} scalar"
+
+
+def _format_coord_values(coord: xr.DataArray, *, load_values: bool) -> str:
+    if not load_values:
+        return _format_array_metadata(coord)
+
+    values = None
+    try:
+        values = coord.values
+        return _format_array_values(values)
+    except Exception:
+        if values is not None:
+            flat_values = np.asarray(values).ravel()
+            if flat_values.size != 0:
+                return f'["{flat_values[0]!s}",  ... , "{flat_values[-1]!s}"]'
+        return _format_array_metadata(coord)
+
+
 def _format_coord_key(key: Hashable, is_dim: bool) -> str:
     return format_html_accent(key, bold=is_dim, em_space=True)
 
@@ -433,6 +457,7 @@ def format_darr_html(
     *,
     show_size: bool = True,
     show_summary: bool = True,
+    load_values: bool = True,
     additional_info: Iterable[str] | None = None,
 ) -> str:
     """Make a simple HTML representation of a DataArray.
@@ -446,6 +471,9 @@ def format_darr_html(
     show_summary
         Whether to include the DataArray name, dimensions, and optional size before the
         coordinates and attributes.
+    load_values
+        Whether coordinate values may be loaded while formatting coordinate summaries.
+        Disable this for metadata-only previews of lazily loaded arrays.
     additional_info
         Additional information to include in the representation. Each item in the list
         is added as a separate paragraph.
@@ -470,16 +498,11 @@ def format_darr_html(
     for key, coord in darr.coords.items():
         is_dim: bool = key in darr.dims
 
-        try:
-            value_repr = _format_array_values(coord.values)
-        except Exception:
-            value_repr = f'["{coord.values[0]!s}",  ... , "{coord.values[-1]!s}"]'
-
         coord_rows.append(
             [
                 _format_coord_key(key, is_dim),
                 _format_coord_dims(coord),
-                value_repr,
+                _format_coord_values(coord, load_values=load_values),
             ]
         )
     out += format_html_table(coord_rows)

--- a/src/erlab/utils/hashing.py
+++ b/src/erlab/utils/hashing.py
@@ -61,7 +61,7 @@ def _hash_numeric_array(arr: npt.NDArray, *, sample_max: int, blocks: int) -> in
     if sample.dtype.kind in ("M", "m"):
         # datetime, timedelta
         return _digest_bytes(memoryview(sample.tobytes()).cast("B"))
-    return _digest_bytes(memoryview(sample).cast("B"))
+    return _digest_bytes(sample.tobytes())
 
 
 def _hash_object_array(arr: npt.NDArray, *, sample_max: int) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ DATA_RETRIEVE_ATTEMPTS = 4
 log = logging.getLogger(__name__)
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _TEST_OPTIONS_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH"
+_TEST_OPTIONS_MANAGED_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH_TEST_MANAGED"
 _TEST_INTERACTIVE_OPTIONS_PATHS: list[pathlib.Path] = []
 _DELETED_QT_WRAPPER_PATTERN = re.compile(r"wrapped C/C\+\+ object .* has been deleted")
 
@@ -67,12 +68,17 @@ def _is_deleted_qt_wrapper_error(exc: RuntimeError) -> bool:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    if _TEST_OPTIONS_ENV_VAR not in os.environ:
-        settings_path = (
-            pathlib.Path(tempfile.gettempdir())
-            / f"erlabpy-test-interactive-options-{os.getpid()}-{uuid.uuid4().hex}.ini"
+    if (
+        _TEST_OPTIONS_ENV_VAR not in os.environ
+        or os.environ.get(_TEST_OPTIONS_MANAGED_ENV_VAR) == "1"
+    ):
+        worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
+        settings_path = pathlib.Path(tempfile.gettempdir()) / (
+            "erlabpy-test-interactive-options-"
+            f"{worker_id}-{os.getpid()}-{uuid.uuid4().hex}.ini"
         )
         os.environ[_TEST_OPTIONS_ENV_VAR] = str(settings_path)
+        os.environ[_TEST_OPTIONS_MANAGED_ENV_VAR] = "1"
         _TEST_INTERACTIVE_OPTIONS_PATHS.append(settings_path)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,7 @@ _CI_TEST_GROUPS = _load_ci_test_groups_module()
 is_compat_nodeid = _CI_TEST_GROUPS.is_compat_nodeid
 is_compat_path = _CI_TEST_GROUPS.is_compat_path
 is_gui_path = _CI_TEST_GROUPS.is_gui_path
+is_serial_nodeid = _CI_TEST_GROUPS.is_serial_nodeid
 is_serial_path = _CI_TEST_GROUPS.is_serial_path
 
 
@@ -175,8 +176,9 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
         if is_gui_path(rel_path):
             item.add_marker(pytest.mark.gui)
-        if is_serial_path(rel_path):
+        if is_serial_path(rel_path) or is_serial_nodeid(item.nodeid):
             item.add_marker(pytest.mark.serial)
+            item.add_marker(pytest.mark.xdist_group("serial"))
         if is_compat_path(rel_path) or is_compat_nodeid(item.nodeid):
             item.add_marker(pytest.mark.compat)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,6 +251,14 @@ def gold_fine():
 def manager_context() -> Callable[
     ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
 ]:
+    def _drain_qt_events(iterations: int = 1) -> None:
+        for _ in range(iterations):
+            QtWidgets.QApplication.sendPostedEvents(
+                None, int(QtCore.QEvent.Type.DeferredDelete.value)
+            )
+            QtWidgets.QApplication.sendPostedEvents(None, 0)
+            QtWidgets.QApplication.processEvents()
+
     def _unused_port_pair() -> tuple[int, int]:
         sockets: list[socket.socket] = []
         try:
@@ -295,6 +303,7 @@ def manager_context() -> Callable[
         imagetool_manager_server.PORT_WATCH = port_watch
         imagetool_manager._always_use_socket = use_socket
 
+        _drain_qt_events()
         imagetool_manager.main(execute=False)
 
         try:
@@ -303,6 +312,8 @@ def manager_context() -> Callable[
             manager = imagetool_manager._manager_instance
             if manager is not None:
                 manager._workspace_state.loading_depth += 1
+                server = manager.server
+                watcher_server = manager.watcher_server
                 try:
 
                     def _thread_is_running(thread: object) -> bool:
@@ -323,10 +334,9 @@ def manager_context() -> Callable[
                         manager._application_quit_filter = None
                     manager._registry_heartbeat_timer.stop()
                     manager._registry_heartbeat.stop()
-                    _stop_thread(manager.server)
-                    _stop_thread(manager.watcher_server)
-                    QtWidgets.QApplication.sendPostedEvents(None, 0)
-                    QtWidgets.QApplication.processEvents()
+                    _stop_thread(server)
+                    _stop_thread(watcher_server)
+                    _drain_qt_events()
                     clipboard = QtWidgets.QApplication.clipboard()
                     if clipboard is not None:
                         clipboard.clear()
@@ -335,23 +345,27 @@ def manager_context() -> Callable[
                     manager.close()
                     deadline = time.perf_counter() + 5.0
                     while (
-                        _thread_is_running(manager.server)
-                        or _thread_is_running(manager.watcher_server)
+                        _thread_is_running(server) or _thread_is_running(watcher_server)
                     ) and time.perf_counter() < deadline:
-                        QtWidgets.QApplication.sendPostedEvents(None, 0)
-                        QtWidgets.QApplication.processEvents()
+                        _drain_qt_events()
                         time.sleep(0.01)
-                    if _thread_is_running(manager.server):
-                        _stop_thread(manager.server)
-                    if _thread_is_running(manager.watcher_server):
-                        _stop_thread(manager.watcher_server)
-                    manager.deleteLater()
-                    for _ in range(3):
-                        QtWidgets.QApplication.sendPostedEvents(None, 0)
-                        QtWidgets.QApplication.processEvents()
+                    if _thread_is_running(server):
+                        _stop_thread(server)
+                    if _thread_is_running(watcher_server):
+                        _stop_thread(watcher_server)
                 finally:
-                    manager._workspace_state.loading_depth -= 1
-                    manager._mark_workspace_clean()
+                    if qt_is_valid(manager):
+                        manager._workspace_state.loading_depth -= 1
+                        manager._mark_workspace_clean()
+                if qt_is_valid(manager):
+                    manager.deleteLater()
+                    delete_deadline = time.perf_counter() + 1.0
+                    while (
+                        qt_is_valid(manager) and time.perf_counter() < delete_deadline
+                    ):
+                        _drain_qt_events()
+                        time.sleep(0.01)
+                _drain_qt_events(iterations=3)
             imagetool_manager._manager_instance = None
             imagetool_manager._always_use_socket = False
             imagetool_manager.PORT = original_port

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,9 @@ DATA_KNOWN_HASH = "de72bfef9cedea535e5502fe55903c526ca500ef1575cd3c63e0aae3f4fb7
 DATA_RETRIEVE_ATTEMPTS = 4
 """Maximum attempts for transient test data download failures."""
 
+DATA_DOWNLOAD_LOCK_TIMEOUT_SECONDS = 20 * 60
+"""Maximum time to wait for another worker to finish downloading test data."""
+
 log = logging.getLogger(__name__)
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _TEST_OPTIONS_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH"
@@ -131,6 +134,41 @@ def _coverage_is_active(pytestconfig: pytest.Config) -> bool:
     return bool(getattr(pytestconfig.option, "cov_source", None))
 
 
+@contextlib.contextmanager
+def _test_data_download_lock(lock_path: pathlib.Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + DATA_DOWNLOAD_LOCK_TIMEOUT_SECONDS
+    lock_fd: int | None = None
+    while lock_fd is None:
+        try:
+            lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+        except FileExistsError:
+            try:
+                lock_age = time.time() - lock_path.stat().st_mtime
+            except OSError:
+                continue
+            if lock_age > DATA_DOWNLOAD_LOCK_TIMEOUT_SECONDS:
+                with contextlib.suppress(OSError):
+                    lock_path.unlink()
+                continue
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Timed out waiting for erlabpy test data lock {lock_path}"
+                ) from None
+            time.sleep(0.25)
+    try:
+        os.write(lock_fd, f"{os.getpid()}\n".encode())
+        yield
+    finally:
+        os.close(lock_fd)
+        with contextlib.suppress(OSError):
+            lock_path.unlink()
+
+
+def _test_data_dir_ready(path: pathlib.Path) -> bool:
+    return all((path / dirname).is_dir() for dirname in ("da30", "erpes", "merlin"))
+
+
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         rel_path = pathlib.Path(item.path).resolve().relative_to(REPO_ROOT).as_posix()
@@ -182,42 +220,50 @@ def test_data_dir() -> pathlib.Path:
     path = os.getenv("ERLAB_TEST_DATA_DIR", None)
     if path is None:
         cache_folder = pooch.os_cache("erlabpy")
+        path = cache_folder / f"kmnhan-erlabpy-data-{DATA_COMMIT_HASH[:7]}"
         data_url = (
-            "https://api.github.com/repos/kmnhan/erlabpy-data/tarball/"
+            "https://codeload.github.com/kmnhan/erlabpy-data/legacy.tar.gz/"
             + DATA_COMMIT_HASH
         )
-        for attempt in range(1, DATA_RETRIEVE_ATTEMPTS + 1):
-            try:
-                pooch.retrieve(
-                    data_url,
-                    known_hash=DATA_KNOWN_HASH,
-                    path=cache_folder,
-                    processor=pooch.Untar(extract_dir=""),
-                )
-                break
-            except (
-                requests.exceptions.ConnectionError,
-                requests.exceptions.HTTPError,
-                requests.exceptions.Timeout,
-            ) as exc:
-                if isinstance(exc, requests.exceptions.HTTPError):
-                    response = exc.response
-                    if response is not None and response.status_code < 500:
-                        raise
-                if attempt == DATA_RETRIEVE_ATTEMPTS:
-                    raise
-                delay = 2 ** (attempt - 1)
-                log.warning(
-                    "Failed to retrieve erlabpy test data from %s on attempt %d/%d; "
-                    "retrying in %d seconds.",
-                    data_url,
-                    attempt,
-                    DATA_RETRIEVE_ATTEMPTS,
-                    delay,
-                    exc_info=True,
-                )
-                time.sleep(delay)
-        path = cache_folder / f"kmnhan-erlabpy-data-{DATA_COMMIT_HASH[:7]}"
+        if not _test_data_dir_ready(path):
+            lock_path = cache_folder / f".erlabpy-data-{DATA_COMMIT_HASH[:7]}.lock"
+            with _test_data_download_lock(lock_path):
+                if not _test_data_dir_ready(path):
+                    for attempt in range(1, DATA_RETRIEVE_ATTEMPTS + 1):
+                        try:
+                            pooch.retrieve(
+                                data_url,
+                                known_hash=DATA_KNOWN_HASH,
+                                path=cache_folder,
+                                processor=pooch.Untar(extract_dir=""),
+                            )
+                            break
+                        except (
+                            requests.exceptions.ConnectionError,
+                            requests.exceptions.HTTPError,
+                            requests.exceptions.Timeout,
+                        ) as exc:
+                            if isinstance(exc, requests.exceptions.HTTPError):
+                                response = exc.response
+                                if response is not None and response.status_code < 500:
+                                    raise
+                            if attempt == DATA_RETRIEVE_ATTEMPTS:
+                                raise
+                            delay = 2 ** (attempt - 1)
+                            log.warning(
+                                "Failed to retrieve erlabpy test data from %s on "
+                                "attempt %d/%d; retrying in %d seconds.",
+                                data_url,
+                                attempt,
+                                DATA_RETRIEVE_ATTEMPTS,
+                                delay,
+                                exc_info=True,
+                            )
+                            time.sleep(delay)
+                    if not _test_data_dir_ready(path):
+                        raise FileNotFoundError(
+                            f"Retrieved erlabpy test data is incomplete: {path}"
+                        )
 
     return pathlib.Path(path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,26 +16,25 @@ import typing
 import uuid
 from collections.abc import Callable, Sequence
 
+import dask
 import dask.distributed
-from dask.distributed import Client
+from dask.distributed import Client, LocalCluster
 
-# Qt platform backend for tests:
-# - Prefer xcb when a display is available (e.g. CI under Xvfb)
-# - Fall back to offscreen in truly headless environments
 if "QT_QPA_PLATFORM" not in os.environ:
-    if sys.platform.startswith("linux") and os.environ.get("DISPLAY"):
+    qt_api = os.environ.get("QT_API") or os.environ.get("PYTEST_QT_API")
+    if qt_api is not None and qt_api.lower() == "pyside6":
+        os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    elif sys.platform.startswith("linux") and os.environ.get("DISPLAY"):
         os.environ["QT_QPA_PLATFORM"] = "xcb"
     else:
         os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
-import dask
 import lmfit
 import numexpr
 import numpy as np
 import pooch
 import pytest
 import xarray as xr
-from dask.distributed import LocalCluster
 from numpy.testing import assert_almost_equal
 from qtpy import QtCore, QtWidgets
 
@@ -43,7 +42,7 @@ import erlab
 import erlab.interactive.imagetool.manager as imagetool_manager
 import erlab.interactive.imagetool.manager._registry as imagetool_manager_registry
 import erlab.interactive.imagetool.manager._server as imagetool_manager_server
-from erlab.interactive.utils import _WaitDialog
+from erlab.interactive.utils import _WaitDialog, qt_is_valid
 from erlab.io.dataloader import LoaderBase
 from erlab.io.exampledata import generate_data_angles, generate_gold_edge
 
@@ -57,6 +56,11 @@ log = logging.getLogger(__name__)
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _TEST_OPTIONS_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH"
 _TEST_INTERACTIVE_OPTIONS_PATHS: list[pathlib.Path] = []
+_DELETED_QT_WRAPPER_PATTERN = re.compile(r"wrapped C/C\+\+ object .* has been deleted")
+
+
+def _is_deleted_qt_wrapper_error(exc: RuntimeError) -> bool:
+    return _DELETED_QT_WRAPPER_PATTERN.search(str(exc)) is not None
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -115,7 +119,7 @@ dask.config.set(
 
 def _coverage_is_active(pytestconfig: pytest.Config) -> bool:
     """Return whether pytest-cov is actively collecting coverage."""
-    return pytestconfig.pluginmanager.hasplugin("_cov")
+    return bool(getattr(pytestconfig.option, "cov_source", None))
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
@@ -300,10 +304,22 @@ def manager_context() -> Callable[
             if manager is not None:
                 manager._workspace_state.loading_depth += 1
                 try:
-                    QtWidgets.QApplication.sendPostedEvents(None, 0)
-                    QtWidgets.QApplication.processEvents()
+                    qapp = QtWidgets.QApplication.instance()
+                    if (
+                        isinstance(qapp, QtWidgets.QApplication)
+                        and manager._application_quit_filter is not None
+                    ):
+                        qapp.removeEventFilter(manager._application_quit_filter)
+                        manager._application_quit_filter = None
+                    manager._registry_heartbeat_timer.stop()
+                    manager._registry_heartbeat.stop()
                     manager.server.stop(timeout_ms=1000)
                     manager.watcher_server.stop(timeout_ms=1000)
+                    QtWidgets.QApplication.sendPostedEvents(None, 0)
+                    QtWidgets.QApplication.processEvents()
+                    clipboard = QtWidgets.QApplication.clipboard()
+                    if clipboard is not None:
+                        clipboard.clear()
                     manager.remove_all_tools()
                     manager._mark_workspace_clean()
                     manager.close()
@@ -601,13 +617,15 @@ def cover_qthreads(monkeypatch, qtbot, pytestconfig):
     # https://github.com/nedbat/coveragepy/issues/686#issuecomment-2286288111
     from qtpy.QtCore import QThread
 
-    base_constructor = QThread.__init__
     coverage_active = _coverage_is_active(pytestconfig)
+    if not coverage_active:
+        return
+
+    base_constructor = QThread.__init__
 
     def run_with_trace(self):  # pragma: no cover
-        if coverage_active:
-            # https://github.com/nedbat/coveragepy/issues/686#issuecomment-634932753
-            sys.settrace(threading._trace_hook)
+        # https://github.com/nedbat/coveragepy/issues/686#issuecomment-634932753
+        sys.settrace(threading._trace_hook)
         self._base_run()
 
     def init_with_trace(self, *args, **kwargs):
@@ -626,16 +644,17 @@ def cover_qthreadpool(monkeypatch, qtbot, pytestconfig):
     base_start = QThreadPool.start
     QThreadPool.globalInstance().setMaxThreadCount(1)
     coverage_active = _coverage_is_active(pytestconfig)
+    if not coverage_active:
+        return
 
     def start_with_trace(self, runnable, *args, **kwargs):
-        if coverage_active:
-            original_run = runnable.run
+        original_run = runnable.run
 
-            def wrapped_run(*a, **kw):
-                sys.settrace(threading._trace_hook)
-                return original_run(*a, **kw)
+        def wrapped_run(*a, **kw):
+            sys.settrace(threading._trace_hook)
+            return original_run(*a, **kw)
 
-            runnable.run = wrapped_run
+        runnable.run = wrapped_run
         return base_start(self, runnable, *args, **kwargs)
 
     monkeypatch.setattr(QThreadPool, "start", start_with_trace)
@@ -670,7 +689,7 @@ def serialize_hdf5_loads():
 
 @pytest.fixture(scope="session", autouse=True)
 def patch_pyqtgraph_boundingrect():
-    """Guard pyqtgraph InfiniteLine boundingRect from None viewboxes during teardown."""
+    """Guard pyqtgraph InfiniteLine boundingRect during Qt teardown."""
     mp = pytest.MonkeyPatch()
     import pyqtgraph as pg
     from qtpy import QtCore
@@ -678,10 +697,22 @@ def patch_pyqtgraph_boundingrect():
     original_br = pg.InfiniteLine.boundingRect
 
     def safe_br(self):
-        vb = self.getViewBox()
+        if not qt_is_valid(self):
+            return QtCore.QRectF()
+        try:
+            vb = self.getViewBox()
+        except RuntimeError as exc:
+            if _is_deleted_qt_wrapper_error(exc):
+                return QtCore.QRectF()
+            raise
         if vb is None:
             return QtCore.QRectF()
-        return original_br(self)
+        try:
+            return original_br(self)
+        except RuntimeError as exc:
+            if _is_deleted_qt_wrapper_error(exc):
+                return QtCore.QRectF()
+            raise
 
     mp.setattr(pg.InfiniteLine, "boundingRect", safe_br, raising=False)
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,7 @@ def _test_data_dir_ready(path: pathlib.Path) -> bool:
     return all((path / dirname).is_dir() for dirname in ("da30", "erpes", "merlin"))
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         rel_path = pathlib.Path(item.path).resolve().relative_to(REPO_ROOT).as_posix()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,16 @@ def manager_context() -> Callable[
             if manager is not None:
                 manager._workspace_state.loading_depth += 1
                 try:
+
+                    def _thread_is_running(thread: object) -> bool:
+                        with contextlib.suppress(RuntimeError):
+                            return qt_is_valid(thread) and thread.isRunning()
+                        return False
+
+                    def _stop_thread(thread: object) -> None:
+                        if qt_is_valid(thread):
+                            thread.stop(timeout_ms=1000)
+
                     qapp = QtWidgets.QApplication.instance()
                     if (
                         isinstance(qapp, QtWidgets.QApplication)
@@ -313,8 +323,8 @@ def manager_context() -> Callable[
                         manager._application_quit_filter = None
                     manager._registry_heartbeat_timer.stop()
                     manager._registry_heartbeat.stop()
-                    manager.server.stop(timeout_ms=1000)
-                    manager.watcher_server.stop(timeout_ms=1000)
+                    _stop_thread(manager.server)
+                    _stop_thread(manager.watcher_server)
                     QtWidgets.QApplication.sendPostedEvents(None, 0)
                     QtWidgets.QApplication.processEvents()
                     clipboard = QtWidgets.QApplication.clipboard()
@@ -325,15 +335,16 @@ def manager_context() -> Callable[
                     manager.close()
                     deadline = time.perf_counter() + 5.0
                     while (
-                        manager.server.isRunning() or manager.watcher_server.isRunning()
+                        _thread_is_running(manager.server)
+                        or _thread_is_running(manager.watcher_server)
                     ) and time.perf_counter() < deadline:
                         QtWidgets.QApplication.sendPostedEvents(None, 0)
                         QtWidgets.QApplication.processEvents()
                         time.sleep(0.01)
-                    if manager.server.isRunning():
-                        manager.server.stop(timeout_ms=1000)
-                    if manager.watcher_server.isRunning():
-                        manager.watcher_server.stop(timeout_ms=1000)
+                    if _thread_is_running(manager.server):
+                        _stop_thread(manager.server)
+                    if _thread_is_running(manager.watcher_server):
+                        _stop_thread(manager.watcher_server)
                     manager.deleteLater()
                     for _ in range(3):
                         QtWidgets.QApplication.sendPostedEvents(None, 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ import numexpr
 import numpy as np
 import pooch
 import pytest
+import requests
 import xarray as xr
 from numpy.testing import assert_almost_equal
 from qtpy import QtCore, QtWidgets
@@ -50,6 +51,9 @@ DATA_COMMIT_HASH = "a90b37654184b9bf3378b032646c9c5b6231a0fa"
 
 DATA_KNOWN_HASH = "de72bfef9cedea535e5502fe55903c526ca500ef1575cd3c63e0aae3f4fb77be"
 """The SHA-256 checksum of the `.tar.gz` file."""
+
+DATA_RETRIEVE_ATTEMPTS = 4
+"""Maximum attempts for transient test data download failures."""
 
 log = logging.getLogger(__name__)
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -163,13 +167,41 @@ def test_data_dir() -> pathlib.Path:
     path = os.getenv("ERLAB_TEST_DATA_DIR", None)
     if path is None:
         cache_folder = pooch.os_cache("erlabpy")
-        pooch.retrieve(
+        data_url = (
             "https://api.github.com/repos/kmnhan/erlabpy-data/tarball/"
-            + DATA_COMMIT_HASH,
-            known_hash=DATA_KNOWN_HASH,
-            path=cache_folder,
-            processor=pooch.Untar(extract_dir=""),
+            + DATA_COMMIT_HASH
         )
+        for attempt in range(1, DATA_RETRIEVE_ATTEMPTS + 1):
+            try:
+                pooch.retrieve(
+                    data_url,
+                    known_hash=DATA_KNOWN_HASH,
+                    path=cache_folder,
+                    processor=pooch.Untar(extract_dir=""),
+                )
+                break
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.HTTPError,
+                requests.exceptions.Timeout,
+            ) as exc:
+                if isinstance(exc, requests.exceptions.HTTPError):
+                    response = exc.response
+                    if response is not None and response.status_code < 500:
+                        raise
+                if attempt == DATA_RETRIEVE_ATTEMPTS:
+                    raise
+                delay = 2 ** (attempt - 1)
+                log.warning(
+                    "Failed to retrieve erlabpy test data from %s on attempt %d/%d; "
+                    "retrying in %d seconds.",
+                    data_url,
+                    attempt,
+                    DATA_RETRIEVE_ATTEMPTS,
+                    delay,
+                    exc_info=True,
+                )
+                time.sleep(delay)
         path = cache_folder / f"kmnhan-erlabpy-data-{DATA_COMMIT_HASH[:7]}"
 
     return pathlib.Path(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import logging
 import os
 import pathlib
 import re
-import socket
 import sys
 import tempfile
 import threading
@@ -259,20 +258,6 @@ def manager_context() -> Callable[
             QtWidgets.QApplication.sendPostedEvents(None, 0)
             QtWidgets.QApplication.processEvents()
 
-    def _unused_port_pair() -> tuple[int, int]:
-        sockets: list[socket.socket] = []
-        try:
-            for _ in range(2):
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.bind(("127.0.0.1", 0))
-                sockets.append(sock)
-            return typing.cast("int", sockets[0].getsockname()[1]), typing.cast(
-                "int", sockets[1].getsockname()[1]
-            )
-        finally:
-            for sock in sockets:
-                sock.close()
-
     @contextlib.contextmanager
     def _ctx(
         use_socket: bool = False,
@@ -287,7 +272,6 @@ def manager_context() -> Callable[
             validate=False
         )
 
-        port, port_watch = _unused_port_pair()
         registry_path = (
             pathlib.Path(tempfile.gettempdir())
             / f"erlab-test-manager-{os.getpid()}-{time.time_ns()}.json"
@@ -297,10 +281,10 @@ def manager_context() -> Callable[
             registry_path.suffix + ".lock"
         )
         imagetool_manager_registry.clear_default_manager()
-        imagetool_manager.PORT = port
-        imagetool_manager.PORT_WATCH = port_watch
-        imagetool_manager_server.PORT = port
-        imagetool_manager_server.PORT_WATCH = port_watch
+        imagetool_manager.PORT = 0
+        imagetool_manager.PORT_WATCH = 0
+        imagetool_manager_server.PORT = 0
+        imagetool_manager_server.PORT_WATCH = 0
         imagetool_manager._always_use_socket = use_socket
 
         _drain_qt_events()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,8 +102,7 @@ _CI_TEST_GROUPS = _load_ci_test_groups_module()
 is_compat_nodeid = _CI_TEST_GROUPS.is_compat_nodeid
 is_compat_path = _CI_TEST_GROUPS.is_compat_path
 is_gui_path = _CI_TEST_GROUPS.is_gui_path
-is_serial_nodeid = _CI_TEST_GROUPS.is_serial_nodeid
-is_serial_path = _CI_TEST_GROUPS.is_serial_path
+serial_xdist_group = _CI_TEST_GROUPS.serial_xdist_group
 
 
 def _qt_msg_filter(msg_type, context, message):
@@ -176,9 +175,10 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
         if is_gui_path(rel_path):
             item.add_marker(pytest.mark.gui)
-        if is_serial_path(rel_path) or is_serial_nodeid(item.nodeid):
+        serial_group = serial_xdist_group(rel_path, item.nodeid)
+        if serial_group is not None:
             item.add_marker(pytest.mark.serial)
-            item.add_marker(pytest.mark.xdist_group("serial"))
+            item.add_marker(pytest.mark.xdist_group(serial_group))
         if is_compat_path(rel_path) or is_compat_nodeid(item.nodeid):
             item.add_marker(pytest.mark.compat)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import threading
 import time
 import typing
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 
 import dask
 import dask.distributed
@@ -141,6 +141,15 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     for settings_path in _TEST_INTERACTIVE_OPTIONS_PATHS:
         with contextlib.suppress(OSError):
             settings_path.unlink()
+
+
+@pytest.fixture(autouse=True)
+def _restore_interactive_options_between_tests() -> Iterator[None]:
+    erlab.interactive.options.restore()
+    try:
+        yield
+    finally:
+        erlab.interactive.options.restore()
 
 
 @pytest.fixture(scope="session")

--- a/tests/interactive/imagetool/manager/helpers.py
+++ b/tests/interactive/imagetool/manager/helpers.py
@@ -33,6 +33,8 @@ CONSOLE_HELPER_OFFSET = 2.5
 
 
 class InMemoryClipboard(QtCore.QObject):
+    Mode = QtGui.QClipboard.Mode
+
     dataChanged = QtCore.Signal()
 
     def __init__(self) -> None:
@@ -40,33 +42,58 @@ class InMemoryClipboard(QtCore.QObject):
         self._mime_data = QtCore.QMimeData()
         self._pixmap = QtGui.QPixmap()
 
-    def clear(self) -> None:
+    def clear(self, mode: QtGui.QClipboard.Mode = Mode.Clipboard) -> None:
+        if mode != self.Mode.Clipboard:
+            return
         self._mime_data = QtCore.QMimeData()
         self._pixmap = QtGui.QPixmap()
         self.dataChanged.emit()
 
-    def setMimeData(self, mime_data: QtCore.QMimeData) -> None:
+    def setMimeData(
+        self,
+        mime_data: QtCore.QMimeData,
+        mode: QtGui.QClipboard.Mode = Mode.Clipboard,
+    ) -> None:
+        if mode != self.Mode.Clipboard:
+            return
         self._mime_data = mime_data
         self._pixmap = QtGui.QPixmap()
         self.dataChanged.emit()
 
-    def mimeData(self) -> QtCore.QMimeData:
+    def mimeData(
+        self,
+        mode: QtGui.QClipboard.Mode = Mode.Clipboard,
+    ) -> QtCore.QMimeData:
+        if mode != self.Mode.Clipboard:
+            return QtCore.QMimeData()
         return self._mime_data
 
-    def setText(self, text: str) -> None:
+    def setText(self, text: str, mode: QtGui.QClipboard.Mode = Mode.Clipboard) -> None:
+        if mode != self.Mode.Clipboard:
+            return
         mime_data = QtCore.QMimeData()
         mime_data.setText(text)
         self.setMimeData(mime_data)
 
-    def text(self) -> str:
+    def text(self, mode: QtGui.QClipboard.Mode = Mode.Clipboard) -> str:
+        if mode != self.Mode.Clipboard:
+            return ""
         return self._mime_data.text()
 
-    def setPixmap(self, pixmap: QtGui.QPixmap) -> None:
+    def setPixmap(
+        self,
+        pixmap: QtGui.QPixmap,
+        mode: QtGui.QClipboard.Mode = Mode.Clipboard,
+    ) -> None:
+        if mode != self.Mode.Clipboard:
+            return
         self._mime_data = QtCore.QMimeData()
         self._pixmap = QtGui.QPixmap(pixmap)
         self.dataChanged.emit()
 
-    def pixmap(self) -> QtGui.QPixmap:
+    def pixmap(self, mode: QtGui.QClipboard.Mode = Mode.Clipboard) -> QtGui.QPixmap:
+        if mode != self.Mode.Clipboard:
+            return QtGui.QPixmap()
         return QtGui.QPixmap(self._pixmap)
 
 

--- a/tests/interactive/imagetool/manager/helpers.py
+++ b/tests/interactive/imagetool/manager/helpers.py
@@ -32,6 +32,69 @@ logger = logging.getLogger(__name__)
 CONSOLE_HELPER_OFFSET = 2.5
 
 
+class InMemoryClipboard(QtCore.QObject):
+    dataChanged = QtCore.Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._mime_data = QtCore.QMimeData()
+        self._pixmap = QtGui.QPixmap()
+
+    def clear(self) -> None:
+        self._mime_data = QtCore.QMimeData()
+        self._pixmap = QtGui.QPixmap()
+        self.dataChanged.emit()
+
+    def setMimeData(self, mime_data: QtCore.QMimeData) -> None:
+        self._mime_data = mime_data
+        self._pixmap = QtGui.QPixmap()
+        self.dataChanged.emit()
+
+    def mimeData(self) -> QtCore.QMimeData:
+        return self._mime_data
+
+    def setText(self, text: str) -> None:
+        mime_data = QtCore.QMimeData()
+        mime_data.setText(text)
+        self.setMimeData(mime_data)
+
+    def text(self) -> str:
+        return self._mime_data.text()
+
+    def setPixmap(self, pixmap: QtGui.QPixmap) -> None:
+        self._mime_data = QtCore.QMimeData()
+        self._pixmap = QtGui.QPixmap(pixmap)
+        self.dataChanged.emit()
+
+    def pixmap(self) -> QtGui.QPixmap:
+        return QtGui.QPixmap(self._pixmap)
+
+
+def install_in_memory_clipboard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> InMemoryClipboard:
+    clipboard = InMemoryClipboard()
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "clipboard",
+        staticmethod(lambda: clipboard),
+    )
+    return clipboard
+
+
+def activate_widget_shortcut(widget: QtWidgets.QWidget, sequence: str) -> None:
+    for shortcut in widget.findChildren(QtWidgets.QShortcut):
+        if shortcut.parent() is not widget:
+            continue
+        shortcut_sequence = shortcut.key().toString(
+            QtGui.QKeySequence.SequenceFormat.PortableText
+        )
+        if shortcut_sequence == sequence:
+            shortcut.activated.emit()
+            return
+    raise AssertionError(f"{sequence!r} shortcut is not registered on {widget!r}")
+
+
 def console_helper_dependency(value):
     return value + CONSOLE_HELPER_OFFSET
 

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -547,6 +547,28 @@ def test_manager_macos_dock_menu_actions(
     assert manager._macos_dock_menu is None
 
 
+def test_manager_macos_dock_menu_uninstall_ignores_deleted_menu(qtbot) -> None:
+    class _DeletedDockMenu:
+        def __init__(self) -> None:
+            self.deleted = False
+
+        def close(self) -> None:
+            raise RuntimeError("menu wrapper already deleted")
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    manager = QtWidgets.QWidget()
+    qtbot.addWidget(manager)
+    dock_menu = _DeletedDockMenu()
+    manager._macos_dock_menu = dock_menu  # type: ignore[attr-defined]
+
+    manager_desktop.uninstall_macos_dock_menu(manager)
+
+    assert manager._macos_dock_menu is None  # type: ignore[attr-defined]
+    assert not dock_menu.deleted
+
+
 def test_manager_desktop_configure_process_platform_branch(monkeypatch) -> None:
     calls: list[str] = []
 

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -498,6 +498,8 @@ def test_manager_macos_dock_menu_actions(
     ],
 ) -> None:
     dock_menus: list[QtWidgets.QMenu] = []
+    deleted_menus: list[QtWidgets.QMenu] = []
+    original_delete_later = manager_desktop.QtWidgets.QMenu.deleteLater
 
     monkeypatch.setattr(manager_desktop.sys, "platform", "darwin")
     monkeypatch.setattr(
@@ -505,6 +507,11 @@ def test_manager_macos_dock_menu_actions(
         "setAsDockMenu",
         lambda menu: dock_menus.append(menu),
         raising=False,
+    )
+    monkeypatch.setattr(
+        manager_desktop.QtWidgets.QMenu,
+        "deleteLater",
+        lambda menu: (deleted_menus.append(menu), original_delete_later(menu)),
     )
 
     with manager_context() as manager:
@@ -529,6 +536,11 @@ def test_manager_macos_dock_menu_actions(
 
         assert load_calls == [True]
         assert new_manager_calls == [True]
+
+        manager.close()
+
+        assert deleted_menus == [dock_menu]
+        assert manager._macos_dock_menu is None
 
 
 def test_manager_desktop_configure_process_platform_branch(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -181,7 +181,7 @@ def test_manager_reload(
             )
             qtbot.wait_until(
                 lambda: manager.ntools == 1 and len(manager._file_handlers) == 0,
-                timeout=5000,
+                timeout=15000,
             )
         finally:
             if gc_enabled:

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -253,7 +253,7 @@ def test_manager_cloudpickle(
             sock.connect(
                 "tcp://"
                 f"{erlab.interactive.imagetool.manager.HOST_IP}:"
-                f"{erlab.interactive.imagetool.manager.PORT}"
+                f"{manager._manager_record.port}"
             )
             frames = _create_frames(content, pickler_cls=pickle.Pickler)
             del sys.modules[modname]

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -493,10 +493,21 @@ def test_manager_standalone_app_menus(
 
 def test_manager_macos_dock_menu_actions(
     monkeypatch,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
+    qtbot,
 ) -> None:
+    class _DockMenuManager(QtWidgets.QWidget):
+        def __init__(self) -> None:
+            super().__init__()
+            self._macos_dock_menu: QtWidgets.QMenu | None = None
+            self.load_calls: list[bool] = []
+            self.new_manager_calls: list[bool] = []
+
+        def load(self) -> None:
+            self.load_calls.append(True)
+
+        def open_new_manager_instance(self) -> None:
+            self.new_manager_calls.append(True)
+
     dock_menus: list[QtWidgets.QMenu] = []
     deleted_menus: list[QtWidgets.QMenu] = []
     original_delete_later = manager_desktop.QtWidgets.QMenu.deleteLater
@@ -514,33 +525,26 @@ def test_manager_macos_dock_menu_actions(
         lambda menu: (deleted_menus.append(menu), original_delete_later(menu)),
     )
 
-    with manager_context() as manager:
-        load_calls: list[bool] = []
-        new_manager_calls: list[bool] = []
-        monkeypatch.setattr(manager, "load", lambda: load_calls.append(True))
-        monkeypatch.setattr(
-            manager,
-            "open_new_manager_instance",
-            lambda: new_manager_calls.append(True),
-        )
+    manager = _DockMenuManager()
+    qtbot.addWidget(manager)
 
-        dock_menu = manager_desktop.install_macos_dock_menu(manager)
+    dock_menu = manager_desktop.install_macos_dock_menu(manager)
 
-        assert dock_menu is not None
-        assert dock_menus == [dock_menu]
-        assert manager._macos_dock_menu is dock_menu
+    assert dock_menu is not None
+    assert dock_menus == [dock_menu]
+    assert manager._macos_dock_menu is dock_menu
 
-        actions = action_map_by_object_name(dock_menu)
-        actions["manager_dock_open_workspace_action"].trigger()
-        actions["manager_dock_new_manager_action"].trigger()
+    actions = action_map_by_object_name(dock_menu)
+    actions["manager_dock_open_workspace_action"].trigger()
+    actions["manager_dock_new_manager_action"].trigger()
 
-        assert load_calls == [True]
-        assert new_manager_calls == [True]
+    assert manager.load_calls == [True]
+    assert manager.new_manager_calls == [True]
 
-        manager.close()
+    manager_desktop.uninstall_macos_dock_menu(manager)
 
-        assert deleted_menus == [dock_menu]
-        assert manager._macos_dock_menu is None
+    assert deleted_menus == [dock_menu]
+    assert manager._macos_dock_menu is None
 
 
 def test_manager_desktop_configure_process_platform_branch(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -3251,8 +3251,6 @@ def test_manager_console_replacement_updates_provenance_and_descendants(
 
     with manager_context() as manager:
         manager.show()
-        manager.toggle_console()
-        qtbot.wait_until(manager.console.isVisible, timeout=5000)
 
         itool([data0, data1], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
@@ -3264,6 +3262,9 @@ def test_manager_console_replacement_updates_provenance_and_descendants(
             timeout=5000,
         )
         child = next(iter(manager._tool_graph.root_wrappers[0]._childtools.values()))
+
+        manager.toggle_console()
+        qtbot.wait_until(manager.console.isVisible, timeout=5000)
 
         manager.console._console_widget.execute(
             "tools[0].data = tools[0].assign_coords(time=tools[1].time)"

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from IPython.core.interactiveshell import InteractiveShell
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager._console as manager_console
@@ -148,6 +148,202 @@ def test_manager_console(
         # Destroy console
         manager.console._console_widget.shutdown_kernel()
         InteractiveShell.clear_instance()
+
+
+def test_manager_console_show_event_defers_kernel_initialization(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.ensure_console_initialized()
+        scheduled: list[
+            tuple[
+                QtCore.QObject,
+                int,
+                Callable[[], None],
+                tuple[QtCore.QObject | None, ...],
+            ]
+        ] = []
+        initialized: list[str] = []
+
+        def fake_single_shot(
+            receiver: QtCore.QObject,
+            msec: int,
+            callback: Callable[[], None],
+            *guards: QtCore.QObject | None,
+        ) -> None:
+            scheduled.append((receiver, msec, callback, guards))
+
+        monkeypatch.setattr(erlab.interactive.utils, "single_shot", fake_single_shot)
+        monkeypatch.setattr(
+            manager.console._console_widget,
+            "initialize_kernel",
+            lambda: initialized.append("kernel"),
+        )
+        monkeypatch.setattr(
+            manager.console._console_widget,
+            "_update_colors",
+            lambda: initialized.append("colors"),
+        )
+
+        assert not manager.console.eventFilter(
+            manager.console._console_widget,
+            QtCore.QEvent(QtCore.QEvent.Type.Show),
+        )
+
+        assert initialized == []
+        assert len(scheduled) == 1
+        receiver, msec, callback, guards = scheduled[0]
+        assert receiver is manager.console._console_widget
+        assert msec == 0
+        assert guards == (manager.console,)
+
+        callback()
+        assert initialized == ["kernel", "colors"]
+
+
+def test_manager_console_queued_show_callback_ignores_shutdown_kernel(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.ensure_console_initialized()
+        scheduled: list[
+            tuple[
+                QtCore.QObject,
+                int,
+                Callable[[], None],
+                tuple[QtCore.QObject | None, ...],
+            ]
+        ] = []
+        initialized: list[str] = []
+
+        def fake_single_shot(
+            receiver: QtCore.QObject,
+            msec: int,
+            callback: Callable[[], None],
+            *guards: QtCore.QObject | None,
+        ) -> None:
+            scheduled.append((receiver, msec, callback, guards))
+
+        monkeypatch.setattr(erlab.interactive.utils, "single_shot", fake_single_shot)
+        monkeypatch.setattr(
+            manager.console._console_widget,
+            "initialize_kernel",
+            lambda: initialized.append("kernel"),
+        )
+        monkeypatch.setattr(
+            manager.console._console_widget,
+            "_update_colors",
+            lambda: initialized.append("colors"),
+        )
+
+        assert not manager.console.eventFilter(
+            manager.console._console_widget,
+            QtCore.QEvent(QtCore.QEvent.Type.Show),
+        )
+        assert len(scheduled) == 1
+
+        manager.console._console_widget.shutdown_kernel()
+        scheduled[0][2]()
+
+        assert initialized == []
+
+
+def test_manager_console_shutdown_blocks_late_kernel_start(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.ensure_console_initialized()
+        console_widget = manager.console._console_widget
+
+        console_widget.shutdown_kernel()
+        console_widget.initialize_kernel()
+        console_widget.execute("late_value = 1")
+
+        assert console_widget.kernel_manager.kernel is None
+
+
+def test_manager_console_event_filter_ignores_invalid_events(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.ensure_console_initialized()
+        scheduled: list[object] = []
+        monkeypatch.setattr(
+            erlab.interactive.utils,
+            "single_shot",
+            lambda *args: scheduled.append(args),
+        )
+
+        assert not manager.console.eventFilter(manager.console._console_widget, None)
+
+        other = QtWidgets.QWidget()
+        qtbot.addWidget(other)
+        assert not manager.console.eventFilter(
+            other,
+            QtCore.QEvent(QtCore.QEvent.Type.Show),
+        )
+
+        assert not manager.console.eventFilter(
+            manager.console._console_widget,
+            QtCore.QEvent(QtCore.QEvent.Type.Hide),
+        )
+        assert scheduled == []
+
+        initialized: list[str] = []
+        monkeypatch.setattr(
+            manager.console._console_widget,
+            "initialize_kernel",
+            lambda: initialized.append("kernel"),
+        )
+        monkeypatch.setattr(
+            manager.console._console_widget,
+            "_update_colors",
+            lambda: initialized.append("colors"),
+        )
+        monkeypatch.setattr(
+            erlab.interactive.utils, "qt_is_valid", lambda *_objs: False
+        )
+        manager.console._initialize_visible_console()
+        assert initialized == []
+
+        invalid_event = QtCore.QEvent(QtCore.QEvent.Type.Show)
+        original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+
+        def fake_qt_is_valid(*objects: object) -> bool:
+            if any(obj is invalid_event for obj in objects):
+                return False
+            return original_qt_is_valid(*objects)
+
+        monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", fake_qt_is_valid)
+        assert not manager.console.eventFilter(
+            manager.console._console_widget,
+            invalid_event,
+        )
+
+        class DeletedEvent:
+            def type(self) -> QtCore.QEvent.Type:
+                raise RuntimeError("wrapped C/C++ object has been deleted")
+
+        monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", lambda *_objs: True)
+        assert not manager.console.eventFilter(
+            manager.console._console_widget,
+            typing.cast("QtCore.QEvent", DeletedEvent()),
+        )
+        assert scheduled == []
 
 
 def test_manager_console_handles_use_filtered_display_data(

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -3092,14 +3092,15 @@ def test_manager_reload_self_replacement_uses_recorded_source(
 
     with manager_context() as manager:
         manager.show()
-        manager.toggle_console()
-        qtbot.wait_until(manager.console.isVisible, timeout=5000)
         itool(data, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         wrapper = manager._tool_graph.root_wrappers[0]
         wrapper.set_detached_provenance(file_spec)
 
-        manager.console._console_widget.execute("tools[0].data = tools[0] + 1.0")
+        tools = manager_console.ToolsNamespace(manager)
+        tool = tools[0]
+        assert tool is not None
+        tool.data = tool + 1.0
         expected = data + 1.0
         xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
 
@@ -3118,9 +3119,6 @@ def test_manager_reload_self_replacement_uses_recorded_source(
         assert rebuilt_spec.script_inputs[0].node_snapshot_token is None
         assert rebuilt_spec.script_inputs[0].parsed_provenance_spec() == file_spec
 
-        manager.console._console_widget.shutdown_kernel()
-        InteractiveShell.clear_instance()
-
 
 def test_manager_reload_raw_self_replacement_unavailable(
     qtbot,
@@ -3136,12 +3134,13 @@ def test_manager_reload_raw_self_replacement_unavailable(
 
     with manager_context() as manager:
         manager.show()
-        manager.toggle_console()
-        qtbot.wait_until(manager.console.isVisible, timeout=5000)
         itool(data, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        manager.console._console_widget.execute("tools[0].data = tools[0] + 1.0")
+        tools = manager_console.ToolsNamespace(manager)
+        tool = tools[0]
+        assert tool is not None
+        tool.data = tool + 1.0
         expected = data + 1.0
         xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
 
@@ -3155,9 +3154,6 @@ def test_manager_reload_raw_self_replacement_unavailable(
         manager.reload_selected()
 
         xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
-
-        manager.console._console_widget.shutdown_kernel()
-        InteractiveShell.clear_instance()
 
 
 def test_unavailable_replay_code_details_lists_unique_labels_and_fallback() -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -5281,30 +5281,50 @@ def test_figure_composer_export_dpi_must_be_positive(dpi: int) -> None:
 
 def test_figure_composer_generated_code_uses_available_stylesheets(
     qtbot,
+    monkeypatch,
     restore_interactive_options,
+    tmp_path: Path,
 ) -> None:
-    _set_figure_stylesheets(["classic", "missing-style"])
-    data = xr.DataArray(
-        np.arange(4.0),
-        dims=("x",),
-        coords={"x": np.arange(4.0)},
-        name="data",
-    )
-    tool = FigureComposerTool(data)
-    qtbot.addWidget(tool)
+    style_name = "erlab-test-available-style"
+    style_dir = tmp_path / "stylelib"
+    style_dir.mkdir()
+    (style_dir / f"{style_name}.mplstyle").write_text("axes.facecolor: white\n")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=mpl.MatplotlibDeprecationWarning)
+        import matplotlib.style.core as mpl_style_core
 
-    code = tool.generated_code()
+    mpl_style_core.USER_LIBRARY_PATHS.append(str(style_dir))
+    try:
+        mpl_style.reload_library()
+        monkeypatch.setattr(
+            figurecomposer_defaults,
+            "_configured_stylesheets",
+            lambda: (style_name, "missing-style"),
+        )
+        data = xr.DataArray(
+            np.arange(4.0),
+            dims=("x",),
+            coords={"x": np.arange(4.0)},
+            name="data",
+        )
+        tool = FigureComposerTool(data)
+        qtbot.addWidget(tool)
 
-    assert "plt.style.use(['classic'])" in code
-    assert "# Skipped unavailable stylesheets: 'missing-style'" in code
-    assert tool.preview_pixmap is None
-    assert tool.refresh_preview_pixmap() is None
-    assert tool.refresh_preview_pixmap(allow_offscreen=True) is not None
-    assert tool.preview_pixmap is not None
-    namespace = {"data": data}
-    with mpl.rc_context():
-        exec(code, namespace)  # noqa: S102
-    namespace["plt"].close(namespace["fig"])
+        code = tool.generated_code()
+
+        assert f"plt.style.use(['{style_name}'])" in code
+        assert "# Skipped unavailable stylesheets: 'missing-style'" in code
+        assert tool.preview_pixmap is None
+        assert tool.refresh_preview_pixmap() is None
+        assert tool.refresh_preview_pixmap(allow_offscreen=True) is not None
+        assert tool.preview_pixmap is not None
+        namespace = {"data": data}
+        with mpl.rc_context():
+            exec(code, namespace)  # noqa: S102
+        namespace["plt"].close(namespace["fig"])
+    finally:
+        mpl_style_core.USER_LIBRARY_PATHS.remove(str(style_dir))
+        mpl_style.reload_library()
 
 
 def test_figure_composer_preview_uses_live_canvas_without_rerender(
@@ -5483,7 +5503,11 @@ def test_figure_composer_rechecks_configured_stylesheets_after_erlab_import(
         "load_erlab_plotting_stylesheets",
         lambda: available.append("classic"),
     )
-    _set_figure_stylesheets(["classic"])
+    monkeypatch.setattr(
+        figurecomposer_defaults,
+        "_configured_stylesheets",
+        lambda: ("classic",),
+    )
     data = xr.DataArray(
         np.arange(4.0),
         dims=("x",),
@@ -5532,7 +5556,11 @@ def test_figure_composer_generated_code_imports_erlab_for_erlab_stylesheet(
     )
     erlab.interactive._stylesheets._ERLAB_REGISTERED_STYLESHEETS.clear()
     monkeypatch.setattr(figurecomposer_defaults.mpl_style, "context", style_context)
-    _set_figure_stylesheets(["erlab-test-style"])
+    monkeypatch.setattr(
+        figurecomposer_defaults,
+        "_configured_stylesheets",
+        lambda: ("erlab-test-style",),
+    )
     data = xr.DataArray(
         np.arange(4.0),
         dims=("x",),
@@ -5561,9 +5589,14 @@ def test_figure_composer_generated_code_imports_erlab_for_erlab_stylesheet(
 
 def test_figure_composer_generated_code_imports_erlab_for_preloaded_erlab_style(
     qtbot,
+    monkeypatch,
     restore_interactive_options,
 ) -> None:
-    _set_figure_stylesheets(["nature"])
+    monkeypatch.setattr(
+        figurecomposer_defaults,
+        "_configured_stylesheets",
+        lambda: ("nature",),
+    )
     data = xr.DataArray(
         np.arange(4.0),
         dims=("x",),

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -16589,6 +16589,7 @@ def test_manager_append_figure_warns_for_uneditable_plot_slices_selection(
 
 
 def test_manager_figures_tab_does_not_set_empty_minimum_width(
+    qtbot,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -16610,8 +16611,13 @@ def test_manager_figures_tab_does_not_set_empty_minimum_width(
 
         assert manager.left_tabs.count() == 2
         assert manager.left_tabs.indexOf(manager.figure_tab) == 1
+        manager._show_figure_menu(QtCore.QPoint())
+        menu = manager._figure_menu
+        assert isinstance(menu, QtWidgets.QMenu)
+        qtbot.wait_until(menu.isVisible, timeout=5000)
 
         manager._remove_childtool(figure_uid)
+        qtbot.wait_until(lambda: manager._figure_menu is None, timeout=5000)
 
         assert manager.left_tabs.count() == 1
         assert not hasattr(manager, "figure_tab")
@@ -16621,6 +16627,58 @@ def test_manager_figures_tab_does_not_set_empty_minimum_width(
         manager._figure_selection_changed()
         manager._show_figure_item(QtWidgets.QListWidgetItem("removed"))
         manager._show_figure_menu(QtCore.QPoint())
+
+
+def test_manager_figure_menu_helpers_release_stale_wrappers(
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager._close_figure_menu()
+        assert manager._figure_menu is None
+
+        menu = QtWidgets.QMenu(manager)
+        manager._figure_menu = menu
+        manager._close_figure_menu()
+        assert manager._figure_menu is None
+
+        stale_menu = QtWidgets.QMenu(manager)
+        manager._figure_menu = stale_menu
+        original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+
+        def fake_qt_is_valid(*objects: object) -> bool:
+            if any(obj is stale_menu for obj in objects):
+                return False
+            return original_qt_is_valid(*objects)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(erlab.interactive.utils, "qt_is_valid", fake_qt_is_valid)
+            manager._close_figure_menu()
+            assert manager._figure_menu is None
+            manager._release_figure_menu(stale_menu)
+
+
+def test_manager_figure_menu_releases_menu_without_viewport(
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="line",
+    )
+    with manager_context() as manager:
+        manager.add_figuretool(FigureComposerTool(data), show=False)
+        monkeypatch.setattr(type(manager.figure_list), "viewport", lambda _self: None)
+
+        manager._show_figure_menu(QtCore.QPoint())
+
+        assert manager._figure_menu is None
 
 
 def _selection_shortcut_sequences(widget: QtWidgets.QWidget) -> set[str]:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -86,7 +86,10 @@ from erlab.interactive._options import options
 from erlab.interactive._options.schema import AppOptions, FigureOptions
 from erlab.interactive.imagetool import itool, provenance
 from tests.interactive.imagetool.manager.helpers import (
+    InMemoryClipboard,
     _exec_generated_code,
+    activate_widget_shortcut,
+    install_in_memory_clipboard,
     select_child_tool,
     select_tools,
     trigger_menu_action,
@@ -109,9 +112,82 @@ def restore_interactive_options():
         plt.close("all")
 
 
+@pytest.fixture(autouse=True)
+def isolate_qt_clipboard(monkeypatch: pytest.MonkeyPatch) -> InMemoryClipboard:
+    return install_in_memory_clipboard(monkeypatch)
+
+
 def _set_figure_stylesheets(stylesheets: list[str]) -> None:
     options.model = options.model.model_copy(
         update={"figure": FigureOptions(stylesheets=stylesheets)}
+    )
+
+
+def _send_mouse_event(
+    widget: QtWidgets.QWidget,
+    event_type: QtCore.QEvent.Type,
+    pos: QtCore.QPoint,
+    *,
+    button: QtCore.Qt.MouseButton = QtCore.Qt.MouseButton.NoButton,
+    buttons: QtCore.Qt.MouseButton = QtCore.Qt.MouseButton.NoButton,
+    modifiers: QtCore.Qt.KeyboardModifier = QtCore.Qt.KeyboardModifier.NoModifier,
+) -> None:
+    global_pos = widget.mapToGlobal(pos)
+    event = QtGui.QMouseEvent(
+        event_type,
+        QtCore.QPointF(pos),
+        QtCore.QPointF(global_pos),
+        button,
+        buttons,
+        modifiers,
+    )
+    QtWidgets.QApplication.sendEvent(widget, event)
+    QtWidgets.QApplication.processEvents()
+
+
+def _send_mouse_move(
+    widget: QtWidgets.QWidget,
+    pos: QtCore.QPoint,
+    *,
+    buttons: QtCore.Qt.MouseButton = QtCore.Qt.MouseButton.NoButton,
+    modifiers: QtCore.Qt.KeyboardModifier = QtCore.Qt.KeyboardModifier.NoModifier,
+) -> None:
+    _send_mouse_event(
+        widget,
+        QtCore.QEvent.Type.MouseMove,
+        pos,
+        buttons=buttons,
+        modifiers=modifiers,
+    )
+
+
+def _drag_widget(
+    widget: QtWidgets.QWidget,
+    start: QtCore.QPoint,
+    end: QtCore.QPoint,
+    *,
+    modifiers: QtCore.Qt.KeyboardModifier = QtCore.Qt.KeyboardModifier.NoModifier,
+) -> None:
+    _send_mouse_event(
+        widget,
+        QtCore.QEvent.Type.MouseButtonPress,
+        start,
+        button=QtCore.Qt.MouseButton.LeftButton,
+        buttons=QtCore.Qt.MouseButton.LeftButton,
+        modifiers=modifiers,
+    )
+    _send_mouse_move(
+        widget,
+        end,
+        buttons=QtCore.Qt.MouseButton.LeftButton,
+        modifiers=modifiers,
+    )
+    _send_mouse_event(
+        widget,
+        QtCore.QEvent.Type.MouseButtonRelease,
+        end,
+        button=QtCore.Qt.MouseButton.LeftButton,
+        modifiers=modifiers,
     )
 
 
@@ -187,7 +263,7 @@ def _selected_operation_rows(tool: FigureComposerTool) -> tuple[int, ...]:
     )
 
 
-def _clear_clipboard() -> QtGui.QClipboard:
+def _clear_clipboard() -> InMemoryClipboard:
     clipboard = QtWidgets.QApplication.clipboard()
     clipboard.clear()
     return clipboard
@@ -3050,17 +3126,11 @@ def test_figure_composer_axes_selector_widget_mouse_selection(qtbot) -> None:
         pos=selector.cell_rect((0, 0)).center(),
     )
 
-    qtbot.mousePress(
+    _drag_widget(
         selector,
-        QtCore.Qt.MouseButton.LeftButton,
-        QtCore.Qt.KeyboardModifier.ControlModifier,
-        pos=selector.cell_rect((0, 0)).center(),
-    )
-    qtbot.mouseMove(selector, selector.cell_rect((1, 1)).center())
-    qtbot.mouseRelease(
-        selector,
-        QtCore.Qt.MouseButton.LeftButton,
-        pos=selector.cell_rect((1, 1)).center(),
+        selector.cell_rect((0, 0)).center(),
+        selector.cell_rect((1, 1)).center(),
+        modifiers=QtCore.Qt.KeyboardModifier.ControlModifier,
     )
     assert selected[-1] == ((0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2))
     selector.mousePressEvent(None)
@@ -3070,7 +3140,7 @@ def test_figure_composer_axes_selector_widget_mouse_selection(qtbot) -> None:
     add_requests: list[str] = []
     selector.sigAddRowRequested.connect(lambda: add_requests.append("row"))
     selector.sigAddColumnRequested.connect(lambda: add_requests.append("column"))
-    qtbot.mouseMove(selector, selector._add_pill_rect("row").center())
+    _send_mouse_move(selector, selector._add_pill_rect("row").center())
     qtbot.mouseClick(
         selector,
         QtCore.Qt.MouseButton.LeftButton,
@@ -3258,17 +3328,11 @@ def test_figure_composer_gridspec_view_widget_selection_and_editing(qtbot) -> No
         pos=selector.axis_rect("main-axis").center(),
     )
     assert selected[-1] == ("child-axis",)
-    qtbot.mousePress(
+    _drag_widget(
         selector,
-        QtCore.Qt.MouseButton.LeftButton,
-        QtCore.Qt.KeyboardModifier.ControlModifier,
-        pos=selector.axis_rect("main-axis").center(),
-    )
-    qtbot.mouseMove(selector, selector.axis_rect("child-axis").center())
-    qtbot.mouseRelease(
-        selector,
-        QtCore.Qt.MouseButton.LeftButton,
-        pos=selector.axis_rect("child-axis").center(),
+        selector.axis_rect("main-axis").center(),
+        selector.axis_rect("child-axis").center(),
+        modifiers=QtCore.Qt.KeyboardModifier.ControlModifier,
     )
     assert selected[-1] == ("main-axis", "child-axis")
     selector.mouseMoveEvent(None)
@@ -3402,16 +3466,10 @@ def test_figure_composer_gridspec_view_widget_selection_and_editing(qtbot) -> No
         pos=QtCore.QPoint(-10, -10),
     )
     assert created == []
-    qtbot.mousePress(
+    _drag_widget(
         editor,
-        QtCore.Qt.MouseButton.LeftButton,
-        pos=editor.cell_rect((1, 0)).center(),
-    )
-    qtbot.mouseMove(editor, editor.cell_rect((1, 0)).center())
-    qtbot.mouseRelease(
-        editor,
-        QtCore.Qt.MouseButton.LeftButton,
-        pos=editor.cell_rect((1, 0)).center(),
+        editor.cell_rect((1, 0)).center(),
+        editor.cell_rect((1, 0)).center(),
     )
     assert created[-1] == FigureGridSpecSpanState(
         row_start=1,
@@ -7766,9 +7824,7 @@ def test_figure_composer_gridspec_widget_resizes_selected_region(qtbot) -> None:
 
     handle_pos = widget.span_rect(original_span).bottomRight() - QtCore.QPoint(2, 2)
     end_pos = widget.cell_rect((0, 1)).center()
-    qtbot.mousePress(widget, QtCore.Qt.MouseButton.LeftButton, pos=handle_pos)
-    qtbot.mouseMove(widget, end_pos)
-    qtbot.mouseRelease(widget, QtCore.Qt.MouseButton.LeftButton, pos=end_pos)
+    _drag_widget(widget, handle_pos, end_pos)
 
     assert len(tool.tool_status.setup.gridspec.root.axes) == 1
     assert tool.tool_status.setup.gridspec.root.axes[0].span == (
@@ -7802,16 +7858,10 @@ def test_figure_composer_gridspec_widget_moves_selected_region(qtbot) -> None:
     widget = tool.gridspec_layout_widget
     widget.resize(widget.sizeHint())
 
-    qtbot.mousePress(
+    _drag_widget(
         widget,
-        QtCore.Qt.MouseButton.LeftButton,
-        pos=widget.span_rect(original_span).center(),
-    )
-    qtbot.mouseMove(widget, widget.cell_rect((1, 2)).center())
-    qtbot.mouseRelease(
-        widget,
-        QtCore.Qt.MouseButton.LeftButton,
-        pos=widget.cell_rect((1, 2)).center(),
+        widget.span_rect(original_span).center(),
+        widget.cell_rect((1, 2)).center(),
     )
 
     assert len(tool.tool_status.setup.gridspec.root.axes) == 1
@@ -7958,7 +8008,7 @@ def test_figure_composer_gridspec_row_shrink_ignores_invalid_regions(qtbot) -> N
     assert any(not region.valid for region in widget._regions)
     assert widget.span_rect(removed_span) == QtCore.QRect()
     assert widget._region_at(widget.cell_rect((0, 0)).center()) is not None
-    qtbot.mouseMove(widget, widget.cell_rect((0, 0)).center())
+    _send_mouse_move(widget, widget.cell_rect((0, 0)).center())
 
 
 def test_figure_composer_gridspec_axes_targets_survive_region_delete(qtbot) -> None:
@@ -8487,9 +8537,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     tool._target_current_operation_valid_axes()
     start = selector.cell_rect((0, 0)).center()
     end = selector.cell_rect((0, 1)).center()
-    qtbot.mousePress(selector, QtCore.Qt.MouseButton.LeftButton, pos=start)
-    qtbot.mouseMove(selector, end)
-    qtbot.mouseRelease(selector, QtCore.Qt.MouseButton.LeftButton, pos=end)
+    _drag_widget(selector, start, end)
     qtbot.wait(1)
     assert tool.tool_status.operations[0].axes.axes == ((0, 0), (0, 1))
     assert (
@@ -16690,20 +16738,18 @@ def _selection_shortcut_sequences(widget: QtWidgets.QWidget) -> set[str]:
 
 
 @pytest.mark.parametrize(
-    ("platform", "rename_key", "show_key", "show_modifier", "expected_shortcuts"),
+    ("platform", "rename_shortcut", "show_shortcut", "expected_shortcuts"),
     [
         (
             "darwin",
-            QtCore.Qt.Key.Key_Return,
-            QtCore.Qt.Key.Key_Down,
-            QtCore.Qt.KeyboardModifier.ControlModifier,
+            "Return",
+            "Ctrl+Down",
             {"Return", "Enter", "Ctrl+Down"},
         ),
         (
             "linux",
-            QtCore.Qt.Key.Key_F2,
-            QtCore.Qt.Key.Key_Return,
-            QtCore.Qt.KeyboardModifier.NoModifier,
+            "F2",
+            "Return",
             {"F2", "Return", "Enter"},
         ),
     ],
@@ -16715,9 +16761,8 @@ def test_manager_figure_list_selection_shortcuts_are_platform_native(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
     platform: str,
-    rename_key: QtCore.Qt.Key,
-    show_key: QtCore.Qt.Key,
-    show_modifier: QtCore.Qt.KeyboardModifier,
+    rename_shortcut: str,
+    show_shortcut: str,
     expected_shortcuts: set[str],
 ) -> None:
     monkeypatch.setattr(manager_mainwindow.sys, "platform", platform)
@@ -16735,9 +16780,7 @@ def test_manager_figure_list_selection_shortcuts_are_platform_native(
         assert manager.show_action.shortcut().isEmpty()
         assert _selection_shortcut_sequences(manager.figure_list) == expected_shortcuts
 
-        manager.figure_list.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
-        qtbot.wait_until(manager.figure_list.hasFocus, timeout=5000)
-        qtbot.keyClick(manager.figure_list, rename_key)
+        activate_widget_shortcut(manager.figure_list, rename_shortcut)
         qtbot.wait_until(
             lambda: (
                 manager.figure_list.state()
@@ -16756,9 +16799,7 @@ def test_manager_figure_list_selection_shortcuts_are_platform_native(
 
         shown: list[str] = []
         monkeypatch.setattr(manager, "show_childtool", shown.append)
-        manager.figure_list.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
-        qtbot.wait_until(manager.figure_list.hasFocus, timeout=5000)
-        qtbot.keyClick(manager.figure_list, show_key, show_modifier)
+        activate_widget_shortcut(manager.figure_list, show_shortcut)
         qtbot.wait_until(lambda: shown == [figure_uid], timeout=5000)
 
 

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -5242,9 +5242,15 @@ def test_figure_composer_editor_signal_allows_callback_to_delete_sender(qtbot) -
 
 
 def test_figure_composer_defaults_follow_stylesheet_rcparams(
+    monkeypatch,
     restore_interactive_options,
 ) -> None:
     _set_figure_stylesheets(["classic"])
+    monkeypatch.setattr(
+        figurecomposer_defaults,
+        "_configured_stylesheets",
+        lambda: ("classic",),
+    )
 
     with mpl_style.context(["classic"]):
         expected_figsize = tuple(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -3563,18 +3563,18 @@ def test_manager_selected_reload_targets_handles_stale_selection(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    with manager_context() as manager:
-        monkeypatch.setattr(
+    with manager_context() as manager, monkeypatch.context() as stale_selection:
+        stale_selection.setattr(
             type(manager.tree_view),
             "selected_imagetool_indices",
             property(lambda _view: []),
         )
-        monkeypatch.setattr(
+        stale_selection.setattr(
             type(manager.tree_view),
             "selected_childtool_uids",
             property(lambda _view: ["stale-child"]),
         )
-        monkeypatch.setattr(
+        stale_selection.setattr(
             manager,
             "_child_node",
             lambda _uid: (_ for _ in ()).throw(KeyError("missing")),
@@ -3583,8 +3583,8 @@ def test_manager_selected_reload_targets_handles_stale_selection(
         assert manager._selected_reload_targets() is None
 
         child_node = types.SimpleNamespace(has_source_binding=True)
-        monkeypatch.setattr(manager, "_child_node", lambda _uid: child_node)
-        monkeypatch.setattr(
+        stale_selection.setattr(manager, "_child_node", lambda _uid: child_node)
+        stale_selection.setattr(
             manager,
             "_parent_node",
             lambda _node: (_ for _ in ()).throw(KeyError("missing-parent")),
@@ -3599,18 +3599,19 @@ def test_manager_reload_selected_skips_child_refresh_when_parent_reload_fails(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    with manager_context() as manager:
+    with manager_context() as manager, monkeypatch.context() as reload_failure:
         node = types.SimpleNamespace(
             imagetool=object(),
             slicer_area=types.SimpleNamespace(_reload=lambda: False),
         )
         refreshed: list[str] = []
-        monkeypatch.setattr(
+        reload_failure.setattr(
             manager, "_selected_reload_targets", lambda: ([0], {0: ["child"]})
         )
-        monkeypatch.setattr(manager, "_node_for_target", lambda _target: node)
-        monkeypatch.setattr(manager, "_refresh_source_chain_to_uid", refreshed.append)
-
+        reload_failure.setattr(manager, "_node_for_target", lambda _target: node)
+        reload_failure.setattr(
+            manager, "_refresh_source_chain_to_uid", refreshed.append
+        )
         manager.reload_selected()
 
         assert refreshed == []

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -2365,9 +2365,8 @@ def test_remove_from_window_shortcut(
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
 
-def test_remove_childtool_delete_shortcut(
+def test_remove_childtool_direct_removal(
     qtbot,
-    accept_dialog,
     test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -2387,14 +2386,9 @@ def test_remove_childtool_delete_shortcut(
             timeout=5000,
         )
         wrapper = manager._tool_graph.root_wrappers[0]
-        uid, child = next(iter(wrapper._childtools.items()))
+        uid, _child = next(iter(wrapper._childtools.items()))
 
-        with qtbot.waitExposed(child):
-            child.activateWindow()
-            child.raise_()
-            child.setFocus()
-
-        accept_dialog(lambda: qtbot.keyClick(child, QtCore.Qt.Key.Key_Delete))
+        manager._remove_childtool(uid)
         qtbot.wait_until(lambda: uid not in wrapper._childtools, timeout=5000)
 
 

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -343,7 +343,6 @@ def test_batch_dialog_defensive_paths_and_launch(
         )
         select_tools(manager, [0, 1])
         dialog = _BatchOperationDialog(manager)
-        qtbot.addWidget(dialog)
 
         with monkeypatch.context() as mp:
             mp.setattr(
@@ -708,7 +707,6 @@ def test_batch_dialog_categories_and_target_checks_update_manager_selection(
 
         select_tools(manager, [0, 1])
         dialog = _BatchOperationDialog(manager)
-        qtbot.addWidget(dialog)
 
         assert dialog._operation_tree.topLevelItemCount() == 4
         rendered_dialogs = []
@@ -758,7 +756,6 @@ def test_batch_dialog_open_refreshes_cached_targets(
 
         manager.show_batch_operations()
         dialog = manager._actions_controller._batch_dialog
-        qtbot.addWidget(dialog)
         qtbot.wait_until(lambda: dialog.isVisible(), timeout=1000)
         assert set(dialog._target_items) == {0, 1}
 
@@ -813,7 +810,6 @@ def test_batch_dialog_expands_child_targets(
 
         manager.show_batch_operations()
         dialog = manager._actions_controller._batch_dialog
-        qtbot.addWidget(dialog)
         qtbot.wait_until(lambda: dialog.isVisible(), timeout=1000)
 
         parent_item = dialog._target_tree.topLevelItem(0)

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -44,6 +44,7 @@ from erlab.interactive.imagetool.manager._widgets import (
 
 from .helpers import (
     _exec_generated_code,
+    activate_widget_shortcut,
     assert_nonempty_tooltip,
     bring_manager_to_top,
     child_status_badge,
@@ -129,20 +130,18 @@ def _selection_shortcut_sequences(
 
 
 @pytest.mark.parametrize(
-    ("platform", "rename_key", "show_key", "show_modifier", "expected_shortcuts"),
+    ("platform", "rename_shortcut", "show_shortcut", "expected_shortcuts"),
     [
         (
             "darwin",
-            QtCore.Qt.Key.Key_Return,
-            QtCore.Qt.Key.Key_Down,
-            QtCore.Qt.KeyboardModifier.ControlModifier,
+            "Return",
+            "Ctrl+Down",
             {"Return", "Enter", "Ctrl+Down"},
         ),
         (
             "linux",
-            QtCore.Qt.Key.Key_F2,
-            QtCore.Qt.Key.Key_Return,
-            QtCore.Qt.KeyboardModifier.NoModifier,
+            "F2",
+            "Return",
             {"F2", "Return", "Enter"},
         ),
     ],
@@ -155,9 +154,8 @@ def test_manager_tree_view_selection_shortcuts_are_platform_native(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
     platform: str,
-    rename_key: QtCore.Qt.Key,
-    show_key: QtCore.Qt.Key,
-    show_modifier: QtCore.Qt.KeyboardModifier,
+    rename_shortcut: str,
+    show_shortcut: str,
     expected_shortcuts: set[str],
 ) -> None:
     monkeypatch.setattr(manager_mainwindow.sys, "platform", platform)
@@ -174,11 +172,8 @@ def test_manager_tree_view_selection_shortcuts_are_platform_native(
 
         tool = manager.get_imagetool(0)
         tool.hide()
-        bring_manager_to_top(qtbot, manager)
-        manager.tree_view.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
-        qtbot.wait_until(manager.tree_view.hasFocus, timeout=5000)
 
-        qtbot.keyClick(manager.tree_view, rename_key)
+        activate_widget_shortcut(manager.tree_view, rename_shortcut)
         qtbot.wait_until(
             lambda: (
                 manager.tree_view.state()
@@ -199,9 +194,7 @@ def test_manager_tree_view_selection_shortcuts_are_platform_native(
         )
         assert not tool.isVisible()
 
-        manager.tree_view.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
-        qtbot.wait_until(manager.tree_view.hasFocus, timeout=5000)
-        qtbot.keyClick(manager.tree_view, show_key, show_modifier)
+        activate_widget_shortcut(manager.tree_view, show_shortcut)
         qtbot.wait_until(tool.isVisible, timeout=5000)
 
 
@@ -2288,18 +2281,21 @@ def test_manager(
             manager.raise_()
             manager.preview_action.setChecked(True)
 
-        # Test mouse hover over list view
-        # This may not work on all systems due to the way the mouse events are generated
-        delegate._force_hover = True
-
+        # Test hover-preview delegate painting without moving the shared display cursor.
         first_index = manager.tree_view.model().index(0, 0)
-        first_rect_center = manager.tree_view.visualRect(first_index).center()
-        qtbot.mouseMove(manager.tree_view.viewport())
-        qtbot.mouseMove(manager.tree_view.viewport(), first_rect_center)
-        qtbot.mouseMove(
-            manager.tree_view.viewport(), first_rect_center - QtCore.QPoint(10, 10)
+        option = delegate._option_for_index(manager.tree_view, first_index)
+        option.state |= QtWidgets.QStyle.StateFlag.State_MouseOver
+        pixmap = QtGui.QPixmap(manager.tree_view.viewport().size())
+        pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+        painter = QtGui.QPainter(pixmap)
+        try:
+            delegate.paint(painter, option, first_index)
+        finally:
+            painter.end()
+        delegate.eventFilter(
+            manager.tree_view.viewport(),
+            QtCore.QEvent(QtCore.QEvent.Type.Leave),
         )
-        qtbot.mouseMove(manager.tree_view.viewport())  # move to blank should hide popup
 
         # Remove third tool
         select_tools(manager, [3])

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -2398,7 +2398,7 @@ def test_remove_childtool_delete_shortcut(
         qtbot.wait_until(lambda: uid not in wrapper._childtools, timeout=5000)
 
 
-def test_remove_child_imagetool_delete_shortcut(
+def test_remove_child_imagetool_remove_action(
     qtbot,
     accept_dialog,
     test_data,
@@ -2427,7 +2427,7 @@ def test_remove_child_imagetool_delete_shortcut(
 
         assert child.remove_act.isVisible()
 
-        accept_dialog(lambda: qtbot.keyClick(child, QtCore.Qt.Key.Key_Delete))
+        accept_dialog(child.remove_act.trigger)
         qtbot.wait_until(
             lambda: child_uid not in manager._tool_graph.nodes, timeout=5000
         )

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -303,12 +303,8 @@ def test_treeview(qtbot, accept_dialog, test_data) -> None:
 
     # Show context menu
     manager.tree_view._show_menu(first_row_rect.center())
-    menu = None
-    for tl in QtWidgets.QApplication.topLevelWidgets():
-        if isinstance(tl, QtWidgets.QMenu):
-            menu = tl
-            break
-    assert isinstance(menu, QtWidgets.QMenu)
+    menu = manager.tree_view._menu
+    qtbot.wait_until(menu.isVisible)
     menu.close()
     QtWidgets.QApplication.processEvents()
 

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -293,7 +293,6 @@ def test_treeview(qtbot, accept_dialog, test_data) -> None:
     first_row_rect = manager.tree_view.visualRect(model.index(0, 0))
 
     # Click on first row
-    qtbot.mouseMove(manager.tree_view.viewport(), first_row_rect.center())
     qtbot.mousePress(
         manager.tree_view.viewport(),
         QtCore.Qt.MouseButton.LeftButton,

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -2113,6 +2113,49 @@ def test_manager_provenance_edit_controller_dialog_execution_branches(
         )
 
 
+def test_manager_provenance_edit_controller_skips_deleted_temp_tool_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _fake_edit_controller()
+    data = xr.DataArray(np.arange(6, dtype=float).reshape((2, 3)), dims=("x", "y"))
+    operation = provenance.NormalizeOperation(dims=("x",), mode="area")
+    original_itool = erlab.interactive.itool
+    original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+    created_tools: list[QtWidgets.QWidget] = []
+
+    def recording_itool(*args, **kwargs):
+        tool = original_itool(*args, **kwargs)
+        created_tools.append(tool)
+        return tool
+
+    def fake_qt_is_valid(*objects: object) -> bool:
+        if created_tools and any(obj is created_tools[-1] for obj in objects):
+            return False
+        return original_qt_is_valid(*objects)
+
+    monkeypatch.setattr(
+        manager_provenance_edit.dialogs.NormalizeDialog,
+        "exec",
+        lambda self: int(QtWidgets.QDialog.DialogCode.Rejected),
+    )
+    with monkeypatch.context() as context:
+        context.setattr(erlab.interactive, "itool", recording_itool)
+        context.setattr(erlab.interactive.utils, "qt_is_valid", fake_qt_is_valid)
+        assert (
+            controller._edited_operations_from_dialog(
+                manager_provenance_edit.dialogs.NormalizeDialog,
+                operation,
+                data,
+            )
+            is None
+        )
+
+    for tool in created_tools:
+        if original_qt_is_valid(tool):
+            tool.close()
+            tool.deleteLater()
+
+
 def test_manager_provenance_validation_reports_active_filter_replay_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -3839,40 +3839,47 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
             "_prompt_existing_output_imagetool",
             lambda: (_ for _ in ()).throw(AssertionError("prompt should not open")),
         )
-        child.timeout_spin.setValue(30.0)
-        child.nfev_spin.setValue(0)
-        child.y_index_spin.setValue(child.y_min_spin.value())
-        child._run_fit_2d("up")
-        qtbot.wait_until(
-            lambda: all(ds is not None for ds in child._result_ds_full),
-            timeout=10000,
-        )
 
-        child.param_plot_combo.setCurrentIndex(0)
-        first_param_name = child.param_plot_combo.currentText()
-        assert first_param_name
+        param_names = [
+            child.param_plot_combo.itemText(index)
+            for index in range(child.param_plot_combo.count())
+        ]
+        first_param_name, second_param_name = param_names[:2]
+        first_param_index = child.param_plot_combo.findText(first_param_name)
+        second_param_index = child.param_plot_combo.findText(second_param_name)
+        assert first_param_index >= 0
+        assert second_param_index >= 0
+        params_full = []
+        for index in range(len(child._params_full)):
+            params = child._params.copy()
+            params[first_param_name].set(value=1.0 + index)
+            params[first_param_name].stderr = 0.01 + index
+            params[second_param_name].set(value=10.0 + index)
+            params[second_param_name].stderr = 0.1 + index
+            params_full.append(params)
+        child._params_full = params_full
+        child._result_ds_full = [xr.Dataset() for _ in params_full]
+
+        child.param_plot_combo.setCurrentIndex(first_param_index)
+        assert child.param_plot_combo.currentText() == first_param_name
         first_values = child._param_plot_dataarray(first_param_name, stderr=False)
-        second_param_name = ""
-        second_values = None
-        for index in range(1, child.param_plot_combo.count()):
-            candidate = child.param_plot_combo.itemText(index)
-            candidate_values = child._param_plot_dataarray(candidate, stderr=False)
-            if not candidate_values.identical(first_values):
-                second_param_name = candidate
-                second_values = candidate_values
-                break
-        assert second_param_name
-        assert second_values is not None
+        child.param_plot_combo.setCurrentIndex(second_param_index)
+        assert child.param_plot_combo.currentText() == second_param_name
+        second_values = child._param_plot_dataarray(second_param_name, stderr=False)
+        assert not second_values.identical(first_values)
 
+        child.param_plot_combo.setCurrentIndex(first_param_index)
         child.param_plot._show_parameter_values()
         child_node = manager._child_node(child_uid)
         qtbot.wait_until(lambda: len(child_node._childtool_indices) == 1, timeout=5000)
 
-        child.param_plot_combo.setCurrentText(second_param_name)
+        child.param_plot_combo.setCurrentIndex(second_param_index)
+        assert child.param_plot_combo.currentText() == second_param_name
         child.param_plot._show_parameter_values()
         qtbot.wait_until(lambda: len(child_node._childtool_indices) == 2, timeout=5000)
 
-        child.param_plot_combo.setCurrentText(first_param_name)
+        child.param_plot_combo.setCurrentIndex(first_param_index)
+        assert child.param_plot_combo.currentText() == first_param_name
         child.param_plot._show_parameter_stderr()
         qtbot.wait_until(lambda: len(child_node._childtool_indices) == 3, timeout=5000)
 
@@ -3905,7 +3912,7 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
             fetch(stderr_uid),
             child._param_plot_dataarray(first_param_name, stderr=True),
         )
-        child.param_plot_combo.setCurrentText(second_param_name)
+        child.param_plot_combo.setCurrentIndex(second_param_index)
         assert first_values_node._update_from_parent_source()
         xr.testing.assert_identical(fetch(first_values_uid), first_values)
         assert not fetch(first_values_uid).identical(second_values)

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -34,12 +34,14 @@ from erlab.interactive.imagetool.manager._modelview import (
 from erlab.interactive.imagetool.manager._server import _remove_idx, _show_idx
 
 from .helpers import (
+    InMemoryClipboard,
     _assert_modelfit_code_replays_source,
     _exec_generated_code,
     child_status_badge,
     click_child_status_badge,
     configure_goldtool_child,
     copy_full_code_for_uid,
+    install_in_memory_clipboard,
     make_fit1d_child,
     make_fit2d_child,
     manager_preview_pixmap,
@@ -52,6 +54,11 @@ from .helpers import (
     set_transform_launch_mode,
     trigger_menu_action,
 )
+
+
+@pytest.fixture(autouse=True)
+def isolate_qt_clipboard(monkeypatch: pytest.MonkeyPatch) -> InMemoryClipboard:
+    return install_in_memory_clipboard(monkeypatch)
 
 
 def _manager_provenance_file_spec(path: pathlib.Path):
@@ -4494,6 +4501,10 @@ def test_manager_promote_child_imagetool_rehomes_subtree_and_detaches_provenance
         assert promoted.provenance_spec is not None
         assert promoted._childtool_indices == [nested_uid]
         assert manager._child_node(nested_uid).parent_uid == child_uid
+        qtbot.wait_until(
+            lambda: manager.tree_view.selected_imagetool_indices == [promoted_index],
+            timeout=5000,
+        )
         assert manager.tree_view.selected_imagetool_indices == [promoted_index]
         assert manager.tree_view.selected_childtool_uids == []
         assert manager._root_wrapper_for_uid(nested_uid).index == promoted_index

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -876,6 +876,45 @@ def test_manager_registry_heartbeat_logs_thread_stop_timeout(
     )
 
 
+def test_manager_registry_heartbeat_stop_orphans_when_refresh_does_not_idle(
+    monkeypatch,
+    caplog,
+) -> None:
+    controller = manager_heartbeat._RegistryHeartbeatController("manager-id")
+    thread = controller._thread
+    worker = controller._worker
+    assert thread is not None
+    assert worker is not None
+    retained: list[
+        tuple[
+            QtCore.QThread,
+            manager_heartbeat._RegistryHeartbeatWorker,
+        ]
+    ] = []
+    monkeypatch.setattr(controller, "_wait_until_idle", lambda _timeout_ms: False)
+    monkeypatch.setattr(
+        manager_heartbeat._RegistryHeartbeatController,
+        "_retain_orphaned_thread",
+        staticmethod(lambda thread, worker: retained.append((thread, worker))),
+    )
+
+    with caplog.at_level(logging.WARNING, logger=manager_heartbeat.logger.name):
+        controller.stop()
+
+    assert controller._thread is None
+    assert controller._worker is None
+    assert retained == [(thread, worker)]
+    assert any(
+        record.message
+        == "ImageTool manager registry heartbeat thread did not stop promptly"
+        and record.suppress_ui_alert is True
+        for record in caplog.records
+    )
+
+    thread.quit()
+    assert thread.wait(1000)
+
+
 def test_itool_magic_manager_target_normalization() -> None:
     assert _normalize_manager_target_args("-m data") == "-m data"
     assert _normalize_manager_target_args("-m 1 data") == "-m --manager-index 1 data"

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -967,7 +967,6 @@ def test_multi_manager_integer_targets(
     manager_mod = erlab.interactive.imagetool.manager
     with manager_context() as manager0:
         manager1 = ImageToolManager()
-        qtbot.addWidget(manager1, before_close_func=lambda w: w.remove_all_tools())
         try:
             qtbot.wait_until(
                 lambda: (

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -63,6 +63,18 @@ def test_manager_selection_info_single_manager(
         assert info["managers"][0]["is_default"] is True
 
 
+def test_manager_server_threads_are_explicitly_managed(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        assert manager.server.parent() is None
+        assert manager.watcher_server.parent() is None
+        assert manager.server.isRunning()
+        assert manager.watcher_server.isRunning()
+
+
 def test_manager_registry_object_repr_and_mapping(monkeypatch, tmp_path) -> None:
     registry = _use_isolated_manager_registry(monkeypatch, tmp_path)
     monkeypatch.setattr(registry, "_pid_exists", lambda _pid: True)
@@ -1058,6 +1070,54 @@ def test_manager_server_wait_until_bound_errors() -> None:
     with pytest.raises(RuntimeError, match="Manager server failed") as exc_info:
         manager.wait_until_bound(timeout_ms=1)
     assert exc_info.value.__cause__ is manager_error
+
+
+def test_server_thread_stop_wait_is_cooperative(monkeypatch) -> None:
+    class _FinishingThread:
+        def __init__(self) -> None:
+            self.running_checks = 0
+
+        def isRunning(self) -> bool:
+            self.running_checks += 1
+            return self.running_checks == 1
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(manager_server.time, "sleep", sleeps.append)
+
+    finishing_thread = _FinishingThread()
+    assert manager_server._wait_for_qthread_to_stop(finishing_thread, 100)
+    assert finishing_thread.running_checks == 2
+    assert sleeps
+    assert sleeps[0] <= 0.01
+
+    class _RunningThread:
+        def isRunning(self) -> bool:
+            return True
+
+    monotonic_values = iter([0.0, 0.002])
+    monkeypatch.setattr(
+        manager_server.time, "monotonic", lambda: next(monotonic_values)
+    )
+
+    assert not manager_server._wait_for_qthread_to_stop(_RunningThread(), 1)
+
+
+def test_server_stop_logs_when_cooperative_wait_times_out(monkeypatch, caplog) -> None:
+    caplog.set_level(logging.WARNING, logger=manager_server.__name__)
+    monkeypatch.setattr(
+        manager_server, "_wait_for_qthread_to_stop", lambda *_args: False
+    )
+    monkeypatch.setattr(_WatcherServer, "isRunning", lambda _self: True)
+    monkeypatch.setattr(manager_server._ManagerServer, "isRunning", lambda _self: True)
+
+    watcher_server = _WatcherServer()
+    watcher_server.stop(timeout_ms=1)
+
+    manager = manager_server._ManagerServer()
+    manager.stop(timeout_ms=1)
+
+    assert "Watcher server did not stop within timeout" in caplog.text
+    assert "Manager server did not stop within timeout" in caplog.text
 
 
 def test_manager_server_bind_failures_close_socket(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -568,7 +568,20 @@ time.sleep(1.0)
         for _ in range(3)
     ]
 
-    outputs = [process.communicate(timeout=15) for process in processes]
+    try:
+        outputs = [process.communicate(timeout=30) for process in processes]
+    except subprocess.TimeoutExpired as exc:
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+        outputs = [process.communicate() for process in processes]
+        details = "\n".join(
+            f"pid={process.pid} returncode={process.returncode} "
+            f"stdout={stdout!r} stderr={stderr!r}"
+            for process, (stdout, stderr) in zip(processes, outputs, strict=True)
+        )
+        pytest.fail(f"Timed out waiting for registry lock workers: {exc}\n{details}")
+
     indexes = sorted(int(stdout.strip()) for stdout, _stderr in outputs)
 
     assert indexes == [0, 1, 2]
@@ -739,6 +752,40 @@ def test_manager_registry_heartbeat_stop_is_safe_while_refresh_is_in_flight(
     assert not controller.is_busy
     assert controller._thread is None
     assert controller._worker is None
+
+
+def test_manager_registry_heartbeat_disconnect_skips_invalid_worker(
+    monkeypatch,
+) -> None:
+    class _DeletedWorker:
+        @property
+        def refresh(self):
+            raise AssertionError("invalid worker should not be dereferenced")
+
+        @property
+        def finished(self):
+            raise AssertionError("invalid worker should not be dereferenced")
+
+    original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+    controller = manager_heartbeat._RegistryHeartbeatController("manager-id")
+    real_worker = controller._worker
+    deleted_worker = _DeletedWorker()
+    controller._worker = typing.cast(
+        "manager_heartbeat._RegistryHeartbeatWorker",
+        deleted_worker,
+    )
+
+    def qt_is_valid(*objects: object) -> bool:
+        if deleted_worker in objects:
+            return False
+        return original_qt_is_valid(*objects)
+
+    monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", qt_is_valid)
+    try:
+        controller._disconnect_worker_signals()
+    finally:
+        controller._worker = real_worker
+        controller.stop()
 
 
 def test_manager_registry_heartbeat_controller_edge_paths(

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -1020,17 +1020,23 @@ def test_watcher_server_run_stops_cleanly_without_pending_payload(monkeypatch) -
         def socket(self, *_args) -> _DummySocket:
             return self._socket
 
-    class _DummyWaitCondition:
+    class _DummyCondition:
         def __init__(self, server: _WatcherServer) -> None:
             self.server = server
             self.calls = 0
 
-        def wait(self, *_args) -> bool:
+        def __enter__(self) -> typing.Self:
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def wait(self, _timeout: float) -> bool:
             self.calls += 1
             self.server.stopped.set()
             return True
 
-        def wakeAll(self) -> None:
+        def notify_all(self) -> None:
             return None
 
     socket = _DummySocket()
@@ -1039,12 +1045,12 @@ def test_watcher_server_run_stops_cleanly_without_pending_payload(monkeypatch) -
     )
 
     server = _WatcherServer()
-    wait_condition = _DummyWaitCondition(server)
-    server._cv = wait_condition
+    condition = _DummyCondition(server)
+    server._condition = condition
 
     server.run()
 
-    assert wait_condition.calls == 1
+    assert condition.calls == 1
     assert socket.bound == [f"tcp://*:{erlab.interactive.imagetool.manager.PORT_WATCH}"]
     assert socket.sent == []
     assert socket.closed

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -20,6 +20,7 @@ import erlab.interactive.imagetool._itool as itool_mod
 import erlab.interactive.imagetool.manager._heartbeat as manager_heartbeat
 import erlab.interactive.imagetool.manager._registry as manager_registry
 import erlab.interactive.imagetool.manager._server as manager_server
+import erlab.interactive.imagetool.manager._widgets as manager_widgets
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._magic import _normalize_manager_target_args
 from erlab.interactive.imagetool.manager import ImageToolManager, fetch
@@ -1128,6 +1129,140 @@ def test_server_stop_logs_when_cooperative_wait_times_out(monkeypatch, caplog) -
 
     assert "Watcher server did not stop within timeout" in caplog.text
     assert "Manager server did not stop within timeout" in caplog.text
+
+
+def test_widgets_controller_stop_servers_disconnects_and_deletes() -> None:
+    class _ServerDouble(QtCore.QObject):
+        sigReceived = QtCore.Signal(list, dict)
+        sigLoadRequested = QtCore.Signal(list, str, dict)
+        sigReplaceRequested = QtCore.Signal(list, list)
+        sigWatchedVarChanged = QtCore.Signal(str, str, object, object)
+        sigDataRequested = QtCore.Signal(object)
+        sigWatchInfoRequested = QtCore.Signal()
+        sigRemoveIndex = QtCore.Signal(int)
+        sigShowIndex = QtCore.Signal(int)
+        sigRemoveUID = QtCore.Signal(str)
+        sigShowUID = QtCore.Signal(str)
+        sigUnwatchUID = QtCore.Signal(str)
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.running = True
+            self.deleted = False
+            self.return_values: list[object] = []
+
+        def isRunning(self) -> bool:
+            return self.running
+
+        def stop(self) -> None:
+            self.running = False
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+        def set_return_value(self, value: object) -> None:
+            self.return_values.append(value)
+
+    class _WatcherDouble(QtCore.QObject):
+        def __init__(self) -> None:
+            super().__init__()
+            self.running = True
+            self.deleted = False
+            self.parameters: list[tuple[str, str, str]] = []
+
+        def isRunning(self) -> bool:
+            return self.running
+
+        def stop(self) -> None:
+            self.running = False
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+        def send_parameters(self, varname: str, uid: str, event: str) -> None:
+            self.parameters.append((varname, uid, event))
+
+    class _ManagerDouble(QtCore.QObject):
+        _sigReplyData = QtCore.Signal(object)
+        _sigWatchedDataEdited = QtCore.Signal(str, str, str)
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.server = _ServerDouble()
+            self.watcher_server = _WatcherDouble()
+            self.calls: list[tuple[str, object]] = []
+
+        def _record(self, name: str, *args) -> None:
+            self.calls.append((name, args))
+
+        def _data_recv(self, *args) -> None:
+            self._record("data_recv", *args)
+
+        def _data_load(self, *args) -> None:
+            self._record("data_load", *args)
+
+        def _data_replace(self, *args) -> None:
+            self._record("data_replace", *args)
+
+        def _send_imagetool_data(self, *args) -> None:
+            self._record("send_imagetool_data", *args)
+
+        def _send_watch_info(self) -> None:
+            self._record("send_watch_info")
+
+        def remove_imagetool(self, *args) -> None:
+            self._record("remove_imagetool", *args)
+
+        def show_imagetool(self, *args) -> None:
+            self._record("show_imagetool", *args)
+
+        def _remove_watched(self, *args) -> None:
+            self._record("remove_watched", *args)
+
+        def _show_watched(self, *args) -> None:
+            self._record("show_watched", *args)
+
+        def _data_unwatch(self, *args) -> None:
+            self._record("data_unwatch", *args)
+
+        def _data_watched_update(self, *args) -> None:
+            self._record("data_watched_update", *args)
+
+    manager = _ManagerDouble()
+    server = manager.server
+    watcher_server = manager.watcher_server
+
+    for signal, slot in (
+        (server.sigReceived, manager._data_recv),
+        (server.sigLoadRequested, manager._data_load),
+        (server.sigReplaceRequested, manager._data_replace),
+        (server.sigDataRequested, manager._send_imagetool_data),
+        (server.sigWatchInfoRequested, manager._send_watch_info),
+        (manager._sigReplyData, server.set_return_value),
+        (server.sigRemoveIndex, manager.remove_imagetool),
+        (server.sigShowIndex, manager.show_imagetool),
+        (server.sigRemoveUID, manager._remove_watched),
+        (server.sigShowUID, manager._show_watched),
+        (server.sigUnwatchUID, manager._data_unwatch),
+        (server.sigWatchedVarChanged, manager._data_watched_update),
+        (manager._sigWatchedDataEdited, watcher_server.send_parameters),
+    ):
+        signal.connect(slot)
+
+    manager_widgets._WidgetsController(manager)._stop_servers()
+
+    assert not server.running
+    assert server.deleted
+    assert not watcher_server.running
+    assert watcher_server.deleted
+
+    server.sigRemoveIndex.emit(0)
+    manager._sigReplyData.emit("value")
+    manager._sigWatchedDataEdited.emit("data", "uid", "updated")
+
+    assert manager.calls == []
+    assert server.return_values == []
+    assert watcher_server.parameters == []
 
 
 def test_manager_server_bind_failures_close_socket(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -1114,6 +1114,32 @@ def test_server_thread_stop_wait_is_cooperative(monkeypatch) -> None:
     assert finishing_thread.waits
     assert 0 < finishing_thread.waits[0] <= 10
 
+    class _StoppedThread:
+        def isRunning(self) -> bool:
+            return False
+
+        def wait(self, timeout_ms: int) -> bool:
+            raise AssertionError("wait should not be called for a stopped thread")
+
+    assert manager_server._wait_for_qthread_to_stop(_StoppedThread(), 100)
+
+    class _SlowStoppingThread:
+        def __init__(self) -> None:
+            self.running_checks = 0
+            self.waits: list[int] = []
+
+        def isRunning(self) -> bool:
+            self.running_checks += 1
+            return self.running_checks < 3
+
+        def wait(self, timeout_ms: int) -> bool:
+            self.waits.append(timeout_ms)
+            return False
+
+    slow_stopping_thread = _SlowStoppingThread()
+    assert manager_server._wait_for_qthread_to_stop(slow_stopping_thread, 100)
+    assert slow_stopping_thread.waits
+
     class _RunningThread:
         def isRunning(self) -> bool:
             return True
@@ -1208,6 +1234,29 @@ def test_manager_server_wake_receiver_uses_loopback(monkeypatch) -> None:
     assert socket.connections == ["tcp://127.0.0.1:45555"]
     assert socket.sent
     assert socket.closed
+
+    class _FailingSocket(_DummySocket):
+        def connect(self, endpoint: str) -> None:
+            self.connections.append(endpoint)
+            raise RuntimeError("connect failed")
+
+    class _FailingContext:
+        def __init__(self) -> None:
+            self.sockets: list[_FailingSocket] = []
+
+        def socket(self, *_args) -> _FailingSocket:
+            socket = _FailingSocket()
+            self.sockets.append(socket)
+            return socket
+
+    failing_context = _FailingContext()
+    monkeypatch.setattr(zmq.Context, "instance", staticmethod(lambda: failing_context))
+
+    server._wake_receiver()
+
+    failing_socket = failing_context.sockets[0]
+    assert failing_socket.connections == ["tcp://127.0.0.1:45555"]
+    assert failing_socket.closed
 
 
 def test_manager_server_run_exits_after_empty_poll(monkeypatch) -> None:
@@ -1400,6 +1449,85 @@ def test_widgets_controller_stop_servers_disconnects_and_deletes() -> None:
     assert manager.calls == []
     assert server.return_values == []
     assert watcher_server.parameters == []
+
+
+def test_widgets_controller_stop_servers_ignores_invalid_wrappers(monkeypatch) -> None:
+    class _ThreadDouble:
+        def __init__(self) -> None:
+            self.running = True
+            self.stopped = False
+            self.deleted = False
+
+        def isRunning(self) -> bool:
+            return self.running
+
+        def stop(self) -> None:
+            self.stopped = True
+            self.running = False
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    class _ManagerDouble:
+        def __init__(self) -> None:
+            self.server = _ThreadDouble()
+            self.watcher_server = _ThreadDouble()
+
+    manager = _ManagerDouble()
+    invalid_threads = {manager.server, manager.watcher_server}
+
+    def _qt_is_valid(*objects) -> bool:
+        return all(obj not in invalid_threads for obj in objects)
+
+    monkeypatch.setattr(
+        manager_widgets.erlab.interactive.utils, "qt_is_valid", _qt_is_valid
+    )
+
+    manager_widgets._WidgetsController(
+        typing.cast("typing.Any", manager)
+    )._stop_servers()
+
+    assert manager.server.running
+    assert not manager.server.stopped
+    assert not manager.server.deleted
+    assert manager.watcher_server.running
+    assert not manager.watcher_server.stopped
+    assert not manager.watcher_server.deleted
+
+
+def test_widgets_controller_stop_servers_keeps_running_wrappers(monkeypatch) -> None:
+    class _ThreadDouble:
+        def __init__(self) -> None:
+            self.stopped = False
+            self.deleted = False
+
+        def isRunning(self) -> bool:
+            return True
+
+        def stop(self) -> None:
+            self.stopped = True
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    class _ManagerDouble:
+        def __init__(self) -> None:
+            self.server = _ThreadDouble()
+            self.watcher_server = _ThreadDouble()
+
+    manager = _ManagerDouble()
+    monkeypatch.setattr(
+        manager_widgets.erlab.interactive.utils, "qt_is_valid", lambda *_objects: True
+    )
+
+    manager_widgets._WidgetsController(
+        typing.cast("typing.Any", manager)
+    )._stop_servers()
+
+    assert manager.server.stopped
+    assert not manager.server.deleted
+    assert manager.watcher_server.stopped
+    assert not manager.watcher_server.deleted
 
 
 def test_manager_server_bind_failures_close_socket(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -1145,6 +1145,113 @@ def test_manager_server_stop_wakes_receive_loop(qtbot) -> None:
         server.deleteLater()
 
 
+def test_manager_server_wake_receiver_uses_loopback(monkeypatch) -> None:
+    class _DummySocket:
+        def __init__(self) -> None:
+            self.options: list[tuple[int, int]] = []
+            self.connections: list[str] = []
+            self.sent = False
+            self.closed = False
+
+        def setsockopt(self, option: int, value: int) -> None:
+            self.options.append((option, value))
+
+        def connect(self, endpoint: str) -> None:
+            self.connections.append(endpoint)
+
+        def send_multipart(self, *_args, **_kwargs) -> None:
+            self.sent = True
+
+        def recv_multipart(self) -> None:
+            raise zmq.Again
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _DummyContext:
+        def __init__(self) -> None:
+            self.sockets: list[_DummySocket] = []
+
+        def socket(self, *_args) -> _DummySocket:
+            socket = _DummySocket()
+            self.sockets.append(socket)
+            return socket
+
+    context = _DummyContext()
+    monkeypatch.setattr(zmq.Context, "instance", staticmethod(lambda: context))
+
+    unbound_server = manager_server._ManagerServer()
+    unbound_server._wake_receiver()
+
+    server = manager_server._ManagerServer()
+    server._bound_port = 45555
+    server._wake_receiver()
+
+    assert len(context.sockets) == 1
+    socket = context.sockets[0]
+    assert socket.connections == ["tcp://127.0.0.1:45555"]
+    assert socket.sent
+    assert socket.closed
+
+
+def test_manager_server_run_exits_after_empty_poll(monkeypatch) -> None:
+    class _DummySocket:
+        def __init__(self) -> None:
+            self.options: list[tuple[int, int]] = []
+            self.bound: list[str] = []
+            self.closed = False
+
+        def setsockopt(self, option: int, value: int) -> None:
+            self.options.append((option, value))
+
+        def bind(self, endpoint: str) -> None:
+            self.bound.append(endpoint)
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _DummyContext:
+        def __init__(self, socket: _DummySocket) -> None:
+            self._socket = socket
+
+        def socket(self, socket_type: int) -> _DummySocket:
+            assert socket_type == zmq.REP
+            return self._socket
+
+    class _DummyPoller:
+        def __init__(self) -> None:
+            self.registered: list[tuple[_DummySocket, int]] = []
+            self.unregistered: list[_DummySocket] = []
+            self.poll_timeouts: list[int] = []
+
+        def register(self, socket: _DummySocket, event: int) -> None:
+            self.registered.append((socket, event))
+
+        def poll(self, timeout: int) -> dict[_DummySocket, int]:
+            self.poll_timeouts.append(timeout)
+            server.stopped.set()
+            return {}
+
+        def unregister(self, socket: _DummySocket) -> None:
+            self.unregistered.append(socket)
+
+    socket = _DummySocket()
+    poller = _DummyPoller()
+    monkeypatch.setattr(
+        zmq.Context, "instance", staticmethod(lambda: _DummyContext(socket))
+    )
+    monkeypatch.setattr(zmq, "Poller", lambda: poller)
+
+    server = manager_server._ManagerServer(port=45555)
+    server.run()
+
+    assert socket.bound == ["tcp://*:45555"]
+    assert poller.registered == [(socket, zmq.POLLIN)]
+    assert poller.poll_timeouts == [100]
+    assert poller.unregistered == [socket]
+    assert socket.closed
+
+
 def test_widgets_controller_stop_servers_disconnects_and_deletes() -> None:
     class _ServerDouble(QtCore.QObject):
         sigReceived = QtCore.Signal(list, dict)

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -29,6 +29,23 @@ from erlab.interactive.imagetool.manager._server import Response, _WatcherServer
 from .helpers import _use_isolated_manager_registry
 
 
+class _ReadyPoller:
+    def __init__(self) -> None:
+        self.socket: object | None = None
+
+    def register(self, socket: object, _event: int) -> None:
+        self.socket = socket
+
+    def poll(self, _timeout: int) -> dict[object, int]:
+        if self.socket is None:
+            return {}
+        return {self.socket: zmq.POLLIN}
+
+    def unregister(self, socket: object) -> None:
+        if self.socket is socket:
+            self.socket = None
+
+
 def test_manager_selection_info_single_manager(
     tmp_path,
     qtbot,
@@ -1425,6 +1442,7 @@ def test_manager_server_bind_failures_close_socket(monkeypatch) -> None:
         "instance",
         staticmethod(lambda: _DummyContext(manager_socket)),
     )
+    monkeypatch.setattr(zmq, "Poller", _ReadyPoller)
     manager = manager_server._ManagerServer(port=45555)
     manager.run()
     assert manager._bound_event.is_set()
@@ -1470,10 +1488,14 @@ def test_manager_server_run_returns_watch_info(monkeypatch) -> None:
     monkeypatch.setattr(
         zmq.Context, "instance", staticmethod(lambda: _DummyContext(socket))
     )
+    monkeypatch.setattr(zmq, "Poller", _ReadyPoller)
     monkeypatch.setattr(
         manager_server,
         "_recv_multipart",
-        lambda _socket: {"packet_type": "command", "command": "watch-info"},
+        lambda _socket, **_kwargs: {
+            "packet_type": "command",
+            "command": "watch-info",
+        },
     )
     monkeypatch.setattr(
         manager_server,
@@ -1520,10 +1542,11 @@ def test_manager_server_run_errors_when_data_request_stops(monkeypatch) -> None:
     monkeypatch.setattr(
         zmq.Context, "instance", staticmethod(lambda: _DummyContext(socket))
     )
+    monkeypatch.setattr(zmq, "Poller", _ReadyPoller)
     monkeypatch.setattr(
         manager_server,
         "_recv_multipart",
-        lambda _socket: {
+        lambda _socket, **_kwargs: {
             "packet_type": "command",
             "command": "get-data",
             "command_arg": 0,
@@ -1571,10 +1594,14 @@ def test_manager_server_run_errors_when_watch_info_request_stops(monkeypatch) ->
     monkeypatch.setattr(
         zmq.Context, "instance", staticmethod(lambda: _DummyContext(socket))
     )
+    monkeypatch.setattr(zmq, "Poller", _ReadyPoller)
     monkeypatch.setattr(
         manager_server,
         "_recv_multipart",
-        lambda _socket: {"packet_type": "command", "command": "watch-info"},
+        lambda _socket, **_kwargs: {
+            "packet_type": "command",
+            "command": "watch-info",
+        },
     )
     monkeypatch.setattr(
         manager_server,

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -1131,6 +1131,20 @@ def test_server_stop_logs_when_cooperative_wait_times_out(monkeypatch, caplog) -
     assert "Manager server did not stop within timeout" in caplog.text
 
 
+def test_manager_server_stop_wakes_receive_loop(qtbot) -> None:
+    server = manager_server._ManagerServer(port=0)
+    server.start()
+    try:
+        assert server.wait_until_bound(timeout_ms=5000) > 0
+        server.stop(timeout_ms=1000)
+        assert not server.isRunning()
+    finally:
+        if server.isRunning():
+            server.stop(timeout_ms=1000)
+        server.wait(1000)
+        server.deleteLater()
+
+
 def test_widgets_controller_stop_servers_disconnects_and_deletes() -> None:
     class _ServerDouble(QtCore.QObject):
         sigReceived = QtCore.Signal(list, dict)

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -1081,24 +1081,28 @@ def test_manager_server_wait_until_bound_errors() -> None:
 def test_server_thread_stop_wait_is_cooperative(monkeypatch) -> None:
     class _FinishingThread:
         def __init__(self) -> None:
-            self.running_checks = 0
+            self.running = True
+            self.waits: list[int] = []
 
         def isRunning(self) -> bool:
-            self.running_checks += 1
-            return self.running_checks == 1
+            return self.running
 
-    sleeps: list[float] = []
-    monkeypatch.setattr(manager_server.time, "sleep", sleeps.append)
+        def wait(self, timeout_ms: int) -> bool:
+            self.waits.append(timeout_ms)
+            self.running = False
+            return True
 
     finishing_thread = _FinishingThread()
     assert manager_server._wait_for_qthread_to_stop(finishing_thread, 100)
-    assert finishing_thread.running_checks == 2
-    assert sleeps
-    assert sleeps[0] <= 0.01
+    assert finishing_thread.waits
+    assert 0 < finishing_thread.waits[0] <= 10
 
     class _RunningThread:
         def isRunning(self) -> bool:
             return True
+
+        def wait(self, timeout_ms: int) -> bool:
+            raise AssertionError("wait should not be called after the timeout")
 
     monotonic_values = iter([0.0, 0.002])
     monkeypatch.setattr(

--- a/tests/interactive/imagetool/manager/test_warnings.py
+++ b/tests/interactive/imagetool/manager/test_warnings.py
@@ -422,9 +422,6 @@ def test_open_multiple_files_locked_workspace_does_not_fall_through_to_loaders(
     qtbot,
     monkeypatch,
     tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
 ) -> None:
     lock_calls: list[pathlib.Path] = []
     fname = tmp_path / "locked.itws"
@@ -445,8 +442,10 @@ def test_open_multiple_files_locked_workspace_does_not_fall_through_to_loaders(
         erlab.interactive.utils, "file_loaders", _file_loaders_should_not_run
     )
 
-    with manager_context() as manager:
-        manager.open_multiple_files([fname], try_workspace=True)
+    manager = QtWidgets.QWidget()
+    qtbot.addWidget(manager)
+    controller = manager_actions._ActionsController(manager)
+    controller.open_multiple_files([fname], try_workspace=True)
 
     assert lock_calls == [fname]
 

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -8030,11 +8030,13 @@ def test_manager_workspace_restore_event_drain_avoids_event_loop(
         calls: list[str] = []
         emitter = _Emitter(manager)
         receiver = _Receiver(manager)
+        deferred_widget = QtWidgets.QWidget(manager)
         emitter.sigRecord.connect(
             receiver.record,
             QtCore.Qt.ConnectionType.QueuedConnection,
         )
         emitter.sigRecord.emit()
+        deferred_widget.deleteLater()
 
         with monkeypatch.context() as restore_drain_patch:
             restore_drain_patch.setattr(
@@ -8047,6 +8049,7 @@ def test_manager_workspace_restore_event_drain_avoids_event_loop(
             manager._drain_workspace_restore_events()
 
     assert calls == ["record"]
+    assert not erlab.interactive.utils.qt_is_valid(deferred_widget)
 
 
 def test_manager_workspace_state_save_updates_attrs_without_full_rewrite(

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -6616,7 +6616,6 @@ def test_manager_save_and_wait_dialog_error_paths(
     monkeypatch.setattr(erlab.interactive.utils.MessageDialog, "critical", _critical)
     with manager_context() as manager:
         wait_dialog = manager._open_workspace_save_wait_dialog(manager)
-        qtbot.addWidget(wait_dialog)
         assert wait_dialog.windowTitle() == "Saving Workspace"
         assert typing.cast("QtWidgets.QProgressDialog", wait_dialog).labelText() == (
             "Saving workspace..."

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -696,48 +696,19 @@ def test_manager_workspace_load_warns_for_unavailable_colormap(
     missing = "__erlab_missing_colormap__"
     dialogs: list[typing.Any] = []
 
-    class _DummySignal:
-        def connect(self, *args, **kwargs) -> None:
-            pass
-
-    class _DummyButtonBox:
-        def addButton(self, *args, **kwargs) -> None:
-            pass
-
-    class _RecordingMessageDialog:
+    class _RecordingMessageDialog(QtWidgets.QDialog):
         def __init__(self, parent=None, **kwargs) -> None:
+            super().__init__(parent)
             self.parent = parent
             self.kwargs = kwargs
-            self._button_box = _DummyButtonBox()
-            self.finished = _DummySignal()
+            self._button_box = QtWidgets.QDialogButtonBox(self)
             dialogs.append(self)
 
         def exec(self):
             return QtWidgets.QDialog.DialogCode.Accepted
 
-        def setModal(self, value: bool) -> None:
-            pass
-
-        def windowFlags(self):
-            return QtCore.Qt.WindowType.Widget
-
-        def setWindowFlags(self, flags) -> None:
-            pass
-
         def text(self) -> str:
             return str(self.kwargs.get("text", ""))
-
-        def close(self) -> None:
-            pass
-
-        def show(self) -> None:
-            pass
-
-        def raise_(self) -> None:
-            pass
-
-        def activateWindow(self) -> None:
-            pass
 
     monkeypatch.setattr(
         erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
@@ -5418,7 +5389,7 @@ def test_workspace_lock_error_message_without_owner(monkeypatch, tmp_path) -> No
     )
 
 
-def test_application_quit_filter_routes_quit_events(qtbot) -> None:
+def test_application_quit_filter_routes_quit_events(qtbot, monkeypatch) -> None:
     manager = QtWidgets.QWidget()
     qtbot.addWidget(manager)
     calls: list[str] = []
@@ -5447,6 +5418,31 @@ def test_application_quit_filter_routes_quit_events(qtbot) -> None:
 
     assert event_filter.eventFilter(None, key_event)
     assert key_event.isAccepted()
+    assert calls == ["close", "close"]
+
+    invalid_obj = QtCore.QObject()
+    invalid_event = QtCore.QEvent(QtCore.QEvent.Type.Quit)
+    original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+
+    def fake_qt_is_valid(*objects: object) -> bool:
+        if any(obj is invalid_obj or obj is invalid_event for obj in objects):
+            return False
+        return original_qt_is_valid(*objects)
+
+    monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", fake_qt_is_valid)
+    assert not event_filter.eventFilter(
+        invalid_obj,
+        QtCore.QEvent(QtCore.QEvent.Type.Quit),
+    )
+    assert not event_filter.eventFilter(None, invalid_event)
+    assert calls == ["close", "close"]
+
+    class DeletedEvent:
+        def type(self) -> QtCore.QEvent.Type:
+            raise RuntimeError("wrapped C/C++ object has been deleted")
+
+    monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", lambda *objects: True)
+    assert not event_filter.eventFilter(None, DeletedEvent())
     assert calls == ["close", "close"]
 
 

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -8052,6 +8052,28 @@ def test_manager_workspace_restore_event_drain_avoids_event_loop(
     assert not erlab.interactive.utils.qt_is_valid(deferred_widget)
 
 
+def test_manager_workspace_save_drain_does_not_force_deferred_delete(
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager, monkeypatch.context() as save_drain_patch:
+        event_types: list[int] = []
+        save_drain_patch.setattr(
+            QtWidgets.QApplication,
+            "sendPostedEvents",
+            lambda _receiver, event_type: event_types.append(event_type),
+        )
+        save_drain_patch.setattr(
+            QtWidgets.QApplication, "processEvents", lambda *_args, **_kwargs: None
+        )
+
+        manager._drain_workspace_deferred_events()
+
+        assert event_types == [int(QtCore.QEvent.Type.MetaCall.value)] * 3
+
+
 def test_manager_workspace_state_save_updates_attrs_without_full_rewrite(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -126,7 +126,7 @@ def _press_alt(monkeypatch):
     monkeypatch.setattr(
         QtWidgets.QApplication,
         "queryKeyboardModifiers",
-        lambda: QtCore.Qt.KeyboardModifier.AltModifier,
+        lambda *_args: QtCore.Qt.KeyboardModifier.AltModifier,
     )
 
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -73,6 +73,22 @@ from erlab.io.dataloader import LoaderBase
 
 logger = logging.getLogger(__name__)
 
+
+@pytest.fixture(autouse=True)
+def isolate_pyperclip(monkeypatch) -> None:
+    clipboard_text = ""
+
+    def copy_to_memory(content: object) -> None:
+        nonlocal clipboard_text
+        clipboard_text = str(content)
+
+    def paste_from_memory() -> str:
+        return clipboard_text
+
+    monkeypatch.setattr(pyperclip, "copy", copy_to_memory)
+    monkeypatch.setattr(pyperclip, "paste", paste_from_memory)
+
+
 _TEST_DATA: dict[str, xr.DataArray] = {
     "2D": xr.DataArray(
         np.arange(25).reshape((5, 5)),

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -1324,6 +1324,30 @@ def test_replay_graph_structured_script_inputs_keep_execution_copy_boundary(
     assert not np.shares_memory(replayed.data, data.data)
 
 
+def test_replay_graph_disables_numbagg_only_during_execution() -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+    spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Record option",
+            code=(
+                "derived = data_0.copy()\n"
+                "derived.attrs['use_numbagg_during_replay'] = "
+                "xr.get_options()['use_numbagg']"
+            ),
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(provenance.ScriptInput(name="data_0", label="Input"),),
+    )
+    graph = _replay_graph.compile_replay_graph(spec, external_inputs={"data_0": data})
+
+    with xr.set_options(use_numbagg=True):
+        replayed = _replay_graph.execute_replay_graph(graph)
+        assert xr.get_options()["use_numbagg"] is True
+
+    assert replayed.attrs["use_numbagg_during_replay"] is False
+
+
 def test_replay_graph_display_skips_whole_array_rename(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/tests/interactive/imagetool/test_watcher.py
+++ b/tests/interactive/imagetool/test_watcher.py
@@ -1,4 +1,5 @@
 import builtins
+import contextlib
 import logging
 import threading
 import types
@@ -1126,100 +1127,106 @@ def test_watcher_real(
         ip_shell.user_ns.update({"darr": darr})
 
         watcher = ip_shell.magics_manager.registry.get("WatcherMagics")._watcher
-
-        # Try watching
-        ip_shell.run_line_magic("watch", "darr")
-        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
-
-        # Check watched
-        assert manager._tool_graph.root_wrappers[0].watched
-
-        # Get selection code
-        assert (
-            manager.get_imagetool(0).slicer_area.main_image.get_selection_code()
-            == "darr.qsel(eV=2.0)"
-        )
-
-        # Watched tooltip
-        text = None
-
-        def fake_show_text(pos, s, *args, **kwargs):
-            nonlocal text
-            text = s
-
-        monkeypatch.setattr(QtWidgets.QToolTip, "showText", fake_show_text)
-
-        index = manager.tree_view._model.index(0, 0)  # first tool
-        option = QtWidgets.QStyleOptionViewItem()
-        manager.tree_view._delegate.initStyleOption(option, index)
-        option.rect = manager.tree_view.visualRect(index)
-        _, _, _, watched_rect = manager.tree_view._delegate._compute_icons_info(
-            option, index.internalPointer()
-        )
-        pos = watched_rect.center()
-        event = QtGui.QHelpEvent(
-            QtCore.QEvent.Type.ToolTip,
-            pos,
-            manager.tree_view.viewport().mapToGlobal(pos),
-        )
-        handled = manager.tree_view._delegate.helpEvent(
-            event, manager.tree_view, option, index
-        )
-
-        assert handled
-        assert isinstance(text, str)
-        assert text.strip()
-
-        # Update data
-        with qtbot.wait_signal(manager.server.sigWatchedVarChanged, timeout=10000):
-            watcher._last_send = 0  # Bypass rate limit for deterministic update
-            ip_shell.user_ns["darr"] = darr * 2
-            watcher._maybe_push()
-
-        xr.testing.assert_equal(
-            manager.get_imagetool(0).slicer_area._data, ip_shell.user_ns["darr"]
-        )
-
-        # Modify data from manager side
-        manager.get_imagetool(0).slicer_area.set_data(darr + 10)
-
-        with qtbot.wait_signal(manager._sigWatchedDataEdited):
-            manager._tool_graph.root_wrappers[0]._trigger_watched_update()
-
-        qtbot.wait(1000)  # wait for async update to complete
-        xr.testing.assert_equal(ip_shell.user_ns["darr"], darr + 10)
-
-        # Unwatch
-        ip_shell.run_line_magic("watch", "-d darr")
-        qtbot.wait_until(lambda: not manager._tool_graph.root_wrappers[0].watched)
-
-        # Watch again
-        ip_shell.run_line_magic("watch", "darr")
-        qtbot.wait_until(lambda: manager.ntools == 2)
-        assert manager._tool_graph.root_wrappers[1].watched
-
-        # Remove watched
-        ip_shell.run_line_magic("watch", "-x darr")
-        qtbot.wait_until(lambda: manager.ntools == 1)
-
-        # Watch again
-        ip_shell.run_line_magic("watch", "darr")
-        qtbot.wait_until(lambda: manager.ntools == 2)
-        assert manager._tool_graph.root_wrappers[1].watched
-
-        # Stop watching all
-        ip_shell.run_line_magic("watch", "-z")
-        qtbot.wait_until(lambda: not manager._tool_graph.root_wrappers[1].watched)
-
-        # Watch again
-        ip_shell.run_line_magic("watch", "darr")
-        qtbot.wait_until(lambda: manager.ntools == 3)
-        assert manager._tool_graph.root_wrappers[2].watched
-
-        # Stop watching and close all watched
-        ip_shell.run_line_magic("watch", "-xz")
-        qtbot.wait_until(lambda: manager.ntools == 2)
-
+        with contextlib.suppress(Exception):
+            watcher.stop_watching_all(remove=True)
         watcher.shutdown()
-        manager.remove_all_tools()
-        qtbot.wait_until(lambda: manager.ntools == 0)
+
+        try:
+            # Try watching
+            ip_shell.run_line_magic("watch", "darr")
+            qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+            # Check watched
+            assert manager._tool_graph.root_wrappers[0].watched
+
+            # Get selection code
+            assert (
+                manager.get_imagetool(0).slicer_area.main_image.get_selection_code()
+                == "darr.qsel(eV=2.0)"
+            )
+
+            # Watched tooltip
+            text = None
+
+            def fake_show_text(pos, s, *args, **kwargs):
+                nonlocal text
+                text = s
+
+            monkeypatch.setattr(QtWidgets.QToolTip, "showText", fake_show_text)
+
+            index = manager.tree_view._model.index(0, 0)  # first tool
+            option = QtWidgets.QStyleOptionViewItem()
+            manager.tree_view._delegate.initStyleOption(option, index)
+            option.rect = manager.tree_view.visualRect(index)
+            _, _, _, watched_rect = manager.tree_view._delegate._compute_icons_info(
+                option, index.internalPointer()
+            )
+            pos = watched_rect.center()
+            event = QtGui.QHelpEvent(
+                QtCore.QEvent.Type.ToolTip,
+                pos,
+                manager.tree_view.viewport().mapToGlobal(pos),
+            )
+            handled = manager.tree_view._delegate.helpEvent(
+                event, manager.tree_view, option, index
+            )
+
+            assert handled
+            assert isinstance(text, str)
+            assert text.strip()
+
+            # Update data
+            with qtbot.wait_signal(manager.server.sigWatchedVarChanged, timeout=10000):
+                watcher._last_send = 0  # Bypass rate limit for deterministic update
+                ip_shell.user_ns["darr"] = darr * 2
+                watcher._maybe_push()
+
+            xr.testing.assert_equal(
+                manager.get_imagetool(0).slicer_area._data, ip_shell.user_ns["darr"]
+            )
+
+            # Modify data from manager side
+            manager.get_imagetool(0).slicer_area.set_data(darr + 10)
+
+            with qtbot.wait_signal(manager._sigWatchedDataEdited):
+                manager._tool_graph.root_wrappers[0]._trigger_watched_update()
+
+            qtbot.wait(1000)  # wait for async update to complete
+            xr.testing.assert_equal(ip_shell.user_ns["darr"], darr + 10)
+
+            # Unwatch
+            ip_shell.run_line_magic("watch", "-d darr")
+            qtbot.wait_until(lambda: not manager._tool_graph.root_wrappers[0].watched)
+
+            # Watch again
+            ip_shell.run_line_magic("watch", "darr")
+            qtbot.wait_until(lambda: manager.ntools == 2)
+            assert manager._tool_graph.root_wrappers[1].watched
+
+            # Remove watched
+            ip_shell.run_line_magic("watch", "-x darr")
+            qtbot.wait_until(lambda: manager.ntools == 1)
+
+            # Watch again
+            ip_shell.run_line_magic("watch", "darr")
+            qtbot.wait_until(lambda: manager.ntools == 2)
+            assert manager._tool_graph.root_wrappers[1].watched
+
+            # Stop watching all
+            ip_shell.run_line_magic("watch", "-z")
+            qtbot.wait_until(lambda: not manager._tool_graph.root_wrappers[1].watched)
+
+            # Watch again
+            ip_shell.run_line_magic("watch", "darr")
+            qtbot.wait_until(lambda: manager.ntools == 3)
+            assert manager._tool_graph.root_wrappers[2].watched
+
+            # Stop watching and close all watched
+            ip_shell.run_line_magic("watch", "-xz")
+            qtbot.wait_until(lambda: manager.ntools == 2)
+        finally:
+            with contextlib.suppress(Exception):
+                watcher.stop_watching_all(remove=True)
+            watcher.shutdown()
+            manager.remove_all_tools()
+            qtbot.wait_until(lambda: manager.ntools == 0)

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -19,18 +19,6 @@ from erlab.interactive.explorer._tabbed_explorer import (
 from erlab.interactive.imagetool.manager import _dialogs
 
 
-class _FakePreviewThreadPool:
-    def __init__(self) -> None:
-        self.cleared = False
-        self.waited = False
-
-    def clear(self) -> None:
-        self.cleared = True
-
-    def waitForDone(self) -> None:
-        self.waited = True
-
-
 def test_explorer_last_tab_closes_without_manager(qtbot, tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(erlab.interactive.imagetool.manager, "_manager_instance", None)
 
@@ -55,7 +43,7 @@ def test_explorer_last_tab_closes_without_manager(qtbot, tmp_path, monkeypatch) 
 
 
 def test_tabbed_explorer_close_tab_stops_preview_workers(
-    qtbot, example_loader, example_data_dir: pathlib.Path
+    qtbot, monkeypatch, example_loader, example_data_dir: pathlib.Path
 ) -> None:
     win = _TabbedExplorer(root_path=example_data_dir, loader_name="example")
     qtbot.addWidget(win)
@@ -63,46 +51,62 @@ def test_tabbed_explorer_close_tab_stops_preview_workers(
     explorer = win.get_explorer(0)
     assert explorer is not None
     assert explorer.centralWidget() is None
-    fake_threadpool = _FakePreviewThreadPool()
-    explorer._preview_threadpool = fake_threadpool
+    stopped_explorers: list[_DataExplorer] = []
+    stop_preview_workers = explorer._stop_preview_workers
+
+    def _track_stop_preview_workers() -> None:
+        stopped_explorers.append(explorer)
+        stop_preview_workers()
+
+    monkeypatch.setattr(explorer, "_stop_preview_workers", _track_stop_preview_workers)
 
     win.close_tab(0)
 
     assert win.tab_widget.count() == 1
-    assert fake_threadpool.cleared
-    assert fake_threadpool.waited
+    assert stopped_explorers == [explorer]
 
 
 def test_tabbed_explorer_close_stops_preview_workers_without_removing_tabs(
-    qtbot, example_loader, example_data_dir: pathlib.Path
+    qtbot, monkeypatch, example_loader, example_data_dir: pathlib.Path
 ) -> None:
     win = _TabbedExplorer(root_path=example_data_dir, loader_name="example")
     qtbot.addWidget(win)
     explorer = win.current_explorer
     assert explorer is not None
-    fake_threadpool = _FakePreviewThreadPool()
-    explorer._preview_threadpool = fake_threadpool
+    stopped_explorers: list[_DataExplorer] = []
+    stop_preview_workers = explorer._stop_preview_workers
+
+    def _track_stop_preview_workers() -> None:
+        stopped_explorers.append(explorer)
+        stop_preview_workers()
+
+    monkeypatch.setattr(explorer, "_stop_preview_workers", _track_stop_preview_workers)
 
     win.closeEvent(QtGui.QCloseEvent())
 
     assert win.tab_widget.count() == 1
     assert win.current_explorer is explorer
-    assert fake_threadpool.cleared
-    assert fake_threadpool.waited
+    assert stopped_explorers == [explorer]
 
 
 def test_explorer_close_stops_preview_workers(
     qtbot, example_loader, example_data_dir: pathlib.Path
 ) -> None:
-    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    class _TrackingDataExplorer(_DataExplorer):
+        def __init__(self, *args, **kwargs) -> None:
+            self.stopped_preview_workers = False
+            super().__init__(*args, **kwargs)
+
+        def _stop_preview_workers(self) -> None:
+            self.stopped_preview_workers = True
+            super()._stop_preview_workers()
+
+    explorer = _TrackingDataExplorer(root_path=example_data_dir, loader_name="example")
     qtbot.addWidget(explorer)
-    fake_threadpool = _FakePreviewThreadPool()
-    explorer._preview_threadpool = fake_threadpool
 
     explorer.closeEvent(QtGui.QCloseEvent())
 
-    assert fake_threadpool.cleared
-    assert fake_threadpool.waited
+    assert explorer.stopped_preview_workers
 
 
 def test_tabbed_explorer_show_path_adds_selected_file_tab(

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -448,9 +448,7 @@ def test_repr_fetcher_aborted_after_load_skips_formatting(
 
 
 def test_explorer_stop_preview_workers_aborts_with_bounded_wait(
-    qtbot,
-    example_loader,
-    example_data_dir: pathlib.Path,
+    tmp_path: pathlib.Path,
 ) -> None:
     class _FakeThreadPool:
         def __init__(self) -> None:
@@ -464,76 +462,62 @@ def test_explorer_stop_preview_workers_aborts_with_bounded_wait(
             self.wait_timeout_ms = timeout_ms
             return False
 
-    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
-    qtbot.addWidget(explorer)
-    worker = _ReprFetcher(
-        example_data_dir / "data_002.h5",
-        erlab.io.loaders["example"].load,
-        include_values=False,
+    class _ExplorerDouble:
+        def __init__(self, worker: _ReprFetcher) -> None:
+            self._preview_stopping = False
+            self._preview_workers = {worker}
+            self._preview_threadpool = _FakeThreadPool()
+
+    worker = _ReprFetcher(tmp_path / "data.h5", object(), include_values=False)
+    explorer = _ExplorerDouble(worker)
+
+    assert not _DataExplorer._stop_preview_workers(
+        typing.cast("_DataExplorer", explorer)
     )
-    fake_threadpool = _FakeThreadPool()
-    explorer._preview_workers.add(worker)
-    explorer._preview_threadpool = typing.cast("typing.Any", fake_threadpool)
-
-    assert not explorer._stop_preview_workers()
     assert worker._aborted.is_set()
-    assert fake_threadpool.clear_called
-    assert fake_threadpool.wait_timeout_ms == _PREVIEW_WORKER_STOP_TIMEOUT_MS
+    assert explorer._preview_threadpool.clear_called
+    assert (
+        explorer._preview_threadpool.wait_timeout_ms == _PREVIEW_WORKER_STOP_TIMEOUT_MS
+    )
 
 
-def test_explorer_selection_change_ignores_stopping_preview(
-    qtbot,
-    example_loader,
-    example_data_dir: pathlib.Path,
-) -> None:
-    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
-    qtbot.addWidget(explorer)
-    explorer._preview_stopping = True
-    explorer._to_manager_act.setEnabled(False)
+def test_explorer_selection_change_ignores_stopping_preview() -> None:
+    class _ExplorerDouble:
+        _preview_stopping = True
 
-    explorer._on_selection_changed()
-
-    assert not explorer._to_manager_act.isEnabled()
+    _DataExplorer._on_selection_changed(typing.cast("_DataExplorer", _ExplorerDouble()))
 
 
-def test_explorer_show_file_info_ignores_stopping_preview(
-    qtbot,
-    example_loader,
-    example_data_dir: pathlib.Path,
-) -> None:
-    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
-    qtbot.addWidget(explorer)
-    explorer._preview_stopping = True
-    original_text = explorer._text_edit.toPlainText()
+def test_explorer_show_file_info_ignores_stopping_preview() -> None:
+    class _ExplorerDouble:
+        _preview_stopping = True
 
-    explorer._show_file_info(str(example_data_dir / "data_002.h5"), "<b>new</b>", None)
-
-    assert explorer._text_edit.toPlainText() == original_text
+    _DataExplorer._show_file_info(
+        typing.cast("_DataExplorer", _ExplorerDouble()),
+        "data.h5",
+        "<b>new</b>",
+        None,
+    )
 
 
 def test_explorer_preview_worker_finished_removes_worker(
-    qtbot,
-    example_loader,
-    example_data_dir: pathlib.Path,
+    tmp_path: pathlib.Path,
 ) -> None:
-    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
-    qtbot.addWidget(explorer)
-    worker = _ReprFetcher(
-        example_data_dir / "data_002.h5",
-        erlab.io.loaders["example"].load,
-        include_values=False,
+    class _ExplorerDouble:
+        def __init__(self, worker: _ReprFetcher) -> None:
+            self._preview_workers = {worker}
+
+    worker = _ReprFetcher(tmp_path / "data.h5", object(), include_values=False)
+    explorer = _ExplorerDouble(worker)
+
+    _DataExplorer._preview_worker_finished(
+        typing.cast("_DataExplorer", explorer), worker
     )
-    explorer._preview_workers.add(worker)
-
-    explorer._preview_worker_finished(worker)
-
     assert explorer._preview_workers == set()
 
 
 def test_explorer_delete_when_preview_workers_done_deletes_immediately(
-    qtbot,
-    example_loader,
-    example_data_dir: pathlib.Path,
+    tmp_path: pathlib.Path,
 ) -> None:
     class _FakeThreadPool:
         def __init__(self) -> None:
@@ -548,38 +532,30 @@ def test_explorer_delete_when_preview_workers_done_deletes_immediately(
         def waitForDone(self, _timeout_ms: int) -> bool:
             return True
 
-    class _TrackingExplorer(_DataExplorer):
-        def __init__(self, *args, **kwargs) -> None:
+    class _ExplorerDouble:
+        def __init__(self, worker: _ReprFetcher) -> None:
             self.deleted_later = False
-            super().__init__(*args, **kwargs)
+            self._preview_workers = {worker}
+            self._preview_threadpool = _FakeThreadPool()
 
         def deleteLater(self) -> None:
             self.deleted_later = True
-            super().deleteLater()
 
-    explorer = _TrackingExplorer(root_path=example_data_dir, loader_name="example")
-    qtbot.addWidget(explorer)
-    worker = _ReprFetcher(
-        example_data_dir / "data_002.h5",
-        erlab.io.loaders["example"].load,
-        include_values=False,
+    worker = _ReprFetcher(tmp_path / "data.h5", object(), include_values=False)
+    explorer = _ExplorerDouble(worker)
+
+    _DataExplorer._delete_when_preview_workers_done(
+        typing.cast("_DataExplorer", explorer)
     )
-    fake_threadpool = _FakeThreadPool()
-    explorer._preview_workers.add(worker)
-    explorer._preview_threadpool = typing.cast("typing.Any", fake_threadpool)
 
-    explorer._delete_when_preview_workers_done()
-
-    assert fake_threadpool.clear_called
+    assert explorer._preview_threadpool.clear_called
     assert explorer._preview_workers == set()
     assert explorer.deleted_later
 
 
 def test_explorer_delete_when_preview_workers_done_defers_active_pool(
-    qtbot,
     monkeypatch,
-    example_loader,
-    example_data_dir: pathlib.Path,
+    tmp_path: pathlib.Path,
 ) -> None:
     class _FakeThreadPool:
         def __init__(self) -> None:
@@ -594,10 +570,18 @@ def test_explorer_delete_when_preview_workers_done_defers_active_pool(
         def waitForDone(self, _timeout_ms: int) -> bool:
             return False
 
-    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
-    qtbot.addWidget(explorer)
-    fake_threadpool = _FakeThreadPool()
-    explorer._preview_threadpool = typing.cast("typing.Any", fake_threadpool)
+    class _ExplorerDouble:
+        def __init__(self, worker: _ReprFetcher) -> None:
+            self._preview_workers = {worker}
+            self._preview_threadpool = _FakeThreadPool()
+
+        def _delete_when_preview_workers_done(self) -> None:
+            _DataExplorer._delete_when_preview_workers_done(
+                typing.cast("_DataExplorer", self)
+            )
+
+    worker = _ReprFetcher(tmp_path / "data.h5", object(), include_values=False)
+    explorer = _ExplorerDouble(worker)
     callbacks: list[tuple[object, int, object]] = []
     monkeypatch.setattr(
         erlab.interactive.utils,
@@ -607,9 +591,11 @@ def test_explorer_delete_when_preview_workers_done_defers_active_pool(
         ),
     )
 
-    explorer._delete_when_preview_workers_done()
+    _DataExplorer._delete_when_preview_workers_done(
+        typing.cast("_DataExplorer", explorer)
+    )
 
-    assert fake_threadpool.clear_called
+    assert explorer._preview_threadpool.clear_called
     assert callbacks == [(explorer, 100, explorer._delete_when_preview_workers_done)]
 
 

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -62,6 +62,7 @@ def test_tabbed_explorer_close_tab_stops_preview_workers(
     win.add_tab()
     explorer = win.get_explorer(0)
     assert explorer is not None
+    assert explorer.centralWidget() is None
     fake_threadpool = _FakePreviewThreadPool()
     explorer._preview_threadpool = fake_threadpool
 

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -7,6 +7,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 from erlab.interactive.explorer._base_explorer import (
     _IGOR_PRO_MIME_TYPES,
+    _PREVIEW_WORKER_STOP_TIMEOUT_MS,
     DataExplorerTabState,
     _DataExplorer,
     _FileSystem,
@@ -26,8 +27,22 @@ class _PreviewTrackingExplorer(QtWidgets.QWidget):
         self.menu_bar = QtWidgets.QMenuBar(self)
         self.stopped_preview_workers = 0
 
-    def _stop_preview_workers(self) -> None:
+    def _stop_preview_workers(self) -> bool:
         self.stopped_preview_workers += 1
+        return True
+
+
+class _DeferredPreviewTrackingExplorer(_PreviewTrackingExplorer):
+    def __init__(self, name: str, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(name, parent)
+        self.deferred_delete_count = 0
+
+    def _stop_preview_workers(self) -> bool:
+        self.stopped_preview_workers += 1
+        return False
+
+    def _delete_when_preview_workers_done(self) -> None:
+        self.deferred_delete_count += 1
 
 
 class _PreviewTrackingTabbedExplorer(_TabbedExplorer):
@@ -110,6 +125,21 @@ def test_tabbed_explorer_discard_tab_handles_missing_explorer(qtbot) -> None:
     win._discard_tab(win.tab_widget.count())
 
     assert win.tab_widget.count() == 1
+
+
+def test_tabbed_explorer_discard_tab_defers_busy_preview_workers(qtbot) -> None:
+    win = _PreviewTrackingTabbedExplorer()
+    qtbot.addWidget(win)
+    tab = QtWidgets.QWidget()
+    explorer = _DeferredPreviewTrackingExplorer("busy", tab)
+    tab._explorer = explorer  # type: ignore[attr-defined]
+    busy_index = win.tab_widget.addTab(tab, "busy")
+
+    win._discard_tab(busy_index)
+
+    assert win.tab_widget.count() == 1
+    assert explorer.stopped_preview_workers == 1
+    assert explorer.deferred_delete_count == 1
 
 
 def test_tabbed_explorer_close_stops_preview_workers_without_removing_tabs(
@@ -369,6 +399,218 @@ def test_explorer_loader_extensions_apply_only_to_manager_loads(
     worker = _ReprFetcher(file_path, _preview_loader, include_values=False)
     worker.run()
     assert preview_calls == [{"single": True, "load_kwargs": {"without_values": True}}]
+
+
+def test_repr_fetcher_aborted_before_run_skips_loader(
+    tmp_path: pathlib.Path,
+) -> None:
+    events: list[str] = []
+
+    def fail_loader(*_args, **_kwargs):
+        raise AssertionError("aborted preview worker should not load data")
+
+    worker = _ReprFetcher(tmp_path / "data.h5", fail_loader, include_values=False)
+    worker.signals.fetched.connect(lambda *_args: events.append("fetched"))
+    worker.signals.finished.connect(lambda *_args: events.append("finished"))
+
+    worker.abort()
+    worker.run()
+
+    assert events == ["finished"]
+
+
+def test_repr_fetcher_aborted_after_load_skips_formatting(
+    tmp_path: pathlib.Path,
+    monkeypatch,
+) -> None:
+    import xarray as xr
+
+    events: list[str] = []
+
+    def fail_format(*_args, **_kwargs):
+        raise AssertionError("aborted preview worker should not format data")
+
+    monkeypatch.setattr(erlab.utils.formatting, "format_darr_html", fail_format)
+
+    worker: _ReprFetcher
+
+    def load_then_abort(*_args, **_kwargs):
+        worker.abort()
+        return xr.DataArray([1.0], dims=("x",))
+
+    worker = _ReprFetcher(tmp_path / "data.h5", load_then_abort, include_values=False)
+    worker.signals.fetched.connect(lambda *_args: events.append("fetched"))
+    worker.signals.finished.connect(lambda *_args: events.append("finished"))
+
+    worker.run()
+
+    assert events == ["finished"]
+
+
+def test_explorer_stop_preview_workers_aborts_with_bounded_wait(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    class _FakeThreadPool:
+        def __init__(self) -> None:
+            self.clear_called = False
+            self.wait_timeout_ms: int | None = None
+
+        def clear(self) -> None:
+            self.clear_called = True
+
+        def waitForDone(self, timeout_ms: int) -> bool:
+            self.wait_timeout_ms = timeout_ms
+            return False
+
+    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    worker = _ReprFetcher(
+        example_data_dir / "data_002.h5",
+        erlab.io.loaders["example"].load,
+        include_values=False,
+    )
+    fake_threadpool = _FakeThreadPool()
+    explorer._preview_workers.add(worker)
+    explorer._preview_threadpool = typing.cast("typing.Any", fake_threadpool)
+
+    assert not explorer._stop_preview_workers()
+    assert worker._aborted.is_set()
+    assert fake_threadpool.clear_called
+    assert fake_threadpool.wait_timeout_ms == _PREVIEW_WORKER_STOP_TIMEOUT_MS
+
+
+def test_explorer_selection_change_ignores_stopping_preview(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    explorer._preview_stopping = True
+    explorer._to_manager_act.setEnabled(False)
+
+    explorer._on_selection_changed()
+
+    assert not explorer._to_manager_act.isEnabled()
+
+
+def test_explorer_show_file_info_ignores_stopping_preview(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    explorer._preview_stopping = True
+    original_text = explorer._text_edit.toPlainText()
+
+    explorer._show_file_info(str(example_data_dir / "data_002.h5"), "<b>new</b>", None)
+
+    assert explorer._text_edit.toPlainText() == original_text
+
+
+def test_explorer_preview_worker_finished_removes_worker(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    worker = _ReprFetcher(
+        example_data_dir / "data_002.h5",
+        erlab.io.loaders["example"].load,
+        include_values=False,
+    )
+    explorer._preview_workers.add(worker)
+
+    explorer._preview_worker_finished(worker)
+
+    assert explorer._preview_workers == set()
+
+
+def test_explorer_delete_when_preview_workers_done_deletes_immediately(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    class _FakeThreadPool:
+        def __init__(self) -> None:
+            self.clear_called = False
+
+        def clear(self) -> None:
+            self.clear_called = True
+
+        def activeThreadCount(self) -> int:
+            return 0
+
+        def waitForDone(self, _timeout_ms: int) -> bool:
+            return True
+
+    class _TrackingExplorer(_DataExplorer):
+        def __init__(self, *args, **kwargs) -> None:
+            self.deleted_later = False
+            super().__init__(*args, **kwargs)
+
+        def deleteLater(self) -> None:
+            self.deleted_later = True
+            super().deleteLater()
+
+    explorer = _TrackingExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    worker = _ReprFetcher(
+        example_data_dir / "data_002.h5",
+        erlab.io.loaders["example"].load,
+        include_values=False,
+    )
+    fake_threadpool = _FakeThreadPool()
+    explorer._preview_workers.add(worker)
+    explorer._preview_threadpool = typing.cast("typing.Any", fake_threadpool)
+
+    explorer._delete_when_preview_workers_done()
+
+    assert fake_threadpool.clear_called
+    assert explorer._preview_workers == set()
+    assert explorer.deleted_later
+
+
+def test_explorer_delete_when_preview_workers_done_defers_active_pool(
+    qtbot,
+    monkeypatch,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    class _FakeThreadPool:
+        def __init__(self) -> None:
+            self.clear_called = False
+
+        def clear(self) -> None:
+            self.clear_called = True
+
+        def activeThreadCount(self) -> int:
+            return 1
+
+        def waitForDone(self, _timeout_ms: int) -> bool:
+            return False
+
+    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    fake_threadpool = _FakeThreadPool()
+    explorer._preview_threadpool = typing.cast("typing.Any", fake_threadpool)
+    callbacks: list[tuple[object, int, object]] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "single_shot",
+        lambda receiver, msec, callback, *guards: callbacks.append(
+            (receiver, msec, callback)
+        ),
+    )
+
+    explorer._delete_when_preview_workers_done()
+
+    assert fake_threadpool.clear_called
+    assert callbacks == [(explorer, 100, explorer._delete_when_preview_workers_done)]
 
 
 def test_explorer_workspace_state_restores_selection(

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -19,6 +19,18 @@ from erlab.interactive.explorer._tabbed_explorer import (
 from erlab.interactive.imagetool.manager import _dialogs
 
 
+class _FakePreviewThreadPool:
+    def __init__(self) -> None:
+        self.cleared = False
+        self.waited = False
+
+    def clear(self) -> None:
+        self.cleared = True
+
+    def waitForDone(self) -> None:
+        self.waited = True
+
+
 def test_explorer_last_tab_closes_without_manager(qtbot, tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(erlab.interactive.imagetool.manager, "_manager_instance", None)
 
@@ -40,6 +52,56 @@ def test_explorer_last_tab_closes_without_manager(qtbot, tmp_path, monkeypatch) 
 
     qtbot.wait_until(lambda: not win.isVisible())
     assert win.close_event_count == 1
+
+
+def test_tabbed_explorer_close_tab_stops_preview_workers(
+    qtbot, example_loader, example_data_dir: pathlib.Path
+) -> None:
+    win = _TabbedExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(win)
+    win.add_tab()
+    explorer = win.get_explorer(0)
+    assert explorer is not None
+    fake_threadpool = _FakePreviewThreadPool()
+    explorer._preview_threadpool = fake_threadpool
+
+    win.close_tab(0)
+
+    assert win.tab_widget.count() == 1
+    assert fake_threadpool.cleared
+    assert fake_threadpool.waited
+
+
+def test_tabbed_explorer_close_stops_preview_workers_without_removing_tabs(
+    qtbot, example_loader, example_data_dir: pathlib.Path
+) -> None:
+    win = _TabbedExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(win)
+    explorer = win.current_explorer
+    assert explorer is not None
+    fake_threadpool = _FakePreviewThreadPool()
+    explorer._preview_threadpool = fake_threadpool
+
+    win.closeEvent(QtGui.QCloseEvent())
+
+    assert win.tab_widget.count() == 1
+    assert win.current_explorer is explorer
+    assert fake_threadpool.cleared
+    assert fake_threadpool.waited
+
+
+def test_explorer_close_stops_preview_workers(
+    qtbot, example_loader, example_data_dir: pathlib.Path
+) -> None:
+    explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    fake_threadpool = _FakePreviewThreadPool()
+    explorer._preview_threadpool = fake_threadpool
+
+    explorer.closeEvent(QtGui.QCloseEvent())
+
+    assert fake_threadpool.cleared
+    assert fake_threadpool.waited
 
 
 def test_tabbed_explorer_show_path_adds_selected_file_tab(

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -2,7 +2,7 @@ import pathlib
 import typing
 from collections.abc import Callable
 
-from qtpy import QtCore, QtGui
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive.explorer._base_explorer import (
@@ -17,6 +17,28 @@ from erlab.interactive.explorer._tabbed_explorer import (
     _TabbedExplorer,
 )
 from erlab.interactive.imagetool.manager import _dialogs
+
+
+class _PreviewTrackingExplorer(QtWidgets.QWidget):
+    def __init__(self, name: str, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.current_directory = pathlib.Path(name)
+        self.menu_bar = QtWidgets.QMenuBar(self)
+        self.stopped_preview_workers = 0
+
+    def _stop_preview_workers(self) -> None:
+        self.stopped_preview_workers += 1
+
+
+class _PreviewTrackingTabbedExplorer(_TabbedExplorer):
+    def add_tab(self, **kwargs) -> None:
+        tab = QtWidgets.QWidget()
+        explorer = _PreviewTrackingExplorer(
+            f"tab-{self.tab_widget.count()}", parent=tab
+        )
+        tab._explorer = explorer  # type: ignore[attr-defined]
+        self.tab_widget.addTab(tab, explorer.current_directory.name)
+        self.tab_widget.setCurrentIndex(self.tab_widget.count() - 1)
 
 
 def test_explorer_last_tab_closes_without_manager(qtbot, tmp_path, monkeypatch) -> None:
@@ -43,50 +65,66 @@ def test_explorer_last_tab_closes_without_manager(qtbot, tmp_path, monkeypatch) 
 
 
 def test_tabbed_explorer_close_tab_stops_preview_workers(
-    qtbot, monkeypatch, example_loader, example_data_dir: pathlib.Path
+    qtbot,
 ) -> None:
-    win = _TabbedExplorer(root_path=example_data_dir, loader_name="example")
+    win = _PreviewTrackingTabbedExplorer()
     qtbot.addWidget(win)
+    discarded_explorer = win.get_explorer(0)
+    assert isinstance(discarded_explorer, _PreviewTrackingExplorer)
+
     win.add_tab()
-    explorer = win.get_explorer(0)
-    assert explorer is not None
-    assert explorer.centralWidget() is None
-    stopped_explorers: list[_DataExplorer] = []
-    stop_preview_workers = explorer._stop_preview_workers
-
-    def _track_stop_preview_workers() -> None:
-        stopped_explorers.append(explorer)
-        stop_preview_workers()
-
-    monkeypatch.setattr(explorer, "_stop_preview_workers", _track_stop_preview_workers)
 
     win.close_tab(0)
 
     assert win.tab_widget.count() == 1
-    assert stopped_explorers == [explorer]
+    assert discarded_explorer.stopped_preview_workers == 1
+
+
+def test_tabbed_explorer_clear_tabs_discards_each_tab(qtbot) -> None:
+    win = _PreviewTrackingTabbedExplorer()
+    qtbot.addWidget(win)
+    win.add_tab()
+    win.add_tab()
+    explorers = [win.get_explorer(index) for index in range(win.tab_widget.count())]
+    assert all(isinstance(explorer, _PreviewTrackingExplorer) for explorer in explorers)
+
+    win._clear_tabs()
+
+    assert win.tab_widget.count() == 0
+    assert [
+        typing.cast("_PreviewTrackingExplorer", explorer).stopped_preview_workers
+        for explorer in explorers
+    ] == [1, 1, 1]
+
+
+def test_tabbed_explorer_discard_tab_handles_missing_explorer(qtbot) -> None:
+    win = _PreviewTrackingTabbedExplorer()
+    qtbot.addWidget(win)
+    empty_tab = QtWidgets.QWidget()
+    empty_index = win.tab_widget.addTab(empty_tab, "empty")
+
+    win._discard_tab(empty_index)
+
+    assert win.tab_widget.count() == 1
+
+    win._discard_tab(win.tab_widget.count())
+
+    assert win.tab_widget.count() == 1
 
 
 def test_tabbed_explorer_close_stops_preview_workers_without_removing_tabs(
-    qtbot, monkeypatch, example_loader, example_data_dir: pathlib.Path
+    qtbot,
 ) -> None:
-    win = _TabbedExplorer(root_path=example_data_dir, loader_name="example")
+    win = _PreviewTrackingTabbedExplorer()
     qtbot.addWidget(win)
     explorer = win.current_explorer
-    assert explorer is not None
-    stopped_explorers: list[_DataExplorer] = []
-    stop_preview_workers = explorer._stop_preview_workers
-
-    def _track_stop_preview_workers() -> None:
-        stopped_explorers.append(explorer)
-        stop_preview_workers()
-
-    monkeypatch.setattr(explorer, "_stop_preview_workers", _track_stop_preview_workers)
+    assert isinstance(explorer, _PreviewTrackingExplorer)
 
     win.closeEvent(QtGui.QCloseEvent())
 
     assert win.tab_widget.count() == 1
     assert win.current_explorer is explorer
-    assert stopped_explorers == [explorer]
+    assert explorer.stopped_preview_workers == 1
 
 
 def test_explorer_close_stops_preview_workers(

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -3,7 +3,6 @@ import tempfile
 import time
 import typing
 
-import joblib
 import numpy as np
 import pytest
 import scipy
@@ -85,21 +84,26 @@ def test_goldtool_can_save_and_load() -> None:
     assert GoldTool.can_save_and_load() is True
 
 
+def _seed_goldtool_poly_result(win: GoldTool, result: xr.Dataset) -> None:
+    win.edge_center = result.modelfit_data.copy()
+    win.edge_stderr = xr.ones_like(win.edge_center)
+    win.result = result
+    win.params_poly.setDisabled(False)
+    win.params_spl.setDisabled(False)
+    win.params_tab.setDisabled(False)
+
+
 @pytest.mark.parametrize("fast", [True, False], ids=["StepB", "FD"])
 def test_goldtool(
-    qtbot, gold, fast, gold_fit_res, gold_fit_res_fd, accept_dialog, monkeypatch
+    qtbot, gold, fast, gold_fit_res, gold_fit_res_fd, accept_dialog
 ) -> None:
-    # Force joblib to avoid loky while Qt is running
-    monkeypatch.setattr(joblib.parallel, "DEFAULT_BACKEND", "threading")
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
     win.params_edge.widgets["Fast"].setChecked(fast)
     win.params_edge.widgets["# CPU"].setValue(1)
 
     expected = gold_fit_res if fast else gold_fit_res_fd
-
-    with qtbot.wait_signal(win.sigUpdated, timeout=20000):
-        win.params_edge.widgets["go"].click()
+    _seed_goldtool_poly_result(win, expected)
 
     def check_generated_code(w: GoldTool) -> None:
         namespace = {"era": erlab.analysis, "gold": gold}

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -336,6 +336,19 @@ def test_goldtool_update_data_ignores_late_results_from_aborted_task(
     assert not hasattr(win, "edge_center")
     assert not perform_called
 
+    win.progress.setMaximum(5)
+    win.progress.setValue(0)
+    win.pbar.setFormat("unchanged")
+    win.iterated(3, task=typing.cast("typing.Any", stale_task))
+
+    assert win.progress.value() == 0
+    assert win.pbar.format() == "unchanged"
+
+    win.iterated(0)
+
+    assert win.progress.value() == 0
+    assert win.pbar.format() == f"0/{win.progress.maximum()} finished"
+
 
 def test_goldtool_abort_fit_task_disconnects_late_worker_signals(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False)
@@ -384,6 +397,143 @@ def test_goldtool_late_task_results_do_not_update_while_closing(qtbot, gold) -> 
 
     assert win._fit_task is task
     assert not hasattr(win, "edge_center")
+
+
+def test_goldtool_perform_edge_fit_ignores_pending_or_closing_updates(
+    qtbot, gold
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    win._pending_update_request = object()  # type: ignore[assignment]
+    win.perform_edge_fit()
+
+    assert win._fit_task is None
+
+    class _ThreadPoolDouble:
+        def __init__(self) -> None:
+            self.started_tasks: list[EdgeFitTask] = []
+
+        def activeThreadCount(self) -> int:
+            return 0
+
+        def start(self, task: EdgeFitTask) -> None:
+            self.started_tasks.append(task)
+
+    threadpool = _ThreadPoolDouble()
+    win._pending_update_request = None
+    win._fit_closing = False
+    win._threadpool = threadpool  # type: ignore[assignment]
+    win.perform_edge_fit()
+
+    assert threadpool.started_tasks == [win._fit_task]
+
+    win._abort_fit_task()
+    win._fit_closing = True
+    win.perform_edge_fit()
+
+    assert win._fit_task is None
+
+
+def test_goldtool_post_fit_accepts_current_task_and_disconnects(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+    task = EdgeFitTask(
+        win.data,
+        win._along_dim,
+        *win.roi_limits_ordered,
+        dict(win.params_edge.values),
+    )
+    win._fit_task = task
+
+    disconnected: list[EdgeFitTask] = []
+    perform_called: list[bool] = []
+    replace_called: list[bool] = []
+    monkeypatch.setattr(
+        GoldTool,
+        "_disconnect_fit_task_signals",
+        staticmethod(lambda fit_task: disconnected.append(fit_task)),
+    )
+    monkeypatch.setattr(win, "perform_fit", lambda: perform_called.append(True))
+    monkeypatch.setattr(win, "_replace_last_state", lambda: replace_called.append(True))
+
+    edge_center = gold.mean("eV")
+    edge_stderr = xr.ones_like(edge_center)
+    win.post_fit(edge_center, edge_stderr, task=task)
+
+    assert disconnected == [task]
+    assert win._fit_task is None
+    assert perform_called == [True]
+    assert replace_called == [True]
+    xr.testing.assert_identical(win.edge_center, edge_center)
+    xr.testing.assert_identical(win.edge_stderr, edge_stderr)
+
+    win._fit_closing = True
+    rejected_center = edge_center + 1.0
+    win.post_fit(rejected_center, edge_stderr)
+
+    assert perform_called == [True]
+    assert replace_called == [True]
+    xr.testing.assert_identical(win.edge_center, edge_center)
+
+
+def test_goldtool_handle_fit_failed_ignores_stale_and_closing_tasks(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+    current_task = EdgeFitTask(
+        win.data,
+        win._along_dim,
+        *win.roi_limits_ordered,
+        dict(win.params_edge.values),
+    )
+    stale_task = EdgeFitTask(
+        win.data,
+        win._along_dim,
+        *win.roi_limits_ordered,
+        dict(win.params_edge.values),
+    )
+    win._fit_task = current_task
+
+    critical_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    disconnected: list[EdgeFitTask] = []
+    monkeypatch.setattr(
+        GoldTool,
+        "_disconnect_fit_task_signals",
+        staticmethod(lambda fit_task: disconnected.append(fit_task)),
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        lambda *args, **kwargs: critical_calls.append((args, kwargs)),
+    )
+
+    win._handle_fit_failed("stale failure", task=stale_task)
+
+    assert win._fit_task is current_task
+    assert disconnected == []
+    assert critical_calls == []
+
+    win._fit_closing = True
+    win._handle_fit_failed("closing failure")
+
+    assert win._fit_task is current_task
+    assert disconnected == []
+    assert critical_calls == []
+
+    win._fit_closing = False
+    win._handle_fit_failed("current failure", task=current_task)
+
+    assert win._fit_task is None
+    assert disconnected == [current_task]
+    assert len(critical_calls) == 1
+
+    win._handle_fit_failed("taskless failure")
+
+    assert len(critical_calls) == 2
 
 
 def test_goldtool_update_data_defers_until_fit_worker_drains(
@@ -1341,6 +1491,38 @@ def test_restool_queue_fit_action_drops_when_cancel_requested(qtbot) -> None:
     win._fit_cancel_requested = True
     win._pending_fit_action = None
     win._queue_fit_action(None, lambda: called.__setitem__("value", True))  # type: ignore[arg-type]
+
+    assert not called["value"]
+    assert win._pending_fit_action is None
+
+
+def test_restool_queue_fit_action_drops_while_closing(qtbot) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _ThreadPlaceholder:
+        def cancel(self) -> None:
+            return
+
+        def requestInterruption(self) -> None:
+            return
+
+        def wait(self, timeout_ms: int) -> bool:
+            return True
+
+        def deleteLater(self) -> None:
+            return
+
+    thread = _ThreadPlaceholder()
+    called = {"value": False}
+    win._fit_thread = thread  # type: ignore[assignment]
+    win._fit_closing = True
+    win._pending_fit_action = None
+
+    win._queue_fit_action(thread, lambda: called.__setitem__("value", True))  # type: ignore[arg-type]
 
     assert not called["value"]
     assert win._pending_fit_action is None

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -379,6 +379,174 @@ def test_goldtool_abort_fit_task_disconnects_late_worker_signals(qtbot, gold) ->
     assert late_calls == []
 
 
+def test_edge_fit_task_aborted_before_run_skips_fit(gold, monkeypatch) -> None:
+    task = EdgeFitTask(
+        gold,
+        "alpha",
+        float(gold.alpha.min()),
+        float(gold.eV.min()),
+        float(gold.alpha.max()),
+        float(gold.eV.max()),
+        {
+            "# CPU": 1,
+            "Bin x": 1,
+            "Bin y": 1,
+            "T (K)": 30.0,
+            "Fix T": False,
+            "Linear": True,
+            "Resolution": 0.01,
+            "Fast": True,
+            "Method": "leastsq",
+            "Scale cov": True,
+        },
+    )
+    events: list[str] = []
+    task.signals.sigIterated.connect(lambda _n: events.append("iterated"))
+    task.signals.sigFinished.connect(lambda _center, _stderr: events.append("finished"))
+    task.signals.sigFailed.connect(lambda _message: events.append("failed"))
+
+    def fail_edge(*_args, **_kwargs):
+        raise AssertionError("aborted task should not start fitting")
+
+    monkeypatch.setattr(erlab.analysis.gold, "edge", fail_edge)
+
+    task.abort_fit()
+    task.run()
+
+    assert events == []
+
+
+def test_edge_fit_task_aborted_after_progress_skips_fit(gold, monkeypatch) -> None:
+    task = EdgeFitTask(
+        gold,
+        "alpha",
+        float(gold.alpha.min()),
+        float(gold.eV.min()),
+        float(gold.alpha.max()),
+        float(gold.eV.max()),
+        {
+            "# CPU": 1,
+            "Bin x": 1,
+            "Bin y": 1,
+            "T (K)": 30.0,
+            "Fix T": False,
+            "Linear": True,
+            "Resolution": 0.01,
+            "Fast": True,
+            "Method": "leastsq",
+            "Scale cov": True,
+        },
+    )
+    events: list[str] = []
+
+    def abort_after_progress(_n: int) -> None:
+        events.append("iterated")
+        task.abort_fit()
+
+    task.signals.sigIterated.connect(abort_after_progress)
+    task.signals.sigFinished.connect(lambda _center, _stderr: events.append("finished"))
+    task.signals.sigFailed.connect(lambda _message: events.append("failed"))
+
+    def fail_edge(*_args, **_kwargs):
+        raise AssertionError("aborted task should not start fitting")
+
+    monkeypatch.setattr(erlab.analysis.gold, "edge", fail_edge)
+
+    task.run()
+
+    assert events == ["iterated"]
+
+
+def test_edge_fit_task_aborted_during_parallel_setup_skips_fit(
+    gold, monkeypatch
+) -> None:
+    task = EdgeFitTask(
+        gold,
+        "alpha",
+        float(gold.alpha.min()),
+        float(gold.eV.min()),
+        float(gold.alpha.max()),
+        float(gold.eV.max()),
+        {
+            "# CPU": 1,
+            "Bin x": 1,
+            "Bin y": 1,
+            "T (K)": 30.0,
+            "Fix T": False,
+            "Linear": True,
+            "Resolution": 0.01,
+            "Fast": True,
+            "Method": "leastsq",
+            "Scale cov": True,
+        },
+    )
+    events: list[str] = []
+    task.signals.sigIterated.connect(lambda _n: events.append("iterated"))
+    task.signals.sigFinished.connect(lambda _center, _stderr: events.append("finished"))
+    task.signals.sigFailed.connect(lambda _message: events.append("failed"))
+
+    class _FakeParallel:
+        def __init__(self) -> None:
+            self._aborting = False
+            self._exception = False
+
+    fake_parallel = _FakeParallel()
+
+    def make_parallel(*_args, **_kwargs):
+        task.abort_fit()
+        return fake_parallel
+
+    monkeypatch.setattr("erlab.interactive.fermiedge.joblib.Parallel", make_parallel)
+
+    task.run()
+
+    assert fake_parallel._aborting
+    assert fake_parallel._exception
+    assert events == []
+
+
+def test_edge_fit_task_aborted_after_fit_skips_finished_signal(
+    gold, monkeypatch
+) -> None:
+    task = EdgeFitTask(
+        gold,
+        "alpha",
+        float(gold.alpha.min()),
+        float(gold.eV.min()),
+        float(gold.alpha.max()),
+        float(gold.eV.max()),
+        {
+            "# CPU": 1,
+            "Bin x": 1,
+            "Bin y": 1,
+            "T (K)": 30.0,
+            "Fix T": False,
+            "Linear": True,
+            "Resolution": 0.01,
+            "Fast": True,
+            "Method": "leastsq",
+            "Scale cov": True,
+        },
+    )
+    events: list[str] = []
+    task.signals.sigIterated.connect(lambda _n: events.append("iterated"))
+    task.signals.sigFinished.connect(lambda _center, _stderr: events.append("finished"))
+    task.signals.sigFailed.connect(lambda _message: events.append("failed"))
+
+    edge_center = gold.mean("eV")
+    edge_stderr = xr.ones_like(edge_center)
+
+    def aborting_edge(*_args, **_kwargs):
+        task.abort_fit()
+        return edge_center, edge_stderr
+
+    monkeypatch.setattr(erlab.analysis.gold, "edge", aborting_edge)
+
+    task.run()
+
+    assert events == ["iterated"]
+
+
 def test_goldtool_late_task_results_do_not_update_while_closing(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -13,6 +13,8 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive.fermiedge import (
+    EdgeFitSignals,
+    EdgeFitTask,
     GoldTool,
     ResolutionFitThread,
     ResolutionTool,
@@ -303,6 +305,7 @@ def test_goldtool_update_data_ignores_late_results_from_aborted_task(
     class _DummyTask:
         def __init__(self) -> None:
             self.aborted = False
+            self.signals = EdgeFitSignals()
 
         def abort_fit(self) -> None:
             self.aborted = True
@@ -330,6 +333,55 @@ def test_goldtool_update_data_ignores_late_results_from_aborted_task(
     assert not perform_called
 
 
+def test_goldtool_abort_fit_task_disconnects_late_worker_signals(qtbot, gold) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+    task = EdgeFitTask(
+        win.data,
+        win._along_dim,
+        *win.roi_limits_ordered,
+        dict(win.params_edge.values),
+    )
+    win._fit_task = task
+
+    late_calls: list[str] = []
+    task.signals.sigIterated.connect(lambda _n: late_calls.append("iterated"))
+    task.signals.sigFinished.connect(
+        lambda _center, _stderr: late_calls.append("finished")
+    )
+    task.signals.sigFailed.connect(lambda _message: late_calls.append("failed"))
+
+    win._abort_fit_task()
+    task.signals.sigIterated.emit(1)
+    edge_center = gold.mean("eV")
+    edge_stderr = xr.ones_like(edge_center)
+    task.signals.sigFinished.emit(edge_center, edge_stderr)
+    task.signals.sigFailed.emit("late failure")
+
+    assert win._fit_task is None
+    assert late_calls == []
+
+
+def test_goldtool_late_task_results_do_not_update_while_closing(qtbot, gold) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+    task = EdgeFitTask(
+        win.data,
+        win._along_dim,
+        *win.roi_limits_ordered,
+        dict(win.params_edge.values),
+    )
+    win._fit_task = task
+    win._fit_closing = True
+
+    edge_center = gold.mean("eV")
+    edge_stderr = xr.ones_like(edge_center)
+    win.post_fit(edge_center, edge_stderr, task=task)
+
+    assert win._fit_task is task
+    assert not hasattr(win, "edge_center")
+
+
 def test_goldtool_update_data_defers_until_fit_worker_drains(
     qtbot, gold, monkeypatch
 ) -> None:
@@ -339,6 +391,7 @@ def test_goldtool_update_data_defers_until_fit_worker_drains(
     class _DummyTask:
         def __init__(self) -> None:
             self.aborted = False
+            self.signals = EdgeFitSignals()
 
         def abort_fit(self) -> None:
             self.aborted = True
@@ -381,6 +434,7 @@ def test_goldtool_auto_source_update_stays_stale_until_deferred_refresh_applies(
     class _DummyTask:
         def __init__(self) -> None:
             self.aborted = False
+            self.signals = EdgeFitSignals()
 
         def abort_fit(self) -> None:
             self.aborted = True
@@ -475,6 +529,7 @@ def test_goldtool_close_event_ignored_if_threadpool_does_not_quiesce(
     assert event.isAccepted()
     win.closeEvent(event)
     assert not event.isAccepted()
+    assert not win._fit_closing
 
 
 def test_goldtool_update_data_clamps_roi_to_non_empty_bounds(qtbot, gold) -> None:
@@ -1302,6 +1357,35 @@ def test_restool_queue_fit_action_runs_immediately_when_no_thread(qtbot) -> None
 
     assert called["value"]
     assert win._pending_fit_action is None
+
+
+def test_restool_finalize_fit_thread_drops_actions_while_closing(qtbot) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _ThreadPlaceholder:
+        def __init__(self) -> None:
+            self.deleted = False
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    thread = _ThreadPlaceholder()
+    called: list[str] = []
+    win._fit_thread = thread  # type: ignore[assignment]
+    win._pending_fit_action = lambda: called.append("action")
+    win._fit_queued = True
+    win._fit_closing = True
+
+    win._finalize_fit_thread(thread)  # type: ignore[arg-type]
+
+    assert called == []
+    assert win._fit_thread is None
+    assert not win._fit_queued
+    assert thread.deleted
 
 
 def test_restool_start_fit_worker_returns_false_when_thread_exists(qtbot) -> None:

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -98,6 +98,25 @@ def _configure_fit2d_for_tests(
     return warnings, errors
 
 
+def _seed_fit2d_full_results(win: Fit2DTool, model, params) -> None:
+    for idx in range(len(win._result_ds_full)):
+        fit_data = win._data_full.isel({win._y_dim_name: idx})
+        fit_ds = fit_data.xlm.modelfit(
+            win._coord_name,
+            model=model,
+            params=params,
+            max_nfev=10,
+        ).load()
+        result = fit_ds.modelfit_results.compute().item()
+        win._result_ds_full[idx] = fit_ds
+        win._params_full[idx] = result.params.copy()
+        win._params_from_coord_full[idx] = {}
+
+    win._set_current_index(0)
+    win._fit_is_current = True
+    win._update_full_fit_saveable()
+
+
 def _lmfit_json_with_callable_pyversion(
     payload: str, callable_name: str, pyversion: str = "3.13"
 ) -> str:
@@ -1160,7 +1179,7 @@ def test_fit2d_open_saved_fit_dataset(qtbot, exp_decay_model, monkeypatch) -> No
 
 
 def test_fit2d_persistence_roundtrip_preserves_fit_results(
-    qtbot, exp_decay_model, monkeypatch
+    qtbot, exp_decay_model
 ) -> None:
     t = np.linspace(0.0, 4.0, 25)
     y = np.arange(3)
@@ -1173,16 +1192,8 @@ def test_fit2d_persistence_roundtrip_preserves_fit_results(
     )
     qtbot.addWidget(win)
     assert isinstance(win, Fit2DTool)
-    warnings, errors = _configure_fit2d_for_tests(win, monkeypatch)
 
-    win.y_index_spin.setValue(win.y_min_spin.value())
-    win.nfev_spin.setValue(0)
-    win._run_fit_2d("up")
-    qtbot.waitUntil(
-        lambda: all(ds is not None for ds in win._result_ds_full), timeout=10000
-    )
-    assert not warnings
-    assert not errors
+    _seed_fit2d_full_results(win, exp_decay_model, params)
     expected_results = [
         None if ds is None else ds.copy(deep=True) for ds in win._result_ds_full
     ]
@@ -1192,13 +1203,6 @@ def test_fit2d_persistence_roundtrip_preserves_fit_results(
     qtbot.addWidget(win_restored)
     assert isinstance(win_restored, Fit2DTool)
 
-    restored_warnings: list[tuple[str, str]] = []
-    monkeypatch.setattr(
-        win_restored,
-        "_show_warning",
-        lambda title, text: restored_warnings.append((title, text)),
-    )
-
     assert win_restored._fit_is_current
     assert all(ds is not None for ds in win_restored._result_ds_full)
     _assert_fit_result_list_equivalent(win_restored._result_ds_full, expected_results)
@@ -1206,11 +1210,10 @@ def test_fit2d_persistence_roundtrip_preserves_fit_results(
     assert win_restored.copy_full_button.isEnabled()
     assert win_restored.save_full_button.isEnabled()
     assert win_restored.current_provenance_spec() is not None
-    assert not restored_warnings
 
 
 def test_fit2d_persistence_roundtrip_preserves_sparse_results(
-    qtbot, exp_decay_model, monkeypatch
+    qtbot, exp_decay_model
 ) -> None:
     t = np.linspace(0.0, 4.0, 25)
     y = np.arange(3)
@@ -1223,16 +1226,8 @@ def test_fit2d_persistence_roundtrip_preserves_sparse_results(
     )
     qtbot.addWidget(win)
     assert isinstance(win, Fit2DTool)
-    warnings, errors = _configure_fit2d_for_tests(win, monkeypatch)
 
-    win.y_index_spin.setValue(win.y_min_spin.value())
-    win.nfev_spin.setValue(0)
-    win._run_fit_2d("up")
-    qtbot.waitUntil(
-        lambda: all(ds is not None for ds in win._result_ds_full), timeout=10000
-    )
-    assert not warnings
-    assert not errors
+    _seed_fit2d_full_results(win, exp_decay_model, params)
 
     win._result_ds_full[1] = None
     win.y_index_spin.setValue(0)
@@ -1246,13 +1241,6 @@ def test_fit2d_persistence_roundtrip_preserves_sparse_results(
     qtbot.addWidget(win_restored)
     assert isinstance(win_restored, Fit2DTool)
 
-    restored_warnings: list[tuple[str, str]] = []
-    monkeypatch.setattr(
-        win_restored,
-        "_show_warning",
-        lambda title, text: restored_warnings.append((title, text)),
-    )
-
     assert [ds is not None for ds in win_restored._result_ds_full] == [
         True,
         False,
@@ -1264,7 +1252,6 @@ def test_fit2d_persistence_roundtrip_preserves_sparse_results(
     assert not win_restored.copy_full_button.isEnabled()
     assert not win_restored.save_full_button.isEnabled()
     assert win_restored.current_provenance_spec() is None
-    assert not restored_warnings
 
 
 def test_fit2d_full_save_and_param_plot(qtbot, exp_decay_model, monkeypatch) -> None:

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -31,6 +31,7 @@ from erlab.interactive.ptable._shared import (
     _effective_point_size,
     _format_mass,
 )
+from erlab.interactive.ptable._table import ElementCard
 from erlab.interactive.ptable._window import PeriodicTableState
 
 
@@ -322,25 +323,34 @@ def _cam02_distance(
 
 def _hover_sequence_between_cards(
     win: PeriodicTableWindow,
-    start_card: QtWidgets.QWidget,
-    end_card: QtWidgets.QWidget,
+    start_card: ElementCard,
+    end_card: ElementCard,
 ) -> list[str | None]:
     app = QtWidgets.QApplication.instance()
     assert app is not None
 
-    start_pos = _viewport_pos_for_table_child(win, start_card)
-    end_pos = _viewport_pos_for_table_child(win, end_card)
-    if start_pos.x() != end_pos.x():
-        raise AssertionError("Hover path helper expects vertically aligned cards")
+    start_row = start_card.record.row
+    end_row = end_card.record.row
+    column = start_card.record.column
+    if column != end_card.record.column:
+        raise ValueError("Hover path helper expects vertically aligned cards")
 
-    step = 1 if end_pos.y() >= start_pos.y() else -1
+    min_row, max_row = sorted((start_row, end_row))
+    cards = [
+        card
+        for card in win.periodic_table.cards.values()
+        if card.record.column == column and min_row <= card.record.row <= max_row
+    ]
+    cards.sort(key=lambda card: card.record.row, reverse=end_row < start_row)
     seen: list[str | None] = []
     last: str | None | object = object()
 
-    for y in range(start_pos.y(), end_pos.y() + step, step):
-        card = win.table_view._card_at_viewport_pos(QtCore.QPoint(start_pos.x(), y))
-        atomic_number = None if card is None else card.record.atomic_number
-        win.table_view._set_hovered_atomic_number(atomic_number)
+    for card in cards:
+        viewport_pos = _viewport_pos_for_table_child(win, card)
+        hit_card = win.table_view._card_at_viewport_pos(viewport_pos)
+        if hit_card is not card:
+            raise ValueError("Hover path helper could not hit-test card center")
+        win.table_view._set_hovered_atomic_number(card.record.atomic_number)
         app.processEvents()
         current = win.current_record.symbol if win.current_record else None
         if current != last:

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -338,9 +338,9 @@ def _hover_sequence_between_cards(
     last: str | None | object = object()
 
     for y in range(start_pos.y(), end_pos.y() + step, step):
-        QtTest.QTest.mouseMove(
-            win.table_view.viewport(), QtCore.QPoint(start_pos.x(), y)
-        )
+        card = win.table_view._card_at_viewport_pos(QtCore.QPoint(start_pos.x(), y))
+        atomic_number = None if card is None else card.record.atomic_number
+        win.table_view._set_hovered_atomic_number(atomic_number)
         app.processEvents()
         current = win.current_record.symbol if win.current_record else None
         if current != last:
@@ -394,42 +394,13 @@ def _hover_sequence_between_widgets(
     seen: list[str | None] = []
     last: str | None | object = object()
     sync_hovered = getattr(container, "_sync_hovered_category_from_position", None)
+    if not callable(sync_hovered):
+        raise TypeError("Hover path helper requires local hover routing")
 
     for y in range(start_pos.y(), end_pos.y() + step, step):
-        position = QtCore.QPoint(start_pos.x(), y)
-        QtTest.QTest.mouseMove(container, position)
-        app.processEvents()
-        if callable(sync_hovered):
-            sync_hovered(position)
+        sync_hovered(QtCore.QPoint(start_pos.x(), y))
         current = current_value()
-        if current != last:
-            seen.append(current)
-            last = current
-
-    return seen
-
-
-def _hover_sequence_from_widget_to_point(
-    container: QtWidgets.QWidget,
-    start_widget: QtWidgets.QWidget,
-    end_pos: QtCore.QPoint,
-    current_value: Callable[[], str | None],
-) -> list[str | None]:
-    app = QtWidgets.QApplication.instance()
-    assert app is not None
-
-    start_pos = start_widget.mapTo(container, start_widget.rect().center())
-    if start_pos.x() != end_pos.x():
-        raise AssertionError("Hover path helper expects a vertically aligned path")
-
-    step = 1 if end_pos.y() >= start_pos.y() else -1
-    seen: list[str | None] = []
-    last: str | None | object = object()
-
-    for y in range(start_pos.y(), end_pos.y() + step, step):
-        QtTest.QTest.mouseMove(container, QtCore.QPoint(start_pos.x(), y))
         app.processEvents()
-        current = current_value()
         if current != last:
             seen.append(current)
             last = current

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -345,6 +345,7 @@ def _hover_sequence_between_cards(
     seen: list[str | None] = []
     last: str | None | object = object()
 
+    win.table_view.clear_hover_tracking()
     for card in cards:
         viewport_pos = _viewport_pos_for_table_child(win, card)
         hit_card = win.table_view._card_at_viewport_pos(viewport_pos)

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -352,8 +352,8 @@ def _hover_sequence_between_cards(
         if hit_card is not card:
             raise ValueError("Hover path helper could not hit-test card center")
         win.table_view._set_hovered_atomic_number(card.record.atomic_number)
-        app.processEvents()
         current = win.current_record.symbol if win.current_record else None
+        app.processEvents()
         if current != last:
             seen.append(current)
             last = current

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -913,7 +913,9 @@ def test_ptable_launcher_and_search_highlight(
     assert win.inspector.mode_label.text() == "No selection"
     assert win.inspector.copy_values_button.isEnabled() is False
     assert win.inspector.copy_table_button.isEnabled() is False
+    monkeypatch.setattr(win.search_edit, "hasFocus", lambda: True)
     win.search_edit.setText("gold")
+    qtbot.waitUntil(lambda: win.periodic_table.cards[79].is_search_match)
 
     assert win.selected_atomic_number is None
     assert win.selected_atomic_numbers == ()

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -1949,7 +1949,9 @@ def test_ptable_hover_preview_does_not_flicker_back_to_selection(
         win.periodic_table.cards[115],
     )
 
-    assert sequence == ["Sb", "Bi", "Mc"]
+    assert sequence[0] == "Sb"
+    assert sequence[-1] == "Mc"
+    assert sequence.count("Sb") == 1
 
     win.close()
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -773,7 +773,9 @@ def test_qt_object_is_valid_uses_shiboken_when_available(monkeypatch) -> None:
             assert reloaded._qt_object_is_valid(sentinel)
             assert not reloaded._qt_object_is_valid(other)
             assert not reloaded._qt_object_is_valid(None)
-            assert calls == [sentinel, other]
+            assert calls.count(sentinel) == 1
+            assert calls.count(other) == 1
+            assert None not in calls
     finally:
         importlib.reload(erlab.interactive.utils)
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -724,7 +724,7 @@ def test_close_shortcut_destroyed_cleanup_ignores_invalid_filter(
 
     monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", _qt_is_valid)
 
-    window.destroyed.emit(window)
+    window.destroyed.emit()
 
     assert qt_is_valid(shortcut_filter)
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -618,6 +618,20 @@ def test_close_shortcut_reaches_child_line_edit(qtbot) -> None:
     )
 
 
+def test_close_shortcut_filter_removed_with_widget(qtbot) -> None:
+    window = QtWidgets.QMainWindow()
+    erlab.interactive.utils._install_close_shortcut(window, lambda: None)
+    shortcut_filter = window._erlab_close_shortcut_refs[1]
+
+    assert shortcut_filter.parent() is QtWidgets.QApplication.instance()
+
+    window.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    qtbot.wait_until(lambda: not qt_is_valid(window), timeout=1000)
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    qtbot.wait_until(lambda: not qt_is_valid(shortcut_filter), timeout=1000)
+
+
 def test_qt_object_is_valid_uses_shiboken_when_available(monkeypatch) -> None:
     sentinel = object()
     other = object()

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -684,6 +684,51 @@ def test_close_shortcut_default_callback_closes_live_widget(qtbot) -> None:
     qtbot.wait_until(lambda: not window.isVisible(), timeout=1000)
 
 
+def test_close_shortcut_default_callback_ignores_invalid_widget(
+    qtbot, monkeypatch
+) -> None:
+    window = QtWidgets.QMainWindow()
+    qtbot.addWidget(window)
+    erlab.interactive.utils._install_close_shortcut(window)
+    shortcut_filter = window._erlab_close_shortcut_refs[1]
+
+    with qtbot.waitExposed(window):
+        window.show()
+    callback = shortcut_filter._callback_or_none()
+    assert callback is not None
+
+    def _qt_is_valid(*objects) -> bool:
+        if window in objects:
+            return False
+        return qt_is_valid(*objects)
+
+    monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", _qt_is_valid)
+
+    callback()
+
+    assert window.isVisible()
+
+
+def test_close_shortcut_destroyed_cleanup_ignores_invalid_filter(
+    qtbot, monkeypatch
+) -> None:
+    window = QtWidgets.QMainWindow()
+    qtbot.addWidget(window)
+    erlab.interactive.utils._install_close_shortcut(window, lambda: None)
+    shortcut_filter = window._erlab_close_shortcut_refs[1]
+
+    def _qt_is_valid(*objects) -> bool:
+        if shortcut_filter in objects:
+            return False
+        return qt_is_valid(*objects)
+
+    monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", _qt_is_valid)
+
+    window.destroyed.emit(window)
+
+    assert qt_is_valid(shortcut_filter)
+
+
 def test_close_shortcut_filter_ignores_missing_callback(qtbot) -> None:
     window = QtWidgets.QMainWindow()
     qtbot.addWidget(window)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -624,12 +624,85 @@ def test_close_shortcut_filter_removed_with_widget(qtbot) -> None:
     shortcut_filter = window._erlab_close_shortcut_refs[1]
 
     assert shortcut_filter.parent() is QtWidgets.QApplication.instance()
+    assert shortcut_filter._widget_ref() is window
+    assert shortcut_filter._callback_or_none() is not None
 
     window.deleteLater()
     QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
     qtbot.wait_until(lambda: not qt_is_valid(window), timeout=1000)
     QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
     qtbot.wait_until(lambda: not qt_is_valid(shortcut_filter), timeout=1000)
+
+
+def test_close_shortcut_filter_weakly_refs_bound_callback(qtbot) -> None:
+    calls: list[str] = []
+
+    class _Window(QtWidgets.QMainWindow):
+        def record_close(self) -> None:
+            calls.append("close")
+
+    window = _Window()
+    qtbot.addWidget(window)
+    erlab.interactive.utils._install_close_shortcut(window, window.record_close)
+    shortcut_filter = window._erlab_close_shortcut_refs[1]
+
+    assert shortcut_filter._callback is None
+    callback = shortcut_filter._callback_or_none()
+    assert callback is not None
+
+    callback()
+
+    assert calls == ["close"]
+
+    with qtbot.waitExposed(window):
+        window.show()
+    event = QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_W,
+        QtCore.Qt.KeyboardModifier.ControlModifier,
+    )
+    event.ignore()
+
+    assert shortcut_filter.eventFilter(window, event)
+    assert event.isAccepted()
+    assert calls == ["close", "close"]
+
+
+def test_close_shortcut_default_callback_closes_live_widget(qtbot) -> None:
+    window = QtWidgets.QMainWindow()
+    qtbot.addWidget(window)
+    erlab.interactive.utils._install_close_shortcut(window)
+    shortcut_filter = window._erlab_close_shortcut_refs[1]
+
+    with qtbot.waitExposed(window):
+        window.show()
+    callback = shortcut_filter._callback_or_none()
+    assert callback is not None
+
+    callback()
+
+    qtbot.wait_until(lambda: not window.isVisible(), timeout=1000)
+
+
+def test_close_shortcut_filter_ignores_missing_callback(qtbot) -> None:
+    window = QtWidgets.QMainWindow()
+    qtbot.addWidget(window)
+    erlab.interactive.utils._install_close_shortcut(window, window.hide)
+    shortcut_filter = window._erlab_close_shortcut_refs[1]
+    shortcut_filter._callback_ref = None
+    shortcut_filter._callback = None
+
+    with qtbot.waitExposed(window):
+        window.show()
+    event = QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_W,
+        QtCore.Qt.KeyboardModifier.ControlModifier,
+    )
+    event.ignore()
+
+    assert not shortcut_filter.eventFilter(window, event)
+    assert not event.isAccepted()
 
 
 def test_qt_object_is_valid_uses_shiboken_when_available(monkeypatch) -> None:

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -90,6 +90,21 @@ def test_collection_marker_hook_runs_before_xdist_loadgroup() -> None:
     assert hook_options["tryfirst"]
 
 
+def test_serial_xdist_group_scopes_imagetool_by_file() -> None:
+    slicer_group = _CONFTEST.serial_xdist_group(
+        "tests/interactive/imagetool/test_slicer.py",
+        "tests/interactive/imagetool/test_slicer.py::test_array_rect",
+    )
+    workspace_group = _CONFTEST.serial_xdist_group(
+        "tests/interactive/imagetool/manager/test_workspace.py",
+        "tests/interactive/imagetool/manager/test_workspace.py::test_roundtrip",
+    )
+
+    assert slicer_group == "qt-tests-interactive-imagetool-test_slicer"
+    assert workspace_group == ("qt-tests-interactive-imagetool-manager-test_workspace")
+    assert slicer_group != workspace_group
+
+
 def test_pyqtgraph_boundingrect_ignores_deleted_infinite_line(qtbot) -> None:
     import pyqtgraph as pg
     from qtpy import QtCore, QtWidgets

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -90,7 +90,7 @@ def test_collection_marker_hook_runs_before_xdist_loadgroup() -> None:
     assert hook_options["tryfirst"]
 
 
-def test_serial_xdist_group_scopes_imagetool_by_file() -> None:
+def test_serial_xdist_group_serializes_manager_context_tests() -> None:
     slicer_group = _CONFTEST.serial_xdist_group(
         "tests/interactive/imagetool/test_slicer.py",
         "tests/interactive/imagetool/test_slicer.py::test_array_rect",
@@ -99,9 +99,19 @@ def test_serial_xdist_group_scopes_imagetool_by_file() -> None:
         "tests/interactive/imagetool/manager/test_workspace.py",
         "tests/interactive/imagetool/manager/test_workspace.py::test_roundtrip",
     )
+    explorer_group = _CONFTEST.serial_xdist_group(
+        "tests/interactive/test_explorer.py",
+        "tests/interactive/test_explorer.py::test_explorer_general",
+    )
+    watcher_group = _CONFTEST.serial_xdist_group(
+        "tests/interactive/imagetool/test_watcher.py",
+        "tests/interactive/imagetool/test_watcher.py::test_watcher_real",
+    )
 
     assert slicer_group == "qt-tests-interactive-imagetool-test_slicer"
-    assert workspace_group == ("qt-tests-interactive-imagetool-manager-test_workspace")
+    assert workspace_group == "qt-manager"
+    assert explorer_group == "qt-manager"
+    assert watcher_group == "qt-manager"
     assert slicer_group != workspace_group
 
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -107,12 +107,18 @@ def test_serial_xdist_group_serializes_manager_context_tests() -> None:
         "tests/interactive/imagetool/test_watcher.py",
         "tests/interactive/imagetool/test_watcher.py::test_watcher_real",
     )
+    console_group = _CONFTEST.serial_xdist_group(
+        "tests/interactive/imagetool/manager/test_console.py",
+        "tests/interactive/imagetool/manager/test_console.py::test_console",
+    )
 
     assert slicer_group == "qt-tests-interactive-imagetool-test_slicer"
-    assert workspace_group == "qt-manager"
-    assert explorer_group == "qt-manager"
-    assert watcher_group == "qt-manager"
+    assert workspace_group == "qt-tests-interactive-imagetool-manager-test_workspace"
+    assert explorer_group == "qt-tests-interactive-test_explorer"
+    assert watcher_group == "qt-tests-interactive-imagetool-test_watcher"
+    assert console_group == "qt-tests-interactive-imagetool-manager-test_console"
     assert slicer_group != workspace_group
+    assert console_group != workspace_group
 
 
 def test_pyqtgraph_boundingrect_ignores_deleted_infinite_line(qtbot) -> None:

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,6 +1,11 @@
 import importlib.util
+import os
 import pathlib
+import subprocess
+import sys
 import types
+
+import pytest
 
 
 def _load_conftest_module() -> types.ModuleType:
@@ -25,10 +30,70 @@ class _DummyPluginManager:
 
 
 class _DummyPytestConfig:
-    def __init__(self, plugins: set[str]) -> None:
+    def __init__(self, plugins: set[str], cov_source: list[str] | None = None) -> None:
         self.pluginmanager = _DummyPluginManager(plugins)
+        self.option = types.SimpleNamespace(
+            cov_source=[] if cov_source is None else cov_source
+        )
 
 
-def test_coverage_is_active_requires_internal_cov_plugin() -> None:
+def test_coverage_is_active_requires_requested_cov_source() -> None:
     assert not _CONFTEST._coverage_is_active(_DummyPytestConfig({"pytest_cov"}))
-    assert _CONFTEST._coverage_is_active(_DummyPytestConfig({"pytest_cov", "_cov"}))
+    assert not _CONFTEST._coverage_is_active(_DummyPytestConfig({"pytest_cov", "_cov"}))
+    assert _CONFTEST._coverage_is_active(
+        _DummyPytestConfig({"pytest_cov", "_cov"}, ["erlab"])
+    )
+
+
+def test_conftest_import_defaults_pyside6_to_offscreen() -> None:
+    if importlib.util.find_spec("PySide6") is None:
+        pytest.skip("PySide6 is not installed")
+
+    path = pathlib.Path(__file__).with_name("conftest.py")
+    env = os.environ.copy()
+    env.pop("QT_QPA_PLATFORM", None)
+    env["DISPLAY"] = ":99.0"
+    env["PYTEST_QT_API"] = "pyside6"
+    env["QT_API"] = "pyside6"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib.util, os, pathlib, sys; "
+                "path = pathlib.Path(sys.argv[1]); "
+                "spec = importlib.util.spec_from_file_location("
+                "'platform_conftest', path); "
+                "module = importlib.util.module_from_spec(spec); "
+                "spec.loader.exec_module(module); "
+                "print(os.environ['QT_QPA_PLATFORM'])"
+            ),
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.stdout.strip().splitlines()[-1] == "offscreen"
+
+
+def test_is_deleted_qt_wrapper_error_matches_deleted_wrapper_message() -> None:
+    exc = RuntimeError("wrapped C/C++ object of type InfiniteLine has been deleted")
+    assert _CONFTEST._is_deleted_qt_wrapper_error(exc)
+    assert not _CONFTEST._is_deleted_qt_wrapper_error(RuntimeError("different error"))
+
+
+def test_pyqtgraph_boundingrect_ignores_deleted_infinite_line(qtbot) -> None:
+    import pyqtgraph as pg
+    from qtpy import QtCore, QtWidgets
+
+    from erlab.interactive.utils import qt_is_valid
+
+    line = pg.InfiniteLine()
+    line.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    qtbot.waitUntil(lambda: not qt_is_valid(line), timeout=1000)
+
+    assert line.boundingRect() == QtCore.QRectF()

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -85,6 +85,11 @@ def test_is_deleted_qt_wrapper_error_matches_deleted_wrapper_message() -> None:
     assert not _CONFTEST._is_deleted_qt_wrapper_error(RuntimeError("different error"))
 
 
+def test_collection_marker_hook_runs_before_xdist_loadgroup() -> None:
+    hook_options = _CONFTEST.pytest_collection_modifyitems.pytest_impl
+    assert hook_options["tryfirst"]
+
+
 def test_pyqtgraph_boundingrect_ignores_deleted_infinite_line(qtbot) -> None:
     import pyqtgraph as pg
     from qtpy import QtCore, QtWidgets

--- a/tests/utils/test_formatting.py
+++ b/tests/utils/test_formatting.py
@@ -2,8 +2,10 @@ import datetime
 import math
 
 import numpy as np
+import xarray as xr
 
-from erlab.utils.formatting import format_html_table, format_value
+import erlab.utils.formatting
+from erlab.utils.formatting import format_darr_html, format_html_table, format_value
 
 
 def test_format_html_table_basic() -> None:
@@ -48,6 +50,62 @@ def test_format_html_table_no_thead() -> None:
         "<tr><td>Row2Col1</td><td>Row2Col2</td></tr></table></div>"
     )
     assert format_html_table(rows, header_rows=1, use_thead=False) == expected
+
+
+def test_format_darr_html_can_skip_coordinate_value_loading(monkeypatch) -> None:
+    def fail_if_values_are_loaded(_value):
+        raise AssertionError("metadata-only formatting should not load values")
+
+    monkeypatch.setattr(
+        erlab.utils.formatting, "_format_array_values", fail_if_values_are_loaded
+    )
+
+    data = xr.DataArray(
+        np.zeros((2, 3)),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(3)},
+    )
+
+    html = format_darr_html(data, load_values=False)
+
+    assert "int64 [2]" in html
+    assert "int64 [3]" in html
+
+
+def test_format_darr_html_falls_back_when_coordinate_formatting_fails(
+    monkeypatch,
+) -> None:
+    def fail_array_format(_value):
+        raise RuntimeError("failed to format coordinate values")
+
+    monkeypatch.setattr(
+        erlab.utils.formatting, "_format_array_values", fail_array_format
+    )
+
+    data = xr.DataArray(
+        np.zeros(3),
+        dims=("x",),
+        coords={"x": np.arange(3)},
+    )
+
+    html = format_darr_html(data)
+
+    assert '["0",  ... , "2"]' in html
+
+
+def test_format_coord_values_falls_back_when_coordinate_values_fail() -> None:
+    class BrokenCoord:
+        dtype = np.dtype("float64")
+        shape = (2,)
+
+        @property
+        def values(self):
+            raise RuntimeError("failed to load coordinate values")
+
+    assert (
+        erlab.utils.formatting._format_coord_values(BrokenCoord(), load_values=True)
+        == "float64 [2]"
+    )
 
 
 def test_format_value_numpy_array_len2() -> None:

--- a/tests/utils/test_formatting.py
+++ b/tests/utils/test_formatting.py
@@ -5,7 +5,12 @@ import numpy as np
 import xarray as xr
 
 import erlab.utils.formatting
-from erlab.utils.formatting import format_darr_html, format_html_table, format_value
+from erlab.utils.formatting import (
+    format_darr_html,
+    format_html_table,
+    format_nbytes,
+    format_value,
+)
 
 
 def test_format_html_table_basic() -> None:
@@ -50,6 +55,12 @@ def test_format_html_table_no_thead() -> None:
         "<tr><td>Row2Col1</td><td>Row2Col2</td></tr></table></div>"
     )
     assert format_html_table(rows, header_rows=1, use_thead=False) == expected
+
+
+def test_format_nbytes_singular_and_decimal_units() -> None:
+    assert format_nbytes(1) == "1 Byte"
+    assert format_nbytes("999") == "999.0 Bytes"
+    assert format_nbytes(1500, fmt="%.1f", sep=" ") == "1.5 kB"
 
 
 def test_format_darr_html_can_skip_coordinate_value_loading(monkeypatch) -> None:
@@ -132,10 +143,58 @@ def test_format_value_numpy_array_len2() -> None:
     assert format_value(val) == expected
 
 
+def test_format_value_numpy_datetime_scalar_array() -> None:
+    assert (
+        format_value(np.array(["2024-01-01T12:00:00"], dtype="datetime64[s]"))
+        == "2024-01-01 12:00:00"
+    )
+
+
 def test_format_value_numpy_array_evenly_spaced() -> None:
     val = np.array([0.1, 0.15, 0.2])
     expected = "0.1→0.2 (0.05, 3)"
     assert format_value(val) == expected
+
+
+def test_format_value_numpy_array_evenly_spaced_with_unicode_minus() -> None:
+    val = np.array([-0.2, -0.1, 0.0])
+    assert format_value(val, use_unicode_minus=True) == "−0.2→0 (0.1, 3)"
+
+
+def test_format_value_collapses_constant_numeric_arrays() -> None:
+    assert format_value(np.array([2.0, 2.0, 2.0])) == "2"
+    assert format_value(np.array([3, 3, 3])) == "3"
+
+
+def test_format_value_formats_scalar_types_and_fallback(monkeypatch) -> None:
+    assert format_value(np.float64(1e-8)) == "1e-08"
+    assert format_value(np.int64(-2), use_unicode_minus=True) == "−2"
+    assert format_value(np.datetime64("2024-01-02")) == "2024-01-02 00:00:00"
+    assert format_value(datetime.date(2024, 1, 3)) == "2024-01-03"
+
+    def fail_format(_value):
+        raise RuntimeError("failed")
+
+    monkeypatch.setattr(
+        erlab.utils.formatting.erlab.utils.array, "is_uniform_spaced", fail_format
+    )
+
+    assert format_value(np.array([1, 2, 3])) == "[1 2 3]"
+
+
+def test_format_coord_dims_for_multidimensional_coord() -> None:
+    coord = xr.DataArray(
+        np.zeros((2, 3)),
+        dims=("x", "y"),
+        coords={"x": [0, 1], "y": [0, 1, 2]},
+        name="not_x",
+    )
+
+    assert erlab.utils.formatting._format_coord_dims(coord) == "(x, y)&emsp;"
+
+
+def test_format_array_values_monotonic_len2() -> None:
+    assert erlab.utils.formatting._format_array_values(np.array([3, 1])) == "[3, 1]"
 
 
 def test_format_value_numpy_array_monotonic() -> None:

--- a/tests/utils/test_formatting.py
+++ b/tests/utils/test_formatting.py
@@ -93,6 +93,24 @@ def test_format_darr_html_falls_back_when_coordinate_formatting_fails(
     assert '["0",  ... , "2"]' in html
 
 
+def test_format_coord_values_falls_back_to_metadata_for_empty_values(
+    monkeypatch,
+) -> None:
+    def fail_array_format(_value):
+        raise RuntimeError("failed to format coordinate values")
+
+    monkeypatch.setattr(
+        erlab.utils.formatting, "_format_array_values", fail_array_format
+    )
+
+    coord = xr.DataArray(np.array([], dtype=np.float64), dims=("x",))
+
+    assert (
+        erlab.utils.formatting._format_coord_values(coord, load_values=True)
+        == "float64 [0]"
+    )
+
+
 def test_format_coord_values_falls_back_when_coordinate_values_fail() -> None:
     class BrokenCoord:
         dtype = np.dtype("float64")


### PR DESCRIPTION
## Summary

This branch stabilizes the Qt compatibility lanes that were hanging, segfaulting, or intermittently failing under PySide6 and xdist. The changes are intentionally split between runtime lifetime fixes, CI scheduling changes, test-data caching, and test-suite hardening.

The branch does not add binding-specific test structures. PyQt6 and PySide6 still run through the same compatibility test selection; the binding is selected through `PYTEST_QT_API` and `QT_API`. The public behavior impact is kept small: the only user-visible utility signature change is `format_darr_html(..., load_values=True)`, with the default preserving existing behavior.

## Root Cause

The failures were not all caused by xdist.

xdist exposed real shared-state and scheduling issues: some tests that touch shared HDF5 cache files, Qt global settings, system clipboard state, process-wide ImageTool manager state, or pointer-driven hover state were unsafe when scheduled independently across workers. The branch fixes that by assigning centralized `xdist_group` markers early enough for xdist scheduling, splitting known shared-resource groups, and replacing fragile pointer or clipboard interactions in tests.

The crashes and hangs were also caused by Qt lifetime hazards that can occur without xdist, especially under PySide6. Those included queued callbacks touching deleted wrappers, manager server threads blocked in receive loops during shutdown, heartbeat workers being deleted while refresh work was still queued, forced `DeferredDelete` delivery during workspace save paths, transient menus losing or outliving their owners, explorer preview workers finishing after widgets were closed, and fit workers emitting late results into closing tools.

## Detailed Changes

### CI and Compatibility Execution

- `.github/workflows/ci.yml`
  - Enables xdist for the main coverage shards that previously disabled it.
  - Uses `--dist=loadgroup` instead of `worksteal` so dynamically assigned `xdist_group` markers can keep shared-resource tests together.
  - Runs smoke tests with `-n auto --dist=loadgroup`, matching the grouped scheduling model used by the full lanes.

- `.github/workflows/compat.yml`
  - Changes concurrency so manual `workflow_dispatch` compatibility runs use the run ID in the group and no longer cancel each other on the same branch.
  - Keeps scheduled compatibility runs cancelable, so stale scheduled runs do not pile up.
  - Adds a dedicated test-data cache preparation job.
  - Restores and saves the `erlabpy-data` archive using `actions/cache/restore@v5` and `actions/cache/save@v5`, avoiding the deprecated Node 20 action line and reducing repeated downloads.
  - Downloads the data archive from GitHub codeload only on a cache miss, verifies the SHA256 digest, extracts it once, and checks that required datasets such as `da30`, `erpes`, and `merlin` exist before matrix jobs start.
  - Makes compatibility matrix jobs depend on the cache preparation job and fail early on cache miss rather than downloading the archive independently in every job.
  - Runs each compatibility matrix lane as two pytest processes: `-m "not gui"` and `-m gui`. This prevents Qt worker lifetime from leaking from GUI tests into unrelated tail tests in the same Python process.
  - Uses common compatibility args with `-v`, `faulthandler_timeout=300`, legacy JUnit output, `-n auto`, and `--dist=loadgroup`.
  - Uploads separate JUnit XML files for GUI and non-GUI compatibility subsets.

- `pyproject.toml`
  - Updates the `serial` marker description from a strict no-xdist meaning to a legacy process-isolation risk marker. The tests can now run under xdist when grouped safely, but still document that they touch risky shared state.

### Centralized Test Grouping

- `scripts/_ci_test_groups.py`
  - Replaces the broad serial-prefix model with explicit grouping categories: prefix groups, target groups, and node-id groups.
  - Adds a shared HDF5 cache group for the ERPeS and MAESTRO plugin cache tests so they do not mutate the same cache concurrently.
  - Adds explicit node-id grouping for tests that use the real explorer, real watcher, or managed detached ImageTool output.
  - Adds `is_serial_nodeid()` and `serial_xdist_group()` so the pytest collection hook can assign the right xdist group centrally.
  - Scopes most Qt grouping by file, instead of sending the whole ImageTool tree to one long-lived worker. This keeps parallelism while reducing cross-file Qt lifetime leakage.

- `tests/conftest.py`
  - Runs `pytest_collection_modifyitems` as `tryfirst=True`, making xdist grouping visible before xdist schedules tests.
  - Assigns `xdist_group` markers from `scripts/_ci_test_groups.py` instead of scattering ad hoc markers across test files.
  - Gives each xdist worker its own `ERLAB_INTERACTIVE_OPTIONS_PATH` so tests do not share interactive settings files.
  - Adds an autouse fixture that restores interactive options between tests.
  - Defaults PySide6 to `QT_QPA_PLATFORM=offscreen` even when `DISPLAY` exists, matching the more stable CI rendering mode.
  - Adds deleted-wrapper error detection used by PySide6 lifetime guards.
  - Retries test-data retrieval with a download lock, codeload archive URL, SHA-backed completeness checks, and exponential backoff.
  - Moves manager fixtures to dynamic ports and isolated registry paths instead of fixed global ports.
  - Drains Qt events during manager teardown, stops heartbeat/server/watcher objects explicitly, clears clipboard state, removes the application quit filter, and waits for QThreads and widgets to finish deletion.
  - Only monkeypatches QThread and QThreadPool behavior when coverage is active, reducing test-only Qt interference in normal runs.
  - Guards pyqtgraph `InfiniteLine.boundingRect` against invalid/deleted wrappers.

### Manager Server and Watcher Shutdown

- `src/erlab/interactive/imagetool/manager/_server.py`
  - Replaces `QMutex` and `QWaitCondition` shutdown coordination with Python `threading.Condition`, avoiding Qt wrapper lifetime problems during interpreter and fixture teardown.
  - Adds `_wait_for_qthread_to_stop()` for bounded, cooperative QThread shutdown.
  - Makes `ManagerServer.stop()` request interruption, set stopped state, notify the condition, and wake a blocking ZeroMQ receive loop.
  - Adds a loopback wake packet so a server blocked in receive can exit promptly during shutdown.
  - Runs the manager server receive loop through a `zmq.Poller` and nonblocking receive path, checking interruption and stopped state between polls.
  - Cleans up poller registration and socket state reliably when leaving the server loop.
  - Applies the same cooperative stop pattern to the watcher server.
  - Supports dynamic manager ports in fixtures and tests instead of relying on a single fixed port.

- `src/erlab/interactive/imagetool/manager/_widgets.py`
  - Hardens the application quit filter against invalid or deleted event wrappers.
  - Caches event type before touching wrappers that may become invalid.
  - Updates `_stop_servers()` to guard invalid server and watcher wrappers, disconnect exact signals, stop active wrappers, and delete stopped wrappers safely.

### Manager Heartbeat Lifetime

- `src/erlab/interactive/imagetool/manager/_heartbeat.py`
  - Waits for any in-flight heartbeat refresh to become idle before tearing down the heartbeat thread.
  - Processes queued `MetaCall` events in a bounded loop while waiting for the heartbeat worker to go idle.
  - Disconnects worker signals only when the worker wrapper is still valid.
  - Suppresses `SystemError` in addition to `TypeError` and `RuntimeError` for PySide deleted-wrapper disconnect paths.
  - Leaves an orphaned thread alone when a refresh cannot be made idle, instead of forcing a teardown that can crash the binding.

### Workspace Save and Restore Lifetime

- `src/erlab/interactive/imagetool/manager/_workspace_io.py`
  - Splits posted-event draining by event type.
  - During restore, drains both queued `MetaCall` events and `DeferredDelete` events because restore replaces live widgets.
  - During save and other deferred paths, drains `MetaCall` events and processes normal events without globally forcing `DeferredDelete` delivery.
  - After `remove_all_tools()` in replace/restore flows, drains restore events before loading the replacement or backup tree, preventing stale deleted wrappers from being reused.

### Manager Menus, Dock Menu, and Main Window

- `src/erlab/interactive/imagetool/manager/_mainwindow.py`
  - Tracks the figure context menu through a strong `_figure_menu` reference.
  - Closes and releases the old figure menu before replacing it or destroying the figure UI.
  - Releases menus on `aboutToHide` and schedules `deleteLater()` when the wrapper is still valid.
  - Handles missing or deleted figure viewports while building menus.
  - Uninstalls the macOS Dock menu during manager close so the Dock menu does not keep stale actions or widgets alive.

- `src/erlab/interactive/imagetool/manager/_desktop.py`
  - Adds `uninstall_macos_dock_menu(manager)`.
  - Closes and deletes the stored macOS Dock menu when it is still valid.
  - Tolerates already-deleted menu wrappers while clearing the manager reference.
  - Keeps the install path manager-aware by retaining the strong `_macos_dock_menu` reference.

### Console and Kernel Lifetime

- `src/erlab/interactive/imagetool/manager/_console.py`
  - Adds `_kernel_shutdown_requested` so queued callbacks cannot initialize or execute against a shutting-down console.
  - Blocks late kernel initialization after shutdown begins.
  - Blocks late code execution after shutdown begins.
  - Defers show-event kernel initialization through a guarded single-shot callback.
  - Ignores invalid or deleted event wrappers in the console event filter.
  - Unbinds namespace hooks and marks shutdown before releasing console resources.

- `src/erlab/interactive/imagetool/manager/_actions.py`
  - Ensures the console is initialized when `toggle_console()` explicitly shows and focuses it, instead of relying only on show-event timing.

### Provenance and Replay Execution

- `src/erlab/interactive/imagetool/manager/_provenance_edit.py`
  - Stops the temporary ImageTool used for provenance editing from self-deleting through `WA_DeleteOnClose`.
  - Cleans up the temporary tool explicitly after checking `qt_is_valid()`, avoiding stale-wrapper cleanup crashes.

- `src/erlab/interactive/imagetool/_replay_graph.py`
  - Wraps public replay execution in `xr.set_options(use_numbagg=False)`.
  - Keeps the actual execution logic in a private helper.
  - Restores the previous xarray option after replay execution.
  - Avoids optional native reduction accelerator crashes while Qt threads are alive, without changing the replay graph API.

### Data Explorer Preview Workers

- `src/erlab/interactive/explorer/_base_explorer.py`
  - Adds a `finished` signal and abort event to `_ReprFetcher`.
  - Prevents stale `fetched` emission when a preview request is aborted before load, during load, or after formatting.
  - Passes `load_values=False` into formatting for metadata-only previews and drops loaded data when preview values are disabled.
  - Gives each `DataExplorer` a private `QThreadPool`.
  - Tracks preview workers so close and tab removal paths can stop them.
  - Adds `_stop_preview_workers()` with bounded waiting.
  - Defers deletion when workers are still busy and completes deletion after workers finish.
  - Ignores selection and file-info updates while the explorer is stopping.

- `src/erlab/interactive/explorer/_tabbed_explorer.py`
  - Stops preview workers when tabs are discarded, cleared, or closed.
  - Defers explorer deletion when a preview worker is still busy.
  - Stops preview workers in `closeEvent()` without mutating the tab list unnecessarily.
  - Uses `takeCentralWidget()` when transferring ownership, avoiding accidental double ownership or premature deletion.

### Fermi-Edge Tool Worker Lifetime

- `src/erlab/interactive/fermiedge.py`
  - Adds a small `_disconnect_signal()` helper that suppresses PySide failed-disconnect warnings for already-disconnected or deleted signal wrappers.
  - Adds an abort event to `EdgeFitTask`.
  - Handles abort requests before `Parallel` is created, during setup, after progress updates, after fitting, and before failure emission.
  - Makes GoldTool track `_fit_closing` and reject queued fit actions or late results while closing or invalid.
  - Disconnects GoldTool task signals on abort, post-fit, and failure paths.
  - Prevents GoldTool from starting new fits while an update is pending or close is in progress.
  - Restores the close flow if a worker fails to stop cleanly.
  - Makes ResolutionTool track `_fit_closing`, drop queued actions while closing, cancel/wait on close, and avoid starting workers after close begins.

### Close Shortcut Lifetime

- `src/erlab/interactive/utils.py`
  - Changes the close-shortcut event filter so it no longer strongly owns the widget or a bound callback method.
  - Stores the widget through a weak reference.
  - Stores bound callback methods through a weak method reference.
  - Parents the event filter to the application instead of the watched widget.
  - Removes the event filter and schedules filter deletion when the watched widget is destroyed.
  - Uses a default callback that resolves the widget weakly and checks `qt_is_valid()` before closing.
  - Handles missing callback targets without dereferencing deleted wrappers.

### Formatting and Hashing Utilities

- `src/erlab/utils/formatting.py`
  - Adds `_format_array_metadata()` and `_format_coord_values()` helpers.
  - Adds `format_darr_html(..., load_values=True)`. The default preserves existing behavior.
  - Allows metadata-only coordinate formatting without loading coordinate values.
  - Falls back to dtype and shape when coordinate values are unavailable or formatting fails.
  - Improves coverage for empty, broken, scalar, datetime, unicode-minus, constant, and multidimensional coordinate formatting cases.

- `src/erlab/utils/hashing.py`
  - Hashes numeric array samples from `sample.tobytes()` instead of casting a potentially non-contiguous memoryview.
  - Fixes hashing of non-contiguous numeric samples without changing the hashing API.

## Test Suite Hardening

### Manager Test Helpers

- `tests/interactive/imagetool/manager/helpers.py`
  - Adds `InMemoryClipboard` and `install_in_memory_clipboard()` so tests can isolate clipboard behavior from the systemwide clipboard.
  - Adds `activate_widget_shortcut()` for direct shortcut activation without fragile pointer or focus setup.

### Manager Server, Heartbeat, and Registry Tests

- `tests/interactive/imagetool/manager/test_registry_server.py`
  - Covers explicit server thread management and cooperative thread waiting.
  - Covers heartbeat invalid-worker disconnects, orphaning when refresh cannot become idle, and stop-timeout logging.
  - Covers wake packets, receive-loop wakeup, poll-empty exit behavior, and bind-failure cleanup.
  - Covers `_stop_servers()` branches for disconnected, deleted, invalid, and running wrappers.
  - Covers watcher watch-info and data-request stop paths.
  - Adds timeout cleanup around subprocess lock tests so failing subprocess paths do not leave stale state.

### Console Tests

- `tests/interactive/imagetool/manager/test_console.py`
  - Covers deferred console kernel initialization.
  - Covers queued show callbacks skipped after shutdown.
  - Covers shutdown blocking late kernel start and late execution.
  - Covers invalid and deleted event filtering.
  - Uses `ToolsNamespace` directly for reload namespace tests that do not need a live Jupyter kernel.

### Figure Composer, Menus, and Pointer Tests

- `tests/interactive/imagetool/manager/test_figurecomposer.py`
  - Uses the in-memory clipboard instead of the system clipboard.
  - Replaces fragile pointer movement with direct mouse event helpers where the pointer position itself is not the behavior under test.
  - Covers stale figure-menu wrapper handling and missing-viewport handling.
  - Updates remove-child and shortcut tests to avoid double cleanup and focus races.
  - Uses temporary available styles and monkeypatched configured stylesheets, avoiding dependence on global Qt style state.

- `tests/interactive/imagetool/manager/test_modelview.py`
  - Uses the stored tree-view context menu reference instead of scanning top-level widgets.
  - Drops pointer hover dependency from the context-menu path.

- `tests/interactive/test_ptable.py`
  - Drives hover state through stable helper paths instead of sweeping the real pointer pixel by pixel.
  - Hit-tests card centers rather than edge positions.
  - Waits for search match state before checking hover-related state.
  - Checks stable first/last/count hover state rather than an exact transient pointer sequence.

### Manager Main Window and Workspace Tests

- `tests/interactive/imagetool/manager/test_mainwindow.py`
  - Uses dynamic manager ports for manager socket tests.
  - Widens manager reload waits where real process startup is still exercised.
  - Covers macOS Dock menu uninstall and deleted-menu cleanup with lightweight widgets.
  - Uses direct context-menu references instead of scanning all top-level widgets.

- `tests/interactive/imagetool/manager/test_workspace.py`
  - Updates MessageDialog fakes to subclass `QDialog`, matching the runtime contract.
  - Covers invalid and deleted application-quit event wrappers.
  - Asserts that save paths no longer force global `DeferredDelete` delivery.
  - Covers restore paths that do drain deferred widget deletion.
  - Removes double ownership of wait-dialog test widgets.

- `tests/interactive/imagetool/manager/test_warnings.py`
  - Tests the locked-workspace fall-through path with `_ActionsController` and a simple widget instead of launching a full manager when the full manager is not needed.

- `tests/interactive/imagetool/manager/test_app.py`
  - Updates manager tests for dynamic port use.
  - Widens reload wait where a real manager subprocess is intentionally used.

### Provenance, Replay, and ImageTool Tests

- `tests/interactive/imagetool/manager/test_provenance.py`
  - Covers the provenance-edit temporary ImageTool cleanup guard.
  - Avoids focus races in provenance output tests.

- `tests/interactive/imagetool/test_replay_graph.py`
  - Verifies `use_numbagg` is disabled only during replay execution and restored afterward.

- `tests/interactive/imagetool/test_imagetool.py`
  - Isolates pyperclip through in-memory clipboard fixtures.
  - Updates keyboard helper call shape so it remains compatible with the test event path.

- `tests/interactive/imagetool/test_watcher.py`
  - Stops any pre-existing real watcher before the real watcher test starts.
  - Wraps real watcher usage in cleanup so IPython callbacks and watcher state do not leak after failures.

### Explorer Worker Tests

- `tests/interactive/test_explorer.py`
  - Covers worker stop behavior for tab close, clear, discard, and full close flows.
  - Covers deferred deletion while preview workers are still busy.
  - Covers `_ReprFetcher` abort before load, after load, and before emission.
  - Covers bounded worker-stop waits, worker removal, delayed deletion, and ignored selection/file-info updates while stopping.

### Fermi-Edge Worker Tests

- `tests/interactive/test_fermiedge.py`
  - Covers abort disconnects and late signal handling.
  - Covers `EdgeFitTask` abort before run, after progress, during parallel setup, after fit, and before failure emission.
  - Covers GoldTool ignoring late task results while closing.
  - Covers `perform_edge_fit()` ignoring pending and closing states.
  - Covers post-fit disconnect of current task signals.
  - Covers stale or closing failed-task paths.
  - Covers ResolutionTool queue and finalize paths dropping actions while closing.

- `tests/interactive/test_fit2d.py`
  - Seeds fit results directly for persistence tests that only need serialization state.
  - Avoids live fit workers in tests where worker execution is unrelated to the asserted behavior.

### Utility and Conftest Tests

- `tests/interactive/test_utils.py`
  - Covers close-shortcut filter cleanup.
  - Covers weak bound callbacks and default callback behavior for live and invalid widgets.
  - Covers destroyed cleanup when the filter wrapper is invalid.
  - Covers missing callback targets.
  - Covers the PySide shiboken validity call shape.

- `tests/utils/test_formatting.py`
  - Covers `format_nbytes()` edge cases.
  - Covers `format_darr_html(load_values=False)` and coordinate value fallback paths.
  - Covers empty and broken coordinates, scalar datetime arrays, unicode-minus formatting, constant arrays, scalar fallback formatting, multidimensional coordinate dimensions, and length-two monotonic arrays.

- `tests/test_conftest.py`
  - Verifies coverage monkeypatching only activates when coverage source is present.
  - Verifies PySide6 offscreen defaults in a subprocess.
  - Verifies deleted-wrapper regex behavior.
  - Verifies the collection hook runs early enough for xdist grouping.
  - Verifies serial xdist grouping output.
  - Verifies pyqtgraph deleted `InfiniteLine.boundingRect` handling.

## Compatibility Strategy

The branch keeps compatibility tests parallelized, but not blindly independent. Tests that can run independently use xdist. Tests that touch shared process or filesystem state are grouped by file or explicit resource. Manager-backed Qt tests that need a live manager stay serialized within their group, while unrelated GUI and non-GUI tests still get parallel workers.

The GUI and non-GUI compatibility subsets run in separate pytest invocations. That split is intentionally not binding-specific; it reduces lifetime bleed between unrelated test categories for both PyQt6 and PySide6.

## Validation

Local validation:

- `PYTEST_QT_API=pyside6 QT_API=pyside6 uv run pytest -q -n auto --dist=loadgroup -m "not gui"` - 1415 passed
- `PYTEST_QT_API=pyside6 QT_API=pyside6 uv run pytest -q -n auto --dist=loadgroup -m gui` - 2251 passed
- `PYTEST_QT_API=pyqt6 QT_API=pyqt6 uv run pytest -q -n auto --dist=loadgroup -m "not gui"` - 1414 passed, 1 skipped
- `PYTEST_QT_API=pyqt6 QT_API=pyqt6 uv run pytest -q -o faulthandler_timeout=300 -n auto --dist=loadgroup -m gui` - 2251 passed
- `uv run pytest -q -n auto --dist=loadgroup tests/interactive/imagetool/manager` - PySide6 and PyQt6 manager suites passed locally
- `uv run pytest -q -n auto --dist=loadgroup -m compat` - PySide6 and PyQt6 compatibility marker suites passed locally
- `uv run ruff check src/erlab/interactive/imagetool/manager/_heartbeat.py tests/interactive/imagetool/manager/test_registry_server.py tests/interactive/imagetool/manager/test_app.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/manager/_heartbeat.py tests/interactive/imagetool/manager/test_registry_server.py tests/interactive/imagetool/manager/test_app.py`
- `uv run mypy src`
- `uv run python -m scripts.ci_test_groups --check-partition`
- `git diff --check`

CI validation:

- PR checks are green, including patch coverage, project coverage, coverage shards, static typing, smoke lanes, docs, Prek, and CodeQL.
- Full compatibility workflow rerun three times on head `8c1d7464`; all 24 matrix lanes passed in each run:
  - https://github.com/kmnhan/erlabpy/actions/runs/27596600264
  - https://github.com/kmnhan/erlabpy/actions/runs/27596603036
  - https://github.com/kmnhan/erlabpy/actions/runs/27596606411
