### PR TITLE
docs: update ImageTool and ARPES analysis docs

### DIFF
--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -26,11 +26,19 @@ Inspired by *Image Tool* for Igor Pro, developed by the Advanced Light Source at
 ## Launching ImageTool
 
 ImageTool expects *image-like* data—usually a {class}`DataArray <xarray.DataArray>`—with
-2–4 dimensions. ImageTool tries to handle incompatible input dimensions by adding a new
-dimension for 1D data and squeezing out dimensions of size 1 for 5D+ data. Non-uniform
-coordinates gain parallel `_idx` indices so you can still slice by position. Supported
-inputs include numpy arrays, {class}`Dataset <xarray.Dataset>`, or entire
-{class}`DataTree <xarray.DataTree>` objects.
+2–4 effective dimensions, where an effective dimension has length greater than 1.
+ImageTool adds a display axis for 1D input and ignores singleton dimensions when
+deciding whether data can be opened directly. Non-uniform coordinates gain parallel
+`_idx` indices so you can still slice by position. Supported inputs include numpy
+arrays, {class}`Dataset <xarray.Dataset>`, or entire {class}`DataTree
+<xarray.DataTree>` objects.
+
+When input has more than four effective dimensions, ImageTool opens the
+{guilabel}`Reduce Dimensions to Open` dialog before creating the window. For each
+dimension, choose whether to keep it, select one value, or aggregate it with a reducer
+such as mean, minimum, maximum, or sum. The dialog shows the resulting dimensions and
+generated Python code, and {guilabel}`Open` becomes available once the result is a
+non-empty 2D, 3D, or 4D array. Canceling the dialog leaves the original data unopened.
 
 (imagetool-entry-points)=
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -146,6 +146,13 @@ Once the manager is running, you can open ImageTools in several ways:
   {func}`erlab.interactive.imagetool.manager.load_in_manager` directly (see
   {ref}`imagetool-manager-automation`).
 
+Manual manager opening paths, including `manager=True`, `%itool -m`, file loading,
+drag-and-drop, Data Explorer, `show_in_manager`, and `load_in_manager`, use the same
+ImageTool input preparation as a standalone ImageTool window. When opened data has more
+than four effective dimensions, the manager shows {guilabel}`Reduce Dimensions to Open`
+before adding the ImageTool row. Select or aggregate dimensions there until the preview
+shows a non-empty 2D, 3D, or 4D result, or cancel to skip opening that data.
+
 (imagetool-manager-multiple-instances)=
 
 ## Multiple manager instances

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arpes-analysis
-description: Use when answering questions or working on ERLabPy ARPES analysis workflows in Python, including loaders, xarray/qsel selection, momentum conversion, plotting, fitting, filtering, and interactive ImageTool or ImageTool Manager workflows. Use when teaching users how to use ERLabPy, writing example code, linking to stable documentation, or troubleshooting ERLabPy and xarray-lmfit behavior.
+description: Use when answering questions or working on ERLabPy ARPES analysis workflows in Python, including loaders, xarray/qsel selection, momentum conversion, plotting, fitting, filtering, and interactive ImageTool, ImageTool Manager, or Figure Composer workflows. Use when teaching users how to use ERLabPy, writing example code, linking to stable documentation, or troubleshooting ERLabPy and xarray-lmfit behavior.
 ---
 
 # ERLabPy ARPES Analysis
@@ -76,9 +76,12 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `COPY_PROVENANCE`, `ToolScriptProvenanceDefinition`, `expression_method`,
   `assign`, `IMAGE_TOOL_OUTPUTS`, `set_source_binding`, or `update_data` for
   contributor questions about adding new interactive tools.
-- Search `Figure Composer`, `Add to Figure`, `Append to Figure`,
-  `plot_array`, `plot_slices`, `qplot`, `fermiline`, `nice_colorbar`, or
-  `plot_bz` for plotting questions.
+- Search `Figure Composer`, `Add to Figure`, `Append to Figure`, `New Figure`,
+  `Recipe steps`, `Step sources`, `Sources`, `Add New Step`, `Add Source Only`,
+  `Replace Source`, `plot_array`, `plot_slices`, `qplot`, `fermiline`,
+  `nice_colorbar`, `plot_bz`, `BZ Overlay`, `Photon Energy Overlay`,
+  `plot_in_plane_bz`, `plot_out_of_plane_bz`, or `hv_to_kz` for plotting and
+  Figure Composer questions.
 
 ## Linking and Citation
 
@@ -109,7 +112,11 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   notebook synchronization is relevant.
 - Mention `%watch --restore` when a saved manager workspace contains disconnected
   watched rows that should reconnect to variables in an open notebook.
-- Mention Figure Composer when the user wants to create matplotlib figures from the GUI.
+- Mention Figure Composer when the user wants to create Matplotlib figures from the GUI.
+- Mention the Figure Composer `BZ Overlay` step when the user wants
+  Brillouin-zone slice overlays on in-plane or out-of-plane momentum plots.
+- Mention the Figure Composer `Photon Energy Overlay` step when the user wants
+  constant-photon-energy annotations on `k_parallel`-`k_z` plots.
 
 ## Troubleshooting
 

--- a/skills/arpes-analysis/references/docs-links.md
+++ b/skills/arpes-analysis/references/docs-links.md
@@ -1,6 +1,6 @@
 # ERLabPy docs links (stable)
 
-Last verified: 2026-05-22.
+Last updated: 2026-06-18.
 
 ## Base links
 
@@ -52,6 +52,16 @@ Last verified: 2026-05-22.
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/manager.html#imagetool-manager-data-explorer
 - Manager automation APIs:
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/manager.html#imagetool-manager-automation
+- Figure Composer:
+  https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/figure-composer.html
+- Figure Composer opening:
+  https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/figure-composer.html#figure-composer-open
+- Figure Composer recipe steps:
+  https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/figure-composer.html#figure-composer-recipe
+- Figure Composer step sources:
+  https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/figure-composer.html#figure-composer-sources
+- Manager Figure Composer workflow:
+  https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/manager.html#imagetool-manager-figure-composer
 - Other interactive tools:
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/misc-tools.html
 - ktool:
@@ -105,6 +115,12 @@ Last verified: 2026-05-22.
   https://erlabpy.readthedocs.io/en/stable/accessors/xarray.DataArray.kspace.convert.html
 - `xarray.DataArray.kspace.convert_coords`:
   https://erlabpy.readthedocs.io/en/stable/accessors/xarray.DataArray.kspace.convert_coords.html
+- `xarray.DataArray.kspace.hv_to_kz`:
+  https://erlabpy.readthedocs.io/en/stable/accessors/xarray.DataArray.kspace.hv_to_kz.html
+- `erlab.plotting.plot_in_plane_bz`:
+  https://erlabpy.readthedocs.io/en/stable/erlab.plotting.html#erlab.plotting.plot_in_plane_bz
+- `erlab.plotting.plot_out_of_plane_bz`:
+  https://erlabpy.readthedocs.io/en/stable/erlab.plotting.html#erlab.plotting.plot_out_of_plane_bz
 - `xarray.DataArray.xlm.modelfit`:
   https://xarray-lmfit.readthedocs.io/stable/accessors/xarray.DataArray.xlm.modelfit.html
 - `xarray.Dataset.xlm.modelfit`:
@@ -118,3 +134,9 @@ Last verified: 2026-05-22.
   `https://erlabpy.readthedocs.io/en/stable/accessors/<accessor.page.name>.html`
 - Site-search fallback:
   `site:erlabpy.readthedocs.io/en/stable "<symbol or topic>"`
+- Figure Composer search hints:
+  `site:erlabpy.readthedocs.io/en/stable "Figure Composer" "BZ Overlay"`,
+  `site:erlabpy.readthedocs.io/en/stable "Figure Composer" "Step sources"`,
+  `site:erlabpy.readthedocs.io/en/stable "Add to Figure" "Replace Source"`,
+  `site:erlabpy.readthedocs.io/en/stable "plot_in_plane_bz"`, and
+  `site:erlabpy.readthedocs.io/en/stable "hv_to_kz" "Photon Energy Overlay"`


### PR DESCRIPTION
## Summary

- Update the ImageTool user guide to describe high-dimensional input in terms of effective dimensions and the `Reduce Dimensions to Open` dialog.
- Document the same high-dimensional reduction flow for manual ImageTool Manager opening paths.
- Refresh the ARPES analysis skill with stable Figure Composer links, BZ Overlay search hints, and related plotting/API references.

## Validation

- `uv run python /Users/khan/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/arpes-analysis`
- `git diff --check origin/main...HEAD`
- `rg -n "5D\\+|squeezing out|squeeze out|versionchanged|latest fallback|stable.*lag|404|caught up" docs/source/user-guide/interactive/imagetool.md docs/source/user-guide/interactive/manager.md skills/arpes-analysis/SKILL.md skills/arpes-analysis/references/docs-links.md` returned no matches
- Attempted `uv run --directory docs make html` after `uv sync --all-extras --dev --group docs`; it progressed into notebook execution but was interrupted after several minutes without output in `user-guide/curve-fitting.ipynb`, exiting during nbclient cleanup with code 130.
