### PR TITLE
Allow replayable for-loops in ImageTool provenance

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -8,6 +8,7 @@ import functools
 import json
 import math
 import textwrap
+import traceback
 import typing
 import uuid
 import weakref
@@ -4917,7 +4918,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         try:
             code = self.generated_code()
         except ValueError as exc:
-            QtWidgets.QMessageBox.warning(self, "Cannot Copy Figure Code", str(exc))
+            erlab.interactive.utils.MessageDialog(
+                self,
+                title="Cannot Copy Figure Code",
+                text=str(exc),
+                detailed_text=erlab.interactive.utils._format_traceback(
+                    traceback.format_exc()
+                ),
+                buttons=QtWidgets.QDialogButtonBox.StandardButton.Ok,
+                icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning,
+            ).exec()
             return
         erlab.interactive.utils.copy_to_clipboard(code)
 

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -179,7 +179,6 @@ _SCRIPT_REPLAY_FORBIDDEN_NODES = (
     ast.Await,
     ast.ClassDef,
     ast.Delete,
-    ast.For,
     ast.Global,
     ast.Lambda,
     ast.Match,
@@ -191,7 +190,15 @@ _SCRIPT_REPLAY_FORBIDDEN_NODES = (
     ast.Yield,
     ast.YieldFrom,
 )
-_SCRIPT_REPLAY_FORBIDDEN_CALLS = {"__import__", "compile", "eval", "exec", "open"}
+_SCRIPT_REPLAY_FORBIDDEN_CALLS = {
+    "__import__",
+    "compile",
+    "eval",
+    "exec",
+    "globals",
+    "locals",
+    "open",
+}
 
 
 @dataclass(frozen=True)

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -308,6 +308,36 @@ def _validate_script_code_names(
                 validate_stmt(orelse_stmt)
             return
 
+        if isinstance(stmt, ast.If):
+            test_names = _CurrentScopeNames()
+            test_names.visit(stmt.test)
+            require_loads(test_names)
+
+            available_before = set(available_names)
+            dependencies_before = dict(function_dependencies)
+            branch_stores: set[str] = set()
+            branch_dependencies: dict[str, set[str]] = {}
+            for branch in (stmt.body, stmt.orelse):
+                available_names.clear()
+                available_names.update(available_before)
+                function_dependencies.clear()
+                function_dependencies.update(dependencies_before)
+                for branch_stmt in branch:
+                    validate_stmt(branch_stmt)
+                branch_stores.update(available_names - available_before)
+                for name, dependencies in function_dependencies.items():
+                    if dependencies_before.get(name) == dependencies:
+                        continue
+                    branch_dependencies.setdefault(name, set()).update(dependencies)
+
+            available_names.clear()
+            available_names.update(available_before)
+            available_names.update(branch_stores)
+            function_dependencies.clear()
+            function_dependencies.update(dependencies_before)
+            function_dependencies.update(branch_dependencies)
+            return
+
         names = _statement_scope_names(stmt)
         require_loads(names)
         if isinstance(stmt, ast.FunctionDef):

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -284,20 +284,41 @@ def _validate_script_code_names(
         visiting.remove(name)
         return None
 
-    for stmt in module.body:
-        names = _statement_scope_names(stmt)
+    def require_loads(names: _CurrentScopeNames) -> None:
         for name in sorted(names.loads):
             missing = require(name)
             if missing is not None:
                 raise ReplayGraphError(
                     f"Script provenance references unresolved name {missing!r}"
                 )
+
+    def validate_stmt(stmt: ast.stmt) -> None:
+        if isinstance(stmt, ast.For):
+            iter_names = _CurrentScopeNames()
+            iter_names.visit(stmt.iter)
+            require_loads(iter_names)
+
+            target_names = _CurrentScopeNames()
+            target_names.visit(stmt.target)
+            require_loads(target_names)
+            available_names.update(target_names.stores)
+            for body_stmt in stmt.body:
+                validate_stmt(body_stmt)
+            for orelse_stmt in stmt.orelse:
+                validate_stmt(orelse_stmt)
+            return
+
+        names = _statement_scope_names(stmt)
+        require_loads(names)
         if isinstance(stmt, ast.FunctionDef):
             function_dependencies[stmt.name] = new_function_dependencies.get(
                 (stmt.name, stmt.lineno),
                 set(),
             )
         available_names.update(names.stores)
+
+    for stmt in module.body:
+        validate_stmt(stmt)
 
 
 def _simple_assignment_source_name(code: str, target_name: str) -> str | None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -6,6 +6,7 @@ import ast
 import contextlib
 import math
 import operator
+import traceback
 import typing
 import weakref
 from collections.abc import Callable, Mapping
@@ -61,6 +62,21 @@ if typing.TYPE_CHECKING:
     from erlab.interactive.imagetool.viewer_state import ColorMapState
 
 _GAUSSIAN_FWHM_FACTOR: float = 2 * math.sqrt(2 * math.log(2))
+
+
+def _show_warning_with_traceback(
+    parent: QtWidgets.QWidget,
+    title: str,
+    text: str,
+) -> None:
+    erlab.interactive.utils.MessageDialog(
+        parent,
+        title=title,
+        text=text,
+        detailed_text=erlab.interactive.utils._format_traceback(traceback.format_exc()),
+        buttons=QtWidgets.QDialogButtonBox.StandardButton.Ok,
+        icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning,
+    ).exec()
 
 
 def _set_combo_data(combo: QtWidgets.QComboBox, value: typing.Any) -> bool:
@@ -1776,7 +1792,7 @@ class InterpolationDialog(DataTransformDialog):
         try:
             self._target_values()
         except Exception as exc:
-            QtWidgets.QMessageBox.warning(
+            _show_warning_with_traceback(
                 self,
                 "Invalid Target Coordinates",
                 str(exc),
@@ -3693,7 +3709,7 @@ class AssignCoordsDialog(DataTransformDialog):
         try:
             self._add_coord_values()
         except Exception as exc:
-            QtWidgets.QMessageBox.warning(
+            _show_warning_with_traceback(
                 self,
                 "Invalid Coordinate Value",
                 str(exc),
@@ -3946,7 +3962,7 @@ class AssignAttrsDialog(DataTransformDialog):
         try:
             self._attrs_from_table()
         except Exception as exc:
-            QtWidgets.QMessageBox.warning(
+            _show_warning_with_traceback(
                 self,
                 "Invalid Attribute Value",
                 str(exc),

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import html
 import json
 import logging
+import traceback
 import typing
 
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.slicer
-from erlab.interactive.imagetool import provenance
+import erlab.interactive.utils
+from erlab.interactive.imagetool import _replay_graph, provenance
 from erlab.interactive.imagetool.manager._widgets import (
     _METADATA_DERIVATION_ACTIVATABLE_ROLE,
     _METADATA_DERIVATION_CODE_ROLE,
@@ -634,21 +637,52 @@ class _DetailsPanelController:
             )
         return "The replay graph could not be emitted as Python code."
 
+    def _unavailable_replay_code_traceback(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> str | None:
+        spec = node.displayed_provenance_spec
+        if spec is None or spec.kind != "script" or not spec.operations:
+            return None
+        try:
+            graph = _replay_graph.compile_replay_graph(spec, display=True)
+            _replay_graph.emit_replay_code(
+                graph,
+                output_name=typing.cast("str", spec.active_name),
+            )
+        except _replay_graph.ReplayGraphError as exc:
+            return "".join(traceback.TracebackException.from_exception(exc).format())
+        return None
+
+    def _unavailable_replay_code_dialog_details(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> str:
+        details = "<br>".join(
+            html.escape(line)
+            for line in self._unavailable_replay_code_details(node).splitlines()
+        )
+        exc_text = self._unavailable_replay_code_traceback(node)
+        if exc_text is None:
+            return details
+        traceback_html = erlab.interactive.utils._format_traceback(exc_text)
+        return f"{details}<hr>{traceback_html}"
+
     def _show_unavailable_replay_code_dialog(
         self, node: _ImageToolWrapper | _ManagedWindowNode
     ) -> None:
-        msg_box = QtWidgets.QMessageBox(self._manager)
-        msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
-        msg_box.setWindowTitle("Replay Code Unavailable")
-        msg_box.setText("Replay code cannot be copied for the selected result.")
-        msg_box.setInformativeText(
-            "The result has provenance, but at least one recorded input or step "
-            "cannot be converted to replayable Python, so nothing was copied."
+        dialog = erlab.interactive.utils.MessageDialog(
+            self._manager,
+            title="Replay Code Unavailable",
+            text="Replay code cannot be copied for the selected result.",
+            informative_text=(
+                "The result has provenance, but at least one recorded input or step "
+                "cannot be converted to replayable Python, so nothing was copied."
+            ),
+            detailed_text=self._unavailable_replay_code_dialog_details(node),
+            buttons=QtWidgets.QDialogButtonBox.StandardButton.Ok,
+            default_button=QtWidgets.QDialogButtonBox.StandardButton.Ok,
+            icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning,
         )
-        msg_box.setDetailedText(self._unavailable_replay_code_details(node))
-        msg_box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
-        msg_box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Ok)
-        msg_box.exec()
+        dialog.exec()
 
     def _copy_full_derivation_code(self) -> None:
         node = (

--- a/src/erlab/interactive/imagetool/manager/_updater_gui.py
+++ b/src/erlab/interactive/imagetool/manager/_updater_gui.py
@@ -6,6 +6,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import traceback
 import typing
 import zipfile
 
@@ -31,7 +32,7 @@ if typing.TYPE_CHECKING:
 class Downloader(QtCore.QThread):
     progress = QtCore.Signal(int, int)  # bytes_received, total_bytes (-1 if unknown)
     finished_ok = QtCore.Signal(str)  # path to zip
-    failed = QtCore.Signal(str)  # error message
+    failed = QtCore.Signal(str, str)  # error message, traceback
 
     def __init__(
         self,
@@ -65,7 +66,7 @@ class Downloader(QtCore.QThread):
                             self.progress.emit(received, total)
             self.finished_ok.emit(str(self.out_path))
         except Exception as e:
-            self.failed.emit(f"Download failed: {e}")
+            self.failed.emit(f"Download failed: {e}", traceback.format_exc())
 
     def stop(self):
         self._stop = True
@@ -75,7 +76,7 @@ class Downloader(QtCore.QThread):
 class Extractor(QtCore.QThread):
     progress = QtCore.Signal(int, int)  # bytes_processed, total_bytes (-1 if unknown)
     finished_ok = QtCore.Signal(str)  # path to extracted dir
-    failed = QtCore.Signal(str)
+    failed = QtCore.Signal(str, str)
 
     def __init__(self, zip_path: pathlib.Path, out_dir: pathlib.Path):
         super().__init__()
@@ -99,7 +100,7 @@ class Extractor(QtCore.QThread):
                     self.progress.emit(processed, total or -1)
             self.finished_ok.emit(str(self.out_dir))
         except Exception as e:
-            self.failed.emit(f"Extraction failed: {e}")
+            self.failed.emit(f"Extraction failed: {e}", traceback.format_exc())
 
     def stop(self):
         self._stop = True
@@ -249,9 +250,15 @@ class AutoUpdater(QtCore.QObject):
                     f"Downloading…<br>{done / factor:.1f} / {total / factor:.1f} MiB"
                 )
 
-        def _on_fail(msg: str):
+        def _on_fail(msg: str, traceback_text: str):
             progress.cancel()
-            QtWidgets.QMessageBox.critical(parent, "Download failed", msg)
+            erlab.interactive.utils.MessageDialog.critical(
+                parent,
+                "Download failed",
+                "The update could not be downloaded.",
+                informative_text=msg,
+                detailed_text=erlab.interactive.utils._format_traceback(traceback_text),
+            )
 
         def _on_ok(path: str):
             progress.close()
@@ -345,8 +352,11 @@ class AutoUpdater(QtCore.QObject):
                     ["/bin/bash", str(script_path.resolve())], close_fds=True
                 )
             except Exception as e:
-                QtWidgets.QMessageBox.critical(
-                    parent, "Update", f"Failed to start updater: {e}"
+                erlab.interactive.utils.MessageDialog.critical(
+                    parent,
+                    "Update",
+                    "Failed to start updater.",
+                    informative_text=str(e),
                 )
                 return
 

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -24,6 +24,7 @@ import erlab.interactive.imagetool.manager as manager_package
 import erlab.interactive.imagetool.manager.__main__ as manager_main
 import erlab.interactive.imagetool.manager._desktop as manager_desktop
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
+import erlab.interactive.imagetool.manager._updater_gui as manager_updater_gui
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
 from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
@@ -56,6 +57,51 @@ def test_manager_runtime_icon_is_sanitized(qapp) -> None:
 
     assert not pixmap.isNull()
     assert not pixmap.toImage().colorSpace().isValid()
+
+
+def test_update_workers_emit_failure_tracebacks(qapp, tmp_path, monkeypatch) -> None:
+    assert qapp is QtWidgets.QApplication.instance()
+
+    def _raise_get(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(manager_updater_gui.requests, "get", _raise_get)
+
+    download_failures: list[tuple[str, str]] = []
+    downloader = manager_updater_gui.Downloader(
+        "https://example.invalid/update.zip",
+        tmp_path / "update.zip",
+        None,
+        {},
+    )
+    downloader.failed.connect(
+        lambda message, traceback_text: download_failures.append(
+            (message, traceback_text)
+        )
+    )
+    downloader.run()
+
+    assert download_failures
+    assert download_failures[0][0] == "Download failed: network down"
+    assert "Traceback" in download_failures[0][1]
+    assert "RuntimeError: network down" in download_failures[0][1]
+
+    bad_zip = tmp_path / "bad.zip"
+    bad_zip.write_text("not a zip archive")
+
+    extract_failures: list[tuple[str, str]] = []
+    extractor = manager_updater_gui.Extractor(bad_zip, tmp_path / "extracted")
+    extractor.failed.connect(
+        lambda message, traceback_text: extract_failures.append(
+            (message, traceback_text)
+        )
+    )
+    extractor.run()
+
+    assert extract_failures
+    assert extract_failures[0][0].startswith("Extraction failed:")
+    assert "Traceback" in extract_failures[0][1]
+    assert "zipfile.BadZipFile" in extract_failures[0][1]
 
 
 def test_manager_main_cache_directory_uses_qstandardpaths(

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -3595,15 +3595,21 @@ def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
         dims=("x", "y"),
         coords={"x": np.arange(2), "y": np.arange(2)},
     )
-    dialogs: list[QtWidgets.QMessageBox] = []
+    dialogs: list[erlab.interactive.utils.MessageDialog] = []
 
-    def _record_dialog(
-        dialog: QtWidgets.QMessageBox,
-    ) -> QtWidgets.QMessageBox.StandardButton:
-        dialogs.append(dialog)
-        return QtWidgets.QMessageBox.StandardButton.Ok
+    class _RecordingMessageDialog(erlab.interactive.utils.MessageDialog):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            dialogs.append(self)
 
-    monkeypatch.setattr(QtWidgets.QMessageBox, "exec", _record_dialog)
+        def exec(self) -> int:
+            return int(QtWidgets.QDialog.DialogCode.Accepted)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "MessageDialog",
+        _RecordingMessageDialog,
+    )
 
     with manager_context() as manager:
         manager.show()
@@ -3634,11 +3640,13 @@ def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
         manager._copy_full_derivation_code()
         assert not copied
         assert len(dialogs) == 1
-        assert dialogs[0].icon() == QtWidgets.QMessageBox.Icon.Warning
+        assert dialogs[0].windowTitle() == "Replay Code Unavailable"
         assert dialogs[0].text()
         assert dialogs[0].informativeText()
-        assert dialogs[0].detailedText()
-        assert "Run opaque code" in dialogs[0].detailedText()
+        details = dialogs[0].detailedText()
+        assert "Run opaque code" in details
+        assert "ReplayGraphError" in details
+        assert "non-replayable code" in details
 
 
 def test_manager_console_replacement_updates_provenance_and_descendants(

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -12,6 +12,7 @@ from qtpy import QtCore, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager._console as manager_console
+import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.utils
 from erlab.interactive.imagetool import _provenance_framework, itool, provenance
@@ -3581,6 +3582,47 @@ def test_unavailable_replay_code_details_lists_unique_labels_and_fallback() -> N
         types.SimpleNamespace(derivation_entries=(start_entry,))
     )
     assert fallback
+
+    no_spec_node = types.SimpleNamespace(
+        derivation_entries=(start_entry, unavailable_entry),
+        displayed_provenance_spec=None,
+    )
+    assert controller._unavailable_replay_code_traceback(no_spec_node) is None
+    dialog_details = controller._unavailable_replay_code_dialog_details(no_spec_node)
+    assert "Opaque step" in dialog_details
+    assert "Traceback" not in dialog_details
+
+
+def test_unavailable_replay_code_traceback_ignores_successful_emit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = object.__new__(_DetailsPanelController)
+    spec = types.SimpleNamespace(
+        kind="script",
+        operations=(object(),),
+        active_name="derived",
+    )
+    node = types.SimpleNamespace(displayed_provenance_spec=spec)
+    calls: list[tuple[typing.Any, str]] = []
+
+    monkeypatch.setattr(
+        manager_details_panel._replay_graph,
+        "compile_replay_graph",
+        lambda received_spec, *, display: ("graph", received_spec, display),
+    )
+
+    def _emit_replay_code(graph, *, output_name: str) -> str:
+        calls.append((graph, output_name))
+        return "derived = data"
+
+    monkeypatch.setattr(
+        manager_details_panel._replay_graph,
+        "emit_replay_code",
+        _emit_replay_code,
+    )
+
+    assert controller._unavailable_replay_code_traceback(node) is None
+    assert calls == [(("graph", spec, True), "derived")]
 
 
 def test_manager_reload_data_hidden_for_non_replayable_script_provenance(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -15826,15 +15826,25 @@ def test_figure_composer_line_normalization_reports_zero_scale(
     with pytest.raises(ValueError, match="Cannot normalize profile by max"):
         tool.generated_code()
 
-    warnings: list[str] = []
+    dialogs: list[typing.Any] = []
+
+    class _RecordingMessageDialog:
+        def __init__(self, parent=None, **kwargs) -> None:
+            self.parent = parent
+            self.kwargs = kwargs
+            dialogs.append(self)
+
+        def exec(self) -> int:
+            return int(QtWidgets.QDialog.DialogCode.Accepted)
+
     monkeypatch.setattr(
-        QtWidgets.QMessageBox,
-        "warning",
-        lambda parent, title, text: warnings.append(text),
+        erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
     )
     tool.copy_code()
-    assert warnings
-    assert "Cannot normalize profile by max" in warnings[0]
+    assert dialogs
+    assert dialogs[0].kwargs["title"] == "Cannot Copy Figure Code"
+    assert "Cannot normalize profile by max" in dialogs[0].kwargs["text"]
+    assert "Traceback" in dialogs[0].kwargs["detailed_text"]
 
 
 def test_figure_composer_line_profile_helper_contracts(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -19798,15 +19798,20 @@ def test_manager_copy_full_code_for_memory_figure_reports_unavailable(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    dialogs: list[QtWidgets.QMessageBox] = []
+    dialogs: list[typing.Any] = []
 
-    def _record_dialog(
-        dialog: QtWidgets.QMessageBox,
-    ) -> QtWidgets.QMessageBox.StandardButton:
-        dialogs.append(dialog)
-        return QtWidgets.QMessageBox.StandardButton.Ok
+    class _RecordingMessageDialog:
+        def __init__(self, parent=None, **kwargs) -> None:
+            self.parent = parent
+            self.kwargs = kwargs
+            dialogs.append(self)
 
-    monkeypatch.setattr(QtWidgets.QMessageBox, "exec", _record_dialog)
+        def exec(self) -> int:
+            return int(QtWidgets.QDialog.DialogCode.Accepted)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
+    )
 
     with manager_context() as manager:
         manager.show()
@@ -19836,10 +19841,13 @@ def test_manager_copy_full_code_for_memory_figure_reports_unavailable(
         trigger_menu_action(menu, manager._metadata_copy_full_action)
         assert not copied
         assert len(dialogs) == 1
-        assert dialogs[0].icon() == QtWidgets.QMessageBox.Icon.Warning
-        assert dialogs[0].text()
-        assert dialogs[0].informativeText()
-        assert dialogs[0].detailedText()
+        assert (
+            dialogs[0].kwargs["icon_pixmap"]
+            == QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning
+        )
+        assert dialogs[0].kwargs["text"]
+        assert dialogs[0].kwargs["informative_text"]
+        assert dialogs[0].kwargs["detailed_text"]
 
 
 def test_manager_figure_action_new_target_creates_second_figure(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2112,7 +2112,6 @@ def test_associated_coord_dialog_empty_warning(qtbot, monkeypatch) -> None:
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     dialog = _AssociatedCoordsDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
     warnings: list[tuple[str, str]] = []
 
     def _record_warning(_parent, title, message, *args, **kwargs):
@@ -8629,20 +8628,29 @@ def test_interpolation_dialog_rejects_invalid_target_values(qtbot, monkeypatch) 
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     dialog = InterpolationDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
     dialog.launch_mode_combo.setCurrentText("Replace Current")
     dialog.coord_widget.table.item(0, 0).setText("bad")
 
-    warnings: list[tuple[str, str]] = []
+    dialogs: list[typing.Any] = []
 
-    def _record_warning(_parent, title, message, *args, **kwargs):
-        warnings.append((title, message))
-        return QtWidgets.QMessageBox.StandardButton.Ok
+    class _RecordingMessageDialog:
+        def __init__(self, parent=None, **kwargs) -> None:
+            self.parent = parent
+            self.kwargs = kwargs
+            dialogs.append(self)
 
-    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+        def exec(self) -> int:
+            return int(QtWidgets.QDialog.DialogCode.Accepted)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
+    )
     dialog.accept()
 
-    assert warnings == [("Invalid Target Coordinates", "Invalid value in row 0: bad")]
+    assert len(dialogs) == 1
+    assert dialogs[0].kwargs["title"] == "Invalid Target Coordinates"
+    assert dialogs[0].kwargs["text"] == "Invalid value in row 0: bad"
+    assert "Traceback" in dialogs[0].kwargs["detailed_text"]
     xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
 
     dialog.close()
@@ -9326,16 +9334,28 @@ def test_assign_coords_add_dialog_accept_validates_inputs(qtbot, monkeypatch) ->
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     dialog = AssignCoordsDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
     dialog._mode_tabs.setCurrentIndex(1)
 
     warnings: list[tuple[str, str]] = []
+    dialogs: list[typing.Any] = []
 
     def _record_warning(_parent, title, message, *args, **kwargs):
         warnings.append((title, message))
         return QtWidgets.QMessageBox.StandardButton.Ok
 
+    class _RecordingMessageDialog:
+        def __init__(self, parent=None, **kwargs) -> None:
+            self.parent = parent
+            self.kwargs = kwargs
+            dialogs.append(self)
+
+        def exec(self) -> int:
+            return int(QtWidgets.QDialog.DialogCode.Accepted)
+
     monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+    monkeypatch.setattr(
+        erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
+    )
 
     dialog._add_name_edit.setText("x")
     dialog.accept()
@@ -9355,10 +9375,12 @@ def test_assign_coords_add_dialog_accept_validates_inputs(qtbot, monkeypatch) ->
         "Duplicate Name",
         "A coordinate or dimension named 'x' already exists.",
     )
-    assert [title for title, _message in warnings[1:]] == [
+    assert [title for title, _message in warnings[1:]] == []
+    assert [dialog.kwargs["title"] for dialog in dialogs] == [
         "Invalid Coordinate Value",
         "Invalid Coordinate Value",
     ]
+    assert all("Traceback" in dialog.kwargs["detailed_text"] for dialog in dialogs)
     xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
 
     dialog.close()
@@ -9462,15 +9484,27 @@ def test_assign_attrs_dialog_accept_validates_inputs(qtbot, monkeypatch) -> None
     win = itool(data, execute=False)
     qtbot.addWidget(win)
     dialog = AssignAttrsDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
 
     warnings: list[tuple[str, str]] = []
+    dialogs: list[typing.Any] = []
 
     def _record_warning(_parent, title, message, *args, **kwargs):
         warnings.append((title, message))
         return QtWidgets.QMessageBox.StandardButton.Ok
 
+    class _RecordingMessageDialog:
+        def __init__(self, parent=None, **kwargs) -> None:
+            self.parent = parent
+            self.kwargs = kwargs
+            dialogs.append(self)
+
+        def exec(self) -> int:
+            return int(QtWidgets.QDialog.DialogCode.Accepted)
+
     monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+    monkeypatch.setattr(
+        erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
+    )
 
     dialog.accept()
     dialog._add_empty_row()
@@ -9485,10 +9519,13 @@ def test_assign_attrs_dialog_accept_validates_inputs(qtbot, monkeypatch) -> None
 
     assert [title for title, _message in warnings] == [
         "No Attributes Changed",
-        "Invalid Attribute Value",
         "Duplicate Names",
+    ]
+    assert [dialog.kwargs["title"] for dialog in dialogs] == [
+        "Invalid Attribute Value",
         "Invalid Attribute Value",
     ]
+    assert all("Traceback" in dialog.kwargs["detailed_text"] for dialog in dialogs)
     xarray.testing.assert_identical(win.slicer_area._data.rename(None), data)
 
     dialog.close()

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -157,6 +157,19 @@ class Child(Base, metaclass=data_5):
             set(),
             {},
         )
+    loop_names = {"axs", "profiles"}
+    _replay_graph._validate_script_code_names(
+        "for profile in profiles:\n    profile.plot(ax=axs, x='alpha')",
+        loop_names,
+        {},
+    )
+    assert "profile" in loop_names
+    with pytest.raises(_replay_graph.ReplayGraphError, match="unresolved name"):
+        _replay_graph._validate_script_code_names(
+            "for holder.profile in profiles:\n    pass",
+            {"profiles"},
+            {},
+        )
 
     with pytest.raises(_replay_graph.ReplayGraphError, match="Expected script"):
         _replay_graph._validate_script_provenance(
@@ -1674,6 +1687,107 @@ def test_replay_graph_script_nodes_are_not_deduplicated() -> None:
         namespace["derived"],
         xr.DataArray([11.0, 22.0], dims=["x"]),
     )
+
+
+def test_replay_graph_allows_for_loop_script_code() -> None:
+    spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Build figure",
+            code=(
+                "fig = []\n"
+                "profiles = list(profile_data.transpose('eV', ...))\n"
+                "for profile in profiles:\n"
+                "    fig.append(profile.sum())"
+            ),
+        ),
+        start_label="Build figure",
+        seed_code=(
+            "profile_data = xr.DataArray("
+            "np.arange(6.0).reshape(2, 3), "
+            "dims=('eV', 'alpha'), "
+            "coords={'alpha': [0.0, 1.0, 2.0]}"
+            ")"
+        ),
+        active_name="fig",
+    )
+
+    graph = _replay_graph.compile_replay_graph(spec, display=True)
+    code = _replay_graph.emit_replay_code(graph, output_name="fig")
+    namespace = _exec_generated_code(code)
+
+    assert "for profile in profiles:" in code
+    assert len(namespace["fig"]) == 2
+    xr.testing.assert_identical(namespace["fig"][0], xr.DataArray(3.0))
+    xr.testing.assert_identical(namespace["fig"][1], xr.DataArray(12.0))
+
+
+def test_replay_graph_allows_for_loop_with_script_input() -> None:
+    profile_source = provenance.script(
+        start_label="Make profile data",
+        seed_code=(
+            "profile_data = xr.DataArray("
+            "np.arange(6.0).reshape(2, 3), "
+            "dims=('eV', 'alpha'), "
+            "coords={'alpha': [0.0, 1.0, 2.0]}"
+            ")"
+        ),
+        active_name="profile_data",
+    )
+    spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="Build figure",
+            code=(
+                "fig = []\n"
+                "profiles = list(profile_data.transpose('eV', ...))\n"
+                "for profile in profiles:\n"
+                "    fig.append(profile.sum())"
+            ),
+        ),
+        start_label="Build figure",
+        active_name="fig",
+        script_inputs=(
+            provenance.ScriptInput(
+                name="profile_data",
+                label="Profile data",
+                provenance_spec=profile_source,
+            ),
+        ),
+    )
+
+    code = typing.cast("str", spec.derivation_code())
+    namespace = _exec_generated_code(code)
+
+    assert "for profile in profiles:" in code
+    assert len(namespace["fig"]) == 2
+    xr.testing.assert_identical(namespace["fig"][0], xr.DataArray(3.0))
+    xr.testing.assert_identical(namespace["fig"][1], xr.DataArray(12.0))
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        ("while True:\n    derived = data", "unsupported While"),
+        (
+            "try:\n    derived = data\nexcept Exception:\n    derived = data",
+            "unsupported Try",
+        ),
+        ("with open('scan.nc') as handle:\n    derived = data", "unsupported With"),
+        ("derived = globals()", "cannot call 'globals'"),
+        ("derived = locals()", "cannot call 'locals'"),
+    ],
+)
+def test_replay_graph_rejects_unsupported_script_constructs(
+    code: str, message: str
+) -> None:
+    data = xr.DataArray([1.0], dims=("x",))
+    spec = provenance.script(
+        provenance.ScriptCodeOperation(label="Unsupported", code=code),
+        start_label="Run script",
+        active_name="derived",
+    )
+
+    with pytest.raises(_replay_graph.ReplayGraphError, match=re.escape(message)):
+        _replay_graph.compile_replay_graph(spec, external_inputs={"data": data})
 
 
 def test_replay_graph_raises_typed_errors_for_unsupported_script() -> None:

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -164,10 +164,25 @@ class Child(Base, metaclass=data_5):
         {},
     )
     assert "profile" in loop_names
+    nested_loop_names = {"axs", "profiles", "show_profiles"}
+    _replay_graph._validate_script_code_names(
+        "if show_profiles:\n"
+        "    for profile in profiles:\n"
+        "        profile.plot(ax=axs, x='alpha')",
+        nested_loop_names,
+        {},
+    )
+    assert "profile" in nested_loop_names
     with pytest.raises(_replay_graph.ReplayGraphError, match="unresolved name"):
         _replay_graph._validate_script_code_names(
             "for holder.profile in profiles:\n    pass",
             {"profiles"},
+            {},
+        )
+    with pytest.raises(_replay_graph.ReplayGraphError, match="unresolved name"):
+        _replay_graph._validate_script_code_names(
+            "if use_left:\n    local_value = data\nelse:\n    derived = local_value",
+            {"data", "use_left"},
             {},
         )
 

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -173,6 +173,13 @@ class Child(Base, metaclass=data_5):
         {},
     )
     assert "profile" in nested_loop_names
+    loop_else_names = {"items"}
+    _replay_graph._validate_script_code_names(
+        "for item in items:\n    pass\nelse:\n    derived = item",
+        loop_else_names,
+        {},
+    )
+    assert {"item", "derived"}.issubset(loop_else_names)
     with pytest.raises(_replay_graph.ReplayGraphError, match="unresolved name"):
         _replay_graph._validate_script_code_names(
             "for holder.profile in profiles:\n    pass",
@@ -185,6 +192,26 @@ class Child(Base, metaclass=data_5):
             {"data", "use_left"},
             {},
         )
+    unchanged_dependencies = {"helper": {"data"}}
+    _replay_graph._validate_script_code_names(
+        "if use_left:\n    left = data\nelse:\n    right = data",
+        {"data", "use_left", "helper"},
+        unchanged_dependencies,
+    )
+    assert unchanged_dependencies == {"helper": {"data"}}
+    new_branch_dependencies: dict[str, set[str]] = {}
+    _replay_graph._validate_script_code_names(
+        "if use_left:\n"
+        "    def choose():\n"
+        "        return data\n"
+        "else:\n"
+        "    def choose():\n"
+        "        return fallback\n"
+        "derived = choose()",
+        {"data", "fallback", "use_left"},
+        new_branch_dependencies,
+    )
+    assert new_branch_dependencies["choose"] == {"data", "fallback"}
 
     with pytest.raises(_replay_graph.ReplayGraphError, match="Expected script"):
         _replay_graph._validate_script_provenance(

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -10,7 +10,7 @@ from qtpy import QtCore, QtWidgets
 
 import erlab
 from erlab.interactive.derivative import DerivativeTool, dtool
-from erlab.interactive.imagetool import provenance
+from erlab.interactive.imagetool import _replay_graph, provenance
 
 
 def _exec_generated_code(
@@ -121,6 +121,19 @@ def test_dtool_smoothing_copy_code_uses_readable_steps(qtbot) -> None:
     namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
     assert isinstance(namespace["result"], xr.DataArray)
     xr.testing.assert_identical(win.result, namespace["result"])
+
+    spec = provenance.script(
+        *win._copy_provenance(input_name="data"),
+        start_label="Compute derivative output",
+        active_name="result",
+        script_inputs=(provenance.ScriptInput(name="data", label="Input"),),
+    )
+    assert provenance.script_provenance_replayable(spec)
+    graph = _replay_graph.compile_replay_graph(
+        spec, external_inputs={"data": data.copy(deep=True)}
+    )
+    result = _replay_graph.execute_replay_graph(graph)
+    xr.testing.assert_identical(win.result, result)
 
 
 def test_dtool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> None:


### PR DESCRIPTION
## Summary
- Permit `for` loops in replayable ImageTool script provenance while still rejecting other unsupported constructs.
- Tighten replay validation to treat `globals()` and `locals()` as forbidden and to resolve loop-scoped names correctly.
- Show richer unavailable-replay-code details in the manager dialog, including traceback text when replay compilation fails.
- Add regression coverage for loop replay, unsupported constructs, and the updated manager dialog behavior.

## Testing
- Added unit tests for replay graph validation and execution of loop-based provenance.
- Added manager-level unit coverage for the unavailable replay-code dialog content.
- Added derivative provenance replay coverage to confirm generated code still round-trips correctly.