### PR TITLE
Refine Figure Composer handling in ImageTool manager

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -106,9 +106,10 @@ also bring the data sources they use.
 
 ### Step sources
 
-The step controls include a {guilabel}`Sources` view. It lists the data stored with the
-figure, indicates which sources are used by the selected step, and lets you update the
-data available to recipe steps without rebuilding the rest of the figure.
+Because data sources are selected and updated per recipe step, the step controls include
+a {guilabel}`Sources` view. It lists the data stored with the figure, indicates which
+sources are used by the selected step, and lets you update the data available to recipe
+steps without rebuilding the rest of the figure.
 
 When you choose {guilabel}`Add to Figure…` from ImageTool Manager, the
 {guilabel}`Action` menu updates this same source set:

--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -22,9 +22,8 @@ There are three main entry points:
     for quickly generating comparison figures with several slices of the same data.
 - From ImageTool, choose {guilabel}`Append to Figure` from the same context menu to add
   the current plot to an existing figure.
-- From the manager, select one or more ImageTool rows and click {guilabel}`Figure` in
-  the right-click context menu of the selection. You can choose to create a new figure
-  or append to an existing one.
+- From the manager, select one or more ImageTool rows and click
+  {guilabel}`Add to Figure…` in the right-click context menu of the selection.
 
 Figures are listed in the manager's {guilabel}`Figures` tab, which is hidden until a
 figure is created.
@@ -82,14 +81,6 @@ There are several step types, each with a different set of controls for the gene
 - {guilabel}`Figure Method` for a subset of Matplotlib `fig.*` methods.
 - {guilabel}`Custom Code` for arbitrary code snippets.
 
-(figure-composer-toolbar)=
-
-## Toolbar controls
-
-In addition to the recipe controls, plots can also be customized with the toolbar of the
-figure window. You can edit the subplot spacing and edit various figure elements from
-dialogs opened from the toolbar buttons.
-
 ### Editing steps
 
 Selecting a step opens its controls, which vary based on the step type. Each control is
@@ -110,6 +101,39 @@ to all selected steps. Copied or cut steps can be pasted into another Figure Com
 
 When the source and destination composers are open in the same app process, pasted steps
 also bring the data sources they use.
+
+(figure-composer-sources)=
+
+### Step sources
+
+The step controls include a {guilabel}`Sources` view. It lists the data stored with the
+figure, indicates which sources are used by the selected step, and lets you update the
+data available to recipe steps without rebuilding the rest of the figure.
+
+When you choose {guilabel}`Add to Figure…` from ImageTool Manager, the
+{guilabel}`Action` menu updates this same source set:
+
+- {guilabel}`New Figure` creates another Figure Composer window.
+- {guilabel}`Add New Step` adds the selected ImageTool data and appends a plotting step.
+- {guilabel}`Add Source Only` adds the selected ImageTool data to the figure without
+  creating or changing recipe steps.
+- {guilabel}`Replace Source` keeps the existing figure recipe intact but swaps one source
+  to use data from the selected ImageTool. This is useful when you have formatted a
+  figure and want to reuse the same recipe, axes, styles, and generated variable names
+  with updated or comparable data.
+
+The {guilabel}`Sources` view also provides refresh controls. Click the row button next
+to one source to refresh only that source from its linked open ImageTool, or click
+{guilabel}`Refresh Sources` to refresh every source in the figure that is still linked
+to an open ImageTool.
+
+(figure-composer-toolbar)=
+
+## Toolbar controls
+
+In addition to the recipe controls, plots can also be customized with the toolbar of the
+figure window. You can edit the subplot spacing and edit various figure elements from
+dialogs opened from the toolbar buttons.
 
 (figure-composer-reproducibility)=
 

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -244,6 +244,8 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
   On image plots, the context menu can launch {ref}`goldtool <guide-goldtool>`,
   {ref}`restool <guide-restool>`, {ref}`dtool <guide-dtool>`, and {ref}`ftool
   <guide-ftool>`. On line plots, the context menu offers {ref}`ftool <guide-ftool>`.
+  Image and line plot context menus can also send the current plot to
+  {ref}`Figure Composer <figure-composer>`.
 
   Tools opened from ImageTool remember the slice or selection that opened them. If that
   ImageTool is updated with compatible data, the tool shows a {guilabel}`Stale` badge

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -239,10 +239,11 @@ and right-click context menus:
   Combine selected data with {func}`xarray.concat` and open the result in a new
   ImageTool window.
 
-- {guilabel}`Figure`
+- {guilabel}`Add to Figure…`
 
-  Create a new {ref}`Figure Composer <figure-composer>` figure from the selected rows,
-  or append a new plotting step to an existing figure.
+  Create a new {ref}`Figure Composer <figure-composer>` figure from the selected rows.
+  When figures already exist, this action can also add a new plotting step, add data
+  sources without changing the recipe, or replace a source in the selected figure.
 
 - {guilabel}`Reload Data`
 
@@ -269,9 +270,13 @@ the {guilabel}`Changed` or {guilabel}`Missing` badges described in
 
 ## Creating Matplotlib figures
 
-Use {guilabel}`Figure` from the right-click context menu of one or more ImageTool rows
-to create a new figure in {ref}`Figure Composer <figure-composer>`. New figures will
-appear in a new {guilabel}`Figures` tab in the manager.
+Use {guilabel}`Add to Figure…` from the right-click context menu of one or more
+ImageTool rows to send their data to {ref}`Figure Composer <figure-composer>`. When no
+figures exist, the manager creates a new figure immediately. When figures already exist,
+choose whether to create another figure, append a new recipe step, add the selected data
+as sources only, or replace one source in the selected figure.
+
+New figures appear in a {guilabel}`Figures` tab in the manager.
 
 See {ref}`Figure Composer <figure-composer>` for details.
 

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -76,7 +76,7 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `COPY_PROVENANCE`, `ToolScriptProvenanceDefinition`, `expression_method`,
   `assign`, `IMAGE_TOOL_OUTPUTS`, `set_source_binding`, or `update_data` for
   contributor questions about adding new interactive tools.
-- Search `Figure Composer`, `Append to Figure`,
+- Search `Figure Composer`, `Add to Figure`, `Append to Figure`,
   `plot_array`, `plot_slices`, `qplot`, `fermiline`, `nice_colorbar`, or
   `plot_bz` for plotting questions.
 

--- a/src/erlab/interactive/_figurecomposer/_exceptions.py
+++ b/src/erlab/interactive/_figurecomposer/_exceptions.py
@@ -19,5 +19,8 @@ class FigureComposerSelectionError(ValueError):
 class FigureComposerPlotSlicesSelectionError(FigureComposerSelectionError):
     """Raised when an ImageTool pane cannot seed editable plot_slices selection."""
 
-    def __init__(self) -> None:
-        super().__init__(PLOT_SLICES_SELECTION_ERROR_MESSAGE)
+    def __init__(self, detail: str | None = None) -> None:
+        message = PLOT_SLICES_SELECTION_ERROR_MESSAGE
+        if detail:
+            message = f"{message}\n\nDetails: {detail}"
+        super().__init__(message)

--- a/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
@@ -28,6 +28,7 @@ from erlab.interactive._figurecomposer._line_style import (
 )
 from erlab.interactive._figurecomposer._line_transform import (
     add_line_transform_controls,
+    line_transform_active,
     profile_stack_transform_code,
     profile_transform_code_lines,
     transform_profiles,
@@ -57,7 +58,9 @@ from erlab.interactive._figurecomposer._text import (
     _code_kwargs,
     _dict_from_text,
     _format_dict,
+    _format_plot_limit,
     _format_string_tuple,
+    _plot_limit_from_text,
     _string_tuple_from_text,
 )
 from erlab.interactive._figurecomposer._widgets import (
@@ -90,6 +93,13 @@ _LINE_REDUCE_TEXT = {
     "coarsen": "Coarsen",
     "thin": "Thin",
     "both": "Both",
+}
+
+_SECTION_TOOLTIPS = {
+    "selection": "Choose profile coordinates, qsel selection, and profile extraction.",
+    "view": "Choose profile placement, axis direction, and plot limits.",
+    "style": "Set labels, colors, line style, and marker style.",
+    "other": "Normalize, scale, and offset extracted profiles.",
 }
 
 
@@ -199,9 +209,14 @@ def _available_line_offset_coords(
 def _build_line_editor(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> list[tuple[str, str, QtWidgets.QWidget]]:
-    page, layout = tool._new_step_form_page("figureComposerLinePage")
-    tool.operation_editor = page
-    tool.operation_editor_layout = layout
+    selection_page, selection_layout = tool._new_step_form_page(
+        "figureComposerLineSelectionPage"
+    )
+    view_page, view_layout = tool._new_step_form_page("figureComposerLineViewPage")
+    style_page, style_layout = tool._new_step_form_page("figureComposerLineStylePage")
+    other_page, other_layout = tool._new_step_form_page("figureComposerLineOtherPage")
+    tool.operation_editor = selection_page
+    tool.operation_editor_layout = selection_layout
     coordinate_options = _available_line_coordinate_names(tool, operation)
     coordinate_options_match = tool._batch_options_match(
         operation, lambda target: _available_line_coordinate_names(tool, target)
@@ -212,13 +227,13 @@ def _build_line_editor(
         None if coordinate_mixed else operation.line_x,
         "Automatic profile coordinate",
         lambda value: tool._update_current_operation(line_x=value),
-        parent=page,
+        parent=selection_page,
         mixed=coordinate_mixed,
         enabled=coordinate_options_match,
     )
     coordinate_combo.setObjectName("figureComposerProfileCoordinateCombo")
     tool._add_form_row(
-        tool.operation_editor_layout,
+        selection_layout,
         "Profile coordinate",
         coordinate_combo,
         "Coordinate along each profile.\n"
@@ -241,13 +256,13 @@ def _build_line_editor(
         None if value_mixed else operation.line_y,
         "Data array values",
         lambda value: tool._update_current_operation_rebuild(line_y=value),
-        parent=page,
+        parent=selection_page,
         mixed=value_mixed,
         enabled=value_options_match,
     )
     values_combo.setObjectName("figureComposerProfileValuesCombo")
     tool._add_form_row(
-        tool.operation_editor_layout,
+        selection_layout,
         "Profile values",
         values_combo,
         "Values plotted from the selected profile.\n"
@@ -260,58 +275,10 @@ def _build_line_editor(
         ),
     )
 
-    labels_text, labels_mixed = tool._batch_text(
-        operation,
-        lambda target: target.line_labels,
-        lambda value: _format_string_tuple(typing.cast("tuple[str, ...]", value)),
-    )
-    labels_edit = tool._line_edit(labels_text)
-    tool._apply_mixed_line_edit(labels_edit, labels_mixed)
-    labels_edit.setObjectName("figureComposerLineLabelsEdit")
-    tool._connect_line_edit_finished(
-        labels_edit,
-        lambda text: _update_current_line_labels(tool, text),
-    )
-    tool._add_form_row(
-        tool.operation_editor_layout,
-        "Legend labels",
-        labels_edit,
-        "Optional legend labels.\n"
-        "Use one value for every profile, or one value per profile.",
-    )
-
-    colors_text, colors_mixed = tool._batch_text(
-        operation,
-        lambda target: target.line_colors,
-        lambda value: _format_string_tuple(typing.cast("tuple[str, ...]", value)),
-    )
-    colors_widget = _ColorListEditorWidget(
-        _string_tuple_from_text(colors_text), parent=page
-    )
-    colors_widget.setMainEditObjectName("figureComposerLineColorsEdit")
-    if colors_mixed:
-        colors_widget.setMixedPlaceholder("(multiple values)")
-    tool._connect_value_signal(
-        colors_widget,
-        colors_widget.colorsChanged,
-        lambda colors: tuple(colors),
-        lambda colors: tool._update_current_operation(line_colors=colors),
-        unchanged_mixed=colors_widget.batchUnchanged,
-    )
-    tool._add_form_row(
-        tool.operation_editor_layout,
-        "Colors",
-        colors_widget,
-        "Optional Matplotlib colors.\n"
-        "Use one value for every profile, or one value per profile.",
-    )
-
-    _add_line_style_controls(tool, operation, page)
-
     selection_text, selection_mixed = tool._batch_text(
         operation, lambda target: target.line_selection, _format_dict
     )
-    selection_edit = tool._line_edit(selection_text)
+    selection_edit = tool._line_edit(selection_text, parent=selection_page)
     tool._apply_mixed_line_edit(selection_edit, selection_mixed)
     selection_edit.setObjectName("figureComposerLineSelectionEdit")
     tool._connect_line_edit_finished(
@@ -321,7 +288,7 @@ def _build_line_editor(
         ),
     )
     tool._add_form_row(
-        tool.operation_editor_layout,
+        selection_layout,
         "Data selection",
         selection_edit,
         "Selection kwargs passed to qsel.\n"
@@ -346,12 +313,13 @@ def _build_line_editor(
         iter_dim_options,
         None if iter_dim_mixed else operation.line_iter_dim or "",
         lambda text: _update_current_line_iter_dim(tool, text),
-        parent=page,
+        parent=selection_page,
         mixed=iter_dim_mixed,
         enabled=iter_dim_options_match,
     )
+    iter_dim_combo.setObjectName("figureComposerProfileIterDimCombo")
     tool._add_form_row(
-        tool.operation_editor_layout,
+        selection_layout,
         "One profile per",
         iter_dim_combo,
         "Optional dimension used to split selected data into one profile per axis."
@@ -362,7 +330,7 @@ def _build_line_editor(
         ),
     )
     if _line_reduce_controls_visible(tool, operation):
-        _add_line_reduce_controls(tool, operation, page)
+        _add_line_reduce_controls(tool, operation, selection_page, selection_layout)
 
     placement_mixed = tool._batch_is_mixed(
         operation, lambda target: target.line_placement
@@ -373,12 +341,12 @@ def _build_line_editor(
         lambda text: tool._update_current_operation(
             line_placement=_line_placement_from_text(text)
         ),
-        parent=page,
+        parent=view_page,
         mixed=placement_mixed,
     )
     placement_combo.setObjectName("figureComposerProfilePlacementCombo")
     tool._add_form_row(
-        tool.operation_editor_layout,
+        view_layout,
         "Profile placement",
         placement_combo,
         "Choose how extracted profiles map onto selected axes.\n"
@@ -393,28 +361,132 @@ def _build_line_editor(
         ["y", "x"],
         None if values_axis_mixed else operation.line_values_axis,
         lambda text: tool._update_current_operation(line_values_axis=text),
-        parent=page,
+        parent=view_page,
         mixed=values_axis_mixed,
     )
     values_axis_combo.setObjectName("figureComposerDataValuesAxisCombo")
     tool._add_form_row(
-        tool.operation_editor_layout,
+        view_layout,
         "Data values axis",
         values_axis_combo,
         "Axis that receives profile data values.\n"
         "y: coordinate on x, values on y.\n"
         "x: values on x, coordinate on y.",
     )
+    _add_line_limit_controls(tool, operation, view_page, view_layout)
+
+    labels_text, labels_mixed = tool._batch_text(
+        operation,
+        lambda target: target.line_labels,
+        lambda value: _format_string_tuple(typing.cast("tuple[str, ...]", value)),
+    )
+    labels_edit = tool._line_edit(labels_text, parent=style_page)
+    tool._apply_mixed_line_edit(labels_edit, labels_mixed)
+    labels_edit.setObjectName("figureComposerLineLabelsEdit")
+    tool._connect_line_edit_finished(
+        labels_edit,
+        lambda text: _update_current_line_labels(tool, text),
+    )
+    tool._add_form_row(
+        style_layout,
+        "Legend labels",
+        labels_edit,
+        "Optional legend labels.\n"
+        "Use one value for every profile, or one value per profile.",
+    )
+
+    colors_text, colors_mixed = tool._batch_text(
+        operation,
+        lambda target: target.line_colors,
+        lambda value: _format_string_tuple(typing.cast("tuple[str, ...]", value)),
+    )
+    colors_widget = _ColorListEditorWidget(
+        _string_tuple_from_text(colors_text), parent=style_page
+    )
+    colors_widget.setMainEditObjectName("figureComposerLineColorsEdit")
+    if colors_mixed:
+        colors_widget.setMixedPlaceholder("(multiple values)")
+    tool._connect_value_signal(
+        colors_widget,
+        colors_widget.colorsChanged,
+        lambda colors: tuple(colors),
+        lambda colors: tool._update_current_operation(line_colors=colors),
+        unchanged_mixed=colors_widget.batchUnchanged,
+    )
+    tool._add_form_row(
+        style_layout,
+        "Colors",
+        colors_widget,
+        "Optional Matplotlib colors.\n"
+        "Use one value for every profile, or one value per profile.",
+    )
+
+    _add_line_style_controls(tool, operation, style_page, style_layout)
 
     add_line_transform_controls(
         tool,
         operation,
-        page,
-        tool.operation_editor_layout,
+        other_page,
+        other_layout,
         object_prefix="figureComposerLine",
         offset_coord_options=lambda target: _available_line_offset_coords(tool, target),
     )
-    return [("line", "Line", page)]
+    return [
+        ("selection", "Selection", selection_page),
+        ("view", "View", view_page),
+        ("style", "Style", style_page),
+        ("other", "Other", other_page),
+    ]
+
+
+def _line_limit_update_callback(
+    tool: FigureComposerTool, attr: typing.Literal["xlim", "ylim"]
+) -> typing.Callable[[str], None]:
+    def update(text: str) -> None:
+        tool._update_current_operation(**{attr: _plot_limit_from_text(text)})
+
+    return update
+
+
+def _add_line_limit_controls(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
+) -> None:
+    limit_controls: list[tuple[str, QtWidgets.QWidget, str]] = []
+    for label, attr, object_name in (
+        ("x", "xlim", "figureComposerLineXLimEdit"),
+        ("y", "ylim", "figureComposerLineYLimEdit"),
+    ):
+        text, mixed = tool._batch_text(
+            operation,
+            lambda target, attr=attr: getattr(target, attr),
+            _format_plot_limit,
+        )
+        edit = tool._line_edit(text, parent=page)
+        tool._apply_mixed_line_edit(edit, mixed)
+        edit.setObjectName(object_name)
+        tool._connect_line_edit_finished(
+            edit,
+            _line_limit_update_callback(
+                tool, typing.cast("typing.Literal['xlim', 'ylim']", attr)
+            ),
+        )
+        limit_controls.append(
+            (
+                label,
+                edit,
+                f"Optional {attr}: one number for symmetric limits, "
+                "or two comma-separated numbers for lower and upper limits.",
+            )
+        )
+    tool._add_compound_form_row(
+        layout,
+        "Limits",
+        limit_controls,
+        "Optional x/y plot limits for this step.",
+    )
 
 
 def _update_current_line_iter_dim(tool: FigureComposerTool, text: str) -> None:
@@ -437,6 +509,7 @@ def _add_line_reduce_controls(
     tool: FigureComposerTool,
     operation: FigureOperationState,
     page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
 ) -> None:
     reduce_mixed = tool._batch_is_mixed(operation, lambda target: target.line_reduce)
     reduce_combo = tool._combo(
@@ -487,7 +560,7 @@ def _add_line_reduce_controls(
         )
     row_layout.addStretch(1)
     tool._add_form_row(
-        tool.operation_editor_layout,
+        layout,
         "Reduce",
         row,
         "Reduce the One profile per axis before profile extraction.",
@@ -530,6 +603,7 @@ def _add_line_style_controls(
     tool: FigureComposerTool,
     operation: FigureOperationState,
     page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
 ) -> None:
     line_style_mixed = tool._batch_is_mixed(
         operation, lambda target: line_kw_style_value(target, "linestyle", "ls")
@@ -566,7 +640,7 @@ def _add_line_style_controls(
         line_width_spin, mixed=line_width_mixed, parent=page
     )
     tool._add_compound_form_row(
-        tool.operation_editor_layout,
+        layout,
         "Line",
         (
             (
@@ -618,7 +692,7 @@ def _add_line_style_controls(
         marker_size_spin, mixed=marker_size_mixed, parent=page
     )
     tool._add_compound_form_row(
-        tool.operation_editor_layout,
+        layout,
         "Marker",
         (
             (
@@ -695,7 +769,7 @@ def _add_line_style_controls(
         ),
     )
     tool._add_compound_form_row(
-        tool.operation_editor_layout,
+        layout,
         "Marker colors",
         (
             (
@@ -1498,7 +1572,7 @@ def _editor_sections(
             key,
             title,
             page,
-            "Configure the line/profile overlay for this step.",
+            _SECTION_TOOLTIPS[key],
         )
         for key, title, page in _build_line_editor(tool, operation)
     )
@@ -1514,10 +1588,28 @@ def _section_summary(
             return tool._source_display_name(operation.line_source)
         case "axes":
             return tool._axes_target_text(operation.axes)
-        case "line":
+        case "selection":
+            if operation.line_iter_dim is not None:
+                return f"one per {operation.line_iter_dim}"
+            if operation.line_selection:
+                return "qsel"
+            return operation.line_x or "profile"
+        case "view":
             if operation.line_placement == "one_per_axis":
                 return "one per axis"
-            return operation.line_x or "profile"
+            if operation.line_values_axis == "x":
+                return "values on x"
+            return "all axes"
+        case "style":
+            if operation.line_colors:
+                return (
+                    operation.line_colors[0]
+                    if len(operation.line_colors) == 1
+                    else "colors"
+                )
+            return line_kw_text(operation, "color", "c") or "default"
+        case "other":
+            return "set" if line_transform_active(operation) else ""
     return ""
 
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
@@ -70,7 +70,7 @@ from erlab.interactive._figurecomposer._widgets import (
 from erlab.interactive.imagetool import provenance
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     import matplotlib.axes
     import xarray as xr
@@ -441,11 +441,19 @@ def _build_line_editor(
 
 def _line_limit_update_callback(
     tool: FigureComposerTool, attr: typing.Literal["xlim", "ylim"]
-) -> typing.Callable[[str], None]:
+) -> Callable[[str], None]:
     def update(text: str) -> None:
         tool._update_current_operation(**{attr: _plot_limit_from_text(text)})
 
     return update
+
+
+def _line_limit_getter(
+    attr: typing.Literal["xlim", "ylim"],
+) -> Callable[[FigureOperationState], FigureLimit | None]:
+    if attr == "xlim":
+        return lambda target: target.xlim
+    return lambda target: target.ylim
 
 
 def _add_line_limit_controls(
@@ -455,13 +463,17 @@ def _add_line_limit_controls(
     layout: QtWidgets.QFormLayout,
 ) -> None:
     limit_controls: list[tuple[str, QtWidgets.QWidget, str]] = []
-    for label, attr, object_name in (
+    limit_specs: tuple[
+        tuple[str, typing.Literal["xlim", "ylim"], str],
+        ...,
+    ] = (
         ("x", "xlim", "figureComposerLineXLimEdit"),
         ("y", "ylim", "figureComposerLineYLimEdit"),
-    ):
+    )
+    for label, attr, object_name in limit_specs:
         text, mixed = tool._batch_text(
             operation,
-            lambda target, attr=attr: getattr(target, attr),
+            _line_limit_getter(attr),
             _format_plot_limit,
         )
         edit = tool._line_edit(text, parent=page)
@@ -469,9 +481,7 @@ def _add_line_limit_controls(
         edit.setObjectName(object_name)
         tool._connect_line_edit_finished(
             edit,
-            _line_limit_update_callback(
-                tool, typing.cast("typing.Literal['xlim', 'ylim']", attr)
-            ),
+            _line_limit_update_callback(tool, attr),
         )
         limit_controls.append(
             (

--- a/src/erlab/interactive/_figurecomposer/_operations/_method.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method.py
@@ -3825,6 +3825,9 @@ def _open_method_doc_url(url: str) -> None:
 def _update_current_method_family(
     tool: FigureComposerTool, family: FigureMethodFamily
 ) -> None:
+    current = tool._current_operation()
+    if current is not None and current[1].method_family == family:
+        return
     spec = next(iter(_method_specs(family).values()))
     axes = (
         tool._selected_axes_state()
@@ -3848,28 +3851,26 @@ def _update_current_method_family(
 
 
 def _update_current_method_name(tool: FigureComposerTool, name: str) -> None:
+    if tool._updating_controls:
+        return
     current = tool._current_operation()
     if current is None:
         return
     _index, operation = current
-    spec = _method_specs(operation.method_family)[name]
-    axes = (
-        operation.axes
-        if spec.target_domain == MethodTargetDomain.AXES
-        else FigureAxesSelectionState(axes=())
-    )
-    tool._update_current_operation_rebuild(
-        label=spec.label,
-        method_name=spec.name,
-        method_args=_default_method_args(tool, spec, axes),
-        method_kwargs={},
-        method_call_policy=None,
-        text_values=(),
-        method_transform="data",
-        method_transform_x="data",
-        method_transform_y="axes",
-        method_transform_expression="",
-        axes=axes,
+    if operation.method_name == name:
+        return
+
+    def update_method(
+        _operation_index: int, target: FigureOperationState
+    ) -> FigureOperationState:
+        target_spec = _method_specs(target.method_family)[name]
+        return target.model_copy(
+            update=_method_transfer_updates(tool, target, target_spec)
+        )
+
+    tool._update_operations(
+        update_method,
+        rebuild_editor=True,
     )
 
 
@@ -4020,6 +4021,176 @@ def _label_values(operation: FigureOperationState) -> str | list[str]:
 
 def _method_has_transform_control(spec: MethodSpec) -> bool:
     return any(control.kind == MethodControlKind.TRANSFORM for control in spec.controls)
+
+
+def _control_accepts_value(control: MethodControlSpec, value: typing.Any) -> bool:
+    if control.kind in {
+        MethodControlKind.ARG_COMBO,
+        MethodControlKind.KWARG_COMBO,
+    }:
+        if value is None:
+            return control.none_label is not None
+        return str(value) in control.options
+    if control.kind in {
+        MethodControlKind.BOOL_ARG_COMBO,
+        MethodControlKind.BOOL_KWARG_COMBO,
+    }:
+        return isinstance(value, bool)
+    return True
+
+
+def _transfer_axis_label_loc(
+    source_spec: MethodSpec, target_spec: MethodSpec, value: typing.Any
+) -> typing.Any:
+    if source_spec.name == "set_xlabel" and target_spec.name == "set_ylabel":
+        return {"left": "bottom", "center": "center", "right": "top"}.get(value, value)
+    if source_spec.name == "set_ylabel" and target_spec.name == "set_xlabel":
+        return {"bottom": "left", "center": "center", "top": "right"}.get(value, value)
+    return value
+
+
+def _method_transfer_updates(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    target_spec: MethodSpec,
+) -> dict[str, typing.Any]:
+    source_spec = _method_spec(operation)
+    axes = (
+        operation.axes
+        if target_spec.target_domain == MethodTargetDomain.AXES
+        else FigureAxesSelectionState(axes=())
+    )
+    source_args = {
+        control.arg_index: control
+        for control in source_spec.controls
+        if control.arg_index is not None
+    }
+    target_args = {
+        control.arg_index: control
+        for control in target_spec.controls
+        if control.arg_index is not None
+    }
+    args = list(_default_method_args(tool, target_spec, axes))
+    source_kinds = {control.kind for control in source_spec.controls}
+    target_kinds = {control.kind for control in target_spec.controls}
+    if (
+        operation.method_args
+        and MethodControlKind.FLOAT_PAIR_ARGS in source_kinds
+        and MethodControlKind.FLOAT_PAIR_ARGS in target_kinds
+    ) or (
+        operation.method_args
+        and MethodControlKind.PLOT_DATA_ARGS in source_kinds
+        and MethodControlKind.PLOT_DATA_ARGS in target_kinds
+    ):
+        args = list(operation.method_args)
+    elif operation.method_args:
+        for index, target_control in target_args.items():
+            source_control = source_args.get(index)
+            if (
+                source_control is None
+                or source_control.kind != target_control.kind
+                or index >= len(operation.method_args)
+            ):
+                continue
+            value = operation.method_args[index]
+            if (
+                index < len(source_spec.default_args)
+                and value == source_spec.default_args[index]
+            ):
+                continue
+            if not _control_accepts_value(target_control, value):
+                continue
+            while len(args) <= index:
+                args.append(None)
+            args[index] = value
+
+    source_kwargs = {
+        control.key: control
+        for control in source_spec.controls
+        if control.key is not None
+    }
+    target_kwargs = {
+        control.key: control
+        for control in target_spec.controls
+        if control.key is not None
+    }
+    source_signature = tuple(
+        (control.kind, control.arg_index, control.key, control.none_label is not None)
+        for control in source_spec.controls
+        if control.kind != MethodControlKind.TRANSFORM
+    )
+    target_signature = tuple(
+        (control.kind, control.arg_index, control.key, control.none_label is not None)
+        for control in target_spec.controls
+        if control.kind != MethodControlKind.TRANSFORM
+    )
+    transfer_extra_kwargs = (
+        source_spec.family == target_spec.family
+        and source_spec.target_domain == target_spec.target_domain
+        and source_spec.allow_extra_kwargs
+        and target_spec.allow_extra_kwargs
+        and source_signature == target_signature
+    )
+    kwargs: dict[str, typing.Any] = {}
+    for key, value in operation.method_kwargs.items():
+        target_control = target_kwargs.get(key)
+        if target_control is None:
+            if key not in source_kwargs and transfer_extra_kwargs:
+                kwargs[key] = value
+            continue
+        source_control = source_kwargs.get(key)
+        if source_control is None or source_control.kind != target_control.kind:
+            continue
+        if key == "loc":
+            value = _transfer_axis_label_loc(source_spec, target_spec, value)
+        if _control_accepts_value(target_control, value):
+            kwargs[key] = value
+
+    method_call_policy = None
+    if operation.method_call_policy is not None:
+        with contextlib.suppress(ValueError):
+            policy = MethodCallPolicy(operation.method_call_policy)
+            if policy in target_spec.selectable_call_policies:
+                method_call_policy = (
+                    None if policy == target_spec.call_policy else policy.value
+                )
+
+    text_values = ()
+    if (
+        source_spec.text_values_policy != MethodTextValuesPolicy.NONE
+        and source_spec.text_values_policy == target_spec.text_values_policy
+        and (
+            source_spec.text_values_policy != MethodTextValuesPolicy.KWARG
+            or source_spec.text_values_kwarg == target_spec.text_values_kwarg
+        )
+    ):
+        text_values = operation.text_values
+
+    updates: dict[str, typing.Any] = {
+        "label": target_spec.label,
+        "method_name": target_spec.name,
+        "method_args": tuple(args),
+        "method_kwargs": kwargs,
+        "method_call_policy": method_call_policy,
+        "text_values": text_values,
+        "method_transform": "data",
+        "method_transform_x": "data",
+        "method_transform_y": "axes",
+        "method_transform_expression": "",
+        "axes": axes,
+    }
+    if _method_has_transform_control(source_spec) and _method_has_transform_control(
+        target_spec
+    ):
+        updates.update(
+            {
+                "method_transform": operation.method_transform,
+                "method_transform_x": operation.method_transform_x,
+                "method_transform_y": operation.method_transform_y,
+                "method_transform_expression": operation.method_transform_expression,
+            }
+        )
+    return updates
 
 
 def _transform_component(

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -1693,8 +1693,8 @@ def _build_plot_slices_editor(
     is_line_plot = panel_kind == _PLOT_SLICES_PANEL_LINE
     is_image_plot = panel_kind == _PLOT_SLICES_PANEL_IMAGE
     is_mixed_panel_kind = panel_kind == _PLOT_SLICES_PANEL_MIXED
-    cuts_page, basic_layout = tool._new_step_form_page(
-        "figureComposerPlotSlicesCutsPage"
+    selection_page, selection_layout = tool._new_step_form_page(
+        "figureComposerPlotSlicesSelectionPage"
     )
     view_page, view_layout = tool._new_step_form_page(
         "figureComposerPlotSlicesViewPage"
@@ -1705,8 +1705,8 @@ def _build_plot_slices_editor(
     advanced_page, advanced_layout = tool._new_step_form_page(
         "figureComposerPlotSlicesAdvancedPage"
     )
-    tool.operation_editor = cuts_page
-    tool.operation_editor_layout = basic_layout
+    tool.operation_editor = selection_page
+    tool.operation_editor_layout = selection_layout
 
     shape_summary = QtWidgets.QLabel(
         "\n".join(
@@ -1716,14 +1716,14 @@ def _build_plot_slices_editor(
                 *(("Status: " + shape.selection_text,) if not shape.valid else ()),
             )
         ),
-        cuts_page,
+        selection_page,
     )
     shape_summary.setObjectName("figureComposerPlotSlicesShapeSummary")
     shape_summary.setWordWrap(True)
     if not shape.valid:
         shape_summary.setForegroundRole(QtGui.QPalette.ColorRole.Link)
     tool._add_form_row(
-        basic_layout,
+        selection_layout,
         "Dimensions",
         shape_summary,
         "Shows the input dimensions and the dimensions plotted by this step.",
@@ -1739,7 +1739,7 @@ def _build_plot_slices_editor(
     )
     dim_combo.setObjectName("figureComposerPlotSlicesDimensionCombo")
     tool._add_form_row(
-        basic_layout,
+        selection_layout,
         "Dimension",
         dim_combo,
         "Data dimension passed as the slice keyword to plot_slices.",
@@ -1758,7 +1758,7 @@ def _build_plot_slices_editor(
         ),
     )
     tool._add_form_row(
-        basic_layout,
+        selection_layout,
         "Values",
         values_edit,
         "Comma-separated coordinate values to select along the dimension.",
@@ -1779,10 +1779,10 @@ def _build_plot_slices_editor(
         ),
     )
     tool._add_form_row(
-        basic_layout,
+        selection_layout,
         "Integration width",
         width_edit,
-        "Optional qsel width around each cut value before plotting.",
+        "Optional qsel width around each selected value before plotting.",
     )
 
     slice_kwargs_text, slice_kwargs_mixed = tool._batch_text(
@@ -1796,7 +1796,7 @@ def _build_plot_slices_editor(
         lambda text: _update_current_slice_kwargs(tool, text),
     )
     tool._add_form_row(
-        basic_layout,
+        selection_layout,
         "Additional slice kwargs",
         slice_kwargs_edit,
         "Additional plot_slices selection kwargs passed to qsel.\n"
@@ -1816,8 +1816,8 @@ def _build_plot_slices_editor(
         view_layout,
         "Panel order",
         order_combo,
-        "C places sources by row and cuts by column. F places cuts by row "
-        "and sources by column.",
+        "C places sources by row and selected values by column. F places selected "
+        "values by row and sources by column.",
     )
 
     transpose_mixed = tool._batch_is_mixed(operation, lambda target: target.transpose)
@@ -2634,7 +2634,7 @@ def _build_plot_slices_editor(
         "Dict literal or keyword arguments merged into the plot_slices call.",
     )
     return [
-        ("cuts", "Selection", cuts_page),
+        ("selection", "Selection", selection_page),
         ("view", "View", view_page),
         ("colors", "Colors", colors_page),
         ("advanced", "Other", advanced_page),
@@ -3432,7 +3432,7 @@ def _plot_slices_transformed_code_kwargs(
 
 
 _SECTION_TOOLTIPS = {
-    "cuts": "Choose dimension, values, and extraction options.",
+    "selection": "Choose dimension, values, and extraction options.",
     "view": "Set orientation, axis limits, labels, and annotation behavior.",
     "colors": "Set image color scaling or 1D line styling for this plot_slices step.",
     "advanced": "Pass advanced keyword arguments to plot_slices.",
@@ -3458,10 +3458,10 @@ def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> 
     shape = _plot_slices_shape(tool, operation)
     plot_kind = "Line slices" if shape.plot_ndim == 1 else "Image slices"
     if operation.slice_dim and operation.slice_values:
-        cut_text = f"{operation.slice_dim} = {len(operation.slice_values)} cuts"
+        selection_text = f"{operation.slice_dim} = {len(operation.slice_values)} values"
     else:
-        cut_text = "current selection"
-    return f"{prefix}{plot_kind}: {source_text}, {cut_text}"
+        selection_text = "current selection"
+    return f"{prefix}{plot_kind}: {source_text}, {selection_text}"
 
 
 def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:
@@ -3797,7 +3797,7 @@ def _section_summary(
             return ", ".join(tool._source_display_names(operation.sources)) or "none"
         case "axes":
             return tool._axes_target_text(operation.axes)
-        case "cuts":
+        case "selection":
             if operation.slice_dim and operation.slice_values:
                 return f"{operation.slice_dim}, {len(operation.slice_values)}"
             if operation.slice_kwargs:

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -1859,6 +1859,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def refresh_source_controls(self) -> None:
         self._refresh_source_controls()
 
+    def _set_source_status_text(self, text: str | None) -> None:
+        self.source_status_label.setText("" if text is None else text)
+        self.source_status_label.setVisible(bool(text))
+
     def _refresh_source_from_button(self, name: str, _checked: bool = False) -> None:
         callback = self._source_refresh_callback
         if callback is None or not self._source_refresh_available(name):
@@ -1868,7 +1872,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         refreshed = callback(name)
         self._refresh_source_controls()
         if refreshed:
-            self.source_status_label.setText(f"Refreshed {display}.")
+            self._set_source_status_text(f"Refreshed {display}.")
 
     def _refresh_sources_from_button(self, _checked: bool = False) -> None:
         callback = self._source_refresh_many_callback
@@ -1880,9 +1884,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._refresh_source_controls()
         if refreshed_count:
             noun = "source" if refreshed_count == 1 else "sources"
-            self.source_status_label.setText(f"Refreshed {refreshed_count} {noun}.")
+            self._set_source_status_text(f"Refreshed {refreshed_count} {noun}.")
         else:
-            self.source_status_label.setText("No sources were refreshed.")
+            self._set_source_status_text("No sources were refreshed.")
 
     def _set_source_list_row_used(
         self, item: QtWidgets.QTreeWidgetItem, used: bool
@@ -4034,7 +4038,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         sources: Sequence[FigureSourceState],
         source_data: Mapping[str, xr.DataArray],
     ) -> None:
-        """Add or refresh recipe sources used by appended operations."""
+        """Add or update source data without changing existing recipe steps.
+
+        This supports appending operations and the manager's source-only workflow. The
+        source list, backing data, preview, persistent state, and data-dirty signals are
+        updated together so workspace saves include the new source data.
+        """
         existing = {source.name: source for source in self._recipe.sources}
         for source in sources:
             existing[source.name] = source
@@ -4044,6 +4053,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._refresh_source_list()
         self._update_source_section()
         _render_preview(self)
+        self.sigDataChanged.emit()
         self.sigInfoChanged.emit()
         self._write_state()
 
@@ -4053,7 +4063,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         source: FigureSourceState,
         data: xr.DataArray,
     ) -> bool:
-        """Replace a figure source's backing data while preserving its alias."""
+        """Replace source data while preserving the recipe-facing source name.
+
+        The incoming source metadata and data replace the stored source slot, but
+        recipe steps and generated code keep referring to the stored source name.
+        Returns ``False`` when no matching stored source or backing data slot exists.
+        """
         source_list = list(self._recipe.sources)
         for index, existing_source in enumerate(source_list):
             if existing_source.name == alias:
@@ -4336,31 +4351,28 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _update_source_status(self, operation: FigureOperationState | None) -> None:
         if operation is None:
-            self.source_status_label.setText("Select a step to choose data sources.")
+            self._set_source_status_text("Select a step to choose data sources.")
             return
         if (input_error := self._operation_input_error_text(operation)) is not None:
-            self.source_status_label.setText(f"Invalid input: {input_error}")
+            self._set_source_status_text(f"Invalid input: {input_error}")
             return
         if (
             render_error := self._operation_render_errors.get(operation.operation_id)
         ) is not None:
-            self.source_status_label.setText(f"Render error: {render_error}")
+            self._set_source_status_text(f"Render error: {render_error}")
             return
         selected_sources = self._selected_sources_for_operation(operation)
         missing = [
             source for source in selected_sources if source not in self._source_data
         ]
         if missing:
-            self.source_status_label.setText(
+            self._set_source_status_text(
                 "Missing sources: " + ", ".join(self._source_display_names(missing))
             )
         elif selected_sources:
-            self.source_status_label.setText(
-                "Selected sources: "
-                + ", ".join(self._source_display_names(selected_sources))
-            )
+            self._set_source_status_text(None)
         else:
-            self.source_status_label.setText("This step does not read a data source.")
+            self._set_source_status_text("This step does not read a data source.")
 
     def _update_source_section(self) -> None:
         self._clear_step_source_controls()
@@ -4922,7 +4934,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 continue
             if source_name == erlab.interactive.utils._SAVED_TOOL_DATA_NAME:
                 raise ValueError(
-                    "Figure source aliases cannot use the reserved saved-tool data name"
+                    "Figure source names cannot use the reserved saved-tool data name"
                 )
             items[source_name] = data
         return items

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -4081,6 +4081,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
         self._source_data[alias] = data
         self._recipe = self._recipe.model_copy(update={"sources": tuple(source_list)})
+        self._refresh_operation_list()
+        self._refresh_step_section_button_texts()
         self._refresh_source_list()
         self._update_source_section()
         _render_preview(self)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -137,6 +137,9 @@ _COMBO_POPUP_REBUILD_GRACE_MS = 150
 _COMBO_INTERACTION_REBUILD_GRACE_MS = 250
 _COMBO_TRACKED_PROPERTY = "figure_composer_combo_tracked"
 _COMBO_POPUP_GUARD_ID_PROPERTY = "figure_composer_combo_popup_guard_id"
+_SOURCE_LIST_SOURCE_COLUMN = 0
+_SOURCE_LIST_SHAPE_COLUMN = 1
+_SOURCE_LIST_REFRESH_COLUMN = 2
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
@@ -336,6 +339,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             str, weakref.ReferenceType[QtWidgets.QWidget]
         ] = {}
         self._source_data: dict[str, xr.DataArray] = {}
+        self._source_refresh_available_callback: Callable[[str], bool] | None = None
+        self._source_refresh_callback: Callable[[str], bool] | None = None
+        self._source_refresh_many_callback: Callable[[Sequence[str]], int] | None = None
+        self._source_refresh_label_callback: Callable[[str], str | None] | None = None
         self._recipe = recipe or self._default_recipe(data)
         self._active_gridspec_grid_id = self._recipe.setup.gridspec.root.grid_id
         self._gridspec_breadcrumb_buttons: list[QtWidgets.QToolButton] = []
@@ -1095,10 +1102,28 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.source_status_label.setObjectName("figureComposerSourceStatus")
         self.source_status_label.setWordWrap(True)
         sources_layout.addWidget(self.source_status_label)
+        self.source_actions = QtWidgets.QWidget(self.step_sources_page)
+        self.source_actions.setObjectName("figureComposerSourceActions")
+        source_actions_layout = QtWidgets.QHBoxLayout(self.source_actions)
+        source_actions_layout.setContentsMargins(0, 0, 0, 0)
+        source_actions_layout.setSpacing(4)
+        source_actions_layout.addStretch(1)
+        self.refresh_sources_button = QtWidgets.QToolButton(self.source_actions)
+        self.refresh_sources_button.setObjectName("figureComposerRefreshSourcesButton")
+        self.refresh_sources_button.setText("Refresh Sources")
+        self.refresh_sources_button.setAccessibleName("Refresh Sources")
+        self.refresh_sources_button.setIcon(QtGui.QIcon.fromTheme("view-refresh"))
+        self.refresh_sources_button.setToolButtonStyle(
+            QtCore.Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+        )
+        self.refresh_sources_button.setAutoRaise(True)
+        self.refresh_sources_button.clicked.connect(self._refresh_sources_from_button)
+        source_actions_layout.addWidget(self.refresh_sources_button)
+        sources_layout.addWidget(self.source_actions)
         self.source_list = QtWidgets.QTreeWidget(self.step_sources_page)
         self.source_list.setObjectName("figureComposerSourceList")
-        self.source_list.setColumnCount(2)
-        self.source_list.setHeaderLabels(("Source", "Shape"))
+        self.source_list.setColumnCount(3)
+        self.source_list.setHeaderLabels(("Source", "Shape", ""))
         self.source_list.setRootIsDecorated(False)
         self.source_list.setIndentation(0)
         self.source_list.setUniformRowHeights(True)
@@ -1117,10 +1142,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if source_header is not None:
             source_header.setStretchLastSection(False)
             source_header.setSectionResizeMode(
-                0, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+                _SOURCE_LIST_SOURCE_COLUMN,
+                QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
             )
             source_header.setSectionResizeMode(
-                1, QtWidgets.QHeaderView.ResizeMode.Stretch
+                _SOURCE_LIST_SHAPE_COLUMN,
+                QtWidgets.QHeaderView.ResizeMode.Stretch,
+            )
+            source_header.setSectionResizeMode(
+                _SOURCE_LIST_REFRESH_COLUMN,
+                QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
             )
         sources_layout.addWidget(self.source_list, 1)
 
@@ -1582,6 +1613,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         index = combo.findText(value)
         combo.setCurrentIndex(max(index, 0))
 
+    def _set_source_refresh_callbacks(
+        self,
+        *,
+        can_refresh_source: Callable[[str], bool] | None = None,
+        refresh_source: Callable[[str], bool] | None = None,
+        refresh_sources: Callable[[Sequence[str]], int] | None = None,
+        source_label: Callable[[str], str | None] | None = None,
+    ) -> None:
+        self._source_refresh_available_callback = can_refresh_source
+        self._source_refresh_callback = refresh_source
+        self._source_refresh_many_callback = refresh_sources
+        self._source_refresh_label_callback = source_label
+        self._refresh_source_controls()
+
     def _sync_size_mm_controls(self, figsize: tuple[float, float]) -> None:
         self.width_mm_spin.setValue(figsize[0] * _MM_PER_INCH)
         self.height_mm_spin.setValue(figsize[1] * _MM_PER_INCH)
@@ -1618,6 +1663,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.source_list.clear()
         source_by_name = {source.name: source for source in self._recipe.sources}
         duplicate_labels = _source_duplicate_labels(self._recipe.sources)
+        current = self._current_operation()
+        used_sources = (
+            set(self._selected_sources_for_operation(current[1]))
+            if current is not None
+            else set()
+        )
         for name, data in self._source_data.items():
             source = source_by_name.get(name)
             display = _source_display_label(
@@ -1634,6 +1685,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 _source_display_tooltip(source, name),
                 data=data,
                 missing=source is None,
+                used=name in used_sources,
             )
 
         missing = [
@@ -1652,8 +1704,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 source.name,
                 _source_display_tooltip(source, source.name),
                 missing=True,
+                used=source.name in used_sources,
             )
-        self.source_list.resizeColumnToContents(0)
+        self.source_list.resizeColumnToContents(_SOURCE_LIST_SOURCE_COLUMN)
+        self.source_list.resizeColumnToContents(_SOURCE_LIST_REFRESH_COLUMN)
+        self._refresh_source_controls()
 
     def _add_source_list_row(
         self,
@@ -1663,16 +1718,31 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         *,
         data: xr.DataArray | None = None,
         missing: bool = False,
+        used: bool = False,
     ) -> None:
-        item = QtWidgets.QTreeWidgetItem([display, "missing" if data is None else ""])
-        item.setData(0, QtCore.Qt.ItemDataRole.UserRole, name)
+        item = QtWidgets.QTreeWidgetItem(
+            [display, "missing" if data is None else "", ""]
+        )
+        item.setData(_SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole, name)
+        item.setData(
+            _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole + 2, tooltip
+        )
         item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
-        for column in range(self.source_list.columnCount()):
-            item.setToolTip(column, tooltip)
         if missing:
-            item.setForeground(0, QtGui.QBrush(QtGui.QColor("darkRed")))
-            item.setForeground(1, QtGui.QBrush(QtGui.QColor("darkRed")))
+            item.setForeground(
+                _SOURCE_LIST_SOURCE_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
+            )
+            item.setForeground(
+                _SOURCE_LIST_SHAPE_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
+            )
         self.source_list.addTopLevelItem(item)
+        self._set_source_list_row_used(item, used)
+        refresh_button = self._source_refresh_button(name)
+        item.setSizeHint(_SOURCE_LIST_REFRESH_COLUMN, refresh_button.sizeHint())
+        self.source_list.setItemWidget(
+            item, _SOURCE_LIST_REFRESH_COLUMN, refresh_button
+        )
+        self._set_source_refresh_button_state(refresh_button, name, display)
         if data is None:
             return
 
@@ -1690,15 +1760,170 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             QtCore.Qt.TextInteractionFlag.NoTextInteraction
         )
         shape_label.setContentsMargins(4, 0, 4, 0)
-        shape_label.setToolTip(tooltip)
+        shape_label.setToolTip(item.toolTip(_SOURCE_LIST_SOURCE_COLUMN))
         if missing:
             palette = shape_label.palette()
             palette.setColor(
                 QtGui.QPalette.ColorRole.WindowText, QtGui.QColor("darkRed")
             )
             shape_label.setPalette(palette)
-        item.setSizeHint(1, shape_label.sizeHint())
-        self.source_list.setItemWidget(item, 1, shape_label)
+        item.setSizeHint(_SOURCE_LIST_SHAPE_COLUMN, shape_label.sizeHint())
+        self.source_list.setItemWidget(item, _SOURCE_LIST_SHAPE_COLUMN, shape_label)
+
+    def _source_refresh_button(self, name: str) -> QtWidgets.QToolButton:
+        button = QtWidgets.QToolButton(self.source_list)
+        button.setObjectName("figureComposerRefreshSourceButton")
+        button.setProperty("figure_source_name", name)
+        button.setAccessibleName("Refresh Source")
+        button.setIcon(QtGui.QIcon.fromTheme("view-refresh"))
+        button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly)
+        button.setAutoRaise(True)
+        button.clicked.connect(
+            functools.partial(self._refresh_source_from_button, name)
+        )
+        return button
+
+    def _source_refresh_available(self, name: str) -> bool:
+        if (
+            self._source_refresh_available_callback is None
+            or self._source_refresh_callback is None
+        ):
+            return False
+        with contextlib.suppress(LookupError, RuntimeError, ValueError):
+            return bool(self._source_refresh_available_callback(name))
+        return False
+
+    def _source_refresh_label(self, name: str) -> str | None:
+        if self._source_refresh_label_callback is None:
+            return None
+        with contextlib.suppress(LookupError, RuntimeError, ValueError):
+            label = self._source_refresh_label_callback(name)
+            return label or None
+        return None
+
+    def _set_source_refresh_button_state(
+        self, button: QtWidgets.QToolButton, name: str, display: str
+    ) -> bool:
+        enabled = self._source_refresh_available(name)
+        button.setEnabled(enabled)
+        if enabled:
+            source_label = self._source_refresh_label(name)
+            tooltip = (
+                f"Refresh “{display}” from {source_label}"
+                if source_label
+                else f"Refresh “{display}”"
+            )
+        else:
+            tooltip = "This source is not linked to an open ImageTool"
+        button.setToolTip(tooltip)
+        button.setStatusTip(tooltip)
+        return enabled
+
+    def _refreshable_source_names(self) -> tuple[str, ...]:
+        return tuple(
+            name
+            for name in self._source_names()
+            if self._source_refresh_available(name)
+        )
+
+    def _refresh_source_controls(self) -> None:
+        has_refreshable_source = False
+        for row in range(self.source_list.topLevelItemCount()):
+            item = self.source_list.topLevelItem(row)
+            if item is None:
+                continue
+            source_name = item.data(
+                _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
+            )
+            button = self.source_list.itemWidget(item, _SOURCE_LIST_REFRESH_COLUMN)
+            if not isinstance(source_name, str) or not isinstance(
+                button, QtWidgets.QToolButton
+            ):
+                continue
+            has_refreshable_source |= self._set_source_refresh_button_state(
+                button, source_name, item.text(_SOURCE_LIST_SOURCE_COLUMN)
+            )
+
+        enabled = (
+            has_refreshable_source and self._source_refresh_many_callback is not None
+        )
+        self.refresh_sources_button.setEnabled(enabled)
+        tooltip = (
+            "Refresh all sources linked to open ImageTools"
+            if enabled
+            else "No sources are linked to open ImageTools"
+        )
+        self.refresh_sources_button.setToolTip(tooltip)
+        self.refresh_sources_button.setStatusTip(tooltip)
+
+    def refresh_source_controls(self) -> None:
+        self._refresh_source_controls()
+
+    def _refresh_source_from_button(self, name: str, _checked: bool = False) -> None:
+        callback = self._source_refresh_callback
+        if callback is None or not self._source_refresh_available(name):
+            self._refresh_source_controls()
+            return
+        display = self._source_display_name(name)
+        refreshed = callback(name)
+        self._refresh_source_controls()
+        if refreshed:
+            self.source_status_label.setText(f"Refreshed {display}.")
+
+    def _refresh_sources_from_button(self, _checked: bool = False) -> None:
+        callback = self._source_refresh_many_callback
+        source_names = self._refreshable_source_names()
+        if callback is None or not source_names:
+            self._refresh_source_controls()
+            return
+        refreshed_count = callback(source_names)
+        self._refresh_source_controls()
+        if refreshed_count:
+            noun = "source" if refreshed_count == 1 else "sources"
+            self.source_status_label.setText(f"Refreshed {refreshed_count} {noun}.")
+        else:
+            self.source_status_label.setText("No sources were refreshed.")
+
+    def _set_source_list_row_used(
+        self, item: QtWidgets.QTreeWidgetItem, used: bool
+    ) -> None:
+        item.setData(
+            _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole + 1, used
+        )
+        base_tooltip = item.data(
+            _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole + 2
+        )
+        tooltip = (
+            base_tooltip
+            if isinstance(base_tooltip, str)
+            else item.toolTip(_SOURCE_LIST_SOURCE_COLUMN)
+        )
+        if used:
+            tooltip = f"Used by selected step.\n{tooltip}"
+        font = item.font(_SOURCE_LIST_SOURCE_COLUMN)
+        font.setBold(used)
+        item.setFont(_SOURCE_LIST_SOURCE_COLUMN, font)
+        for column in (_SOURCE_LIST_SOURCE_COLUMN, _SOURCE_LIST_SHAPE_COLUMN):
+            item.setToolTip(column, tooltip)
+            widget = self.source_list.itemWidget(item, column)
+            if widget is not None:
+                widget.setToolTip(tooltip)
+
+    def _sync_source_list_used_state(self) -> None:
+        current = self._current_operation()
+        used_sources = (
+            set(self._selected_sources_for_operation(current[1]))
+            if current is not None
+            else set()
+        )
+        for row in range(self.source_list.topLevelItemCount()):
+            item = self.source_list.topLevelItem(row)
+            if item is None:
+                continue
+            source_name = item.data(
+                _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
+            )
+            self._set_source_list_row_used(item, source_name in used_sources)
 
     def _rebuild_axes_grid(self) -> None:
         self.axes_selector.set_grid(
@@ -3822,6 +4047,33 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.sigInfoChanged.emit()
         self._write_state()
 
+    def replace_source(
+        self,
+        alias: str,
+        source: FigureSourceState,
+        data: xr.DataArray,
+    ) -> bool:
+        """Replace a figure source's backing data while preserving its alias."""
+        source_list = list(self._recipe.sources)
+        for index, existing_source in enumerate(source_list):
+            if existing_source.name == alias:
+                source_list[index] = source.model_copy(update={"name": alias})
+                break
+        else:
+            if alias not in self._source_data:
+                return False
+            source_list.append(source.model_copy(update={"name": alias}))
+
+        self._source_data[alias] = data
+        self._recipe = self._recipe.model_copy(update={"sources": tuple(source_list)})
+        self._refresh_source_list()
+        self._update_source_section()
+        _render_preview(self)
+        self.sigDataChanged.emit()
+        self.sigInfoChanged.emit()
+        self._write_state()
+        return True
+
     @staticmethod
     def _remove_posted_events_recursive(widget: QtWidgets.QWidget) -> None:
         for child in widget.findChildren(QtCore.QObject):
@@ -4112,6 +4364,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _update_source_section(self) -> None:
         self._clear_step_source_controls()
+        self._sync_source_list_used_state()
         current = self._current_operation()
         if current is None:
             self._update_source_status(None)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -1922,11 +1922,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if callback is None or not self._source_refresh_available(name):
             self._refresh_source_controls()
             return
-        display = self._source_display_name(name)
-        refreshed = callback(name)
+        callback(name)
         self._refresh_source_controls()
-        if refreshed:
-            self._set_source_status_text(f"Refreshed {display}.")
 
     def _refresh_sources_from_button(self, _checked: bool = False) -> None:
         callback = self._source_refresh_many_callback
@@ -1934,13 +1931,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if callback is None or not source_names:
             self._refresh_source_controls()
             return
-        refreshed_count = callback(source_names)
+        callback(source_names)
         self._refresh_source_controls()
-        if refreshed_count:
-            noun = "source" if refreshed_count == 1 else "sources"
-            self._set_source_status_text(f"Refreshed {refreshed_count} {noun}.")
-        else:
-            self._set_source_status_text("No sources were refreshed.")
 
     def _source_used_by_operation(self, name: str) -> bool:
         return any(
@@ -1971,11 +1963,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return enabled
 
     def _remove_source_from_button(self, name: str, _checked: bool = False) -> None:
-        display = self._source_display_name(name)
         if not self.remove_source(name):
             self._refresh_source_controls()
-            return
-        self._set_source_status_text(f"Removed {display}.")
 
     def _set_source_list_row_used(
         self, item: QtWidgets.QTreeWidgetItem, used: bool

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -1713,7 +1713,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _clear_source_list_widgets(self) -> None:
         for row in range(self.source_list.topLevelItemCount()):
             item = self.source_list.topLevelItem(row)
-            if item is None:
+            if item is None:  # pragma: no cover
+                # Qt can report stale rows during teardown.
                 continue
             for column in range(self.source_list.columnCount()):
                 widget = self.source_list.itemWidget(item, column)
@@ -1875,7 +1876,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         has_refreshable_source = False
         for row in range(self.source_list.topLevelItemCount()):
             item = self.source_list.topLevelItem(row)
-            if item is None:
+            if item is None:  # pragma: no cover
+                # Qt can report stale rows during teardown.
                 continue
             source_name = item.data(
                 _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
@@ -2011,7 +2013,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         for row in range(self.source_list.topLevelItemCount()):
             item = self.source_list.topLevelItem(row)
-            if item is None:
+            if item is None:  # pragma: no cover
+                # Qt can report stale rows during teardown.
                 continue
             source_name = item.data(
                 _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -139,7 +139,7 @@ _COMBO_TRACKED_PROPERTY = "figure_composer_combo_tracked"
 _COMBO_POPUP_GUARD_ID_PROPERTY = "figure_composer_combo_popup_guard_id"
 _SOURCE_LIST_SOURCE_COLUMN = 0
 _SOURCE_LIST_SHAPE_COLUMN = 1
-_SOURCE_LIST_REFRESH_COLUMN = 2
+_SOURCE_LIST_ACTION_COLUMN = 2
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
@@ -1150,7 +1150,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 QtWidgets.QHeaderView.ResizeMode.Stretch,
             )
             source_header.setSectionResizeMode(
-                _SOURCE_LIST_REFRESH_COLUMN,
+                _SOURCE_LIST_ACTION_COLUMN,
                 QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
             )
         sources_layout.addWidget(self.source_list, 1)
@@ -1660,7 +1660,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return values
 
     def _refresh_source_list(self) -> None:
-        self.source_list.clear()
+        self._clear_source_list_widgets()
         source_by_name = {source.name: source for source in self._recipe.sources}
         duplicate_labels = _source_duplicate_labels(self._recipe.sources)
         current = self._current_operation()
@@ -1707,8 +1707,22 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 used=source.name in used_sources,
             )
         self.source_list.resizeColumnToContents(_SOURCE_LIST_SOURCE_COLUMN)
-        self.source_list.resizeColumnToContents(_SOURCE_LIST_REFRESH_COLUMN)
+        self.source_list.resizeColumnToContents(_SOURCE_LIST_ACTION_COLUMN)
         self._refresh_source_controls()
+
+    def _clear_source_list_widgets(self) -> None:
+        for row in range(self.source_list.topLevelItemCount()):
+            item = self.source_list.topLevelItem(row)
+            if item is None:
+                continue
+            for column in range(self.source_list.columnCount()):
+                widget = self.source_list.itemWidget(item, column)
+                if widget is None:
+                    continue
+                self.source_list.removeItemWidget(item, column)
+                widget.setParent(None)
+                widget.deleteLater()
+        self.source_list.clear()
 
     def _add_source_list_row(
         self,
@@ -1737,12 +1751,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
         self.source_list.addTopLevelItem(item)
         self._set_source_list_row_used(item, used)
-        refresh_button = self._source_refresh_button(name)
-        item.setSizeHint(_SOURCE_LIST_REFRESH_COLUMN, refresh_button.sizeHint())
-        self.source_list.setItemWidget(
-            item, _SOURCE_LIST_REFRESH_COLUMN, refresh_button
-        )
-        self._set_source_refresh_button_state(refresh_button, name, display)
+        action_widget = self._source_action_widget(name, display)
+        item.setSizeHint(_SOURCE_LIST_ACTION_COLUMN, action_widget.sizeHint())
+        self.source_list.setItemWidget(item, _SOURCE_LIST_ACTION_COLUMN, action_widget)
         if data is None:
             return
 
@@ -1782,6 +1793,40 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             functools.partial(self._refresh_source_from_button, name)
         )
         return button
+
+    def _source_remove_button(self, name: str) -> QtWidgets.QToolButton:
+        button = QtWidgets.QToolButton(self.source_list)
+        button.setObjectName("figureComposerRemoveSourceButton")
+        button.setProperty("figure_source_name", name)
+        button.setAccessibleName("Remove Source")
+        button.setIcon(QtGui.QIcon.fromTheme("edit-delete"))
+        button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly)
+        button.setAutoRaise(True)
+        button.clicked.connect(functools.partial(self._remove_source_from_button, name))
+        return button
+
+    def _source_action_widget(self, name: str, display: str) -> QtWidgets.QWidget:
+        widget = QtWidgets.QWidget(self.source_list)
+        layout = QtWidgets.QHBoxLayout(widget)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+        refresh_button = self._source_refresh_button(name)
+        remove_button = self._source_remove_button(name)
+        layout.addWidget(refresh_button)
+        layout.addWidget(remove_button)
+        self._set_source_refresh_button_state(refresh_button, name, display)
+        self._set_source_remove_button_state(remove_button, name, display)
+        return widget
+
+    def _source_list_row_button(
+        self, item: QtWidgets.QTreeWidgetItem, object_name: str
+    ) -> QtWidgets.QToolButton | None:
+        widget = self.source_list.itemWidget(item, _SOURCE_LIST_ACTION_COLUMN)
+        if isinstance(widget, QtWidgets.QToolButton):
+            return widget if widget.objectName() == object_name else None
+        if isinstance(widget, QtWidgets.QWidget):
+            return widget.findChild(QtWidgets.QToolButton, object_name)
+        return None
 
     def _source_refresh_available(self, name: str) -> bool:
         if (
@@ -1835,14 +1880,23 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             source_name = item.data(
                 _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
             )
-            button = self.source_list.itemWidget(item, _SOURCE_LIST_REFRESH_COLUMN)
-            if not isinstance(source_name, str) or not isinstance(
-                button, QtWidgets.QToolButton
-            ):
+            if not isinstance(source_name, str):
                 continue
-            has_refreshable_source |= self._set_source_refresh_button_state(
-                button, source_name, item.text(_SOURCE_LIST_SOURCE_COLUMN)
+            display = item.text(_SOURCE_LIST_SOURCE_COLUMN)
+            refresh_button = self._source_list_row_button(
+                item, "figureComposerRefreshSourceButton"
             )
+            if refresh_button is not None:
+                has_refreshable_source |= self._set_source_refresh_button_state(
+                    refresh_button, source_name, display
+                )
+            remove_button = self._source_list_row_button(
+                item, "figureComposerRemoveSourceButton"
+            )
+            if remove_button is not None:
+                self._set_source_remove_button_state(
+                    remove_button, source_name, display
+                )
 
         enabled = (
             has_refreshable_source and self._source_refresh_many_callback is not None
@@ -1888,6 +1942,41 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         else:
             self._set_source_status_text("No sources were refreshed.")
 
+    def _source_used_by_operation(self, name: str) -> bool:
+        return any(
+            name in self._operation_source_names(operation)
+            for operation in self._recipe.operations
+        )
+
+    def _source_removable(self, name: str) -> bool:
+        return (
+            name in self._source_by_name()
+            and len(self._recipe.sources) > 1
+            and not self._source_used_by_operation(name)
+        )
+
+    def _set_source_remove_button_state(
+        self, button: QtWidgets.QToolButton, name: str, display: str
+    ) -> bool:
+        enabled = self._source_removable(name)
+        button.setEnabled(enabled)
+        if enabled:
+            tooltip = f"Remove “{display}” from this figure"
+        elif self._source_used_by_operation(name):
+            tooltip = "This source is used by one or more steps"
+        else:
+            tooltip = "This source cannot be removed"
+        button.setToolTip(tooltip)
+        button.setStatusTip(tooltip)
+        return enabled
+
+    def _remove_source_from_button(self, name: str, _checked: bool = False) -> None:
+        display = self._source_display_name(name)
+        if not self.remove_source(name):
+            self._refresh_source_controls()
+            return
+        self._set_source_status_text(f"Removed {display}.")
+
     def _set_source_list_row_used(
         self, item: QtWidgets.QTreeWidgetItem, used: bool
     ) -> None:
@@ -1907,6 +1996,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         font = item.font(_SOURCE_LIST_SOURCE_COLUMN)
         font.setBold(used)
         item.setFont(_SOURCE_LIST_SOURCE_COLUMN, font)
+        source_name = item.data(
+            _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
+        )
+        if isinstance(source_name, str):
+            remove_button = self._source_list_row_button(
+                item, "figureComposerRemoveSourceButton"
+            )
+            if remove_button is not None:
+                self._set_source_remove_button_state(
+                    remove_button, source_name, item.text(_SOURCE_LIST_SOURCE_COLUMN)
+                )
         for column in (_SOURCE_LIST_SOURCE_COLUMN, _SOURCE_LIST_SHAPE_COLUMN):
             item.setToolTip(column, tooltip)
             widget = self.source_list.itemWidget(item, column)
@@ -4081,6 +4181,29 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
         self._source_data[alias] = data
         self._recipe = self._recipe.model_copy(update={"sources": tuple(source_list)})
+        self._refresh_operation_list()
+        self._refresh_step_section_button_texts()
+        self._refresh_source_list()
+        self._update_source_section()
+        _render_preview(self)
+        self.sigDataChanged.emit()
+        self.sigInfoChanged.emit()
+        self._write_state()
+        return True
+
+    def remove_source(self, name: str) -> bool:
+        """Remove an unused source from this figure."""
+        if not self._source_removable(name):
+            return False
+
+        source_list = tuple(
+            source for source in self._recipe.sources if source.name != name
+        )
+        updates: dict[str, typing.Any] = {"sources": source_list}
+        if self._recipe.primary_source == name:
+            updates["primary_source"] = source_list[0].name
+        self._recipe = self._recipe.model_copy(update=updates)
+        self._source_data.pop(name, None)
         self._refresh_operation_list()
         self._refresh_step_section_button_texts()
         self._refresh_source_list()

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -86,6 +86,10 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _NEW_FIGURE_TARGET = "__new_figure__"
+_FIGURE_DIALOG_NEW = "new_figure"
+_FIGURE_DIALOG_ADD_STEP = "add_step"
+_FIGURE_DIALOG_ADD_SOURCE = "add_source"
+_FIGURE_DIALOG_REPLACE_SOURCE = "replace_source"
 _FIGURE_VIEW_MODE_SETTINGS_KEY = "figures/view_mode"
 _FIGURE_GALLERY_SIZE_SETTINGS_KEY = "figures/gallery_thumbnail_size"
 _FIGURE_VIEW_MODE_LIST = "list"
@@ -100,7 +104,7 @@ _FIGURE_GALLERY_THUMBNAIL_SIZES = {
 
 
 class _AppendFigureTargetDialog(QtWidgets.QDialog):
-    """Prompt for a Figure Composer target figure and axes selection."""
+    """Prompt for a Figure Composer target figure and source workflow."""
 
     def __init__(
         self,
@@ -109,6 +113,8 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         operation: typing.Any | None,
         *,
         allow_new_figure: bool = False,
+        source_count: int = 1,
+        selected_figure_uid: str | None = None,
     ) -> None:
         from erlab.interactive._figurecomposer._widgets import (
             _AxesSelectorWidget,
@@ -119,8 +125,10 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         self._manager = manager
         self._figure_uids = figure_uids
         self._operation = operation
+        self._allow_new_figure = allow_new_figure
+        self._source_count = source_count
         self.setObjectName("managerAppendFigureTargetDialog")
-        self.setWindowTitle("Figure" if allow_new_figure else "Append to Figure")
+        self.setWindowTitle("Add to Figure" if allow_new_figure else "Append to Figure")
         self.setModal(True)
 
         layout = QtWidgets.QVBoxLayout(self)
@@ -132,22 +140,45 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         )
         layout.addLayout(form)
 
+        self.action_combo = QtWidgets.QComboBox(self)
+        self.action_combo.setObjectName("managerFigureActionCombo")
+        if allow_new_figure:
+            self.action_combo.addItem("New Figure", _FIGURE_DIALOG_NEW)
+            self.action_combo.addItem("Add New Step", _FIGURE_DIALOG_ADD_STEP)
+            self.action_combo.addItem("Add Source Only", _FIGURE_DIALOG_ADD_SOURCE)
+            self.action_combo.addItem("Replace Source", _FIGURE_DIALOG_REPLACE_SOURCE)
+            form.addRow("Action", self.action_combo)
+        else:
+            self.action_combo.addItem("Add New Step", _FIGURE_DIALOG_ADD_STEP)
+            self.action_combo.setVisible(False)
+
         self.figure_combo = QtWidgets.QComboBox(self)
         self.figure_combo.setObjectName("managerAppendFigureCombo")
-        if allow_new_figure:
-            self.figure_combo.addItem("New Figure", _NEW_FIGURE_TARGET)
         for uid in figure_uids:
             self.figure_combo.addItem(manager._child_node(uid).display_text, uid)
         self.figure_combo.setVisible(self.figure_combo.count() > 1)
         if self.figure_combo.count() > 1:
             form.addRow("Figure", self.figure_combo)
+            self.figure_field_widget: QtWidgets.QWidget = self.figure_combo
         else:
+            figure_label = QtWidgets.QLabel(
+                manager._child_node(figure_uids[0]).display_text, self
+            )
             form.addRow(
                 "Figure",
-                QtWidgets.QLabel(
-                    manager._child_node(figure_uids[0]).display_text, self
-                ),
+                figure_label,
             )
+            self.figure_field_widget = figure_label
+        self.figure_label = form.labelForField(self.figure_field_widget)
+        if selected_figure_uid in figure_uids:
+            figure_index = self.figure_combo.findData(selected_figure_uid)
+            if figure_index >= 0:
+                self.figure_combo.setCurrentIndex(figure_index)
+
+        self.source_combo = QtWidgets.QComboBox(self)
+        self.source_combo.setObjectName("managerReplaceFigureSourceCombo")
+        form.addRow("Source", self.source_combo)
+        self.source_label = form.labelForField(self.source_combo)
 
         self.selector_stack = QtWidgets.QStackedWidget(self)
         self.selector_stack.setObjectName("managerAppendAxesSelectorStack")
@@ -158,6 +189,7 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         self.selector_stack.addWidget(self.axes_selector)
         self.selector_stack.addWidget(self.gridspec_axes_selector)
         form.addRow("Axes", self.selector_stack)
+        self.axes_label = form.labelForField(self.selector_stack)
 
         self.status_label = QtWidgets.QLabel(self)
         self.status_label.setObjectName("managerAppendAxesStatusLabel")
@@ -185,7 +217,9 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         self.button_box.setObjectName("managerAppendFigureButtonBox")
         layout.addWidget(self.button_box)
 
+        self.action_combo.currentIndexChanged.connect(self._action_changed)
         self.figure_combo.currentIndexChanged.connect(self._figure_changed)
+        self.source_combo.currentIndexChanged.connect(self._selection_changed)
         self.axes_selector.sigSelectionChanged.connect(self._selection_changed)
         self.axes_selector.sigAddRowRequested.connect(self._add_subplot_row)
         self.axes_selector.sigAddColumnRequested.connect(self._add_subplot_column)
@@ -194,21 +228,36 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         self.clear_axes_button.clicked.connect(self._clear_axes)
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
+        self._set_default_action(selected_figure_uid)
         self._figure_changed()
 
     def figure_uid(self) -> str:
         uid = self.figure_combo.currentData()
-        if isinstance(uid, str):
+        if isinstance(uid, str) and uid != _NEW_FIGURE_TARGET:
             return uid
         return self._figure_uids[0]
 
+    def selected_action(self) -> str:
+        action = self.action_combo.currentData()
+        return action if isinstance(action, str) else _FIGURE_DIALOG_ADD_STEP
+
     def is_new_figure(self) -> bool:
-        return self.figure_combo.currentData() == _NEW_FIGURE_TARGET
+        return self.selected_action() == _FIGURE_DIALOG_NEW
+
+    def is_add_source_only(self) -> bool:
+        return self.selected_action() == _FIGURE_DIALOG_ADD_SOURCE
+
+    def is_replace_source(self) -> bool:
+        return self.selected_action() == _FIGURE_DIALOG_REPLACE_SOURCE
+
+    def selected_source_alias(self) -> str | None:
+        alias = self.source_combo.currentData()
+        return alias if isinstance(alias, str) else None
 
     def axes_selection(self) -> typing.Any | None:
         from erlab.interactive._figurecomposer import FigureAxesSelectionState
 
-        if self.is_new_figure():
+        if self.selected_action() != _FIGURE_DIALOG_ADD_STEP:
             return None
         tool = self._figure_tool()
         if tool is None:
@@ -225,29 +274,85 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         return FigureAxesSelectionState(axes=axes)
 
     def selected_target(self) -> tuple[str, typing.Any] | None:
-        if self.is_new_figure():
+        if self.selected_action() != _FIGURE_DIALOG_ADD_STEP:
             return None
         selection = self.axes_selection()
         if selection is None:
             return None
         return self.figure_uid(), selection
 
+    def _set_default_action(self, selected_figure_uid: str | None) -> None:
+        if not self._allow_new_figure:
+            return
+        default_action = _FIGURE_DIALOG_ADD_STEP
+        if (
+            selected_figure_uid in self._figure_uids
+            and self._source_count == 1
+            and self._figure_source_count(selected_figure_uid) == 1
+        ):
+            default_action = _FIGURE_DIALOG_REPLACE_SOURCE
+        action_index = self.action_combo.findData(default_action)
+        if action_index >= 0:
+            self.action_combo.setCurrentIndex(action_index)
+
+    def _figure_source_count(self, figure_uid: str | None) -> int:
+        if figure_uid is None:
+            return 0
+        current_index = self.figure_combo.currentIndex()
+        figure_index = self.figure_combo.findData(figure_uid)
+        if figure_index < 0:
+            return 0
+        try:
+            self.figure_combo.setCurrentIndex(figure_index)
+            tool = self._figure_tool()
+            if tool is None:
+                return 0
+            return len(tool._source_names())
+        finally:
+            self.figure_combo.setCurrentIndex(current_index)
+
+    def _action_requires_figure(self) -> bool:
+        return self.selected_action() in {
+            _FIGURE_DIALOG_ADD_STEP,
+            _FIGURE_DIALOG_ADD_SOURCE,
+            _FIGURE_DIALOG_REPLACE_SOURCE,
+        }
+
+    def _action_uses_axes(self) -> bool:
+        return self.selected_action() == _FIGURE_DIALOG_ADD_STEP
+
+    def _refresh_source_combo(self) -> None:
+        self.source_combo.blockSignals(True)
+        try:
+            self.source_combo.clear()
+            tool = self._figure_tool()
+            if tool is None:
+                return
+            for name in tool._source_names():
+                display = tool._source_display_name(name)
+                item_text = display if name in display else f"{display} ({name})"
+                self.source_combo.addItem(item_text, name)
+                index = self.source_combo.count() - 1
+                self.source_combo.setItemData(
+                    index,
+                    tool._source_tooltip(name),
+                    QtCore.Qt.ItemDataRole.ToolTipRole,
+                )
+        finally:
+            self.source_combo.blockSignals(False)
+
     @QtCore.Slot()
     def _figure_changed(self) -> None:
-        if self.is_new_figure():
-            self.selector_stack.setVisible(False)
-            self.all_axes_button.setVisible(False)
-            self.clear_axes_button.setVisible(False)
-            self._ok_button().setEnabled(True)
-            self.status_label.setText("A new figure will be created.")
+        self._refresh_source_combo()
+        if not self._action_requires_figure():
+            self._selection_changed()
             return
         self.selector_stack.setVisible(True)
         self.all_axes_button.setVisible(True)
         self.clear_axes_button.setVisible(True)
         tool = self._figure_tool()
         if tool is None:
-            self._ok_button().setEnabled(False)
-            self.status_label.setText("The selected figure is unavailable.")
+            self._selection_changed()
             return
         setup = tool.tool_status.setup
         if setup.layout_mode == "gridspec":
@@ -286,7 +391,63 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         self._selection_changed()
 
     @QtCore.Slot()
+    def _action_changed(self) -> None:
+        self._figure_changed()
+
+    @QtCore.Slot()
     def _selection_changed(self, *_args: typing.Any) -> None:
+        action = self.selected_action()
+        new_figure = action == _FIGURE_DIALOG_NEW
+        uses_figure = self._action_requires_figure()
+        uses_axes = self._action_uses_axes()
+        replace_source = action == _FIGURE_DIALOG_REPLACE_SOURCE
+        figure_tool = self._figure_tool() if uses_figure else None
+        has_figure = figure_tool is not None
+
+        figure_visible = uses_figure
+        if self.figure_label is not None:
+            self.figure_label.setVisible(figure_visible)
+        self.figure_field_widget.setVisible(
+            figure_visible and self.figure_combo.count() <= 1
+        )
+        self.figure_combo.setVisible(figure_visible and self.figure_combo.count() > 1)
+
+        if self.axes_label is not None:
+            self.axes_label.setVisible(uses_axes and has_figure)
+        self.selector_stack.setVisible(uses_axes and has_figure)
+        self.all_axes_button.setVisible(uses_axes and has_figure)
+        self.clear_axes_button.setVisible(uses_axes and has_figure)
+
+        if self.source_label is not None:
+            self.source_label.setVisible(replace_source and has_figure)
+        self.source_combo.setVisible(replace_source and has_figure)
+
+        if new_figure:
+            self._ok_button().setEnabled(True)
+            self.status_label.setText("A new figure will be created.")
+            return
+        if not has_figure:
+            self._ok_button().setEnabled(False)
+            self.status_label.setText("The selected figure is unavailable.")
+            return
+        if action == _FIGURE_DIALOG_ADD_SOURCE:
+            self._ok_button().setEnabled(True)
+            self.status_label.setText("Source data will be added without a new step.")
+            return
+        if replace_source:
+            selected_alias = self.selected_source_alias()
+            enabled = self._source_count == 1 and selected_alias is not None
+            self._ok_button().setEnabled(enabled)
+            if self._source_count != 1:
+                self.status_label.setText(
+                    "Select one ImageTool source to replace one figure source."
+                )
+            elif selected_alias is None:
+                self.status_label.setText("Select the figure source to replace.")
+            else:
+                self.status_label.setText("The selected source will be replaced.")
+            return
+
         selection = self.axes_selection()
         self._ok_button().setEnabled(selection is not None)
         if selection is None:
@@ -697,11 +858,11 @@ class ImageToolManager(_ImageToolManagerBase):
         self.batch_action.triggered.connect(self.show_batch_operations)
         self.batch_action.setToolTip("Apply an operation to multiple ImageTools")
 
-        self.create_figure_action = QtWidgets.QAction("Figure", self)
+        self.create_figure_action = QtWidgets.QAction("Add to Figure…", self)
         self.create_figure_action.setObjectName("manager_figure_action")
         self.create_figure_action.triggered.connect(self.create_figure_from_selection)
         self.create_figure_action.setToolTip(
-            "Create or append an editable Matplotlib figure from the selected data"
+            "Create, extend, or replace source data in an editable Matplotlib figure"
         )
         self.create_figure_action.setIcon(QtGui.QIcon.fromTheme("insert-image"))
 
@@ -1192,6 +1353,7 @@ class ImageToolManager(_ImageToolManagerBase):
             return
         self._dependency_tracker.clear_uid(uid)
         self._refresh_dependency_dependents(uid)
+        self._refresh_figure_source_controls()
 
     def _iter_descendant_uids(self, uid: str) -> list[str]:
         return self._tool_graph.descendant_uids(uid)
@@ -1949,6 +2111,182 @@ class ImageToolManager(_ImageToolManagerBase):
             )
         return FigureSubplotsState(nrows=max(len(squeezed), 1), ncols=1)
 
+    def _figure_sources_from_targets(
+        self, targets: Iterable[int | str]
+    ) -> tuple[tuple[int | str, ...], tuple[typing.Any, ...], dict[str, xr.DataArray]]:
+        from erlab.interactive._figurecomposer import FigureSourceState
+
+        resolved_targets = tuple(dict.fromkeys(targets))
+        source_data: dict[str, xr.DataArray] = {}
+        sources = []
+        for target in resolved_targets:
+            node = self._node_for_target(target)
+            data = node.current_source_data()
+            source = FigureSourceState.from_script_input(
+                self._script_input_for_node(node)
+            )
+            source_data[source.name] = data
+            sources.append(source)
+        return resolved_targets, tuple(sources), source_data
+
+    def _selected_figure_uid_for_figure_dialog(self) -> str | None:
+        selected_uids = self._selected_figure_uids()
+        if len(selected_uids) == 1:
+            return selected_uids[0]
+        return None
+
+    def _add_sources_to_figure(
+        self,
+        figure_uid: str,
+        sources: tuple[typing.Any, ...],
+        source_data: Mapping[str, xr.DataArray],
+        *,
+        show: bool = True,
+    ) -> bool:
+        from erlab.interactive._figurecomposer import FigureComposerTool
+
+        if not self._is_figure_uid(figure_uid):
+            return False
+        node = self._child_node(figure_uid)
+        tool = node.tool_window
+        if not isinstance(tool, FigureComposerTool):
+            return False
+        tool.add_sources(sources, source_data)
+        self._mark_workspace_dirty(uid=figure_uid, state=True)
+        self._select_figure_uid(figure_uid)
+        if show:
+            node.show()
+        return True
+
+    def _replace_figure_source(
+        self,
+        figure_uid: str,
+        alias: str,
+        sources: tuple[typing.Any, ...],
+        source_data: Mapping[str, xr.DataArray],
+        *,
+        show: bool = True,
+    ) -> bool:
+        from erlab.interactive._figurecomposer import FigureComposerTool
+
+        if len(sources) != 1 or not self._is_figure_uid(figure_uid):
+            return False
+        replacement = sources[0]
+        data = source_data.get(replacement.name)
+        if data is None:
+            return False
+        node = self._child_node(figure_uid)
+        tool = node.tool_window
+        if not isinstance(tool, FigureComposerTool):
+            return False
+        if not tool.replace_source(alias, replacement, data):
+            return False
+        self._mark_workspace_dirty(uid=figure_uid, state=True)
+        self._select_figure_uid(figure_uid)
+        if show:
+            node.show()
+        return True
+
+    def _install_figure_source_refresh_callbacks(
+        self, figure_uid: str, tool: typing.Any
+    ) -> None:
+        tool._set_source_refresh_callbacks(
+            can_refresh_source=lambda source_name: self._can_refresh_figure_source(
+                figure_uid, source_name
+            ),
+            refresh_source=lambda source_name: self._refresh_figure_source(
+                figure_uid, source_name
+            ),
+            refresh_sources=lambda source_names: self._refresh_figure_sources(
+                figure_uid, source_names
+            ),
+            source_label=lambda source_name: self._figure_source_refresh_label(
+                figure_uid, source_name
+            ),
+        )
+
+    @staticmethod
+    def _figure_source_state(tool: typing.Any, source_name: str) -> typing.Any | None:
+        for source in tool.source_states():
+            if source.name == source_name:
+                return source
+        return None
+
+    def _figure_source_live_node(
+        self, figure_uid: str, source_name: str
+    ) -> _ImageToolWrapper | _ManagedWindowNode | None:
+        from erlab.interactive._figurecomposer import FigureComposerTool
+
+        if not self._is_figure_uid(figure_uid):
+            return None
+        figure_node = self._child_node(figure_uid)
+        tool = figure_node.tool_window
+        if not isinstance(tool, FigureComposerTool):
+            return None
+        source = self._figure_source_state(tool, source_name)
+        if source is None or source.node_uid is None:
+            return None
+        node = self._tool_graph.nodes.get(source.node_uid)
+        if node is None:
+            return None
+        window = node.window
+        if window is None or not erlab.interactive.utils.qt_is_valid(window):
+            return None
+        return node
+
+    def _can_refresh_figure_source(self, figure_uid: str, source_name: str) -> bool:
+        return self._figure_source_live_node(figure_uid, source_name) is not None
+
+    def _figure_source_refresh_label(
+        self, figure_uid: str, source_name: str
+    ) -> str | None:
+        node = self._figure_source_live_node(figure_uid, source_name)
+        return None if node is None else node.display_text
+
+    def _refresh_figure_source(self, figure_uid: str, source_name: str) -> bool:
+        from erlab.interactive._figurecomposer import (
+            FigureComposerTool,
+            FigureSourceState,
+        )
+
+        source_node = self._figure_source_live_node(figure_uid, source_name)
+        if source_node is None or not self._is_figure_uid(figure_uid):
+            return False
+        figure_node = self._child_node(figure_uid)
+        tool = figure_node.tool_window
+        if not isinstance(tool, FigureComposerTool):
+            return False
+
+        data = source_node.current_source_data()
+        source = FigureSourceState.from_script_input(
+            self._script_input_for_node(source_node)
+        )
+        if not tool.replace_source(source_name, source, data):
+            return False
+        self._mark_workspace_dirty(uid=figure_uid, data=True, state=True)
+        self._update_figure_gallery_icon(figure_uid)
+        return True
+
+    def _refresh_figure_sources(
+        self, figure_uid: str, source_names: Iterable[str]
+    ) -> int:
+        refreshed = 0
+        for source_name in tuple(source_names):
+            if self._refresh_figure_source(figure_uid, source_name):
+                refreshed += 1
+        return refreshed
+
+    def _refresh_figure_source_controls(self) -> None:
+        from erlab.interactive._figurecomposer import FigureComposerTool
+
+        for figure_uid in self._figure_uids():
+            node = self._tool_graph.nodes.get(figure_uid)
+            if not isinstance(node, _ManagedWindowNode):
+                continue
+            tool = node.tool_window
+            if isinstance(tool, FigureComposerTool):
+                tool.refresh_source_controls()
+
     def create_figure_from_targets(
         self,
         targets: Iterable[int | str],
@@ -2068,9 +2406,14 @@ class ImageToolManager(_ImageToolManagerBase):
         targets = self._selected_figure_source_targets()
         if not targets:
             return
+        resolved_targets, sources, source_data = self._figure_sources_from_targets(
+            targets
+        )
+        if not resolved_targets:
+            return
         figure_uids = tuple(self._figure_uids())
         if not figure_uids:
-            self.create_figure_from_targets(targets)
+            self.create_figure_from_targets(resolved_targets)
             return
 
         dialog = _AppendFigureTargetDialog(
@@ -2078,18 +2421,35 @@ class ImageToolManager(_ImageToolManagerBase):
             figure_uids,
             None,
             allow_new_figure=True,
+            source_count=len(sources),
+            selected_figure_uid=self._selected_figure_uid_for_figure_dialog(),
         )
         if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
             return
-        if dialog.is_new_figure():
-            self.create_figure_from_targets(targets)
+        action = dialog.selected_action()
+        if action == _FIGURE_DIALOG_NEW:
+            self.create_figure_from_targets(resolved_targets)
+            return
+        if action == _FIGURE_DIALOG_ADD_SOURCE:
+            self._add_sources_to_figure(dialog.figure_uid(), sources, source_data)
+            return
+        if action == _FIGURE_DIALOG_REPLACE_SOURCE:
+            alias = dialog.selected_source_alias()
+            if alias is None:
+                return
+            self._replace_figure_source(
+                dialog.figure_uid(),
+                alias,
+                sources,
+                source_data,
+            )
             return
         target = dialog.selected_target()
         if target is None:
             return
         figure_uid, axes_selection = target
         self.append_figure_from_targets(
-            targets,
+            resolved_targets,
             figure_uid=figure_uid,
             axes_selection=axes_selection,
         )
@@ -2281,6 +2641,7 @@ class ImageToolManager(_ImageToolManagerBase):
 
         self._tool_graph.unregister_root(index)
         self._refresh_dependency_dependents(wrapper.uid)
+        self._refresh_figure_source_controls()
         wrapper.dispose()
         wrapper.deleteLater()
 
@@ -3624,6 +3985,8 @@ class ImageToolManager(_ImageToolManagerBase):
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
     ) -> str:
+        from erlab.interactive._figurecomposer import FigureComposerTool
+
         node = _ManagedWindowNode(
             self,
             self._next_node_uid(uid),
@@ -3635,6 +3998,8 @@ class ImageToolManager(_ImageToolManagerBase):
         if not tool._tool_display_name:
             tool._tool_display_name = self._next_figure_display_name()
         self._register_figure_node(node)
+        if isinstance(tool, FigureComposerTool):
+            self._install_figure_source_refresh_callbacks(node.uid, tool)
         self._mark_node_added(node.uid)
         self._sync_figures_ui(select_uid=node.uid if show else None)
         if show:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2234,7 +2234,8 @@ class ImageToolManager(_ImageToolManagerBase):
             return None
         window = node.window
         if window is None or not erlab.interactive.utils.qt_is_valid(window):
-            return None
+            # Invalid Qt wrappers are binding- and lifetime-dependent.
+            return None  # pragma: no cover
         return node
 
     def _can_refresh_figure_source(self, figure_uid: str, source_name: str) -> bool:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2143,6 +2143,7 @@ class ImageToolManager(_ImageToolManagerBase):
         *,
         show: bool = True,
     ) -> bool:
+        """Add or update figure sources without appending recipe operations."""
         from erlab.interactive._figurecomposer import FigureComposerTool
 
         if not self._is_figure_uid(figure_uid):
@@ -2167,6 +2168,7 @@ class ImageToolManager(_ImageToolManagerBase):
         *,
         show: bool = True,
     ) -> bool:
+        """Replace one stored figure source with one selected ImageTool source."""
         from erlab.interactive._figurecomposer import FigureComposerTool
 
         if len(sources) != 1 or not self._is_figure_uid(figure_uid):
@@ -2190,6 +2192,7 @@ class ImageToolManager(_ImageToolManagerBase):
     def _install_figure_source_refresh_callbacks(
         self, figure_uid: str, tool: typing.Any
     ) -> None:
+        """Connect Figure Composer source refresh controls to live manager nodes."""
         tool._set_source_refresh_callbacks(
             can_refresh_source=lambda source_name: self._can_refresh_figure_source(
                 figure_uid, source_name
@@ -2244,6 +2247,7 @@ class ImageToolManager(_ImageToolManagerBase):
         return None if node is None else node.display_text
 
     def _refresh_figure_source(self, figure_uid: str, source_name: str) -> bool:
+        """Refresh one figure source from its linked open ImageTool window."""
         from erlab.interactive._figurecomposer import (
             FigureComposerTool,
             FigureSourceState,
@@ -2270,6 +2274,7 @@ class ImageToolManager(_ImageToolManagerBase):
     def _refresh_figure_sources(
         self, figure_uid: str, source_names: Iterable[str]
     ) -> int:
+        """Refresh all linked figure sources named in ``source_names``."""
         refreshed = 0
         for source_name in tuple(source_names):
             if self._refresh_figure_source(figure_uid, source_name):

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -1687,6 +1687,12 @@ class ItoolPlotItem(pg.PlotItem):
 
     @staticmethod
     def _plot_slices_qsel_key_is_editable(key: Hashable) -> bool:
+        """Return whether ``key`` can be edited by Figure Composer plot_slices.
+
+        String qsel dimensions do not need to be valid Python identifiers. Internal
+        non-uniform ``*_idx`` dimensions and their width companions remain rejected
+        because they do not map to editable qsel controls.
+        """
         if not isinstance(key, str):
             return False
         dim_name = key.removesuffix("_width") if key.endswith("_width") else key
@@ -1795,7 +1801,13 @@ class ItoolPlotItem(pg.PlotItem):
                 self.slicer_area.manual_limits.pop(dim, None)
 
     def figure_composer_operation(self, *, source_name: str):
-        """Build a Figure Composer operation from the current ImageTool plot state."""
+        """Build a Figure Composer operation from the current ImageTool plot state.
+
+        Image plots seed editable ``plot_slices`` operations when their non-display
+        selections can be represented as qsel keyword arguments, including string
+        dimensions that are not Python identifiers. Unsupported image selections raise
+        a Figure Composer selection error with details for the warning dialog.
+        """
         self._sync_figure_composer_view_limits()
         non_display_axes = tuple(
             sorted(set(range(self.slicer_area.data.ndim)) - set(self.display_axis))

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -1690,7 +1690,7 @@ class ItoolPlotItem(pg.PlotItem):
         if not isinstance(key, str):
             return False
         dim_name = key.removesuffix("_width") if key.endswith("_width") else key
-        return dim_name.isidentifier() and not dim_name.endswith("_idx")
+        return bool(dim_name) and not dim_name.endswith("_idx")
 
     @staticmethod
     def _show_plot_slices_selection_error(
@@ -1818,7 +1818,7 @@ class ItoolPlotItem(pg.PlotItem):
                     FigureComposerPlotSlicesSelectionError,
                 )
 
-                raise FigureComposerPlotSlicesSelectionError from exc
+                raise FigureComposerPlotSlicesSelectionError(str(exc)) from exc
             result = None
             selection_exprs = [""]
             variable_dim = None
@@ -1827,16 +1827,33 @@ class ItoolPlotItem(pg.PlotItem):
             }
             selection_count = self.slicer_area.n_cursors
 
+        invalid_qsel_keys = (
+            tuple(
+                key for key in result if not self._plot_slices_qsel_key_is_editable(key)
+            )
+            if result is not None
+            else ()
+        )
         if self.is_image and (
-            selection_exprs is not None
-            or result is None
-            or any(not self._plot_slices_qsel_key_is_editable(key) for key in result)
+            selection_exprs is not None or result is None or invalid_qsel_keys
         ):
             from erlab.interactive._figurecomposer._exceptions import (
                 FigureComposerPlotSlicesSelectionError,
             )
 
-            raise FigureComposerPlotSlicesSelectionError
+            detail = None
+            if invalid_qsel_keys:
+                detail = "Unsupported qsel selection keys: " + ", ".join(
+                    repr(key) for key in invalid_qsel_keys
+                )
+            elif selection_exprs is not None:
+                detail = (
+                    "Selection requires per-cursor expressions that cannot be "
+                    "edited by plot_slices."
+                )
+            elif result is None:
+                detail = "Selection did not produce qsel coordinates for plot_slices."
+            raise FigureComposerPlotSlicesSelectionError(detail)
 
         map_selections = (
             self._figure_composer_map_selections(
@@ -2400,11 +2417,6 @@ class ItoolPlotItem(pg.PlotItem):
                     "gamma": color_props["gamma"],
                     "high_contrast": color_props["high_contrast"],
                     "zero_centered": color_props["zero_centered"],
-                    "transpose": (
-                        self.is_image
-                        and len(data.dims) >= 2
-                        and data.dims[0] != self.axis_dims[0]
-                    ),
                     "file_path": self.slicer_area._file_path,
                 }
             )

--- a/src/erlab/plotting/stylelib/fira.mplstyle
+++ b/src/erlab/plotting/stylelib/fira.mplstyle
@@ -7,7 +7,7 @@
 # * FONT                                                                    *
 # ***************************************************************************
 # The font properties used by `text.Text`.
-# See https://matplotlib.org/api/font_manager_api.html for more information
+# See https://matplotlib.org/stable/api/font_manager_api.html for more information
 # on font properties.  The 6 font properties used for font matching are
 # given below with their default values.
 #
@@ -32,7 +32,7 @@
 #
 # The font.variant property has two values: normal or small-caps.  For
 # TrueType fonts, which are scalable fonts, small-caps is equivalent
-# to using a font size of 'smaller', or about 83%% of the current font
+# to using a font size of 'small', or about 83 % of the current font
 # size.
 #
 # The font.weight property has effectively 13 values: normal, bold,
@@ -52,31 +52,13 @@
 # special text sizes tick labels, axes, labels, title, etc., see the rc
 # settings for axes and ticks.  Special text sizes can be defined
 # relative to font.size, using the following values: xx-small, x-small,
-# small, medium, large, x-large, xx-large, larger, or smaller
+# small, medium, large, x-large, xx-large
 
 font.family: Fira Sans, sans-serif
 font.style: normal
 font.variant: normal
 font.weight: regular
 font.stretch: normal
-
-font.serif: DejaVu Serif, Bitstream Vera Serif, Computer Modern Roman, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
-font.sans-serif: DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
-font.cursive: Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, Comic Neue, Comic Sans MS, cursive
-font.fantasy: Chicago, Charcoal, Impact, Western, Humor Sans, xkcd, fantasy
-font.monospace: DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
-
-
-# ***************************************************************************
-# * TEXT                                                                    *
-# ***************************************************************************
-# The text properties used by `text.Text`.
-# See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
-# for more information on text properties
-text.hinting: force_autohint
-text.hinting_factor: 8
-text.kerning_factor: 0
-
 
 # ***************************************************************************
 # * LaTeX                                                                   *

--- a/src/erlab/plotting/stylelib/firalight.mplstyle
+++ b/src/erlab/plotting/stylelib/firalight.mplstyle
@@ -60,24 +60,6 @@ font.variant: normal
 font.weight: 300
 font.stretch: normal
 
-font.serif: DejaVu Serif, Bitstream Vera Serif, Computer Modern Roman, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
-font.sans-serif: DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
-font.cursive: Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, Comic Neue, Comic Sans MS, cursive
-font.fantasy: Chicago, Charcoal, Impact, Western, Humor Sans, xkcd, fantasy
-font.monospace: DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
-
-
-# ***************************************************************************
-# * TEXT                                                                    *
-# ***************************************************************************
-# The text properties used by `text.Text`.
-# See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
-# for more information on text properties
-text.hinting: force_autohint
-text.hinting_factor: 8
-text.kerning_factor: 0
-
-
 # ***************************************************************************
 # * LaTeX                                                                   *
 # ***************************************************************************

--- a/src/erlab/plotting/stylelib/nature.mplstyle
+++ b/src/erlab/plotting/stylelib/nature.mplstyle
@@ -25,7 +25,7 @@ patch.linewidth: 0.5
 # * FONT                                                                    *
 # ***************************************************************************
 # The font properties used by `text.Text`.
-# See https://matplotlib.org/api/font_manager_api.html for more information
+# See https://matplotlib.org/stable/api/font_manager_api.html for more information
 # on font properties.  The 6 font properties used for font matching are
 # given below with their default values.
 #
@@ -50,7 +50,7 @@ patch.linewidth: 0.5
 #
 # The font.variant property has two values: normal or small-caps.  For
 # TrueType fonts, which are scalable fonts, small-caps is equivalent
-# to using a font size of 'smaller', or about 83%% of the current font
+# to using a font size of 'small', or about 83 % of the current font
 # size.
 #
 # The font.weight property has effectively 13 values: normal, bold,
@@ -70,7 +70,7 @@ patch.linewidth: 0.5
 # special text sizes tick labels, axes, labels, title, etc., see the rc
 # settings for axes and ticks.  Special text sizes can be defined
 # relative to font.size, using the following values: xx-small, x-small,
-# small, medium, large, x-large, xx-large, larger, or smaller
+# small, medium, large, x-large, xx-large
 
 font.family: sans-serif
 font.style: normal
@@ -78,24 +78,11 @@ font.variant: normal
 font.weight: normal
 font.stretch: normal
 
-# font.serif: Symbol, Times New Roman, serif
 font.serif: Times New Roman, Symbol, serif
-font.sans-serif: Arial, Symbol
+font.sans-serif: Arial, Helvetica, Symbol
 font.cursive: Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, Comic Neue, Comic Sans MS, cursive
 font.fantasy: xkcd, fantasy
 font.monospace: Courier New, Courier, Fixed, Terminal, monospace
-
-
-# ***************************************************************************
-# * TEXT                                                                    *
-# ***************************************************************************
-# The text properties used by `text.Text`.
-# See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
-# for more information on text properties
-text.hinting: default
-text.hinting_factor: 8
-text.kerning_factor: 0
-
 
 # ***************************************************************************
 # * LaTeX                                                                   *

--- a/src/erlab/plotting/stylelib/times.mplstyle
+++ b/src/erlab/plotting/stylelib/times.mplstyle
@@ -7,7 +7,7 @@
 # * FONT                                                                    *
 # ***************************************************************************
 # The font properties used by `text.Text`.
-# See https://matplotlib.org/api/font_manager_api.html for more information
+# See https://matplotlib.org/stable/api/font_manager_api.html for more information
 # on font properties.  The 6 font properties used for font matching are
 # given below with their default values.
 #
@@ -32,7 +32,7 @@
 #
 # The font.variant property has two values: normal or small-caps.  For
 # TrueType fonts, which are scalable fonts, small-caps is equivalent
-# to using a font size of 'smaller', or about 83%% of the current font
+# to using a font size of 'small', or about 83 % of the current font
 # size.
 #
 # The font.weight property has effectively 13 values: normal, bold,
@@ -52,7 +52,7 @@
 # special text sizes tick labels, axes, labels, title, etc., see the rc
 # settings for axes and ticks.  Special text sizes can be defined
 # relative to font.size, using the following values: xx-small, x-small,
-# small, medium, large, x-large, xx-large, larger, or smaller
+# small, medium, large, x-large, xx-large
 
 font.family: serif
 font.style: normal
@@ -63,20 +63,8 @@ font.stretch: normal
 font.serif: Times New Roman, Times, serif
 font.sans-serif: DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
 font.cursive: Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, Comic Neue, Comic Sans MS, cursive
-font.fantasy: Chicago, Charcoal, Impact, Western, Humor Sans, xkcd, fantasy
+font.fantasy: Chicago, Charcoal, Impact, Western, xkcd script, fantasy
 font.monospace: DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
-
-
-# ***************************************************************************
-# * TEXT                                                                    *
-# ***************************************************************************
-# The text properties used by `text.Text`.
-# See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
-# for more information on text properties
-text.hinting: force_autohint
-text.hinting_factor: 8
-text.kerning_factor: 0
-
 
 # ***************************************************************************
 # * LaTeX                                                                   *

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -929,6 +929,33 @@ def test_imagetool_main_image_seeds_nonuniform_plot_slices_selection(qtbot) -> N
     assert "sample_temp_idx" not in operation.model_dump_json()
 
 
+def test_imagetool_main_image_seeds_plot_slices_selection_with_spaced_dim(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 2, 2),
+        dims=("Track Shift", "kx", "ky"),
+        coords={
+            "Track Shift": [0.0, 1.0, 2.0],
+            "kx": [0.0, 1.0],
+            "ky": [0.0, 1.0],
+        },
+        name="map",
+    )
+    tool = erlab.interactive.itool(data, manager=False, execute=False)
+    assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+    qtbot.addWidget(tool)
+
+    tool.slicer_area.set_value(axis=0, value=1.0, cursor=0)
+    operation = tool.slicer_area.images[2].figure_composer_operation(source_name="data")
+
+    assert operation.kind == FigureOperationKind.PLOT_SLICES
+    assert operation.map_selections == ()
+    assert operation.slice_dim == "Track Shift"
+    assert operation.slice_values == (1.0,)
+    assert operation.slice_kwargs == {}
+
+
 def test_imagetool_rejects_uneditable_plot_slices_selection(qtbot) -> None:
     tool = erlab.interactive.itool(
         _unsupported_plot_slices_data(), manager=False, execute=False
@@ -938,8 +965,46 @@ def test_imagetool_rejects_uneditable_plot_slices_selection(qtbot) -> None:
 
     _set_unsupported_plot_slices_cursor_state(tool)
 
-    with pytest.raises(FigureComposerPlotSlicesSelectionError):
+    with pytest.raises(
+        FigureComposerPlotSlicesSelectionError,
+        match="Cannot plot when more than one dimension",
+    ):
         tool.slicer_area.images[0].figure_composer_operation(source_name="data")
+
+
+def test_imagetool_plot_slices_selection_warning_shows_error_detail(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tool = erlab.interactive.itool(
+        _unsupported_plot_slices_data(), manager=False, execute=False
+    )
+    assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+    qtbot.addWidget(tool)
+
+    _set_unsupported_plot_slices_cursor_state(tool)
+
+    with pytest.raises(FigureComposerPlotSlicesSelectionError) as exc_info:
+        tool.slicer_area.images[0].figure_composer_operation(source_name="data")
+
+    messages: list[tuple[QtWidgets.QWidget | None, str, str]] = []
+
+    def warning(
+        parent: QtWidgets.QWidget | None, title: str, text: str
+    ) -> QtWidgets.QMessageBox.StandardButton:
+        messages.append((parent, title, text))
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", warning)
+
+    tool.slicer_area.images[0]._show_plot_slices_selection_error(
+        tool.slicer_area, exc_info.value
+    )
+
+    assert len(messages) == 1
+    assert messages[0][0] is tool.slicer_area
+    assert messages[0][1] == "Cannot Create Plot Slices Figure"
+    assert "Details:" in messages[0][2]
+    assert "Cannot plot when more than one dimension" in messages[0][2]
 
 
 def test_figure_composer_raw_sources_use_public_nonuniform_dims(qtbot) -> None:
@@ -16150,8 +16215,9 @@ def test_figure_composer_imagetool_operation_seed_helpers_cover_branches() -> No
 
     assert ItoolPlotItem._plot_slices_qsel_key_is_editable("eV")
     assert ItoolPlotItem._plot_slices_qsel_key_is_editable("eV_width")
-    assert not ItoolPlotItem._plot_slices_qsel_key_is_editable("Track Shift")
+    assert ItoolPlotItem._plot_slices_qsel_key_is_editable("Track Shift")
     assert not ItoolPlotItem._plot_slices_qsel_key_is_editable("sample_temp_idx")
+    assert not ItoolPlotItem._plot_slices_qsel_key_is_editable("sample_temp_idx_width")
     assert not ItoolPlotItem._plot_slices_qsel_key_is_editable(("bad", "key"))
 
     selected_maps_operation = ItoolPlotItem._figure_composer_plot_slices_operation(
@@ -16300,6 +16366,46 @@ def test_figure_composer_imagetool_operation_seed_helpers_cover_branches() -> No
         {"('bad', 'key')": 0.0},
         {"('bad', 'key')": 1.0},
     )
+
+
+def test_figure_composer_plot_slices_spaced_qsel_dimension_codegen_executes(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 2, 2),
+        dims=("Track Shift", "kx", "ky"),
+        coords={
+            "Track Shift": [0.0, 1.0, 2.0],
+            "kx": [0.0, 1.0],
+            "ky": [0.0, 1.0],
+        },
+        name="data",
+    )
+    operation = FigureOperationState.plot_slices(
+        label="spaced",
+        sources=("data",),
+        slice_dim="Track Shift",
+        slice_values=(1.0,),
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+        source_data={"data": data},
+    )
+    qtbot.addWidget(tool)
+
+    _render_figure_composer_rgba(tool)
+    code = tool.generated_code()
+    assert "Track Shift" in code
+    assert "**{" in code
+
+    namespace: dict[str, typing.Any] = {"data": data}
+    exec(code, namespace)  # noqa: S102
+    assert len(namespace["axs"][0, 0].images) == 1
 
 
 def test_figure_composer_powernorm_codegen_uses_plot_kwargs(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -721,6 +721,9 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
     assert tool.refresh_sources_button.toolTip() == (
         "No sources are linked to open ImageTools"
     )
+    assert tool._source_refresh_label("data_0") is None
+    tool._refresh_source_from_button("data_0")
+    tool._refresh_sources_from_button()
 
     refreshed: list[tuple[str, str | tuple[str, ...]]] = []
 
@@ -792,6 +795,55 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
     assert refreshed[-1] == ("none", ("data_0",))
     assert tool.source_status_label.text() == "diagnostic"
 
+    tool._set_source_refresh_callbacks(
+        can_refresh_source=lambda _name: False,
+        refresh_source=refresh_source,
+        refresh_sources=refresh_sources,
+        source_label=source_label,
+    )
+    refreshed.clear()
+    tool._refresh_source_from_button("data_0")
+    tool._refresh_sources_from_button()
+    assert refreshed == []
+
+    def raise_lookup(name: str) -> bool:
+        raise LookupError(name)
+
+    def raise_lookup_label(name: str) -> str | None:
+        raise LookupError(name)
+
+    tool._set_source_refresh_callbacks(
+        can_refresh_source=raise_lookup,
+        refresh_source=refresh_source,
+        refresh_sources=refresh_sources,
+        source_label=raise_lookup_label,
+    )
+    assert not tool._source_refresh_available("data_0")
+    assert tool._source_refresh_label("data_0") is None
+
+    tool._set_source_refresh_callbacks(
+        can_refresh_source=can_refresh_source,
+        refresh_source=refresh_source,
+        refresh_sources=refresh_sources,
+        source_label=lambda _name: "",
+    )
+    assert tool._source_refresh_label("data_0") is None
+
+    direct_item = QtWidgets.QTreeWidgetItem(["direct", "", ""])
+    tool.source_list.addTopLevelItem(direct_item)
+    direct_button = QtWidgets.QToolButton(tool.source_list)
+    direct_button.setObjectName("figureComposerRefreshSourceButton")
+    tool.source_list.setItemWidget(direct_item, 2, direct_button)
+    assert (
+        tool._source_list_row_button(direct_item, "figureComposerRefreshSourceButton")
+        is direct_button
+    )
+    assert (
+        tool._source_list_row_button(direct_item, "figureComposerRemoveSourceButton")
+        is None
+    )
+    tool._refresh_source_controls()
+
 
 def test_figure_composer_source_remove_controls_disable_used_sources(qtbot) -> None:
     image = _figure_composer_image_source("image")
@@ -848,6 +900,9 @@ def test_figure_composer_source_remove_controls_disable_used_sources(qtbot) -> N
     buttons["profile"].click()
     assert tool.tool_status == before_status
     assert set(tool.source_data()) == set(before_source_data)
+    tool._remove_source_from_button("profile")
+    assert tool.tool_status == before_status
+    assert set(tool.source_data()) == set(before_source_data)
     assert not tool.remove_source("profile")
     assert not tool.remove_source("missing")
 
@@ -881,7 +936,7 @@ def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> 
                 FigureSourceState(name="extra", label="Extra"),
             ),
             operations=(operation,),
-            primary_source="data_0",
+            primary_source="extra",
         ),
         source_data={"data_0": image, "extra": extra},
     )
@@ -899,6 +954,7 @@ def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> 
     assert tuple(source.name for source in tool.source_states()) == ("data_0",)
     assert set(tool.source_data()) == {"data_0"}
     assert tool.tool_status.operations == (operation,)
+    assert tool.tool_status.primary_source == "data_0"
     assert tool.source_status_label.text() == ""
     buttons = _source_remove_buttons(tool)
     assert set(buttons) == {"data_0"}
@@ -921,11 +977,13 @@ def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> 
     assert tool.undoable
     tool.undo()
     assert tuple(source.name for source in tool.source_states()) == ("data_0", "extra")
+    assert tool.tool_status.primary_source == "extra"
     xr.testing.assert_identical(tool.source_data()["extra"], extra)
     assert tool.redoable
     tool.redo()
     assert tuple(source.name for source in tool.source_states()) == ("data_0",)
     assert set(tool.source_data()) == {"data_0"}
+    assert tool.tool_status.primary_source == "data_0"
     tool._refresh_source_list()
     assert set(_source_remove_buttons(tool)) == {"data_0"}
 
@@ -956,6 +1014,15 @@ def test_figure_composer_source_display_helpers_keep_alias_secondary() -> None:
         )
         == "ImageTool (data_0)"
     )
+
+
+def test_figure_composer_plot_slices_selection_error_details() -> None:
+    plain = str(FigureComposerPlotSlicesSelectionError())
+    assert "Details:" not in plain
+
+    detailed = str(FigureComposerPlotSlicesSelectionError("bad key"))
+    assert plain in detailed
+    assert "Details: bad key" in detailed
 
 
 def test_figure_composer_replace_source_preserves_alias_and_generated_code(
@@ -1064,6 +1131,23 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
         captured,
         replacement.sel(eV=float(captured.coords["eV"])),
     )
+
+    assert not tool.replace_source(
+        "missing",
+        FigureSourceState(name="data_2", label="Missing"),
+        replacement,
+    )
+    tool._source_data["orphan"] = original
+    assert tool.replace_source(
+        "orphan",
+        FigureSourceState(name="data_2", label="Orphan"),
+        original,
+    )
+    assert tuple(source.name for source in tool.source_states()) == (
+        "data_0",
+        "orphan",
+    )
+    assert tool.source_states()[-1].label == "Orphan"
 
 
 def test_figure_composer_text_helpers_parse_user_inputs() -> None:
@@ -13107,6 +13191,283 @@ def test_figure_composer_method_selector_preserves_compatible_values(qtbot) -> N
     assert operation.method_kwargs == {}
 
 
+def test_figure_composer_method_transfer_edge_contracts(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="set_xlim",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    initial_operation = tool.tool_status.operations[0]
+    figurecomposer_method._update_current_method_family(tool, FigureMethodFamily.AXES)
+    assert tool.tool_status.operations[0] == initial_operation
+
+    tool._updating_controls = True
+    try:
+        figurecomposer_method._update_current_method_name(tool, "set_ylim")
+    finally:
+        tool._updating_controls = False
+    assert tool.tool_status.operations[0] == initial_operation
+
+    combo_no_none = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.ARG_COMBO,
+        label="Choice",
+        tooltip="choice",
+        object_name="choice",
+        arg_index=0,
+        options=("keep",),
+    )
+    combo_with_none = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.ARG_COMBO,
+        label="Choice",
+        tooltip="choice",
+        object_name="choice",
+        arg_index=0,
+        options=("keep",),
+        none_label="None",
+    )
+    bool_combo = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.BOOL_KWARG_COMBO,
+        label="Flag",
+        tooltip="flag",
+        object_name="flag",
+        key="flag",
+    )
+    assert not figurecomposer_method._control_accepts_value(combo_no_none, None)
+    assert figurecomposer_method._control_accepts_value(combo_with_none, None)
+    assert figurecomposer_method._control_accepts_value(bool_combo, True)
+    assert not figurecomposer_method._control_accepts_value(bool_combo, "True")
+
+    assert (
+        figurecomposer_method._transfer_axis_label_loc(
+            figurecomposer_method.AXES_METHODS["set_ylabel"],
+            figurecomposer_method.AXES_METHODS["set_xlabel"],
+            "top",
+        )
+        == "right"
+    )
+    assert (
+        figurecomposer_method._transfer_axis_label_loc(
+            figurecomposer_method.AXES_METHODS["set_title"],
+            figurecomposer_method.AXES_METHODS["set_xlabel"],
+            "unchanged",
+        )
+        == "unchanged"
+    )
+
+    float_pair_updates = figurecomposer_method._method_transfer_updates(
+        tool,
+        FigureOperationState.method(
+            family=FigureMethodFamily.AXES,
+            name="set_xlim",
+            args=(1.0, 2.0),
+            axes=FigureAxesSelectionState(axes=((0, 0),)),
+        ),
+        figurecomposer_method.AXES_METHODS["set_ylim"],
+    )
+    assert float_pair_updates["method_args"] == (1.0, 2.0)
+
+    default_arg_updates = figurecomposer_method._method_transfer_updates(
+        tool,
+        FigureOperationState.method(
+            family=FigureMethodFamily.AXES,
+            name="set_xlabel",
+            args=("x",),
+            axes=FigureAxesSelectionState(axes=((0, 0),)),
+        ),
+        figurecomposer_method.AXES_METHODS["set_ylabel"],
+    )
+    assert default_arg_updates["method_args"] == ("y",)
+
+    plot_operation = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="plot",
+        args=((0.0, 1.0), (1.0, 2.0)),
+        kwargs={"custom": "value"},
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+    ).model_copy(
+        update={
+            "method_transform": "custom",
+            "method_transform_x": "figure",
+            "method_transform_y": "data",
+            "method_transform_expression": "ax.transData",
+        }
+    )
+    plot_updates = figurecomposer_method._method_transfer_updates(
+        tool,
+        plot_operation,
+        figurecomposer_method.AXES_METHODS["plot"],
+    )
+    assert plot_updates["method_args"] == plot_operation.method_args
+    assert plot_updates["method_kwargs"] == {"custom": "value"}
+    assert plot_updates["method_transform"] == "custom"
+    assert plot_updates["method_transform_x"] == "figure"
+    assert plot_updates["method_transform_y"] == "data"
+    assert plot_updates["method_transform_expression"] == "ax.transData"
+
+    text_arg = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.TEXT_ARG,
+        label="Text",
+        tooltip="text",
+        object_name="text",
+        arg_index=0,
+    )
+    accepted_combo = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.ARG_COMBO,
+        label="Accepted",
+        tooltip="accepted",
+        object_name="accepted",
+        arg_index=2,
+        options=("keep",),
+    )
+    source_rejected_combo = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.ARG_COMBO,
+        label="Rejected",
+        tooltip="rejected",
+        object_name="rejected",
+        arg_index=3,
+        options=("bad",),
+    )
+    target_rejected_combo = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.ARG_COMBO,
+        label="Rejected",
+        tooltip="rejected",
+        object_name="rejected",
+        arg_index=3,
+        options=("ok",),
+    )
+    same_kwarg = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.FLOAT_KWARG,
+        label="Same",
+        tooltip="same",
+        object_name="same",
+        key="same",
+    )
+    source_mismatch_kwarg = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.TEXT_KWARG,
+        label="Mismatch",
+        tooltip="mismatch",
+        object_name="mismatch",
+        key="mismatch",
+    )
+    target_mismatch_kwarg = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.FLOAT_KWARG,
+        label="Mismatch",
+        tooltip="mismatch",
+        object_name="mismatch",
+        key="mismatch",
+    )
+    transform_control = figurecomposer_method.MethodControlSpec(
+        kind=figurecomposer_method.MethodControlKind.TRANSFORM,
+        label="Transform",
+        tooltip="transform",
+        object_name="transform",
+    )
+    source_spec = figurecomposer_method.MethodSpec(
+        family=FigureMethodFamily.AXES,
+        name="transfer_source",
+        label="transfer_source",
+        tooltip="test",
+        target_domain=figurecomposer_method.MethodTargetDomain.AXES,
+        call_policy=figurecomposer_method.MethodCallPolicy.BOUND_EACH_AXIS,
+        allowed_call_policies=(
+            figurecomposer_method.MethodCallPolicy.BOUND_EACH_AXIS,
+            figurecomposer_method.MethodCallPolicy.AX_KEYWORD,
+        ),
+        default_args=("default",),
+        controls=(
+            text_arg,
+            accepted_combo,
+            source_rejected_combo,
+            same_kwarg,
+            source_mismatch_kwarg,
+            transform_control,
+        ),
+        text_values_policy=figurecomposer_method.MethodTextValuesPolicy.POSITIONAL,
+    )
+    target_spec = figurecomposer_method.MethodSpec(
+        family=FigureMethodFamily.AXES,
+        name="transfer_target",
+        label="transfer_target",
+        tooltip="test",
+        target_domain=figurecomposer_method.MethodTargetDomain.AXES,
+        call_policy=figurecomposer_method.MethodCallPolicy.BOUND_EACH_AXIS,
+        allowed_call_policies=(
+            figurecomposer_method.MethodCallPolicy.BOUND_EACH_AXIS,
+            figurecomposer_method.MethodCallPolicy.AX_KEYWORD,
+        ),
+        controls=(
+            text_arg,
+            accepted_combo,
+            target_rejected_combo,
+            same_kwarg,
+            target_mismatch_kwarg,
+            transform_control,
+        ),
+        text_values_policy=figurecomposer_method.MethodTextValuesPolicy.POSITIONAL,
+    )
+    monkeypatch.setitem(
+        figurecomposer_method.AXES_METHODS, "transfer_source", source_spec
+    )
+    monkeypatch.setitem(
+        figurecomposer_method.AXES_METHODS, "transfer_target", target_spec
+    )
+    transfer_operation = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="transfer_source",
+        args=("default", "ignored", "keep", "bad"),
+        kwargs={"same": 2.0, "mismatch": "skip"},
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+    ).model_copy(
+        update={
+            "method_call_policy": (
+                figurecomposer_method.MethodCallPolicy.AX_KEYWORD.value
+            ),
+            "text_values": ("A", "B"),
+            "method_transform": "custom",
+            "method_transform_x": "figure",
+            "method_transform_y": "data",
+            "method_transform_expression": "ax.transData",
+        }
+    )
+
+    transfer_updates = figurecomposer_method._method_transfer_updates(
+        tool,
+        transfer_operation,
+        target_spec,
+    )
+    assert transfer_updates["method_args"] == (None, None, "keep")
+    assert transfer_updates["method_kwargs"] == {"same": 2.0}
+    assert (
+        transfer_updates["method_call_policy"]
+        == figurecomposer_method.MethodCallPolicy.AX_KEYWORD.value
+    )
+    assert transfer_updates["text_values"] == ("A", "B")
+    assert transfer_updates["method_transform"] == "custom"
+    assert transfer_updates["method_transform_x"] == "figure"
+    assert transfer_updates["method_transform_y"] == "data"
+    assert transfer_updates["method_transform_expression"] == "ax.transData"
+
+
 def test_figure_composer_batch_same_method_edits_selected_steps(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
@@ -14200,6 +14561,12 @@ def test_figure_composer_line_profile_helper_contracts(qtbot) -> None:
         ),
     )
     qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+
+    figurecomposer_line_profile._line_limit_update_callback(tool, "xlim")("0, 1")
+    assert tool.tool_status.operations[0].xlim == (0.0, 1.0)
+    figurecomposer_line_profile._line_limit_update_callback(tool, "ylim")("")
+    assert tool.tool_status.operations[0].ylim is None
 
     assert (
         figurecomposer_line_profile._line_placement_text("one_per_axis")
@@ -18641,6 +19008,7 @@ def test_manager_figure_target_dialog_defaults_to_add_step_without_selected_figu
 
 def test_manager_figure_target_dialog_defaults_to_replace_selected_single_source(
     qtbot,
+    monkeypatch: pytest.MonkeyPatch,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -18679,6 +19047,15 @@ def test_manager_figure_target_dialog_defaults_to_replace_selected_single_source
         button = dialog.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
         assert button is not None
         assert button.isEnabled()
+        assert dialog._figure_source_count(None) == 0
+        assert dialog._figure_source_count("missing") == 0
+
+        class EmptyFigureNode:
+            tool_window = None
+
+        with monkeypatch.context() as context:
+            context.setattr(manager, "_child_node", lambda _uid: EmptyFigureNode())
+            assert dialog._figure_source_count(figure_uid) == 0
 
 
 def test_manager_figure_target_dialog_switches_and_repairs_axes_selection(
@@ -18766,6 +19143,12 @@ def test_manager_figure_target_dialog_switches_and_repairs_axes_selection(
         assert dialog.selected_source_alias() == "line"
         assert dialog.selector_stack.isHidden()
         assert not dialog.source_combo.isHidden()
+        assert ok_button.isEnabled()
+        dialog.source_combo.setCurrentIndex(-1)
+        dialog._selection_changed()
+        assert not ok_button.isEnabled()
+        dialog.source_combo.setCurrentIndex(0)
+        dialog._selection_changed()
         assert ok_button.isEnabled()
 
         dialog.action_combo.setCurrentIndex(
@@ -19316,6 +19699,170 @@ def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
         snapshot = manager._workspace_state_snapshot()
         assert figure_uid in snapshot["dirty_data"]
         assert figure_uid in snapshot["dirty_state"]
+
+
+def test_manager_figure_source_helper_edge_contracts(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        data = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="data",
+        )
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        image_uid = manager._node_for_target(0).uid
+        child = itool(data.sum("y"), manager=False, execute=False)
+        assert isinstance(child, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(child, 0, show=False)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        select_child_tool(manager, figure_uid)
+        assert manager._selected_figure_uid_for_figure_dialog() == figure_uid
+
+        source_states = figure_tool.source_states()
+        source_data = figure_tool.source_data()
+        replacement_source = FigureSourceState(
+            name="replacement",
+            label="replacement",
+            node_uid=image_uid,
+        )
+        assert not manager._add_sources_to_figure(
+            "missing",
+            source_states,
+            source_data,
+            show=False,
+        )
+        assert manager._figure_source_state(figure_tool, "missing") is None
+        assert manager._figure_source_live_node("missing", "data_0") is None
+        assert not manager._refresh_figure_source(figure_uid, "missing")
+        assert not manager._replace_figure_source(
+            figure_uid,
+            "data_0",
+            (),
+            {},
+            show=False,
+        )
+        assert not manager._replace_figure_source(
+            figure_uid,
+            "data_0",
+            (replacement_source,),
+            {},
+            show=False,
+        )
+
+        with monkeypatch.context() as context:
+            context.setattr(
+                manager,
+                "_is_figure_uid",
+                lambda uid: uid in {figure_uid, child_uid},
+            )
+            assert not manager._add_sources_to_figure(
+                child_uid,
+                source_states,
+                source_data,
+                show=False,
+            )
+            assert not manager._replace_figure_source(
+                child_uid,
+                "data_0",
+                (replacement_source,),
+                {"replacement": data},
+                show=False,
+            )
+            assert manager._figure_source_live_node(child_uid, "data_0") is None
+            assert not manager._refresh_figure_source(child_uid, "data_0")
+
+        with monkeypatch.context() as context:
+            context.setattr(figure_tool, "replace_source", lambda *_args: False)
+            assert not manager._replace_figure_source(
+                figure_uid,
+                "data_0",
+                (replacement_source,),
+                {"replacement": data},
+                show=False,
+            )
+            assert not manager._refresh_figure_source(figure_uid, "data_0")
+
+        with monkeypatch.context() as context:
+            context.setattr(
+                manager,
+                "_figure_source_live_node",
+                lambda *_args: manager._node_for_target(0),
+            )
+            context.setattr(manager, "_is_figure_uid", lambda uid: uid == child_uid)
+            assert not manager._refresh_figure_source(child_uid, "data_0")
+
+        with monkeypatch.context() as context:
+            context.setattr(manager, "_figure_uids", lambda: ("missing",))
+            manager._refresh_figure_source_controls()
+
+        with monkeypatch.context() as context:
+            context.setattr(manager, "_selected_figure_source_targets", lambda: (0,))
+            context.setattr(
+                manager,
+                "_figure_sources_from_targets",
+                lambda _targets: ((), (), {}),
+            )
+            manager.create_figure_from_selection()
+
+        dialog_events: list[str] = []
+
+        class AliasNoneDialog:
+            def __init__(
+                self,
+                _manager: erlab.interactive.imagetool.manager.ImageToolManager,
+                _figure_uids: tuple[str, ...],
+                _operation: FigureOperationState | None,
+                *,
+                allow_new_figure: bool = False,
+                source_count: int = 1,
+                selected_figure_uid: str | None = None,
+            ) -> None:
+                assert allow_new_figure is True
+                assert source_count == 1
+                assert selected_figure_uid == figure_uid
+                dialog_events.append("init")
+
+            def exec(self) -> QtWidgets.QDialog.DialogCode:
+                return QtWidgets.QDialog.DialogCode.Accepted
+
+            def selected_action(self) -> str:
+                return manager_mainwindow._FIGURE_DIALOG_REPLACE_SOURCE
+
+            def selected_source_alias(self) -> str | None:
+                dialog_events.append("alias")
+                return None
+
+        with monkeypatch.context() as context:
+            context.setattr(manager, "_selected_figure_source_targets", lambda: (0,))
+            context.setattr(manager, "_figure_uids", lambda: (figure_uid,))
+            context.setattr(
+                manager,
+                "_figure_sources_from_targets",
+                lambda _targets: ((0,), source_states, source_data),
+            )
+            context.setattr(
+                manager,
+                "_selected_figure_uid_for_figure_dialog",
+                lambda: figure_uid,
+            )
+            context.setattr(
+                manager_mainwindow,
+                "_AppendFigureTargetDialog",
+                AliasNoneDialog,
+            )
+            manager.create_figure_from_selection()
+        assert dialog_events == ["init", "alias"]
 
 
 def test_manager_figure_action_add_source_only_keeps_recipe_steps(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -833,6 +833,13 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
         source_data={"data_0": original},
     )
     qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+
+    assert "ImageTool 0: original" in tool.operation_list.item(0).text()
+    assert "ImageTool 0: original" in tool.operation_list.item(1).text()
+    assert tool.step_section_buttons["sources"].text() == (
+        "Sources: ImageTool 0: original"
+    )
 
     replaced = tool.replace_source(
         "data_0",
@@ -856,6 +863,13 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
     xr.testing.assert_identical(tool.source_data()["data_0"], replacement)
     assert tool.tool_status.operations[0].sources == ("data_0",)
     assert tool.tool_status.operations[1].line_source == "data_0"
+    assert "ImageTool 1: replacement" in tool.operation_list.item(0).text()
+    assert "ImageTool 0: original" not in tool.operation_list.item(0).text()
+    assert "ImageTool 1: replacement" in tool.operation_list.item(1).text()
+    assert "ImageTool 0: original" not in tool.operation_list.item(1).text()
+    assert tool.step_section_buttons["sources"].text() == (
+        "Sources: ImageTool 1: replacement"
+    )
 
     _render_figure_composer_rgba(tool)
     assert tool._operation_render_errors == {}

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -321,6 +321,18 @@ def _source_refresh_buttons(
     }
 
 
+def _source_remove_buttons(
+    tool: FigureComposerTool,
+) -> dict[str, QtWidgets.QToolButton]:
+    return {
+        str(source_name): button
+        for button in tool.source_list.findChildren(
+            QtWidgets.QToolButton, "figureComposerRemoveSourceButton"
+        )
+        if (source_name := button.property("figure_source_name")) is not None
+    }
+
+
 def _plot_source_move_buttons(
     tool: FigureComposerTool,
 ) -> dict[tuple[str, str], QtWidgets.QToolButton]:
@@ -752,6 +764,138 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
 
     tool.refresh_sources_button.click()
     assert refreshed[-1] == ("many", ("data_0",))
+
+
+def test_figure_composer_source_remove_controls_disable_used_sources(qtbot) -> None:
+    image = _figure_composer_image_source("image")
+    profile = _figure_composer_profile_source("profile")
+    unused = xr.DataArray(
+        np.array([10.0, 11.0]),
+        dims=("q",),
+        coords={"q": [0.0, 1.0]},
+        name="unused",
+    )
+    tool = FigureComposerTool(
+        image,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=1),
+            sources=(
+                FigureSourceState(name="data_0", label="ImageTool 0: image"),
+                FigureSourceState(name="profile", label="Profile"),
+                FigureSourceState(name="unused", label="Unused"),
+            ),
+            operations=(
+                FigureOperationState.plot_slices(
+                    label="plot_slices",
+                    sources=("data_0",),
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                    slice_dim="eV",
+                    slice_values=(0.0,),
+                ),
+                FigureOperationState.line(
+                    label="profile",
+                    source="profile",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ),
+            ),
+            primary_source="data_0",
+        ),
+        source_data={"data_0": image, "profile": profile, "unused": unused},
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+
+    buttons = _source_remove_buttons(tool)
+    assert set(buttons) == {"data_0", "profile", "unused"}
+    assert buttons["unused"].property("figure_source_name") == "unused"
+    assert buttons["unused"].accessibleName() == "Remove Source"
+    assert not buttons["data_0"].isEnabled()
+    assert buttons["data_0"].toolTip() == "This source is used by one or more steps"
+    assert not buttons["profile"].isEnabled()
+    assert buttons["profile"].toolTip() == "This source is used by one or more steps"
+    assert buttons["unused"].isEnabled()
+    assert buttons["unused"].toolTip() == "Remove “Unused” from this figure"
+
+    before_status = tool.tool_status
+    before_source_data = tool.source_data()
+    buttons["profile"].click()
+    assert tool.tool_status == before_status
+    assert set(tool.source_data()) == set(before_source_data)
+    assert not tool.remove_source("profile")
+    assert not tool.remove_source("missing")
+
+
+def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> None:
+    image = _figure_composer_image_source("image")
+    extra = xr.DataArray(
+        np.array([1.0, 2.0]),
+        dims=("q",),
+        coords={"q": [0.0, 1.0]},
+        name="extra",
+    )
+    operation = FigureOperationState.plot_slices(
+        label="plot_slices",
+        sources=("data_0",),
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        slice_dim="eV",
+        slice_values=(0.0,),
+    )
+    tool = FigureComposerTool(
+        image,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=1),
+            sources=(
+                FigureSourceState(name="data_0", label="ImageTool 0: image"),
+                FigureSourceState(name="extra", label="Extra"),
+            ),
+            operations=(operation,),
+            primary_source="data_0",
+        ),
+        source_data={"data_0": image, "extra": extra},
+    )
+    qtbot.addWidget(tool)
+    data_changed: list[None] = []
+    info_changed: list[None] = []
+    tool.sigDataChanged.connect(lambda: data_changed.append(None))
+    tool.sigInfoChanged.connect(lambda: info_changed.append(None))
+
+    assert not tool.remove_source("data_0")
+    assert tool.remove_source("extra")
+
+    assert data_changed == [None]
+    assert info_changed == [None]
+    assert tuple(source.name for source in tool.source_states()) == ("data_0",)
+    assert set(tool.source_data()) == {"data_0"}
+    assert tool.tool_status.operations == (operation,)
+    assert tool.source_status_label.text() == ""
+    buttons = _source_remove_buttons(tool)
+    assert set(buttons) == {"data_0"}
+    assert not buttons["data_0"].isEnabled()
+    assert buttons["data_0"].toolTip() == "This source is used by one or more steps"
+
+    _render_figure_composer_rgba(tool)
+    assert tool._operation_render_errors == {}
+    namespace = _exec_generated_code(tool.generated_code(), {"data_0": image})
+    assert isinstance(namespace["fig"], Figure)
+    restored = FigureComposerTool(
+        image,
+        recipe=tool.tool_status,
+        source_data=tool.source_data(),
+    )
+    qtbot.addWidget(restored)
+    assert tuple(source.name for source in restored.source_states()) == ("data_0",)
+    assert set(restored.source_data()) == {"data_0"}
+
+    assert tool.undoable
+    tool.undo()
+    assert tuple(source.name for source in tool.source_states()) == ("data_0", "extra")
+    xr.testing.assert_identical(tool.source_data()["extra"], extra)
+    assert tool.redoable
+    tool.redo()
+    assert tuple(source.name for source in tool.source_states()) == ("data_0",)
+    assert set(tool.source_data()) == {"data_0"}
+    tool._refresh_source_list()
+    assert set(_source_remove_buttons(tool)) == {"data_0"}
 
 
 def test_figure_composer_source_display_helpers_keep_alias_secondary() -> None:
@@ -19156,6 +19300,74 @@ def test_manager_figure_action_add_source_only_keeps_recipe_steps(
         loaded_tool = manager._child_node(figure_uid).tool_window
         assert isinstance(loaded_tool, FigureComposerTool)
         xr.testing.assert_identical(loaded_tool.source_data()["data_1"], second)
+
+
+def test_manager_figure_remove_unused_source_persists_workspace(
+    qtbot,
+    tmp_path: Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        first = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="first",
+        )
+        second = xr.DataArray(
+            np.arange(4.0, 8.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="second",
+        )
+        itool(first, manager=True)
+        itool(second, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        _resolved_targets, sources, source_data = manager._figure_sources_from_targets(
+            (1,)
+        )
+        [source] = sources
+        manager._add_sources_to_figure(figure_uid, sources, source_data, show=False)
+        assert source.name in figure_tool.source_data()
+        manager._mark_workspace_clean()
+
+        buttons = _source_remove_buttons(figure_tool)
+        assert buttons[source.name].isEnabled()
+        with qtbot.wait_signal(figure_tool.sigDataChanged, timeout=5000):
+            buttons[source.name].click()
+
+        assert source.name not in figure_tool.source_data()
+        assert source.name not in {
+            source.name for source in figure_tool.source_states()
+        }
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid in snapshot["dirty_data"]
+        assert figure_uid in snapshot["dirty_state"]
+
+        workspace_path = tmp_path / "remove-unused-figure-source.itws"
+        manager._save_workspace_document(workspace_path, force_full=True)
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+        assert manager._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        loaded_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(loaded_tool, FigureComposerTool)
+        assert source.name not in loaded_tool.source_data()
+        assert source.name not in {
+            source.name for source in loaded_tool.source_states()
+        }
 
 
 def test_manager_figure_action_multi_source_append_preserves_panel_colormaps(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -2157,7 +2157,7 @@ def test_figure_composer_plot_slices_panel_helpers_cover_style_contract(
     )
     qtbot.addWidget(tool)
     operation = FigureOperationState.plot_slices(
-        label="cuts",
+        label="selection",
         sources=("data",),
         slice_dim="eV",
         slice_values=(0.0, 1.0),
@@ -2855,7 +2855,7 @@ def test_figure_composer_plot_slices_shape_and_source_editor_contracts(
     assert invalid_shape.plot_ndim == 0
     assert not invalid_shape.valid
     assert (
-        figurecomposer_plot_slices._section_summary(tool, "cuts", first_operation)
+        figurecomposer_plot_slices._section_summary(tool, "selection", first_operation)
         == "additional"
     )
     assert (
@@ -3875,7 +3875,7 @@ def test_figure_composer_subplots_plot_roundtrip_restores_exact_render(
         sharey=False,
     )
     plot_operation = FigureOperationState.plot_slices(
-        label="constant energy cuts",
+        label="constant energy selection",
         sources=("image_source",),
         axes=FigureAxesSelectionState(axes=((0, 0), (0, 1))),
         slice_dim="eV",
@@ -4006,7 +4006,7 @@ def test_figure_composer_gridspec_plot_roundtrip_restores_exact_render(
         slice_values=(0.0,),
     ).model_copy(update={"annotate": False, "cmap": "magma"})
     line_slices_operation = FigureOperationState.plot_slices(
-        label="line cuts",
+        label="line selection",
         sources=("line_source",),
         axes=FigureAxesSelectionState(axes_ids=("line-top", "line-bottom")),
         slice_dim="eV",
@@ -8627,7 +8627,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     assert tool.step_section_keys == [
         "sources",
         "axes",
-        "cuts",
+        "selection",
         "view",
         "colors",
         "advanced",
@@ -8638,7 +8638,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     ] == [
         "figureComposerStepSourcesPage",
         "figureComposerTargetAxesPage",
-        "figureComposerPlotSlicesCutsPage",
+        "figureComposerPlotSlicesSelectionPage",
         "figureComposerPlotSlicesViewPage",
         "figureComposerPlotSlicesColorsPage",
         "figureComposerPlotSlicesAdvancedPage",
@@ -8647,7 +8647,9 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     colors_page = tool.findChild(
         QtWidgets.QWidget, "figureComposerPlotSlicesColorsPage"
     )
-    cuts_page = tool.findChild(QtWidgets.QWidget, "figureComposerPlotSlicesCutsPage")
+    selection_page = tool.findChild(
+        QtWidgets.QWidget, "figureComposerPlotSlicesSelectionPage"
+    )
     view_page = tool.findChild(QtWidgets.QWidget, "figureComposerPlotSlicesViewPage")
     crop_check = tool.findChild(
         QtWidgets.QCheckBox, "figureComposerPlotSlicesCropCheck"
@@ -8667,7 +8669,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         QtWidgets.QLineEdit, "figureComposerColorbarKwEdit"
     )
     assert colors_page is not None
-    assert cuts_page is not None
+    assert selection_page is not None
     assert view_page is not None
     assert crop_check is not None
     assert order_combo is not None
@@ -8679,7 +8681,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     assert view_page.isAncestorOf(crop_check)
     assert view_page.isAncestorOf(order_combo)
     assert view_page.isAncestorOf(transpose_check)
-    assert not cuts_page.isAncestorOf(crop_check)
+    assert not selection_page.isAncestorOf(crop_check)
     assert same_limits_combo.parent() is colors_page
     assert axis_combo.parent() is view_page
     assert annotate_kwargs_edit.parent() is view_page
@@ -9050,6 +9052,136 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     assert "colorbar_kw" in code
     assert "tools[" not in code
     assert "_manager" not in code
+
+
+def test_figure_composer_line_profile_operation_uses_semantic_sections(
+    qtbot,
+) -> None:
+    data = _figure_composer_line_slice_source("profile_data")
+    operation = FigureOperationState.line(
+        label="profiles",
+        source="profile_data",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+    ).model_copy(
+        update={
+            "line_x": "kx",
+            "line_iter_dim": "eV",
+            "line_selection": {"eV": slice(-0.5, 0.5)},
+            "line_reduce": "both",
+            "line_labels": ("left", "right"),
+            "line_colors": ("C0", "C1"),
+            "line_kw": {"linestyle": "--", "marker": "o"},
+            "line_normalize": "max",
+            "line_scales": (2.0,),
+            "line_offsets": (0.0, 1.0),
+            "xlim": (-0.5, 0.5),
+            "ylim": (0.0, None),
+        }
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="profile_data", label="profile_data"),),
+            operations=(operation,),
+            primary_source="profile_data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    assert tool.step_section_keys == [
+        "sources",
+        "axes",
+        "selection",
+        "view",
+        "style",
+        "other",
+    ]
+    assert [
+        tool.step_editor_stack.widget(index).objectName()
+        for index in range(tool.step_editor_stack.count())
+    ] == [
+        "figureComposerStepSourcesPage",
+        "figureComposerTargetAxesPage",
+        "figureComposerLineSelectionPage",
+        "figureComposerLineViewPage",
+        "figureComposerLineStylePage",
+        "figureComposerLineOtherPage",
+    ]
+
+    selection_page = tool.findChild(
+        QtWidgets.QWidget, "figureComposerLineSelectionPage"
+    )
+    view_page = tool.findChild(QtWidgets.QWidget, "figureComposerLineViewPage")
+    style_page = tool.findChild(QtWidgets.QWidget, "figureComposerLineStylePage")
+    other_page = tool.findChild(QtWidgets.QWidget, "figureComposerLineOtherPage")
+    assert selection_page is not None
+    assert view_page is not None
+    assert style_page is not None
+    assert other_page is not None
+
+    section_controls = (
+        (
+            selection_page,
+            (
+                "figureComposerProfileCoordinateCombo",
+                "figureComposerProfileValuesCombo",
+                "figureComposerLineSelectionEdit",
+                "figureComposerProfileIterDimCombo",
+                "figureComposerProfileReduceCombo",
+            ),
+        ),
+        (
+            view_page,
+            (
+                "figureComposerProfilePlacementCombo",
+                "figureComposerDataValuesAxisCombo",
+                "figureComposerLineXLimEdit",
+                "figureComposerLineYLimEdit",
+            ),
+        ),
+        (
+            style_page,
+            (
+                "figureComposerLineLabelsEdit",
+                "figureComposerLineColorsEdit",
+                "figureComposerLineStyleCombo",
+                "figureComposerLineWidthSpin",
+                "figureComposerLineMarkerCombo",
+                "figureComposerLineMarkerSizeSpin",
+                "figureComposerLineMarkerFaceColorEdit",
+                "figureComposerLineMarkerEdgeColorEdit",
+            ),
+        ),
+        (
+            other_page,
+            (
+                "figureComposerLineNormalizeCombo",
+                "figureComposerLineScalesEdit",
+                "figureComposerLineOffsetSourceCombo",
+                "figureComposerLineOffsetsEdit",
+            ),
+        ),
+    )
+    pages = (selection_page, view_page, style_page, other_page)
+    for expected_page, control_names in section_controls:
+        for name in control_names:
+            widget = tool.findChild(QtWidgets.QWidget, name)
+            assert widget is not None
+            for page in pages:
+                if page is expected_page:
+                    assert page.isAncestorOf(widget)
+                else:
+                    assert not page.isAncestorOf(widget)
+
+    for key, page in (
+        ("selection", selection_page),
+        ("view", view_page),
+        ("style", style_page),
+        ("other", other_page),
+    ):
+        tool._select_step_section(key)
+        assert tool.step_editor_stack.currentWidget() is page
+        assert tool.tool_status.operations[0] == operation
 
 
 def test_figure_composer_step_section_buttons_are_tab_focusable(qtbot) -> None:
@@ -11103,20 +11235,16 @@ def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
     qtbot.addWidget(tool)
 
     _select_operation_rows(tool, (2,))
-    tool._select_step_section("line")
-    line_page = tool.step_editor_stack.currentWidget()
-    profile_coordinate_combo = line_page.findChild(
+    tool._select_step_section("selection")
+    selection_page = tool.step_editor_stack.currentWidget()
+    profile_coordinate_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileCoordinateCombo"
     )
-    profile_values_combo = line_page.findChild(
+    profile_values_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileValuesCombo"
-    )
-    data_values_axis_combo = line_page.findChild(
-        QtWidgets.QComboBox, "figureComposerDataValuesAxisCombo"
     )
     assert profile_coordinate_combo is not None
     assert profile_values_combo is not None
-    assert data_values_axis_combo is not None
     assert profile_coordinate_combo.itemData(0) is None
     assert profile_values_combo.itemData(0) is None
     assert profile_coordinate_combo.findData("kx") >= 0
@@ -11129,30 +11257,42 @@ def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
     assert tool.tool_status.operations[2].line_x is None
     _activate_combo_index(profile_values_combo, profile_values_combo.findData("kx"))
     assert tool.tool_status.operations[2].line_y == "kx"
-    line_page = tool.step_editor_stack.currentWidget()
-    profile_values_combo = line_page.findChild(
+    selection_page = tool.step_editor_stack.currentWidget()
+    profile_values_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileValuesCombo"
     )
     assert profile_values_combo is not None
     _activate_combo_index(profile_values_combo, 0)
     assert tool.tool_status.operations[2].line_y is None
-    line_page = tool.step_editor_stack.currentWidget()
-    profile_coordinate_combo = line_page.findChild(
+    selection_page = tool.step_editor_stack.currentWidget()
+    profile_coordinate_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileCoordinateCombo"
     )
-    profile_values_combo = line_page.findChild(
+    profile_values_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileValuesCombo"
     )
     assert profile_coordinate_combo is not None
     assert profile_values_combo is not None
     assert profile_coordinate_combo.toolTip()
     assert profile_values_combo.toolTip()
-    assert data_values_axis_combo.toolTip()
     assert all(
-        widget.toolTip() for widget in line_page.findChildren(QtWidgets.QLineEdit)
+        widget.toolTip() for widget in selection_page.findChildren(QtWidgets.QLineEdit)
     )
     assert all(
-        widget.toolTip() for widget in line_page.findChildren(QtWidgets.QCheckBox)
+        widget.toolTip() for widget in selection_page.findChildren(QtWidgets.QCheckBox)
+    )
+    tool._select_step_section("view")
+    view_page = tool.step_editor_stack.currentWidget()
+    data_values_axis_combo = view_page.findChild(
+        QtWidgets.QComboBox, "figureComposerDataValuesAxisCombo"
+    )
+    assert data_values_axis_combo is not None
+    assert data_values_axis_combo.toolTip()
+    assert all(
+        widget.toolTip() for widget in view_page.findChildren(QtWidgets.QLineEdit)
+    )
+    assert all(
+        widget.toolTip() for widget in view_page.findChildren(QtWidgets.QCheckBox)
     )
 
     _select_operation_rows(tool, (3,))
@@ -13957,19 +14097,15 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     qtbot.addWidget(tool)
     profiles = figurecomposer_line_profile._line_data_items(tool, operation)
 
-    tool._select_step_section("line")
-    line_page = tool.step_editor_stack.currentWidget()
-    offset_source_combo = line_page.findChild(
-        QtWidgets.QComboBox, "figureComposerLineOffsetSourceCombo"
-    )
-    reduce_combo = line_page.findChild(
+    tool._select_step_section("selection")
+    selection_page = tool.step_editor_stack.currentWidget()
+    reduce_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileReduceCombo"
     )
-    assert offset_source_combo is not None
     assert reduce_combo is not None
     assert reduce_combo.currentText() == "Disabled"
     assert (
-        line_page.findChild(
+        selection_page.findChild(
             QtWidgets.QSpinBox, "figureComposerProfileReduceCoarsenSpin"
         )
         is None
@@ -13984,11 +14120,11 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
         ),
         timeout=1000,
     )
-    line_page = tool.step_editor_stack.currentWidget()
-    coarsen_spin = line_page.findChild(
+    selection_page = tool.step_editor_stack.currentWidget()
+    coarsen_spin = selection_page.findChild(
         QtWidgets.QSpinBox, "figureComposerProfileReduceCoarsenSpin"
     )
-    thin_spin = line_page.findChild(
+    thin_spin = selection_page.findChild(
         QtWidgets.QSpinBox, "figureComposerProfileReduceThinSpin"
     )
     assert tool.tool_status.operations[0].line_reduce == "both"
@@ -13998,47 +14134,49 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     thin_spin.setValue(3)
     assert tool.tool_status.operations[0].line_reduce_thin == 3
     tool._replace_operation(0, operation)
-    tool._select_step_section("line")
-    line_page = tool.step_editor_stack.currentWidget()
-    offset_source_combo = line_page.findChild(
+    tool._select_step_section("other")
+    other_page = tool.step_editor_stack.currentWidget()
+    offset_source_combo = other_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineOffsetSourceCombo"
     )
     assert offset_source_combo is not None
     assert (
-        line_page.findChild(
+        other_page.findChild(
             QtWidgets.QComboBox, "figureComposerLineOffsetCoordinateCombo"
         )
         is not None
     )
     assert (
-        line_page.findChild(
+        other_page.findChild(
             QtWidgets.QDoubleSpinBox, "figureComposerLineOffsetScaleEdit"
         )
         is not None
     )
     assert (
-        line_page.findChild(QtWidgets.QLineEdit, "figureComposerLineOffsetsEdit")
+        other_page.findChild(QtWidgets.QLineEdit, "figureComposerLineOffsetsEdit")
         is None
     )
-    line_style_combo = line_page.findChild(
+    tool._select_step_section("style")
+    style_page = tool.step_editor_stack.currentWidget()
+    line_style_combo = style_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineStyleCombo"
     )
-    line_width_spin = line_page.findChild(
+    line_width_spin = style_page.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerLineWidthSpin"
     )
-    marker_combo = line_page.findChild(
+    marker_combo = style_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineMarkerCombo"
     )
-    marker_size_spin = line_page.findChild(
+    marker_size_spin = style_page.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerLineMarkerSizeSpin"
     )
-    marker_face_edit = line_page.findChild(
+    marker_face_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineMarkerFaceColorEdit"
     )
-    marker_edge_edit = line_page.findChild(
+    marker_edge_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineMarkerEdgeColorEdit"
     )
-    marker_face_button = line_page.findChild(
+    marker_face_button = style_page.findChild(
         figurecomposer_widgets._ColorPickerButton,
         "figureComposerLineMarkerFaceColorButton",
     )
@@ -14056,10 +14194,10 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     assert marker_edge_edit is not None
     assert marker_edge_edit.text() == "black"
 
-    color_text_edit = line_page.findChild(
+    color_text_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineColorsEdit"
     )
-    first_color_edit = line_page.findChild(
+    first_color_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineColorItemEdit_0"
     )
     assert color_text_edit is not None
@@ -14081,6 +14219,12 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
 
     operation = tool.tool_status.operations[0]
 
+    tool._select_step_section("other")
+    other_page = tool.step_editor_stack.currentWidget()
+    offset_source_combo = other_page.findChild(
+        QtWidgets.QComboBox, "figureComposerLineOffsetSourceCombo"
+    )
+    assert offset_source_combo is not None
     _activate_combo_text(offset_source_combo, "manual")
     qtbot.waitUntil(
         lambda: (
@@ -14091,27 +14235,27 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
         ),
         timeout=1000,
     )
-    line_page = tool.step_editor_stack.currentWidget()
+    other_page = tool.step_editor_stack.currentWidget()
     assert tool.tool_status.operations[0].line_offset_source == "manual"
     assert tool.tool_status.operations[0].line_offset_scale == 1.0
     assert (
-        line_page.findChild(
+        other_page.findChild(
             QtWidgets.QComboBox, "figureComposerLineOffsetCoordinateCombo"
         )
         is None
     )
     assert (
-        line_page.findChild(
+        other_page.findChild(
             QtWidgets.QDoubleSpinBox, "figureComposerLineOffsetScaleEdit"
         )
         is None
     )
     assert (
-        line_page.findChild(QtWidgets.QLineEdit, "figureComposerLineOffsetsEdit")
+        other_page.findChild(QtWidgets.QLineEdit, "figureComposerLineOffsetsEdit")
         is not None
     )
 
-    offset_source_combo = line_page.findChild(
+    offset_source_combo = other_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineOffsetSourceCombo"
     )
     assert offset_source_combo is not None
@@ -14125,22 +14269,22 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
         ),
         timeout=1000,
     )
-    line_page = tool.step_editor_stack.currentWidget()
+    other_page = tool.step_editor_stack.currentWidget()
     assert tool.tool_status.operations[0].line_offset_source == "index"
     assert (
-        line_page.findChild(
+        other_page.findChild(
             QtWidgets.QComboBox, "figureComposerLineOffsetCoordinateCombo"
         )
         is None
     )
     assert (
-        line_page.findChild(
+        other_page.findChild(
             QtWidgets.QDoubleSpinBox, "figureComposerLineOffsetScaleEdit"
         )
         is not None
     )
     assert (
-        line_page.findChild(QtWidgets.QLineEdit, "figureComposerLineOffsetsEdit")
+        other_page.findChild(QtWidgets.QLineEdit, "figureComposerLineOffsetsEdit")
         is None
     )
     tool._replace_operation(0, operation)
@@ -14276,7 +14420,7 @@ def test_figure_composer_one_profile_per_axis_codegen_executes(qtbot) -> None:
             sources=(FigureSourceState(name="data", label="data"),),
             operations=(
                 FigureOperationState.plot_slices(
-                    label="cuts",
+                    label="selection",
                     sources=("data",),
                     axes=FigureAxesSelectionState(axes=((0, 0), (0, 1), (0, 2))),
                     slice_dim="cut",
@@ -14508,7 +14652,7 @@ def test_figure_composer_line_action_seeds_from_selected_slice_step(
             sources=(FigureSourceState(name="data", label="data"),),
             operations=(
                 FigureOperationState.plot_slices(
-                    label="cuts",
+                    label="selection",
                     sources=("data",),
                     axes=FigureAxesSelectionState(axes=((0, 0), (0, 1), (0, 2))),
                     slice_dim="cut",
@@ -14536,16 +14680,18 @@ def test_figure_composer_line_action_seeds_from_selected_slice_step(
     assert operation.line_selection == {"cut": [0.0, 1.0, 2.0], "cut_width": 0.25}
     assert operation.axes.axes == ((0, 0), (0, 1), (0, 2))
 
-    tool._select_step_section("line")
+    tool._select_step_section("view")
     placement_combo = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QComboBox, "figureComposerProfilePlacementCombo"
     )
+    assert placement_combo is not None
+    assert placement_combo.currentText() == "One profile per axis"
+
+    tool._select_step_section("other")
     normalize_combo = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QComboBox, "figureComposerLineNormalizeCombo"
     )
-    assert placement_combo is not None
     assert normalize_combo is not None
-    assert placement_combo.currentText() == "One profile per axis"
     assert normalize_combo.currentText() == "Each profile by maximum"
     assert "each extracted 1D profile independently" in normalize_combo.toolTip()
 
@@ -14666,7 +14812,7 @@ def test_figure_composer_line_labels_auto_add_axes_legend_step(
     qtbot.addWidget(tool)
 
     tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("line")
+    tool._select_step_section("style")
     labels_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QLineEdit, "figureComposerLineLabelsEdit"
     )
@@ -14721,9 +14867,9 @@ def test_figure_composer_batch_line_edits_update_selected_steps(qtbot) -> None:
     qtbot.addWidget(tool)
 
     _select_operation_rows(tool, (0, 1, 2))
-    tool._select_step_section("line")
-    line_page = tool.step_editor_stack.currentWidget()
-    normalize_combo = line_page.findChild(
+    tool._select_step_section("other")
+    other_page = tool.step_editor_stack.currentWidget()
+    normalize_combo = other_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineNormalizeCombo"
     )
     assert normalize_combo is not None
@@ -14765,9 +14911,9 @@ def test_figure_composer_batch_line_mixed_values_do_not_overwrite_on_blur(
     qtbot.addWidget(tool)
 
     _select_operation_rows(tool, (0, 1))
-    tool._select_step_section("line")
-    line_page = tool.step_editor_stack.currentWidget()
-    color_edit = line_page.findChild(
+    tool._select_step_section("style")
+    style_page = tool.step_editor_stack.currentWidget()
+    color_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineColorsEdit"
     )
     assert color_edit is not None
@@ -14822,9 +14968,9 @@ def test_figure_composer_batch_line_source_dependent_combos_disable(
     qtbot.addWidget(tool)
 
     _select_operation_rows(tool, (0, 1))
-    tool._select_step_section("line")
-    line_page = tool.step_editor_stack.currentWidget()
-    coordinate_combo = line_page.findChild(
+    tool._select_step_section("selection")
+    selection_page = tool.step_editor_stack.currentWidget()
+    coordinate_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileCoordinateCombo"
     )
     assert coordinate_combo is not None
@@ -14871,7 +15017,7 @@ def test_figure_composer_batch_line_labels_add_one_legend_per_axes_group(
     qtbot.addWidget(tool)
 
     _select_operation_rows(tool, (0, 1, 2))
-    tool._select_step_section("line")
+    tool._select_step_section("style")
     labels_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QLineEdit, "figureComposerLineLabelsEdit"
     )
@@ -14907,7 +15053,7 @@ def test_figure_composer_editor_widget_rebuilds_are_deferred(
             sources=(FigureSourceState(name="data", label="data"),),
             operations=(
                 FigureOperationState.plot_slices(
-                    label="cuts",
+                    label="selection",
                     sources=("data",),
                     slice_dim="eV",
                     slice_values=(0.0,),
@@ -14918,7 +15064,7 @@ def test_figure_composer_editor_widget_rebuilds_are_deferred(
     )
     qtbot.addWidget(tool)
     tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("cuts")
+    tool._select_step_section("selection")
     values_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesValuesEdit"
     )
@@ -14994,7 +15140,7 @@ def test_figure_composer_editor_widget_rebuilds_are_deferred(
     assert tool._operation_editor_update_pending is False
 
 
-def test_figure_composer_plot_slices_qsel_kwargs_display_in_cuts(qtbot) -> None:
+def test_figure_composer_plot_slices_qsel_kwargs_display_in_selection(qtbot) -> None:
     data = _figure_composer_image_source("data")
     operation = FigureOperationState.plot_slices(
         label="image",
@@ -15020,18 +15166,18 @@ def test_figure_composer_plot_slices_qsel_kwargs_display_in_cuts(qtbot) -> None:
     qtbot.addWidget(tool)
 
     tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("cuts")
-    cuts_page = tool.step_editor_stack.currentWidget()
-    dimension_combo = cuts_page.findChild(
+    tool._select_step_section("selection")
+    selection_page = tool.step_editor_stack.currentWidget()
+    dimension_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerPlotSlicesDimensionCombo"
     )
-    values_edit = cuts_page.findChild(
+    values_edit = selection_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesValuesEdit"
     )
-    width_edit = cuts_page.findChild(
+    width_edit = selection_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesWidthEdit"
     )
-    slice_kwargs_edit = cuts_page.findChild(
+    slice_kwargs_edit = selection_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesSliceKwargsEdit"
     )
     assert dimension_combo is not None
@@ -15055,7 +15201,7 @@ def test_figure_composer_plot_slices_qsel_kwargs_display_in_cuts(qtbot) -> None:
     assert "beta=slice(-0.5, 0.5)" in code
 
 
-def test_figure_composer_plot_slices_advanced_qsel_kwargs_move_to_cuts(
+def test_figure_composer_plot_slices_advanced_qsel_kwargs_move_to_selection(
     qtbot,
 ) -> None:
     data = _figure_composer_image_source("data")
@@ -15098,7 +15244,7 @@ def test_figure_composer_plot_slices_advanced_qsel_kwargs_move_to_cuts(
         lambda: not tool._operation_editor_update_pending,
         timeout=1000,
     )
-    tool._select_step_section("cuts")
+    tool._select_step_section("selection")
     slice_kwargs_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesSliceKwargsEdit"
     )
@@ -15121,7 +15267,7 @@ def test_figure_composer_retired_editor_widgets_drain_after_popup(
             sources=(FigureSourceState(name="data", label="data"),),
             operations=(
                 FigureOperationState.plot_slices(
-                    label="cuts",
+                    label="selection",
                     sources=("data",),
                     slice_dim="eV",
                     slice_values=(0.0,),
@@ -15132,7 +15278,7 @@ def test_figure_composer_retired_editor_widgets_drain_after_popup(
     )
     qtbot.addWidget(tool)
     tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("cuts")
+    tool._select_step_section("selection")
     old_page = tool.step_editor_stack.currentWidget()
     active_popup: list[QtWidgets.QWidget | None] = [None]
     monkeypatch.setattr(
@@ -15946,9 +16092,9 @@ def test_figure_composer_plot_slices_mixed_image_line_batch_hides_color_controls
         is None
     )
 
-    tool._select_step_section("cuts")
-    cuts_page = tool.step_editor_stack.currentWidget()
-    assert cuts_page.findChild(
+    tool._select_step_section("selection")
+    selection_page = tool.step_editor_stack.currentWidget()
+    assert selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerPlotSlicesDimensionCombo"
     )
 
@@ -16288,13 +16434,15 @@ def test_figure_composer_dict_inputs_prefer_keyword_form(qtbot) -> None:
     assert gradient_kwargs_edit.text() == 'color="C0", alpha=0.25'
 
     _select_operation_rows(tool, (2,))
-    tool._select_step_section("line")
-    line_page = tool.step_editor_stack.currentWidget()
+    tool._select_step_section("selection")
+    selection_page = tool.step_editor_stack.currentWidget()
     assert (
-        line_page.findChild(QtWidgets.QComboBox, "figureComposerProfileReduceCombo")
+        selection_page.findChild(
+            QtWidgets.QComboBox, "figureComposerProfileReduceCombo"
+        )
         is None
     )
-    line_selection_edit = line_page.findChild(
+    line_selection_edit = selection_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineSelectionEdit"
     )
     assert line_selection_edit is not None

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -759,11 +759,38 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
         "Refresh all sources linked to open ImageTools"
     )
 
+    status_before_refresh = (
+        tool.source_status_label.text(),
+        tool.source_status_label.isVisible(),
+    )
     buttons["data_0"].click()
     assert refreshed[-1] == ("one", "data_0")
+    assert (
+        tool.source_status_label.text(),
+        tool.source_status_label.isVisible(),
+    ) == status_before_refresh
 
     tool.refresh_sources_button.click()
     assert refreshed[-1] == ("many", ("data_0",))
+    assert (
+        tool.source_status_label.text(),
+        tool.source_status_label.isVisible(),
+    ) == status_before_refresh
+
+    def refresh_no_sources(names: Sequence[str]) -> int:
+        refreshed.append(("none", tuple(names)))
+        return 0
+
+    tool._set_source_refresh_callbacks(
+        can_refresh_source=can_refresh_source,
+        refresh_source=refresh_source,
+        refresh_sources=refresh_no_sources,
+        source_label=source_label,
+    )
+    tool._set_source_status_text("diagnostic")
+    tool.refresh_sources_button.click()
+    assert refreshed[-1] == ("none", ("data_0",))
+    assert tool.source_status_label.text() == "diagnostic"
 
 
 def test_figure_composer_source_remove_controls_disable_used_sources(qtbot) -> None:
@@ -823,6 +850,11 @@ def test_figure_composer_source_remove_controls_disable_used_sources(qtbot) -> N
     assert set(tool.source_data()) == set(before_source_data)
     assert not tool.remove_source("profile")
     assert not tool.remove_source("missing")
+
+    buttons["unused"].click()
+    assert "unused" not in tool.source_data()
+    assert tool.source_status_label.text() == ""
+    assert tool.source_status_label.isHidden()
 
 
 def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> None:
@@ -13003,6 +13035,78 @@ def test_figure_composer_limit_methods_default_to_current_axis_limits(qtbot) -> 
     assert limits_edit.text() == f"{expected_ylim[0]:g}, {expected_ylim[1]:g}"
 
 
+def test_figure_composer_method_selector_preserves_compatible_values(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=1),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="set_xlabel",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ).model_copy(
+                    update={
+                        "method_args": ("Momentum",),
+                        "method_kwargs": {
+                            "loc": "right",
+                            "labelpad": 3.0,
+                            "fontsize": 12,
+                        },
+                    }
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("method")
+
+    method_page = tool.step_editor_stack.currentWidget()
+    method_combo = method_page.findChild(
+        QtWidgets.QComboBox, "figureComposerAxesMethodCombo"
+    )
+    assert method_combo is not None
+    initial_operation = tool.tool_status.operations[0]
+    method_combo.activated.emit(method_combo.currentIndex())
+    assert tool.tool_status.operations[0] == initial_operation
+
+    ylabel_index = method_combo.findData("set_ylabel")
+    assert ylabel_index >= 0
+    _activate_combo_index(method_combo, ylabel_index)
+    operation = tool.tool_status.operations[0]
+    assert operation.method_name == "set_ylabel"
+    assert operation.method_args == ("Momentum",)
+    assert operation.method_kwargs == {
+        "loc": "top",
+        "labelpad": 3.0,
+        "fontsize": 12,
+    }
+    assert operation.axes == FigureAxesSelectionState(axes=((0, 0),))
+
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+    assert not tool._operation_render_errors
+    assert tool.figure.axes[0].get_ylabel() == "Momentum"
+
+    namespace: dict[str, typing.Any] = {}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    assert namespace["axs"][0, 0].get_ylabel() == "Momentum"
+
+    figurecomposer_method._update_current_method_name(tool, "set_xlim")
+    operation = tool.tool_status.operations[0]
+    assert operation.method_name == "set_xlim"
+    assert operation.method_args != ("Momentum",)
+    assert operation.method_kwargs == {}
+
+
 def test_figure_composer_batch_same_method_edits_selected_steps(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
@@ -19206,7 +19310,8 @@ def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
         xr.testing.assert_identical(source_data["data_1"], updated_second)
         xr.testing.assert_identical(source_data["detached"], detached)
         assert figure_tool.tool_status.operations == operations
-        assert figure_tool.source_status_label.text() == "Refreshed 2 sources."
+        assert figure_tool.source_status_label.text() == ""
+        assert figure_tool.source_status_label.isHidden()
         assert figure_tool._operation_render_errors == {}
         snapshot = manager._workspace_state_snapshot()
         assert figure_uid in snapshot["dirty_data"]

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -563,6 +563,8 @@ def test_figure_composer_plot_slices_source_selector_updates_sources(
     assert set(checks) == {"first_source", "second_source"}
     assert checks["first_source"].checkState() == QtCore.Qt.CheckState.Checked
     assert checks["second_source"].checkState() == QtCore.Qt.CheckState.Unchecked
+    assert tool.source_status_label.text() == ""
+    assert tool.source_status_label.isHidden()
 
     checks["second_source"].setCheckState(QtCore.Qt.CheckState.Checked)
 
@@ -18908,6 +18910,7 @@ def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
 def test_manager_figure_action_add_source_only_keeps_recipe_steps(
     qtbot,
     monkeypatch,
+    tmp_path: Path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -18934,6 +18937,8 @@ def test_manager_figure_action_add_source_only_keeps_recipe_steps(
         figure_tool = manager._child_node(figure_uid).tool_window
         assert isinstance(figure_tool, FigureComposerTool)
         operation_count = len(figure_tool.tool_status.operations)
+        workspace_path = tmp_path / "add-source-only-delta.itws"
+        manager._save_workspace_document(workspace_path, force_full=True)
 
         select_tools(manager, [1])
 
@@ -18974,6 +18979,21 @@ def test_manager_figure_action_add_source_only_keeps_recipe_steps(
             "data_0",
             "data_1",
         }
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid in snapshot["dirty_data"]
+        assert figure_uid in snapshot["dirty_state"]
+
+        manager._save_workspace_document(workspace_path)
+        assert manager._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        loaded_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(loaded_tool, FigureComposerTool)
+        xr.testing.assert_identical(loaded_tool.source_data()["data_1"], second)
 
 
 def test_manager_figure_action_multi_source_append_preserves_panel_colormaps(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -4,7 +4,7 @@ import gc
 import json
 import typing
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import matplotlib as mpl
@@ -306,6 +306,18 @@ def _plot_source_checks(tool: FigureComposerTool) -> dict[str, QtWidgets.QCheckB
         str(source_name): check
         for check in tool.step_source_controls.findChildren(QtWidgets.QCheckBox)
         if (source_name := check.property("figure_source_name")) is not None
+    }
+
+
+def _source_refresh_buttons(
+    tool: FigureComposerTool,
+) -> dict[str, QtWidgets.QToolButton]:
+    return {
+        str(source_name): button
+        for button in tool.source_list.findChildren(
+            QtWidgets.QToolButton, "figureComposerRefreshSourceButton"
+        )
+        if (source_name := button.property("figure_source_name")) is not None
     }
 
 
@@ -616,6 +628,11 @@ def test_figure_composer_source_ui_keeps_aliases_as_internal_keys(qtbot) -> None
     first_item = tool.source_list.topLevelItem(0)
     assert first_item is not None
     assert first_item.data(0, QtCore.Qt.ItemDataRole.UserRole) == "data_0"
+    assert first_item.data(0, QtCore.Qt.ItemDataRole.UserRole + 1) is True
+    assert first_item.font(0).bold()
+    second_item = tool.source_list.topLevelItem(1)
+    assert second_item is not None
+    assert second_item.data(0, QtCore.Qt.ItemDataRole.UserRole + 1) is False
 
     tool._select_step_section("sources")
     checks = _plot_source_checks(tool)
@@ -653,6 +670,88 @@ def test_figure_composer_source_ui_uses_shared_shape_formatter(
     assert calls == [(tuple(str(dim) for dim in data.dims), False, None)]
 
 
+def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
+    qtbot,
+) -> None:
+    image = _figure_composer_image_source("image")
+    profile = _figure_composer_profile_source("profile")
+    tool = FigureComposerTool(
+        image,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=1),
+            sources=(
+                FigureSourceState(
+                    name="data_0",
+                    label="ImageTool 0: image",
+                    node_uid="node-0",
+                ),
+                FigureSourceState(name="profile", label="Detached"),
+            ),
+            operations=(),
+            primary_source="data_0",
+        ),
+        source_data={"data_0": image, "profile": profile},
+    )
+    qtbot.addWidget(tool)
+
+    buttons = _source_refresh_buttons(tool)
+    assert set(buttons) == {"data_0", "profile"}
+    assert buttons["data_0"].property("figure_source_name") == "data_0"
+    assert buttons["data_0"].accessibleName() == "Refresh Source"
+    assert not buttons["data_0"].isEnabled()
+    assert (
+        buttons["data_0"].toolTip() == "This source is not linked to an open ImageTool"
+    )
+    assert tool.refresh_sources_button.accessibleName() == "Refresh Sources"
+    assert not tool.refresh_sources_button.isEnabled()
+    assert tool.refresh_sources_button.toolTip() == (
+        "No sources are linked to open ImageTools"
+    )
+
+    refreshed: list[tuple[str, str | tuple[str, ...]]] = []
+
+    def can_refresh_source(name: str) -> bool:
+        return name == "data_0"
+
+    def refresh_source(name: str) -> bool:
+        refreshed.append(("one", name))
+        return True
+
+    def refresh_sources(names: Sequence[str]) -> int:
+        refreshed.append(("many", tuple(names)))
+        return len(names)
+
+    def source_label(name: str) -> str | None:
+        return "ImageTool 0: image" if name == "data_0" else None
+
+    tool._set_source_refresh_callbacks(
+        can_refresh_source=can_refresh_source,
+        refresh_source=refresh_source,
+        refresh_sources=refresh_sources,
+        source_label=source_label,
+    )
+
+    buttons = _source_refresh_buttons(tool)
+    assert buttons["data_0"].isEnabled()
+    assert buttons["data_0"].toolTip() == (
+        "Refresh “ImageTool 0: image” from ImageTool 0: image"
+    )
+    assert not buttons["profile"].isEnabled()
+    assert buttons["profile"].toolTip() == (
+        "This source is not linked to an open ImageTool"
+    )
+    assert tool.refresh_sources_button.isEnabled()
+    assert tool.refresh_sources_button.toolTip() == (
+        "Refresh all sources linked to open ImageTools"
+    )
+
+    buttons["data_0"].click()
+    assert refreshed[-1] == ("one", "data_0")
+
+    tool.refresh_sources_button.click()
+    assert refreshed[-1] == ("many", ("data_0",))
+
+
 def test_figure_composer_source_display_helpers_keep_alias_secondary() -> None:
     source = FigureSourceState(name="data_0", label="ImageTool 0: sample_map")
     assert (
@@ -678,6 +777,100 @@ def test_figure_composer_source_display_helpers_keep_alias_secondary() -> None:
             disambiguate=True,
         )
         == "ImageTool (data_0)"
+    )
+
+
+def test_figure_composer_replace_source_preserves_alias_and_generated_code(
+    qtbot, monkeypatch
+) -> None:
+    original = _figure_composer_image_source("original")
+    replacement = original.copy(
+        data=np.asarray(original.data) + 10.0,
+        deep=True,
+    )
+    replacement.name = "replacement"
+    old_snapshot_id = "old-snapshot"
+    new_snapshot_id = "new-snapshot"
+    tool = FigureComposerTool(
+        original,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=1),
+            sources=(
+                FigureSourceState(
+                    name="data_0",
+                    label="ImageTool 0: original",
+                    node_uid="old-node",
+                    node_snapshot_token=old_snapshot_id,
+                    provenance_spec={"source": "old"},
+                ),
+            ),
+            operations=(
+                FigureOperationState.plot_slices(
+                    label="plot_slices",
+                    sources=("data_0",),
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                    slice_dim="eV",
+                    slice_values=(0.0,),
+                ),
+                FigureOperationState.line(
+                    label="profile",
+                    source="data_0",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ).model_copy(
+                    update={
+                        "line_selection": {
+                            "eV": 0.0,
+                            "beta": float(original.coords["beta"].values[0]),
+                        },
+                        "line_x": "alpha",
+                    }
+                ),
+            ),
+            primary_source="data_0",
+        ),
+        source_data={"data_0": original},
+    )
+    qtbot.addWidget(tool)
+
+    replaced = tool.replace_source(
+        "data_0",
+        FigureSourceState(
+            name="data_1",
+            label="ImageTool 1: replacement",
+            node_uid="new-node",
+            node_snapshot_token=new_snapshot_id,
+            provenance_spec={"source": "new"},
+        ),
+        replacement,
+    )
+
+    assert replaced is True
+    [source] = tool.source_states()
+    assert source.name == "data_0"
+    assert source.label == "ImageTool 1: replacement"
+    assert source.node_uid == "new-node"
+    assert source.node_snapshot_token == new_snapshot_id
+    assert source.provenance_spec == {"source": "new"}
+    xr.testing.assert_identical(tool.source_data()["data_0"], replacement)
+    assert tool.tool_status.operations[0].sources == ("data_0",)
+    assert tool.tool_status.operations[1].line_source == "data_0"
+
+    _render_figure_composer_rgba(tool)
+    assert tool._operation_render_errors == {}
+
+    captured_maps: list[tuple[xr.DataArray, ...]] = []
+
+    def capture_plot_slices(maps, **_kwargs):
+        captured_maps.append(tuple(maps))
+
+    monkeypatch.setattr(eplt, "plot_slices", capture_plot_slices)
+    exec(tool.generated_code(), {"data_0": replacement})  # noqa: S102
+
+    assert captured_maps
+    captured = captured_maps[0][0]
+    xr.testing.assert_identical(
+        captured,
+        replacement.sel(eV=float(captured.coords["eV"])),
     )
 
 
@@ -17353,12 +17546,19 @@ def test_manager_figure_action_new_target_creates_second_figure(
                 _operation: FigureOperationState | None,
                 *,
                 allow_new_figure: bool = False,
+                source_count: int = 1,
+                selected_figure_uid: str | None = None,
             ) -> None:
                 assert figure_uids == (first_uid,)
                 assert allow_new_figure is True
+                assert source_count == 1
+                assert selected_figure_uid is None
 
             def exec(self) -> QtWidgets.QDialog.DialogCode:
                 return QtWidgets.QDialog.DialogCode.Accepted
+
+            def selected_action(self) -> str:
+                return manager_mainwindow._FIGURE_DIALOG_NEW
 
             def is_new_figure(self) -> bool:
                 return True
@@ -17409,12 +17609,19 @@ def test_manager_figure_action_appends_to_selected_subplots_axes(
                 _operation: FigureOperationState | None,
                 *,
                 allow_new_figure: bool = False,
+                source_count: int = 1,
+                selected_figure_uid: str | None = None,
             ) -> None:
                 assert figure_uids == (figure_uid,)
                 assert allow_new_figure is True
+                assert source_count == 1
+                assert selected_figure_uid is None
 
             def exec(self) -> QtWidgets.QDialog.DialogCode:
                 return QtWidgets.QDialog.DialogCode.Accepted
+
+            def selected_action(self) -> str:
+                return manager_mainwindow._FIGURE_DIALOG_ADD_STEP
 
             def is_new_figure(self) -> bool:
                 return False
@@ -17489,12 +17696,19 @@ def test_manager_figure_action_appends_to_selected_gridspec_axes(
                 _operation: FigureOperationState | None,
                 *,
                 allow_new_figure: bool = False,
+                source_count: int = 1,
+                selected_figure_uid: str | None = None,
             ) -> None:
                 assert figure_uids == (figure_uid,)
                 assert allow_new_figure is True
+                assert source_count == 1
+                assert selected_figure_uid is None
 
             def exec(self) -> QtWidgets.QDialog.DialogCode:
                 return QtWidgets.QDialog.DialogCode.Accepted
+
+            def selected_action(self) -> str:
+                return manager_mainwindow._FIGURE_DIALOG_ADD_STEP
 
             def is_new_figure(self) -> bool:
                 return False
@@ -17965,7 +18179,7 @@ def test_manager_append_to_subplots_figure_uses_axes_selector(
         assert dialog.axes_selection() == FigureAxesSelectionState(axes=((0, 1),))
 
 
-def test_manager_figure_target_dialog_defaults_to_new_figure(
+def test_manager_figure_target_dialog_defaults_to_add_step_without_selected_figure(
     qtbot,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -17992,9 +18206,64 @@ def test_manager_figure_target_dialog_defaults_to_new_figure(
         )
         qtbot.addWidget(dialog)
 
+        assert dialog.selected_action() == manager_mainwindow._FIGURE_DIALOG_ADD_STEP
+        assert not dialog.is_new_figure()
+        assert not dialog.selector_stack.isHidden()
+        assert dialog.selected_target() == (
+            figure_uid,
+            FigureAxesSelectionState(axes=((0, 0), (0, 1))),
+        )
+        button = dialog.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        assert button is not None
+        assert button.isEnabled()
+
+        dialog.action_combo.setCurrentIndex(
+            dialog.action_combo.findData(manager_mainwindow._FIGURE_DIALOG_NEW)
+        )
+
         assert dialog.is_new_figure()
         assert dialog.selector_stack.isHidden()
         assert dialog.selected_target() is None
+        assert button.isEnabled()
+
+
+def test_manager_figure_target_dialog_defaults_to_replace_selected_single_source(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        data = xr.DataArray(np.arange(4.0), dims=("x",), name="line")
+        figure_tool = FigureComposerTool(
+            data,
+            recipe=FigureRecipeState(
+                setup=FigureSubplotsState(nrows=1, ncols=2),
+                sources=(FigureSourceState(name="line", label="Line Source"),),
+                operations=(),
+                primary_source="line",
+            ),
+        )
+        figure_uid = manager.add_figuretool(figure_tool, show=False)
+
+        dialog = manager_mainwindow._AppendFigureTargetDialog(
+            manager,
+            (figure_uid,),
+            None,
+            allow_new_figure=True,
+            source_count=1,
+            selected_figure_uid=figure_uid,
+        )
+        qtbot.addWidget(dialog)
+
+        assert (
+            dialog.selected_action() == manager_mainwindow._FIGURE_DIALOG_REPLACE_SOURCE
+        )
+        assert dialog.is_replace_source()
+        assert dialog.selected_source_alias() == "line"
+        assert "line" in dialog.source_combo.currentText()
+        assert dialog.selector_stack.isHidden()
+        assert not dialog.source_combo.isHidden()
         button = dialog.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
         assert button is not None
         assert button.isEnabled()
@@ -18039,8 +18308,9 @@ def test_manager_figure_target_dialog_switches_and_repairs_axes_selection(
         )
         qtbot.addWidget(dialog)
 
-        assert dialog.is_new_figure()
-        assert dialog.selector_stack.isHidden()
+        assert dialog.selected_action() == manager_mainwindow._FIGURE_DIALOG_ADD_STEP
+        assert not dialog.is_new_figure()
+        assert not dialog.selector_stack.isHidden()
         ok_button = dialog.button_box.button(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
         )
@@ -18067,6 +18337,28 @@ def test_manager_figure_target_dialog_switches_and_repairs_axes_selection(
             FigureAxesSelectionState(axes=((0, 0), (0, 1))),
         )
 
+        dialog.action_combo.setCurrentIndex(
+            dialog.action_combo.findData(manager_mainwindow._FIGURE_DIALOG_ADD_SOURCE)
+        )
+        assert dialog.is_add_source_only()
+        assert dialog.selected_target() is None
+        assert dialog.selector_stack.isHidden()
+        assert ok_button.isEnabled()
+
+        dialog.action_combo.setCurrentIndex(
+            dialog.action_combo.findData(
+                manager_mainwindow._FIGURE_DIALOG_REPLACE_SOURCE
+            )
+        )
+        assert dialog.is_replace_source()
+        assert dialog.selected_source_alias() == "line"
+        assert dialog.selector_stack.isHidden()
+        assert not dialog.source_combo.isHidden()
+        assert ok_button.isEnabled()
+
+        dialog.action_combo.setCurrentIndex(
+            dialog.action_combo.findData(manager_mainwindow._FIGURE_DIALOG_ADD_STEP)
+        )
         dialog.figure_combo.setCurrentIndex(dialog.figure_combo.findData(second_uid))
         assert dialog.axes_selection() == FigureAxesSelectionState(axes=((0, 0),))
 
@@ -18079,6 +18371,46 @@ def test_manager_figure_target_dialog_switches_and_repairs_axes_selection(
 
         dialog.figure_combo.setItemData(dialog.figure_combo.currentIndex(), None)
         assert dialog.figure_uid() == first_uid
+
+
+def test_manager_figure_target_dialog_disables_replace_for_multiple_sources(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        data = xr.DataArray(np.arange(4.0), dims=("x",), name="line")
+        figure_tool = FigureComposerTool(
+            data,
+            recipe=FigureRecipeState(
+                setup=FigureSubplotsState(nrows=1, ncols=1),
+                sources=(FigureSourceState(name="line", label="line"),),
+                operations=(),
+                primary_source="line",
+            ),
+        )
+        figure_uid = manager.add_figuretool(figure_tool, show=False)
+
+        dialog = manager_mainwindow._AppendFigureTargetDialog(
+            manager,
+            (figure_uid,),
+            None,
+            allow_new_figure=True,
+            source_count=2,
+            selected_figure_uid=figure_uid,
+        )
+        qtbot.addWidget(dialog)
+
+        dialog.action_combo.setCurrentIndex(
+            dialog.action_combo.findData(
+                manager_mainwindow._FIGURE_DIALOG_REPLACE_SOURCE
+            )
+        )
+        button = dialog.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        assert button is not None
+        assert not button.isEnabled()
+        assert "one ImageTool source" in dialog.status_label.text()
 
 
 def test_manager_prompt_append_figure_target_auto_and_cancel_paths(
@@ -18356,6 +18688,294 @@ def test_manager_append_operation_uses_axes_dialog_selection(
         assert figure_tool.tool_status.operations[-1].axes.axes == ((0, 1),)
 
 
+def test_manager_figure_action_replace_source_keeps_recipe_steps(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        first = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="first",
+        )
+        second = xr.DataArray(
+            np.arange(4.0, 8.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="second",
+        )
+        itool(first, manager=True)
+        itool(second, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        operation_count = len(figure_tool.tool_status.operations)
+
+        select_tools(manager, [1])
+
+        class FakeReplaceDialog:
+            def __init__(
+                self,
+                _manager: erlab.interactive.imagetool.manager.ImageToolManager,
+                figure_uids: tuple[str, ...],
+                _operation: FigureOperationState | None,
+                *,
+                allow_new_figure: bool = False,
+                source_count: int = 1,
+                selected_figure_uid: str | None = None,
+            ) -> None:
+                assert figure_uids == (figure_uid,)
+                assert allow_new_figure is True
+                assert source_count == 1
+                assert selected_figure_uid is None
+
+            def exec(self) -> QtWidgets.QDialog.DialogCode:
+                return QtWidgets.QDialog.DialogCode.Accepted
+
+            def selected_action(self) -> str:
+                return manager_mainwindow._FIGURE_DIALOG_REPLACE_SOURCE
+
+            def figure_uid(self) -> str:
+                return figure_uid
+
+            def selected_source_alias(self) -> str:
+                return "data_0"
+
+        monkeypatch.setattr(
+            manager_mainwindow, "_AppendFigureTargetDialog", FakeReplaceDialog
+        )
+
+        manager.create_figure_action.trigger()
+
+        assert len(figure_tool.tool_status.operations) == operation_count
+        xr.testing.assert_identical(figure_tool.source_data()["data_0"], second)
+        [source] = figure_tool.source_states()
+        assert source.name == "data_0"
+        assert source.node_uid == manager._node_for_target(1).uid
+        assert "data_1" not in figure_tool.source_data()
+
+
+def test_manager_figure_source_row_refresh_updates_only_selected_source(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        first = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="first",
+        )
+        second = xr.DataArray(
+            np.arange(4.0, 8.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="second",
+        )
+        itool(first, manager=True)
+        itool(second, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0, 1), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        original_second = figure_tool.source_data()["data_1"]
+        operations = figure_tool.tool_status.operations
+        manager._mark_workspace_clean()
+
+        updated_first = first.copy(data=np.asarray(first.data) + 100.0, deep=True)
+        updated_first.name = "first updated"
+        updated_second = second.copy(data=np.asarray(second.data) + 200.0, deep=True)
+        updated_second.name = "second updated"
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            itool(updated_first, manager=True, replace=0)
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            itool(updated_second, manager=True, replace=1)
+
+        buttons = _source_refresh_buttons(figure_tool)
+        assert buttons["data_0"].isEnabled()
+        assert buttons["data_1"].isEnabled()
+        with qtbot.wait_signal(figure_tool.sigDataChanged, timeout=5000):
+            buttons["data_0"].click()
+
+        source_data = figure_tool.source_data()
+        xr.testing.assert_identical(source_data["data_0"], updated_first)
+        xr.testing.assert_identical(source_data["data_1"], original_second)
+        [source_0, source_1] = figure_tool.source_states()
+        assert source_0.name == "data_0"
+        assert source_0.node_uid == manager._node_for_target(0).uid
+        assert source_1.name == "data_1"
+        assert figure_tool.tool_status.operations == operations
+        assert "data_0" in figure_tool.generated_code()
+
+        _render_figure_composer_rgba(figure_tool)
+        namespace = _exec_generated_code(
+            figure_tool.generated_code(),
+            {"data_0": updated_first, "data_1": original_second},
+        )
+        assert isinstance(namespace["fig"], Figure)
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid in snapshot["dirty_data"]
+        assert figure_uid in snapshot["dirty_state"]
+
+        manager.remove_imagetool(0)
+        buttons = _source_refresh_buttons(figure_tool)
+        assert not buttons["data_0"].isEnabled()
+        assert (
+            buttons["data_0"].toolTip()
+            == "This source is not linked to an open ImageTool"
+        )
+
+
+def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        first = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="first",
+        )
+        second = xr.DataArray(
+            np.arange(4.0, 8.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="second",
+        )
+        detached = xr.DataArray(
+            np.array([1.0, 2.0]),
+            dims=("x",),
+            coords={"x": [0.0, 1.0]},
+            name="detached",
+        )
+        itool(first, manager=True)
+        itool(second, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0, 1), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        figure_tool.add_sources(
+            (FigureSourceState(name="detached", label="Detached"),),
+            {"detached": detached},
+        )
+        operations = figure_tool.tool_status.operations
+        manager._mark_workspace_clean()
+
+        updated_first = first.copy(data=np.asarray(first.data) + 100.0, deep=True)
+        updated_first.name = "first updated"
+        updated_second = second.copy(data=np.asarray(second.data) + 200.0, deep=True)
+        updated_second.name = "second updated"
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            itool(updated_first, manager=True, replace=0)
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            itool(updated_second, manager=True, replace=1)
+
+        buttons = _source_refresh_buttons(figure_tool)
+        assert buttons["data_0"].isEnabled()
+        assert buttons["data_1"].isEnabled()
+        assert not buttons["detached"].isEnabled()
+        assert figure_tool.refresh_sources_button.isEnabled()
+        figure_tool.refresh_sources_button.click()
+
+        source_data = figure_tool.source_data()
+        xr.testing.assert_identical(source_data["data_0"], updated_first)
+        xr.testing.assert_identical(source_data["data_1"], updated_second)
+        xr.testing.assert_identical(source_data["detached"], detached)
+        assert figure_tool.tool_status.operations == operations
+        assert figure_tool.source_status_label.text() == "Refreshed 2 sources."
+        assert figure_tool._operation_render_errors == {}
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid in snapshot["dirty_data"]
+        assert figure_uid in snapshot["dirty_state"]
+
+
+def test_manager_figure_action_add_source_only_keeps_recipe_steps(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        first = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="first",
+        )
+        second = xr.DataArray(
+            np.arange(4.0, 8.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="second",
+        )
+        itool(first, manager=True)
+        itool(second, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        operation_count = len(figure_tool.tool_status.operations)
+
+        select_tools(manager, [1])
+
+        class FakeSourceOnlyDialog:
+            def __init__(
+                self,
+                _manager: erlab.interactive.imagetool.manager.ImageToolManager,
+                figure_uids: tuple[str, ...],
+                _operation: FigureOperationState | None,
+                *,
+                allow_new_figure: bool = False,
+                source_count: int = 1,
+                selected_figure_uid: str | None = None,
+            ) -> None:
+                assert figure_uids == (figure_uid,)
+                assert allow_new_figure is True
+                assert source_count == 1
+                assert selected_figure_uid is None
+
+            def exec(self) -> QtWidgets.QDialog.DialogCode:
+                return QtWidgets.QDialog.DialogCode.Accepted
+
+            def selected_action(self) -> str:
+                return manager_mainwindow._FIGURE_DIALOG_ADD_SOURCE
+
+            def figure_uid(self) -> str:
+                return figure_uid
+
+        monkeypatch.setattr(
+            manager_mainwindow, "_AppendFigureTargetDialog", FakeSourceOnlyDialog
+        )
+
+        manager.create_figure_action.trigger()
+
+        assert len(figure_tool.tool_status.operations) == operation_count
+        xr.testing.assert_identical(figure_tool.source_data()["data_1"], second)
+        assert {source.name for source in figure_tool.source_states()} == {
+            "data_0",
+            "data_1",
+        }
+
+
 def test_manager_figure_action_multi_source_append_preserves_panel_colormaps(
     qtbot,
     monkeypatch,
@@ -18403,12 +19023,19 @@ def test_manager_figure_action_multi_source_append_preserves_panel_colormaps(
                 _operation: FigureOperationState | None,
                 *,
                 allow_new_figure: bool = False,
+                source_count: int = 1,
+                selected_figure_uid: str | None = None,
             ) -> None:
                 assert figure_uids == (figure_uid,)
                 assert allow_new_figure is True
+                assert source_count == 2
+                assert selected_figure_uid is None
 
             def exec(self) -> QtWidgets.QDialog.DialogCode:
                 return QtWidgets.QDialog.DialogCode.Accepted
+
+            def selected_action(self) -> str:
+                return manager_mainwindow._FIGURE_DIALOG_ADD_STEP
 
             def is_new_figure(self) -> bool:
                 return False

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -469,6 +469,7 @@ def test_remove_imagetool_removes_childtools() -> None:
     uid = "child-uid-0"
     removed_uids: list[str] = []
     removed_rows: list[int] = []
+    refresh_calls: list[None] = []
 
     class _DummyWrapper:
         def __init__(self):
@@ -492,6 +493,7 @@ def test_remove_imagetool_removes_childtools() -> None:
         _mark_removed_subtree_dirty=lambda _uid: None,
         _remove_uid_target=lambda child_uid: removed_uids.append(child_uid),
         _refresh_dependency_dependents=lambda _uid: None,
+        _refresh_figure_source_controls=lambda: refresh_calls.append(None),
         tree_view=types.SimpleNamespace(
             imagetool_removed=lambda index: removed_rows.append(index)
         ),
@@ -500,6 +502,7 @@ def test_remove_imagetool_removes_childtools() -> None:
     ImageToolManager.remove_imagetool(manager, 0)
     assert removed_uids == [uid]
     assert removed_rows == [0]
+    assert refresh_calls == [None]
     assert wrapper.disposed
     assert wrapper.deleted
     assert manager._tool_graph.root_wrappers == {}

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -24,7 +24,7 @@ import erlab.interactive.imagetool._itool as itool_mod
 import erlab.interactive.imagetool._mainwindow as imagetool_mainwindow
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state
-from erlab.interactive._figurecomposer import FigureOperationKind
+from erlab.interactive._figurecomposer import FigureOperationKind, FigureOperationState
 from erlab.interactive.derivative import DerivativeTool, dtool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
 from erlab.interactive.imagetool import ImageTool, itool, provenance
@@ -1555,9 +1555,7 @@ def test_plot_with_matplotlib_executes_in_manager(qtbot, monkeypatch) -> None:
     win.close()
 
 
-def test_plot_with_matplotlib_rejects_non_identifier_selection_dim(
-    qtbot, monkeypatch
-) -> None:
+def test_plot_with_matplotlib_accepts_spaced_selection_dim(qtbot, monkeypatch) -> None:
     data = xr.DataArray(
         np.arange(125).reshape((5, 5, 5)),
         dims=("alpha", "eV", "Track Shift"),
@@ -1607,10 +1605,14 @@ def test_plot_with_matplotlib_rejects_non_identifier_selection_dim(
 
     main_image.plot_with_matplotlib()
 
-    assert created == []
-    assert len(warnings_shown) == 1
-    assert warnings_shown[0][0] is win.slicer_area
-    assert "editable plot_slices" in warnings_shown[0][2]
+    assert len(created) == 1
+    assert warnings_shown == []
+    operation = created[0]["operation"]
+    assert isinstance(operation, FigureOperationState)
+    assert operation.kind == FigureOperationKind.PLOT_SLICES
+    assert operation.slice_dim == "Track Shift"
+    assert operation.slice_values == (2.0,)
+    assert operation.map_selections == ()
 
     win.close()
 
@@ -3290,6 +3292,55 @@ def test_image_child_from_gaussian_filtered_itool_keeps_display_provenance(
     assert display_code is not None
     namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
     xarray.testing.assert_identical(namespace["derived"], expected)
+
+    child.close()
+    win.close()
+
+
+def test_image_open_in_new_window_preserves_spaced_qsel_dimension(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 2, 2),
+        dims=("Track Shift", "kx", "ky"),
+        coords={
+            "Track Shift": [0.0, 1.0, 2.0],
+            "kx": [0.0, 1.0],
+            "ky": [0.0, 1.0],
+        },
+        name="map",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    image = win.slicer_area.images[2]
+    win.slicer_area.set_value(axis=0, value=1.0, cursor=0)
+    expected = image.current_data
+    source_spec = image.make_tool_source_spec()
+    xarray.testing.assert_identical(
+        source_spec.apply(data).rename(None),
+        expected.rename(None),
+    )
+
+    image.open_in_new_window()
+    qtbot.wait_until(
+        lambda: isinstance(win.slicer_area._associated_tools_list[-1], ImageTool),
+        timeout=5000,
+    )
+    child = typing.cast("ImageTool", win.slicer_area._associated_tools_list[-1])
+
+    xarray.testing.assert_identical(
+        child.slicer_area.data.rename(None),
+        expected.rename(None),
+    )
+    assert child.provenance_spec is not None
+    display_code = child.provenance_spec.display_code()
+    assert display_code is not None
+    assert "qsel({" in display_code
+    assert "Track Shift" in display_code
+    namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
+    xarray.testing.assert_identical(
+        namespace["derived"].rename(None),
+        expected.rename(None),
+    )
 
     child.close()
     win.close()

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -25,6 +25,9 @@ import erlab.interactive.imagetool._mainwindow as imagetool_mainwindow
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state
 from erlab.interactive._figurecomposer import FigureOperationKind, FigureOperationState
+from erlab.interactive._figurecomposer._exceptions import (
+    FigureComposerPlotSlicesSelectionError,
+)
 from erlab.interactive.derivative import DerivativeTool, dtool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
 from erlab.interactive.imagetool import ImageTool, itool, provenance
@@ -1613,6 +1616,40 @@ def test_plot_with_matplotlib_accepts_spaced_selection_dim(qtbot, monkeypatch) -
     assert operation.slice_dim == "Track Shift"
     assert operation.slice_values == (2.0,)
     assert operation.map_selections == ()
+
+    win.close()
+
+
+def test_figure_composer_operation_reports_uneditable_plot_slices_details(
+    qtbot, monkeypatch
+) -> None:
+    win = itool(_TEST_DATA["3D"], execute=False)
+    qtbot.addWidget(win)
+    main_image = win.slicer_area.images[0]
+
+    cases = (
+        (
+            ({("bad", "key"): 0.0}, None, None, set()),
+            "Unsupported qsel selection keys: ('bad', 'key')",
+        ),
+        (
+            ({"beta": 0.0}, ["data.qsel(beta=0.0)"], None, {"beta"}),
+            "Selection requires per-cursor expressions",
+        ),
+        (
+            (None, None, None, set()),
+            "Selection did not produce qsel coordinates",
+        ),
+    )
+    for plan, detail in cases:
+        monkeypatch.setattr(
+            main_image,
+            "_multicursor_selection_plan",
+            lambda _plan=plan, **_kwargs: _plan,
+        )
+        with pytest.raises(FigureComposerPlotSlicesSelectionError) as exc_info:
+            main_image.figure_composer_operation(source_name="data")
+        assert detail in str(exc_info.value)
 
     win.close()
 


### PR DESCRIPTION
## Summary
- Improve Figure Composer integration across ImageTool and the manager window
- Tighten exception handling and plot-item behavior for composer-driven interactions
- Add coverage for manager and ImageTool paths that exercise the updated flow

## Testing
- Added targeted tests for Figure Composer manager behavior and ImageTool integration
- Existing validation for the touched paths passes at a high level; no additional manual UI checks were requested