### PR TITLE
Fix explorer preview worker shutdown handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,8 +193,6 @@ jobs:
           PYTEST_QT_API=${{ matrix.qt-api }} QT_API=${{ matrix.qt-api }} \
             uv run pytest \
             -m compat \
-            -n auto \
-            --dist=loadgroup \
             -o faulthandler_timeout=300 \
             --junitxml "junit-smoke-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
             -o junit_family=legacy \

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -8,6 +8,7 @@ further analysis.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import pathlib
 import stat
@@ -544,6 +545,9 @@ class _ReprFetcher(QtCore.QRunnable):
         self, file_path: str | pathlib.Path, load_method, include_values: bool
     ) -> None:
         super().__init__()
+        # The explorer keeps Python references and sends the worker through queued
+        # signals, so Qt must not delete the QRunnable out from under the wrapper.
+        self.setAutoDelete(False)
         self.signals = _ReprFetcherSignals()
         self.file_path = pathlib.Path(file_path)
         self.load_method = load_method
@@ -1312,9 +1316,17 @@ class _DataExplorer(QtWidgets.QMainWindow):
             worker.abort()
         self._preview_threadpool.clear()
         if self._preview_threadpool.waitForDone(timeout_ms):
+            for worker in tuple(self._preview_workers):
+                self._disconnect_preview_worker(worker)
             self._preview_workers.clear()
             return True
         return False
+
+    def _disconnect_preview_worker(self, worker: _ReprFetcher) -> None:
+        with contextlib.suppress(TypeError, RuntimeError):
+            worker.signals.fetched.disconnect(self._show_file_info)
+        with contextlib.suppress(TypeError, RuntimeError):
+            worker.signals.finished.disconnect(self._preview_worker_finished)
 
     def _delete_when_preview_workers_done(self) -> None:
         self._preview_threadpool.clear()
@@ -1329,7 +1341,10 @@ class _DataExplorer(QtWidgets.QMainWindow):
         self.deleteLater()
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
-        self._stop_preview_workers()
+        if not self._stop_preview_workers():
+            if event is not None:
+                event.ignore()
+            return
         super().closeEvent(event)
 
     @property
@@ -1459,6 +1474,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
     @QtCore.Slot(object)
     def _preview_worker_finished(self, worker: object) -> None:
         if isinstance(worker, _ReprFetcher):
+            self._disconnect_preview_worker(worker)
             self._preview_workers.discard(worker)
 
     @QtCore.Slot(str, str, object)

--- a/src/erlab/interactive/explorer/_tabbed_explorer.py
+++ b/src/erlab/interactive/explorer/_tabbed_explorer.py
@@ -256,14 +256,19 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
         if tab is not None:
             tab.deleteLater()
 
-    def _stop_preview_workers(self) -> None:
+    def _stop_preview_workers(self) -> bool:
+        stopped = True
         for index in range(self.tab_widget.count()):
             explorer = self.get_explorer(index)
             if explorer is not None:
-                explorer._stop_preview_workers()
+                stopped = explorer._stop_preview_workers() and stopped
+        return stopped
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
-        self._stop_preview_workers()
+        if not self._stop_preview_workers():
+            if event is not None:
+                event.ignore()
+            return
         super().closeEvent(event)
 
     @QtCore.Slot()

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -56,6 +56,17 @@ class _PreviewTrackingTabbedExplorer(_TabbedExplorer):
         self.tab_widget.setCurrentIndex(self.tab_widget.count() - 1)
 
 
+class _DeferredPreviewTrackingTabbedExplorer(_TabbedExplorer):
+    def add_tab(self, **kwargs) -> None:
+        tab = QtWidgets.QWidget()
+        explorer = _DeferredPreviewTrackingExplorer(
+            f"tab-{self.tab_widget.count()}", parent=tab
+        )
+        tab._explorer = explorer  # type: ignore[attr-defined]
+        self.tab_widget.addTab(tab, explorer.current_directory.name)
+        self.tab_widget.setCurrentIndex(self.tab_widget.count() - 1)
+
+
 def test_explorer_last_tab_closes_without_manager(qtbot, tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(erlab.interactive.imagetool.manager, "_manager_instance", None)
 
@@ -157,6 +168,21 @@ def test_tabbed_explorer_close_stops_preview_workers_without_removing_tabs(
     assert explorer.stopped_preview_workers == 1
 
 
+def test_tabbed_explorer_close_ignores_busy_preview_workers(qtbot) -> None:
+    win = _DeferredPreviewTrackingTabbedExplorer()
+    qtbot.addWidget(win)
+    explorer = win.current_explorer
+    assert isinstance(explorer, _DeferredPreviewTrackingExplorer)
+    event = QtGui.QCloseEvent()
+
+    win.closeEvent(event)
+
+    assert not event.isAccepted()
+    assert win.tab_widget.count() == 1
+    assert win.current_explorer is explorer
+    assert explorer.stopped_preview_workers == 1
+
+
 def test_explorer_close_stops_preview_workers(
     qtbot, example_loader, example_data_dir: pathlib.Path
 ) -> None:
@@ -165,9 +191,11 @@ def test_explorer_close_stops_preview_workers(
             self.stopped_preview_workers = False
             super().__init__(*args, **kwargs)
 
-        def _stop_preview_workers(self) -> None:
+        def _stop_preview_workers(
+            self, timeout_ms: int = _PREVIEW_WORKER_STOP_TIMEOUT_MS
+        ) -> bool:
             self.stopped_preview_workers = True
-            super()._stop_preview_workers()
+            return super()._stop_preview_workers(timeout_ms)
 
     explorer = _TrackingDataExplorer(root_path=example_data_dir, loader_name="example")
     qtbot.addWidget(explorer)
@@ -175,6 +203,30 @@ def test_explorer_close_stops_preview_workers(
     explorer.closeEvent(QtGui.QCloseEvent())
 
     assert explorer.stopped_preview_workers
+
+
+def test_explorer_close_ignores_busy_preview_workers(
+    qtbot, example_loader, example_data_dir: pathlib.Path
+) -> None:
+    class _BusyDataExplorer(_DataExplorer):
+        def __init__(self, *args, **kwargs) -> None:
+            self.stopped_preview_workers = False
+            super().__init__(*args, **kwargs)
+
+        def _stop_preview_workers(
+            self, timeout_ms: int = _PREVIEW_WORKER_STOP_TIMEOUT_MS
+        ) -> bool:
+            self.stopped_preview_workers = True
+            return False
+
+    explorer = _BusyDataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    event = QtGui.QCloseEvent()
+
+    explorer.closeEvent(event)
+
+    assert explorer.stopped_preview_workers
+    assert not event.isAccepted()
 
 
 def test_tabbed_explorer_show_path_adds_selected_file_tab(
@@ -419,6 +471,14 @@ def test_repr_fetcher_aborted_before_run_skips_loader(
     assert events == ["finished"]
 
 
+def test_repr_fetcher_keeps_python_ownership_until_finished(
+    tmp_path: pathlib.Path,
+) -> None:
+    worker = _ReprFetcher(tmp_path / "data.h5", object(), include_values=False)
+
+    assert not worker.autoDelete()
+
+
 def test_repr_fetcher_aborted_after_load_skips_formatting(
     tmp_path: pathlib.Path,
     monkeypatch,
@@ -507,6 +567,9 @@ def test_explorer_preview_worker_finished_removes_worker(
         def __init__(self, worker: _ReprFetcher) -> None:
             self._preview_workers = {worker}
 
+        def _disconnect_preview_worker(self, worker: _ReprFetcher) -> None:
+            return None
+
     worker = _ReprFetcher(tmp_path / "data.h5", object(), include_values=False)
     explorer = _ExplorerDouble(worker)
 
@@ -514,6 +577,33 @@ def test_explorer_preview_worker_finished_removes_worker(
         typing.cast("_DataExplorer", explorer), worker
     )
     assert explorer._preview_workers == set()
+
+
+def test_explorer_preview_worker_finished_disconnects_worker_signals(
+    qtbot,
+    example_loader,
+    example_data_dir: pathlib.Path,
+) -> None:
+    class _TrackingDataExplorer(_DataExplorer):
+        def __init__(self, *args, **kwargs) -> None:
+            self.preview_calls: list[tuple[str, str, object]] = []
+            super().__init__(*args, **kwargs)
+
+        def _show_file_info(self, file_path: str, text: str, data: object) -> None:
+            self.preview_calls.append((file_path, text, data))
+
+    explorer = _TrackingDataExplorer(root_path=example_data_dir, loader_name="example")
+    qtbot.addWidget(explorer)
+    worker = _ReprFetcher(example_data_dir / "data_001.h5", object(), False)
+    worker.signals.fetched.connect(explorer._show_file_info)
+    worker.signals.finished.connect(explorer._preview_worker_finished)
+    explorer._preview_workers.add(worker)
+
+    explorer._preview_worker_finished(worker)
+    worker.signals.fetched.emit(str(worker.file_path), "preview", None)
+
+    assert explorer._preview_workers == set()
+    assert explorer.preview_calls == []
 
 
 def test_explorer_delete_when_preview_workers_done_deletes_immediately(

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -182,6 +182,10 @@ def test_tabbed_explorer_close_ignores_busy_preview_workers(qtbot) -> None:
     assert win.current_explorer is explorer
     assert explorer.stopped_preview_workers == 1
 
+    win.closeEvent(None)
+
+    assert explorer.stopped_preview_workers == 2
+
 
 def test_explorer_close_stops_preview_workers(
     qtbot, example_loader, example_data_dir: pathlib.Path
@@ -227,6 +231,11 @@ def test_explorer_close_ignores_busy_preview_workers(
 
     assert explorer.stopped_preview_workers
     assert not event.isAccepted()
+
+    explorer.stopped_preview_workers = False
+    explorer.closeEvent(None)
+
+    assert explorer.stopped_preview_workers
 
 
 def test_tabbed_explorer_show_path_adds_selected_file_tab(
@@ -539,6 +548,44 @@ def test_explorer_stop_preview_workers_aborts_with_bounded_wait(
     assert (
         explorer._preview_threadpool.wait_timeout_ms == _PREVIEW_WORKER_STOP_TIMEOUT_MS
     )
+
+
+def test_explorer_stop_preview_workers_disconnects_finished_workers(
+    tmp_path: pathlib.Path,
+) -> None:
+    class _FakeThreadPool:
+        def __init__(self) -> None:
+            self.clear_called = False
+            self.wait_timeout_ms: int | None = None
+
+        def clear(self) -> None:
+            self.clear_called = True
+
+        def waitForDone(self, timeout_ms: int) -> bool:
+            self.wait_timeout_ms = timeout_ms
+            return True
+
+    class _ExplorerDouble:
+        def __init__(self, worker: _ReprFetcher) -> None:
+            self._preview_stopping = False
+            self._preview_workers = {worker}
+            self._preview_threadpool = _FakeThreadPool()
+            self.disconnected_workers: list[_ReprFetcher] = []
+
+        def _disconnect_preview_worker(self, worker: _ReprFetcher) -> None:
+            self.disconnected_workers.append(worker)
+
+    worker = _ReprFetcher(tmp_path / "data.h5", object(), include_values=False)
+    explorer = _ExplorerDouble(worker)
+
+    assert _DataExplorer._stop_preview_workers(typing.cast("_DataExplorer", explorer))
+    assert worker._aborted.is_set()
+    assert explorer._preview_threadpool.clear_called
+    assert (
+        explorer._preview_threadpool.wait_timeout_ms == _PREVIEW_WORKER_STOP_TIMEOUT_MS
+    )
+    assert explorer.disconnected_workers == [worker]
+    assert explorer._preview_workers == set()
 
 
 def test_explorer_selection_change_ignores_stopping_preview() -> None:


### PR DESCRIPTION
## Summary
- keep preview QRunnables alive until queued signals finish
- disconnect preview worker signals before dropping references
- ignore close requests while preview workers are still running
- remove the Qt smoke-job xdist flags that were contributing to hangs

## Testing
- Added unit tests for worker ownership, signal disconnection, and busy-close behavior
- Added tabbed and single explorer coverage for close handling