### PR TITLE
Add concatenate replace support in ImageTool manager

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -400,6 +400,12 @@ class _ConcatDialog(QtWidgets.QDialog):
         layout.addWidget(button_box)
 
     def open(self) -> None:
+        self._result_combo.setCurrentIndex(
+            self._result_combo.findData(self._RESULT_NEW)
+        )
+        self._sources_combo.setCurrentIndex(
+            self._sources_combo.findData(self._SOURCES_KEEP)
+        )
         self._refresh_selected_targets()
         super().open()
 
@@ -502,7 +508,9 @@ class _ConcatDialog(QtWidgets.QDialog):
             try:
                 selected = list(self._selected_targets)
                 to_concat = [
-                    manager.get_imagetool(idx).slicer_area.displayed_data
+                    manager.get_imagetool(idx)
+                    .slicer_area.persistence_data_and_state()[0]
+                    .copy(deep=False)
                     for idx in selected
                 ]
                 concat_kwargs = self.concat_kwargs()
@@ -515,6 +523,7 @@ class _ConcatDialog(QtWidgets.QDialog):
                         selected,
                         operation_label="Concatenate selected ImageTools",
                         operation_code=operation_code,
+                        use_displayed_provenance=False,
                     )
                 else:
                     replacement_node = manager._node_for_target(replacement_target)
@@ -525,9 +534,10 @@ class _ConcatDialog(QtWidgets.QDialog):
                             operation_label="Concatenate selected ImageTools",
                             operation_code=operation_code,
                             detached_input_uid=replacement_node.uid,
+                            use_displayed_provenance=False,
                         ),
                         propagate_descendants=True,
-                        preserve_filter=True,
+                        preserve_filter=False,
                     )
                     manager.tree_view.refresh(replacement_node.uid)
                     if manager._metadata_node_uid == replacement_node.uid:

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -314,6 +314,11 @@ class _BatchOperationDialog(QtWidgets.QDialog):
 
 
 class _ConcatDialog(QtWidgets.QDialog):
+    _RESULT_NEW = "new"
+    _RESULT_REPLACE = "replace"
+    _SOURCES_KEEP = "keep"
+    _SOURCES_REMOVE = "remove"
+
     def __init__(self, manager: ImageToolManager) -> None:
         super().__init__(manager)
         self.setWindowTitle("Concatenate Selected Tools")
@@ -321,6 +326,7 @@ class _ConcatDialog(QtWidgets.QDialog):
         self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, False)
         self._manager = weakref.ref(manager)
+        self._selected_targets: list[int | str] = []
 
         layout = QtWidgets.QVBoxLayout(self)
         self.setLayout(layout)
@@ -367,8 +373,19 @@ class _ConcatDialog(QtWidgets.QDialog):
         docs_label.setOpenExternalLinks(True)
         option_layout.addRow(docs_label)
 
-        self._remove_original_check = QtWidgets.QCheckBox("Remove Originals")
-        self._remove_original_check.setChecked(False)
+        self._result_combo = QtWidgets.QComboBox()
+        self._result_combo.addItem("Open as New ImageTool", self._RESULT_NEW)
+        self._result_combo.addItem("Replace Source Tool", self._RESULT_REPLACE)
+        self._result_combo.currentIndexChanged.connect(self._update_result_controls)
+        option_layout.addRow("Result", self._result_combo)
+
+        self._replace_target_combo = QtWidgets.QComboBox()
+        option_layout.addRow("Replace", self._replace_target_combo)
+
+        self._sources_combo = QtWidgets.QComboBox()
+        self._sources_combo.addItem("Keep Source Tools", self._SOURCES_KEEP)
+        self._sources_combo.addItem("Remove Source Tools", self._SOURCES_REMOVE)
+        option_layout.addRow("Sources", self._sources_combo)
 
         button_box = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
@@ -380,8 +397,48 @@ class _ConcatDialog(QtWidgets.QDialog):
 
         # Populate layout
         layout.addWidget(option_group)
-        layout.addWidget(self._remove_original_check)
         layout.addWidget(button_box)
+
+    def open(self) -> None:
+        self._refresh_selected_targets()
+        super().open()
+
+    def _refresh_selected_targets(self) -> None:
+        manager = self._manager()
+        self._selected_targets = (
+            [] if manager is None else list(manager._selected_imagetool_targets())
+        )
+        current_target = self._replace_target_combo.currentData()
+        self._replace_target_combo.clear()
+        if manager is not None:
+            for target in self._selected_targets:
+                node = manager._node_for_target(target)
+                self._replace_target_combo.addItem(node.display_text, target)
+
+        current_index = self._replace_target_combo.findData(current_target)
+        if current_index >= 0:
+            self._replace_target_combo.setCurrentIndex(current_index)
+        self._update_result_controls()
+
+    @QtCore.Slot()
+    @QtCore.Slot(int)
+    def _update_result_controls(self, *_args: object) -> None:
+        replace_selected = self.result_mode() == self._RESULT_REPLACE
+        self._replace_target_combo.setEnabled(replace_selected)
+
+    def result_mode(self) -> str:
+        value = self._result_combo.currentData()
+        return self._RESULT_NEW if value is None else str(value)
+
+    def sources_mode(self) -> str:
+        value = self._sources_combo.currentData()
+        return self._SOURCES_KEEP if value is None else str(value)
+
+    def replacement_target(self) -> int | str | None:
+        if self.result_mode() != self._RESULT_REPLACE:
+            return None
+        value = self._replace_target_combo.currentData()
+        return typing.cast("int | str | None", value)
 
     def concat_kwargs(self) -> dict[str, typing.Any]:
         return {
@@ -392,35 +449,91 @@ class _ConcatDialog(QtWidgets.QDialog):
             "combine_attrs": self._combine_attrs_combo.currentText(),
         }
 
+    def _operation_code(
+        self, manager: ImageToolManager, selected: list[int | str]
+    ) -> str:
+        concat_kwargs = self.concat_kwargs()
+        input_names = [
+            manager._script_input_name_for_node(manager._node_for_target(target))
+            for target in selected
+        ]
+        return (
+            f"derived = xr.concat([{', '.join(input_names)}], "
+            + ", ".join(f"{key}={value!r}" for key, value in concat_kwargs.items())
+            + ")"
+        )
+
+    def _remove_source_targets(
+        self,
+        manager: ImageToolManager,
+        selected: list[int | str],
+        *,
+        preserved_target: int | str | None = None,
+    ) -> None:
+        if self.sources_mode() != self._SOURCES_REMOVE:
+            return
+
+        preserved_uid = (
+            None
+            if preserved_target is None
+            else manager._node_for_target(preserved_target).uid
+        )
+        preserved_subtree_uids = (
+            set()
+            if preserved_uid is None
+            else set(manager._tool_graph.subtree_uids(preserved_uid))
+        )
+        to_remove: list[int | str] = []
+        for target in selected:
+            node = manager._node_for_target(target)
+            if node.uid in preserved_subtree_uids:
+                continue
+            if (
+                preserved_uid is not None
+                and preserved_uid in manager._tool_graph.subtree_uids(node.uid)
+            ):
+                continue
+            to_remove.append(target)
+        manager._remove_imagetools(to_remove)
+
     def accept(self) -> None:
         manager = self._manager()
         if manager is not None:  # pragma: no branch
             try:
-                selected = list(manager._selected_imagetool_targets())
+                selected = list(self._selected_targets)
                 to_concat = [
                     manager.get_imagetool(idx).slicer_area.displayed_data
                     for idx in selected
                 ]
                 concat_kwargs = self.concat_kwargs()
-                input_names = [
-                    manager._script_input_name_for_node(
-                        manager._node_for_target(target)
+                operation_code = self._operation_code(manager, selected)
+                result_data = xr.concat(to_concat, **concat_kwargs)
+                replacement_target = self.replacement_target()
+                if replacement_target is None:
+                    created_index = manager._show_multi_input_script_result(
+                        result_data,
+                        selected,
+                        operation_label="Concatenate selected ImageTools",
+                        operation_code=operation_code,
                     )
-                    for target in selected
-                ]
-                operation_code = (
-                    f"derived = xr.concat([{', '.join(input_names)}], "
-                    + ", ".join(
-                        f"{key}={value!r}" for key, value in concat_kwargs.items()
+                else:
+                    replacement_node = manager._node_for_target(replacement_target)
+                    replacement_node.replace_with_detached_data(
+                        result_data,
+                        manager._multi_input_script_provenance(
+                            selected,
+                            operation_label="Concatenate selected ImageTools",
+                            operation_code=operation_code,
+                            detached_input_uid=replacement_node.uid,
+                        ),
+                        propagate_descendants=True,
+                        preserve_filter=True,
                     )
-                    + ")"
-                )
-                created_index = manager._show_multi_input_script_result(
-                    xr.concat(to_concat, **concat_kwargs),
-                    selected,
-                    operation_label="Concatenate selected ImageTools",
-                    operation_code=operation_code,
-                )
+                    manager.tree_view.refresh(replacement_node.uid)
+                    if manager._metadata_node_uid == replacement_node.uid:
+                        manager._set_metadata_node(replacement_node)
+                    manager._sigDataReplaced.emit()
+                    created_index = replacement_target
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(
                     self,
@@ -434,16 +547,12 @@ class _ConcatDialog(QtWidgets.QDialog):
                         "Error",
                         "An error occurred while concatenating data.",
                     )
-                elif self._remove_original_check.isChecked():
-                    for index in sorted(
+                else:
+                    self._remove_source_targets(
+                        manager,
                         selected,
-                        key=str,
-                        reverse=True,
-                    ):
-                        if isinstance(index, int):
-                            manager.remove_imagetool(index)
-                        else:
-                            manager._remove_childtool(index)
+                        preserved_target=replacement_target,
+                    )
         super().accept()
 
 

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -222,7 +222,10 @@ class _LineageController:
         return f"data_{suffix}"
 
     def _script_input_for_node(
-        self, node: _ImageToolWrapper | _ManagedWindowNode
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        *,
+        detached_input_uid: str | None = None,
     ) -> provenance.ScriptInput:
         displayed_provenance = node.displayed_provenance_spec
         provenance_spec = (
@@ -236,6 +239,12 @@ class _LineageController:
             label = node.display_text
         if isinstance(node, _ImageToolWrapper) and node.name:
             label += f": {node.name}"
+        if node.uid == detached_input_uid:
+            return provenance.ScriptInput(
+                name=self._manager._script_input_name_for_node(node),
+                label=label,
+                provenance_spec=provenance_spec,
+            )
         return provenance.ScriptInput(
             name=self._manager._script_input_name_for_node(node),
             label=label,
@@ -252,6 +261,7 @@ class _LineageController:
         operation_code: str,
         active_name: str = "derived",
         start_label: str = "Run ImageTool manager action",
+        detached_input_uid: str | None = None,
     ) -> provenance.ToolProvenanceSpec:
         return provenance.script(
             provenance.ScriptCodeOperation(
@@ -262,7 +272,8 @@ class _LineageController:
             active_name=active_name,
             script_inputs=tuple(
                 self._manager._script_input_for_node(
-                    self._manager._node_for_target(target)
+                    self._manager._node_for_target(target),
+                    detached_input_uid=detached_input_uid,
                 )
                 for target in input_targets
             ),

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -226,11 +226,16 @@ class _LineageController:
         node: _ImageToolWrapper | _ManagedWindowNode,
         *,
         detached_input_uid: str | None = None,
+        use_displayed_provenance: bool = True,
     ) -> provenance.ScriptInput:
-        displayed_provenance = node.displayed_provenance_spec
+        input_provenance = (
+            node.displayed_provenance_spec
+            if use_displayed_provenance
+            else node.provenance_spec
+        )
         provenance_spec = (
-            displayed_provenance.model_dump(mode="json")
-            if displayed_provenance is not None
+            input_provenance.model_dump(mode="json")
+            if input_provenance is not None
             else None
         )
         if isinstance(node, _ImageToolWrapper):
@@ -262,6 +267,7 @@ class _LineageController:
         active_name: str = "derived",
         start_label: str = "Run ImageTool manager action",
         detached_input_uid: str | None = None,
+        use_displayed_provenance: bool = True,
     ) -> provenance.ToolProvenanceSpec:
         return provenance.script(
             provenance.ScriptCodeOperation(
@@ -274,6 +280,7 @@ class _LineageController:
                 self._manager._script_input_for_node(
                     self._manager._node_for_target(target),
                     detached_input_uid=detached_input_uid,
+                    use_displayed_provenance=use_displayed_provenance,
                 )
                 for target in input_targets
             ),
@@ -286,6 +293,7 @@ class _LineageController:
         *,
         operation_label: str,
         operation_code: str,
+        use_displayed_provenance: bool = True,
     ) -> int | None:
         input_targets = tuple(input_targets)
         tool = erlab.interactive.itool(data, manager=False, execute=False)
@@ -299,6 +307,7 @@ class _LineageController:
                 input_targets,
                 operation_label=operation_label,
                 operation_code=operation_code,
+                use_displayed_provenance=use_displayed_provenance,
             ),
         )
 

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3211,10 +3211,12 @@ class ImageToolManager(_ImageToolManagerBase):
         node: _ImageToolWrapper | _ManagedWindowNode,
         *,
         detached_input_uid: str | None = None,
+        use_displayed_provenance: bool = True,
     ) -> provenance.ScriptInput:
         return self._lineage_controller._script_input_for_node(
             node,
             detached_input_uid=detached_input_uid,
+            use_displayed_provenance=use_displayed_provenance,
         )
 
     def _multi_input_script_provenance(
@@ -3226,6 +3228,7 @@ class ImageToolManager(_ImageToolManagerBase):
         active_name: str = "derived",
         start_label: str = "Run ImageTool manager action",
         detached_input_uid: str | None = None,
+        use_displayed_provenance: bool = True,
     ) -> provenance.ToolProvenanceSpec:
         return self._lineage_controller._multi_input_script_provenance(
             input_targets,
@@ -3234,6 +3237,7 @@ class ImageToolManager(_ImageToolManagerBase):
             active_name=active_name,
             start_label=start_label,
             detached_input_uid=detached_input_uid,
+            use_displayed_provenance=use_displayed_provenance,
         )
 
     def _show_multi_input_script_result(
@@ -3243,12 +3247,14 @@ class ImageToolManager(_ImageToolManagerBase):
         *,
         operation_label: str,
         operation_code: str,
+        use_displayed_provenance: bool = True,
     ) -> int | None:
         return self._lineage_controller._show_multi_input_script_result(
             data,
             input_targets,
             operation_label=operation_label,
             operation_code=operation_code,
+            use_displayed_provenance=use_displayed_provenance,
         )
 
     def _script_provenance_inputs_current(

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3207,9 +3207,15 @@ class ImageToolManager(_ImageToolManagerBase):
         return self._lineage_controller._script_input_name_for_node(node)
 
     def _script_input_for_node(
-        self, node: _ImageToolWrapper | _ManagedWindowNode
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        *,
+        detached_input_uid: str | None = None,
     ) -> provenance.ScriptInput:
-        return self._lineage_controller._script_input_for_node(node)
+        return self._lineage_controller._script_input_for_node(
+            node,
+            detached_input_uid=detached_input_uid,
+        )
 
     def _multi_input_script_provenance(
         self,
@@ -3219,6 +3225,7 @@ class ImageToolManager(_ImageToolManagerBase):
         operation_code: str,
         active_name: str = "derived",
         start_label: str = "Run ImageTool manager action",
+        detached_input_uid: str | None = None,
     ) -> provenance.ToolProvenanceSpec:
         return self._lineage_controller._multi_input_script_provenance(
             input_targets,
@@ -3226,6 +3233,7 @@ class ImageToolManager(_ImageToolManagerBase):
             operation_code=operation_code,
             active_name=active_name,
             start_label=start_label,
+            detached_input_uid=detached_input_uid,
         )
 
     def _show_multi_input_script_result(

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -2007,7 +2007,9 @@ def test_manager_concat_records_dependencies_and_handles_removed_inputs(
         )
 
         def _remove_originals(dialog: _ConcatDialog) -> None:
-            dialog._remove_original_check.setChecked(True)
+            dialog._sources_combo.setCurrentIndex(
+                dialog._sources_combo.findData(_ConcatDialog._SOURCES_REMOVE)
+            )
 
         accept_dialog(manager.concat_action.trigger, pre_call=_remove_originals)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
@@ -2019,6 +2021,190 @@ def test_manager_concat_records_dependencies_and_handles_removed_inputs(
         xr.testing.assert_identical(
             manager.get_imagetool(3).slicer_area.data,
             expected_removed_inputs,
+        )
+
+
+def test_manager_concat_can_replace_source_tool_and_preserve_children(
+    qtbot,
+    accept_dialog,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 10.0
+    expected = xr.concat(
+        [data0, data1],
+        dim="concat_dim",
+        coords="minimal",
+        compat="override",
+        join="outer",
+        combine_attrs="override",
+    ).assign_coords(concat_dim=np.arange(2))
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        old_root_provenance = provenance.full_data()
+        manager._tool_graph.root_wrappers[0].set_detached_provenance(
+            old_root_provenance
+        )
+
+        compatible_child = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(data0.copy(deep=True), manager=False, execute=False),
+        )
+        incompatible_child = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(data0.transpose("y", "x"), manager=False, execute=False),
+        )
+        compatible_uid = manager.add_imagetool_child(
+            compatible_child,
+            0,
+            source_spec=provenance.full_data(),
+            source_auto_update=True,
+            show=False,
+        )
+        incompatible_uid = manager.add_imagetool_child(
+            incompatible_child,
+            0,
+            source_spec=provenance.full_data(
+                provenance.TransposeOperation(dims=("y", "x"))
+            ),
+            source_auto_update=True,
+            show=False,
+        )
+
+        select_tools(manager, [0, 1])
+
+        def _replace_first_source(dialog: _ConcatDialog) -> None:
+            assert dialog.result_mode() == _ConcatDialog._RESULT_NEW
+            assert dialog.sources_mode() == _ConcatDialog._SOURCES_KEEP
+            assert not dialog._replace_target_combo.isEnabled()
+
+            dialog._result_combo.setCurrentIndex(
+                dialog._result_combo.findData(_ConcatDialog._RESULT_REPLACE)
+            )
+            assert dialog._replace_target_combo.isEnabled()
+            dialog._replace_target_combo.setCurrentIndex(
+                dialog._replace_target_combo.findData(0)
+            )
+
+        accept_dialog(manager.concat_action.trigger, pre_call=_replace_first_source)
+        qtbot.wait_until(
+            lambda: manager.get_imagetool(compatible_uid).slicer_area.data.identical(
+                expected
+            ),
+            timeout=5000,
+        )
+
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+        xr.testing.assert_identical(manager.get_imagetool(1).slicer_area.data, data1)
+        assert compatible_uid in manager._tool_graph.root_wrappers[0]._childtool_indices
+        assert (
+            incompatible_uid in manager._tool_graph.root_wrappers[0]._childtool_indices
+        )
+
+        compatible_node = manager._child_node(compatible_uid)
+        incompatible_node = manager._child_node(incompatible_uid)
+        assert compatible_node.source_state == "fresh"
+        assert incompatible_node.source_state == "unavailable"
+        xr.testing.assert_identical(
+            manager.get_imagetool(incompatible_uid).slicer_area.data,
+            data0.transpose("y", "x"),
+        )
+
+        replacement_wrapper = manager._tool_graph.root_wrappers[0]
+        replacement_provenance = replacement_wrapper.provenance_spec
+        assert replacement_provenance is not None
+        assert manager.dependency_status_for_uid(replacement_wrapper.uid) == "current"
+        assert [source.node_uid for source in replacement_provenance.script_inputs] == [
+            None,
+            manager._tool_graph.root_wrappers[1].uid,
+        ]
+        assert [
+            source.node_snapshot_token
+            for source in replacement_provenance.script_inputs
+        ] == [
+            None,
+            manager._tool_graph.root_wrappers[1].snapshot_token,
+        ]
+        assert (
+            replacement_provenance.script_inputs[0].parsed_provenance_spec()
+            == old_root_provenance
+        )
+
+
+def test_manager_concat_replace_can_remove_unpreserved_sources(
+    qtbot,
+    accept_dialog,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+    )
+    data1 = data0 + 10.0
+    expected = xr.concat(
+        [data0, data1],
+        dim="concat_dim",
+        coords="minimal",
+        compat="override",
+        join="outer",
+        combine_attrs="override",
+    ).assign_coords(concat_dim=np.arange(2))
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data0, data1], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        child = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(data0.copy(deep=True), manager=False, execute=False),
+        )
+        child_uid = manager.add_imagetool_child(
+            child,
+            0,
+            source_spec=provenance.full_data(),
+            source_auto_update=True,
+            show=False,
+        )
+
+        select_tools(manager, [0, 1])
+
+        def _replace_first_source_and_remove_others(dialog: _ConcatDialog) -> None:
+            dialog._result_combo.setCurrentIndex(
+                dialog._result_combo.findData(_ConcatDialog._RESULT_REPLACE)
+            )
+            dialog._replace_target_combo.setCurrentIndex(
+                dialog._replace_target_combo.findData(0)
+            )
+            dialog._sources_combo.setCurrentIndex(
+                dialog._sources_combo.findData(_ConcatDialog._SOURCES_REMOVE)
+            )
+
+        accept_dialog(
+            manager.concat_action.trigger,
+            pre_call=_replace_first_source_and_remove_others,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        assert list(manager._tool_graph.root_wrappers) == [0]
+        assert child_uid in manager._tool_graph.nodes
+        assert child_uid in manager._tool_graph.root_wrappers[0]._childtool_indices
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+        xr.testing.assert_identical(
+            manager.get_imagetool(child_uid).slicer_area.data,
+            expected,
         )
 
 

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -2037,6 +2037,10 @@ def test_manager_concat_can_replace_source_tool_and_preserve_children(
         coords={"x": np.arange(2), "y": np.arange(2)},
     )
     data1 = data0 + 10.0
+    operation = erlab.interactive.imagetool.provenance.NormalizeOperation(
+        dims=("x",),
+        mode="min",
+    )
     expected = xr.concat(
         [data0, data1],
         dim="concat_dim",
@@ -2053,6 +2057,10 @@ def test_manager_concat_can_replace_source_tool_and_preserve_children(
         old_root_provenance = provenance.full_data()
         manager._tool_graph.root_wrappers[0].set_detached_provenance(
             old_root_provenance
+        )
+        manager.get_imagetool(0).slicer_area.apply_filter_operation(
+            operation,
+            emit_edited=True,
         )
 
         compatible_child = typing.cast(
@@ -2104,6 +2112,7 @@ def test_manager_concat_can_replace_source_tool_and_preserve_children(
         )
 
         xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+        assert not manager.get_imagetool(0).slicer_area.has_active_filter
         xr.testing.assert_identical(manager.get_imagetool(1).slicer_area.data, data1)
         assert compatible_uid in manager._tool_graph.root_wrappers[0]._childtool_indices
         assert (
@@ -2138,6 +2147,20 @@ def test_manager_concat_can_replace_source_tool_and_preserve_children(
             replacement_provenance.script_inputs[0].parsed_provenance_spec()
             == old_root_provenance
         )
+
+        dialog = manager._actions_controller._concat_dialog
+        dialog._result_combo.setCurrentIndex(
+            dialog._result_combo.findData(_ConcatDialog._RESULT_REPLACE)
+        )
+        dialog._sources_combo.setCurrentIndex(
+            dialog._sources_combo.findData(_ConcatDialog._SOURCES_REMOVE)
+        )
+        select_tools(manager, [0, 1])
+        dialog.open()
+        assert dialog.result_mode() == _ConcatDialog._RESULT_NEW
+        assert dialog.sources_mode() == _ConcatDialog._SOURCES_KEEP
+        assert not dialog._replace_target_combo.isEnabled()
+        dialog.reject()
 
 
 def test_manager_concat_replace_can_remove_unpreserved_sources(
@@ -2208,7 +2231,7 @@ def test_manager_concat_replace_can_remove_unpreserved_sources(
         )
 
 
-def test_manager_concat_uses_filtered_display_data(
+def test_manager_concat_uses_unfiltered_source_data(
     qtbot,
     accept_dialog,
     manager_context: Callable[
@@ -2225,7 +2248,6 @@ def test_manager_concat_uses_filtered_display_data(
         dims=("x",),
         mode="min",
     )
-    filtered0 = operation.apply(data0, parent_data=data0)
 
     with manager_context() as manager:
         manager.show()
@@ -2237,7 +2259,7 @@ def test_manager_concat_uses_filtered_display_data(
             emit_edited=True,
         )
         expected = xr.concat(
-            [filtered0, data1],
+            [data0, data1],
             dim="concat_dim",
             coords="minimal",
             compat="override",
@@ -2252,15 +2274,7 @@ def test_manager_concat_uses_filtered_display_data(
         xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, expected)
         provenance = manager._tool_graph.root_wrappers[2].provenance_spec
         assert provenance is not None
-        first_input_spec = provenance.script_inputs[0].parsed_provenance_spec()
-        assert first_input_spec is not None
-        first_input_code = first_input_spec.display_code()
-        assert first_input_code is not None
-        namespace = _exec_generated_code(
-            first_input_code,
-            {"data": data0.copy(deep=True)},
-        )
-        xr.testing.assert_identical(namespace["derived"], filtered0)
+        assert provenance.script_inputs[0].parsed_provenance_spec() is None
 
 
 def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -2321,7 +2321,9 @@ def test_manager(
         select_tools(manager, [1, 2])
 
         def _handle_concat(dialog: _ConcatDialog):
-            dialog._remove_original_check.setChecked(True)
+            dialog._sources_combo.setCurrentIndex(
+                dialog._sources_combo.findData(_ConcatDialog._SOURCES_REMOVE)
+            )
 
         accept_dialog(manager.concat_action.trigger, pre_call=_handle_concat)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)


### PR DESCRIPTION
## Summary
- Add a concatenate dialog mode that can replace an existing source tool instead of always creating a new result
- Preserve provenance for replaced tools and keep descendant updates working through the detached input path
- Keep the existing remove-sources behavior, with source removal now respecting the preserved replacement target
- Update manager dialog tests to cover replacing a source tool and removing unpreserved sources

## Testing
- Added unit/UI coverage for the new replace workflow, including child preservation and source removal behavior
- Updated existing concat dialog tests to use the new controls