### PR TITLE
Fix child ImageTool reload shortcuts

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -706,7 +706,12 @@ class ImageToolManager(_ImageToolManagerBase):
         self.create_figure_action.setIcon(QtGui.QIcon.fromTheme("insert-image"))
 
         self.reload_action = QtWidgets.QAction("Reload Data", self)
+        self.reload_action.setObjectName("manager_reload_data_action")
         self.reload_action.triggered.connect(self.reload_selected)
+        self.reload_action.setShortcut(QtGui.QKeySequence.StandardKey.Refresh)
+        self.reload_action.setShortcutContext(
+            QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
         self.reload_action.setToolTip(
             "Reload selected data from its saved files, parent, or inputs"
         )
@@ -777,6 +782,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self.file_menu.addSeparator()
         self.file_menu.addAction(self.remove_action)
         self.file_menu.addAction(self.offload_action)
+        self.file_menu.addAction(self.reload_action)
         self.file_menu.addSeparator()
         self.file_menu.addAction(self.settings_action)
 

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1959,22 +1959,40 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def reloadable(self) -> bool:
         """Check if the displayed data can be reloaded.
 
-        Direct file-backed windows reload from their stored loader. Detached
-        file-rooted provenance reloads by replaying its self-contained code.
-        Managed script-derived ImageTools reload through the manager from their
-        recorded inputs.
+        Managed child ImageTools reload through the manager when they can refresh
+        from a reloadable ancestor. Direct file-backed windows reload from their
+        stored loader. Detached file-rooted provenance reloads by replaying its
+        self-contained code. Managed script-derived ImageTools reload through the
+        manager from their recorded inputs.
 
         Returns
         -------
         bool
             `True` if the data can be reloaded, `False` otherwise.
         """
-        if self._direct_reloadable() or self._provenance_reloadable():
+        if (
+            self._managed_source_chain_reload_target() is not None
+            or self._direct_reloadable()
+            or self._provenance_reloadable()
+        ):
             return True
         manager = self._manager_instance if self._in_manager else None
         return manager is not None and manager._script_reload_from_slicer_area(
             self, execute=False
         )
+
+    def _managed_source_chain_reload_target(
+        self,
+    ) -> tuple[erlab.interactive.imagetool.manager.ImageToolManager, str] | None:
+        manager = self._manager_instance if self._in_manager else None
+        if manager is None:
+            return None
+        target = manager.target_from_slicer_area(self)
+        if not isinstance(target, str):
+            return None
+        if manager._reload_target_for_child(target) is None:
+            return None
+        return manager, target
 
     def _direct_reloadable(self) -> bool:
         """Return whether direct file metadata can reload the current source."""
@@ -2050,6 +2068,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     def _reload(self) -> bool:
         """Reload the displayed data and return whether the reload succeeded."""
+        managed_reload = self._managed_source_chain_reload_target()
+        if managed_reload is not None:
+            manager, target = managed_reload
+            return manager._reload_source_chain_for_child(target)
         if self._direct_reloadable() or self._provenance_reloadable():
             try:
                 data, kwargs = self._fetch_reload_data()

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -2949,6 +2949,16 @@ def test_manager_reload_selected_preserves_manual_child_imagetool_name(
         manager.tree_view.clearSelection()
         select_child_tool(manager, child_uid)
         manager._update_actions()
+        refresh_key = QtGui.QKeySequence(QtGui.QKeySequence.StandardKey.Refresh)
+        assert (
+            manager.reload_action.shortcut().matches(refresh_key)
+            == QtGui.QKeySequence.SequenceMatch.ExactMatch
+        )
+        assert (
+            manager.reload_action.shortcutContext()
+            == QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
+        assert manager.reload_action in manager.file_menu.actions()
         assert manager.reload_action.isVisible()
 
         with qtbot.wait_signal(child_tool.slicer_area.sigDataChanged, timeout=5000):
@@ -2965,6 +2975,63 @@ def test_manager_reload_selected_preserves_manual_child_imagetool_name(
         xr.testing.assert_identical(
             fetch(child_uid), updated.rename("manual child name")
         )
+
+
+def test_managed_child_imagetool_file_menu_reload_refreshes_file_parent(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = xr.DataArray(
+        np.arange(24, dtype=float).reshape((6, 4)),
+        dims=["x", "y"],
+        coords={"x": np.arange(6), "y": np.arange(4)},
+        name="scan",
+    )
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            source,
+            manager=True,
+            file_path=file_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child_tool = itool(source.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=provenance.full_data(),
+            source_auto_update=False,
+        )
+
+        child_menu_bar = typing.cast(
+            "erlab.interactive.imagetool._mainwindow.ItoolMenuBar",
+            child_tool.menuBar(),
+        )
+        child_file_menu = child_menu_bar.menu_dict["fileMenu"]
+        child_file_menu.aboutToShow.emit()
+        assert child_tool.slicer_area.reload_act.isVisible()
+
+        updated = (source + 75.0).rename("reloaded_scan")
+        updated.to_netcdf(file_path, engine="h5netcdf")
+
+        with qtbot.wait_signal(child_tool.slicer_area.sigDataChanged, timeout=5000):
+            child_tool.slicer_area.reload_act.trigger()
+
+        assert manager._child_node(child_uid).source_state == "fresh"
+        xr.testing.assert_identical(fetch(0), updated)
+        xr.testing.assert_identical(fetch(child_uid), updated)
 
 
 def test_manager_workspace_reload_preserves_manual_root_name(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -3034,6 +3034,34 @@ def test_managed_child_imagetool_file_menu_reload_refreshes_file_parent(
         xr.testing.assert_identical(fetch(child_uid), updated)
 
 
+def test_imagetool_source_chain_reload_target_falls_back_without_managed_source(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    standalone_tool = itool(test_data, manager=False, execute=False)
+    assert isinstance(standalone_tool, erlab.interactive.imagetool.ImageTool)
+    assert standalone_tool.slicer_area._managed_source_chain_reload_target() is None
+    assert not standalone_tool.slicer_area._reload()
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        root_tool = manager.get_imagetool(0)
+        assert root_tool.slicer_area._managed_source_chain_reload_target() is None
+
+        child_tool = itool(test_data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool_child(child_tool, 0, show=False)
+        assert child_tool.slicer_area._managed_source_chain_reload_target() is None
+
+
 def test_manager_workspace_reload_preserves_manual_root_name(
     qtbot,
     tmp_path: pathlib.Path,


### PR DESCRIPTION
## Summary
- add the standard Refresh shortcut and menu-bar placement to the manager Reload Data action
- route managed child ImageTool reload commands through the manager source-chain reload path when a reloadable ancestor exists
- cover manager action discoverability and child ImageTool file-menu reload behavior

## Root cause
Manager-owned child reloads were split across two actions: the manager context menu had the source-chain reload action, while child ImageTool windows exposed their own slicer reload action. The manager action was not in the menu bar and had no shortcut, so Refresh from a child window could miss the manager-managed reload path.

## Validation
- `uv run ruff format --check src/erlab/interactive/imagetool/manager/_mainwindow.py src/erlab/interactive/imagetool/viewer.py tests/interactive/imagetool/manager/test_mainwindow.py`
- `uv run ruff check src/erlab/interactive/imagetool/manager/_mainwindow.py src/erlab/interactive/imagetool/viewer.py tests/interactive/imagetool/manager/test_mainwindow.py`
- `uv run pytest tests/interactive/imagetool/manager/test_mainwindow.py -k reload`
- `uv run pytest tests/interactive/imagetool/manager/test_mainwindow.py`
- `uv run mypy src/erlab/interactive/imagetool/viewer.py src/erlab/interactive/imagetool/manager/_mainwindow.py`