### PR TITLE
Add Brillouin-zone overlay support to Figure Composer and plotting APIs

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -75,11 +75,23 @@ There are several step types, each with a different set of controls for the gene
   ability to create MDC/EDC stack plots. You can either use this step as a simple
   interface to {meth}`xarray.DataArray.plot` with 1D data, or use it to extract multiple
   profiles from higher dimensional data.
+- {guilabel}`BZ Overlay` for in-plane and out-of-plane Brillouin-zone slice overlays
+  drawn with {func}`erlab.plotting.plot_in_plane_bz` and
+  {func}`erlab.plotting.plot_out_of_plane_bz`.
 - {guilabel}`ERLab Method` for a subset of {mod}`erlab.plotting` functions such as
   colorbar and annotation utilities.
 - {guilabel}`Axes Method` for a subset of Matplotlib `ax.*` methods.
 - {guilabel}`Figure Method` for a subset of Matplotlib `fig.*` methods.
 - {guilabel}`Custom Code` for arbitrary code snippets.
+
+The {guilabel}`BZ Overlay` step stores conventional-cell lattice parameters,
+centering, slice mode, angle, normalized `kz` in units of `pi/c`, optional bounds, and
+line or point styling. When code is copied, the recipe explicitly constructs the real
+lattice vectors, converts non-primitive cells to primitive vectors when needed, converts
+to reciprocal vectors, and calls the public plotting helper for the selected slice.
+Figures created from ktool converted outputs copy the current ktool BZ settings when the
+ktool overlay is enabled; ordinary momentum-cut ImageTool data can seed the slice mode
+and bounds from `kx`, `ky`, and `kz` coordinates.
 
 ### Editing steps
 

--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -78,20 +78,13 @@ There are several step types, each with a different set of controls for the gene
 - {guilabel}`BZ Overlay` for in-plane and out-of-plane Brillouin-zone slice overlays
   drawn with {func}`erlab.plotting.plot_in_plane_bz` and
   {func}`erlab.plotting.plot_out_of_plane_bz`.
+- {guilabel}`Photon Energy Overlay` for annotating constant photon energies on
+  $k_\parallel$-$k_z$ plots using {meth}`xarray.DataArray.kspace.hv_to_kz`.
 - {guilabel}`ERLab Method` for a subset of {mod}`erlab.plotting` functions such as
   colorbar and annotation utilities.
 - {guilabel}`Axes Method` for a subset of Matplotlib `ax.*` methods.
 - {guilabel}`Figure Method` for a subset of Matplotlib `fig.*` methods.
 - {guilabel}`Custom Code` for arbitrary code snippets.
-
-The {guilabel}`BZ Overlay` step stores conventional-cell lattice parameters,
-centering, slice mode, angle, normalized `kz` in units of `pi/c`, optional bounds, and
-line or point styling. When code is copied, the recipe explicitly constructs the real
-lattice vectors, converts non-primitive cells to primitive vectors when needed, converts
-to reciprocal vectors, and calls the public plotting helper for the selected slice.
-Figures created from ktool converted outputs copy the current ktool BZ settings when the
-ktool overlay is enabled; ordinary momentum-cut ImageTool data can seed the slice mode
-and bounds from `kx`, `ky`, and `kz` coordinates.
 
 ### Editing steps
 

--- a/docs/source/user-guide/plotting.ipynb
+++ b/docs/source/user-guide/plotting.ipynb
@@ -590,7 +590,7 @@
    "source": [
     "## Brillouin zones\n",
     "\n",
-    "You can plot Brillouin zones (BZs) sliced along arbitrary planes in k-space using the helper functions in {mod}`erlab.lattice`.\n"
+    "You can plot Brillouin zones (BZs) with the helper functions in {mod}`erlab.plotting`. Lower-level slice geometry is also available in {mod}`erlab.lattice`.\n"
    ]
   },
   {
@@ -643,13 +643,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Plotting arbitrary Brillouin zone slices\n",
+    "### Plotting three-dimensional Brillouin zone slices\n",
     "\n",
-    "Three dimensional Brillouin zones often need more general slicing.\n",
+    "Three-dimensional Brillouin zones often need more general slicing.\n",
     "\n",
-    "The most general function is {func}`erlab.lattice.get_bz_slice`, which takes the full 3 × 3 reciprocal lattice vectors and a plane definition in k-space and returns the BZ edges sliced by that plane.\n",
+    "The underlying geometry function is {func}`erlab.lattice.get_bz_slice`, which takes the full 3 × 3 reciprocal lattice vectors and a plane definition in k-space and returns the BZ edges sliced by that plane. Use it directly when you need arbitrary planes or want to inspect the returned segments before plotting.\n",
     "\n",
-    "However, we usually slice along constant $k_z$ or $k_x$ (or $k_y$) planes. For these common cases, {func}`erlab.lattice.get_in_plane_bz` and {func}`erlab.lattice.get_out_of_plane_bz` are provided for convenience.\n",
+    "For common constant-$k_z$ and out-of-plane cuts, {func}`eplt.plot_in_plane_bz <erlab.plotting.plot_in_plane_bz>` and {func}`eplt.plot_out_of_plane_bz <erlab.plotting.plot_out_of_plane_bz>` are convenient entry points. These plotting helpers accept the same reciprocal lattice vectors, call the lattice slice routines, and draw the BZ slice directly on a Matplotlib axes.\n",
     "\n",
     "Let's consider a face-centered orthorhombic ($Fmmm$) crystal with lattice parameters $a = 6.0$ Å, $b = 10.0$ Å, and $c = 25.0$ Å. The lattice vectors are given by:"
    ]
@@ -684,7 +684,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We plot the in-plane BZ for $k_z=0.2~\\mathrm{Å}^{-1}$ by using {func}`erlab.lattice.get_in_plane_bz`:"
+    "We plot the in-plane BZ for $k_z=0.2~\\mathrm{Å}^{-1}$ by using {func}`eplt.plot_in_plane_bz <erlab.plotting.plot_in_plane_bz>`:"
    ]
   },
   {
@@ -699,16 +699,17 @@
    },
    "outputs": [],
    "source": [
-    "segments, vertices = erlab.lattice.get_in_plane_bz(\n",
-    "    bvec, kz=0.2, angle=60.0, bounds=(-1.5, 1.5, -1.5, 1.5)\n",
-    ")\n",
-    "\n",
     "fig, ax = plt.subplots(figsize=(2.5, 2.5))\n",
-    "\n",
-    "for seg in segments:\n",
-    "    ax.plot(seg[:, 0], seg[:, 1], color=\"tab:purple\", lw=1.5)\n",
-    "\n",
-    "ax.scatter(vertices[:, 0], vertices[:, 1], s=20, c=\"tab:purple\")\n",
+    "eplt.plot_in_plane_bz(\n",
+    "    bvec,\n",
+    "    kz=0.2,\n",
+    "    angle=60.0,\n",
+    "    bounds=(-1.5, 1.5, -1.5, 1.5),\n",
+    "    ax=ax,\n",
+    "    vertices=True,\n",
+    "    color=\"tab:purple\",\n",
+    "    lw=1.5,\n",
+    ")\n",
     "ax.set(xlabel=r\"$k_x$ (Å$^{-1}$)\", ylabel=r\"$k_y$ (Å$^{-1}$)\", aspect=\"equal\")"
    ]
   },
@@ -716,7 +717,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also plot the out-of-plane BZ along $k_y = 0$ using {func}`erlab.lattice.get_out_of_plane_bz`:"
+    "We can also plot the out-of-plane BZ along $k_y = 0$ using {func}`eplt.plot_out_of_plane_bz <erlab.plotting.plot_out_of_plane_bz>`:"
    ]
   },
   {
@@ -725,16 +726,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "segments, vertices = erlab.lattice.get_out_of_plane_bz(\n",
-    "    bvec, k_parallel=0.0, angle=60.0, bounds=(-1.5, 1.5, -1.5, 1.5)\n",
-    ")\n",
-    "\n",
     "fig, ax = plt.subplots(figsize=(2.5, 2.5))\n",
-    "\n",
-    "for seg in segments:\n",
-    "    ax.plot(seg[:, 0], seg[:, 1], color=\"tab:purple\", lw=1.5)\n",
-    "\n",
-    "ax.scatter(vertices[:, 0], vertices[:, 1], s=20, c=\"tab:purple\")\n",
+    "eplt.plot_out_of_plane_bz(\n",
+    "    bvec,\n",
+    "    k_parallel=0.0,\n",
+    "    angle=60.0,\n",
+    "    bounds=(-1.5, 1.5, -1.5, 1.5),\n",
+    "    ax=ax,\n",
+    "    vertices=True,\n",
+    "    color=\"tab:purple\",\n",
+    "    lw=1.5,\n",
+    ")\n",
     "ax.set(xlabel=r\"$k_x$ (Å$^{-1}$)\", ylabel=r\"$k_z$ (Å$^{-1}$)\", aspect=\"equal\")"
    ]
   },

--- a/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 import numpy as np
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 import erlab
 import erlab.plotting as eplt
@@ -273,14 +273,83 @@ def _spinbox(
     maximum: float = 1_000_000.0,
     step: float = 0.1,
     decimals: int = 4,
+    suffix: str = "",
 ) -> QtWidgets.QDoubleSpinBox:
     spinbox = QtWidgets.QDoubleSpinBox(parent)
     spinbox.setRange(minimum, maximum)
     spinbox.setDecimals(decimals)
     spinbox.setSingleStep(step)
+    spinbox.setSuffix(suffix)
     spinbox.setKeyboardTracking(False)
     spinbox.setValue(float(value))
     return spinbox
+
+
+def _kz_absolute(kz_pi_over_c: float, c: float) -> float:
+    return kz_pi_over_c * np.pi / c
+
+
+def _kz_pi_over_c(kz_absolute: float, c: float) -> float:
+    return kz_absolute * c / np.pi
+
+
+def _operation_kz_absolute(operation: FigureOperationState) -> float:
+    return _kz_absolute(operation.bz_kz_pi_over_c, operation.bz_c)
+
+
+def _set_spinbox_value(spinbox: QtWidgets.QDoubleSpinBox, value: float) -> None:
+    with QtCore.QSignalBlocker(spinbox):
+        spinbox.setValue(float(value))
+
+
+def _current_bz_operation(
+    tool: FigureComposerTool, fallback: FigureOperationState
+) -> FigureOperationState:
+    current = tool._current_operation()
+    if current is None:
+        return fallback
+    return current[1]
+
+
+def _update_bz_kz_pi_over_c(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    spinbox: QtWidgets.QDoubleSpinBox,
+    value: float,
+) -> None:
+    operation = _current_bz_operation(tool, operation)
+    _set_spinbox_value(spinbox, _kz_absolute(value, operation.bz_c))
+    tool._update_current_operation(bz_kz_pi_over_c=value)
+
+
+def _update_bz_kz_absolute(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    spinbox: QtWidgets.QDoubleSpinBox,
+    value: float,
+) -> None:
+    operation = _current_bz_operation(tool, operation)
+    _set_spinbox_value(spinbox, _kz_pi_over_c(value, operation.bz_c))
+    tool._update_operations(
+        lambda _index, target: target.model_copy(
+            update={"bz_kz_pi_over_c": _kz_pi_over_c(value, target.bz_c)}
+        )
+    )
+
+
+def _update_bz_c_preserve_kz_absolute(tool: FigureComposerTool, value: float) -> None:
+    new_c = float(value)
+
+    def update_c(_index: int, operation: FigureOperationState) -> FigureOperationState:
+        kz_absolute = _operation_kz_absolute(operation)
+        return operation.model_copy(
+            update={
+                "bz_c": new_c,
+                "bz_kz_pi_over_c": _kz_pi_over_c(kz_absolute, new_c),
+            }
+        )
+
+    tool._update_operations(update_c, rebuild_editor=True)
 
 
 def _lattice_spinbox(
@@ -293,6 +362,7 @@ def _lattice_spinbox(
     maximum = 1_000_000.0 if field in {"bz_a", "bz_b", "bz_c"} else 180.0
     step = 0.1 if field in {"bz_a", "bz_b", "bz_c"} else 1.0
     decimals = 4 if field in {"bz_a", "bz_b", "bz_c"} else 3
+    suffix = " Å" if field in {"bz_a", "bz_b", "bz_c"} else "°"
     return _spinbox(
         typing.cast("float", getattr(operation, field)),
         parent=parent,
@@ -300,6 +370,7 @@ def _lattice_spinbox(
         maximum=maximum,
         step=step,
         decimals=decimals,
+        suffix=suffix,
     )
 
 
@@ -314,24 +385,90 @@ def _add_spinbox_row(
     tooltip: str,
     parent: QtWidgets.QWidget,
     spinbox_factory: Callable[..., QtWidgets.QDoubleSpinBox] | None = None,
+    suffix: str = "",
+    update: Callable[[float], None] | None = None,
 ) -> None:
     mixed = tool._batch_is_mixed(operation, lambda target: getattr(target, field))
     if spinbox_factory is None:
         spinbox = _spinbox(float(getattr(operation, field)), parent=parent)
     else:
         spinbox = spinbox_factory(operation, field, parent=parent)
+    if suffix:
+        spinbox.setSuffix(suffix)
     spinbox.setObjectName(object_name)
     tool._connect_value_signal(
         spinbox,
         spinbox.valueChanged,
         float,
-        lambda value: tool._update_current_operation(**{field: value}),
+        update
+        if update is not None
+        else lambda value: tool._update_current_operation(**{field: value}),
     )
     tool._add_form_row(
         layout,
         label,
         tool._mixed_value_widget(spinbox, mixed=mixed, parent=parent),
         tooltip,
+    )
+
+
+def _build_kz_row(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
+) -> None:
+    kz_pi_mixed = tool._batch_is_mixed(operation, lambda target: target.bz_kz_pi_over_c)
+    c_mixed = tool._batch_is_mixed(operation, lambda target: target.bz_c)
+    kz_pi_spin = _spinbox(
+        operation.bz_kz_pi_over_c,
+        parent=page,
+        step=0.1,
+        decimals=4,
+        suffix=" π/c",
+    )
+    kz_pi_spin.setObjectName("figureComposerBZKzSpin")
+    kz_absolute_spin = _spinbox(
+        _operation_kz_absolute(operation),
+        parent=page,
+        step=0.01,
+        decimals=4,
+        suffix=" Å⁻¹",
+    )
+    kz_absolute_spin.setObjectName("figureComposerBZKzAbsoluteSpin")
+
+    tool._connect_value_signal(
+        kz_pi_spin,
+        kz_pi_spin.valueChanged,
+        float,
+        lambda value: _update_bz_kz_pi_over_c(tool, operation, kz_absolute_spin, value),
+    )
+    tool._connect_value_signal(
+        kz_absolute_spin,
+        kz_absolute_spin.valueChanged,
+        float,
+        lambda value: _update_bz_kz_absolute(tool, operation, kz_pi_spin, value),
+    )
+
+    row = QtWidgets.QWidget(page)
+    row_layout = QtWidgets.QHBoxLayout(row)
+    row_layout.setContentsMargins(0, 0, 0, 0)
+    row_layout.setSpacing(6)
+    row_layout.addWidget(
+        tool._mixed_value_widget(kz_pi_spin, mixed=kz_pi_mixed, parent=row),
+        1,
+    )
+    row_layout.addWidget(
+        tool._mixed_value_widget(
+            kz_absolute_spin, mixed=kz_pi_mixed or c_mixed, parent=row
+        ),
+        1,
+    )
+    tool._add_form_row(
+        layout,
+        "kz",
+        row,
+        "Fixed out-of-plane momentum for in-plane slices.",
     )
 
 
@@ -366,17 +503,9 @@ def _build_slice_editor(
         object_name="figureComposerBZAngleSpin",
         tooltip="Rotation angle in degrees.",
         parent=page,
+        suffix="°",
     )
-    _add_spinbox_row(
-        tool,
-        operation,
-        layout,
-        label="kz (pi/c)",
-        field="bz_kz_pi_over_c",
-        object_name="figureComposerBZKzSpin",
-        tooltip="Normalized kz value for in-plane slices, in units of pi/c.",
-        parent=page,
-    )
+    _build_kz_row(tool, operation, page, layout)
     _add_spinbox_row(
         tool,
         operation,
@@ -386,6 +515,7 @@ def _build_slice_editor(
         object_name="figureComposerBZKParallelSpin",
         tooltip="Fixed in-plane momentum component for out-of-plane slices.",
         parent=page,
+        suffix=" Å⁻¹",
     )
 
     bounds_text, bounds_mixed = tool._batch_text(
@@ -412,13 +542,16 @@ def _build_lattice_editor(
     page: QtWidgets.QWidget,
     layout: QtWidgets.QFormLayout,
 ) -> None:
+    def update_c(value: float) -> None:
+        _update_bz_c_preserve_kz_absolute(tool, value)
+
     for label, field, object_name in (
         ("a", "bz_a", "figureComposerBZAEdit"),
         ("b", "bz_b", "figureComposerBZBEdit"),
         ("c", "bz_c", "figureComposerBZCEdit"),
-        ("alpha", "bz_alpha", "figureComposerBZAlphaEdit"),
-        ("beta", "bz_beta", "figureComposerBZBetaEdit"),
-        ("gamma", "bz_gamma", "figureComposerBZGammaEdit"),
+        ("α", "bz_alpha", "figureComposerBZAlphaEdit"),
+        ("β", "bz_beta", "figureComposerBZBetaEdit"),
+        ("γ", "bz_gamma", "figureComposerBZGammaEdit"),
     ):
         _add_spinbox_row(
             tool,
@@ -430,6 +563,7 @@ def _build_lattice_editor(
             tooltip=f"Lattice parameter {label}.",
             parent=page,
             spinbox_factory=_lattice_spinbox,
+            update=update_c if field == "bz_c" else None,
         )
 
     centering_mixed = tool._batch_is_mixed(
@@ -659,11 +793,16 @@ def _section_summary(
             return tool._axes_target_text(operation.axes)
         case "slice":
             if operation.bz_mode == "out_of_plane":
-                return f"out-of-plane, k={operation.bz_k_parallel:g}"
-            return f"in-plane, kz={operation.bz_kz_pi_over_c:g} pi/c"
+                return f"OOP, k={operation.bz_k_parallel:g} Å⁻¹"
+            return (
+                f"IP, kz={operation.bz_kz_pi_over_c:g} π/c; "
+                f"{_operation_kz_absolute(operation):g} Å⁻¹"
+            )
         case "lattice":
             return (
-                f"{operation.bz_a:g}, {operation.bz_b:g}, {operation.bz_c:g}; "
+                f"a={operation.bz_a:g} Å, b={operation.bz_b:g} Å, "
+                f"c={operation.bz_c:g} Å; α={operation.bz_alpha:g}°, "
+                f"β={operation.bz_beta:g}°, γ={operation.bz_gamma:g}°; "
                 f"{operation.bz_centering_type}"
             )
         case "style":

--- a/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
@@ -99,7 +99,12 @@ def _bounds_from_text(text: str) -> tuple[float, float, float, float] | None:
     if len(value) != 4:
         raise _input_error("Enter four comma-separated numbers.")
     try:
-        return tuple(float(item) for item in value)
+        return (
+            float(value[0]),
+            float(value[1]),
+            float(value[2]),
+            float(value[3]),
+        )
     except (TypeError, ValueError) as exc:
         raise _input_error("Enter four comma-separated numbers.") from exc
 
@@ -127,7 +132,7 @@ def _bz_bvec(operation: FigureOperationState) -> np.ndarray:
 def _render_bz_overlay(
     tool: FigureComposerTool,
     operation: FigureOperationState,
-    axs: object,
+    axs: typing.Any,
 ) -> None:
     axes = _iter_axes(
         _axes_from_selection(tool, operation.axes, axs, for_plot_slices=False)
@@ -568,18 +573,24 @@ def _build_style_editor(
             "Keyword arguments forwarded to the midpoint scatter artist.",
         ),
     ):
+
+        def field_getter(
+            target: FigureOperationState, field: str = field
+        ) -> typing.Any:
+            return getattr(target, field)
+
+        def update_field(value: str, field: str = field) -> None:
+            tool._update_current_operation(**{field: _dict_from_text(value)})
+
         text, mixed = tool._batch_text(
-            operation, lambda target, field=field: getattr(target, field), _format_dict
+            operation,
+            field_getter,
+            _format_dict,
         )
         edit = tool._line_edit(text, parent=page)
         edit.setObjectName(object_name)
         tool._apply_mixed_line_edit(edit, mixed)
-        tool._connect_line_edit_finished(
-            edit,
-            lambda value, field=field: tool._update_current_operation(
-                **{field: _dict_from_text(value)}
-            ),
-        )
+        tool._connect_line_edit_finished(edit, update_field)
         tool._add_form_row(layout, label, edit, tooltip)
 
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
@@ -1,0 +1,702 @@
+"""Brillouin-zone overlay operation editor, renderer, and code generation."""
+
+from __future__ import annotations
+
+import typing
+
+import numpy as np
+from qtpy import QtWidgets
+
+import erlab
+import erlab.plotting as eplt
+from erlab.interactive._figurecomposer._code import _axes_code, _axes_sequence_code
+from erlab.interactive._figurecomposer._gridspec import _gridspec_valid_axes_ids
+from erlab.interactive._figurecomposer._line_style import (
+    LINE_STYLE_DEFAULT_LABEL,
+    LINE_STYLE_OPTIONS,
+    color_kw_value_from_text,
+    line_kw_float,
+    line_kw_style_value,
+    line_kw_text,
+    optional_positive_spinbox,
+    optional_positive_spinbox_value,
+    update_current_line_kw,
+)
+from erlab.interactive._figurecomposer._operations._base import (
+    AddStepActionSpec,
+    OperationSpec,
+    StepSection,
+    _empty_source_editor,
+    _empty_source_names,
+    _uses_no_source_section,
+)
+from erlab.interactive._figurecomposer._rendering import (
+    _axes_from_selection,
+    _iter_axes,
+)
+from erlab.interactive._figurecomposer._state import (
+    FigureOperationKind,
+    FigureOperationState,
+)
+from erlab.interactive._figurecomposer._text import (
+    _code_kwargs,
+    _dict_from_text,
+    _format_dict,
+    _input_error,
+    _literal_from_text,
+    _RawCode,
+)
+from erlab.interactive._figurecomposer._widgets import _ColorLineEditWidget
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from erlab.interactive._figurecomposer._tool import FigureComposerTool
+
+
+_CENTERING_TYPES = ("P", "A", "B", "C", "F", "I", "R")
+_MODE_LABELS = {
+    "in_plane": "In-plane",
+    "out_of_plane": "Out-of-plane",
+}
+_SECTION_TOOLTIPS = {
+    "slice": "Choose the Brillouin-zone slice geometry and plotted bounds.",
+    "lattice": "Choose conventional-cell lattice parameters and centering.",
+    "style": "Set line styling and optional vertex or midpoint markers.",
+}
+
+
+def _mode_text(mode: str) -> str:
+    return _MODE_LABELS.get(mode, _MODE_LABELS["in_plane"])
+
+
+def _mode_from_text(text: str) -> typing.Literal["in_plane", "out_of_plane"]:
+    for mode, label in _MODE_LABELS.items():
+        if text == label:
+            return typing.cast("typing.Literal['in_plane', 'out_of_plane']", mode)
+    return "in_plane"
+
+
+def _format_bounds(bounds: tuple[float, float, float, float] | None) -> str:
+    if bounds is None:
+        return ""
+    return ", ".join(f"{value:g}" for value in bounds)
+
+
+def _bounds_from_text(text: str) -> tuple[float, float, float, float] | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    value = _literal_from_text(
+        stripped,
+        message=(
+            "Enter four comma-separated numbers, such as -1, 1, -1, 1, "
+            "or leave blank to infer from axes."
+        ),
+    )
+    if isinstance(value, str | bytes) or not isinstance(value, list | tuple):
+        raise _input_error("Enter four comma-separated numbers.")
+    if len(value) != 4:
+        raise _input_error("Enter four comma-separated numbers.")
+    try:
+        return tuple(float(item) for item in value)
+    except (TypeError, ValueError) as exc:
+        raise _input_error("Enter four comma-separated numbers.") from exc
+
+
+def _bz_avec(operation: FigureOperationState) -> np.ndarray:
+    avec = erlab.lattice.abc2avec(
+        operation.bz_a,
+        operation.bz_b,
+        operation.bz_c,
+        operation.bz_alpha,
+        operation.bz_beta,
+        operation.bz_gamma,
+    )
+    if operation.bz_centering_type != "P":
+        avec = erlab.lattice.to_primitive(
+            avec, centering_type=operation.bz_centering_type
+        )
+    return avec
+
+
+def _bz_bvec(operation: FigureOperationState) -> np.ndarray:
+    return erlab.lattice.to_reciprocal(_bz_avec(operation))
+
+
+def _render_bz_overlay(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    axs: object,
+) -> None:
+    axes = _iter_axes(
+        _axes_from_selection(tool, operation.axes, axs, for_plot_slices=False)
+    )
+    if not axes:
+        return
+
+    bvec = _bz_bvec(operation)
+    common_kwargs = {
+        "angle": operation.bz_angle,
+        "bounds": operation.bz_bounds,
+        "vertices": operation.bz_vertices,
+        "midpoints": operation.bz_midpoints,
+        "vertex_kwargs": dict(operation.bz_vertex_kw) or None,
+        "midpoint_kwargs": dict(operation.bz_midpoint_kw) or None,
+        **operation.line_kw,
+    }
+    if operation.bz_mode == "out_of_plane":
+        for axis in axes:
+            eplt.plot_out_of_plane_bz(
+                bvec,
+                k_parallel=operation.bz_k_parallel,
+                ax=axis,
+                **common_kwargs,
+            )
+        return
+
+    kz = operation.bz_kz_pi_over_c * np.pi / operation.bz_c
+    for axis in axes:
+        eplt.plot_in_plane_bz(
+            bvec,
+            kz=kz,
+            ax=axis,
+            **common_kwargs,
+        )
+
+
+def _lattice_code_lines(operation: FigureOperationState) -> list[str]:
+    args = (
+        operation.bz_a,
+        operation.bz_b,
+        operation.bz_c,
+        operation.bz_alpha,
+        operation.bz_beta,
+        operation.bz_gamma,
+    )
+    lines = [
+        f"avec = erlab.lattice.abc2avec({', '.join(f'{value!r}' for value in args)})"
+    ]
+    if operation.bz_centering_type != "P":
+        lines.append(
+            "avec = erlab.lattice.to_primitive("
+            f'avec, centering_type="{operation.bz_centering_type}")'
+        )
+    lines.append("bvec = erlab.lattice.to_reciprocal(avec)")
+    return lines
+
+
+def _plot_kwargs(
+    operation: FigureOperationState,
+    *,
+    axis_code: str,
+) -> dict[str, typing.Any]:
+    kwargs: dict[str, typing.Any] = {
+        "angle": operation.bz_angle,
+        "bounds": operation.bz_bounds,
+        "ax": _RawCode(axis_code),
+    }
+    if operation.bz_vertices:
+        kwargs["vertices"] = True
+    if operation.bz_midpoints:
+        kwargs["midpoints"] = True
+    if operation.bz_vertex_kw:
+        kwargs["vertex_kwargs"] = dict(operation.bz_vertex_kw)
+    if operation.bz_midpoint_kw:
+        kwargs["midpoint_kwargs"] = dict(operation.bz_midpoint_kw)
+    kwargs.update(operation.line_kw)
+    return kwargs
+
+
+def _plot_call_code(
+    operation: FigureOperationState,
+    *,
+    axis_code: str,
+) -> str:
+    if operation.bz_mode == "out_of_plane":
+        kwargs = {
+            "k_parallel": operation.bz_k_parallel,
+            **_plot_kwargs(operation, axis_code=axis_code),
+        }
+        return f"eplt.plot_out_of_plane_bz(bvec, {_code_kwargs(kwargs)})"
+
+    kwargs = {"kz": _RawCode("kz"), **_plot_kwargs(operation, axis_code=axis_code)}
+    return f"eplt.plot_in_plane_bz(bvec, {_code_kwargs(kwargs)})"
+
+
+def _single_axis_code(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> str | None:
+    if operation.axes.expression:
+        return None
+    setup = tool._recipe.setup
+    if setup.layout_mode == "gridspec":
+        if len(_gridspec_valid_axes_ids(setup, operation.axes.axes_ids)) != 1:
+            return None
+    elif len(operation.axes.valid_axes(setup)) != 1:
+        return None
+    return _axes_code(tool, operation.axes, for_plot_slices=False)
+
+
+def _bz_code_lines(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> list[str]:
+    lines = _lattice_code_lines(operation)
+    if operation.bz_mode == "in_plane":
+        lines.append(f"kz = {operation.bz_kz_pi_over_c!r} * np.pi / {operation.bz_c!r}")
+
+    axis_code = _single_axis_code(tool, operation)
+    if axis_code is not None:
+        lines.append(_plot_call_code(operation, axis_code=axis_code))
+        return lines
+
+    call = _plot_call_code(operation, axis_code="ax")
+    lines.extend(
+        (
+            f"for ax in {_axes_sequence_code(tool, operation.axes)}:",
+            f"    {call}",
+        )
+    )
+    return lines
+
+
+def _spinbox(
+    value: float,
+    *,
+    parent: QtWidgets.QWidget,
+    minimum: float = -1_000_000.0,
+    maximum: float = 1_000_000.0,
+    step: float = 0.1,
+    decimals: int = 4,
+) -> QtWidgets.QDoubleSpinBox:
+    spinbox = QtWidgets.QDoubleSpinBox(parent)
+    spinbox.setRange(minimum, maximum)
+    spinbox.setDecimals(decimals)
+    spinbox.setSingleStep(step)
+    spinbox.setKeyboardTracking(False)
+    spinbox.setValue(float(value))
+    return spinbox
+
+
+def _lattice_spinbox(
+    operation: FigureOperationState,
+    field: str,
+    *,
+    parent: QtWidgets.QWidget,
+) -> QtWidgets.QDoubleSpinBox:
+    minimum = 0.0001 if field in {"bz_a", "bz_b", "bz_c"} else 0.0
+    maximum = 1_000_000.0 if field in {"bz_a", "bz_b", "bz_c"} else 180.0
+    step = 0.1 if field in {"bz_a", "bz_b", "bz_c"} else 1.0
+    decimals = 4 if field in {"bz_a", "bz_b", "bz_c"} else 3
+    return _spinbox(
+        typing.cast("float", getattr(operation, field)),
+        parent=parent,
+        minimum=minimum,
+        maximum=maximum,
+        step=step,
+        decimals=decimals,
+    )
+
+
+def _add_spinbox_row(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    layout: QtWidgets.QFormLayout,
+    *,
+    label: str,
+    field: str,
+    object_name: str,
+    tooltip: str,
+    parent: QtWidgets.QWidget,
+    spinbox_factory: Callable[..., QtWidgets.QDoubleSpinBox] | None = None,
+) -> None:
+    mixed = tool._batch_is_mixed(operation, lambda target: getattr(target, field))
+    if spinbox_factory is None:
+        spinbox = _spinbox(float(getattr(operation, field)), parent=parent)
+    else:
+        spinbox = spinbox_factory(operation, field, parent=parent)
+    spinbox.setObjectName(object_name)
+    tool._connect_value_signal(
+        spinbox,
+        spinbox.valueChanged,
+        float,
+        lambda value: tool._update_current_operation(**{field: value}),
+    )
+    tool._add_form_row(
+        layout,
+        label,
+        tool._mixed_value_widget(spinbox, mixed=mixed, parent=parent),
+        tooltip,
+    )
+
+
+def _build_slice_editor(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
+) -> None:
+    mode_mixed = tool._batch_is_mixed(operation, lambda target: target.bz_mode)
+    mode_combo = tool._combo(
+        tuple(_MODE_LABELS.values()),
+        None if mode_mixed else _mode_text(operation.bz_mode),
+        lambda text: tool._update_current_operation(bz_mode=_mode_from_text(text)),
+        parent=page,
+        mixed=mode_mixed,
+    )
+    mode_combo.setObjectName("figureComposerBZModeCombo")
+    tool._add_form_row(
+        layout,
+        "Mode",
+        mode_combo,
+        "Choose the BZ slice orientation.",
+    )
+
+    _add_spinbox_row(
+        tool,
+        operation,
+        layout,
+        label="Angle",
+        field="bz_angle",
+        object_name="figureComposerBZAngleSpin",
+        tooltip="Rotation angle in degrees.",
+        parent=page,
+    )
+    _add_spinbox_row(
+        tool,
+        operation,
+        layout,
+        label="kz (pi/c)",
+        field="bz_kz_pi_over_c",
+        object_name="figureComposerBZKzSpin",
+        tooltip="Normalized kz value for in-plane slices, in units of pi/c.",
+        parent=page,
+    )
+    _add_spinbox_row(
+        tool,
+        operation,
+        layout,
+        label="k parallel",
+        field="bz_k_parallel",
+        object_name="figureComposerBZKParallelSpin",
+        tooltip="Fixed in-plane momentum component for out-of-plane slices.",
+        parent=page,
+    )
+
+    bounds_text, bounds_mixed = tool._batch_text(
+        operation, lambda target: target.bz_bounds, _format_bounds
+    )
+    bounds_edit = tool._line_edit(bounds_text, parent=page)
+    bounds_edit.setObjectName("figureComposerBZBoundsEdit")
+    tool._apply_mixed_line_edit(bounds_edit, bounds_mixed)
+    tool._connect_line_edit_finished(
+        bounds_edit,
+        lambda text: tool._update_current_operation(bz_bounds=_bounds_from_text(text)),
+    )
+    tool._add_form_row(
+        layout,
+        "Bounds",
+        bounds_edit,
+        "Optional bounds as xmin, xmax, ymin, ymax. Leave blank to infer from axes.",
+    )
+
+
+def _build_lattice_editor(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
+) -> None:
+    for label, field, object_name in (
+        ("a", "bz_a", "figureComposerBZAEdit"),
+        ("b", "bz_b", "figureComposerBZBEdit"),
+        ("c", "bz_c", "figureComposerBZCEdit"),
+        ("alpha", "bz_alpha", "figureComposerBZAlphaEdit"),
+        ("beta", "bz_beta", "figureComposerBZBetaEdit"),
+        ("gamma", "bz_gamma", "figureComposerBZGammaEdit"),
+    ):
+        _add_spinbox_row(
+            tool,
+            operation,
+            layout,
+            label=label,
+            field=field,
+            object_name=object_name,
+            tooltip=f"Lattice parameter {label}.",
+            parent=page,
+            spinbox_factory=_lattice_spinbox,
+        )
+
+    centering_mixed = tool._batch_is_mixed(
+        operation, lambda target: target.bz_centering_type
+    )
+    centering_combo = tool._combo(
+        _CENTERING_TYPES,
+        None if centering_mixed else operation.bz_centering_type,
+        lambda text: tool._update_current_operation(bz_centering_type=text),
+        parent=page,
+        mixed=centering_mixed,
+    )
+    centering_combo.setObjectName("figureComposerBZCenteringCombo")
+    tool._add_form_row(
+        layout,
+        "Centering",
+        centering_combo,
+        "Conventional-cell centering type. P leaves the cell unchanged.",
+    )
+
+
+def _build_style_editor(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
+) -> None:
+    color_text, color_mixed = tool._batch_text(
+        operation,
+        lambda target: line_kw_text(target, "color", "c") or "",
+        str,
+    )
+    color_edit = _ColorLineEditWidget(color_text, parent=page)
+    color_edit.setLineEditObjectName("figureComposerBZColorEdit")
+    color_edit.setColorButtonObjectName("figureComposerBZColorButton")
+    tool._apply_mixed_line_edit(color_edit.line_edit, color_mixed)
+    tool._connect_value_signal(
+        color_edit,
+        color_edit.editingFinished,
+        color_edit.text,
+        lambda text: update_current_line_kw(
+            tool, "color", color_kw_value_from_text(text), aliases=("c",)
+        ),
+        unchanged_mixed=lambda: tool._line_edit_batch_unchanged(color_edit.line_edit),
+    )
+    tool._add_form_row(
+        layout,
+        "Line color",
+        color_edit,
+        "Matplotlib color for BZ boundary lines.",
+    )
+
+    line_style_mixed = tool._batch_is_mixed(
+        operation, lambda target: line_kw_style_value(target, "linestyle", "ls")
+    )
+    line_style_combo = tool._optional_name_combo(
+        LINE_STYLE_OPTIONS,
+        None if line_style_mixed else line_kw_style_value(operation, "linestyle", "ls"),
+        LINE_STYLE_DEFAULT_LABEL,
+        lambda text: update_current_line_kw(tool, "linestyle", text, aliases=("ls",)),
+        parent=page,
+        mixed=line_style_mixed,
+    )
+    line_style_combo.setObjectName("figureComposerBZLineStyleCombo")
+
+    line_width_mixed = tool._batch_is_mixed(
+        operation, lambda target: line_kw_text(target, "linewidth", "lw")
+    )
+    line_width_spin = optional_positive_spinbox(
+        None if line_width_mixed else line_kw_float(operation, "linewidth", "lw"),
+        parent=page,
+    )
+    line_width_spin.setObjectName("figureComposerBZLineWidthSpin")
+    tool._connect_editor_signal(
+        line_width_spin,
+        line_width_spin.valueChanged,
+        lambda value: update_current_line_kw(
+            tool,
+            "linewidth",
+            optional_positive_spinbox_value(value),
+            aliases=("lw",),
+        ),
+    )
+    tool._add_compound_form_row(
+        layout,
+        "Line",
+        (
+            ("Style", line_style_combo, "Matplotlib linestyle for BZ boundaries."),
+            (
+                "Width",
+                tool._mixed_value_widget(
+                    line_width_spin, mixed=line_width_mixed, parent=page
+                ),
+                "Matplotlib linewidth for BZ boundaries.",
+            ),
+        ),
+        "Line style controls for BZ boundaries.",
+    )
+
+    vertices_mixed = tool._batch_is_mixed(operation, lambda target: target.bz_vertices)
+    vertices_check = tool._check_box(
+        operation.bz_vertices,
+        lambda checked: tool._update_current_operation(bz_vertices=checked),
+        parent=page,
+        mixed=vertices_mixed,
+    )
+    vertices_check.setObjectName("figureComposerBZVerticesCheck")
+    vertices_check.setText("")
+    midpoints_mixed = tool._batch_is_mixed(
+        operation, lambda target: target.bz_midpoints
+    )
+    midpoints_check = tool._check_box(
+        operation.bz_midpoints,
+        lambda checked: tool._update_current_operation(bz_midpoints=checked),
+        parent=page,
+        mixed=midpoints_mixed,
+    )
+    midpoints_check.setObjectName("figureComposerBZMidpointsCheck")
+    midpoints_check.setText("")
+    tool._add_compound_form_row(
+        layout,
+        "Points",
+        (
+            ("Vertices", vertices_check, "Draw BZ vertex markers."),
+            ("Midpoints", midpoints_check, "Draw BZ segment midpoint markers."),
+        ),
+        "Optional point overlays.",
+    )
+
+    for label, field, object_name, tooltip in (
+        (
+            "Vertex kwargs",
+            "bz_vertex_kw",
+            "figureComposerBZVertexKwEdit",
+            "Keyword arguments forwarded to the vertex scatter artist.",
+        ),
+        (
+            "Midpoint kwargs",
+            "bz_midpoint_kw",
+            "figureComposerBZMidpointKwEdit",
+            "Keyword arguments forwarded to the midpoint scatter artist.",
+        ),
+    ):
+        text, mixed = tool._batch_text(
+            operation, lambda target, field=field: getattr(target, field), _format_dict
+        )
+        edit = tool._line_edit(text, parent=page)
+        edit.setObjectName(object_name)
+        tool._apply_mixed_line_edit(edit, mixed)
+        tool._connect_line_edit_finished(
+            edit,
+            lambda value, field=field: tool._update_current_operation(
+                **{field: _dict_from_text(value)}
+            ),
+        )
+        tool._add_form_row(layout, label, edit, tooltip)
+
+
+def _build_editor(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> list[tuple[str, str, QtWidgets.QWidget]]:
+    slice_page, slice_layout = tool._new_step_form_page("figureComposerBZSlicePage")
+    lattice_page, lattice_layout = tool._new_step_form_page(
+        "figureComposerBZLatticePage"
+    )
+    style_page, style_layout = tool._new_step_form_page("figureComposerBZStylePage")
+    tool.operation_editor = slice_page
+    tool.operation_editor_layout = slice_layout
+
+    _build_slice_editor(tool, operation, slice_page, slice_layout)
+    _build_lattice_editor(tool, operation, lattice_page, lattice_layout)
+    _build_style_editor(tool, operation, style_page, style_layout)
+
+    return [
+        ("slice", "Slice", slice_page),
+        ("lattice", "Lattice", lattice_page),
+        ("style", "Style", style_page),
+    ]
+
+
+def _editor_sections(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> tuple[StepSection, ...]:
+    return tuple(
+        StepSection(key, title, page, _SECTION_TOOLTIPS[key])
+        for key, title, page in _build_editor(tool, operation)
+    )
+
+
+def _create_operation(tool: FigureComposerTool) -> FigureOperationState:
+    from erlab.interactive._figurecomposer._seeding import _default_bz_updates
+
+    return FigureOperationState.bz_overlay(axes=tool._selected_axes_state()).model_copy(
+        update=_default_bz_updates()
+    )
+
+
+def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
+    prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
+    return f"{prefix}BZ Overlay: {_mode_text(operation.bz_mode)}"
+
+
+def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:
+    return (
+        "Draws a Brillouin-zone slice overlay.\n"
+        f"Targets: {tool._axes_target_text(operation.axes)}"
+    )
+
+
+def _has_invalid_target(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> bool:
+    return tool._axes_selection_has_invalid_target(operation.axes)
+
+
+def _section_summary(
+    tool: FigureComposerTool, key: str, operation: FigureOperationState
+) -> str:
+    match key:
+        case "axes":
+            return tool._axes_target_text(operation.axes)
+        case "slice":
+            if operation.bz_mode == "out_of_plane":
+                return f"out-of-plane, k={operation.bz_k_parallel:g}"
+            return f"in-plane, kz={operation.bz_kz_pi_over_c:g} pi/c"
+        case "lattice":
+            return (
+                f"{operation.bz_a:g}, {operation.bz_b:g}, {operation.bz_c:g}; "
+                f"{operation.bz_centering_type}"
+            )
+        case "style":
+            labels = []
+            if operation.bz_vertices:
+                labels.append("vertices")
+            if operation.bz_midpoints:
+                labels.append("midpoints")
+            return ", ".join(labels) or line_kw_text(operation, "color", "c")
+    return ""
+
+
+def _required_imports(
+    _tool: FigureComposerTool, operation: FigureOperationState
+) -> tuple[str, ...]:
+    imports = ["import erlab", "import erlab.plotting as eplt"]
+    if operation.bz_mode == "in_plane":
+        imports.append("import numpy as np")
+    return tuple(imports)
+
+
+SPEC = OperationSpec(
+    kind=FigureOperationKind.BZ_OVERLAY,
+    add_actions=(
+        AddStepActionSpec(
+            action_id=FigureOperationKind.BZ_OVERLAY.value,
+            text="BZ Overlay",
+            tooltip="Add a Brillouin-zone slice overlay step.",
+            create_operation=_create_operation,
+        ),
+    ),
+    display_text=_display_text,
+    tooltip=_tooltip,
+    target_text=lambda tool, operation: tool._axes_target_text(operation.axes),
+    has_invalid_target=_has_invalid_target,
+    uses_axes=lambda _operation: True,
+    uses_source_section=_uses_no_source_section,
+    source_names=_empty_source_names,
+    build_source_editor=_empty_source_editor,
+    build_editor_sections=_editor_sections,
+    section_summary=_section_summary,
+    render=lambda tool, operation, _figure, axs: _render_bz_overlay(
+        tool, operation, axs
+    ),
+    code_lines=_bz_code_lines,
+    required_imports=_required_imports,
+)

--- a/src/erlab/interactive/_figurecomposer/_operations/_photon_energy.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_photon_energy.py
@@ -259,6 +259,7 @@ def _build_photon_editor(
     )
     photon_edit = tool._line_edit(photon_text, parent=page)
     photon_edit.setObjectName("figureComposerPhotonEnergyValuesEdit")
+    photon_edit.setPlaceholderText("Enter photon energies")
     tool._apply_mixed_line_edit(photon_edit, photon_mixed)
     tool._connect_line_edit_finished(
         photon_edit,
@@ -268,7 +269,7 @@ def _build_photon_editor(
     )
     tool._add_form_row(
         layout,
-        "Photon energies",
+        "hν",
         photon_edit,
         "Photon energies in eV, entered as comma-separated numbers.",
     )
@@ -443,7 +444,7 @@ def _build_editor(
     _build_style_editor(tool, operation, style_page, style_layout)
 
     return [
-        ("photon", "Photon Energy", photon_page),
+        ("photon", "hν", photon_page),
         ("style", "Style", style_page),
     ]
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_photon_energy.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_photon_energy.py
@@ -1,0 +1,602 @@
+"""Photon-energy overlay operation editor, renderer, and code generation."""
+
+from __future__ import annotations
+
+import contextlib
+import typing
+
+from erlab.interactive._figurecomposer._code import _axes_code, _axes_sequence_code
+from erlab.interactive._figurecomposer._gridspec import _gridspec_valid_axes_ids
+from erlab.interactive._figurecomposer._line_style import (
+    LINE_STYLE_DEFAULT_LABEL,
+    LINE_STYLE_OPTIONS,
+    color_kw_value_from_text,
+    line_kw_float,
+    line_kw_style_value,
+    line_kw_text,
+    optional_positive_spinbox,
+    optional_positive_spinbox_value,
+    update_current_line_kw,
+)
+from erlab.interactive._figurecomposer._operations._base import (
+    AddStepActionSpec,
+    OperationSpec,
+    StepSection,
+)
+from erlab.interactive._figurecomposer._rendering import (
+    _axes_from_selection,
+    _iter_axes,
+)
+from erlab.interactive._figurecomposer._sources import (
+    _public_source_data,
+    _valid_source_variable,
+)
+from erlab.interactive._figurecomposer._state import (
+    FigureOperationKind,
+    FigureOperationState,
+)
+from erlab.interactive._figurecomposer._text import (
+    _code_kwargs,
+    _dict_from_text,
+    _float_tuple_from_text,
+    _format_dict,
+    _format_tuple,
+    _input_error,
+    _RawCode,
+)
+from erlab.interactive._figurecomposer._widgets import _ColorLineEditWidget
+
+if typing.TYPE_CHECKING:
+    import xarray as xr
+    from qtpy import QtWidgets
+
+    from erlab.interactive._figurecomposer._tool import FigureComposerTool
+
+
+_DEFAULT_LABEL_TEMPLATE = r"$h\nu = {hv:g}$ eV"
+_SECTION_TOOLTIPS = {
+    "photon": "Choose photon energies and the electron binding-energy slice.",
+    "style": "Set curve styling and legend labels.",
+}
+
+
+def _format_optional_float(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value:g}"
+
+
+def _optional_float_from_text(text: str) -> float | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        return float(stripped)
+    except ValueError as exc:
+        raise _input_error("Enter one number, or leave blank.") from exc
+
+
+def _photon_energies_from_text(text: str) -> tuple[float, ...]:
+    return _float_tuple_from_text(text)
+
+
+def _photon_energies_code(values: tuple[float, ...]) -> str:
+    return "[" + ", ".join(f"{value:g}" for value in values) + "]"
+
+
+def _source_data(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> xr.DataArray:
+    if operation.hv_overlay_source is None:
+        raise ValueError("Select a source data array for the photon-energy overlay")
+    data = tool._source_data.get(operation.hv_overlay_source)
+    if data is None:
+        source_name = tool._source_display_name(operation.hv_overlay_source)
+        raise ValueError(f"Source {source_name!r} is missing")
+    return _public_source_data(data)
+
+
+def _source_is_kparallel_kz(data: xr.DataArray) -> bool:
+    dims = {str(dim) for dim in data.squeeze(drop=True).dims}
+    return "kz" in dims and bool({"kx", "ky"} & dims)
+
+
+def _photon_x_dim(data: xr.DataArray, kz_values: xr.DataArray) -> str:
+    candidates: list[str] = []
+    with contextlib.suppress(AttributeError, KeyError, ValueError):
+        candidates.append(str(data.kspace.slit_axis))
+    candidates.extend(dim for dim in ("kx", "ky") if dim not in candidates)
+    for dim in candidates:
+        if dim in kz_values.dims and dim in kz_values.coords:
+            return dim
+    raise ValueError(
+        "Photon-energy overlays require a kx-kz or ky-kz source data array"
+    )
+
+
+def _kz_values(
+    data: xr.DataArray, operation: FigureOperationState
+) -> tuple[xr.DataArray, str]:
+    if not operation.photon_energies:
+        raise ValueError("Enter at least one photon energy")
+    if not _source_is_kparallel_kz(data):
+        raise ValueError(
+            "Photon-energy overlays require a kx-kz or ky-kz source data array"
+        )
+    kz_values = data.kspace.hv_to_kz(list(operation.photon_energies))
+    if operation.binding_energy is not None:
+        kz_values = kz_values.qsel(eV=operation.binding_energy)
+    x_dim = _photon_x_dim(data, kz_values)
+    if "eV" in kz_values.dims:
+        raise ValueError(
+            "Select a binding energy before plotting photon-energy overlays"
+        )
+    extra_dims = {str(dim) for dim in kz_values.dims} - {"hv", x_dim}
+    if "hv" not in kz_values.dims or extra_dims:
+        raise ValueError(
+            "Photon-energy overlay curves must reduce to hv and one momentum dimension"
+        )
+    return kz_values, x_dim
+
+
+def _label_text(operation: FigureOperationState, kz: xr.DataArray) -> str:
+    return operation.label_template.format(hv=kz.hv)
+
+
+def _line_kwargs(
+    operation: FigureOperationState, kz: xr.DataArray
+) -> dict[str, typing.Any]:
+    kwargs = {key: value for key, value in operation.line_kw.items() if key != "label"}
+    return {"label": _label_text(operation, kz), **kwargs}
+
+
+def _render_photon_energy_overlay(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    axs: typing.Any,
+) -> None:
+    axes = _iter_axes(
+        _axes_from_selection(tool, operation.axes, axs, for_plot_slices=False)
+    )
+    if not axes:
+        return
+
+    kz_values, x_dim = _kz_values(_source_data(tool, operation), operation)
+    for axis in axes:
+        for index in range(kz_values.sizes["hv"]):
+            kz = kz_values.isel(hv=index)
+            axis.plot(kz[x_dim], kz, **_line_kwargs(operation, kz))
+        if operation.show_legend:
+            axis.legend(**operation.legend_kw)
+
+
+def _label_code(operation: FigureOperationState) -> str:
+    if operation.label_template == _DEFAULT_LABEL_TEMPLATE:
+        return 'rf"$h\\nu = {kz.hv:g}$ eV"'
+    return f"{operation.label_template!r}.format(hv=kz.hv)"
+
+
+def _plot_call_code(
+    operation: FigureOperationState, *, axis_name: str, x_dim: str
+) -> str:
+    line_kwargs = {
+        key: value for key, value in operation.line_kw.items() if key != "label"
+    }
+    kwargs = {"label": _RawCode(_label_code(operation)), **line_kwargs}
+    kwargs_text = _code_kwargs(kwargs)
+    return f"{axis_name}.plot(kz.{x_dim}, kz, {kwargs_text})"
+
+
+def _legend_call_code(operation: FigureOperationState, *, axis_name: str) -> str:
+    kwargs_text = _code_kwargs(operation.legend_kw)
+    if kwargs_text:
+        return f"{axis_name}.legend({kwargs_text})"
+    return f"{axis_name}.legend()"
+
+
+def _single_axis_code(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> str | None:
+    if operation.axes.expression:
+        return None
+    setup = tool._recipe.setup
+    if setup.layout_mode == "gridspec":
+        if len(_gridspec_valid_axes_ids(setup, operation.axes.axes_ids)) != 1:
+            return None
+    elif len(operation.axes.valid_axes(setup)) != 1:
+        return None
+    return _axes_code(tool, operation.axes, for_plot_slices=False)
+
+
+def _photon_energy_code_lines(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> list[str]:
+    if operation.hv_overlay_source is None:
+        raise ValueError("Select a source data array for the photon-energy overlay")
+    data = _source_data(tool, operation)
+    _, x_dim = _kz_values(data, operation)
+    source_code = _valid_source_variable(operation.hv_overlay_source)
+    values_code = _photon_energies_code(operation.photon_energies)
+    call_code = f"{source_code}.kspace.hv_to_kz({values_code})"
+    if operation.binding_energy is not None:
+        call_code = f"{call_code}.qsel(eV={operation.binding_energy:g})"
+    lines = [f"kz_values = {call_code}", ""]
+
+    axis_code = _single_axis_code(tool, operation)
+    if axis_code is not None:
+        lines.extend(
+            (
+                "for i in range(len(kz_values.hv)):",
+                "    kz = kz_values.isel(hv=i)",
+                f"    {_plot_call_code(operation, axis_name=axis_code, x_dim=x_dim)}",
+            )
+        )
+        if operation.show_legend:
+            lines.append(_legend_call_code(operation, axis_name=axis_code))
+        return lines
+
+    lines.append(f"for ax in {_axes_sequence_code(tool, operation.axes)}:")
+    lines.extend(
+        (
+            "    for i in range(len(kz_values.hv)):",
+            "        kz = kz_values.isel(hv=i)",
+            f"        {_plot_call_code(operation, axis_name='ax', x_dim=x_dim)}",
+        )
+    )
+    if operation.show_legend:
+        lines.append(f"    {_legend_call_code(operation, axis_name='ax')}")
+    return lines
+
+
+def _build_photon_editor(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
+) -> None:
+    photon_text, photon_mixed = tool._batch_text(
+        operation, lambda target: target.photon_energies, _format_tuple
+    )
+    photon_edit = tool._line_edit(photon_text, parent=page)
+    photon_edit.setObjectName("figureComposerPhotonEnergyValuesEdit")
+    tool._apply_mixed_line_edit(photon_edit, photon_mixed)
+    tool._connect_line_edit_finished(
+        photon_edit,
+        lambda text: tool._update_current_operation(
+            photon_energies=_photon_energies_from_text(text)
+        ),
+    )
+    tool._add_form_row(
+        layout,
+        "Photon energies",
+        photon_edit,
+        "Photon energies in eV, entered as comma-separated numbers.",
+    )
+
+    binding_text, binding_mixed = tool._batch_text(
+        operation, lambda target: target.binding_energy, _format_optional_float
+    )
+    binding_edit = tool._line_edit(binding_text, parent=page)
+    binding_edit.setObjectName("figureComposerPhotonEnergyBindingEnergyEdit")
+    tool._apply_mixed_line_edit(binding_edit, binding_mixed)
+    tool._connect_line_edit_finished(
+        binding_edit,
+        lambda text: tool._update_current_operation(
+            binding_energy=_optional_float_from_text(text)
+        ),
+    )
+    tool._add_form_row(
+        layout,
+        "Binding energy",
+        binding_edit,
+        "Electron binding energy in eV. Leave blank only when the overlay data "
+        "already has no eV dimension.",
+    )
+
+
+def _build_style_editor(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
+) -> None:
+    color_text, color_mixed = tool._batch_text(
+        operation,
+        lambda target: line_kw_text(target, "color", "c") or "",
+        str,
+    )
+    color_edit = _ColorLineEditWidget(color_text, parent=page)
+    color_edit.setLineEditObjectName("figureComposerPhotonEnergyColorEdit")
+    color_edit.setColorButtonObjectName("figureComposerPhotonEnergyColorButton")
+    tool._apply_mixed_line_edit(color_edit.line_edit, color_mixed)
+    tool._connect_value_signal(
+        color_edit,
+        color_edit.editingFinished,
+        color_edit.text,
+        lambda text: update_current_line_kw(
+            tool, "color", color_kw_value_from_text(text), aliases=("c",)
+        ),
+        unchanged_mixed=lambda: tool._line_edit_batch_unchanged(color_edit.line_edit),
+    )
+    tool._add_form_row(
+        layout,
+        "Line color",
+        color_edit,
+        "Matplotlib color for photon-energy annotation curves.",
+    )
+
+    line_style_mixed = tool._batch_is_mixed(
+        operation, lambda target: line_kw_style_value(target, "linestyle", "ls")
+    )
+    line_style_combo = tool._optional_name_combo(
+        LINE_STYLE_OPTIONS,
+        None if line_style_mixed else line_kw_style_value(operation, "linestyle", "ls"),
+        LINE_STYLE_DEFAULT_LABEL,
+        lambda text: update_current_line_kw(tool, "linestyle", text, aliases=("ls",)),
+        parent=page,
+        mixed=line_style_mixed,
+    )
+    line_style_combo.setObjectName("figureComposerPhotonEnergyLineStyleCombo")
+
+    line_width_mixed = tool._batch_is_mixed(
+        operation, lambda target: line_kw_text(target, "linewidth", "lw")
+    )
+    line_width_spin = optional_positive_spinbox(
+        None if line_width_mixed else line_kw_float(operation, "linewidth", "lw"),
+        parent=page,
+    )
+    line_width_spin.setObjectName("figureComposerPhotonEnergyLineWidthSpin")
+    tool._connect_editor_signal(
+        line_width_spin,
+        line_width_spin.valueChanged,
+        lambda value: update_current_line_kw(
+            tool,
+            "linewidth",
+            optional_positive_spinbox_value(value),
+            aliases=("lw",),
+        ),
+    )
+    tool._add_compound_form_row(
+        layout,
+        "Line",
+        (
+            (
+                "Style",
+                line_style_combo,
+                "Matplotlib linestyle for photon-energy annotation curves.",
+            ),
+            (
+                "Width",
+                tool._mixed_value_widget(
+                    line_width_spin, mixed=line_width_mixed, parent=page
+                ),
+                "Matplotlib linewidth for photon-energy annotation curves.",
+            ),
+        ),
+        "Line style controls for photon-energy annotation curves.",
+    )
+
+    legend_mixed = tool._batch_is_mixed(operation, lambda target: target.show_legend)
+    legend_check = tool._check_box(
+        operation.show_legend,
+        lambda checked: tool._update_current_operation(show_legend=checked),
+        parent=page,
+        mixed=legend_mixed,
+    )
+    legend_check.setObjectName("figureComposerPhotonEnergyLegendCheck")
+    legend_check.setText("")
+    tool._add_form_row(
+        layout,
+        "Legend",
+        legend_check,
+        "Add or update the axes legend after plotting the photon-energy curves.",
+    )
+
+    legend_kw_text, legend_kw_mixed = tool._batch_text(
+        operation, lambda target: target.legend_kw, _format_dict
+    )
+    legend_kw_edit = tool._line_edit(legend_kw_text, parent=page)
+    legend_kw_edit.setObjectName("figureComposerPhotonEnergyLegendKwEdit")
+    tool._apply_mixed_line_edit(legend_kw_edit, legend_kw_mixed)
+    tool._connect_line_edit_finished(
+        legend_kw_edit,
+        lambda text: tool._update_current_operation(legend_kw=_dict_from_text(text)),
+    )
+    tool._add_form_row(
+        layout,
+        "Legend kwargs",
+        legend_kw_edit,
+        "Keyword arguments forwarded to the Matplotlib legend.",
+    )
+
+    label_text, label_mixed = tool._batch_text(
+        operation, lambda target: target.label_template, str
+    )
+    label_edit = tool._line_edit(label_text, parent=page)
+    label_edit.setObjectName("figureComposerPhotonEnergyLabelTemplateEdit")
+    tool._apply_mixed_line_edit(label_edit, label_mixed)
+    tool._connect_line_edit_finished(
+        label_edit,
+        lambda text: tool._update_current_operation(label_template=text),
+    )
+    tool._add_form_row(
+        layout,
+        "Label",
+        label_edit,
+        "Legend label template. Use {hv} for the photon energy.",
+    )
+
+
+def _build_editor(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> list[tuple[str, str, QtWidgets.QWidget]]:
+    photon_page, photon_layout = tool._new_step_form_page(
+        "figureComposerPhotonEnergyPage"
+    )
+    style_page, style_layout = tool._new_step_form_page(
+        "figureComposerPhotonEnergyStylePage"
+    )
+    tool.operation_editor = photon_page
+    tool.operation_editor_layout = photon_layout
+
+    _build_photon_editor(tool, operation, photon_page, photon_layout)
+    _build_style_editor(tool, operation, style_page, style_layout)
+
+    return [
+        ("photon", "Photon Energy", photon_page),
+        ("style", "Style", style_page),
+    ]
+
+
+def _editor_sections(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> tuple[StepSection, ...]:
+    return tuple(
+        StepSection(key, title, page, _SECTION_TOOLTIPS[key])
+        for key, title, page in _build_editor(tool, operation)
+    )
+
+
+def _seed_source(tool: FigureComposerTool) -> str | None:
+    current = tool._current_operation()
+    if current is not None:
+        sources = tool._selected_sources_for_operation(current[1])
+        if sources:
+            return sources[0]
+    source_names = tuple(tool._source_names())
+    if tool._recipe.primary_source in source_names:
+        return tool._recipe.primary_source
+    return source_names[0] if source_names else None
+
+
+def _seed_binding_energy(tool: FigureComposerTool) -> float | None:
+    current = tool._current_operation()
+    if current is None:
+        return None
+    operation = current[1]
+    if (
+        operation.kind == FigureOperationKind.PLOT_SLICES
+        and operation.slice_dim == "eV"
+        and len(operation.slice_values) == 1
+    ):
+        return operation.slice_values[0]
+    return None
+
+
+def _create_operation(tool: FigureComposerTool) -> FigureOperationState:
+    return FigureOperationState.photon_energy_overlay(
+        source=_seed_source(tool),
+        axes=tool._selected_axes_state(),
+        binding_energy=_seed_binding_energy(tool),
+    )
+
+
+def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
+    prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
+    source = (
+        tool._source_display_name(operation.hv_overlay_source)
+        if operation.hv_overlay_source is not None
+        else "missing source"
+    )
+    return f"{prefix}Photon Energy Overlay: {source}"
+
+
+def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:
+    return (
+        "Draws constant-photon-energy curves on k_parallel-kz plots.\n"
+        f"Targets: {tool._axes_target_text(operation.axes)}"
+    )
+
+
+def _has_invalid_target(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> bool:
+    return tool._axes_selection_has_invalid_target(operation.axes)
+
+
+def _source_names(operation: FigureOperationState) -> tuple[str, ...]:
+    return (
+        (operation.hv_overlay_source,)
+        if operation.hv_overlay_source is not None
+        else ()
+    )
+
+
+def _build_source_editor(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> None:
+    source_mixed = tool._batch_is_mixed(
+        operation, lambda target: target.hv_overlay_source
+    )
+    source_combo = tool._source_combo(
+        tool._source_names(),
+        None if source_mixed else operation.hv_overlay_source,
+        lambda source: tool._update_current_operation_rebuild(hv_overlay_source=source),
+        parent=tool.step_source_controls,
+        mixed=source_mixed,
+    )
+    source_combo.setObjectName("figureComposerPhotonEnergySourceCombo")
+    tool._add_form_row(
+        tool.step_source_controls_layout,
+        "Overlay data",
+        source_combo,
+        "Data array used to compute the photon-energy annotation curves.",
+    )
+
+
+def _section_summary(
+    tool: FigureComposerTool, key: str, operation: FigureOperationState
+) -> str:
+    match key:
+        case "sources":
+            if operation.hv_overlay_source is None:
+                return "none"
+            return tool._source_display_name(operation.hv_overlay_source)
+        case "axes":
+            return tool._axes_target_text(operation.axes)
+        case "photon":
+            energies = _format_tuple(operation.photon_energies) or "no energies"
+            if operation.binding_energy is None:
+                return energies
+            return f"{energies}; eV={operation.binding_energy:g}"
+        case "style":
+            if operation.show_legend:
+                if operation.legend_kw:
+                    return "legend kwargs"
+                return line_kw_text(operation, "color", "c") or "legend"
+            return line_kw_text(operation, "color", "c") or "no legend"
+    return ""
+
+
+def _required_imports(
+    _tool: FigureComposerTool, _operation: FigureOperationState
+) -> tuple[str, ...]:
+    return ("import erlab",)
+
+
+SPEC = OperationSpec(
+    kind=FigureOperationKind.PHOTON_ENERGY_OVERLAY,
+    add_actions=(
+        AddStepActionSpec(
+            action_id=FigureOperationKind.PHOTON_ENERGY_OVERLAY.value,
+            text="Photon Energy Overlay",
+            tooltip="Add photon-energy annotation curves to a k_parallel-kz plot.",
+            create_operation=_create_operation,
+        ),
+    ),
+    display_text=_display_text,
+    tooltip=_tooltip,
+    target_text=lambda tool, operation: tool._axes_target_text(operation.axes),
+    has_invalid_target=_has_invalid_target,
+    uses_axes=lambda _operation: True,
+    uses_source_section=lambda _operation: True,
+    source_names=_source_names,
+    build_source_editor=_build_source_editor,
+    build_editor_sections=_editor_sections,
+    section_summary=_section_summary,
+    render=lambda tool, operation, _figure, axs: _render_photon_energy_overlay(
+        tool, operation, axs
+    ),
+    code_lines=_photon_energy_code_lines,
+    required_imports=_required_imports,
+)

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -3478,7 +3478,14 @@ def _has_invalid_target(
 
 
 def _source_names(operation: FigureOperationState) -> tuple[str, ...]:
-    return operation.sources
+    names: list[str] = []
+    for source_name in operation.sources:
+        if source_name not in names:
+            names.append(source_name)
+    for selection in operation.map_selections:
+        if selection.source not in names:
+            names.append(selection.source)
+    return tuple(names)
 
 
 def _plot_source_check_state(

--- a/src/erlab/interactive/_figurecomposer/_operations/_registry.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import typing
 
 from erlab.interactive._figurecomposer._operations import (
+    _bz_overlay,
     _custom_code,
     _line_profile,
     _method,
@@ -25,6 +26,7 @@ _OPERATION_SPECS = {
     for spec in (
         _plot_slices.SPEC,
         _line_profile.SPEC,
+        _bz_overlay.SPEC,
         _method.SPEC,
         _custom_code.SPEC,
     )

--- a/src/erlab/interactive/_figurecomposer/_operations/_registry.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_registry.py
@@ -9,6 +9,7 @@ from erlab.interactive._figurecomposer._operations import (
     _custom_code,
     _line_profile,
     _method,
+    _photon_energy,
     _plot_slices,
 )
 
@@ -27,6 +28,7 @@ _OPERATION_SPECS = {
         _plot_slices.SPEC,
         _line_profile.SPEC,
         _bz_overlay.SPEC,
+        _photon_energy.SPEC,
         _method.SPEC,
         _custom_code.SPEC,
     )

--- a/src/erlab/interactive/_figurecomposer/_seeding.py
+++ b/src/erlab/interactive/_figurecomposer/_seeding.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 import typing
 
+import numpy as np
+
+import erlab
 from erlab.interactive._figurecomposer._state import (
+    FigureAxesSelectionState,
     FigureOperationState,
     FigurePlotSlicesPanelStyleState,
 )
+
+if typing.TYPE_CHECKING:
+    import xarray as xr
 
 
 def _plot_slices_style_update(operation: FigureOperationState) -> dict[str, typing.Any]:
@@ -132,3 +139,138 @@ def plot_slices_operation_with_source_styles(
             "panel_styles": tuple(panel_styles),
         }
     )
+
+
+def _default_bz_updates() -> dict[str, typing.Any]:
+    opts = erlab.interactive.options.model.ktool.bz
+    return {
+        "bz_a": opts.default_a,
+        "bz_b": opts.default_b,
+        "bz_c": opts.default_c,
+        "bz_alpha": opts.default_alpha,
+        "bz_beta": opts.default_beta,
+        "bz_gamma": opts.default_gamma,
+        "bz_centering_type": opts.default_centering,
+        "bz_angle": opts.default_rot,
+    }
+
+
+def _coordinate_bounds(data: xr.DataArray, dim: str) -> tuple[float, float] | None:
+    coord = data.coords.get(dim)
+    if coord is None:
+        return None
+    try:
+        values = np.asarray(coord.values, dtype=float)
+    except (TypeError, ValueError):
+        return None
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        return None
+    return float(values.min()), float(values.max())
+
+
+def _momentum_bounds(
+    data: xr.DataArray, x_dim: str, y_dim: str
+) -> tuple[float, float, float, float] | None:
+    x_bounds = _coordinate_bounds(data, x_dim)
+    y_bounds = _coordinate_bounds(data, y_dim)
+    if x_bounds is None or y_bounds is None:
+        return None
+    return (*x_bounds, *y_bounds)
+
+
+def _representative_coord_value(data: xr.DataArray, name: str) -> float | None:
+    coord = data.coords.get(name)
+    if coord is None:
+        return None
+    try:
+        values = np.asarray(coord.values, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        return None
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        return None
+    return float(np.nanmedian(finite))
+
+
+def bz_overlay_operation_from_momentum_data(
+    data: xr.DataArray,
+    *,
+    axes: FigureAxesSelectionState | None = None,
+) -> FigureOperationState | None:
+    """Seed a BZ overlay from simple momentum-cut dimensions and bounds."""
+    from erlab.interactive._figurecomposer._sources import _public_source_data
+
+    data = _public_source_data(data).squeeze(drop=True)
+    dims = {str(dim) for dim in data.dims}
+    updates = _default_bz_updates()
+
+    if {"kx", "ky"}.issubset(dims):
+        bounds = _momentum_bounds(data, "kx", "ky")
+        if bounds is None:
+            return None
+        return FigureOperationState.bz_overlay(axes=axes).model_copy(
+            update={**updates, "bz_mode": "in_plane", "bz_bounds": bounds}
+        )
+
+    if "kz" not in dims:
+        return None
+    for k_parallel_dim in ("kx", "ky"):
+        if k_parallel_dim not in dims:
+            continue
+        bounds = _momentum_bounds(data, k_parallel_dim, "kz")
+        if bounds is None:
+            return None
+        return FigureOperationState.bz_overlay(
+            axes=axes, mode="out_of_plane"
+        ).model_copy(update={**updates, "bz_bounds": bounds})
+    return None
+
+
+def _flat_ktool_out_of_plane_value(
+    data: xr.DataArray, operation: FigureOperationState
+) -> float | None:
+    if operation.bz_mode != "out_of_plane":
+        return None
+    dims = {str(dim) for dim in data.dims}
+    k_parallel_dim = "kx" if "kx" in dims else "ky" if "ky" in dims else None
+    if k_parallel_dim is None:
+        return None
+    fixed_dim = "ky" if k_parallel_dim == "kx" else "kx"
+    return _representative_coord_value(data, fixed_dim)
+
+
+def bz_overlay_operation_from_ktool(
+    tool: typing.Any,
+    data: xr.DataArray,
+    *,
+    axes: FigureAxesSelectionState | None = None,
+) -> FigureOperationState | None:
+    """Seed a BZ overlay from a ktool converted output and current ktool state."""
+    status = tool.tool_status
+    if not status.bz_enabled:
+        return None
+
+    operation = bz_overlay_operation_from_momentum_data(data, axes=axes)
+    if operation is None:
+        return None
+
+    lattice_params = tuple(float(value) for value in status.lattice_params)
+    updates: dict[str, typing.Any] = {
+        "bz_a": lattice_params[0],
+        "bz_b": lattice_params[1],
+        "bz_c": lattice_params[2],
+        "bz_alpha": lattice_params[3],
+        "bz_beta": lattice_params[4],
+        "bz_gamma": lattice_params[5],
+        "bz_centering_type": status.centering,
+        "bz_angle": float(status.rot),
+        "bz_kz_pi_over_c": float(status.kz),
+        "bz_vertices": bool(status.points),
+        "bz_midpoints": bool(status.points),
+        "line_kw": {"color": "m", "linestyle": "-", "linewidth": 2.0},
+    }
+    k_parallel = _flat_ktool_out_of_plane_value(data, operation)
+    if k_parallel is not None:
+        updates["bz_k_parallel"] = k_parallel
+    return operation.model_copy(update=updates)

--- a/src/erlab/interactive/_figurecomposer/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_state.py
@@ -247,6 +247,7 @@ class FigureOperationKind(enum.StrEnum):
     PLOT_SLICES = "plot_slices"
     LINE = "line"
     BZ_OVERLAY = "bz_overlay"
+    PHOTON_ENERGY_OVERLAY = "photon_energy_overlay"
     METHOD = "method"
     CUSTOM = "custom"
 
@@ -390,6 +391,13 @@ class FigureOperationState(pydantic.BaseModel):
     bz_vertex_kw: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
     bz_midpoint_kw: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
 
+    hv_overlay_source: str | None = None
+    photon_energies: tuple[float, ...] = ()
+    binding_energy: float | None = None
+    show_legend: bool = True
+    legend_kw: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    label_template: str = r"$h\nu = {hv:g}$ eV"
+
     method_family: FigureMethodFamily = FigureMethodFamily.ERLAB
     method_name: str = "clean_labels"
     method_args: tuple[typing.Any, ...] = ()
@@ -460,6 +468,23 @@ class FigureOperationState(pydantic.BaseModel):
             label=label,
             axes=axes or FigureAxesSelectionState(),
             bz_mode=mode,
+        )
+
+    @classmethod
+    def photon_energy_overlay(
+        cls,
+        *,
+        label: str = "Photon energy overlay",
+        source: str | None,
+        axes: FigureAxesSelectionState | None = None,
+        binding_energy: float | None = None,
+    ) -> FigureOperationState:
+        return cls(
+            kind=FigureOperationKind.PHOTON_ENERGY_OVERLAY,
+            label=label,
+            axes=axes or FigureAxesSelectionState(),
+            hv_overlay_source=source,
+            binding_energy=binding_energy,
         )
 
     @classmethod

--- a/src/erlab/interactive/_figurecomposer/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_state.py
@@ -246,6 +246,7 @@ class FigureExportState(pydantic.BaseModel):
 class FigureOperationKind(enum.StrEnum):
     PLOT_SLICES = "plot_slices"
     LINE = "line"
+    BZ_OVERLAY = "bz_overlay"
     METHOD = "method"
     CUSTOM = "custom"
 
@@ -372,6 +373,23 @@ class FigureOperationState(pydantic.BaseModel):
     line_offset_coord: str | None = None
     line_offset_scale: float = 1.0
 
+    bz_mode: typing.Literal["in_plane", "out_of_plane"] = "in_plane"
+    bz_a: float = 1.0
+    bz_b: float = 1.0
+    bz_c: float = 1.0
+    bz_alpha: float = 90.0
+    bz_beta: float = 90.0
+    bz_gamma: float = 90.0
+    bz_centering_type: typing.Literal["P", "A", "B", "C", "F", "I", "R"] = "P"
+    bz_angle: float = 0.0
+    bz_kz_pi_over_c: float = 0.0
+    bz_k_parallel: float = 0.0
+    bz_bounds: tuple[float, float, float, float] | None = None
+    bz_vertices: bool = False
+    bz_midpoints: bool = False
+    bz_vertex_kw: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    bz_midpoint_kw: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
     method_family: FigureMethodFamily = FigureMethodFamily.ERLAB
     method_name: str = "clean_labels"
     method_args: tuple[typing.Any, ...] = ()
@@ -427,6 +445,21 @@ class FigureOperationState(pydantic.BaseModel):
             label=label,
             line_source=source,
             axes=axes or FigureAxesSelectionState(),
+        )
+
+    @classmethod
+    def bz_overlay(
+        cls,
+        *,
+        label: str = "BZ overlay",
+        axes: FigureAxesSelectionState | None = None,
+        mode: typing.Literal["in_plane", "out_of_plane"] = "in_plane",
+    ) -> FigureOperationState:
+        return cls(
+            kind=FigureOperationKind.BZ_OVERLAY,
+            label=label,
+            axes=axes or FigureAxesSelectionState(),
+            bz_mode=mode,
         )
 
     @classmethod

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -3792,16 +3792,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     @staticmethod
     def _operation_source_names(operation: FigureOperationState) -> tuple[str, ...]:
-        names: list[str] = []
-        for source_name in operation.sources:
-            if source_name not in names:
-                names.append(source_name)
-        for selection in operation.map_selections:
-            if selection.source not in names:
-                names.append(selection.source)
-        if operation.line_source is not None and operation.line_source not in names:
-            names.append(operation.line_source)
-        return tuple(names)
+        return _registry.spec_for(operation.kind).source_names(operation)
 
     def _clipboard(self) -> QtGui.QClipboard | None:
         application = QtWidgets.QApplication.instance()
@@ -3942,6 +3933,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if operation.line_source is not None:
             updates["line_source"] = rename_map.get(
                 operation.line_source, operation.line_source
+            )
+        if operation.hv_overlay_source is not None:
+            updates["hv_overlay_source"] = rename_map.get(
+                operation.hv_overlay_source, operation.hv_overlay_source
             )
         if not updates:
             return operation

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2080,6 +2080,44 @@ class ImageToolManager(_ImageToolManagerBase):
             selections_per_source=1,
         )
 
+    def _figure_bz_overlay_operation_from_target(
+        self,
+        target: int | str,
+        data: xr.DataArray,
+        *,
+        axes: typing.Any,
+    ) -> typing.Any | None:
+        from erlab.interactive._figurecomposer._seeding import (
+            bz_overlay_operation_from_ktool,
+            bz_overlay_operation_from_momentum_data,
+        )
+        from erlab.interactive.kspace import KspaceTool
+
+        node = self._node_for_target(target)
+        if node.output_id == KspaceTool.Output.CONVERTED.value:
+            parent = self._parent_node(node)
+            if isinstance(parent.tool_window, KspaceTool):
+                return bz_overlay_operation_from_ktool(
+                    parent.tool_window,
+                    data,
+                    axes=axes,
+                )
+            return None
+        return bz_overlay_operation_from_momentum_data(data, axes=axes)
+
+    def _figure_bz_overlay_operation_from_targets(
+        self,
+        targets: tuple[int | str, ...],
+        source_data: Mapping[str, xr.DataArray],
+        *,
+        axes: typing.Any,
+    ) -> typing.Any | None:
+        if len(targets) != 1 or len(source_data) != 1:
+            return None
+        target = targets[0]
+        data = next(iter(source_data.values()))
+        return self._figure_bz_overlay_operation_from_target(target, data, axes=axes)
+
     def _show_figure_plot_slices_selection_error(self, error: Exception) -> None:
         from erlab.interactive._figurecomposer._exceptions import (
             PLOT_SLICES_SELECTION_ERROR_TITLE,
@@ -2367,19 +2405,25 @@ class ImageToolManager(_ImageToolManagerBase):
             None if custom_code is not None else operation or auto_operation,
             source_data,
         )
+        all_axes = FigureAxesSelectionState(
+            axes=self._figure_all_axes(setup.nrows, setup.ncols)
+        )
+        bz_operation = (
+            None
+            if operation is not None or custom_code is not None
+            else self._figure_bz_overlay_operation_from_targets(
+                resolved_targets,
+                source_data,
+                axes=all_axes,
+            )
+        )
         operations: tuple[FigureOperationState, ...]
         if operation is not None:
             if (
                 operation.kind == FigureOperationKind.PLOT_SLICES
                 and not operation.axes.expression
             ):
-                operation = operation.model_copy(
-                    update={
-                        "axes": FigureAxesSelectionState(
-                            axes=self._figure_all_axes(setup.nrows, setup.ncols)
-                        )
-                    }
-                )
+                operation = operation.model_copy(update={"axes": all_axes})
             operations = (operation,)
         elif custom_code is not None:
             operations = (
@@ -2391,13 +2435,7 @@ class ImageToolManager(_ImageToolManagerBase):
             )
         elif auto_operation is not None:
             if not auto_operation.axes.expression:
-                auto_operation = auto_operation.model_copy(
-                    update={
-                        "axes": FigureAxesSelectionState(
-                            axes=self._figure_all_axes(setup.nrows, setup.ncols)
-                        )
-                    }
-                )
+                auto_operation = auto_operation.model_copy(update={"axes": all_axes})
             operations = (auto_operation,)
         else:
             operations = typing.cast(
@@ -2407,6 +2445,8 @@ class ImageToolManager(_ImageToolManagerBase):
                     setup=setup,
                 ),
             )
+        if bz_operation is not None:
+            operations = (*operations, bz_operation)
 
         tool = FigureComposerTool.from_sources(
             source_data,
@@ -2614,6 +2654,14 @@ class ImageToolManager(_ImageToolManagerBase):
                 source_data, setup=tool.tool_status.setup
             )
         )
+        if operation is None:
+            bz_operation = self._figure_bz_overlay_operation_from_targets(
+                resolved_targets,
+                source_data,
+                axes=axes_selection,
+            )
+            if bz_operation is not None:
+                operations = (*operations, bz_operation)
         for appended in operations:
             tool.add_operation(appended.model_copy(update={"axes": axes_selection}))
 

--- a/src/erlab/plotting/__init__.pyi
+++ b/src/erlab/plotting/__init__.pyi
@@ -25,6 +25,8 @@ __all__ = [
     "plot_array_2d",
     "plot_bz",
     "plot_hex_bz",
+    "plot_in_plane_bz",
+    "plot_out_of_plane_bz",
     "plot_slices",
     "property_labels",
     "proportional_colorbar",
@@ -51,7 +53,13 @@ from .annotations import (
     set_ylabels,
     sizebar,
 )
-from .bz import get_bz_edge, plot_bz, plot_hex_bz
+from .bz import (
+    get_bz_edge,
+    plot_bz,
+    plot_hex_bz,
+    plot_in_plane_bz,
+    plot_out_of_plane_bz,
+)
 from .colors import (
     CenteredInversePowerNorm,
     CenteredPowerNorm,

--- a/src/erlab/plotting/bz.py
+++ b/src/erlab/plotting/bz.py
@@ -1,9 +1,16 @@
 """Utilities for plotting Brillouin zones."""
 
-__all__ = ["plot_bz", "plot_hex_bz"]
+__all__ = [
+    "plot_bz",
+    "plot_hex_bz",
+    "plot_in_plane_bz",
+    "plot_out_of_plane_bz",
+]
 
 import typing
 
+import matplotlib.collections
+import matplotlib.lines
 import matplotlib.patches
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,6 +24,68 @@ abbrv_kws: dict[str, tuple[str, typing.Any]] = {
     "linestyle": ("ls", "--"),
     "linewidth": ("lw", 0.5),
 }
+
+
+def _plot_bz_slice(
+    segments: npt.NDArray[np.floating],
+    vertex_points: npt.NDArray[np.floating],
+    midpoint_points: npt.NDArray[np.floating],
+    *,
+    ax: matplotlib.axes.Axes,
+    vertices: bool,
+    midpoints: bool,
+    vertex_kwargs: dict[str, typing.Any] | None,
+    midpoint_kwargs: dict[str, typing.Any] | None,
+    line_kwargs: dict[str, typing.Any],
+) -> tuple[
+    tuple[matplotlib.lines.Line2D, ...],
+    matplotlib.collections.PathCollection | None,
+    matplotlib.collections.PathCollection | None,
+]:
+    if "color" not in line_kwargs and "c" not in line_kwargs:
+        line_kwargs["color"] = line_kwargs.pop("edgecolor", None)
+        if line_kwargs["color"] is None:
+            line_kwargs["color"] = line_kwargs.pop("ec", axes_textcolor(ax))
+    else:
+        line_kwargs.pop("edgecolor", None)
+        line_kwargs.pop("ec", None)
+    line_kwargs["linestyle"] = line_kwargs.pop("linestyle", line_kwargs.pop("ls", "--"))
+    line_kwargs["linewidth"] = line_kwargs.pop("linewidth", line_kwargs.pop("lw", 0.5))
+    line_kwargs.setdefault("zorder", 5)
+
+    lines: list[matplotlib.lines.Line2D] = []
+    for segment in segments:
+        (line,) = ax.plot(segment[:, 0], segment[:, 1], **line_kwargs)
+        lines.append(line)
+
+    color = line_kwargs.get("color", line_kwargs.get("c", axes_textcolor(ax)))
+    vertex_artist = None
+    midpoint_artist = None
+    if vertices:
+        vertex_kwargs = {"marker": "o", "s": 20, "zorder": line_kwargs["zorder"]} | (
+            vertex_kwargs or {}
+        )
+        if "color" not in vertex_kwargs and "c" not in vertex_kwargs:
+            vertex_kwargs["color"] = color
+        vertex_artist = ax.scatter(
+            vertex_points[:, 0],
+            vertex_points[:, 1],
+            **vertex_kwargs,
+        )
+    if midpoints:
+        midpoint_kwargs = {
+            "marker": "x",
+            "s": 20,
+            "zorder": line_kwargs["zorder"],
+        } | (midpoint_kwargs or {})
+        if "color" not in midpoint_kwargs and "c" not in midpoint_kwargs:
+            midpoint_kwargs["color"] = color
+        midpoint_artist = ax.scatter(
+            midpoint_points[:, 0],
+            midpoint_points[:, 1],
+            **midpoint_kwargs,
+        )
+    return tuple(lines), vertex_artist, midpoint_artist
 
 
 def get_bz_edge(
@@ -143,3 +212,151 @@ def plot_hex_bz(
     if clip is not None:
         poly.set_clip_path(clip)
     return poly
+
+
+def plot_in_plane_bz(
+    bvec: npt.NDArray[np.floating],
+    *,
+    kz: float = 0.0,
+    angle: float = 0.0,
+    bounds: tuple[float, float, float, float] | None = None,
+    ax: matplotlib.axes.Axes | None = None,
+    vertices: bool = False,
+    midpoints: bool = False,
+    vertex_kwargs: dict[str, typing.Any] | None = None,
+    midpoint_kwargs: dict[str, typing.Any] | None = None,
+    **line_kwargs,
+) -> tuple[
+    tuple[matplotlib.lines.Line2D, ...],
+    matplotlib.collections.PathCollection | None,
+    matplotlib.collections.PathCollection | None,
+]:
+    """Plot Brillouin-zone boundaries on a constant-``kz`` plane.
+
+    Parameters
+    ----------
+    bvec
+        Reciprocal lattice basis vectors.
+    kz
+        Out-of-plane momentum of the slice.
+    angle
+        Rotation angle in degrees about the ``kz`` axis.
+    bounds
+        ``(kx_min, kx_max, ky_min, ky_max)`` bounds. If `None`, bounds are inferred
+        from the current axes limits.
+    ax
+        The axes to plot the BZ boundaries on. If `None`, the current axes are used.
+    vertices
+        If `True`, also mark BZ vertices.
+    midpoints
+        If `True`, also mark segment midpoints.
+    vertex_kwargs, midpoint_kwargs
+        Additional keyword arguments passed to :meth:`matplotlib.axes.Axes.scatter`
+        for vertices and midpoints.
+    **line_kwargs
+        Additional keyword arguments passed to :meth:`matplotlib.axes.Axes.plot`.
+
+    Returns
+    -------
+    tuple
+        Line artists, vertex scatter artist, and midpoint scatter artist.
+
+    """
+    if ax is None:
+        ax = plt.gca()
+    if bounds is None:
+        x0, x1 = ax.get_xlim()
+        y0, y1 = ax.get_ylim()
+        xmin, xmax = sorted((float(x0), float(x1)))
+        ymin, ymax = sorted((float(y0), float(y1)))
+        bounds = (xmin, xmax, ymin, ymax)
+    segments, vertex_points, midpoint_points = erlab.lattice.get_in_plane_bz(
+        bvec, kz=kz, angle=angle, bounds=bounds, return_midpoints=True
+    )
+    return _plot_bz_slice(
+        segments,
+        vertex_points,
+        midpoint_points,
+        ax=ax,
+        vertices=vertices,
+        midpoints=midpoints,
+        vertex_kwargs=vertex_kwargs,
+        midpoint_kwargs=midpoint_kwargs,
+        line_kwargs=line_kwargs,
+    )
+
+
+def plot_out_of_plane_bz(
+    bvec: npt.NDArray[np.floating],
+    *,
+    k_parallel: float = 0.0,
+    angle: float = 0.0,
+    bounds: tuple[float, float, float, float] | None = None,
+    ax: matplotlib.axes.Axes | None = None,
+    vertices: bool = False,
+    midpoints: bool = False,
+    vertex_kwargs: dict[str, typing.Any] | None = None,
+    midpoint_kwargs: dict[str, typing.Any] | None = None,
+    **line_kwargs,
+) -> tuple[
+    tuple[matplotlib.lines.Line2D, ...],
+    matplotlib.collections.PathCollection | None,
+    matplotlib.collections.PathCollection | None,
+]:
+    """Plot Brillouin-zone boundaries on an out-of-plane momentum slice.
+
+    Parameters
+    ----------
+    bvec
+        Reciprocal lattice basis vectors.
+    k_parallel
+        Fixed in-plane momentum component along ``angle``.
+    angle
+        Angle in degrees of the fixed in-plane momentum direction.
+    bounds
+        ``(kp_min, kp_max, kz_min, kz_max)`` bounds. If `None`, bounds are inferred
+        from the current axes limits.
+    ax
+        The axes to plot the BZ boundaries on. If `None`, the current axes are used.
+    vertices
+        If `True`, also mark BZ vertices.
+    midpoints
+        If `True`, also mark segment midpoints.
+    vertex_kwargs, midpoint_kwargs
+        Additional keyword arguments passed to :meth:`matplotlib.axes.Axes.scatter`
+        for vertices and midpoints.
+    **line_kwargs
+        Additional keyword arguments passed to :meth:`matplotlib.axes.Axes.plot`.
+
+    Returns
+    -------
+    tuple
+        Line artists, vertex scatter artist, and midpoint scatter artist.
+
+    """
+    if ax is None:
+        ax = plt.gca()
+    if bounds is None:
+        x0, x1 = ax.get_xlim()
+        y0, y1 = ax.get_ylim()
+        xmin, xmax = sorted((float(x0), float(x1)))
+        ymin, ymax = sorted((float(y0), float(y1)))
+        bounds = (xmin, xmax, ymin, ymax)
+    segments, vertex_points, midpoint_points = erlab.lattice.get_out_of_plane_bz(
+        bvec,
+        k_parallel=k_parallel,
+        angle=angle,
+        bounds=bounds,
+        return_midpoints=True,
+    )
+    return _plot_bz_slice(
+        segments,
+        vertex_points,
+        midpoint_points,
+        ax=ax,
+        vertices=vertices,
+        midpoints=midpoints,
+        vertex_kwargs=vertex_kwargs,
+        midpoint_kwargs=midpoint_kwargs,
+        line_kwargs=line_kwargs,
+    )

--- a/src/erlab/plotting/bz.py
+++ b/src/erlab/plotting/bz.py
@@ -270,6 +270,7 @@ def plot_in_plane_bz(
         xmin, xmax = sorted((float(x0), float(x1)))
         ymin, ymax = sorted((float(y0), float(y1)))
         bounds = (xmin, xmax, ymin, ymax)
+    bvec = np.asarray(bvec, dtype=float)
     segments, vertex_points, midpoint_points = erlab.lattice.get_in_plane_bz(
         bvec, kz=kz, angle=angle, bounds=bounds, return_midpoints=True
     )
@@ -342,6 +343,7 @@ def plot_out_of_plane_bz(
         xmin, xmax = sorted((float(x0), float(x1)))
         ymin, ymax = sorted((float(y0), float(y1)))
         bounds = (xmin, xmax, ymin, ymax)
+    bvec = np.asarray(bvec, dtype=float)
     segments, vertex_points, midpoint_points = erlab.lattice.get_out_of_plane_bz(
         bvec,
         k_parallel=k_parallel,

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -65,6 +65,9 @@ from erlab.interactive._figurecomposer._exceptions import (
     FigureComposerPlotSlicesSelectionError,
 )
 from erlab.interactive._figurecomposer._operations import (
+    _bz_overlay as figurecomposer_bz_overlay,
+)
+from erlab.interactive._figurecomposer._operations import (
     _custom_code as figurecomposer_custom_code,
 )
 from erlab.interactive._figurecomposer._operations import (
@@ -14278,6 +14281,80 @@ def test_figure_composer_bz_overlay_render_matches_plotting_helper(qtbot) -> Non
     np.testing.assert_allclose(axis.collections[0].get_offsets(), vertices)
     assert all(line.get_color() == "tab:purple" for line in axis.lines)
     assert all(line.get_linewidth() == 1.25 for line in axis.lines)
+
+
+def test_figure_composer_bz_overlay_out_of_plane_render_and_code(qtbot) -> None:
+    bounds = (-4.0, 4.0, -4.0, 4.0)
+    operation = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 0), (0, 1))),
+        mode="out_of_plane",
+    ).model_copy(
+        update={
+            "bz_bounds": bounds,
+            "bz_k_parallel": 0.25,
+            "bz_midpoints": True,
+            "bz_vertex_kw": {"s": 11},
+            "bz_midpoint_kw": {"s": 13},
+            "line_kw": {"color": "tab:orange"},
+        }
+    )
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [-1.0, 1.0], "ky": [-1.0, 1.0]},
+        name="data",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=2),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    figure = Figure(figsize=(4, 2))
+    FigureCanvasAgg(figure)
+    figurecomposer_rendering._render_into_figure(tool, figure, sync_visible=False)
+
+    bvec = erlab.lattice.to_reciprocal(erlab.lattice.abc2avec(1, 1, 1, 90, 90, 90))
+    segments, _vertices, midpoints = erlab.lattice.get_out_of_plane_bz(
+        bvec,
+        k_parallel=0.25,
+        angle=0.0,
+        bounds=bounds,
+        return_midpoints=True,
+    )
+    for axis in figure.axes:
+        _assert_bz_lines_match_segments(axis.lines, segments)
+        assert all(line.get_color() == "tab:orange" for line in axis.lines)
+        assert len(axis.collections) == 1
+        np.testing.assert_allclose(axis.collections[0].get_offsets(), midpoints)
+        assert axis.collections[0].get_sizes()[0] == 13
+
+    code = tool.generated_code()
+    assert "for ax in axs.flat:" in code
+    namespace = _exec_generated_code(code, {"data": tool.source_data()["data"]})
+    assert len(namespace["fig"].axes) == 2
+    assert all(axis.lines for axis in namespace["fig"].axes)
+
+
+def test_figure_composer_bz_overlay_text_parsers() -> None:
+    assert figurecomposer_bz_overlay._mode_from_text("not a mode") == "in_plane"
+    assert figurecomposer_bz_overlay._format_bounds(None) == ""
+    assert figurecomposer_bz_overlay._bounds_from_text("") is None
+    assert figurecomposer_bz_overlay._bounds_from_text("-1, 1, -2, 2") == (
+        -1.0,
+        1.0,
+        -2.0,
+        2.0,
+    )
+
+    for text in ("'not bounds'", "1, 2, 3", "1, 2, 3, object()"):
+        with pytest.raises(ValueError, match="four comma-separated numbers"):
+            figurecomposer_bz_overlay._bounds_from_text(text)
 
 
 def test_figure_composer_bz_overlay_generated_code_static_centering(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -77,6 +77,8 @@ from erlab.interactive._figurecomposer._operations import (
     _plot_slices as figurecomposer_plot_slices,
 )
 from erlab.interactive._figurecomposer._seeding import (
+    bz_overlay_operation_from_ktool,
+    bz_overlay_operation_from_momentum_data,
     plot_slices_operation_with_source_styles,
 )
 from erlab.interactive._figurecomposer._toolbar_dialogs import (
@@ -8881,6 +8883,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     assert [action.data() for action in tool.add_step_menu.actions()] == [
         "plot_slices",
         "line",
+        "bz_overlay",
         "method:erlab",
         "method:axes",
         "method:figure",
@@ -8889,6 +8892,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     assert [action.text() for action in tool.add_step_menu.actions()] == [
         "Slice Plot",
         "Line/Profile",
+        "BZ Overlay",
         "ERLab Method",
         "Axes Method",
         "Figure Method",
@@ -14095,6 +14099,330 @@ def test_figure_composer_colorbar_method_target_policy(qtbot) -> None:
     _activate_combo_text(policy_combo, "Selected axes together")
     assert tool.tool_status.operations[1].method_call_policy == "ax_keyword"
     assert "eplt.nice_colorbar(ax=axs)" in tool.generated_code()
+
+
+def _bz_tool(operation: FigureOperationState) -> FigureComposerTool:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [-1.0, 1.0], "ky": [-1.0, 1.0]},
+        name="data",
+    )
+    return FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+
+
+def _assert_bz_lines_match_segments(
+    lines: Sequence[typing.Any], segments: np.ndarray
+) -> None:
+    assert len(lines) == len(segments)
+    for line, segment in zip(lines, segments, strict=True):
+        np.testing.assert_allclose(line.get_xdata(), segment[:, 0])
+        np.testing.assert_allclose(line.get_ydata(), segment[:, 1])
+
+
+def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
+    operation = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 0),))
+    )
+    tool = _bz_tool(operation)
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+
+    tool._select_step_section("slice")
+    page = tool.step_editor_stack.currentWidget()
+    assert page is not None
+    mode_combo = page.findChild(QtWidgets.QComboBox, "figureComposerBZModeCombo")
+    angle_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZAngleSpin")
+    k_parallel_spin = page.findChild(
+        QtWidgets.QDoubleSpinBox, "figureComposerBZKParallelSpin"
+    )
+    bounds_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerBZBoundsEdit")
+    assert mode_combo is not None
+    assert angle_spin is not None
+    assert k_parallel_spin is not None
+    assert bounds_edit is not None
+
+    _activate_combo_text(mode_combo, "Out-of-plane")
+    angle_spin.setValue(30.0)
+    k_parallel_spin.setValue(0.25)
+    bounds_edit.setText("-2, 2, -3, 3")
+    bounds_edit.editingFinished.emit()
+
+    tool._select_step_section("lattice")
+    page = tool.step_editor_stack.currentWidget()
+    assert page is not None
+    c_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZCEdit")
+    centering_combo = page.findChild(
+        QtWidgets.QComboBox, "figureComposerBZCenteringCombo"
+    )
+    assert c_spin is not None
+    assert centering_combo is not None
+    c_spin.setValue(4.5)
+    _activate_combo_text(centering_combo, "F")
+
+    tool._select_step_section("style")
+    page = tool.step_editor_stack.currentWidget()
+    assert page is not None
+    color_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerBZColorEdit")
+    line_style_combo = page.findChild(
+        QtWidgets.QComboBox, "figureComposerBZLineStyleCombo"
+    )
+    line_width_spin = page.findChild(
+        QtWidgets.QDoubleSpinBox, "figureComposerBZLineWidthSpin"
+    )
+    vertices_check = page.findChild(
+        QtWidgets.QCheckBox, "figureComposerBZVerticesCheck"
+    )
+    vertex_kw_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerBZVertexKwEdit")
+    assert color_edit is not None
+    assert line_style_combo is not None
+    assert line_width_spin is not None
+    assert vertices_check is not None
+    assert vertex_kw_edit is not None
+
+    color_edit.setText("tab:red")
+    color_edit.editingFinished.emit()
+    _activate_combo_text(line_style_combo, "-.")
+    line_width_spin.setValue(1.5)
+    vertices_check.setChecked(True)
+    vertex_kw_edit.setText("s=12, color='tab:green'")
+    vertex_kw_edit.editingFinished.emit()
+
+    updated = tool.tool_status.operations[0]
+    assert updated.bz_mode == "out_of_plane"
+    assert updated.bz_angle == 30.0
+    assert updated.bz_k_parallel == 0.25
+    assert updated.bz_bounds == (-2.0, 2.0, -3.0, 3.0)
+    assert updated.bz_c == 4.5
+    assert updated.bz_centering_type == "F"
+    assert updated.bz_vertices is True
+    assert updated.bz_vertex_kw == {"s": 12, "color": "tab:green"}
+    assert updated.line_kw == {
+        "color": "tab:red",
+        "linestyle": "-.",
+        "linewidth": 1.5,
+    }
+
+
+def test_figure_composer_bz_overlay_state_round_trip() -> None:
+    operation = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        mode="out_of_plane",
+    ).model_copy(
+        update={
+            "bz_a": 2.0,
+            "bz_b": 3.0,
+            "bz_c": 4.0,
+            "bz_centering_type": "I",
+            "bz_angle": 15.0,
+            "bz_k_parallel": 0.25,
+            "bz_bounds": (-1.0, 1.0, -2.0, 2.0),
+            "bz_vertices": True,
+            "bz_midpoint_kw": {"color": "tab:blue"},
+            "line_kw": {"color": "tab:red"},
+        }
+    )
+    recipe = FigureRecipeState(
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+
+    restored = FigureRecipeState.model_validate(recipe.model_dump(mode="json"))
+
+    assert restored.operations[0].kind == FigureOperationKind.BZ_OVERLAY
+    assert restored.operations[0].bz_centering_type == "I"
+    assert restored.operations[0].bz_bounds == (-1.0, 1.0, -2.0, 2.0)
+    assert restored.operations[0].bz_midpoint_kw == {"color": "tab:blue"}
+    assert restored.operations[0].line_kw == {"color": "tab:red"}
+
+
+def test_figure_composer_bz_overlay_render_matches_plotting_helper(qtbot) -> None:
+    bounds = (-4.0, 4.0, -4.0, 4.0)
+    operation = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 0),))
+    ).model_copy(
+        update={
+            "bz_bounds": bounds,
+            "bz_angle": 45.0,
+            "bz_vertices": True,
+            "line_kw": {"color": "tab:purple", "linewidth": 1.25},
+        }
+    )
+    tool = _bz_tool(operation)
+    qtbot.addWidget(tool)
+
+    figure = Figure(figsize=(3, 3))
+    FigureCanvasAgg(figure)
+    figurecomposer_rendering._render_into_figure(tool, figure, sync_visible=False)
+
+    bvec = erlab.lattice.to_reciprocal(erlab.lattice.abc2avec(1, 1, 1, 90, 90, 90))
+    segments, vertices, _midpoints = erlab.lattice.get_in_plane_bz(
+        bvec,
+        kz=0.0,
+        angle=45.0,
+        bounds=bounds,
+        return_midpoints=True,
+    )
+    axis = figure.axes[0]
+    _assert_bz_lines_match_segments(axis.lines, segments)
+    assert axis.collections
+    np.testing.assert_allclose(axis.collections[0].get_offsets(), vertices)
+    assert all(line.get_color() == "tab:purple" for line in axis.lines)
+    assert all(line.get_linewidth() == 1.25 for line in axis.lines)
+
+
+def test_figure_composer_bz_overlay_generated_code_static_centering(qtbot) -> None:
+    primitive = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 0),))
+    ).model_copy(update={"bz_bounds": (-20.0, 20.0, -20.0, 20.0)})
+    primitive_tool = _bz_tool(primitive)
+    qtbot.addWidget(primitive_tool)
+
+    primitive_code = primitive_tool.generated_code()
+    assert "to_primitive" not in primitive_code
+    primitive_namespace = _exec_generated_code(
+        primitive_code, {"data": primitive_tool.source_data()["data"]}
+    )
+    assert primitive_namespace["fig"].axes[0].lines
+
+    nonprimitive = primitive.model_copy(update={"bz_centering_type": "F"})
+    nonprimitive_tool = _bz_tool(nonprimitive)
+    qtbot.addWidget(nonprimitive_tool)
+
+    nonprimitive_code = nonprimitive_tool.generated_code()
+    assert (
+        'avec = erlab.lattice.to_primitive(avec, centering_type="F")'
+        in nonprimitive_code
+    )
+    assert 'if centering_type != "P"' not in nonprimitive_code
+    assert "if " not in "\n".join(
+        line for line in nonprimitive_code.splitlines() if "to_primitive" in line
+    )
+    nonprimitive_namespace = _exec_generated_code(
+        nonprimitive_code, {"data": nonprimitive_tool.source_data()["data"]}
+    )
+    assert nonprimitive_namespace["fig"].axes[0].lines
+
+
+def test_figure_composer_bz_overlay_invalid_axes_block_generated_code(qtbot) -> None:
+    operation = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 1),))
+    )
+    tool = _bz_tool(operation)
+    qtbot.addWidget(tool)
+
+    with pytest.raises(ValueError, match="target axes"):
+        tool.generated_code()
+
+
+def test_figure_composer_bz_overlay_plain_momentum_seeding() -> None:
+    in_plane = xr.DataArray(
+        np.zeros((3, 4)),
+        dims=("kx", "ky"),
+        coords={"kx": [-1.0, 0.0, 1.0], "ky": [-2.0, -1.0, 0.0, 1.0]},
+    )
+    kx_kz = xr.DataArray(
+        np.zeros((3, 4)),
+        dims=("kx", "kz"),
+        coords={"kx": [-0.5, 0.0, 0.5], "kz": [-2.0, -1.0, 0.0, 1.0]},
+    )
+    ky_kz = xr.DataArray(
+        np.zeros((2, 3)),
+        dims=("ky", "kz"),
+        coords={"ky": [0.25, 0.75], "kz": [-1.0, 0.0, 1.0]},
+    )
+
+    in_plane_operation = bz_overlay_operation_from_momentum_data(in_plane)
+    kx_kz_operation = bz_overlay_operation_from_momentum_data(kx_kz)
+    ky_kz_operation = bz_overlay_operation_from_momentum_data(ky_kz)
+
+    assert in_plane_operation is not None
+    assert in_plane_operation.bz_mode == "in_plane"
+    assert in_plane_operation.bz_bounds == (-1.0, 1.0, -2.0, 1.0)
+    assert kx_kz_operation is not None
+    assert kx_kz_operation.bz_mode == "out_of_plane"
+    assert kx_kz_operation.bz_bounds == (-0.5, 0.5, -2.0, 1.0)
+    assert ky_kz_operation is not None
+    assert ky_kz_operation.bz_mode == "out_of_plane"
+    assert ky_kz_operation.bz_bounds == (0.25, 0.75, -1.0, 1.0)
+
+
+def test_figure_composer_bz_overlay_ktool_seeding_snapshot() -> None:
+    data = xr.DataArray(
+        np.zeros((3, 4)),
+        dims=("kz", "kx"),
+        coords={"kz": [-1.0, 0.0, 1.0], "kx": [-0.5, 0.0, 0.5, 1.0], "ky": 0.25},
+    )
+
+    class FakeStatus:
+        bz_enabled = True
+        lattice_params = (2.0, 3.0, 4.0, 90.0, 100.0, 110.0)
+        centering = "I"
+        rot = 15.0
+        kz = 0.5
+        points = True
+
+    class FakeKtool:
+        tool_status = FakeStatus()
+
+    operation = bz_overlay_operation_from_ktool(FakeKtool(), data)
+
+    assert operation is not None
+    assert operation.bz_mode == "out_of_plane"
+    assert operation.bz_a == 2.0
+    assert operation.bz_b == 3.0
+    assert operation.bz_c == 4.0
+    assert operation.bz_centering_type == "I"
+    assert operation.bz_angle == 15.0
+    assert operation.bz_kz_pi_over_c == 0.5
+    assert operation.bz_k_parallel == 0.25
+    assert operation.bz_vertices is True
+    assert operation.bz_midpoints is True
+
+
+def test_figure_composer_bz_overlay_ktool_seeding_uses_fixed_coord_median() -> None:
+    ky_values = np.array(
+        [
+            [np.nan, -0.25, 0.0, 0.25],
+            [0.5, 0.75, 1.0, 1.25],
+            [1.5, 1.75, 2.0, 2.25],
+        ]
+    )
+    data = xr.DataArray(
+        np.zeros((3, 4)),
+        dims=("kz", "kx"),
+        coords={
+            "kz": [-1.0, 0.0, 1.0],
+            "kx": [-0.5, 0.0, 0.5, 1.0],
+            "ky": (("kz", "kx"), ky_values),
+        },
+    )
+
+    class FakeStatus:
+        bz_enabled = True
+        lattice_params = (2.0, 3.0, 4.0, 90.0, 100.0, 110.0)
+        centering = "I"
+        rot = 15.0
+        kz = 0.5
+        points = True
+
+    class FakeKtool:
+        tool_status = FakeStatus()
+
+    operation = bz_overlay_operation_from_ktool(FakeKtool(), data)
+
+    assert operation is not None
+    assert operation.bz_mode == "out_of_plane"
+    assert operation.bz_k_parallel == np.nanmedian(ky_values)
 
 
 def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
@@ -19428,6 +19756,67 @@ def test_manager_append_operation_to_existing_figure(
         assert appended is True
         assert len(figure.tool_status.operations) == operation_count + 1
         assert figure.tool_status.operations[-1].kind.value == "line"
+
+
+def test_manager_ktool_output_figure_seeds_bz_overlay(
+    qtbot,
+    anglemap,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    from erlab.interactive.kspace import KspaceTool
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(anglemap.qsel(eV=-0.1), link=False, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.open_in_ktool()
+        qtbot.wait_until(
+            lambda: len(manager._tool_graph.root_wrappers[0]._childtools) == 1,
+            timeout=5000,
+        )
+
+        child_uid = manager._tool_graph.root_wrappers[0]._childtool_indices[0]
+        child = manager.get_childtool(child_uid)
+        assert isinstance(child, KspaceTool)
+        child._avec = erlab.lattice.abc2avec(2.0, 3.0, 4.0, 90.0, 100.0, 110.0)
+        child.centering_combo.setCurrentText("I")
+        child.rot_spin.setValue(15.0)
+        child.kz_spin.setValue(0.5)
+        child.points_check.setChecked(True)
+        qtbot.wait_until(lambda: child.bz_group.isEnabled(), timeout=5000)
+        child.bz_group.setChecked(True)
+        child.show_converted()
+
+        child_node = manager._child_node(child_uid)
+        qtbot.wait_until(lambda: len(child_node._childtool_indices) == 1, timeout=5000)
+        output_uid = child_node._childtool_indices[0]
+        manager._child_node(output_uid).name = "converted"
+
+        figure_uid = manager.create_figure_from_targets((output_uid,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        operations = figure_tool.tool_status.operations
+
+        assert [operation.kind for operation in operations] == [
+            FigureOperationKind.PLOT_SLICES,
+            FigureOperationKind.BZ_OVERLAY,
+        ]
+        bz_operation = operations[1]
+        assert np.isclose(bz_operation.bz_a, 2.0)
+        assert np.isclose(bz_operation.bz_b, 3.0)
+        assert np.isclose(bz_operation.bz_c, 4.0)
+        assert bz_operation.bz_centering_type == "I"
+        assert bz_operation.bz_angle == 15.0
+        assert bz_operation.bz_kz_pi_over_c == 0.5
+        assert bz_operation.bz_vertices is True
+        assert bz_operation.bz_midpoints is True
 
 
 def test_manager_append_operation_uses_axes_dialog_selection(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1,5 +1,6 @@
 import ast
 import contextlib
+import functools
 import gc
 import json
 import typing
@@ -78,6 +79,9 @@ from erlab.interactive._figurecomposer._operations import (
     _method as figurecomposer_method,
 )
 from erlab.interactive._figurecomposer._operations import (
+    _photon_energy as figurecomposer_photon_energy,
+)
+from erlab.interactive._figurecomposer._operations import (
     _plot_slices as figurecomposer_plot_slices,
 )
 from erlab.interactive._figurecomposer._seeding import (
@@ -91,6 +95,7 @@ from erlab.interactive._figurecomposer._toolbar_dialogs import (
 from erlab.interactive._options import options
 from erlab.interactive._options.schema import AppOptions, FigureOptions
 from erlab.interactive.imagetool import itool, provenance
+from erlab.io.exampledata import generate_hvdep_cuts
 from tests.interactive.imagetool.manager.helpers import (
     InMemoryClipboard,
     _exec_generated_code,
@@ -387,6 +392,7 @@ def test_figure_composer_operation_modules_use_editor_signal_contract() -> None:
         figurecomposer_custom_code,
         figurecomposer_line_profile,
         figurecomposer_method,
+        figurecomposer_photon_energy,
         figurecomposer_plot_slices,
     )
     direct_connects: list[str] = []
@@ -14145,17 +14151,31 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     assert page is not None
     mode_combo = page.findChild(QtWidgets.QComboBox, "figureComposerBZModeCombo")
     angle_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZAngleSpin")
+    kz_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZKzSpin")
+    kz_absolute_spin = page.findChild(
+        QtWidgets.QDoubleSpinBox, "figureComposerBZKzAbsoluteSpin"
+    )
     k_parallel_spin = page.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerBZKParallelSpin"
     )
     bounds_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerBZBoundsEdit")
     assert mode_combo is not None
     assert angle_spin is not None
+    assert kz_spin is not None
+    assert kz_absolute_spin is not None
     assert k_parallel_spin is not None
     assert bounds_edit is not None
+    assert angle_spin.suffix() == "°"
+    assert kz_spin.suffix() == " π/c"
+    assert kz_absolute_spin.suffix() == " Å⁻¹"
+    assert k_parallel_spin.suffix() == " Å⁻¹"
 
     _activate_combo_text(mode_combo, "Out-of-plane")
     angle_spin.setValue(30.0)
+    kz_spin.setValue(0.5)
+    assert np.isclose(kz_absolute_spin.value(), np.pi / 2.0)
+    kz_absolute_spin.setValue(0.25)
+    assert np.isclose(kz_spin.value(), 0.25 / np.pi, atol=5e-5)
     k_parallel_spin.setValue(0.25)
     bounds_edit.setText("-2, 2, -3, 3")
     bounds_edit.editingFinished.emit()
@@ -14163,12 +14183,28 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     tool._select_step_section("lattice")
     page = tool.step_editor_stack.currentWidget()
     assert page is not None
+    a_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZAEdit")
+    b_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZBEdit")
     c_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZCEdit")
+    alpha_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZAlphaEdit")
+    beta_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZBetaEdit")
+    gamma_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZGammaEdit")
     centering_combo = page.findChild(
         QtWidgets.QComboBox, "figureComposerBZCenteringCombo"
     )
+    assert a_spin is not None
+    assert b_spin is not None
     assert c_spin is not None
+    assert alpha_spin is not None
+    assert beta_spin is not None
+    assert gamma_spin is not None
     assert centering_combo is not None
+    assert a_spin.suffix() == " Å"
+    assert b_spin.suffix() == " Å"
+    assert c_spin.suffix() == " Å"
+    assert alpha_spin.suffix() == "°"
+    assert beta_spin.suffix() == "°"
+    assert gamma_spin.suffix() == "°"
     c_spin.setValue(4.5)
     _activate_combo_text(centering_combo, "F")
 
@@ -14203,12 +14239,17 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     updated = tool.tool_status.operations[0]
     assert updated.bz_mode == "out_of_plane"
     assert updated.bz_angle == 30.0
+    assert np.isclose(updated.bz_kz_pi_over_c, 0.25 * 4.5 / np.pi)
     assert updated.bz_k_parallel == 0.25
     assert updated.bz_bounds == (-2.0, 2.0, -3.0, 3.0)
     assert updated.bz_c == 4.5
     assert updated.bz_centering_type == "F"
     assert updated.bz_vertices is True
     assert updated.bz_vertex_kw == {"s": 12, "color": "tab:green"}
+    assert (
+        figurecomposer_bz_overlay._section_summary(tool, "slice", updated)
+        == "OOP, k=0.25 Å⁻¹"
+    )
     assert updated.line_kw == {
         "color": "tab:red",
         "linestyle": "-.",
@@ -14356,6 +14397,14 @@ def test_figure_composer_bz_overlay_text_parsers() -> None:
     for text in ("'not bounds'", "1, 2, 3", "1, 2, 3, object()"):
         with pytest.raises(ValueError, match="four comma-separated numbers"):
             figurecomposer_bz_overlay._bounds_from_text(text)
+
+    operation = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 0),))
+    ).model_copy(update={"bz_kz_pi_over_c": 0.5, "bz_c": 4.0})
+    tool = _bz_tool(operation)
+    assert figurecomposer_bz_overlay._section_summary(tool, "slice", operation) == (
+        f"IP, kz=0.5 π/c; {np.pi / 8:g} Å⁻¹"
+    )
 
 
 def test_figure_composer_bz_overlay_generated_code_static_centering(qtbot) -> None:
@@ -14569,6 +14618,571 @@ def test_figure_composer_bz_overlay_ktool_seeding_uses_fixed_coord_median() -> N
     assert operation is not None
     assert operation.bz_mode == "out_of_plane"
     assert operation.bz_k_parallel == np.nanmedian(ky_values)
+
+
+@functools.cache
+def _cached_photon_energy_source(configuration: int) -> xr.DataArray:
+    data = generate_hvdep_cuts((5, 24, 20), seed=1)
+    data.kspace.inner_potential = 10.0
+    data.attrs["configuration"] = configuration
+    return data.kspace.convert(silent=True)
+
+
+def _photon_energy_source(
+    configuration: int = 1, *, name: str = "hvdep_kconv"
+) -> xr.DataArray:
+    data = _cached_photon_energy_source(configuration).copy(deep=True)
+    data.name = name
+    return data
+
+
+def _photon_energy_tool(
+    operation: FigureOperationState,
+    data: xr.DataArray,
+    *,
+    setup: FigureSubplotsState | None = None,
+    extra_source_data: dict[str, xr.DataArray] | None = None,
+) -> FigureComposerTool:
+    source_name = str(data.name or "hvdep_kconv")
+    source_data = {source_name: data}
+    if extra_source_data:
+        source_data.update(extra_source_data)
+    sources = tuple(FigureSourceState(name=name, label=name) for name in source_data)
+    return FigureComposerTool.from_sources(
+        source_data,
+        sources=sources,
+        operations=(operation,),
+        setup=setup or FigureSubplotsState(),
+        primary_source=source_name,
+    )
+
+
+def _assert_photon_energy_lines_match(
+    lines: Sequence[typing.Any], expected: xr.DataArray, x_dim: str
+) -> None:
+    assert len(lines) == expected.sizes["hv"]
+    for index, line in enumerate(lines):
+        kz = expected.isel(hv=index)
+        np.testing.assert_allclose(line.get_xdata(), kz[x_dim].values)
+        np.testing.assert_allclose(line.get_ydata(), kz.values)
+        assert line.get_label() == f"$h\\nu = {kz.hv:g}$ eV"
+
+
+def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> None:
+    data = _photon_energy_source()
+    other_data = _photon_energy_source(name="other_kconv")
+    operation = FigureOperationState.photon_energy_overlay(
+        source="hvdep_kconv",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        binding_energy=-0.3,
+    ).model_copy(update={"photon_energies": (30.0,)})
+    tool = _photon_energy_tool(
+        operation,
+        data,
+        extra_source_data={"other_kconv": other_data},
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+
+    source_combo = next(
+        (
+            combo
+            for combo in tool.step_source_controls.findChildren(
+                QtWidgets.QComboBox, "figureComposerPhotonEnergySourceCombo"
+            )
+            if combo.property("figure_composer_editor_generation")
+            == tool._operation_editor_generation
+        ),
+        None,
+    )
+    assert source_combo is not None
+    other_index = source_combo.findData("other_kconv")
+    assert other_index >= 0
+    _activate_combo_index(source_combo, other_index)
+
+    tool._select_step_section("photon")
+    page = tool.step_editor_stack.currentWidget()
+    assert page is not None
+    energies_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerPhotonEnergyValuesEdit"
+    )
+    binding_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerPhotonEnergyBindingEnergyEdit"
+    )
+    assert energies_edit is not None
+    assert binding_edit is not None
+    energies_edit.setText("30, 45, 60")
+    energies_edit.editingFinished.emit()
+    binding_edit.setText("-0.3")
+    binding_edit.editingFinished.emit()
+
+    tool._select_step_section("style")
+    page = tool.step_editor_stack.currentWidget()
+    assert page is not None
+    color_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerPhotonEnergyColorEdit"
+    )
+    line_style_combo = page.findChild(
+        QtWidgets.QComboBox, "figureComposerPhotonEnergyLineStyleCombo"
+    )
+    line_width_spin = page.findChild(
+        QtWidgets.QDoubleSpinBox, "figureComposerPhotonEnergyLineWidthSpin"
+    )
+    legend_check = page.findChild(
+        QtWidgets.QCheckBox, "figureComposerPhotonEnergyLegendCheck"
+    )
+    legend_kw_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerPhotonEnergyLegendKwEdit"
+    )
+    label_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerPhotonEnergyLabelTemplateEdit"
+    )
+    assert color_edit is not None
+    assert line_style_combo is not None
+    assert line_width_spin is not None
+    assert legend_check is not None
+    assert legend_kw_edit is not None
+    assert label_edit is not None
+
+    color_edit.setText("tab:red")
+    color_edit.editingFinished.emit()
+    _activate_combo_text(line_style_combo, "--")
+    line_width_spin.setValue(1.5)
+    legend_check.setChecked(False)
+    legend_kw_edit.setText("title='Photon energy', frameon=False")
+    legend_kw_edit.editingFinished.emit()
+    label_edit.setText("hv={hv:g} eV")
+    label_edit.editingFinished.emit()
+
+    updated = tool.tool_status.operations[0]
+    assert updated.hv_overlay_source == "other_kconv"
+    assert updated.photon_energies == (30.0, 45.0, 60.0)
+    assert updated.binding_energy == -0.3
+    assert updated.show_legend is False
+    assert updated.legend_kw == {"title": "Photon energy", "frameon": False}
+    assert updated.label_template == "hv={hv:g} eV"
+    assert updated.line_kw == {
+        "color": "tab:red",
+        "linestyle": "--",
+        "linewidth": 1.5,
+    }
+
+
+def test_figure_composer_photon_energy_overlay_state_round_trip() -> None:
+    operation = FigureOperationState.photon_energy_overlay(
+        source="hvdep_kconv",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        binding_energy=-0.3,
+    ).model_copy(
+        update={
+            "photon_energies": (30.0, 45.0, 60.0),
+            "show_legend": False,
+            "legend_kw": {"title": "Photon energy", "frameon": False},
+            "label_template": "hv={hv:g}",
+            "line_kw": {"color": "tab:green", "linewidth": 1.25},
+        }
+    )
+    recipe = FigureRecipeState(
+        sources=(FigureSourceState(name="hvdep_kconv", label="hvdep_kconv"),),
+        operations=(operation,),
+        primary_source="hvdep_kconv",
+    )
+
+    restored = FigureRecipeState.model_validate(recipe.model_dump(mode="json"))
+
+    assert restored.operations[0].kind == FigureOperationKind.PHOTON_ENERGY_OVERLAY
+    assert restored.operations[0].hv_overlay_source == "hvdep_kconv"
+    assert restored.operations[0].photon_energies == (30.0, 45.0, 60.0)
+    assert restored.operations[0].binding_energy == -0.3
+    assert restored.operations[0].show_legend is False
+    assert restored.operations[0].legend_kw == {
+        "title": "Photon energy",
+        "frameon": False,
+    }
+    assert restored.operations[0].label_template == "hv={hv:g}"
+    assert restored.operations[0].line_kw == {
+        "color": "tab:green",
+        "linewidth": 1.25,
+    }
+
+
+@pytest.mark.parametrize(("configuration", "x_dim"), [(1, "kx"), (2, "ky")])
+def test_figure_composer_photon_energy_overlay_render_and_code(
+    qtbot, configuration: int, x_dim: str
+) -> None:
+    data = _photon_energy_source(configuration)
+    hv_values = (30.0, 45.0, 60.0)
+    binding_energy = -0.3
+    operation = FigureOperationState.photon_energy_overlay(
+        source="hvdep_kconv",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        binding_energy=binding_energy,
+    ).model_copy(
+        update={
+            "photon_energies": hv_values,
+            "line_kw": {"color": "tab:blue", "linewidth": 1.5},
+            "legend_kw": {"title": "Photon energy", "frameon": False},
+        }
+    )
+    tool = _photon_energy_tool(operation, data)
+    qtbot.addWidget(tool)
+
+    figure = Figure(figsize=(3, 3))
+    FigureCanvasAgg(figure)
+    figurecomposer_rendering._render_into_figure(tool, figure, sync_visible=False)
+
+    expected = data.kspace.hv_to_kz(list(hv_values)).qsel(eV=binding_energy)
+    axis = figure.axes[0]
+    _assert_photon_energy_lines_match(axis.lines, expected, x_dim)
+    assert axis.get_legend() is not None
+    assert axis.get_legend().get_title().get_text() == "Photon energy"
+    assert axis.get_legend().get_frame_on() is False
+    assert all(line.get_color() == "tab:blue" for line in axis.lines)
+    assert all(line.get_linewidth() == 1.5 for line in axis.lines)
+
+    code = tool.generated_code()
+    assert "import erlab" in code
+    assert "kz_values = hvdep_kconv.kspace.hv_to_kz([30, 45, 60]).qsel(eV=-0.3)" in code
+    assert "for i in range(len(kz_values.hv)):" in code
+    assert f"axs[0, 0].plot(kz.{x_dim}, kz, label=rf" in code
+    assert "ax.legend()" not in code
+    assert 'axs[0, 0].legend(title="Photon energy", frameon=False)' in code
+
+    namespace = _exec_generated_code(code, {"hvdep_kconv": data})
+    generated_axis = namespace["fig"].axes[0]
+    _assert_photon_energy_lines_match(generated_axis.lines, expected, x_dim)
+    assert generated_axis.get_legend() is not None
+    assert generated_axis.get_legend().get_title().get_text() == "Photon energy"
+    assert generated_axis.get_legend().get_frame_on() is False
+
+
+def test_figure_composer_photon_energy_overlay_multiple_axes_code(qtbot) -> None:
+    data = _photon_energy_source()
+    operation = FigureOperationState.photon_energy_overlay(
+        source="hvdep_kconv",
+        axes=FigureAxesSelectionState(axes=((0, 0), (0, 1))),
+        binding_energy=-0.3,
+    ).model_copy(update={"photon_energies": (30.0, 45.0), "show_legend": False})
+    tool = _photon_energy_tool(
+        operation,
+        data,
+        setup=FigureSubplotsState(nrows=1, ncols=2),
+    )
+    qtbot.addWidget(tool)
+
+    code = tool.generated_code()
+    assert "for ax in axs.flat:\n    for i in range(len(kz_values.hv)):" in code
+    assert "        ax.plot(kz.kx, kz, label=rf" in code
+    assert "legend()" not in code
+
+    namespace = _exec_generated_code(code, {"hvdep_kconv": data})
+    expected = data.kspace.hv_to_kz([30.0, 45.0]).qsel(eV=-0.3)
+    for axis in namespace["fig"].axes:
+        _assert_photon_energy_lines_match(axis.lines, expected, "kx")
+        assert axis.get_legend() is None
+
+
+def test_figure_composer_photon_energy_overlay_custom_label_code(qtbot) -> None:
+    data = _photon_energy_source()
+    operation = FigureOperationState.photon_energy_overlay(
+        source="hvdep_kconv",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        binding_energy=-0.3,
+    ).model_copy(
+        update={
+            "photon_energies": (30.0, 45.0),
+            "label_template": "hv={hv:g} eV",
+            "show_legend": False,
+        }
+    )
+    tool = _photon_energy_tool(operation, data)
+    qtbot.addWidget(tool)
+
+    code = tool.generated_code()
+    assert ".format(hv=kz.hv)" in code
+    assert 'rf"$h\\nu' not in code
+    assert "legend()" not in code
+
+    namespace = _exec_generated_code(code, {"hvdep_kconv": data})
+    expected = data.kspace.hv_to_kz([30.0, 45.0]).qsel(eV=-0.3)
+    axis = namespace["fig"].axes[0]
+    assert axis.get_legend() is None
+    assert [line.get_label() for line in axis.lines] == [
+        f"hv={expected.isel(hv=index).hv:g} eV" for index in range(expected.sizes["hv"])
+    ]
+
+
+def test_figure_composer_photon_energy_overlay_expression_axes_code(qtbot) -> None:
+    data = _photon_energy_source()
+    operation = FigureOperationState.photon_energy_overlay(
+        source="hvdep_kconv",
+        axes=FigureAxesSelectionState(expression="axs[0, :]"),
+        binding_energy=-0.3,
+    ).model_copy(update={"photon_energies": (30.0, 45.0)})
+    tool = _photon_energy_tool(
+        operation,
+        data,
+        setup=FigureSubplotsState(nrows=1, ncols=2),
+    )
+    qtbot.addWidget(tool)
+
+    code = tool.generated_code()
+    assert "for ax in axs[0, :]:\n    for i in range(len(kz_values.hv)):" in code
+    assert "    ax.legend()" in code
+
+    namespace = _exec_generated_code(code, {"hvdep_kconv": data})
+    expected = data.kspace.hv_to_kz([30.0, 45.0]).qsel(eV=-0.3)
+    for axis in namespace["fig"].axes:
+        _assert_photon_energy_lines_match(axis.lines, expected, "kx")
+        assert axis.get_legend() is not None
+
+
+def test_figure_composer_photon_energy_overlay_blocks_invalid_inputs(qtbot) -> None:
+    data = _photon_energy_source()
+    missing_values = FigureOperationState.photon_energy_overlay(
+        source="hvdep_kconv",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        binding_energy=-0.3,
+    )
+    missing_values_tool = _photon_energy_tool(missing_values, data)
+    qtbot.addWidget(missing_values_tool)
+    with pytest.raises(ValueError, match="at least one photon energy"):
+        missing_values_tool.generated_code()
+
+    unselected_energy = missing_values.model_copy(
+        update={"photon_energies": (30.0,), "binding_energy": None}
+    )
+    unselected_tool = _photon_energy_tool(unselected_energy, data)
+    qtbot.addWidget(unselected_tool)
+    with pytest.raises(ValueError, match="Select a binding energy"):
+        unselected_tool.generated_code()
+
+    invalid_axes = missing_values.model_copy(
+        update={"axes": FigureAxesSelectionState(axes=((0, 1),))}
+    )
+    invalid_axes_tool = _photon_energy_tool(invalid_axes, data)
+    qtbot.addWidget(invalid_axes_tool)
+    with pytest.raises(ValueError, match="target axes"):
+        invalid_axes_tool.generated_code()
+
+    invalid_source = xr.DataArray(
+        np.zeros((2, 2)),
+        dims=("kx", "ky"),
+        coords={"kx": [-1.0, 1.0], "ky": [-1.0, 1.0]},
+        name="hvdep_kconv",
+    )
+    invalid_source_operation = missing_values.model_copy(
+        update={"photon_energies": (30.0,)}
+    )
+    invalid_source_tool = _photon_energy_tool(invalid_source_operation, invalid_source)
+    qtbot.addWidget(invalid_source_tool)
+    with pytest.raises(ValueError, match="kx-kz or ky-kz"):
+        invalid_source_tool.generated_code()
+
+    no_source_operation = missing_values.model_copy(update={"hv_overlay_source": None})
+    no_source_tool = _photon_energy_tool(no_source_operation, data)
+    qtbot.addWidget(no_source_tool)
+    with pytest.raises(ValueError, match="Select a source"):
+        no_source_tool.generated_code()
+
+    missing_source_operation = missing_values.model_copy(
+        update={"hv_overlay_source": "missing"}
+    )
+    missing_source_tool = _photon_energy_tool(missing_source_operation, data)
+    qtbot.addWidget(missing_source_tool)
+    with pytest.raises(ValueError, match="Source 'missing' is missing"):
+        missing_source_tool.generated_code()
+
+    figure = Figure(figsize=(3, 3))
+    FigureCanvasAgg(figure)
+    figurecomposer_rendering._render_into_figure(
+        missing_values_tool, figure, sync_visible=False
+    )
+    assert (
+        "at least one photon energy"
+        in missing_values_tool._operation_render_errors[missing_values.operation_id]
+    )
+
+
+def test_figure_composer_photon_energy_overlay_helper_edges(qtbot) -> None:
+    assert figurecomposer_photon_energy._optional_float_from_text("") is None
+    assert figurecomposer_photon_energy._optional_float_from_text(" -0.3 ") == -0.3
+    with pytest.raises(ValueError, match="one number"):
+        figurecomposer_photon_energy._optional_float_from_text("bad")
+    assert figurecomposer_photon_energy._photon_energies_from_text("30, 45") == (
+        30.0,
+        45.0,
+    )
+
+    data = _photon_energy_source()
+    operation = FigureOperationState.photon_energy_overlay(
+        source=None,
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        binding_energy=-0.3,
+    ).model_copy(update={"photon_energies": (30.0,)})
+    tool = _photon_energy_tool(operation, data)
+    qtbot.addWidget(tool)
+
+    assert (
+        figurecomposer_photon_energy._section_summary(tool, "sources", operation)
+        == "none"
+    )
+    with pytest.raises(ValueError, match="Select a source"):
+        figurecomposer_photon_energy._source_data(tool, operation)
+
+    kz_values = xr.DataArray(
+        np.zeros((2, 3)),
+        dims=("hv", "angle"),
+        coords={"hv": [30.0, 45.0], "angle": [0.0, 1.0, 2.0]},
+    )
+    with pytest.raises(ValueError, match="kx-kz or ky-kz"):
+        figurecomposer_photon_energy._photon_x_dim(data, kz_values)
+
+    class FakeKspace:
+        slit_axis = "kx"
+
+        @staticmethod
+        def hv_to_kz(values: Sequence[float]) -> xr.DataArray:
+            return xr.DataArray(
+                np.zeros((len(values), 2, 2)),
+                dims=("hv", "kx", "temperature"),
+                coords={
+                    "hv": list(values),
+                    "kx": [-1.0, 1.0],
+                    "temperature": [20.0, 30.0],
+                },
+            )
+
+    class FakeKParallelKzData:
+        dims = ("kx", "kz")
+        kspace = FakeKspace()
+
+        def squeeze(self, *, drop: bool):
+            return self
+
+    extra_dim_operation = operation.model_copy(update={"binding_energy": None})
+    with pytest.raises(ValueError, match="hv and one momentum dimension"):
+        figurecomposer_photon_energy._kz_values(
+            FakeKParallelKzData(), extra_dim_operation
+        )
+
+
+def test_figure_composer_photon_energy_overlay_add_step_seeds_source_and_binding(
+    qtbot,
+) -> None:
+    data = _photon_energy_source()
+    plot_operation = FigureOperationState.plot_slices(
+        label="hvdep",
+        sources=("hvdep_kconv",),
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        slice_dim="eV",
+        slice_values=(-0.3,),
+    )
+    tool = FigureComposerTool.from_sources(
+        {"hvdep_kconv": data},
+        sources=(FigureSourceState(name="hvdep_kconv", label="hvdep_kconv"),),
+        operations=(plot_operation,),
+        setup=FigureSubplotsState(),
+        primary_source="hvdep_kconv",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+
+    action = next(
+        action
+        for action in tool.add_step_menu.actions()
+        if action.data() == FigureOperationKind.PHOTON_ENERGY_OVERLAY.value
+    )
+    action.trigger()
+
+    operation = tool.tool_status.operations[-1]
+    assert operation.kind == FigureOperationKind.PHOTON_ENERGY_OVERLAY
+    assert operation.hv_overlay_source == "hvdep_kconv"
+    assert operation.binding_energy == -0.3
+    assert operation.photon_energies == ()
+
+
+def test_figure_composer_photon_energy_overlay_seed_fallbacks(qtbot) -> None:
+    data = _photon_energy_source()
+    unused_data = _photon_energy_source(name="unused")
+    tool = FigureComposerTool.from_sources(
+        {"unused": unused_data, "hvdep_kconv": data},
+        sources=(FigureSourceState(name="hvdep_kconv", label="hvdep_kconv"),),
+        operations=(),
+        setup=FigureSubplotsState(),
+        primary_source="unused",
+    )
+    qtbot.addWidget(tool)
+
+    assert figurecomposer_photon_energy._seed_source(tool) == "hvdep_kconv"
+    assert figurecomposer_photon_energy._seed_binding_energy(tool) is None
+
+    line_operation = FigureOperationState.line(
+        label="line", source="hvdep_kconv", axes=FigureAxesSelectionState()
+    )
+    line_tool = FigureComposerTool.from_sources(
+        {"hvdep_kconv": data},
+        sources=(FigureSourceState(name="hvdep_kconv", label="hvdep_kconv"),),
+        operations=(line_operation,),
+        setup=FigureSubplotsState(),
+        primary_source="hvdep_kconv",
+    )
+    qtbot.addWidget(line_tool)
+    line_tool.operation_list.setCurrentRow(0)
+
+    assert figurecomposer_photon_energy._seed_source(line_tool) == "hvdep_kconv"
+    assert figurecomposer_photon_energy._seed_binding_energy(line_tool) is None
+
+
+def test_figure_composer_photon_energy_overlay_tracks_source_ownership(
+    qtbot,
+) -> None:
+    data = _photon_energy_source()
+    existing_data = _photon_energy_source(name="hvdep_kconv")
+    unused_data = _photon_energy_source(name="unused")
+    operation = FigureOperationState.photon_energy_overlay(
+        source="hvdep_kconv",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        binding_energy=-0.3,
+    ).model_copy(update={"photon_energies": (30.0,)})
+    source_tool = _photon_energy_tool(
+        operation,
+        data,
+        extra_source_data={"unused": unused_data},
+    )
+    destination = _photon_energy_tool(
+        FigureOperationState.photon_energy_overlay(
+            source="hvdep_kconv",
+            axes=FigureAxesSelectionState(axes=((0, 0),)),
+            binding_energy=-0.3,
+        ).model_copy(update={"photon_energies": (45.0,)}),
+        existing_data,
+    )
+    qtbot.addWidget(source_tool)
+    qtbot.addWidget(destination)
+    _clear_clipboard()
+
+    assert not source_tool._source_removable("hvdep_kconv")
+    assert source_tool._source_removable("unused")
+
+    _select_operation_rows(source_tool, (0,))
+    source_tool.copy_operation_button.click()
+    payload = source_tool._clipboard_step_payload()
+    assert payload is not None
+    _operations, sources, source_data = payload
+    assert [source.name for source in sources] == ["hvdep_kconv"]
+    xr.testing.assert_identical(source_data["hvdep_kconv"], data)
+
+    destination._paste_operations_from_clipboard()
+
+    pasted = destination.tool_status.operations[-1]
+    assert pasted.hv_overlay_source == "hvdep_kconv_copy"
+    assert [source.name for source in destination.tool_status.sources] == [
+        "hvdep_kconv",
+        "hvdep_kconv_copy",
+    ]
+    xr.testing.assert_identical(destination.source_data()["hvdep_kconv"], existing_data)
+    xr.testing.assert_identical(destination.source_data()["hvdep_kconv_copy"], data)
 
 
 def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1268,6 +1268,13 @@ def test_figure_composer_source_helpers_cover_selection_contract() -> None:
     )
     with pytest.raises(ValueError, match="not a valid variable"):
         figurecomposer_sources._valid_source_variable("bad name")
+    assert figurecomposer_plot_slices._source_names(
+        FigureOperationState.plot_slices(
+            label="mapped",
+            sources=(),
+            map_selections=(FigureDataSelectionState(source="extra"),),
+        )
+    ) == ("extra",)
 
     data = xr.DataArray(
         np.arange(6.0).reshape(2, 3),
@@ -8894,6 +8901,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         "plot_slices",
         "line",
         "bz_overlay",
+        "photon_energy_overlay",
         "method:erlab",
         "method:axes",
         "method:figure",
@@ -8903,6 +8911,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         "Slice Plot",
         "Line/Profile",
         "BZ Overlay",
+        "Photon Energy Overlay",
         "ERLab Method",
         "Axes Method",
         "Figure Method",
@@ -14397,6 +14406,8 @@ def test_figure_composer_bz_overlay_text_parsers() -> None:
     for text in ("'not bounds'", "1, 2, 3", "1, 2, 3, object()"):
         with pytest.raises(ValueError, match="four comma-separated numbers"):
             figurecomposer_bz_overlay._bounds_from_text(text)
+    with pytest.raises(ValueError, match="four comma-separated numbers"):
+        figurecomposer_bz_overlay._bounds_from_text("1, 2, 3, 'bad'")
 
     operation = FigureOperationState.bz_overlay(
         axes=FigureAxesSelectionState(axes=((0, 0),))
@@ -14405,6 +14416,98 @@ def test_figure_composer_bz_overlay_text_parsers() -> None:
     assert figurecomposer_bz_overlay._section_summary(tool, "slice", operation) == (
         f"IP, kz=0.5 π/c; {np.pi / 8:g} Å⁻¹"
     )
+
+
+def test_figure_composer_bz_overlay_helper_edges(qtbot, monkeypatch) -> None:
+    operation = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 0),))
+    )
+    tool = _bz_tool(operation)
+    qtbot.addWidget(tool)
+    empty_tool = FigureComposerTool.from_sources(
+        {"data": xr.DataArray(np.zeros((2, 2)), dims=("kx", "ky"), name="data")},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(),
+        setup=FigureSubplotsState(),
+        primary_source="data",
+    )
+    qtbot.addWidget(empty_tool)
+    assert (
+        figurecomposer_bz_overlay._current_bz_operation(empty_tool, operation)
+        is operation
+    )
+
+    nonprimitive = operation.model_copy(update={"bz_centering_type": "I"})
+    assert figurecomposer_bz_overlay._bz_bvec(nonprimitive).shape == (3, 3)
+    assert (
+        figurecomposer_bz_overlay._single_axis_code(
+            tool,
+            operation.model_copy(
+                update={"axes": FigureAxesSelectionState(expression="axs[:1]")}
+            ),
+        )
+        is None
+    )
+
+    root = FigureGridSpecGridState(
+        grid_id="root",
+        nrows=1,
+        ncols=2,
+        axes=(
+            FigureGridSpecAxesState(
+                axes_id="axis-a",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=0,
+                    col_stop=1,
+                ),
+            ),
+            FigureGridSpecAxesState(
+                axes_id="axis-b",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=1,
+                    col_stop=2,
+                ),
+            ),
+        ),
+    )
+    grid_tool = FigureComposerTool(
+        xr.DataArray(np.zeros((2, 2)), dims=("kx", "ky"), name="data"),
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(
+                layout_mode="gridspec",
+                gridspec=FigureGridSpecLayoutState(root=root),
+            ),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(grid_tool)
+    assert (
+        figurecomposer_bz_overlay._single_axis_code(
+            grid_tool,
+            operation.model_copy(
+                update={"axes": FigureAxesSelectionState(axes_ids=("axis-a", "axis-b"))}
+            ),
+        )
+        is None
+    )
+
+    monkeypatch.setattr(
+        figurecomposer_bz_overlay,
+        "_axes_from_selection",
+        lambda *_args, **_kwargs: (),
+    )
+    figurecomposer_bz_overlay._render_bz_overlay(tool, operation, None)
+
+    tool.operation_list.setCurrentRow(0)
+    created = figurecomposer_bz_overlay._create_operation(tool)
+    assert created.kind == FigureOperationKind.BZ_OVERLAY
+    assert figurecomposer_bz_overlay._section_summary(tool, "unknown", operation) == ""
 
 
 def test_figure_composer_bz_overlay_generated_code_static_centering(qtbot) -> None:
@@ -15006,7 +15109,7 @@ def test_figure_composer_photon_energy_overlay_blocks_invalid_inputs(qtbot) -> N
     )
 
 
-def test_figure_composer_photon_energy_overlay_helper_edges(qtbot) -> None:
+def test_figure_composer_photon_energy_overlay_helper_edges(qtbot, monkeypatch) -> None:
     assert figurecomposer_photon_energy._optional_float_from_text("") is None
     assert figurecomposer_photon_energy._optional_float_from_text(" -0.3 ") == -0.3
     with pytest.raises(ValueError, match="one number"):
@@ -15068,6 +15171,72 @@ def test_figure_composer_photon_energy_overlay_helper_edges(qtbot) -> None:
             FakeKParallelKzData(), extra_dim_operation
         )
 
+    assert (
+        figurecomposer_photon_energy._single_axis_code(
+            tool,
+            operation.model_copy(
+                update={"axes": FigureAxesSelectionState(expression="axs[:1]")}
+            ),
+        )
+        is None
+    )
+
+    root = FigureGridSpecGridState(
+        grid_id="root",
+        nrows=1,
+        ncols=2,
+        axes=(
+            FigureGridSpecAxesState(
+                axes_id="axis-a",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=0,
+                    col_stop=1,
+                ),
+            ),
+            FigureGridSpecAxesState(
+                axes_id="axis-b",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=1,
+                    col_stop=2,
+                ),
+            ),
+        ),
+    )
+    grid_tool = _photon_energy_tool(
+        operation,
+        data,
+        setup=FigureSubplotsState(
+            layout_mode="gridspec",
+            gridspec=FigureGridSpecLayoutState(root=root),
+        ),
+    )
+    qtbot.addWidget(grid_tool)
+    assert (
+        figurecomposer_photon_energy._single_axis_code(
+            grid_tool,
+            operation.model_copy(
+                update={"axes": FigureAxesSelectionState(axes_ids=("axis-a", "axis-b"))}
+            ),
+        )
+        is None
+    )
+
+    render_operation = operation.model_copy(update={"hv_overlay_source": "hvdep_kconv"})
+    monkeypatch.setattr(
+        figurecomposer_photon_energy,
+        "_axes_from_selection",
+        lambda *_args, **_kwargs: (),
+    )
+    render_tool = _photon_energy_tool(render_operation, data)
+    qtbot.addWidget(render_tool)
+    figurecomposer_photon_energy._render_photon_energy_overlay(
+        render_tool, render_operation, None
+    )
+
 
 def test_figure_composer_photon_energy_overlay_add_step_seeds_source_and_binding(
     qtbot,
@@ -15118,6 +15287,16 @@ def test_figure_composer_photon_energy_overlay_seed_fallbacks(qtbot) -> None:
 
     assert figurecomposer_photon_energy._seed_source(tool) == "hvdep_kconv"
     assert figurecomposer_photon_energy._seed_binding_energy(tool) is None
+
+    primary_tool = FigureComposerTool.from_sources(
+        {"hvdep_kconv": data},
+        sources=(FigureSourceState(name="hvdep_kconv", label="hvdep_kconv"),),
+        operations=(),
+        setup=FigureSubplotsState(),
+        primary_source="hvdep_kconv",
+    )
+    qtbot.addWidget(primary_tool)
+    assert figurecomposer_photon_energy._seed_source(primary_tool) == "hvdep_kconv"
 
     line_operation = FigureOperationState.line(
         label="line", source="hvdep_kconv", axes=FigureAxesSelectionState()
@@ -20520,6 +20699,84 @@ def test_manager_append_operation_to_existing_figure(
         assert figure.tool_status.operations[-1].kind.value == "line"
 
 
+def test_manager_append_momentum_source_seeds_bz_overlay(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(9.0).reshape(3, 3),
+        dims=("kx", "ky"),
+        coords={"kx": [-1.0, 0.0, 1.0], "ky": [-2.0, 0.0, 2.0]},
+        name="momentum",
+    )
+    with manager_context() as manager:
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        figure_data = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="existing",
+        )
+        figure_tool = FigureComposerTool(
+            figure_data,
+            recipe=FigureRecipeState(
+                setup=FigureSubplotsState(nrows=1, ncols=1),
+                sources=(FigureSourceState(name="existing", label="existing"),),
+                operations=(),
+                primary_source="existing",
+            ),
+        )
+        figure_uid = manager.add_figuretool(figure_tool, show=False)
+
+        appended = manager.append_figure_from_targets(
+            (0,),
+            figure_uid=figure_uid,
+            axes_selection=FigureAxesSelectionState(axes=((0, 0),)),
+            show=False,
+        )
+
+        assert appended is True
+        assert [operation.kind for operation in figure_tool.tool_status.operations] == [
+            FigureOperationKind.PLOT_SLICES,
+            FigureOperationKind.BZ_OVERLAY,
+        ]
+        assert figure_tool.tool_status.operations[-1].axes.axes == ((0, 0),)
+
+
+def test_manager_create_explicit_plot_slices_fills_axes(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="map",
+    )
+    with manager_context() as manager:
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets(
+            (0,),
+            operation=FigureOperationState.plot_slices(
+                label="plot", sources=("map",), axes=FigureAxesSelectionState()
+            ),
+            show=False,
+        )
+
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        assert figure_tool.tool_status.operations[0].axes.axes == ((0, 0),)
+
+
 def test_manager_ktool_output_figure_seeds_bz_overlay(
     qtbot,
     anglemap,
@@ -20579,6 +20836,60 @@ def test_manager_ktool_output_figure_seeds_bz_overlay(
         assert bz_operation.bz_kz_pi_over_c == 0.5
         assert bz_operation.bz_vertices is True
         assert bz_operation.bz_midpoints is True
+
+
+def test_manager_bz_overlay_ignores_converted_output_without_ktool_parent() -> None:
+    class FakeNode:
+        output_id = "ktool.converted_output"
+
+    class FakeParent:
+        tool_window = object()
+
+    class FakeManager:
+        def _node_for_target(self, target: int | str) -> FakeNode:
+            assert target == "converted"
+            return FakeNode()
+
+        def _parent_node(self, node: FakeNode) -> FakeParent:
+            assert isinstance(node, FakeNode)
+            return FakeParent()
+
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [-1.0, 1.0], "ky": [-2.0, 2.0]},
+        name="momentum",
+    )
+    axes = FigureAxesSelectionState(axes=((0, 0),))
+
+    assert (
+        manager_mainwindow.ImageToolManager._figure_bz_overlay_operation_from_targets(
+            FakeManager(),
+            ("first", "second"),
+            {"momentum": data},
+            axes=axes,
+        )
+        is None
+    )
+    assert (
+        manager_mainwindow.ImageToolManager._figure_bz_overlay_operation_from_targets(
+            FakeManager(),
+            ("converted",),
+            {"first": data, "second": data},
+            axes=axes,
+        )
+        is None
+    )
+
+    assert (
+        manager_mainwindow.ImageToolManager._figure_bz_overlay_operation_from_target(
+            FakeManager(),
+            "converted",
+            data,
+            axes=axes,
+        )
+        is None
+    )
 
 
 def test_manager_append_operation_uses_axes_dialog_selection(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -28,6 +28,7 @@ import erlab.interactive._figurecomposer._line_style as figurecomposer_line_styl
 import erlab.interactive._figurecomposer._norms as figurecomposer_norms
 import erlab.interactive._figurecomposer._provenance as figurecomposer_provenance
 import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
+import erlab.interactive._figurecomposer._seeding as figurecomposer_seeding
 import erlab.interactive._figurecomposer._sources as figurecomposer_sources
 import erlab.interactive._figurecomposer._text as figurecomposer_text
 import erlab.interactive._figurecomposer._tool as figurecomposer_tool_module
@@ -14431,6 +14432,74 @@ def test_figure_composer_bz_overlay_plain_momentum_seeding() -> None:
     assert ky_kz_operation is not None
     assert ky_kz_operation.bz_mode == "out_of_plane"
     assert ky_kz_operation.bz_bounds == (0.25, 0.75, -1.0, 1.0)
+
+
+def test_figure_composer_bz_overlay_seeding_edge_cases() -> None:
+    no_momentum = xr.DataArray(
+        np.zeros(2),
+        dims=("x",),
+        coords={"x": [0.0, 1.0]},
+    )
+    bad_coord = xr.DataArray(
+        np.zeros(2),
+        dims=("kx",),
+        coords={"kx": ["bad", "coord"]},
+    )
+    nan_coord = xr.DataArray(
+        np.zeros(2),
+        dims=("kx",),
+        coords={"kx": [np.nan, np.nan]},
+    )
+
+    assert figurecomposer_seeding._coordinate_bounds(no_momentum, "kx") is None
+    assert figurecomposer_seeding._coordinate_bounds(bad_coord, "kx") is None
+    assert figurecomposer_seeding._coordinate_bounds(nan_coord, "kx") is None
+    assert figurecomposer_seeding._momentum_bounds(nan_coord, "kx", "ky") is None
+    assert figurecomposer_seeding._representative_coord_value(no_momentum, "kx") is None
+    assert figurecomposer_seeding._representative_coord_value(bad_coord, "kx") is None
+    assert figurecomposer_seeding._representative_coord_value(nan_coord, "kx") is None
+
+    in_plane_bad_bounds = xr.DataArray(
+        np.zeros((2, 2)),
+        dims=("kx", "ky"),
+        coords={"kx": [np.nan, np.nan], "ky": [0.0, 1.0]},
+    )
+    out_of_plane_bad_bounds = xr.DataArray(
+        np.zeros((2, 2)),
+        dims=("kx", "kz"),
+        coords={"kx": [np.nan, np.nan], "kz": [0.0, 1.0]},
+    )
+    kz_only = xr.DataArray(
+        np.zeros(2),
+        dims=("kz",),
+        coords={"kz": [0.0, 1.0]},
+    )
+
+    assert bz_overlay_operation_from_momentum_data(in_plane_bad_bounds) is None
+    assert bz_overlay_operation_from_momentum_data(no_momentum) is None
+    assert bz_overlay_operation_from_momentum_data(out_of_plane_bad_bounds) is None
+    assert bz_overlay_operation_from_momentum_data(kz_only) is None
+    assert (
+        figurecomposer_seeding._flat_ktool_out_of_plane_value(
+            kz_only, FigureOperationState.bz_overlay(mode="out_of_plane")
+        )
+        is None
+    )
+
+    class DisabledStatus:
+        bz_enabled = False
+
+    class EnabledStatus:
+        bz_enabled = True
+
+    class DisabledKtool:
+        tool_status = DisabledStatus()
+
+    class EnabledKtool:
+        tool_status = EnabledStatus()
+
+    assert bz_overlay_operation_from_ktool(DisabledKtool(), no_momentum) is None
+    assert bz_overlay_operation_from_ktool(EnabledKtool(), no_momentum) is None
 
 
 def test_figure_composer_bz_overlay_ktool_seeding_snapshot() -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -14711,6 +14711,7 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
     )
     assert energies_edit is not None
     assert binding_edit is not None
+    assert energies_edit.placeholderText() == "Enter photon energies"
     energies_edit.setText("30, 45, 60")
     energies_edit.editingFinished.emit()
     binding_edit.setText("-0.3")
@@ -14761,6 +14762,7 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
     assert updated.show_legend is False
     assert updated.legend_kw == {"title": "Photon energy", "frameon": False}
     assert updated.label_template == "hv={hv:g} eV"
+    assert tool.step_section_buttons["photon"].text() == "hν: 30, 45, 60; eV=-0.3"
     assert updated.line_kw == {
         "color": "tab:red",
         "linestyle": "--",

--- a/tests/plotting/test_bz.py
+++ b/tests/plotting/test_bz.py
@@ -1,8 +1,24 @@
+import matplotlib.colors
 import matplotlib.patches
 import matplotlib.pyplot as plt
 import numpy as np
 
-from erlab.plotting.bz import plot_bz, plot_hex_bz
+import erlab
+import erlab.plotting as eplt
+from erlab.plotting.bz import (
+    plot_bz,
+    plot_hex_bz,
+    plot_in_plane_bz,
+    plot_out_of_plane_bz,
+)
+from erlab.plotting.colors import axes_textcolor
+
+
+def _assert_line_artists_match_segments(lines, segments):
+    assert len(lines) == len(segments)
+    for line, segment in zip(lines, segments, strict=True):
+        np.testing.assert_allclose(line.get_xdata(), segment[:, 0])
+        np.testing.assert_allclose(line.get_ydata(), segment[:, 1])
 
 
 def test_plot_hex_bz():
@@ -114,3 +130,82 @@ def test_plot_bz_options_and_iterable():
     plt.close(fig2)
     plt.close(fig3)
     plt.close(fig4)
+
+
+def test_plot_in_plane_bz_matches_lattice_segments():
+    bvec = erlab.lattice.to_reciprocal(np.eye(3))
+    bounds = (-3.5, 3.5, -3.5, 3.5)
+    segments, _, _ = erlab.lattice.get_in_plane_bz(
+        bvec, kz=0.0, angle=45.0, bounds=bounds, return_midpoints=True
+    )
+
+    fig, ax = plt.subplots()
+    lines, vertex_artist, midpoint_artist = plot_in_plane_bz(
+        bvec,
+        kz=0.0,
+        angle=45.0,
+        bounds=bounds,
+        ax=ax,
+        c="tab:purple",
+        lw=1.5,
+        ls="-.",
+    )
+
+    _assert_line_artists_match_segments(lines, segments)
+    assert vertex_artist is None
+    assert midpoint_artist is None
+    assert all(line.get_color() == "tab:purple" for line in lines)
+    assert all(line.get_linewidth() == 1.5 for line in lines)
+    assert all(line.get_linestyle() == "-." for line in lines)
+
+    plt.close(fig)
+
+
+def test_plot_out_of_plane_bz_infers_bounds_from_axes():
+    bvec = erlab.lattice.to_reciprocal(np.eye(3))
+    bounds = (-4.0, 4.0, -4.0, 4.0)
+    segments, vertices, midpoints = erlab.lattice.get_out_of_plane_bz(
+        bvec,
+        k_parallel=0.0,
+        angle=0.0,
+        bounds=bounds,
+        return_midpoints=True,
+    )
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(bounds[1], bounds[0])
+    ax.set_ylim(bounds[3], bounds[2])
+    lines, vertex_artist, midpoint_artist = plot_out_of_plane_bz(
+        bvec,
+        k_parallel=0.0,
+        angle=0.0,
+        ax=ax,
+        vertices=True,
+        midpoints=True,
+        vertex_kwargs={"s": 12, "c": "tab:red"},
+        midpoint_kwargs={"s": 18, "color": "tab:blue"},
+    )
+
+    _assert_line_artists_match_segments(lines, segments)
+    assert vertex_artist is not None
+    assert midpoint_artist is not None
+    np.testing.assert_allclose(vertex_artist.get_offsets(), vertices)
+    np.testing.assert_allclose(midpoint_artist.get_offsets(), midpoints)
+    assert vertex_artist.get_sizes()[0] == 12
+    assert midpoint_artist.get_sizes()[0] == 18
+    np.testing.assert_allclose(
+        vertex_artist.get_facecolors()[0], matplotlib.colors.to_rgba("tab:red")
+    )
+    np.testing.assert_allclose(
+        midpoint_artist.get_facecolors()[0], matplotlib.colors.to_rgba("tab:blue")
+    )
+    assert all(line.get_color() == axes_textcolor(ax) for line in lines)
+    assert all(line.get_linewidth() == 0.5 for line in lines)
+    assert all(line.get_linestyle() == "--" for line in lines)
+
+    plt.close(fig)
+
+
+def test_bz_slice_helpers_export_from_plotting_namespace():
+    assert eplt.plot_in_plane_bz is plot_in_plane_bz
+    assert eplt.plot_out_of_plane_bz is plot_out_of_plane_bz

--- a/tests/plotting/test_bz.py
+++ b/tests/plotting/test_bz.py
@@ -206,6 +206,43 @@ def test_plot_out_of_plane_bz_infers_bounds_from_axes():
     plt.close(fig)
 
 
+def test_bz_slice_helpers_use_current_axes_and_infer_bounds():
+    bvec = erlab.lattice.to_reciprocal(np.eye(3))
+    bounds = (-3.0, 3.0, -2.0, 2.0)
+
+    fig, ax = plt.subplots()
+    plt.sca(ax)
+    ax.set_xlim(bounds[1], bounds[0])
+    ax.set_ylim(bounds[3], bounds[2])
+    in_plane_segments, _, _ = erlab.lattice.get_in_plane_bz(
+        bvec,
+        kz=0.0,
+        angle=0.0,
+        bounds=bounds,
+        return_midpoints=True,
+    )
+    in_plane_lines, _, _ = plot_in_plane_bz(bvec)
+
+    _assert_line_artists_match_segments(in_plane_lines, in_plane_segments)
+    assert all(line.axes is ax for line in in_plane_lines)
+
+    ax.cla()
+    ax.set_xlim(bounds[1], bounds[0])
+    ax.set_ylim(bounds[3], bounds[2])
+    out_of_plane_segments, _, _ = erlab.lattice.get_out_of_plane_bz(
+        bvec,
+        k_parallel=0.0,
+        angle=0.0,
+        bounds=bounds,
+        return_midpoints=True,
+    )
+    out_of_plane_lines, _, _ = plot_out_of_plane_bz(bvec)
+
+    _assert_line_artists_match_segments(out_of_plane_lines, out_of_plane_segments)
+    assert all(line.axes is ax for line in out_of_plane_lines)
+    plt.close(fig)
+
+
 def test_bz_slice_helpers_export_from_plotting_namespace():
     assert eplt.plot_in_plane_bz is plot_in_plane_bz
     assert eplt.plot_out_of_plane_bz is plot_out_of_plane_bz

--- a/tests/plotting/test_bz.py
+++ b/tests/plotting/test_bz.py
@@ -209,3 +209,16 @@ def test_plot_out_of_plane_bz_infers_bounds_from_axes():
 def test_bz_slice_helpers_export_from_plotting_namespace():
     assert eplt.plot_in_plane_bz is plot_in_plane_bz
     assert eplt.plot_out_of_plane_bz is plot_out_of_plane_bz
+
+
+def test_bz_slice_helpers_accept_sequence_bvec():
+    bvec = erlab.lattice.to_reciprocal(np.eye(3)).tolist()
+    bounds = (-4.0, 4.0, -4.0, 4.0)
+
+    fig, ax = plt.subplots()
+    in_plane_lines, _, _ = plot_in_plane_bz(bvec, bounds=bounds, ax=ax)
+    out_of_plane_lines, _, _ = plot_out_of_plane_bz(bvec, bounds=bounds, ax=ax)
+
+    assert in_plane_lines
+    assert out_of_plane_lines
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- Add a Brillouin-zone overlay operation to Figure Composer and seed it through the manager workflow
- Expose the plotting helper in the public typing surface and wire the new operation into the registry/state handling
- Update user guide content and notebook examples to document the overlay workflow
- Add regression coverage for the new plotting helper and Figure Composer integration

## Testing
- Added targeted unit and integration tests for the plotting helper and Figure Composer manager path
- Documentation and example updates were validated alongside the code changes