### PR TITLE
Fix explorer preview close regressions

### DIFF
--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -580,7 +580,8 @@ class _ReprFetcher(QtCore.QRunnable):
                 dat,
                 additional_info=[],
                 show_size=self.include_values,
-                load_values=self.include_values,
+                # Preview-off loads replace only data values; keep coordinate summaries.
+                load_values=True,
             )
             if not self.include_values:
                 dat = None
@@ -1342,6 +1343,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         if not self._stop_preview_workers():
+            self._preview_stopping = False
             if event is not None:
                 event.ignore()
             return

--- a/src/erlab/interactive/explorer/_tabbed_explorer.py
+++ b/src/erlab/interactive/explorer/_tabbed_explorer.py
@@ -266,6 +266,10 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         if not self._stop_preview_workers():
+            for index in range(self.tab_widget.count()):
+                explorer = self.get_explorer(index)
+                if explorer is not None:
+                    explorer._preview_stopping = False
             if event is not None:
                 event.ignore()
             return

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -37,11 +37,14 @@ class _DeferredPreviewTrackingExplorer(_PreviewTrackingExplorer):
     def __init__(self, name: str, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(name, parent)
         self.deferred_delete_count = 0
+        self.defer_preview_stop = True
 
     def _stop_preview_workers(self) -> bool:
         self.stopped_preview_workers += 1
-        self._preview_stopping = True
-        return False
+        if self.defer_preview_stop:
+            self._preview_stopping = True
+            return False
+        return True
 
     def _delete_when_preview_workers_done(self) -> None:
         self.deferred_delete_count += 1
@@ -175,12 +178,14 @@ def test_tabbed_explorer_close_ignores_busy_preview_workers(qtbot) -> None:
     qtbot.addWidget(win)
     explorer = win.current_explorer
     assert isinstance(explorer, _DeferredPreviewTrackingExplorer)
+    empty_tab = QtWidgets.QWidget()
+    win.tab_widget.addTab(empty_tab, "empty")
     event = QtGui.QCloseEvent()
 
     win.closeEvent(event)
 
     assert not event.isAccepted()
-    assert win.tab_widget.count() == 1
+    assert win.tab_widget.count() == 2
     assert win.current_explorer is explorer
     assert explorer.stopped_preview_workers == 1
     assert not explorer._preview_stopping
@@ -189,6 +194,8 @@ def test_tabbed_explorer_close_ignores_busy_preview_workers(qtbot) -> None:
 
     assert explorer.stopped_preview_workers == 2
     assert not explorer._preview_stopping
+    explorer.defer_preview_stop = False
+    win.close()
 
 
 def test_explorer_close_stops_preview_workers(
@@ -219,14 +226,17 @@ def test_explorer_close_ignores_busy_preview_workers(
     class _BusyDataExplorer(_DataExplorer):
         def __init__(self, *args, **kwargs) -> None:
             self.stopped_preview_workers = False
+            self.defer_preview_stop = True
             super().__init__(*args, **kwargs)
 
         def _stop_preview_workers(
             self, timeout_ms: int = _PREVIEW_WORKER_STOP_TIMEOUT_MS
         ) -> bool:
             self.stopped_preview_workers = True
-            self._preview_stopping = True
-            return False
+            if self.defer_preview_stop:
+                self._preview_stopping = True
+                return False
+            return True
 
     explorer = _BusyDataExplorer(root_path=example_data_dir, loader_name="example")
     qtbot.addWidget(explorer)
@@ -243,6 +253,8 @@ def test_explorer_close_ignores_busy_preview_workers(
 
     assert explorer.stopped_preview_workers
     assert not explorer._preview_stopping
+    explorer.defer_preview_stop = False
+    explorer.close()
 
 
 def test_tabbed_explorer_show_path_adds_selected_file_tab(

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -26,6 +26,7 @@ class _PreviewTrackingExplorer(QtWidgets.QWidget):
         self.current_directory = pathlib.Path(name)
         self.menu_bar = QtWidgets.QMenuBar(self)
         self.stopped_preview_workers = 0
+        self._preview_stopping = False
 
     def _stop_preview_workers(self) -> bool:
         self.stopped_preview_workers += 1
@@ -39,6 +40,7 @@ class _DeferredPreviewTrackingExplorer(_PreviewTrackingExplorer):
 
     def _stop_preview_workers(self) -> bool:
         self.stopped_preview_workers += 1
+        self._preview_stopping = True
         return False
 
     def _delete_when_preview_workers_done(self) -> None:
@@ -181,10 +183,12 @@ def test_tabbed_explorer_close_ignores_busy_preview_workers(qtbot) -> None:
     assert win.tab_widget.count() == 1
     assert win.current_explorer is explorer
     assert explorer.stopped_preview_workers == 1
+    assert not explorer._preview_stopping
 
     win.closeEvent(None)
 
     assert explorer.stopped_preview_workers == 2
+    assert not explorer._preview_stopping
 
 
 def test_explorer_close_stops_preview_workers(
@@ -221,6 +225,7 @@ def test_explorer_close_ignores_busy_preview_workers(
             self, timeout_ms: int = _PREVIEW_WORKER_STOP_TIMEOUT_MS
         ) -> bool:
             self.stopped_preview_workers = True
+            self._preview_stopping = True
             return False
 
     explorer = _BusyDataExplorer(root_path=example_data_dir, loader_name="example")
@@ -231,11 +236,13 @@ def test_explorer_close_ignores_busy_preview_workers(
 
     assert explorer.stopped_preview_workers
     assert not event.isAccepted()
+    assert not explorer._preview_stopping
 
     explorer.stopped_preview_workers = False
     explorer.closeEvent(None)
 
     assert explorer.stopped_preview_workers
+    assert not explorer._preview_stopping
 
 
 def test_tabbed_explorer_show_path_adds_selected_file_tab(
@@ -460,6 +467,39 @@ def test_explorer_loader_extensions_apply_only_to_manager_loads(
     worker = _ReprFetcher(file_path, _preview_loader, include_values=False)
     worker.run()
     assert preview_calls == [{"single": True, "load_kwargs": {"without_values": True}}]
+
+
+def test_repr_fetcher_keeps_coordinate_values_without_preview(
+    tmp_path: pathlib.Path,
+) -> None:
+    import numpy as np
+    import xarray as xr
+
+    data = xr.DataArray(
+        np.zeros((3, 4)),
+        dims=("x", "y"),
+        coords={
+            "x": np.array([10.0, 12.0, 14.0]),
+            "y": np.array([0.0, 0.5, 1.0, 1.5]),
+        },
+        name="demo",
+    )
+    fetched: list[tuple[str, object]] = []
+
+    worker = _ReprFetcher(tmp_path / "data.h5", lambda *_args, **_kwargs: data, False)
+    worker.signals.fetched.connect(
+        lambda _path, text, preview_data: fetched.append((text, preview_data))
+    )
+
+    worker.run()
+
+    assert len(fetched) == 1
+    text, preview_data = fetched[0]
+    assert preview_data is None
+    assert "10 : 2 : 14" in text
+    assert "0 : 0.5 : 1.5" in text
+    assert "float64 [3]" not in text
+    assert "float64 [4]" not in text
 
 
 def test_repr_fetcher_aborted_before_run_skips_loader(

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -163,7 +163,7 @@ def test_tabbed_explorer_close_stops_preview_workers_without_removing_tabs(
     explorer = win.current_explorer
     assert isinstance(explorer, _PreviewTrackingExplorer)
 
-    win.closeEvent(QtGui.QCloseEvent())
+    win.close()
 
     assert win.tab_widget.count() == 1
     assert win.current_explorer is explorer
@@ -208,7 +208,7 @@ def test_explorer_close_stops_preview_workers(
     explorer = _TrackingDataExplorer(root_path=example_data_dir, loader_name="example")
     qtbot.addWidget(explorer)
 
-    explorer.closeEvent(QtGui.QCloseEvent())
+    explorer.close()
 
     assert explorer.stopped_preview_workers
 

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -840,11 +840,15 @@ def test_goldtool_close_event_ignored_if_threadpool_does_not_quiesce(
 ) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
+    threadpool_ready = False
+
+    def _wait_for_threadpool(*args, **kwargs) -> bool:
+        return threadpool_ready
 
     monkeypatch.setattr(
         type(win),
         "_wait_for_threadpool",
-        staticmethod(lambda *args, **kwargs: False),
+        staticmethod(_wait_for_threadpool),
     )
 
     event = QtGui.QCloseEvent()
@@ -852,6 +856,8 @@ def test_goldtool_close_event_ignored_if_threadpool_does_not_quiesce(
     win.closeEvent(event)
     assert not event.isAccepted()
     assert not win._fit_closing
+    threadpool_ready = True
+    win.close()
 
 
 def test_goldtool_update_data_clamps_roi_to_non_empty_bounds(qtbot, gold) -> None:
@@ -1474,13 +1480,14 @@ def test_restool_close_event_ignored_if_fit_thread_stuck(qtbot) -> None:
         def __init__(self) -> None:
             self.cancel_called = False
             self.interrupted = False
+            self.running = True
             self.wait_timeout_ms: int | None = None
 
         def cancel(self) -> None:
             self.cancel_called = True
 
         def isRunning(self) -> bool:
-            return True
+            return self.running
 
         def requestInterruption(self) -> None:
             self.interrupted = True
@@ -1500,6 +1507,8 @@ def test_restool_close_event_ignored_if_fit_thread_stuck(qtbot) -> None:
     assert stuck_thread.cancel_called
     assert stuck_thread.interrupted
     assert stuck_thread.wait_timeout_ms == 5000
+    stuck_thread.running = False
+    win.close()
 
 
 def test_restool_cancel_fit_waits_without_timeout(qtbot) -> None:

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -1378,12 +1378,13 @@ def test_fit1d_close_event_ignored_if_thread_does_not_stop(qtbot) -> None:
     class _StuckThread:
         def __init__(self) -> None:
             self.cancel_called = False
+            self.running = True
 
         def cancel(self) -> None:
             self.cancel_called = True
 
         def isRunning(self) -> bool:
-            return True
+            return self.running
 
         def requestInterruption(self) -> None:
             return
@@ -1399,6 +1400,8 @@ def test_fit1d_close_event_ignored_if_thread_does_not_stop(qtbot) -> None:
     win.closeEvent(event)
     assert not event.isAccepted()
     assert stuck_thread.cancel_called
+    stuck_thread.running = False
+    win.close()
 
 
 def test_fit1d_slider_drag_updates_value(qtbot) -> None:


### PR DESCRIPTION
## Summary
- Keep coordinate summaries visible in explorer repr previews even when value loading is disabled.
- Clear `_preview_stopping` when close handling is interrupted so explorers can recover from a failed shutdown attempt.
- Cover the repr preview and close-event regressions with targeted unit tests.

## Testing
- Added unit tests for repr fetch output and preview-close state resets.
- Not run (not requested)