### PR TITLE
Allow editing replayable script provenance steps

### DIFF
--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -1053,8 +1053,6 @@ def _structured_operation_from_script_code(
     *,
     current_name: str | None,
 ) -> ToolProvenanceOperation:
-    if not _operation_is(operation, "script_code"):
-        return operation
     if current_name is None:
         return operation
     code = getattr(operation, "code", None)
@@ -2699,8 +2697,6 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         def with_scope(
             row: _ProvenanceDisplayRow,
         ) -> _ProvenanceDisplayRow:
-            if scope == "display":
-                return row
             return replace(
                 row,
                 scope=scope,

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -221,6 +221,8 @@ class _ProvenanceDisplayRow:
     edit_ref: _ProvenanceStepRef | None = None
     replay_ref: _ProvenanceStepRef | None = None
     scope: typing.Literal["display", "source"] = "display"
+    children: tuple[_ProvenanceDisplayRow, ...] = ()
+    script_input_path: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -2468,12 +2470,36 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         recorded replay steps available through :meth:`derivation_entries`.
         """
 
+        def with_scope(
+            row: _ProvenanceDisplayRow,
+        ) -> _ProvenanceDisplayRow:
+            if scope == "display":
+                return row
+            return replace(
+                row,
+                scope=scope,
+                children=tuple(with_scope(child) for child in row.children),
+            )
+
         def scoped_rows(
             rows: list[_ProvenanceDisplayRow],
         ) -> list[_ProvenanceDisplayRow]:
             if scope == "display":
                 return rows
-            return [replace(row, scope=scope) for row in rows]
+            return [with_scope(row) for row in rows]
+
+        def input_history_rows(
+            rows: list[_ProvenanceDisplayRow],
+            path: tuple[int, ...],
+        ) -> tuple[_ProvenanceDisplayRow, ...]:
+            return tuple(
+                replace(
+                    row,
+                    script_input_path=path + row.script_input_path,
+                    children=input_history_rows(row.children, path),
+                )
+                for row in rows
+            )
 
         start_ref = _ProvenanceStepRef("file_load" if self.kind == "file" else "start")
         rows = [
@@ -2485,19 +2511,28 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         ]
 
         if self.kind == "script":
-            rows.extend(
-                _ProvenanceDisplayRow(
-                    DerivationEntry(
-                        f"Use {script_input.name} from {script_input.label}",
-                        None,
-                        False,
-                    ),
-                    replay_ref=_ProvenanceStepRef(
-                        "script_input", script_input_index=index
-                    ),
+            for index, script_input in enumerate(self.script_inputs):
+                rows.append(
+                    _ProvenanceDisplayRow(
+                        DerivationEntry(
+                            f"Use {script_input.name} from {script_input.label}",
+                            None,
+                            False,
+                        ),
+                        replay_ref=_ProvenanceStepRef(
+                            "script_input", script_input_index=index
+                        ),
+                        children=(
+                            ()
+                            if (input_spec := script_input.parsed_provenance_spec())
+                            is None
+                            else input_history_rows(
+                                input_spec.display_rows(),
+                                (index,),
+                            )
+                        ),
+                    )
                 )
-                for index, script_input in enumerate(self.script_inputs)
-            )
             rows.extend(
                 _ProvenanceDisplayRow(
                     operation.derivation_entry(),

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -2489,7 +2489,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             return [with_scope(row) for row in rows]
 
         def input_history_rows(
-            rows: list[_ProvenanceDisplayRow],
+            rows: Sequence[_ProvenanceDisplayRow],
             path: tuple[int, ...],
         ) -> tuple[_ProvenanceDisplayRow, ...]:
             return tuple(

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -893,6 +893,168 @@ def _operation_instance(op: str, **kwargs: typing.Any) -> ToolProvenanceOperatio
     return _operation_type(op)(**kwargs)
 
 
+_UNPARSED_LITERAL = object()
+
+
+def _literal_node_value(node: ast.AST) -> typing.Any:
+    try:
+        return ast.literal_eval(node)
+    except (SyntaxError, TypeError, ValueError):
+        pass
+
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "slice"
+        and len(node.args) <= 3
+        and not node.keywords
+    ):
+        values = [_literal_node_value(arg) for arg in node.args]
+        if any(value is _UNPARSED_LITERAL for value in values):
+            return _UNPARSED_LITERAL
+        return slice(*values)
+
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "array"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in {"np", "numpy"}
+        and len(node.args) == 1
+        and not node.keywords
+    ):
+        value = _literal_node_value(node.args[0])
+        if value is _UNPARSED_LITERAL:
+            return _UNPARSED_LITERAL
+        return np.asarray(value)
+
+    return _UNPARSED_LITERAL
+
+
+def _literal_call_args_kwargs(
+    call: ast.Call,
+) -> tuple[tuple[typing.Any, ...], dict[str, typing.Any]] | None:
+    args = tuple(_literal_node_value(arg) for arg in call.args)
+    if any(value is _UNPARSED_LITERAL for value in args):
+        return None
+    kwargs: dict[str, typing.Any] = {}
+    for call_keyword in call.keywords:
+        if call_keyword.arg is None:
+            return None
+        value = _literal_node_value(call_keyword.value)
+        if value is _UNPARSED_LITERAL:
+            return None
+        kwargs[call_keyword.arg] = value
+    return args, kwargs
+
+
+def _receiver_path(node: ast.AST) -> tuple[str, tuple[str, ...]] | None:
+    if isinstance(node, ast.Name):
+        return node.id, ()
+    if isinstance(node, ast.Attribute):
+        resolved = _receiver_path(node.value)
+        if resolved is None:
+            return None
+        receiver_name, path = resolved
+        return receiver_name, (*path, node.attr)
+    return None
+
+
+def _operation_from_self_assignment_call(
+    target_name: str,
+    call: ast.Call,
+) -> ToolProvenanceOperation | None:
+    parsed_args = _literal_call_args_kwargs(call)
+    if parsed_args is None:
+        return None
+    args, kwargs = parsed_args
+
+    if (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr in {"mean", "min", "max", "sum"}
+        and not args
+        and not kwargs
+        and isinstance(call.func.value, ast.Call)
+        and isinstance(call.func.value.func, ast.Attribute)
+        and call.func.value.func.attr == "coarsen"
+        and isinstance(call.func.value.func.value, ast.Name)
+        and call.func.value.func.value.id == target_name
+    ):
+        parsed_coarsen_args = _literal_call_args_kwargs(call.func.value)
+        if parsed_coarsen_args is None:
+            return None
+        coarsen_args, coarsen_kwargs = parsed_coarsen_args
+        return operation_from_console_call(
+            ConsoleCall(
+                dataarray_method="coarsen",
+                args=coarsen_args,
+                kwargs={**coarsen_kwargs, "_reducer": call.func.attr},
+                display_code=ast.unparse(call),
+                has_extra_tracked_inputs=False,
+            )
+        )
+
+    if not isinstance(call.func, ast.Attribute):
+        return None
+    receiver = _receiver_path(call.func.value)
+    if receiver is None:
+        return None
+    receiver_name, accessor_path = receiver
+    if receiver_name != target_name:
+        return None
+
+    operation = operation_from_console_call(
+        ConsoleCall(
+            dataarray_method=call.func.attr if not accessor_path else None,
+            accessor_path=(*accessor_path, call.func.attr) if accessor_path else (),
+            args=args,
+            kwargs=kwargs,
+            display_code=ast.unparse(call),
+            has_extra_tracked_inputs=False,
+        )
+    )
+    if operation is not None:
+        return operation
+    if accessor_path:
+        return None
+    return operation_from_console_call(
+        ConsoleCall(
+            accessor_path=(call.func.attr,),
+            args=args,
+            kwargs=kwargs,
+            display_code=ast.unparse(call),
+            has_extra_tracked_inputs=False,
+        )
+    )
+
+
+def _structured_operation_from_script_code(
+    operation: ToolProvenanceOperation,
+) -> ToolProvenanceOperation:
+    if not _operation_is(operation, "script_code"):
+        return operation
+    code = getattr(operation, "code", None)
+    if not getattr(operation, "copyable", False) or code is None:
+        return operation
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return operation
+    if (
+        len(module.body) != 1
+        or not isinstance(module.body[0], ast.Assign)
+        or len(module.body[0].targets) != 1
+        or not isinstance(module.body[0].targets[0], ast.Name)
+        or not isinstance(module.body[0].value, ast.Call)
+    ):
+        return operation
+    structured = _operation_from_self_assignment_call(
+        module.body[0].targets[0].id,
+        module.body[0].value,
+    )
+    return operation if structured is None else structured
+
+
 def _callable_paths(func: Callable[..., typing.Any]) -> set[str]:
     paths: set[str] = set()
     for value in (func, inspect.unwrap(func)):
@@ -1598,6 +1760,20 @@ def parse_tool_provenance_operation(
             f"expected one of {sorted(_OPERATION_TYPES)}"
         )
     return operation_type.model_validate(value)
+
+
+def _normalize_script_code_operations(
+    spec: ToolProvenanceSpec,
+) -> ToolProvenanceSpec:
+    if spec.kind != "script":
+        return spec
+    operations = tuple(
+        _structured_operation_from_script_code(operation)
+        for operation in spec.operations
+    )
+    if operations == spec.operations:
+        return spec
+    return spec.model_copy(update={"operations": operations})
 
 
 class FileDataSelection(pydantic.BaseModel):
@@ -2354,29 +2530,21 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         Replay specs are the canonical, composable form used for derivation metadata,
         copied code, workspace save/load, and manager dependency status. Structured
         file provenance remains structured so runtime reloads can replay typed
-        operations without ``exec``. Live ImageTool refresh uses the original
-        single-parent spec via
+        operations without ``exec``. Live-source operations are kept structured inside
+        script replay specs so editable manager rows remain typed after composition.
+        Live ImageTool refresh uses the original single-parent spec via
         :func:`require_live_source_spec`.
         """
         if self.kind in {"script", "file"}:
             return self
 
-        entries = self.derivation_entries()
         return ToolProvenanceSpec(
             kind="script",
-            start_label=entries[0].label,
+            start_label=self._start_entry().label,
             seed_code=_DEFAULT_REPLAY_SEED_CODE,
             active_name="derived",
             file_load_source=self.file_load_source,
-            operations=tuple(
-                _operation_instance(
-                    "script_code",
-                    label=entry.label,
-                    code=entry.code,
-                    copyable=entry.copyable,
-                )
-                for entry in entries[1:]
-            ),
+            operations=self.operations,
         )
 
     def apply(self, parent_data: xr.DataArray) -> xr.DataArray:
@@ -2662,7 +2830,7 @@ def parse_tool_provenance_spec(
     if value.get("schema_version") == 1:
         value = dict(value)
         value["schema_version"] = 2
-    return ToolProvenanceSpec.model_validate(value)
+    return _normalize_script_code_operations(ToolProvenanceSpec.model_validate(value))
 
 
 def script_input_dependency_refs(
@@ -2791,20 +2959,22 @@ def compose_display_provenance(
             if saw_squeeze:
                 return parent_spec
 
-    entries = source.display_entries(parent_data=parent_data)
+    source_kind = typing.cast(
+        "typing.Literal['full_data', 'public_data', 'selection']",
+        source.kind,
+    )
     local_spec = ToolProvenanceSpec(
         kind="script",
-        start_label=entries[0].label,
+        start_label=source._start_entry().label,
         seed_code=_DEFAULT_REPLAY_SEED_CODE,
         active_name="derived",
         operations=tuple(
-            _operation_instance(
-                "script_code",
-                label=entry.label,
-                code=entry.code,
-                copyable=entry.copyable,
+            operation
+            for _, operation in ToolProvenanceSpec._streamlined_operation_refs(
+                source_kind,
+                source.operations,
+                parent_data=parent_data,
             )
-            for entry in entries[1:]
         ),
     )
     if parent_spec is None:

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -717,6 +717,26 @@ def _code_stores_name(code: str, name: str) -> bool:
     return any(_statement_store_count(stmt, name) > 0 for stmt in module.body)
 
 
+def _script_codes_output_name(
+    codes: Sequence[str],
+    *,
+    active_name: str,
+    current_name: str | None,
+) -> str | None:
+    candidates = [active_name]
+    for name in (current_name, "derived"):
+        if name is not None and name not in candidates:
+            candidates.append(name)
+    for name in candidates:
+        for code in codes:
+            try:
+                if _code_stores_name(code, name):
+                    return name
+            except SyntaxError:
+                continue
+    return current_name
+
+
 def _simplify_display_code(code: str, *, inline_targets: set[str] | None = None) -> str:
     try:
         module = ast.parse(code, mode="exec")
@@ -1030,8 +1050,12 @@ def _operation_from_self_assignment_call(
 
 def _structured_operation_from_script_code(
     operation: ToolProvenanceOperation,
+    *,
+    current_name: str | None,
 ) -> ToolProvenanceOperation:
     if not _operation_is(operation, "script_code"):
+        return operation
+    if current_name is None:
         return operation
     code = getattr(operation, "code", None)
     if not getattr(operation, "copyable", False) or code is None:
@@ -1048,9 +1072,11 @@ def _structured_operation_from_script_code(
         or not isinstance(module.body[0].value, ast.Call)
     ):
         return operation
+    target_name = module.body[0].targets[0].id
+    if target_name != current_name:
+        return operation
     structured = _operation_from_self_assignment_call(
-        module.body[0].targets[0].id,
-        module.body[0].value,
+        current_name, module.body[0].value
     )
     return operation if structured is None else structured
 
@@ -1765,12 +1791,44 @@ def parse_tool_provenance_operation(
 def _normalize_script_code_operations(
     spec: ToolProvenanceSpec,
 ) -> ToolProvenanceSpec:
-    if spec.kind != "script":
+    active_name = spec.active_name
+    if spec.kind != "script" or active_name is None:
         return spec
-    operations = tuple(
-        _structured_operation_from_script_code(operation)
-        for operation in spec.operations
+    current_name: str | None = (
+        active_name
+        if any(script_input.name == active_name for script_input in spec.script_inputs)
+        else None
     )
+    if spec.seed_code is not None:
+        current_name = _script_codes_output_name(
+            (spec.seed_code,),
+            active_name=active_name,
+            current_name=current_name,
+        )
+
+    normalized_operations: list[ToolProvenanceOperation] = []
+    for operation in spec.operations:
+        if _operation_is(operation, "script_code"):
+            operation_code = getattr(operation, "code", None)
+            structured = _structured_operation_from_script_code(
+                operation,
+                current_name=current_name,
+            )
+            normalized_operations.append(structured)
+            if (
+                _operation_is(structured, "script_code")
+                and getattr(operation, "copyable", False)
+                and operation_code is not None
+            ):
+                current_name = _script_codes_output_name(
+                    (operation_code,),
+                    active_name=active_name,
+                    current_name=current_name,
+                )
+            continue
+        normalized_operations.append(operation)
+
+    operations = tuple(normalized_operations)
     if operations == spec.operations:
         return spec
     return spec.model_copy(update={"operations": operations})

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -325,22 +325,6 @@ def _simple_assignment_source_name(code: str, target_name: str) -> str | None:
     return None
 
 
-def _script_codes_output_name(
-    codes: Sequence[str],
-    *,
-    active_name: str,
-    current_name: str | None,
-) -> str | None:
-    candidates = [active_name]
-    for name in (current_name, "derived"):
-        if name is not None and name not in candidates:
-            candidates.append(name)
-    for name in candidates:
-        if any(_provenance_framework._code_stores_name(code, name) for code in codes):
-            return name
-    return current_name
-
-
 def _validate_script_provenance(
     spec: typing.Any,
     *,
@@ -393,7 +377,7 @@ def _validate_script_provenance(
         active_available = active_available or _provenance_framework._code_stores_name(
             spec.seed_code, spec.active_name
         )
-        current_name = _script_codes_output_name(
+        current_name = _provenance_framework._script_codes_output_name(
             (spec.seed_code,),
             active_name=spec.active_name,
             current_name=current_name,
@@ -427,7 +411,7 @@ def _validate_script_provenance(
                     operation.code, spec.active_name
                 )
             )
-            current_name = _script_codes_output_name(
+            current_name = _provenance_framework._script_codes_output_name(
                 (operation.code,),
                 active_name=spec.active_name,
                 current_name=current_name,
@@ -722,7 +706,7 @@ def _compile_spec(
             nonlocal current_bindings, current_name, pending_codes, script_current_key
             if not pending_codes:
                 return
-            output_name = _script_codes_output_name(
+            output_name = _provenance_framework._script_codes_output_name(
                 pending_codes,
                 active_name=active_name,
                 current_name=current_name,
@@ -817,7 +801,7 @@ def _compile_spec(
                 continue
 
             if pending_codes:
-                pending_output_name = _script_codes_output_name(
+                pending_output_name = _provenance_framework._script_codes_output_name(
                     pending_codes,
                     active_name=active_name,
                     current_name=current_name,

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -111,7 +111,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     left_tabs: QtWidgets.QTabWidget
     link_action: QtGui.QAction
     main_splitter: QtWidgets.QSplitter
-    metadata_derivation_list: QtWidgets.QListWidget
+    metadata_derivation_list: QtWidgets.QTreeWidget
     metadata_details_layout: QtWidgets.QGridLayout
     metadata_details_widget: _HeightForWidthFrame
     metadata_group: _HeightForWidthFrame

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -115,7 +115,8 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     metadata_derivation_list: _MetadataDerivationListWidget
     metadata_details_layout: QtWidgets.QGridLayout
     metadata_details_widget: _HeightForWidthFrame
-    metadata_group: _HeightForWidthFrame
+    metadata_group: QtWidgets.QFrame
+    metadata_splitter: QtWidgets.QSplitter
     offload_action: QtGui.QAction
     open_recent_menu: QtWidgets.QMenu
     preview_widget: _SingleImagePreview

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -116,7 +116,6 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     metadata_details_layout: QtWidgets.QGridLayout
     metadata_details_widget: _HeightForWidthFrame
     metadata_group: QtWidgets.QFrame
-    metadata_splitter: QtWidgets.QSplitter
     offload_action: QtGui.QAction
     open_recent_menu: QtWidgets.QMenu
     preview_widget: _SingleImagePreview

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -51,6 +51,7 @@ if typing.TYPE_CHECKING:
     from erlab.interactive.imagetool.manager._tool_graph import _ManagerToolGraph
     from erlab.interactive.imagetool.manager._widgets import (
         _HeightForWidthFrame,
+        _MetadataDerivationListWidget,
         _SingleImagePreview,
         _StandaloneAppSpec,
         _WarningNotificationHandler,
@@ -111,7 +112,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     left_tabs: QtWidgets.QTabWidget
     link_action: QtGui.QAction
     main_splitter: QtWidgets.QSplitter
-    metadata_derivation_list: QtWidgets.QTreeWidget
+    metadata_derivation_list: _MetadataDerivationListWidget
     metadata_details_layout: QtWidgets.QGridLayout
     metadata_details_widget: _HeightForWidthFrame
     metadata_group: _HeightForWidthFrame

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -393,7 +393,6 @@ class _DetailsPanelController:
         has_metadata = has_details or derivation_count > 0
 
         self._manager.metadata_group.setVisible(has_metadata)
-        self._manager.metadata_splitter.setVisible(has_metadata)
         self._manager.metadata_details_widget.setVisible(has_details)
         self._manager.metadata_derivation_list.setVisible(derivation_count > 0)
 
@@ -415,15 +414,6 @@ class _DetailsPanelController:
         self._manager.metadata_details_widget.updateGeometry()
         self._manager.metadata_derivation_list.updateGeometry()
         self._manager.metadata_details_widget.sync_height_for_width()
-        if has_details and derivation_count > 0:
-            sizes = self._manager.metadata_splitter.sizes()
-            if len(sizes) >= 2 and (sizes[0] <= 0 or sizes[1] <= 0):
-                self._manager.metadata_splitter.setSizes(
-                    [
-                        self._manager.metadata_details_widget.minimumHeight(),
-                        self._manager.metadata_derivation_list.minimumHeight(),
-                    ]
-                )
         self._manager.metadata_group.updateGeometry()
 
     def _selected_derivation_items(self) -> list[_MetadataDerivationTreeItem]:

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -125,7 +125,7 @@ class _DetailsPanelController:
     def _metadata_derivation_item(
         self,
         row: provenance._ProvenanceDisplayRow,
-    ) -> QtWidgets.QTreeWidgetItem:
+    ) -> _MetadataDerivationTreeItem:
         entry = row.entry
         item = _MetadataDerivationTreeItem(entry.label)
         can_activate, activation_reason = (
@@ -414,8 +414,11 @@ class _DetailsPanelController:
         self._manager.metadata_group.sync_height_for_width()
         self._manager.metadata_group.updateGeometry()
 
-    def _selected_derivation_items(self) -> list[QtWidgets.QTreeWidgetItem]:
-        items = list(self._manager.metadata_derivation_list.selectedItems())
+    def _selected_derivation_items(self) -> list[_MetadataDerivationTreeItem]:
+        items = typing.cast(
+            "list[_MetadataDerivationTreeItem]",
+            list(self._manager.metadata_derivation_list.selectedItems()),
+        )
         display_order = getattr(
             self._manager.metadata_derivation_list,
             "display_order",

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -17,6 +17,7 @@ from erlab.interactive.imagetool.manager._widgets import (
     _CenteredIconToolButton,
     _ElidedValueLabel,
     _LoadSourceDetailsDialog,
+    _MetadataDerivationTreeItem,
 )
 from erlab.interactive.imagetool.manager._wrapper import (
     _ImageToolWrapper,
@@ -116,36 +117,44 @@ class _DetailsPanelController:
         with QtCore.QSignalBlocker(self._manager.metadata_derivation_list):
             self._manager.metadata_derivation_list.clear()
             for row in node.derivation_display_rows:
-                entry = row.entry
-                item = QtWidgets.QListWidgetItem(entry.label)
-                can_activate, activation_reason = (
-                    self._manager._provenance_edit_controller.can_edit_row(row)
+                self._manager.metadata_derivation_list.addItem(
+                    self._metadata_derivation_item(row)
                 )
-                tooltip_lines = [entry.label]
-                if not can_activate and activation_reason:
-                    tooltip_lines.extend(("", activation_reason))
-                if (
-                    not entry.copyable
-                    and entry.code is None
-                    and not entry.label.startswith("Start from ")
-                ):
-                    tooltip_lines.extend(
-                        ("", "Replay code is unavailable for this step.")
-                    )
-                item.setToolTip("\n".join(tooltip_lines))
-                item.setData(_METADATA_DERIVATION_CODE_ROLE, entry.code)
-                item.setData(_METADATA_DERIVATION_COPYABLE_ROLE, entry.copyable)
-                item.setData(_METADATA_DERIVATION_ROW_ROLE, row)
-                item.setData(_METADATA_DERIVATION_ACTIVATABLE_ROLE, can_activate)
-                if not can_activate:
-                    item.setForeground(
-                        self._manager.metadata_derivation_list.palette().color(
-                            QtGui.QPalette.ColorGroup.Disabled,
-                            QtGui.QPalette.ColorRole.Text,
-                        )
-                    )
-                self._manager.metadata_derivation_list.addItem(item)
         self._manager._update_metadata_pane()
+
+    def _metadata_derivation_item(
+        self,
+        row: provenance._ProvenanceDisplayRow,
+    ) -> QtWidgets.QTreeWidgetItem:
+        entry = row.entry
+        item = _MetadataDerivationTreeItem(entry.label)
+        can_activate, activation_reason = (
+            self._manager._provenance_edit_controller.can_edit_row(row)
+        )
+        tooltip_lines = [entry.label]
+        if not can_activate and activation_reason:
+            tooltip_lines.extend(("", activation_reason))
+        if (
+            not entry.copyable
+            and entry.code is None
+            and not entry.label.startswith("Start from ")
+        ):
+            tooltip_lines.extend(("", "Replay code is unavailable for this step."))
+        item.setToolTip("\n".join(tooltip_lines))
+        item.setData(_METADATA_DERIVATION_CODE_ROLE, entry.code)
+        item.setData(_METADATA_DERIVATION_COPYABLE_ROLE, entry.copyable)
+        item.setData(_METADATA_DERIVATION_ROW_ROLE, row)
+        item.setData(_METADATA_DERIVATION_ACTIVATABLE_ROLE, can_activate)
+        if not can_activate:
+            item.setForeground(
+                self._manager.metadata_derivation_list.palette().color(
+                    QtGui.QPalette.ColorGroup.Disabled,
+                    QtGui.QPalette.ColorRole.Text,
+                )
+            )
+        for child_row in row.children:
+            item.addChild(self._metadata_derivation_item(child_row))
+        return item
 
     def _set_metadata_fields(self, fields: list[_MetadataField]) -> None:
         layout = self._manager.metadata_details_layout
@@ -405,9 +414,14 @@ class _DetailsPanelController:
         self._manager.metadata_group.sync_height_for_width()
         self._manager.metadata_group.updateGeometry()
 
-    def _selected_derivation_items(self) -> list[QtWidgets.QListWidgetItem]:
+    def _selected_derivation_items(self) -> list[QtWidgets.QTreeWidgetItem]:
         items = list(self._manager.metadata_derivation_list.selectedItems())
-        return sorted(items, key=self._manager.metadata_derivation_list.row)
+        display_order = getattr(
+            self._manager.metadata_derivation_list,
+            "display_order",
+            self._manager.metadata_derivation_list.row,
+        )
+        return sorted(items, key=display_order)
 
     def _selected_derivation_code(self) -> str | None:
         codes: list[str] = []

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -390,8 +390,10 @@ class _DetailsPanelController:
     def _update_metadata_pane(self) -> None:
         has_details = bool(self._manager._metadata_detail_labels)
         derivation_count = self._manager.metadata_derivation_list.count()
+        has_metadata = has_details or derivation_count > 0
 
-        self._manager.metadata_group.setVisible(has_details or derivation_count > 0)
+        self._manager.metadata_group.setVisible(has_metadata)
+        self._manager.metadata_splitter.setVisible(has_metadata)
         self._manager.metadata_details_widget.setVisible(has_details)
         self._manager.metadata_derivation_list.setVisible(derivation_count > 0)
 
@@ -406,12 +408,22 @@ class _DetailsPanelController:
             frame = self._manager.metadata_derivation_list.frameWidth() * 2
             height = visible_rows * row_height + frame + 4
             self._manager.metadata_derivation_list.setMinimumHeight(height)
-            self._manager.metadata_derivation_list.setMaximumHeight(height)
+            self._manager.metadata_derivation_list.setMaximumHeight(
+                QtWidgets.QWIDGETSIZE_MAX
+            )
 
         self._manager.metadata_details_widget.updateGeometry()
         self._manager.metadata_derivation_list.updateGeometry()
         self._manager.metadata_details_widget.sync_height_for_width()
-        self._manager.metadata_group.sync_height_for_width()
+        if has_details and derivation_count > 0:
+            sizes = self._manager.metadata_splitter.sizes()
+            if len(sizes) >= 2 and (sizes[0] <= 0 or sizes[1] <= 0):
+                self._manager.metadata_splitter.setSizes(
+                    [
+                        self._manager.metadata_details_widget.minimumHeight(),
+                        self._manager.metadata_derivation_list.minimumHeight(),
+                    ]
+                )
         self._manager.metadata_group.updateGeometry()
 
     def _selected_derivation_items(self) -> list[_MetadataDerivationTreeItem]:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1077,6 +1077,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self.main_splitter.addWidget(right_panel)
 
         self.right_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        self.right_splitter.setChildrenCollapsible(False)
         self.right_splitter.splitterMoved.connect(
             lambda _pos, _index: self._mark_workspace_layout_dirty()
         )
@@ -1089,18 +1090,28 @@ class ImageToolManager(_ImageToolManagerBase):
         self.preview_widget = _SingleImagePreview(self)
         self.right_splitter.addWidget(self.preview_widget)
 
-        self.metadata_group = _HeightForWidthFrame(self)
+        self.metadata_group = QtWidgets.QFrame(self)
         self.metadata_group.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
         self.metadata_group.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Preferred,
-            QtWidgets.QSizePolicy.Policy.Maximum,
+            QtWidgets.QSizePolicy.Policy.Preferred,
         )
         metadata_layout = QtWidgets.QVBoxLayout(self.metadata_group)
         metadata_layout.setContentsMargins(0, 0, 0, 0)
         metadata_layout.setSpacing(4)
         self.metadata_group.setLayout(metadata_layout)
 
-        self.metadata_details_widget = _HeightForWidthFrame(self.metadata_group)
+        self.metadata_splitter = QtWidgets.QSplitter(
+            QtCore.Qt.Orientation.Vertical, self.metadata_group
+        )
+        self.metadata_splitter.setObjectName("managerMetadataSplitter")
+        self.metadata_splitter.setChildrenCollapsible(False)
+        self.metadata_splitter.splitterMoved.connect(
+            lambda _pos, _index: self._mark_workspace_layout_dirty()
+        )
+        metadata_layout.addWidget(self.metadata_splitter)
+
+        self.metadata_details_widget = _HeightForWidthFrame(self.metadata_splitter)
         self.metadata_details_layout = QtWidgets.QGridLayout(
             self.metadata_details_widget
         )
@@ -1111,17 +1122,21 @@ class ImageToolManager(_ImageToolManagerBase):
         self.metadata_details_widget.setLayout(self.metadata_details_layout)
         self.metadata_details_widget.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Preferred,
-            QtWidgets.QSizePolicy.Policy.Maximum,
+            QtWidgets.QSizePolicy.Policy.Preferred,
         )
         self.metadata_details_widget.setVisible(False)
-        metadata_layout.addWidget(self.metadata_details_widget)
+        self.metadata_splitter.addWidget(self.metadata_details_widget)
         self._metadata_detail_labels: dict[str, QtWidgets.QLabel] = {}
         self._metadata_monospace_font = QtGui.QFontDatabase.systemFont(
             QtGui.QFontDatabase.SystemFont.FixedFont
         )
 
         self.metadata_derivation_list = _MetadataDerivationListWidget(
-            self.metadata_group
+            self.metadata_splitter
+        )
+        self.metadata_derivation_list.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Expanding,
         )
         self.metadata_derivation_list.setSelectionMode(
             QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
@@ -1151,11 +1166,17 @@ class ImageToolManager(_ImageToolManagerBase):
             lambda _item, _column: self._activate_selected_derivation_step()
         )
         self.metadata_derivation_list.setVisible(False)
-        metadata_layout.addWidget(self.metadata_derivation_list)
-        right_layout.addWidget(self.metadata_group, 0)
+        self.metadata_splitter.addWidget(self.metadata_derivation_list)
+        self.metadata_splitter.setStretchFactor(0, 0)
+        self.metadata_splitter.setStretchFactor(1, 1)
+        self.right_splitter.addWidget(self.metadata_group)
+        self.right_splitter.setStretchFactor(0, 2)
+        self.right_splitter.setStretchFactor(1, 1)
+        self.right_splitter.setStretchFactor(2, 1)
 
         # Set initial splitter sizes
-        self.right_splitter.setSizes([280, 140])
+        self.right_splitter.setSizes([260, 140, 100])
+        self.metadata_splitter.setSizes([80, 160])
         self.main_splitter.setSizes([100, 150])
 
         # Store most recent name filter and directory for new windows

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -40,6 +40,7 @@ from erlab.interactive.imagetool.manager._widgets import (
     _HeightForWidthFrame,
     _manager_settings,
     _MetadataDerivationListWidget,
+    _MetadataDerivationTreeItem,
     _SingleImagePreview,
     _StandaloneAppSpec,
     _WarningEmitter,
@@ -2788,7 +2789,7 @@ class ImageToolManager(_ImageToolManagerBase):
     def _update_metadata_pane(self) -> None:
         self._details_panel._update_metadata_pane()
 
-    def _selected_derivation_items(self) -> list[QtWidgets.QTreeWidgetItem]:
+    def _selected_derivation_items(self) -> list[_MetadataDerivationTreeItem]:
         return self._details_panel._selected_derivation_items()
 
     def _selected_derivation_code(self) -> str | None:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1101,17 +1101,7 @@ class ImageToolManager(_ImageToolManagerBase):
         metadata_layout.setSpacing(4)
         self.metadata_group.setLayout(metadata_layout)
 
-        self.metadata_splitter = QtWidgets.QSplitter(
-            QtCore.Qt.Orientation.Vertical, self.metadata_group
-        )
-        self.metadata_splitter.setObjectName("managerMetadataSplitter")
-        self.metadata_splitter.setChildrenCollapsible(False)
-        self.metadata_splitter.splitterMoved.connect(
-            lambda _pos, _index: self._mark_workspace_layout_dirty()
-        )
-        metadata_layout.addWidget(self.metadata_splitter)
-
-        self.metadata_details_widget = _HeightForWidthFrame(self.metadata_splitter)
+        self.metadata_details_widget = _HeightForWidthFrame(self.metadata_group)
         self.metadata_details_layout = QtWidgets.QGridLayout(
             self.metadata_details_widget
         )
@@ -1122,17 +1112,17 @@ class ImageToolManager(_ImageToolManagerBase):
         self.metadata_details_widget.setLayout(self.metadata_details_layout)
         self.metadata_details_widget.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Preferred,
-            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Maximum,
         )
         self.metadata_details_widget.setVisible(False)
-        self.metadata_splitter.addWidget(self.metadata_details_widget)
+        metadata_layout.addWidget(self.metadata_details_widget, 0)
         self._metadata_detail_labels: dict[str, QtWidgets.QLabel] = {}
         self._metadata_monospace_font = QtGui.QFontDatabase.systemFont(
             QtGui.QFontDatabase.SystemFont.FixedFont
         )
 
         self.metadata_derivation_list = _MetadataDerivationListWidget(
-            self.metadata_splitter
+            self.metadata_group
         )
         self.metadata_derivation_list.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Preferred,
@@ -1166,9 +1156,7 @@ class ImageToolManager(_ImageToolManagerBase):
             lambda _item, _column: self._activate_selected_derivation_step()
         )
         self.metadata_derivation_list.setVisible(False)
-        self.metadata_splitter.addWidget(self.metadata_derivation_list)
-        self.metadata_splitter.setStretchFactor(0, 0)
-        self.metadata_splitter.setStretchFactor(1, 1)
+        metadata_layout.addWidget(self.metadata_derivation_list, 1)
         self.right_splitter.addWidget(self.metadata_group)
         self.right_splitter.setStretchFactor(0, 2)
         self.right_splitter.setStretchFactor(1, 1)
@@ -1176,7 +1164,6 @@ class ImageToolManager(_ImageToolManagerBase):
 
         # Set initial splitter sizes
         self.right_splitter.setSizes([260, 140, 100])
-        self.metadata_splitter.setSizes([80, 160])
         self.main_splitter.setSizes([100, 150])
 
         # Store most recent name filter and directory for new windows

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1147,7 +1147,7 @@ class ImageToolManager(_ImageToolManagerBase):
             self._show_metadata_derivation_menu
         )
         self.metadata_derivation_list.itemActivated.connect(
-            self._activate_selected_derivation_step
+            lambda _item, _column: self._activate_selected_derivation_step()
         )
         self.metadata_derivation_list.setVisible(False)
         metadata_layout.addWidget(self.metadata_derivation_list)
@@ -2788,7 +2788,7 @@ class ImageToolManager(_ImageToolManagerBase):
     def _update_metadata_pane(self) -> None:
         self._details_panel._update_metadata_pane()
 
-    def _selected_derivation_items(self) -> list[QtWidgets.QListWidgetItem]:
+    def _selected_derivation_items(self) -> list[QtWidgets.QTreeWidgetItem]:
         return self._details_panel._selected_derivation_items()
 
     def _selected_derivation_code(self) -> str | None:
@@ -2818,7 +2818,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self._details_panel._edit_selected_derivation_step()
 
     def _activate_selected_derivation_step(
-        self, _item: QtWidgets.QListWidgetItem | None = None
+        self, _item: QtWidgets.QTreeWidgetItem | None = None
     ) -> None:
         self._details_panel._activate_selected_derivation_step()
 

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -661,6 +661,17 @@ class _ProvenanceEditController:
                 return False, "This script row is not a replayable step."
             if not provenance.script_provenance_replayable(input_spec):
                 return False, "This script step cannot be replayed automatically."
+            if (
+                row.script_input_path
+                or self._active_filter_ref(node, spec) != row.edit_ref
+            ) and not all(
+                self._manager._script_input_can_reload(
+                    script_input,
+                    target_node_uid=node.uid,
+                )
+                for script_input in input_spec.script_inputs
+            ):
+                return False, "This script step has unavailable inputs."
         if (
             spec.kind in {"full_data", "public_data", "selection"}
             and row.scope != "source"
@@ -764,10 +775,11 @@ class _ProvenanceEditController:
         candidate: provenance.ToolProvenanceSpec | None = None
         try:
             candidate = spec._prefix_through_ref(ref)
+            root_candidate = self._root_candidate_for_row(node, row, candidate)
             self._validate_and_replace(
                 node,
                 row.scope,
-                candidate,
+                root_candidate,
                 where="validating the provenance revert target",
             )
         except Exception as exc:
@@ -812,10 +824,11 @@ class _ProvenanceEditController:
                         )
                     }
                 )
+            root_candidate = self._root_candidate_for_row(node, row, candidate)
             self._validate_and_replace(
                 node,
                 row.scope,
-                candidate,
+                root_candidate,
                 where="validating the provenance delete target",
             )
         except Exception as exc:
@@ -851,9 +864,10 @@ class _ProvenanceEditController:
             and node.parent_uid is not None
             and node.source_spec is not None
             and row.scope == "display"
+            and not row.script_input_path
         )
 
-    def _display_spec_for_row(
+    def _root_display_spec_for_row(
         self,
         node: _ImageToolWrapper | _ManagedWindowNode,
         row: provenance._ProvenanceDisplayRow,
@@ -861,6 +875,78 @@ class _ProvenanceEditController:
         if row.scope == "source":
             return node.displayed_source_spec
         return node.displayed_provenance_spec
+
+    def _display_spec_for_row(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        row: provenance._ProvenanceDisplayRow,
+    ) -> provenance.ToolProvenanceSpec | None:
+        spec = self._root_display_spec_for_row(node, row)
+        if spec is None or not row.script_input_path:
+            return spec
+        return self._script_input_path_spec(spec, row.script_input_path)
+
+    @staticmethod
+    def _script_input_path_spec(
+        spec: provenance.ToolProvenanceSpec,
+        path: tuple[int, ...],
+    ) -> provenance.ToolProvenanceSpec | None:
+        current = spec
+        for index in path:
+            if index < 0 or index >= len(current.script_inputs):
+                return None
+            nested = current.script_inputs[index].parsed_provenance_spec()
+            if nested is None:
+                return None
+            current = nested
+        return current
+
+    def _root_candidate_for_row(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        row: provenance._ProvenanceDisplayRow,
+        candidate: provenance.ToolProvenanceSpec,
+    ) -> provenance.ToolProvenanceSpec:
+        if not row.script_input_path:
+            return candidate
+        root = self._root_display_spec_for_row(node, row)
+        if root is None:
+            raise RuntimeError("No root provenance spec is available")
+        return self._replace_script_input_path_spec(
+            root,
+            row.script_input_path,
+            candidate,
+        )
+
+    def _replace_script_input_path_spec(
+        self,
+        spec: provenance.ToolProvenanceSpec,
+        path: tuple[int, ...],
+        replacement: provenance.ToolProvenanceSpec,
+    ) -> provenance.ToolProvenanceSpec:
+        if not path:
+            return replacement
+        index = path[0]
+        if index < 0 or index >= len(spec.script_inputs):
+            raise IndexError("Script input provenance path is not available")
+        script_input = spec.script_inputs[index]
+        nested = script_input.parsed_provenance_spec()
+        if nested is None:
+            raise RuntimeError("Script input does not have replayable provenance")
+        replaced = self._replace_script_input_path_spec(
+            nested,
+            path[1:],
+            replacement,
+        )
+        script_inputs = list(spec.script_inputs)
+        script_inputs[index] = script_input.model_copy(
+            update={
+                "node_uid": None,
+                "node_snapshot_token": None,
+                "provenance_spec": replaced.model_dump(mode="json"),
+            }
+        )
+        return spec.model_copy(update={"script_inputs": tuple(script_inputs)})
 
     def _file_load_source_edit_target(
         self,
@@ -976,7 +1062,10 @@ class _ProvenanceEditController:
             row.scope,
             spec,
             where="validating the edited file-load provenance",
-            batch_peers=self._file_load_batch_peers(node, spec),
+            row=row,
+            batch_peers=(
+                () if row.script_input_path else self._file_load_batch_peers(node, spec)
+            ),
         )
 
     def _edit_file_load_spec(
@@ -986,6 +1075,7 @@ class _ProvenanceEditController:
         spec: provenance.ToolProvenanceSpec,
         *,
         where: str,
+        row: provenance._ProvenanceDisplayRow | None = None,
         batch_peers: Sequence[_FileLoadBatchPeer] = (),
     ) -> None:
         if spec.kind != "file" or spec.file_load_source is None:
@@ -1001,8 +1091,13 @@ class _ProvenanceEditController:
             active_name=spec.active_name or "derived",
             replay_stages=spec.replay_stages,
         )
+        edit_candidate = (
+            candidate
+            if row is None
+            else self._root_candidate_for_row(node, row, candidate)
+        )
         validated_edits = [
-            self._validated_edit(node, scope, candidate, where=where),
+            self._validated_edit(node, scope, edit_candidate, where=where),
         ]
         failures: list[tuple[_FileLoadBatchPeer, Exception]] = []
         for peer in dialog.selected_batch_peers():
@@ -1044,7 +1139,7 @@ class _ProvenanceEditController:
         dialog_cls = _dialog_class_for_operation(operation)
         if dialog_cls is None:
             raise RuntimeError("No editing dialog is available for this step")
-        if self._active_filter_ref(node, spec) == ref:
+        if not row.script_input_path and self._active_filter_ref(node, spec) == ref:
             self._edit_active_filter(node, operation, dialog_cls)
             return
 
@@ -1064,10 +1159,11 @@ class _ProvenanceEditController:
         if replacements is None:
             return
         candidate = spec._replace_operation_ref(ref, replacements)
+        root_candidate = self._root_candidate_for_row(node, row, candidate)
         self._validate_and_replace(
             node,
             row.scope,
-            candidate,
+            root_candidate,
             where="validating the edited provenance step",
         )
 
@@ -1473,7 +1569,12 @@ class _ProvenanceEditController:
                         "validating provenance after selecting a replacement "
                         "source file"
                     ),
-                    batch_peers=self._file_load_batch_peers(node, spec),
+                    row=row,
+                    batch_peers=(
+                        ()
+                        if row.script_input_path
+                        else self._file_load_batch_peers(node, spec)
+                    ),
                 )
                 break
             except Exception as repair_exc:

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -864,7 +864,6 @@ class _ProvenanceEditController:
             and node.parent_uid is not None
             and node.source_spec is not None
             and row.scope == "display"
-            and not row.script_input_path
         )
 
     def _root_display_spec_for_row(

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -643,8 +643,6 @@ class _ProvenanceEditController:
         spec = self._display_spec_for_row(node, row)
         if spec is None:
             return False, "This row does not have replayable provenance."
-        if spec.kind == "script":
-            return False, "Script provenance rows are not editable in this version."
         if row.edit_ref.kind == "file_load":
             if spec.kind != "file" or spec.file_load_source is None:
                 return False, "This row is not a file load step."
@@ -656,6 +654,13 @@ class _ProvenanceEditController:
             return False, "This operation is not available."
         if isinstance(operation, provenance.ScriptCodeOperation):
             return False, "Free-form script steps are not editable."
+        if spec.kind == "script":
+            try:
+                input_spec = spec._prefix_before_ref(row.edit_ref)
+            except ValueError:
+                return False, "This script row is not a replayable step."
+            if not provenance.script_provenance_replayable(input_spec):
+                return False, "This script step cannot be replayed automatically."
         if (
             spec.kind in {"full_data", "public_data", "selection"}
             and row.scope != "source"

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -655,10 +655,7 @@ class _ProvenanceEditController:
         if isinstance(operation, provenance.ScriptCodeOperation):
             return False, "Free-form script steps are not editable."
         if spec.kind == "script":
-            try:
-                input_spec = spec._prefix_before_ref(row.edit_ref)
-            except ValueError:
-                return False, "This script row is not a replayable step."
+            input_spec = spec._prefix_before_ref(row.edit_ref)
             if not provenance.script_provenance_replayable(input_spec):
                 return False, "This script step cannot be replayed automatically."
             if (

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -250,10 +250,9 @@ class _HeightForWidthFrame(QtWidgets.QFrame):
         if self.isVisible() and self.hasHeightForWidth() and self.width() > 0:
             height = self.heightForWidth(self.width())
             self.setMinimumHeight(height)
-            self.setMaximumHeight(height)
         else:
             self.setMinimumHeight(0)
-            self.setMaximumHeight(_QWIDGETSIZE_MAX)
+        self.setMaximumHeight(_QWIDGETSIZE_MAX)
         self.updateGeometry()
 
     def sizeHint(self) -> QtCore.QSize:

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -206,14 +206,15 @@ class _MetadataDerivationListWidget(QtWidgets.QTreeWidget):
         self.setUniformRowHeights(enabled)
 
     def count(self) -> int:
-        return self.topLevelItemCount()
+        return len(self._flattened_items())
 
     def item(self, row: int) -> QtWidgets.QTreeWidgetItem | None:
-        return self.topLevelItem(row)
+        items = self._flattened_items()
+        if row < 0 or row >= len(items):
+            return None
+        return items[row]
 
     def row(self, item: QtWidgets.QTreeWidgetItem) -> int:
-        if item.parent() is None:
-            return self.indexOfTopLevelItem(item)
         return self.display_order(item)
 
     def display_order(self, item: QtWidgets.QTreeWidgetItem) -> int:

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -111,15 +111,116 @@ class _WarningEmitter(QtCore.QObject):
     warning_received = QtCore.Signal(str, int, str, str)
 
 
-class _MetadataDerivationListWidget(QtWidgets.QListWidget):
+class _MetadataDerivationTreeItem(QtWidgets.QTreeWidgetItem):
+    def __init__(self, text: str = "") -> None:
+        super().__init__([text])
+
+    def text(self, column: int = 0) -> str:
+        return super().text(column)
+
+    def setText(self, *args: typing.Any) -> None:
+        if len(args) == 1:
+            super().setText(0, args[0])
+            return
+        if len(args) == 2:
+            super().setText(args[0], args[1])
+            return
+        raise TypeError("setText() takes 1 or 2 arguments")
+
+    def data(self, *args: typing.Any) -> typing.Any:
+        if len(args) == 1:
+            return super().data(0, args[0])
+        if len(args) == 2:
+            return super().data(args[0], args[1])
+        raise TypeError("data() takes 1 or 2 arguments")
+
+    def setData(self, *args: typing.Any) -> None:
+        if len(args) == 2:
+            super().setData(0, args[0], args[1])
+            return
+        if len(args) == 3:
+            super().setData(args[0], args[1], args[2])
+            return
+        raise TypeError("setData() takes 2 or 3 arguments")
+
+    def toolTip(self, column: int = 0) -> str:
+        return super().toolTip(column)
+
+    def setToolTip(self, *args: typing.Any) -> None:
+        if len(args) == 1:
+            super().setToolTip(0, args[0])
+            return
+        if len(args) == 2:
+            super().setToolTip(args[0], args[1])
+            return
+        raise TypeError("setToolTip() takes 1 or 2 arguments")
+
+    def foreground(self, column: int = 0) -> QtGui.QBrush:
+        return super().foreground(column)
+
+    def setForeground(self, *args: typing.Any) -> None:
+        if len(args) == 1:
+            super().setForeground(0, QtGui.QBrush(args[0]))
+            return
+        if len(args) == 2:
+            super().setForeground(args[0], QtGui.QBrush(args[1]))
+            return
+        raise TypeError("setForeground() takes 1 or 2 arguments")
+
+
+class _MetadataDerivationListWidget(QtWidgets.QTreeWidget):
     copy_requested = QtCore.Signal()
     paste_requested = QtCore.Signal()
     context_menu_requested = QtCore.Signal(QtCore.QPoint)
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)
+        self.setColumnCount(1)
+        self.setHeaderHidden(True)
+        self.setRootIsDecorated(True)
+        self.setItemsExpandable(True)
+        self.setExpandsOnDoubleClick(False)
         self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self.context_menu_requested)
+
+    def _flattened_items(self) -> list[QtWidgets.QTreeWidgetItem]:
+        items: list[QtWidgets.QTreeWidgetItem] = []
+
+        def collect(item: QtWidgets.QTreeWidgetItem) -> None:
+            items.append(item)
+            for child_index in range(item.childCount()):
+                child = item.child(child_index)
+                if child is not None:
+                    collect(child)
+
+        for row in range(self.topLevelItemCount()):
+            item = self.topLevelItem(row)
+            if item is not None:
+                collect(item)
+        return items
+
+    def addItem(self, item: QtWidgets.QTreeWidgetItem) -> None:
+        self.addTopLevelItem(item)
+
+    def setUniformItemSizes(self, enabled: bool) -> None:
+        self.setUniformRowHeights(enabled)
+
+    def count(self) -> int:
+        return self.topLevelItemCount()
+
+    def item(self, row: int) -> QtWidgets.QTreeWidgetItem | None:
+        return self.topLevelItem(row)
+
+    def row(self, item: QtWidgets.QTreeWidgetItem) -> int:
+        if item.parent() is None:
+            return self.indexOfTopLevelItem(item)
+        return self.display_order(item)
+
+    def display_order(self, item: QtWidgets.QTreeWidgetItem) -> int:
+        try:
+            return self._flattened_items().index(item)
+        except ValueError:
+            return -1
 
     def keyPressEvent(self, event: QtGui.QKeyEvent | None) -> None:
         if event is None:
@@ -135,7 +236,7 @@ class _MetadataDerivationListWidget(QtWidgets.QListWidget):
         if event.key() in {QtCore.Qt.Key.Key_Return, QtCore.Qt.Key.Key_Enter}:
             item = self.currentItem()
             if item is not None:
-                self.itemActivated.emit(item)
+                self.itemActivated.emit(item, 0)
                 event.accept()
                 return
         super().keyPressEvent(event)

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -190,12 +190,14 @@ class _MetadataDerivationListWidget(QtWidgets.QTreeWidget):
             items.append(item)
             for child_index in range(item.childCount()):
                 child = item.child(child_index)
-                if child is not None:
+                # Valid child indices return items; guard for Qt binding safety.
+                if child is not None:  # pragma: no branch
                     collect(child)
 
         for row in range(self.topLevelItemCount()):
             item = self.topLevelItem(row)
-            if item is not None:
+            # Valid top-level indices return items; guard for Qt binding safety.
+            if item is not None:  # pragma: no branch
                 collect(item)
         return items
 

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -1767,6 +1767,9 @@ class _WorkspaceIOController:
             "right_splitter": erlab.interactive.utils._qt_bytearray_to_base64(
                 self._manager.right_splitter.saveState()
             ),
+            "metadata_splitter": erlab.interactive.utils._qt_bytearray_to_base64(
+                self._manager.metadata_splitter.saveState()
+            ),
         }
 
     def _restore_workspace_layout(
@@ -1791,6 +1794,12 @@ class _WorkspaceIOController:
         )
         if right_splitter is not None:
             self._manager.right_splitter.restoreState(right_splitter)
+
+        metadata_splitter = erlab.interactive.utils._qt_bytearray_from_base64(
+            layout.get("metadata_splitter")
+        )
+        if metadata_splitter is not None:
+            self._manager.metadata_splitter.restoreState(metadata_splitter)
 
     def _workspace_loader_state_snapshot(self) -> dict[str, typing.Any]:
         manager_loader_kwargs = self._manager._recent_loader_kwargs_by_filter

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -1767,9 +1767,6 @@ class _WorkspaceIOController:
             "right_splitter": erlab.interactive.utils._qt_bytearray_to_base64(
                 self._manager.right_splitter.saveState()
             ),
-            "metadata_splitter": erlab.interactive.utils._qt_bytearray_to_base64(
-                self._manager.metadata_splitter.saveState()
-            ),
         }
 
     def _restore_workspace_layout(
@@ -1794,12 +1791,6 @@ class _WorkspaceIOController:
         )
         if right_splitter is not None:
             self._manager.right_splitter.restoreState(right_splitter)
-
-        metadata_splitter = erlab.interactive.utils._qt_bytearray_from_base64(
-            layout.get("metadata_splitter")
-        )
-        if metadata_splitter is not None:
-            self._manager.metadata_splitter.restoreState(metadata_splitter)
 
     def _workspace_loader_state_snapshot(self) -> dict[str, typing.Any]:
         manager_loader_kwargs = self._manager._recent_loader_kwargs_by_filter

--- a/tests/interactive/imagetool/manager/helpers.py
+++ b/tests/interactive/imagetool/manager/helpers.py
@@ -441,12 +441,23 @@ def select_metadata_rows(
 ) -> None:
     if clear:
         manager.metadata_derivation_list.clearSelection()
+    current_item = None
     for row in rows:
         item = manager.metadata_derivation_list.item(row)
         if item is None:
             continue
         item.setSelected(True)
-        manager.metadata_derivation_list.setCurrentItem(item)
+        current_item = item
+    if current_item is None:
+        return
+    if isinstance(manager.metadata_derivation_list, QtWidgets.QTreeWidget):
+        manager.metadata_derivation_list.setCurrentItem(
+            current_item,
+            0,
+            QtCore.QItemSelectionModel.SelectionFlag.NoUpdate,
+        )
+    else:
+        manager.metadata_derivation_list.setCurrentItem(current_item)
 
 
 def set_transform_launch_mode(

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -2957,7 +2957,7 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         assert manager._metadata_detail_labels["Inputs"].wordWrap()
         assert (
             manager.metadata_details_widget.sizePolicy().verticalPolicy()
-            == QtWidgets.QSizePolicy.Policy.Preferred
+            == QtWidgets.QSizePolicy.Policy.Maximum
         )
         assert (
             manager._metadata_detail_labels["Inputs"].sizePolicy().verticalPolicy()
@@ -2968,13 +2968,13 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
             == QtWidgets.QSizePolicy.Policy.Preferred
         )
         assert manager.metadata_group.parentWidget() is manager.right_splitter
-        assert manager.metadata_splitter.widget(0) is manager.metadata_details_widget
-        assert manager.metadata_splitter.widget(1) is manager.metadata_derivation_list
-        assert manager.metadata_splitter.handleWidth() > 0
-        assert manager.metadata_splitter.styleSheet() == ""
-        handle = manager.metadata_splitter.handle(1)
+        assert manager.metadata_details_widget.parentWidget() is manager.metadata_group
+        assert manager.metadata_derivation_list.parentWidget() is manager.metadata_group
+        assert not isinstance(
+            manager.metadata_details_widget.parentWidget(), QtWidgets.QSplitter
+        )
+        handle = manager.right_splitter.handle(2)
         assert handle is not None
-        assert manager.metadata_splitter.isVisible()
         qtbot.wait_until(handle.isVisible, timeout=5000)
         assert manager.metadata_group.maximumHeight() == QtWidgets.QWIDGETSIZE_MAX
         assert (
@@ -2982,14 +2982,18 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         )
         manager.resize(640, 700)
         manager.right_splitter.setSizes([180, 120, 280])
-        manager.metadata_splitter.setSizes([120, 180])
         QtWidgets.QApplication.processEvents()
-        before_metadata_sizes = manager.metadata_splitter.sizes()
-        manager.metadata_splitter.moveSplitter(before_metadata_sizes[0] + 40, 1)
+        before_right_sizes = manager.right_splitter.sizes()
+        before_details_height = manager.metadata_details_widget.height()
+        before_list_height = manager.metadata_derivation_list.height()
+        manager.right_splitter.moveSplitter(
+            before_right_sizes[0] + before_right_sizes[1] - 40, 2
+        )
         QtWidgets.QApplication.processEvents()
-        after_metadata_sizes = manager.metadata_splitter.sizes()
-        assert after_metadata_sizes[0] > before_metadata_sizes[0]
-        assert after_metadata_sizes[1] < before_metadata_sizes[1]
+        after_right_sizes = manager.right_splitter.sizes()
+        assert after_right_sizes[2] > before_right_sizes[2]
+        assert manager.metadata_details_widget.height() == before_details_height
+        assert manager.metadata_derivation_list.height() > before_list_height
         assert "\n" in details["Inputs"]
         assert "\n\n" not in details["Inputs"]
         assert all(line.strip() for line in details["Inputs"].splitlines())

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -2957,7 +2957,7 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         assert manager._metadata_detail_labels["Inputs"].wordWrap()
         assert (
             manager.metadata_details_widget.sizePolicy().verticalPolicy()
-            == QtWidgets.QSizePolicy.Policy.Maximum
+            == QtWidgets.QSizePolicy.Policy.Preferred
         )
         assert (
             manager._metadata_detail_labels["Inputs"].sizePolicy().verticalPolicy()
@@ -2965,26 +2965,31 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         )
         assert (
             manager.metadata_group.sizePolicy().verticalPolicy()
-            == QtWidgets.QSizePolicy.Policy.Maximum
+            == QtWidgets.QSizePolicy.Policy.Preferred
         )
-        assert not isinstance(
-            manager.metadata_group.parentWidget(), QtWidgets.QSplitter
-        )
-        metadata_layout = manager.metadata_group.layout()
-        assert metadata_layout is not None
+        assert manager.metadata_group.parentWidget() is manager.right_splitter
+        assert manager.metadata_splitter.widget(0) is manager.metadata_details_widget
+        assert manager.metadata_splitter.widget(1) is manager.metadata_derivation_list
+        assert manager.metadata_splitter.handleWidth() > 0
+        assert manager.metadata_splitter.styleSheet() == ""
+        handle = manager.metadata_splitter.handle(1)
+        assert handle is not None
+        assert manager.metadata_splitter.isVisible()
+        qtbot.wait_until(handle.isVisible, timeout=5000)
+        assert manager.metadata_group.maximumHeight() == QtWidgets.QWIDGETSIZE_MAX
         assert (
-            manager.metadata_derivation_list.y()
-            == manager.metadata_details_widget.y()
-            + manager.metadata_details_widget.height()
-            + metadata_layout.spacing()
+            manager.metadata_details_widget.maximumHeight() == QtWidgets.QWIDGETSIZE_MAX
         )
-        qtbot.wait_until(
-            lambda: (
-                manager.metadata_group.height()
-                <= manager.metadata_group.sizeHint().height() + 1
-            ),
-            timeout=5000,
-        )
+        manager.resize(640, 700)
+        manager.right_splitter.setSizes([180, 120, 280])
+        manager.metadata_splitter.setSizes([120, 180])
+        QtWidgets.QApplication.processEvents()
+        before_metadata_sizes = manager.metadata_splitter.sizes()
+        manager.metadata_splitter.moveSplitter(before_metadata_sizes[0] + 40, 1)
+        QtWidgets.QApplication.processEvents()
+        after_metadata_sizes = manager.metadata_splitter.sizes()
+        assert after_metadata_sizes[0] > before_metadata_sizes[0]
+        assert after_metadata_sizes[1] < before_metadata_sizes[1]
         assert "\n" in details["Inputs"]
         assert "\n\n" not in details["Inputs"]
         assert all(line.strip() for line in details["Inputs"].splitlines())

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -18224,7 +18224,14 @@ def test_manager_copy_full_code_for_file_backed_figure_composer_sources(
         manager.tree_view.clearSelection()
         select_child_tool(manager, figure_uid)
         manager._update_info(uid=figure_uid)
-        assert manager.metadata_derivation_list.count() == 4
+        assert manager.metadata_derivation_list.topLevelItemCount() == 4
+        assert manager.metadata_derivation_list.count() == 6
+        child_counts: list[int] = []
+        for row in range(manager.metadata_derivation_list.topLevelItemCount()):
+            item = manager.metadata_derivation_list.topLevelItem(row)
+            assert item is not None
+            child_counts.append(item.childCount())
+        assert child_counts == [0, 1, 1, 0]
 
         copied: list[str] = []
         monkeypatch.setattr(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1166,6 +1166,30 @@ def test_manager_provenance_edit_controller_availability_branches() -> None:
     assert not editable
     assert reason
 
+    script_parent = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Concatenate selected ImageTools",
+            code="derived = data_0 + data_1",
+        ),
+        start_label="Run ImageTool manager action",
+        active_name="derived",
+        script_inputs=(
+            provenance.ScriptInput(name="data_0", label="ImageTool 0: scan"),
+            provenance.ScriptInput(name="data_1", label="ImageTool 1: scan"),
+        ),
+    )
+    script_with_composed_structured_step = provenance.compose_full_provenance(
+        script_parent,
+        provenance.full_data(provenance.SortByOperation(variables=("x",))),
+    )
+    assert script_with_composed_structured_step is not None
+    script_code_row, sort_row = script_with_composed_structured_step.display_rows()[3:]
+    assert not controller.can_edit_row(script_code_row)[0]
+    controller = _fake_edit_controller(
+        _fake_edit_node(script_with_composed_structured_step)
+    )
+    assert controller.can_edit_row(sort_row) == (True, "")
+
     active_filter = provenance.AverageOperation(dims=("x",))
     active_filter_spec = provenance.script(
         provenance.ScriptCodeOperation(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -2757,6 +2757,83 @@ def test_manager_metadata_added_label_does_not_force_splitter_width(
         )
 
 
+def test_manager_metadata_derivation_list_has_visible_splitter(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    rows = [
+        provenance._ProvenanceDisplayRow(
+            provenance.DerivationEntry(f"Step {index}", "derived = data", True)
+        )
+        for index in range(8)
+    ]
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        assert manager.right_splitter.count() == 3
+        assert manager.right_splitter.widget(2) is manager.metadata_group
+        assert manager.metadata_splitter.count() == 2
+        assert manager.metadata_splitter.widget(0) is manager.metadata_details_widget
+        assert manager.metadata_splitter.widget(1) is manager.metadata_derivation_list
+        assert manager.metadata_splitter.handleWidth() > 0
+        assert manager.metadata_splitter.styleSheet() == ""
+
+        manager._set_metadata_node(
+            typing.cast(
+                "typing.Any",
+                types.SimpleNamespace(
+                    uid="node",
+                    displayed_provenance_spec=provenance.full_data(),
+                    metadata_fields=[
+                        manager_wrapper._MetadataField("Kind", "ImageTool")
+                    ],
+                    derivation_display_rows=rows,
+                ),
+            )
+        )
+
+        assert manager.metadata_group.isVisible()
+        assert manager.metadata_splitter.isVisible()
+        assert manager.metadata_details_widget.isVisible()
+        assert manager.metadata_derivation_list.isVisible()
+        handle = manager.metadata_splitter.handle(1)
+        assert handle is not None
+        qtbot.wait_until(handle.isVisible, timeout=5000)
+        assert manager.metadata_derivation_list.minimumHeight() > 0
+        assert (
+            manager.metadata_derivation_list.maximumHeight()
+            == QtWidgets.QWIDGETSIZE_MAX
+        )
+
+        manager.resize(640, 700)
+        manager.right_splitter.setSizes([200, 160, 260])
+        manager.metadata_splitter.setSizes([70, 190])
+        QtWidgets.QApplication.processEvents()
+        assert manager.right_splitter.sizes()[2] > (
+            manager.metadata_derivation_list.minimumHeight()
+        )
+        assert manager.metadata_splitter.sizes()[1] > (
+            manager.metadata_derivation_list.minimumHeight()
+        )
+        before_right_sizes = manager.right_splitter.sizes()
+        manager.right_splitter.moveSplitter(
+            before_right_sizes[0] + before_right_sizes[1] - 40, 2
+        )
+        QtWidgets.QApplication.processEvents()
+        after_right_sizes = manager.right_splitter.sizes()
+        assert after_right_sizes[2] > before_right_sizes[2]
+
+        before_metadata_sizes = manager.metadata_splitter.sizes()
+        manager.metadata_splitter.moveSplitter(before_metadata_sizes[0] + 40, 1)
+        QtWidgets.QApplication.processEvents()
+        after_metadata_sizes = manager.metadata_splitter.sizes()
+        assert after_metadata_sizes[0] > before_metadata_sizes[0]
+        assert after_metadata_sizes[1] < before_metadata_sizes[1]
+
+
 def test_manager_file_label_helpers_and_file_replay_rename_update(tmp_path) -> None:
     paths = [
         tmp_path / "scan_a.h5",

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -526,6 +526,7 @@ def _fake_edit_controller(
     parent: typing.Any | None = None,
     nodes: dict[str, typing.Any] | None = None,
     metadata_uid: str | None = None,
+    script_input_can_reload: Callable[..., bool] | None = None,
 ) -> manager_provenance_edit._ProvenanceEditController:
     graph_nodes = (
         nodes if nodes is not None else ({} if node is None else {"node": node})
@@ -542,7 +543,11 @@ def _fake_edit_controller(
         _metadata_node_uid=metadata_uid,
         _tool_graph=types.SimpleNamespace(nodes=graph_nodes),
         _parent_node=_parent_node,
-        _script_input_can_reload=lambda *_args, **_kwargs: True,
+        _script_input_can_reload=(
+            script_input_can_reload
+            if script_input_can_reload is not None
+            else lambda *_args, **_kwargs: True
+        ),
         _rebuild_script_provenance=lambda spec, **_kwargs: types.SimpleNamespace(
             data=xr.DataArray([1.0], dims=("x",)),
             provenance_spec=spec,
@@ -1104,16 +1109,43 @@ def test_manager_provenance_edit_controller_availability_branches() -> None:
     script_with_structured_step = provenance.script(
         provenance.ScriptCodeOperation(
             label="Create derived data",
-            code="derived = xr.DataArray([1.0, 2.0], dims=('x',))",
+            code="derived = data_0 + 1.0",
         ),
         provenance.AverageOperation(dims=("x",)),
         start_label="Run script",
         active_name="derived",
+        script_inputs=(provenance.ScriptInput(name="data_0", label="Input"),),
     )
     controller = _fake_edit_controller(_fake_edit_node(script_with_structured_step))
-    script_code_row, structured_row = script_with_structured_step.display_rows()[1:]
+    script_code_row, structured_row = script_with_structured_step.display_rows()[2:]
     assert not controller.can_edit_row(script_code_row)[0]
     assert controller.can_edit_row(structured_row) == (True, "")
+
+    controller = _fake_edit_controller(
+        _fake_edit_node(script_with_structured_step),
+        script_input_can_reload=lambda *_args, **_kwargs: False,
+    )
+    editable, reason = controller.can_edit_row(structured_row)
+    assert not editable
+    assert reason
+
+    active_filter = provenance.AverageOperation(dims=("x",))
+    active_filter_spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Create derived data",
+            code="derived = data_0 + 1.0",
+        ),
+        active_filter,
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(provenance.ScriptInput(name="data_0", label="Input"),),
+    )
+    active_row = active_filter_spec.display_rows()[3]
+    controller = _fake_edit_controller(
+        _fake_edit_node(active_filter_spec, active_filter=active_filter),
+        script_input_can_reload=lambda *_args, **_kwargs: False,
+    )
+    assert controller.can_edit_row(active_row) == (True, "")
 
     source_row = provenance._ProvenanceDisplayRow(
         provenance.DerivationEntry("source", None),
@@ -1166,6 +1198,68 @@ def test_manager_provenance_edit_controller_availability_branches() -> None:
         )
     )
     assert controller.can_revert_row(earlier_source_row)[0]
+
+
+def test_manager_provenance_edit_nested_script_input_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_spec = provenance.script(
+        provenance.AverageOperation(dims=("x",)),
+        start_label="Load parent",
+        seed_code="data_0 = xr.DataArray([1.0, 2.0], dims=['x'])",
+        active_name="data_0",
+    )
+    root_spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Use parent",
+            code="derived = data_0",
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            provenance.ScriptInput(
+                name="data_0",
+                label="Parent",
+                node_uid="parent",
+                node_snapshot_token=str(object()),
+                provenance_spec=parent_spec,
+            ),
+        ),
+    )
+    node = _fake_edit_node(root_spec)
+    controller = _fake_edit_controller(node)
+    nested_row = root_spec.display_rows()[1].children[1]
+
+    assert controller._display_spec_for_row(node, nested_row) == parent_spec
+    assert controller.can_edit_row(nested_row) == (True, "")
+
+    replacement = provenance.AverageOperation(dims=("y",))
+    replaced: list[provenance.ToolProvenanceSpec] = []
+    monkeypatch.setattr(
+        controller,
+        "_replay_candidate",
+        lambda *_args, **_kwargs: xr.DataArray([1.0], dims=("x",)),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_edited_operations_from_dialog",
+        lambda *_args, **_kwargs: [replacement],
+    )
+    monkeypatch.setattr(
+        controller,
+        "_validate_and_replace",
+        lambda _node, _scope, candidate, **_kwargs: replaced.append(candidate),
+    )
+
+    controller._edit_operation_row(node, nested_row)
+
+    assert len(replaced) == 1
+    edited_input = replaced[0].script_inputs[0]
+    assert edited_input.node_uid is None
+    assert edited_input.node_snapshot_token is None
+    edited_parent = edited_input.parsed_provenance_spec()
+    assert edited_parent is not None
+    assert edited_parent.operations == (replacement,)
 
 
 def test_manager_provenance_revert_rejects_current_prefixes(
@@ -5064,7 +5158,7 @@ def test_manager_provenance_row_activation_uses_edit_default_action(
         activated_rows.clear()
         item = manager.metadata_derivation_list.item(0)
         assert item is not None
-        manager.metadata_derivation_list.itemActivated.emit(item)
+        manager.metadata_derivation_list.itemActivated.emit(item, 0)
         assert activated_rows == [manager._selected_derivation_row()]
 
         activated_rows.clear()
@@ -5080,7 +5174,7 @@ def test_manager_provenance_row_activation_uses_edit_default_action(
             manager.metadata_derivation_list.model().index(0, 0),
             QtCore.QItemSelectionModel.SelectionFlag.NoUpdate,
         )
-        manager.metadata_derivation_list.itemActivated.emit(item)
+        manager.metadata_derivation_list.itemActivated.emit(item, 0)
         assert activated_rows == []
 
 
@@ -5133,7 +5227,7 @@ def test_manager_provenance_row_activation_ignores_noneditable_row(
                 break
         assert item is not None
         select_metadata_rows(manager, [manager.metadata_derivation_list.row(item)])
-        manager.metadata_derivation_list.itemActivated.emit(item)
+        manager.metadata_derivation_list.itemActivated.emit(item, 0)
 
 
 def test_manager_provenance_context_menu_preserves_extended_selection(
@@ -6442,6 +6536,58 @@ def test_manager_selected_derivation_step_payload_filters_rows() -> None:
 
     selected_items = [item(script_row_a), item(script_row_b)]
     assert controller._selected_derivation_step_payload() is None
+
+
+def test_manager_metadata_derivation_rows_render_as_tree(qtbot) -> None:
+    child_row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("Offset parent", "data_0 = data_0 + 1", True),
+        edit_ref=provenance._ProvenanceStepRef("operation", operation_index=0),
+        replay_ref=provenance._ProvenanceStepRef("operation", operation_index=0),
+        script_input_path=(0,),
+    )
+    parent_row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("Use data_0 from Parent", None, False),
+        replay_ref=provenance._ProvenanceStepRef(
+            "script_input",
+            script_input_index=0,
+        ),
+        children=(child_row,),
+    )
+    derivation_list = manager_widgets._MetadataDerivationListWidget()
+    qtbot.addWidget(derivation_list)
+    manager = types.SimpleNamespace(
+        metadata_derivation_list=derivation_list,
+        _provenance_edit_controller=types.SimpleNamespace(
+            can_edit_row=lambda row: (row is child_row, "")
+        ),
+        _set_metadata_fields=lambda _fields: None,
+        _update_metadata_pane=lambda: None,
+    )
+    controller = manager_details_panel._DetailsPanelController(
+        typing.cast("typing.Any", manager)
+    )
+    node = types.SimpleNamespace(
+        uid="node",
+        displayed_provenance_spec=provenance.full_data(),
+        metadata_fields=[],
+        derivation_display_rows=[parent_row],
+    )
+
+    controller._set_metadata_node(node)
+
+    parent_item = derivation_list.topLevelItem(0)
+    assert parent_item is not None
+    assert parent_item.text() == "Use data_0 from Parent"
+    assert parent_item.childCount() == 1
+    child_item = parent_item.child(0)
+    assert child_item is not None
+    assert child_item.text() == "Offset parent"
+    assert (
+        child_item.data(manager_details_panel._METADATA_DERIVATION_ROW_ROLE)
+        is child_row
+    )
+    assert derivation_list.count() == 1
+    assert derivation_list.display_order(child_item) == 1
 
 
 def test_manager_copy_selected_derivation_code_fallbacks(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1055,6 +1055,43 @@ def test_manager_provenance_edit_controller_availability_branches() -> None:
     assert not controller.can_edit_row(row)[0]
     assert not controller.can_revert_row(row)[0]
 
+    nested_parent_history = provenance.script(
+        provenance.AverageOperation(dims=("x",)),
+        provenance.IselOperation(kwargs={"y": 0}),
+        start_label="Load parent input",
+        seed_code="data_0 = xr.DataArray([[1.0]], dims=['x', 'y'])",
+        active_name="data_0",
+    )
+    parent_context = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Use parent input",
+            code="derived = data_0",
+        ),
+        start_label="Run parent script",
+        active_name="derived",
+        script_inputs=(
+            provenance.ScriptInput(
+                name="data_0",
+                label="Parent input",
+                provenance_spec=nested_parent_history,
+            ),
+        ),
+    )
+    nested_parent_row = parent_context.display_rows()[1].children[1]
+    node = _fake_edit_node(
+        parent_context,
+        source_spec=provenance.selection(),
+        parent_uid="parent",
+    )
+    controller = _fake_edit_controller(node)
+    assert manager_provenance_edit._ProvenanceEditController._source_child_parent_row(
+        typing.cast("typing.Any", node),
+        nested_parent_row,
+    )
+    assert not controller.can_edit_row(nested_parent_row)[0]
+    assert not controller.can_revert_row(nested_parent_row)[0]
+    assert not controller.can_delete_row(nested_parent_row)[0]
+
     node = _fake_edit_node(None)
     controller = _fake_edit_controller(node)
     assert not controller.can_edit_row(row)[0]
@@ -5567,8 +5604,21 @@ def test_manager_provenance_script_structured_row_can_revert(
             if row.replay_ref
             == provenance._ProvenanceStepRef("operation", operation_index=1)
         )
-        row_index = rows.index(aggregate_row)
-        select_metadata_rows(manager, [row_index])
+        aggregate_item = None
+        for row_index in range(manager.metadata_derivation_list.count()):
+            item = manager.metadata_derivation_list.item(row_index)
+            if (
+                item is not None
+                and item.data(manager_details_panel._METADATA_DERIVATION_ROW_ROLE)
+                == aggregate_row
+            ):
+                aggregate_item = item
+                break
+        assert aggregate_item is not None
+        select_metadata_rows(
+            manager,
+            [manager.metadata_derivation_list.row(aggregate_item)],
+        )
         row = manager._selected_derivation_row()
         assert row is not None
 
@@ -6671,6 +6721,10 @@ def test_manager_metadata_derivation_rows_render_as_tree(qtbot) -> None:
         ),
         children=(child_row,),
     )
+    sibling_row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("Use derived data", None, False),
+        replay_ref=provenance._ProvenanceStepRef("operation", operation_index=0),
+    )
     derivation_list = manager_widgets._MetadataDerivationListWidget()
     qtbot.addWidget(derivation_list)
     manager = types.SimpleNamespace(
@@ -6688,7 +6742,7 @@ def test_manager_metadata_derivation_rows_render_as_tree(qtbot) -> None:
         uid="node",
         displayed_provenance_spec=provenance.full_data(),
         metadata_fields=[],
-        derivation_display_rows=[parent_row],
+        derivation_display_rows=[parent_row, sibling_row],
     )
 
     controller._set_metadata_node(node)
@@ -6735,11 +6789,20 @@ def test_manager_metadata_derivation_rows_render_as_tree(qtbot) -> None:
         child_item.data(manager_details_panel._METADATA_DERIVATION_ROW_ROLE)
         is child_row
     )
-    assert derivation_list.count() == 1
+    sibling_item = derivation_list.topLevelItem(1)
+    assert sibling_item is not None
+    assert (
+        sibling_item.data(manager_details_panel._METADATA_DERIVATION_ROW_ROLE)
+        is sibling_row
+    )
+    assert derivation_list.count() == 3
     assert derivation_list.item(0) is parent_item
-    assert derivation_list.item(1) is None
+    assert derivation_list.item(1) is child_item
+    assert derivation_list.item(2) is sibling_item
+    assert derivation_list.item(3) is None
     assert derivation_list.row(parent_item) == 0
     assert derivation_list.row(child_item) == 1
+    assert derivation_list.row(sibling_item) == 2
     assert derivation_list.display_order(child_item) == 1
     assert (
         derivation_list.display_order(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -2775,11 +2775,11 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         assert manager.right_splitter.count() == 3
         assert manager.right_splitter.widget(2) is manager.metadata_group
-        assert manager.metadata_splitter.count() == 2
-        assert manager.metadata_splitter.widget(0) is manager.metadata_details_widget
-        assert manager.metadata_splitter.widget(1) is manager.metadata_derivation_list
-        assert manager.metadata_splitter.handleWidth() > 0
-        assert manager.metadata_splitter.styleSheet() == ""
+        assert manager.metadata_details_widget.parentWidget() is manager.metadata_group
+        assert manager.metadata_derivation_list.parentWidget() is manager.metadata_group
+        assert not isinstance(
+            manager.metadata_derivation_list.parentWidget(), QtWidgets.QSplitter
+        )
 
         manager._set_metadata_node(
             typing.cast(
@@ -2796,10 +2796,9 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
         )
 
         assert manager.metadata_group.isVisible()
-        assert manager.metadata_splitter.isVisible()
         assert manager.metadata_details_widget.isVisible()
         assert manager.metadata_derivation_list.isVisible()
-        handle = manager.metadata_splitter.handle(1)
+        handle = manager.right_splitter.handle(2)
         assert handle is not None
         qtbot.wait_until(handle.isVisible, timeout=5000)
         assert manager.metadata_derivation_list.minimumHeight() > 0
@@ -2810,28 +2809,21 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
 
         manager.resize(640, 700)
         manager.right_splitter.setSizes([200, 160, 260])
-        manager.metadata_splitter.setSizes([70, 190])
         QtWidgets.QApplication.processEvents()
         assert manager.right_splitter.sizes()[2] > (
             manager.metadata_derivation_list.minimumHeight()
         )
-        assert manager.metadata_splitter.sizes()[1] > (
-            manager.metadata_derivation_list.minimumHeight()
-        )
         before_right_sizes = manager.right_splitter.sizes()
+        before_details_height = manager.metadata_details_widget.height()
+        before_list_height = manager.metadata_derivation_list.height()
         manager.right_splitter.moveSplitter(
             before_right_sizes[0] + before_right_sizes[1] - 40, 2
         )
         QtWidgets.QApplication.processEvents()
         after_right_sizes = manager.right_splitter.sizes()
         assert after_right_sizes[2] > before_right_sizes[2]
-
-        before_metadata_sizes = manager.metadata_splitter.sizes()
-        manager.metadata_splitter.moveSplitter(before_metadata_sizes[0] + 40, 1)
-        QtWidgets.QApplication.processEvents()
-        after_metadata_sizes = manager.metadata_splitter.sizes()
-        assert after_metadata_sizes[0] > before_metadata_sizes[0]
-        assert after_metadata_sizes[1] < before_metadata_sizes[1]
+        assert manager.metadata_details_widget.height() == before_details_height
+        assert manager.metadata_derivation_list.height() > before_list_height
 
 
 def test_manager_file_label_helpers_and_file_replay_rename_update(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1262,6 +1262,124 @@ def test_manager_provenance_edit_nested_script_input_operation(
     assert edited_parent.operations == (replacement,)
 
 
+def test_manager_provenance_nested_script_input_revert_delete_and_file_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_spec = _manager_provenance_file_spec(pathlib.Path("scan.h5"))
+    parent_spec = provenance.script(
+        provenance.AverageOperation(dims=("x",)),
+        provenance.IselOperation(kwargs={"y": 0}),
+        start_label="Use file parent",
+        active_name="data_0",
+        script_inputs=(
+            provenance.ScriptInput(
+                name="file_parent",
+                label="File parent",
+                provenance_spec=file_spec,
+            ),
+        ),
+    )
+    root_spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Use parent",
+            code="derived = data_0",
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(
+            provenance.ScriptInput(
+                name="data_0",
+                label="Parent",
+                node_uid="parent",
+                node_snapshot_token=str(object()),
+                provenance_spec=parent_spec,
+            ),
+        ),
+    )
+    node = _fake_edit_node(root_spec)
+    controller = _fake_edit_controller(node)
+    nested_rows = root_spec.display_rows()[1].children
+    nested_revert_row = nested_rows[2]
+    nested_delete_row = nested_rows[3]
+
+    assert controller._display_spec_for_row(node, nested_revert_row) == parent_spec
+    assert controller._script_input_path_spec(root_spec, (99,)) is None
+    assert controller._script_input_path_spec(root_spec, (0, 99)) is None
+    no_history = root_spec.model_copy(
+        update={
+            "script_inputs": (
+                root_spec.script_inputs[0].model_copy(update={"provenance_spec": None}),
+            )
+        }
+    )
+    assert controller._script_input_path_spec(no_history, (0,)) is None
+    assert (
+        controller._root_candidate_for_row(
+            node,
+            root_spec.display_rows()[2],
+            parent_spec,
+        )
+        is parent_spec
+    )
+
+    rootless_controller = _fake_edit_controller(_fake_edit_node(None))
+    with pytest.raises(RuntimeError, match="No root provenance"):
+        rootless_controller._root_candidate_for_row(
+            typing.cast("typing.Any", rootless_controller._metadata_node()),
+            nested_revert_row,
+            parent_spec,
+        )
+    with pytest.raises(IndexError, match="Script input provenance path"):
+        controller._replace_script_input_path_spec(root_spec, (99,), parent_spec)
+    with pytest.raises(RuntimeError, match="does not have replayable provenance"):
+        controller._replace_script_input_path_spec(no_history, (0,), parent_spec)
+
+    replaced: list[provenance.ToolProvenanceSpec] = []
+    monkeypatch.setattr(controller, "can_revert_row", lambda _row: (True, ""))
+    monkeypatch.setattr(controller, "_confirm_revert", lambda: True)
+    monkeypatch.setattr(
+        controller,
+        "_validate_and_replace",
+        lambda _node, _scope, candidate, **_kwargs: replaced.append(candidate),
+    )
+
+    controller.revert_row(nested_revert_row)
+    assert len(replaced) == 1
+    reverted_parent = replaced[-1].script_inputs[0].parsed_provenance_spec()
+    assert reverted_parent is not None
+    assert [operation.op for operation in reverted_parent.operations] == ["average"]
+    assert replaced[-1].script_inputs[0].node_uid is None
+
+    replaced.clear()
+    monkeypatch.setattr(controller, "can_delete_row", lambda _row: (True, ""))
+    controller.delete_row(nested_delete_row)
+    assert len(replaced) == 1
+    deleted_parent = replaced[-1].script_inputs[0].parsed_provenance_spec()
+    assert deleted_parent is not None
+    assert [operation.op for operation in deleted_parent.operations] == ["average"]
+
+    file_load_row = nested_rows[1].children[0]
+    file_load_calls: list[
+        tuple[
+            object,
+            typing.Literal["display", "source"],
+            provenance.ToolProvenanceSpec,
+            provenance._ProvenanceDisplayRow | None,
+            tuple[object, ...],
+        ]
+    ] = []
+    monkeypatch.setattr(
+        controller,
+        "_edit_file_load_spec",
+        lambda edit_node, scope, spec, *, row=None, batch_peers=(), **_kwargs: (
+            file_load_calls.append((edit_node, scope, spec, row, tuple(batch_peers)))
+        ),
+    )
+
+    controller._edit_file_load_row(node, file_load_row)
+    assert file_load_calls == [(node, "display", file_spec, file_load_row, ())]
+
+
 def test_manager_provenance_revert_rejects_current_prefixes(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -6578,6 +6696,37 @@ def test_manager_metadata_derivation_rows_render_as_tree(qtbot) -> None:
     parent_item = derivation_list.topLevelItem(0)
     assert parent_item is not None
     assert parent_item.text() == "Use data_0 from Parent"
+    parent_tree_item = typing.cast(
+        "manager_widgets._MetadataDerivationTreeItem",
+        parent_item,
+    )
+    parent_tree_item.setText("Use data_0 from Renamed Parent")
+    assert parent_tree_item.text() == "Use data_0 from Renamed Parent"
+    parent_tree_item.setText(0, "Use data_0 from Parent")
+    assert parent_tree_item.text(0) == "Use data_0 from Parent"
+    parent_tree_item.setData(QtCore.Qt.ItemDataRole.UserRole + 20, "one-arg")
+    assert parent_tree_item.data(QtCore.Qt.ItemDataRole.UserRole + 20) == "one-arg"
+    parent_tree_item.setData(0, QtCore.Qt.ItemDataRole.UserRole + 21, "two-arg")
+    assert parent_tree_item.data(0, QtCore.Qt.ItemDataRole.UserRole + 21) == "two-arg"
+    parent_tree_item.setToolTip("one-arg tooltip")
+    assert parent_tree_item.toolTip() == "one-arg tooltip"
+    parent_tree_item.setToolTip(0, "two-arg tooltip")
+    assert parent_tree_item.toolTip(0) == "two-arg tooltip"
+    parent_tree_item.setForeground(QtGui.QColor("red"))
+    assert parent_tree_item.foreground().color() == QtGui.QColor("red")
+    parent_tree_item.setForeground(0, QtGui.QColor("blue"))
+    assert parent_tree_item.foreground(0).color() == QtGui.QColor("blue")
+    with pytest.raises(TypeError):
+        parent_tree_item.setText()
+    with pytest.raises(TypeError):
+        parent_tree_item.data()
+    with pytest.raises(TypeError):
+        parent_tree_item.setData(QtCore.Qt.ItemDataRole.UserRole)
+    with pytest.raises(TypeError):
+        parent_tree_item.setToolTip()
+    with pytest.raises(TypeError):
+        parent_tree_item.setForeground()
+
     assert parent_item.childCount() == 1
     child_item = parent_item.child(0)
     assert child_item is not None
@@ -6587,7 +6736,19 @@ def test_manager_metadata_derivation_rows_render_as_tree(qtbot) -> None:
         is child_row
     )
     assert derivation_list.count() == 1
+    assert derivation_list.item(0) is parent_item
+    assert derivation_list.item(1) is None
+    assert derivation_list.row(parent_item) == 0
+    assert derivation_list.row(child_item) == 1
     assert derivation_list.display_order(child_item) == 1
+    assert (
+        derivation_list.display_order(
+            manager_widgets._MetadataDerivationTreeItem("orphan")
+        )
+        == -1
+    )
+    derivation_list.setUniformItemSizes(True)
+    assert derivation_list.uniformRowHeights()
 
 
 def test_manager_copy_selected_derivation_code_fallbacks(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1101,6 +1101,20 @@ def test_manager_provenance_edit_controller_availability_branches() -> None:
     )
     assert not controller.can_edit_row(script_row)[0]
 
+    script_with_structured_step = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Create derived data",
+            code="derived = xr.DataArray([1.0, 2.0], dims=('x',))",
+        ),
+        provenance.AverageOperation(dims=("x",)),
+        start_label="Run script",
+        active_name="derived",
+    )
+    controller = _fake_edit_controller(_fake_edit_node(script_with_structured_step))
+    script_code_row, structured_row = script_with_structured_step.display_rows()[1:]
+    assert not controller.can_edit_row(script_code_row)[0]
+    assert controller.can_edit_row(structured_row) == (True, "")
+
     source_row = provenance._ProvenanceDisplayRow(
         provenance.DerivationEntry("source", None),
         edit_ref=edit_ref,
@@ -5432,6 +5446,86 @@ def test_manager_provenance_structured_operation_edit_accept_and_cancel(
         xr.testing.assert_identical(
             tool.slicer_area._data.rename(None),
             data.qsel.sum("x").rename(None),
+        )
+
+
+def test_manager_provenance_script_derived_structured_step_is_editable(
+    qtbot,
+    accept_dialog,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(24, dtype=float).reshape((3, 4, 2)),
+        dims=("x", "y", "z"),
+        coords={"x": [0.0, 1.0, 2.0], "y": np.arange(4), "z": [0.0, 1.0]},
+        name="scan",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        input_tool = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(data, manager=False, execute=False),
+        )
+        manager.add_imagetool(input_tool, show=False)
+        input_node = manager._tool_graph.root_wrappers[0]
+        derived_data = (data + 1.0).qsel.mean("y")
+        spec = provenance.script(
+            provenance.ScriptCodeOperation(
+                label="Evaluate console expression",
+                code="derived = data_0 + 1.0",
+            ),
+            provenance.QSelAggregationOperation(dims=("y",), func="mean"),
+            start_label="Run ImageTool manager console code",
+            active_name="derived",
+            script_inputs=(
+                provenance.ScriptInput(
+                    name="data_0",
+                    label="ImageTool 0: scan",
+                    node_uid=input_node.uid,
+                    node_snapshot_token=input_node.snapshot_token,
+                ),
+            ),
+        )
+        derived_tool = typing.cast(
+            "erlab.interactive.imagetool.ImageTool",
+            itool(derived_data, manager=False, execute=False),
+        )
+        manager.add_imagetool(derived_tool, show=False, provenance_spec=spec)
+        derived_node = manager._tool_graph.root_wrappers[1]
+
+        select_tools(manager, [1])
+        manager._update_info()
+        script_code_row, structured_row = spec.display_rows()[2:]
+        assert not manager._provenance_edit_controller.can_edit_row(script_code_row)[0]
+        assert manager._provenance_edit_controller.can_edit_row(structured_row) == (
+            True,
+            "",
+        )
+        select_metadata_rows(manager, [3])
+
+        def _edit_aggregate(dialog: QtWidgets.QDialog) -> None:
+            for check in dialog.dim_checks.values():  # type: ignore[attr-defined]
+                check.setChecked(False)
+            dialog.dim_checks["x"].setChecked(True)  # type: ignore[attr-defined]
+            reducer_index = dialog.reducer_combo.findData("sum")  # type: ignore[attr-defined]
+            dialog.reducer_combo.setCurrentIndex(reducer_index)  # type: ignore[attr-defined]
+
+        accept_dialog(manager._edit_selected_derivation_step, pre_call=_edit_aggregate)
+
+        assert derived_node.provenance_spec is not None
+        assert derived_node.provenance_spec.operations == (
+            provenance.ScriptCodeOperation(
+                label="Evaluate console expression",
+                code="derived = data_0 + 1.0",
+            ),
+            provenance.QSelAggregationOperation(dims=("x",), func="sum"),
+        )
+        xr.testing.assert_identical(
+            derived_tool.slicer_area._data.rename(None),
+            (data + 1.0).qsel.sum("x").rename(None),
         )
 
 

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -1227,7 +1227,6 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
         manager.resize(640, 520)
         manager.main_splitter.setSizes([220, 420])
         manager.right_splitter.setSizes([240, 140, 120])
-        manager.metadata_splitter.setSizes([70, 150])
         expected_layout = manager._workspace_layout_snapshot()
         assert "window_state" in expected_layout
         assert "geometry" not in expected_layout
@@ -1235,7 +1234,6 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
         expected_size = manager.size()
         expected_main_sizes = manager.main_splitter.sizes()
         expected_right_sizes = manager.right_splitter.sizes()
-        expected_metadata_sizes = manager.metadata_splitter.sizes()
 
         fname = tmp_path / "manager-layout.itws"
         manager._save_workspace_document(fname, force_full=True)
@@ -1247,7 +1245,6 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
         manager.resize(480, 500)
         manager.main_splitter.setSizes([120, 360])
         manager.right_splitter.setSizes([120, 250, 80])
-        manager.metadata_splitter.setSizes([40, 60])
         assert manager._workspace_layout_snapshot() != expected_layout
 
         assert manager._load_workspace_file(
@@ -1262,7 +1259,6 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
                 manager.size() == expected_size
                 and manager.main_splitter.sizes() == expected_main_sizes
                 and manager.right_splitter.sizes() == expected_right_sizes
-                and manager.metadata_splitter.sizes() == expected_metadata_sizes
             ),
             timeout=5000,
         )
@@ -1392,14 +1388,12 @@ def test_manager_workspace_import_does_not_restore_manager_layout(
         manager.resize(640, 520)
         manager.main_splitter.setSizes([220, 420])
         manager.right_splitter.setSizes([240, 140, 120])
-        manager.metadata_splitter.setSizes([70, 150])
         import_fname = tmp_path / "import-layout.itws"
         manager._save_workspace_document(import_fname, force_full=True)
 
         manager.resize(480, 500)
         manager.main_splitter.setSizes([120, 360])
         manager.right_splitter.setSizes([120, 250, 80])
-        manager.metadata_splitter.setSizes([40, 60])
         current_layout = manager._workspace_layout_snapshot()
 
         import h5py
@@ -2191,7 +2185,6 @@ def test_manager_workspace_restore_layout_ignores_missing_or_invalid_values(
                     "window_state": {"geometry": ""},
                     "main_splitter": "",
                     "right_splitter": "",
-                    "metadata_splitter": "",
                 }
             }
         )

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -1226,7 +1226,8 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
 
         manager.resize(640, 520)
         manager.main_splitter.setSizes([220, 420])
-        manager.right_splitter.setSizes([300, 160])
+        manager.right_splitter.setSizes([240, 140, 120])
+        manager.metadata_splitter.setSizes([70, 150])
         expected_layout = manager._workspace_layout_snapshot()
         assert "window_state" in expected_layout
         assert "geometry" not in expected_layout
@@ -1234,6 +1235,7 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
         expected_size = manager.size()
         expected_main_sizes = manager.main_splitter.sizes()
         expected_right_sizes = manager.right_splitter.sizes()
+        expected_metadata_sizes = manager.metadata_splitter.sizes()
 
         fname = tmp_path / "manager-layout.itws"
         manager._save_workspace_document(fname, force_full=True)
@@ -1244,7 +1246,8 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
 
         manager.resize(480, 500)
         manager.main_splitter.setSizes([120, 360])
-        manager.right_splitter.setSizes([120, 280])
+        manager.right_splitter.setSizes([120, 250, 80])
+        manager.metadata_splitter.setSizes([40, 60])
         assert manager._workspace_layout_snapshot() != expected_layout
 
         assert manager._load_workspace_file(
@@ -1259,6 +1262,7 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
                 manager.size() == expected_size
                 and manager.main_splitter.sizes() == expected_main_sizes
                 and manager.right_splitter.sizes() == expected_right_sizes
+                and manager.metadata_splitter.sizes() == expected_metadata_sizes
             ),
             timeout=5000,
         )
@@ -1387,13 +1391,15 @@ def test_manager_workspace_import_does_not_restore_manager_layout(
 
         manager.resize(640, 520)
         manager.main_splitter.setSizes([220, 420])
-        manager.right_splitter.setSizes([300, 160])
+        manager.right_splitter.setSizes([240, 140, 120])
+        manager.metadata_splitter.setSizes([70, 150])
         import_fname = tmp_path / "import-layout.itws"
         manager._save_workspace_document(import_fname, force_full=True)
 
         manager.resize(480, 500)
         manager.main_splitter.setSizes([120, 360])
-        manager.right_splitter.setSizes([120, 280])
+        manager.right_splitter.setSizes([120, 250, 80])
+        manager.metadata_splitter.setSizes([40, 60])
         current_layout = manager._workspace_layout_snapshot()
 
         import h5py
@@ -2185,6 +2191,7 @@ def test_manager_workspace_restore_layout_ignores_missing_or_invalid_values(
                     "window_state": {"geometry": ""},
                     "main_splitter": "",
                     "right_splitter": "",
+                    "metadata_splitter": "",
                 }
             }
         )

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1620,14 +1620,32 @@ def test_plot_with_matplotlib_accepts_spaced_selection_dim(qtbot, monkeypatch) -
     win.close()
 
 
-def test_figure_composer_operation_reports_uneditable_plot_slices_details(
-    qtbot, monkeypatch
-) -> None:
-    win = itool(_TEST_DATA["3D"], execute=False)
-    qtbot.addWidget(win)
-    main_image = win.slicer_area.images[0]
+def test_figure_composer_operation_reports_uneditable_plot_slices_details() -> None:
+    class _PlotWithSelectionPlan:
+        is_image = True
+        display_axis = (0, 1)
+        slicer_area = types.SimpleNamespace(
+            data=types.SimpleNamespace(ndim=3, dims=("alpha", "beta", "eV")),
+            n_cursors=1,
+        )
+        array_slicer = types.SimpleNamespace(_nonuniform_axes=set())
+        _plot_slices_qsel_key_is_editable = staticmethod(
+            ItoolPlotItem._plot_slices_qsel_key_is_editable
+        )
 
-    cases = (
+        def __init__(self, plan) -> None:
+            self._plan = plan
+
+        def _sync_figure_composer_view_limits(self) -> None:
+            return
+
+        def _selection_dim_name(self, axis: int) -> str:
+            return self.slicer_area.data.dims[axis]
+
+        def _multicursor_selection_plan(self, **_kwargs):
+            return self._plan
+
+    for plan, detail in (
         (
             ({("bad", "key"): 0.0}, None, None, set()),
             "Unsupported qsel selection keys: ('bad', 'key')",
@@ -1640,18 +1658,12 @@ def test_figure_composer_operation_reports_uneditable_plot_slices_details(
             (None, None, None, set()),
             "Selection did not produce qsel coordinates",
         ),
-    )
-    for plan, detail in cases:
-        monkeypatch.setattr(
-            main_image,
-            "_multicursor_selection_plan",
-            lambda _plan=plan, **_kwargs: _plan,
-        )
+    ):
         with pytest.raises(FigureComposerPlotSlicesSelectionError) as exc_info:
-            main_image.figure_composer_operation(source_name="data")
+            ItoolPlotItem.figure_composer_operation(
+                _PlotWithSelectionPlan(plan), source_name="data"
+            )
         assert detail in str(exc_info.value)
-
-    win.close()
 
 
 def test_plot_with_matplotlib_preserves_state_with_editable_selection_dim(

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -2294,6 +2294,101 @@ def test_tool_provenance_parse_restores_active_alias_structured_steps() -> None:
     xr.testing.assert_identical(replayed, data.sortby("x"))
 
 
+def test_tool_provenance_parse_legacy_script_call_parser_edges() -> None:
+    def parse_codes(
+        *codes: str | None,
+        seed_code: str | None = "derived = data",
+        active_name: str = "derived",
+        script_inputs: tuple[dict[str, str], ...] = (),
+        copyable: bool = True,
+    ) -> provenance.ToolProvenanceSpec:
+        parsed = provenance.parse_tool_provenance_spec(
+            {
+                "kind": "script",
+                "start_label": "Run ImageTool manager action",
+                "seed_code": seed_code,
+                "active_name": active_name,
+                "script_inputs": script_inputs,
+                "operations": [
+                    {
+                        "op": "script_code",
+                        "label": "Legacy script step",
+                        "code": code,
+                        "copyable": copyable,
+                    }
+                    for code in codes
+                ],
+            }
+        )
+        assert parsed is not None
+        return parsed
+
+    parsed = parse_codes(
+        "derived = derived.isel(x=slice(0, 2))",
+        "derived = derived.coarsen(x=2).mean()",
+        "derived = derived.qsel(x=1.0)",
+    )
+    assert [operation.op for operation in parsed.operations] == [
+        "isel",
+        "coarsen",
+        "qsel",
+    ]
+    assert parsed.operations[0] == provenance.IselOperation(kwargs={"x": slice(0, 2)})
+    assert parsed.operations[1] == provenance.CoarsenOperation(
+        dim={"x": 2},
+        boundary="exact",
+        side="left",
+        coord_func="mean",
+        reducer="mean",
+    )
+    assert parsed.operations[2] == provenance.QSelOperation(kwargs={"x": 1.0})
+
+    conservative_codes = (
+        "derived = derived.isel(x=slice(0, stop))",
+        'derived = derived.sortby(np.array(["x"]))',
+        "derived = derived.sortby(np.array([unknown]))",
+        "derived = derived.sortby(unknown)",
+        "derived = derived.isel(**extra)",
+        "derived = make_data()",
+        'derived = factory().sortby("x")',
+        'derived = factory().data.sortby("x")',
+        'derived = other.sortby("x")',
+        "derived = derived.unknown.accessor()",
+        "derived = derived.coarsen(x=step).mean()",
+        'derived = derived.sortby("x")\nextra = derived',
+        'derived, other = derived.sortby("x"), other',
+        "derived = 1",
+        'other = derived.sortby("x")',
+    )
+    parsed = parse_codes(*conservative_codes)
+    assert all(
+        isinstance(operation, provenance.ScriptCodeOperation)
+        for operation in parsed.operations
+    )
+    assert [operation.code for operation in parsed.operations] == list(
+        conservative_codes
+    )
+
+    parsed = parse_codes(
+        'derived = derived.sortby("x")',
+        seed_code="derived =",
+        script_inputs=({"name": "derived", "label": "ImageTool"},),
+    )
+    assert [operation.op for operation in parsed.operations] == ["sortby"]
+
+    parsed = parse_codes('derived = derived.sortby("x")', seed_code=None)
+    assert [operation.op for operation in parsed.operations] == ["script_code"]
+
+    parsed = parse_codes('derived = derived.sortby("x")', copyable=False)
+    assert [operation.op for operation in parsed.operations] == ["script_code"]
+
+    parsed = parse_codes(None)
+    assert [operation.op for operation in parsed.operations] == ["script_code"]
+
+    parsed = parse_codes("derived =")
+    assert [operation.op for operation in parsed.operations] == ["script_code"]
+
+
 def test_tool_provenance_parse_restores_mixed_active_legacy_steps() -> None:
     data = _base_data().assign_coords(x=[2.0, 1.0, 0.0])
     payload = {

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -225,6 +225,65 @@ def _file_provenance_spec(path: typing.Any = "scan.h5") -> typing.Any:
     )
 
 
+def _representative_structured_operations() -> tuple[
+    provenance.ToolProvenanceOperation, ...
+]:
+    edge_fit = xr.Dataset({"edge": ("x", [1.0, 2.0, 3.0])})
+    vertices = np.array([[0.0, 10.0], [1.0, 11.0], [2.0, 12.0]])
+    return (
+        provenance.QSelOperation(kwargs={"x": 1.0}),
+        provenance.IselOperation(kwargs={"x": slice(0, 2)}),
+        provenance.SelOperation(kwargs={"y": slice(10.0, 12.0)}),
+        provenance.SortCoordOrderOperation(),
+        provenance.SortByOperation(variables=("x",), ascending=False),
+        provenance.SelectCoordOperation(coord_name="x"),
+        provenance.TransposeOperation(dims=("y", "x", "z")),
+        provenance.SqueezeOperation(),
+        provenance.RenameOperation(name="renamed"),
+        provenance.RestoreNonuniformDimsOperation(),
+        provenance.RotateOperation(angle=0.0, axes=("x", "y"), center=(0.0, 10.0)),
+        provenance.AverageOperation(dims=("x",)),
+        provenance.QSelAggregationOperation(dims=("x",), func="sum"),
+        provenance.InterpolationOperation(dim="x", values=[0.25, 0.75]),
+        provenance.LeadingEdgeOperation(fraction=0.5, dim="x"),
+        provenance.DivideByCoordOperation(coord_name="x"),
+        provenance.GaussianFilterOperation(sigma={"x": 0.5}),
+        provenance.NormalizeOperation(dims=("x",), mode="minmax"),
+        provenance.CoarsenOperation(
+            dim={"x": 2},
+            boundary="trim",
+            side="left",
+            coord_func="mean",
+            reducer="mean",
+        ),
+        provenance.ThinOperation(mode="per_dim", factors={"x": 2}),
+        provenance.SymmetrizeOperation(dim="x", center=1.0),
+        provenance.SymmetrizeNfoldOperation(
+            fold=4,
+            axes=("x", "y"),
+            center={"x": 1.0, "y": 10.0},
+        ),
+        provenance.CorrectWithEdgeOperation(edge_fit=edge_fit, shift_coords=False),
+        provenance.SwapDimsOperation(mapping={"x": "x_alt"}),
+        provenance.RenameDimsCoordsOperation(mapping={"x": "energy"}),
+        provenance.AffineCoordOperation(coord_name="x", scale=2.0, offset=1.0),
+        provenance.AssignCoordsOperation(coord_name="x", values=[0.0, 1.0, 2.0]),
+        provenance.AssignScalarCoordOperation(coord_name="temperature", value=20.0),
+        provenance.AssignCoord1DOperation(
+            coord_name="temperature",
+            dim="x",
+            values=[1.0, 2.0, 3.0],
+        ),
+        provenance.AssignAttrsOperation(attrs={"sample": "test"}),
+        provenance.SliceAlongPathOperation(
+            vertices={"x": [0.0, 1.0], "y": [10.0, 11.0]},
+            step_size=0.1,
+            dim_name="path",
+        ),
+        provenance.MaskWithPolygonOperation(vertices=vertices, dims=("x", "y")),
+    )
+
+
 def test_tool_provenance_codec_and_combinators() -> None:
     edge_fit = xr.Dataset({"edge": ("x", [1.0, 2.0, 3.0])})
     encoded = provenance.encode_provenance_value(
@@ -2130,6 +2189,200 @@ def test_tool_provenance_parse_restores_legacy_structured_script_steps() -> None
         replayed,
         (data + data).sortby("x", ascending=False).qsel.mean("y"),
     )
+
+
+def test_tool_provenance_parse_keeps_non_active_self_assignments_as_script() -> None:
+    data = xr.DataArray(
+        [10.0, 20.0, 30.0],
+        dims=("x",),
+        coords={"x": [2.0, 1.0, 0.0]},
+        name="scan",
+    )
+    payload = {
+        "kind": "script",
+        "start_label": "Run ImageTool manager action",
+        "seed_code": "derived = data",
+        "active_name": "derived",
+        "operations": [
+            {
+                "op": "script_code",
+                "label": "Prepare temporary data",
+                "code": 'temp = derived.sortby("x", ascending=False)',
+            },
+            {
+                "op": "script_code",
+                "label": "Sort temporary data",
+                "code": 'temp = temp.sortby("x")',
+            },
+        ],
+    }
+
+    parsed = provenance.parse_tool_provenance_spec(payload)
+
+    assert parsed is not None
+    assert [operation.op for operation in parsed.operations] == [
+        "script_code",
+        "script_code",
+    ]
+    replayed = provenance.replay_script_provenance(parsed, {"data": data})
+    xr.testing.assert_identical(replayed, data)
+
+
+def test_tool_provenance_parse_keeps_script_input_self_assignment_as_script() -> None:
+    data = xr.DataArray(
+        [10.0, 20.0, 30.0],
+        dims=("x",),
+        coords={"x": [2.0, 1.0, 0.0]},
+        name="scan",
+    )
+    payload = {
+        "kind": "script",
+        "start_label": "Run ImageTool manager action",
+        "active_name": "derived",
+        "script_inputs": [{"name": "data_0", "label": "ImageTool 0"}],
+        "operations": [
+            {
+                "op": "script_code",
+                "label": "Copy input",
+                "code": "derived = data_0",
+            },
+            {
+                "op": "script_code",
+                "label": "Sort input alias",
+                "code": 'data_0 = data_0.sortby("x")',
+            },
+        ],
+    }
+
+    parsed = provenance.parse_tool_provenance_spec(payload)
+
+    assert parsed is not None
+    assert [operation.op for operation in parsed.operations] == [
+        "script_code",
+        "script_code",
+    ]
+    replayed = provenance.replay_script_provenance(parsed, {"data_0": data})
+    xr.testing.assert_identical(replayed, data)
+
+
+def test_tool_provenance_parse_restores_active_alias_structured_steps() -> None:
+    data = xr.DataArray(
+        [10.0, 20.0, 30.0],
+        dims=("x",),
+        coords={"x": [2.0, 1.0, 0.0]},
+        name="scan",
+    )
+    payload = {
+        "kind": "script",
+        "start_label": "Run ImageTool manager action",
+        "seed_code": "result = data",
+        "active_name": "result",
+        "operations": [
+            {
+                "op": "script_code",
+                "label": "Sort active result",
+                "code": 'result = result.sortby("x")',
+            },
+        ],
+    }
+
+    parsed = provenance.parse_tool_provenance_spec(payload)
+
+    assert parsed is not None
+    assert [operation.op for operation in parsed.operations] == ["sortby"]
+    replayed = provenance.replay_script_provenance(parsed, {"data": data})
+    xr.testing.assert_identical(replayed, data.sortby("x"))
+
+
+def test_tool_provenance_parse_restores_mixed_active_legacy_steps() -> None:
+    data = _base_data().assign_coords(x=[2.0, 1.0, 0.0])
+    payload = {
+        "kind": "script",
+        "start_label": "Run ImageTool manager action",
+        "seed_code": "result = data",
+        "active_name": "result",
+        "operations": [
+            {
+                "op": "script_code",
+                "label": "Prepare temporary data",
+                "code": "temp = result + 1.0",
+            },
+            {
+                "op": "script_code",
+                "label": "Sort active result",
+                "code": 'result = result.sortby("x", ascending=False)',
+            },
+            {
+                "op": "script_code",
+                "label": "Average active result",
+                "code": 'result = result.qsel.mean("y")',
+            },
+        ],
+    }
+
+    parsed = provenance.parse_tool_provenance_spec(payload)
+
+    assert parsed is not None
+    assert [operation.op for operation in parsed.operations] == [
+        "script_code",
+        "sortby",
+        "qsel_aggregate",
+    ]
+    replayed = provenance.replay_script_provenance(parsed, {"data": data})
+    xr.testing.assert_identical(
+        replayed,
+        data.sortby("x", ascending=False).qsel.mean("y"),
+    )
+
+
+def test_current_structured_operations_round_trip_without_script_fallback() -> None:
+    operations = _representative_structured_operations()
+    assert {operation.op for operation in operations} == set(
+        provenance._OPERATION_TYPES
+    ) - {"script_code"}
+
+    def assert_round_trip_operations(
+        spec: provenance.ToolProvenanceSpec,
+        expected_ops: tuple[str, ...],
+    ) -> None:
+        parsed = provenance.parse_tool_provenance_spec(spec.model_dump(mode="json"))
+        assert parsed is not None
+        if parsed.kind == "file":
+            parsed_ops = tuple(
+                operation
+                for stage in parsed.replay_stages
+                for operation in stage.operations
+            )
+        else:
+            parsed_ops = parsed.operations
+        assert tuple(operation.op for operation in parsed_ops) == expected_ops
+        assert not any(
+            isinstance(op, provenance.ScriptCodeOperation) for op in parsed_ops
+        )
+
+    for operation in operations:
+        expected = (operation.op,)
+        assert_round_trip_operations(provenance.full_data(operation), expected)
+        assert_round_trip_operations(provenance.public_data(operation), expected)
+        assert_round_trip_operations(provenance.selection(operation), expected)
+        assert_round_trip_operations(
+            provenance.full_data(operation).to_replay_spec(),
+            expected,
+        )
+        assert_round_trip_operations(
+            provenance.file_load(
+                start_label="Load data",
+                seed_code="derived = data",
+                file_load_source=_file_replay_source(),
+                replay_stages=(
+                    provenance.ReplayStage(
+                        source_kind="full_data",
+                        operations=(operation,),
+                    ),
+                ),
+            ),
+            expected,
+        )
 
 
 def test_tool_replay_provenance_helpers_compose_parent_provenance() -> None:

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -2730,6 +2730,10 @@ def test_file_provenance_compose_fallbacks_and_replay_aliases() -> None:
 
 def test_script_provenance_supports_named_console_inputs() -> None:
     left = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Offset left input",
+            code="data_0 = data_0 + 1.0",
+        ),
         start_label="Load left",
         seed_code="data_0 = xr.DataArray([1.0, 2.0], dims=['x'])",
         active_name="data_0",
@@ -2771,11 +2775,28 @@ def test_script_provenance_supports_named_console_inputs() -> None:
         "Use data_1 from ImageTool 1",
         "Subtract console inputs",
     ]
+    rows = spec.display_rows()
+    assert rows[1].children[0].entry.label == "Load left"
+    assert rows[1].children[0].replay_ref == provenance._ProvenanceStepRef("start")
+    assert rows[1].children[0].script_input_path == (0,)
+    assert rows[1].children[1].entry.label == "Offset left input"
+    assert rows[1].children[1].edit_ref is None
+    assert rows[1].children[1].replay_ref == provenance._ProvenanceStepRef(
+        "operation", operation_index=0
+    )
+    assert rows[1].children[1].script_input_path == (0,)
+    assert rows[2].children[0].entry.label == "Load right"
+    assert rows[2].children[0].script_input_path == (1,)
+    assert rows[3].edit_ref is None
+    assert rows[3].replay_ref == provenance._ProvenanceStepRef(
+        "operation",
+        operation_index=0,
+    )
     code = typing.cast("str", spec.derivation_code())
     namespace = _exec_generated_code(code, {})
     xr.testing.assert_identical(
         namespace["derived"],
-        xr.DataArray([0.5, 0.5], dims=["x"]),
+        xr.DataArray([1.5, 1.5], dims=["x"]),
     )
 
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -564,10 +564,15 @@ def test_tool_provenance_parse_legacy_file_script_metadata() -> None:
     assert spec.file_load_source is not None
     assert spec.file_load_source.path == "scan.h5"
     assert spec.file_load_source.replay_call is None
+    assert [operation.op for operation in spec.operations] == ["average"]
+    assert spec.display_rows()[1].edit_ref == provenance._ProvenanceStepRef(
+        "operation",
+        operation_index=0,
+    )
     assert spec.derivation_code() == (
         "import xarray\n\n"
         "derived = xarray.load_dataarray('scan.h5')\n"
-        'derived = derived.qsel.average("x")'
+        'derived = derived.qsel.mean("x")'
     )
 
 
@@ -2073,6 +2078,60 @@ def test_tool_provenance_script_specs_reject_live_source() -> None:
         provenance.require_live_source_spec(reparsed_script)
 
 
+def test_tool_provenance_parse_restores_legacy_structured_script_steps() -> None:
+    payload = {
+        "kind": "script",
+        "start_label": "Run ImageTool manager action",
+        "seed_code": "derived = data",
+        "active_name": "derived",
+        "operations": [
+            {
+                "op": "script_code",
+                "label": "Concatenate selected ImageTools",
+                "code": "derived = left + right",
+            },
+            {
+                "op": "script_code",
+                "label": 'Sort By(variables=("x",), ascending=False)',
+                "code": 'derived = derived.sortby("x", ascending=False)',
+            },
+            {
+                "op": "script_code",
+                "label": "Average(dims=('y',))",
+                "code": 'derived = derived.qsel.mean("y")',
+            },
+        ],
+    }
+
+    parsed = provenance.parse_tool_provenance_spec(payload)
+
+    assert parsed is not None
+    assert [operation.op for operation in parsed.operations] == [
+        "script_code",
+        "sortby",
+        "qsel_aggregate",
+    ]
+    rows = [
+        row
+        for row in parsed.display_rows()
+        if row.replay_ref is not None and row.replay_ref.kind == "operation"
+    ]
+    assert [row.edit_ref is not None for row in rows] == [False, True, True]
+    data = _base_data()
+    replayed = provenance.replay_script_provenance(
+        parsed,
+        {
+            "data": data.copy(deep=True),
+            "left": data.copy(deep=True),
+            "right": data.copy(deep=True),
+        },
+    )
+    xr.testing.assert_identical(
+        replayed,
+        (data + data).sortby("x", ascending=False).qsel.mean("y"),
+    )
+
+
 def test_tool_replay_provenance_helpers_compose_parent_provenance() -> None:
 
     parent = provenance.selection(provenance.IselOperation(kwargs={"x": slice(0, 2)}))
@@ -2123,6 +2182,52 @@ def test_tool_provenance_compose_full_uses_parent_active_name_for_live_local() -
     derived = namespace["derived"]
     assert isinstance(derived, xr.DataArray)
     xr.testing.assert_identical(derived, (data + 1).qsel.mean("x"))
+
+
+def test_tool_provenance_compose_full_preserves_structured_live_steps() -> None:
+    data = _base_data()
+    parent = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Concatenate selected ImageTools",
+            code="derived = data_0 + data_1",
+        ),
+        start_label="Run ImageTool manager action",
+        active_name="derived",
+        script_inputs=(
+            provenance.ScriptInput(name="data_0", label="ImageTool 0: scan"),
+            provenance.ScriptInput(name="data_1", label="ImageTool 1: scan"),
+        ),
+    )
+    local = provenance.full_data(
+        provenance.SortByOperation(variables=("x",), ascending=False),
+        provenance.AverageOperation(dims=("y",)),
+    )
+
+    composed = provenance.compose_full_provenance(parent, local)
+
+    assert composed is not None
+    assert [operation.op for operation in composed.operations] == [
+        "script_code",
+        "sortby",
+        "average",
+    ]
+    rows = [
+        row
+        for row in composed.display_rows()
+        if row.replay_ref is not None and row.replay_ref.kind == "operation"
+    ]
+    assert [row.edit_ref is not None for row in rows] == [False, True, True]
+    derived = provenance.replay_script_provenance(
+        composed,
+        {
+            "data_0": data.copy(deep=True),
+            "data_1": data.copy(deep=True),
+        },
+    )
+    xr.testing.assert_identical(
+        derived,
+        (data + data).sortby("x", ascending=False).qsel.mean("y"),
+    )
 
 
 def test_tool_provenance_script_context_binding_replays_current_output() -> None:
@@ -4337,6 +4442,7 @@ def test_tool_provenance_compose_display_provenance_streamlines_live_source() ->
     )
 
     assert composed is not None
+    assert [operation.op for operation in composed.operations] == ["isel"]
     code = composed.display_code()
     assert code is not None
     namespace = _exec_generated_code(


### PR DESCRIPTION
## Summary
- Allow script provenance rows to be edited when the script prefix can still be replayed automatically
- Keep free-form script code steps non-editable
- Add coverage for availability checks and end-to-end editing of a replayable derived script step

## Testing
- Added unit coverage for script-row edit eligibility branches
- Added Qt UI test coverage for accepting a structured edit and verifying the provenance and data update