### PR TITLE
Add gradient fill support to figure composer lines

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_gridspec.py
+++ b/src/erlab/interactive/_figurecomposer/_gridspec.py
@@ -138,6 +138,8 @@ def _gridspec_axis_variable_name_error(
         return "Variable name must be a valid Python identifier."
     if keyword.iskeyword(name):
         return "Variable name cannot be a Python keyword."
+    if name.startswith("_"):
+        return "Variable name cannot start with an underscore."
     if name in _gridspec_reserved_axis_code_names(setup, reserved_names=reserved_names):
         return "Variable name is reserved for generated code."
     for index, axis in enumerate(_gridspec_all_axes(setup)):
@@ -462,6 +464,7 @@ def _axis_variable_name_is_available(name: str, used: set[str]) -> bool:
         bool(name)
         and name.isidentifier()
         and not keyword.iskeyword(name)
+        and not name.startswith("_")
         and name not in used
     )
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
@@ -6,6 +6,7 @@ import typing
 
 from qtpy import QtWidgets
 
+import erlab.plotting as eplt
 from erlab.interactive._figurecomposer._code import (
     _axes_code,
     _axes_sequence_code,
@@ -796,6 +797,22 @@ def _add_line_style_controls(
         "Marker face and edge colors for the extracted profiles.",
     )
 
+    gradient_mixed = tool._batch_is_mixed(operation, lambda target: target.gradient)
+    gradient_check = tool._check_box(
+        operation.gradient,
+        lambda checked: tool._update_current_operation(gradient=checked),
+        parent=page,
+        mixed=gradient_mixed,
+    )
+    gradient_check.setObjectName("figureComposerLineGradientCheck")
+    gradient_check.setText("Gradient Fill")
+    tool._add_form_row(
+        layout,
+        "Gradient",
+        gradient_check,
+        "Fill the area under each profile with a gradient using the line color.",
+    )
+
 
 def _update_current_line_labels(tool: FigureComposerTool, text: str) -> None:
     editable = tool._editable_operations()
@@ -885,9 +902,10 @@ def _render_line(
         for line_data, kwargs in zip(line_items, styles, strict=True):
             if operation.line_values_axis == "x":
                 coordinate = _line_coordinate(line_data, operation.line_x)
-                axis.plot(line_data.values, coordinate.values, **kwargs)
+                line = axis.plot(line_data.values, coordinate.values, **kwargs)[0]
             else:
-                line_data.plot(ax=axis, x=operation.line_x, **kwargs)
+                line = line_data.plot(ax=axis, x=operation.line_x, **kwargs)[0]
+            _apply_line_gradient_fill(axis, line, operation)
         _apply_line_axes_limits(axis, operation)
 
 
@@ -906,10 +924,27 @@ def _render_one_profile_per_axis(
     for axis, profile, kwargs in zip(axes, profiles, styles, strict=True):
         coordinate = _line_coordinate(profile, operation.line_x)
         if operation.line_values_axis == "x":
-            axis.plot(profile.values, coordinate.values, **kwargs)
+            line = axis.plot(profile.values, coordinate.values, **kwargs)[0]
         else:
-            axis.plot(coordinate.values, profile.values, **kwargs)
+            line = axis.plot(coordinate.values, profile.values, **kwargs)[0]
+        _apply_line_gradient_fill(axis, line, operation)
         _apply_line_axes_limits(axis, operation)
+
+
+def _apply_line_gradient_fill(
+    axis: matplotlib.axes.Axes,
+    line: typing.Any,
+    operation: FigureOperationState,
+) -> None:
+    if not operation.gradient:
+        return
+    eplt.gradient_fill(
+        line.get_xdata(),
+        line.get_ydata(),
+        color=line.get_color(),
+        ax=axis,
+        transpose=operation.line_values_axis == "x",
+    )
 
 
 def _apply_line_axes_limits(
@@ -1229,14 +1264,20 @@ def _regular_line_code(
         call_args = f"profile, {coordinate}"
         if kwargs_text:
             call_args += f", {kwargs_text}"
-        lines.append(f"        ax.plot({call_args})")
+        lines.extend(
+            _line_plot_code(tool, operation, f"ax.plot({call_args})", "ax", "        ")
+        )
     else:
         call_args = "ax=ax"
         if operation.line_x:
             call_args += f", x={operation.line_x!r}"
         if kwargs_text:
             call_args += f", {kwargs_text}"
-        lines.append(f"        profile.plot({call_args})")
+        lines.extend(
+            _line_plot_code(
+                tool, operation, f"profile.plot({call_args})", "ax", "        "
+            )
+        )
     if axes_limits_code := _line_axes_limits_code(operation):
         lines.append(f"    {axes_limits_code}")
     return lines
@@ -1267,14 +1308,26 @@ def _regular_line_single_axis_code(
         call_args = f"profile, {coordinate}"
         if kwargs_text:
             call_args += f", {kwargs_text}"
-        lines.append(f"    {axis_code}.plot({call_args})")
+        lines.extend(
+            _line_plot_code(
+                tool,
+                operation,
+                f"{axis_code}.plot({call_args})",
+                axis_code,
+                "    ",
+            )
+        )
     else:
         call_args = f"ax={axis_code}"
         if operation.line_x:
             call_args += f", x={operation.line_x!r}"
         if kwargs_text:
             call_args += f", {kwargs_text}"
-        lines.append(f"    profile.plot({call_args})")
+        lines.extend(
+            _line_plot_code(
+                tool, operation, f"profile.plot({call_args})", axis_code, "    "
+            )
+        )
     if axes_limits_code := _line_axes_limits_code(operation, axis_name=axis_code):
         lines.append(axes_limits_code)
     return lines
@@ -1360,7 +1413,9 @@ def _one_profile_per_axis_code(
         call_args = f"{coordinate}, profile"
     if kwargs_text:
         call_args += f", {kwargs_text}"
-    lines.append(f"    ax.plot({call_args})")
+    lines.extend(
+        _line_plot_code(tool, operation, f"ax.plot({call_args})", "ax", "    ")
+    )
     if axes_limits_code := _line_axes_limits_code(operation):
         lines.append(f"    {axes_limits_code}")
     return lines
@@ -1393,9 +1448,65 @@ def _one_axis_many_profiles_code(
         call_args = f"{coordinate}, profile"
     if kwargs_text:
         call_args += f", {kwargs_text}"
-    lines.append(f"    {axis_code}.plot({call_args})")
+    lines.extend(
+        _line_plot_code(
+            tool, operation, f"{axis_code}.plot({call_args})", axis_code, "    "
+        )
+    )
     if axes_limits_code := _line_axes_limits_code(operation, axis_name=axis_code):
         lines.append(axes_limits_code)
+    return lines
+
+
+def _line_plot_code(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    call: str,
+    axis_code: str,
+    indent: str,
+) -> list[str]:
+    if not operation.gradient:
+        return [f"{indent}{call}"]
+    line_name = _line_artist_code_name(tool)
+    lines = [f"{indent}{line_name} = {call}[0]"]
+    lines.extend(
+        _line_gradient_code(
+            operation,
+            line_name=line_name,
+            axis_code=axis_code,
+            indent=indent,
+        )
+    )
+    return lines
+
+
+def _line_artist_code_name(tool: FigureComposerTool) -> str:
+    source_names = set(tool._source_names())
+    name = "_line"
+    suffix = 1
+    while name in source_names:
+        suffix += 1
+        name = f"_line_{suffix}"
+    return name
+
+
+def _line_gradient_code(
+    operation: FigureOperationState,
+    *,
+    line_name: str,
+    axis_code: str,
+    indent: str,
+) -> list[str]:
+    lines = [
+        f"{indent}eplt.gradient_fill(",
+        f"{indent}    {line_name}.get_xdata(),",
+        f"{indent}    {line_name}.get_ydata(),",
+        f"{indent}    color={line_name}.get_color(),",
+        f"{indent}    ax={axis_code},",
+    ]
+    if operation.line_values_axis == "x":
+        lines.append(f"{indent}    transpose=True,")
+    lines.append(f"{indent})")
     return lines
 
 
@@ -1623,6 +1734,14 @@ def _section_summary(
     return ""
 
 
+def _required_imports(
+    _tool: FigureComposerTool, operation: FigureOperationState
+) -> tuple[str, ...]:
+    if operation.gradient:
+        return ("import erlab.plotting as eplt",)
+    return ()
+
+
 SPEC = OperationSpec(
     kind=FigureOperationKind.LINE,
     add_actions=(
@@ -1645,4 +1764,5 @@ SPEC = OperationSpec(
     section_summary=_section_summary,
     render=lambda tool, operation, _figure, axs: _render_line(tool, operation, axs),
     code_lines=_line_code,
+    required_imports=_required_imports,
 )

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -2268,7 +2268,7 @@ def _build_plot_slices_editor(
             mixed=gradient_mixed,
         )
         gradient_check.setObjectName("figureComposerGradientCheck")
-        gradient_check.setText("Fill under line")
+        gradient_check.setText("Gradient Fill")
         tool._add_form_row(
             colors_layout,
             "Gradient",

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -16454,6 +16454,7 @@ def test_figure_composer_line_gradient_fill_one_profile_per_axis_executes(
             "line_placement": "one_per_axis",
             "line_x": "kx",
             "line_iter_dim": "cut",
+            "line_values_axis": "x",
             "line_colors": ("red", "blue"),
             "gradient": True,
         }
@@ -16471,9 +16472,12 @@ def test_figure_composer_line_gradient_fill_one_profile_per_axis_executes(
 
     fig = tool.figure
     figurecomposer_rendering._render_into_figure(tool, fig, sync_visible=False)
-    for axis in fig.axes:
+    for index, axis in enumerate(fig.axes):
+        profile = data.isel(cut=index)
         assert len(axis.lines) == 1
         assert len(axis.images) == 1
+        np.testing.assert_allclose(axis.lines[0].get_xdata(), profile.values)
+        np.testing.assert_allclose(axis.lines[0].get_ydata(), kx)
         np.testing.assert_allclose(
             axis.images[0].cmap(1.0),
             mcolors.to_rgba(axis.lines[0].get_color()),
@@ -16482,20 +16486,24 @@ def test_figure_composer_line_gradient_fill_one_profile_per_axis_executes(
 
     code = tool.generated_code()
     assert "for ax, profile, color in zip(" in code
-    assert "_line = ax.plot(profile['kx'], profile, color=color)[0]" in code
+    assert "_line = ax.plot(profile, profile['kx'], color=color)[0]" in code
+    assert "transpose=True" in code
     assert "for _line in" not in code
     assert "ax.lines" not in code
     code_lines = code.splitlines()
     plot_index = code_lines.index(
-        "    _line = ax.plot(profile['kx'], profile, color=color)[0]"
+        "    _line = ax.plot(profile, profile['kx'], color=color)[0]"
     )
     assert code_lines[plot_index + 1] == "    eplt.gradient_fill("
 
     namespace: dict[str, typing.Any] = {"data": data}
     exec(code, namespace)  # noqa: S102
-    for axis in namespace["fig"].axes:
+    for index, axis in enumerate(namespace["fig"].axes):
+        profile = data.isel(cut=index)
         assert len(axis.lines) == 1
         assert len(axis.images) == 1
+        np.testing.assert_allclose(axis.lines[0].get_xdata(), profile.values)
+        np.testing.assert_allclose(axis.lines[0].get_ydata(), kx)
         np.testing.assert_allclose(
             axis.images[0].cmap(1.0),
             mcolors.to_rgba(axis.lines[0].get_color()),
@@ -16510,37 +16518,37 @@ def test_figure_composer_line_gradient_fill_codegen_preserves_line_source(
         np.array([1.0, 2.0, 1.0]),
         dims=("kx",),
         coords={"kx": [-1.0, 0.0, 1.0]},
-        name="line",
+        name="_line",
     )
     tool = FigureComposerTool(
         data,
         recipe=FigureRecipeState(
             setup=FigureSubplotsState(),
-            sources=(FigureSourceState(name="line", label="line"),),
+            sources=(FigureSourceState(name="_line", label="_line"),),
             operations=(
                 FigureOperationState.line(
                     label="gradient",
-                    source="line",
+                    source="_line",
                     axes=FigureAxesSelectionState(axes=((0, 0),)),
                 ).model_copy(update={"gradient": True}),
                 FigureOperationState.line(
                     label="later",
-                    source="line",
+                    source="_line",
                     axes=FigureAxesSelectionState(axes=((0, 0),)),
                 ),
             ),
-            primary_source="line",
+            primary_source="_line",
         ),
     )
     qtbot.addWidget(tool)
 
     code = tool.generated_code()
     code_lines = code.splitlines()
-    assert not any(line.startswith("    line = profile.plot(") for line in code_lines)
-    assert "_line = profile.plot(ax=axs[0, 0])[0]" in code
-    assert "profile_data = line" in code
+    assert not any(line.startswith("    _line = profile.plot(") for line in code_lines)
+    assert "_line_2 = profile.plot(ax=axs[0, 0])[0]" in code
+    assert "profile_data = _line" in code
 
-    namespace: dict[str, typing.Any] = {"line": data}
+    namespace: dict[str, typing.Any] = {"_line": data}
     exec(code, namespace)  # noqa: S102
     assert len(namespace["fig"].axes[0].lines) == 2
     assert len(namespace["fig"].axes[0].images) == 1
@@ -16870,6 +16878,70 @@ def test_figure_composer_regular_line_profiles_render_on_each_selected_axis(
     figurecomposer_line_profile._set_axis_ylim(test_axis, 2.0)
     assert test_axis.get_xlim()[0] < 1.0 < test_axis.get_xlim()[1]
     assert test_axis.get_ylim()[0] == pytest.approx(2.0)
+
+
+def test_figure_composer_regular_line_gradient_fill_codegen_executes(
+    qtbot,
+) -> None:
+    cut_values = np.array([0.0, 1.0])
+    kx = np.array([-1.0, 0.0, 1.0])
+    data = xr.DataArray(
+        np.arange(cut_values.size * kx.size, dtype=float).reshape(
+            cut_values.size, kx.size
+        ),
+        dims=("cut", "kx"),
+        coords={"cut": cut_values, "kx": kx},
+        name="data",
+    )
+    operation = FigureOperationState.line(
+        label="profiles",
+        source="data",
+        axes=FigureAxesSelectionState(axes=((0, 0), (0, 1))),
+    ).model_copy(
+        update={
+            "line_x": "kx",
+            "line_iter_dim": "cut",
+            "line_colors": ("red", "blue"),
+            "gradient": True,
+        }
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=2),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    fig = tool.figure
+    figurecomposer_rendering._render_into_figure(tool, fig, sync_visible=False)
+    for axis in fig.axes:
+        assert len(axis.lines) == 2
+        assert len(axis.images) == 2
+        for index, line in enumerate(axis.lines):
+            np.testing.assert_allclose(line.get_xdata(), kx)
+            np.testing.assert_allclose(line.get_ydata(), data.isel(cut=index).values)
+            assert line.get_color() == ("red", "blue")[index]
+
+    code = tool.generated_code()
+    assert "_line = profile.plot(ax=ax, x='kx', color=color)[0]" in code
+    code_lines = code.splitlines()
+    plot_index = code_lines.index(
+        "        _line = profile.plot(ax=ax, x='kx', color=color)[0]"
+    )
+    assert code_lines[plot_index + 1] == "        eplt.gradient_fill("
+
+    namespace: dict[str, typing.Any] = {"data": data}
+    exec(code, namespace)  # noqa: S102
+    for axis in namespace["fig"].axes:
+        assert len(axis.lines) == 2
+        assert len(axis.images) == 2
+        for index, line in enumerate(axis.lines):
+            np.testing.assert_allclose(line.get_xdata(), kx)
+            np.testing.assert_allclose(line.get_ydata(), data.isel(cut=index).values)
 
 
 def test_figure_composer_line_labels_auto_add_axes_legend_step(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -15,6 +15,7 @@ import matplotlib.transforms as mtransforms
 import numpy as np
 import pytest
 import xarray as xr
+from matplotlib import colors as mcolors
 from matplotlib import style as mpl_style
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
@@ -7643,6 +7644,26 @@ def test_figure_composer_gridspec_helpers_cover_names_and_invalid_regions() -> N
         "keyword": "ax2",
         "child-axis": "ax3",
     }
+    underscore_setup = FigureSubplotsState(
+        layout_mode="gridspec",
+        gridspec=FigureGridSpecLayoutState(
+            root=FigureGridSpecGridState(
+                grid_id="root",
+                nrows=1,
+                ncols=1,
+                axes=(
+                    FigureGridSpecAxesState(
+                        axes_id="underscore",
+                        label="_line",
+                        span=span,
+                    ),
+                ),
+            )
+        ),
+    )
+    assert figurecomposer_gridspec._gridspec_axis_code_names(underscore_setup) == {
+        "underscore": "ax0",
+    }
     assert (
         figurecomposer_gridspec._gridspec_axis_variable_name_error(
             setup, "first", "valid_name"
@@ -7654,6 +7675,9 @@ def test_figure_composer_gridspec_helpers_cover_names_and_invalid_regions() -> N
     )
     assert "keyword" in figurecomposer_gridspec._gridspec_axis_variable_name_error(
         setup, "first", "class"
+    )
+    assert figurecomposer_gridspec._gridspec_axis_variable_name_error(
+        setup, "first", "_line"
     )
     assert "unique" in figurecomposer_gridspec._gridspec_axis_variable_name_error(
         setup, "first", "peak"
@@ -9447,6 +9471,7 @@ def test_figure_composer_line_profile_operation_uses_semantic_sections(
                 "figureComposerLineMarkerSizeSpin",
                 "figureComposerLineMarkerFaceColorEdit",
                 "figureComposerLineMarkerEdgeColorEdit",
+                "figureComposerLineGradientCheck",
             ),
         ),
         (
@@ -15683,7 +15708,7 @@ def test_figure_composer_line_values_axis_swaps_regular_profile(qtbot) -> None:
         label="profile",
         source="profile",
         axes=FigureAxesSelectionState(axes=((0, 0),)),
-    ).model_copy(update={"line_x": "kx", "line_values_axis": "x"})
+    ).model_copy(update={"line_x": "kx", "line_values_axis": "x", "gradient": True})
     tool = FigureComposerTool(
         profile,
         recipe=FigureRecipeState(
@@ -15700,12 +15725,34 @@ def test_figure_composer_line_values_axis_swaps_regular_profile(qtbot) -> None:
     line = fig.axes[0].lines[0]
     np.testing.assert_allclose(line.get_xdata(), profile.values)
     np.testing.assert_allclose(line.get_ydata(), profile["kx"].values)
+    assert len(fig.axes[0].images) == 1
+    np.testing.assert_allclose(
+        fig.axes[0].images[0].cmap(1.0),
+        mcolors.to_rgba(line.get_color()),
+        rtol=1e-7,
+    )
+
+    code = tool.generated_code()
+    assert "import erlab.plotting as eplt" in code
+    assert "_line = axs[0, 0].plot(profile, profile['kx'])[0]" in code
+    assert "transpose=True" in code
+    code_lines = code.splitlines()
+    plot_index = code_lines.index(
+        "    _line = axs[0, 0].plot(profile, profile['kx'])[0]"
+    )
+    assert code_lines[plot_index + 1] == "    eplt.gradient_fill("
 
     namespace: dict[str, typing.Any] = {"profile": profile}
-    exec(tool.generated_code(), namespace)  # noqa: S102
+    exec(code, namespace)  # noqa: S102
     line = namespace["fig"].axes[0].lines[0]
     np.testing.assert_allclose(line.get_xdata(), profile.values)
     np.testing.assert_allclose(line.get_ydata(), profile["kx"].values)
+    assert len(namespace["fig"].axes[0].images) == 1
+    np.testing.assert_allclose(
+        namespace["fig"].axes[0].images[0].cmap(1.0),
+        mcolors.to_rgba(line.get_color()),
+        rtol=1e-7,
+    )
 
 
 def test_figure_composer_line_mean_normalization_executes(qtbot) -> None:
@@ -15981,6 +16028,7 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
             "line_offset_source": "associated",
             "line_offset_coord": "temperature",
             "line_offset_scale": 0.01,
+            "gradient": True,
         }
     )
     tool = FigureComposerTool(
@@ -16074,6 +16122,9 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     marker_edge_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineMarkerEdgeColorEdit"
     )
+    gradient_check = style_page.findChild(
+        QtWidgets.QCheckBox, "figureComposerLineGradientCheck"
+    )
     marker_face_button = style_page.findChild(
         figurecomposer_widgets._ColorPickerButton,
         "figureComposerLineMarkerFaceColorButton",
@@ -16091,6 +16142,8 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     assert marker_face_button is not None
     assert marker_edge_edit is not None
     assert marker_edge_edit.text() == "black"
+    assert gradient_check is not None
+    assert gradient_check.isChecked()
 
     color_text_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineColorsEdit"
@@ -16211,6 +16264,7 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     fig = tool.figure
     figurecomposer_rendering._render_into_figure(tool, fig, sync_visible=False)
     assert fig.axes[0].get_legend() is None
+    assert len(fig.axes[0].images) == 3
     for index, line in enumerate(fig.axes[0].lines):
         np.testing.assert_allclose(line.get_xdata(), profile_data["kx"].values)
         np.testing.assert_allclose(
@@ -16224,15 +16278,31 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
         assert line.get_markersize() == 6.0
         assert line.get_markerfacecolor() == "yellow"
         assert line.get_markeredgecolor() == "black"
+        np.testing.assert_allclose(
+            fig.axes[0].images[index].cmap(1.0),
+            mcolors.to_rgba(line.get_color()),
+            rtol=1e-7,
+        )
 
     namespace: dict[str, typing.Any] = {"profile_data": profile_data}
     code = tool.generated_code()
+    assert "import erlab.plotting as eplt" in code
     assert "ax.legend()" not in code
     assert "profile_offsets =" not in code
     assert "0.01 * profile_data['temperature'] + profile_data" in code
     assert "for ax in" not in code
-    assert "profile.plot(ax=axs[0, 0]" in code
+    assert "_line = profile.plot(ax=axs[0, 0]" in code
+    assert "for _line in" not in code
+    assert "ax.lines" not in code
+    code_lines = code.splitlines()
+    plot_index = next(
+        index
+        for index, line in enumerate(code_lines)
+        if "_line = profile.plot(" in line
+    )
+    assert code_lines[plot_index + 1] == "    eplt.gradient_fill("
     exec(code, namespace)  # noqa: S102
+    assert len(namespace["fig"].axes[0].images) == 3
     for index, line in enumerate(namespace["fig"].axes[0].lines):
         np.testing.assert_allclose(line.get_xdata(), profile_data["kx"].values)
         np.testing.assert_allclose(
@@ -16246,6 +16316,11 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
         assert line.get_markersize() == 6.0
         assert line.get_markerfacecolor() == "yellow"
         assert line.get_markeredgecolor() == "black"
+        np.testing.assert_allclose(
+            namespace["fig"].axes[0].images[index].cmap(1.0),
+            mcolors.to_rgba(line.get_color()),
+            rtol=1e-7,
+        )
 
     shared_label_operation = operation.model_copy(
         update={"line_labels": ("shared",), "line_colors": ()}
@@ -16344,6 +16419,7 @@ def test_figure_composer_one_profile_per_axis_codegen_executes(qtbot) -> None:
     assert "for profile, scale, offset in zip(" in code
     assert "for ax, profile in zip(" in code
     assert "ax.plot(profile['kx'], profile" in code
+    assert "_line = " not in code
 
     namespace: dict[str, typing.Any] = {"data": data}
     exec(code, namespace)  # noqa: S102
@@ -16356,6 +16432,118 @@ def test_figure_composer_one_profile_per_axis_codegen_executes(qtbot) -> None:
         ] + profile_operation.line_scales[index] * (profile / profile.max(skipna=True))
         np.testing.assert_allclose(line.get_xdata(), kx)
         np.testing.assert_allclose(line.get_ydata(), expected.values)
+
+
+def test_figure_composer_line_gradient_fill_one_profile_per_axis_executes(
+    qtbot,
+) -> None:
+    cut_values = np.array([0.0, 1.0])
+    kx = np.array([-1.0, 0.0, 1.0])
+    data = xr.DataArray(
+        np.array([[1.0, 2.0, 1.0], [0.5, 1.5, 0.5]]),
+        dims=("cut", "kx"),
+        coords={"cut": cut_values, "kx": kx},
+        name="data",
+    )
+    operation = FigureOperationState.line(
+        label="profiles",
+        source="data",
+        axes=FigureAxesSelectionState(axes=((0, 0), (0, 1))),
+    ).model_copy(
+        update={
+            "line_placement": "one_per_axis",
+            "line_x": "kx",
+            "line_iter_dim": "cut",
+            "line_colors": ("red", "blue"),
+            "gradient": True,
+        }
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=2),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    fig = tool.figure
+    figurecomposer_rendering._render_into_figure(tool, fig, sync_visible=False)
+    for axis in fig.axes:
+        assert len(axis.lines) == 1
+        assert len(axis.images) == 1
+        np.testing.assert_allclose(
+            axis.images[0].cmap(1.0),
+            mcolors.to_rgba(axis.lines[0].get_color()),
+            rtol=1e-7,
+        )
+
+    code = tool.generated_code()
+    assert "for ax, profile, color in zip(" in code
+    assert "_line = ax.plot(profile['kx'], profile, color=color)[0]" in code
+    assert "for _line in" not in code
+    assert "ax.lines" not in code
+    code_lines = code.splitlines()
+    plot_index = code_lines.index(
+        "    _line = ax.plot(profile['kx'], profile, color=color)[0]"
+    )
+    assert code_lines[plot_index + 1] == "    eplt.gradient_fill("
+
+    namespace: dict[str, typing.Any] = {"data": data}
+    exec(code, namespace)  # noqa: S102
+    for axis in namespace["fig"].axes:
+        assert len(axis.lines) == 1
+        assert len(axis.images) == 1
+        np.testing.assert_allclose(
+            axis.images[0].cmap(1.0),
+            mcolors.to_rgba(axis.lines[0].get_color()),
+            rtol=1e-7,
+        )
+
+
+def test_figure_composer_line_gradient_fill_codegen_preserves_line_source(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.array([1.0, 2.0, 1.0]),
+        dims=("kx",),
+        coords={"kx": [-1.0, 0.0, 1.0]},
+        name="line",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(),
+            sources=(FigureSourceState(name="line", label="line"),),
+            operations=(
+                FigureOperationState.line(
+                    label="gradient",
+                    source="line",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ).model_copy(update={"gradient": True}),
+                FigureOperationState.line(
+                    label="later",
+                    source="line",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ),
+            ),
+            primary_source="line",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    code = tool.generated_code()
+    code_lines = code.splitlines()
+    assert not any(line.startswith("    line = profile.plot(") for line in code_lines)
+    assert "_line = profile.plot(ax=axs[0, 0])[0]" in code
+    assert "profile_data = line" in code
+
+    namespace: dict[str, typing.Any] = {"line": data}
+    exec(code, namespace)  # noqa: S102
+    assert len(namespace["fig"].axes[0].lines) == 2
+    assert len(namespace["fig"].axes[0].images) == 1
 
 
 def test_figure_composer_profile_reduce_codegen_executes(qtbot) -> None:


### PR DESCRIPTION
## Summary
- Add a gradient fill option for figure composer line profiles and render it in both preview and generated code
- Keep generated code import-clean by only adding the plotting helper import when gradient fill is enabled
- Reject underscore-prefixed grid variable names in figure composer code generation
- Update line-profile and plot-slices labels to the shared "Gradient Fill" wording
- Expand tests to cover rendering, codegen, and name validation

## Testing
- Added unit and integration coverage for gradient-filled line rendering and generated code execution
- Added regression coverage for underscore-prefixed axis variable names