### PR TITLE
Work around macOS Qt icon crash and document standalone Manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout-minutes }}
     env:
-      DISPLAY: ":99.0"
+      QT_QPA_PLATFORM: "offscreen"
       QT_API: "pyqt6"
       PYTEST_QT_API: "pyqt6"
     strategy:
@@ -75,11 +75,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - uses: pyvista/setup-headless-display-action@v4
-        with:
-          pyvista: false
-          qt: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -147,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      DISPLAY: ":99.0"
+      QT_QPA_PLATFORM: "offscreen"
     strategy:
       fail-fast: false
       matrix:
@@ -166,11 +161,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - uses: pyvista/setup-headless-display-action@v4
-        with:
-          pyvista: false
-          qt: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout-minutes }}
     env:
-      QT_QPA_PLATFORM: "offscreen"
+      DISPLAY: ":99.0"
       QT_API: "pyqt6"
       PYTEST_QT_API: "pyqt6"
     strategy:
@@ -75,6 +75,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - uses: pyvista/setup-headless-display-action@v4
+        with:
+          pyvista: false
+          qt: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -142,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      QT_QPA_PLATFORM: "offscreen"
+      DISPLAY: ":99.0"
     strategy:
       fail-fast: false
       matrix:
@@ -161,6 +166,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - uses: pyvista/setup-headless-display-action@v4
+        with:
+          pyvista: false
+          qt: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -6,6 +6,8 @@ Welcome to ERLabPy! This page will guide you through the installation process an
 
 - Data structures in ERLabPy are represented using [xarray](https://docs.xarray.dev/){cite:p}`hoyer2017xarray`, which provides a powerful data structure for working with multi-dimensional arrays. Be sure to review the [xarray tutorial](https://tutorial.xarray.dev/) and the [xarray user guide](https://docs.xarray.dev/en/stable/index.html) to get familiar with it before diving into ERLabPy.
 
+- If you want to use the GUI without installing Python, {ref}`ImageTool Manager <imagetool-manager>` is available as a standalone application on [GitHub Releases](https://github.com/kmnhan/erlabpy/releases). See {ref}`imagetool-manager-standalone`.
+
 :::{admonition} Recommended Editor Setup
 :class: important
 

--- a/src/erlab/interactive/imagetool/manager/__init__.py
+++ b/src/erlab/interactive/imagetool/manager/__init__.py
@@ -124,6 +124,15 @@ _STARTUP_TARGET_NEW: typing.Literal["new"] = "new"
 _STARTUP_TARGET_CANCEL: typing.Literal["cancel"] = "cancel"
 
 
+def _runtime_window_icon() -> QtGui.QIcon:
+    # Avoid QTBUG-147602 crashes in QImage::toCGImage() color-space handling.
+    image = QtGui.QImage(_ICON_PATH).convertToFormat(
+        QtGui.QImage.Format.Format_ARGB32_Premultiplied
+    )
+    image.setColorSpace(QtGui.QColorSpace())
+    return QtGui.QIcon(QtGui.QPixmap.fromImage(image))
+
+
 @dataclass(frozen=True)
 class _StartupArgs:
     files: list[pathlib.Path]
@@ -412,7 +421,7 @@ def main(execute: bool = True) -> None:
         sys.platform != "darwin" or not erlab.utils.misc._IS_PACKAGED
     ):
         # Ignore if running in a PyInstaller bundle on macOS.
-        qapp.setWindowIcon(QtGui.QIcon(_ICON_PATH))
+        qapp.setWindowIcon(_runtime_window_icon())
         qapp.setApplicationName("ImageTool Manager")
         qapp.setApplicationDisplayName("ImageTool Manager")
         qapp.setApplicationVersion(erlab.__version__)

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import pathlib
-import sys
 import typing
 import uuid
 from collections.abc import Mapping
@@ -391,15 +390,11 @@ class _WorkspaceIOController:
         )
 
     def _update_workspace_window_title(self) -> None:
-        # macOS represented-file/proxy-icon updates can crash inside Qt/Cocoa
-        # while workspaces are being opened or closed. Keep the visible title
-        # and all workspace state in sync without calling setWindowFilePath().
-        if sys.platform != "darwin":
-            if self._manager._workspace_state.path is None:
-                window_file_path = ""
-            else:
-                window_file_path = typing.cast("str", self._manager.workspace_path)
-            self._manager.setWindowFilePath(window_file_path)
+        if self._manager._workspace_state.path is None:
+            window_file_path = ""
+        else:
+            window_file_path = typing.cast("str", self._manager.workspace_path)
+        self._manager.setWindowFilePath(window_file_path)
         workspace_display_name = (
             "Untitled"
             if self._manager._workspace_state.path is None

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3387,6 +3387,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             if current is not None:
                 self._tool_root_layout.removeWidget(current)
                 current.setParent(None)
+                current.deleteLater()
                 self._tool_content_widget = None
             QtWidgets.QMainWindow.setCentralWidget(self, widget)
             return
@@ -3397,6 +3398,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if current is not None:
             self._tool_root_layout.removeWidget(current)
             current.setParent(None)
+            current.deleteLater()
 
         self._tool_content_widget = widget
         if widget is not None:

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -20,6 +20,7 @@ import zmq
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.manager as manager_package
 import erlab.interactive.imagetool.manager.__main__ as manager_main
 import erlab.interactive.imagetool.manager._desktop as manager_desktop
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
@@ -38,6 +39,23 @@ from erlab.interactive.ptable import PeriodicTableWindow
 from .helpers import action_map_by_object_name, menu_map_by_object_name
 
 logger = logging.getLogger(__name__)
+
+
+def test_manager_runtime_icon_asset_exists() -> None:
+    icon_path = pathlib.Path(manager_widgets._ICON_PATH)
+
+    assert icon_path.name == ("icon.icns" if sys.platform == "darwin" else "icon.png")
+    assert icon_path.is_file()
+
+
+def test_manager_runtime_icon_is_sanitized(qapp) -> None:
+    assert qapp is QtWidgets.QApplication.instance()
+
+    icon = manager_package._runtime_window_icon()
+    pixmap = icon.pixmap(32, 32)
+
+    assert not pixmap.isNull()
+    assert not pixmap.toImage().colorSpace().isValid()
 
 
 def test_manager_main_cache_directory_uses_qstandardpaths(

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -5089,7 +5089,7 @@ def test_workspace_window_title_placeholder_non_macos(monkeypatch) -> None:
     )
 
 
-def test_manager_workspace_window_title_sets_file_path_on_non_macos(
+def test_manager_workspace_window_title_sets_file_path(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -5103,7 +5103,6 @@ def test_manager_workspace_window_title_sets_file_path_on_non_macos(
         file_path_calls: list[str] = []
 
         with monkeypatch.context() as patch:
-            patch.setattr(manager_mainwindow.sys, "platform", "linux")
             patch.setattr(
                 ImageToolManager,
                 "setWindowFilePath",
@@ -5116,34 +5115,31 @@ def test_manager_workspace_window_title_sets_file_path_on_non_macos(
         assert manager.isWindowModified()
 
 
-def test_manager_workspace_window_title_skips_file_path_on_macos(
+def test_manager_workspace_window_title_clears_file_path_without_workspace(
     monkeypatch,
-    tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
     with manager_context() as manager:
-        workspace = tmp_path / "macos-workspace.itws"
-        manager._workspace_state.path = workspace
+        manager._workspace_state.path = None
         manager._workspace_state.structure_modified = True
         file_path_calls: list[str] = []
 
         with monkeypatch.context() as patch:
-            patch.setattr(manager_mainwindow.sys, "platform", "darwin")
             patch.setattr(
                 ImageToolManager,
                 "setWindowFilePath",
                 lambda _manager, path: file_path_calls.append(path),
             )
             manager._update_workspace_window_title()
-            assert file_path_calls == []
 
-        assert workspace.name in manager.windowTitle()
-        assert manager.isWindowModified()
+        assert file_path_calls == [""]
+        assert "Untitled" in manager.windowTitle()
+        assert not manager.isWindowModified()
 
 
-def test_manager_workspace_window_title_skips_file_path_during_macos_close(
+def test_manager_workspace_window_title_sets_file_path_during_close(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -5156,23 +5152,25 @@ def test_manager_workspace_window_title_skips_file_path_during_macos_close(
         manager._workspace_state.structure_modified = True
         previous_closing = manager._workspace_state.closing_document
         manager._workspace_state.closing_document = True
-
-        def _fail_if_called(_manager, _path: str) -> None:
-            raise AssertionError("setWindowFilePath should be skipped")
+        file_path_calls: list[str] = []
 
         try:
             with monkeypatch.context() as patch:
-                patch.setattr(manager_mainwindow.sys, "platform", "darwin")
-                patch.setattr(ImageToolManager, "setWindowFilePath", _fail_if_called)
+                patch.setattr(
+                    ImageToolManager,
+                    "setWindowFilePath",
+                    lambda _manager, path: file_path_calls.append(path),
+                )
                 manager._update_workspace_window_title()
         finally:
             manager._workspace_state.closing_document = previous_closing
 
+        assert file_path_calls == [str(workspace)]
         assert workspace.name in manager.windowTitle()
         assert manager.isWindowModified()
 
 
-def test_manager_loaded_workspace_association_skips_macos_file_path_update(
+def test_manager_loaded_workspace_association_updates_file_path(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -5185,7 +5183,6 @@ def test_manager_loaded_workspace_association_skips_macos_file_path_update(
         file_path_calls: list[str] = []
 
         with monkeypatch.context() as patch:
-            patch.setattr(manager_mainwindow.sys, "platform", "darwin")
             patch.setattr(
                 ImageToolManager,
                 "setWindowFilePath",
@@ -5198,7 +5195,10 @@ def test_manager_loaded_workspace_association_skips_macos_file_path_update(
                     workspace_access=access,
                     rebind_data=False,
                 )
-            assert file_path_calls == []
+            assert file_path_calls == [
+                str(workspace.resolve()),
+                str(workspace.resolve()),
+            ]
 
         assert manager.workspace_path == str(workspace.resolve())
         assert workspace.name in manager.windowTitle()
@@ -5233,7 +5233,7 @@ def test_manager_loaded_workspace_association_rebinds_data_after_path_update(
         assert rebind_paths == [workspace.resolve()]
 
 
-def test_manager_workspace_window_title_sets_file_path_for_non_macos_close(
+def test_manager_workspace_window_title_sets_file_path_for_close(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -5249,7 +5249,6 @@ def test_manager_workspace_window_title_sets_file_path_for_non_macos_close(
 
         try:
             with monkeypatch.context() as patch:
-                patch.setattr(manager_mainwindow.sys, "platform", "linux")
                 patch.setattr(
                     ImageToolManager,
                     "setWindowFilePath",
@@ -5275,24 +5274,26 @@ def test_manager_close_cancel_restores_workspace_document_closing_state(
         manager._workspace_state.structure_modified = True
         manager._workspace_state.closing_document = False
         event = QtGui.QCloseEvent()
-
-        def _fail_if_called(_manager, _path: str) -> None:
-            raise AssertionError("setWindowFilePath should be skipped")
+        file_path_calls: list[str] = []
 
         with monkeypatch.context() as patch:
-            patch.setattr(manager_mainwindow.sys, "platform", "darwin")
-            patch.setattr(ImageToolManager, "setWindowFilePath", _fail_if_called)
+            patch.setattr(
+                ImageToolManager,
+                "setWindowFilePath",
+                lambda _manager, path: file_path_calls.append(path),
+            )
             patch.setattr(
                 manager, "_confirm_save_dirty_workspace", lambda _message: False
             )
             manager._update_workspace_window_title()
             manager.closeEvent(event)
 
+        assert file_path_calls == [str(workspace)]
         assert not event.isAccepted()
         assert not manager._workspace_state.closing_document
 
 
-def test_manager_close_save_path_skips_macos_file_path_update(
+def test_manager_close_save_path_updates_file_path(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -5303,12 +5304,7 @@ def test_manager_close_save_path_skips_macos_file_path_update(
         manager._workspace_state.path = tmp_path / "close-save.itws"
         manager._workspace_state.structure_modified = True
         save_closing_states: list[bool] = []
-
-        def _fail_during_close_file_path_update(
-            window: ImageToolManager, _path: str
-        ) -> None:
-            if window._workspace_state.closing_document:
-                raise AssertionError("setWindowFilePath should be skipped")
+        file_path_calls: list[str] = []
 
         def _save(*, native: bool = True) -> bool:
             save_closing_states.append(manager._workspace_state.closing_document)
@@ -5316,11 +5312,10 @@ def test_manager_close_save_path_skips_macos_file_path_update(
             return True
 
         with monkeypatch.context() as patch:
-            patch.setattr(manager_mainwindow.sys, "platform", "darwin")
             patch.setattr(
                 ImageToolManager,
                 "setWindowFilePath",
-                _fail_during_close_file_path_update,
+                lambda _manager, path: file_path_calls.append(path),
             )
             patch.setattr(
                 QtWidgets.QMessageBox,
@@ -5331,6 +5326,7 @@ def test_manager_close_save_path_skips_macos_file_path_update(
             assert manager.close()
 
         assert save_closing_states == [True]
+        assert file_path_calls == [str(manager._workspace_state.path)]
         assert not manager._workspace_state.closing_document
 
 

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from pydantic import BaseModel, ValidationError
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 import erlab
 from erlab.interactive.derivative import DerivativeTool, dtool
@@ -571,6 +571,8 @@ def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
     tool.setCentralWidget(tool._tool_root_widget)
     assert tool.centralWidget() is tool._tool_root_widget
     assert tool._tool_content_widget is None
+    QtWidgets.QApplication.sendPostedEvents(original, QtCore.QEvent.Type.DeferredDelete)
+    assert not erlab.interactive.utils.qt_is_valid(original)
     tool.setCentralWidget(replacement)
     tool.setCentralWidget(replacement)
     assert tool.centralWidget() is replacement


### PR DESCRIPTION
## Summary
- Sanitize the ImageTool Manager window icon at runtime to avoid the macOS Qt color-space crash path
- Always update the workspace file path in the title flow, including close and reload cases
- Note that ImageTool Manager is available as a standalone app in the getting-started guide
- Strengthen manager tests around icon handling and workspace file-path updates

## Testing
- Added unit tests for runtime icon sanitization and workspace title/file-path behavior
- Not run (not requested)