### PR TITLE
Handle corrupted workspace loads and save errors

### DIFF
--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import enum
 import functools
+import logging
 import os
 import typing
 import urllib.parse
@@ -38,6 +39,8 @@ else:
 
     varname = _lazy.load("varname")
     lmfit = _lazy.load("lmfit")
+
+logger = logging.getLogger(__name__)
 
 _P = typing.ParamSpec("_P")
 _R = typing.TypeVar("_R")
@@ -174,7 +177,19 @@ class _Fit2DParameterPlotItem(pg.PlotItem):
 
         if dialog.exec():
             filename = dialog.selectedFiles()[0]
-            data.to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
+            try:
+                data.to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
+            except Exception:
+                logger.exception(
+                    "Error while saving Fit2D parameter data",
+                    extra={"suppress_ui_alert": True},
+                )
+                erlab.interactive.utils.MessageDialog.critical(
+                    self._tool,
+                    "Error",
+                    "An error occurred while saving the parameter data.",
+                )
+                return
             pg.PlotItem.lastFileDir = os.path.dirname(filename)
 
     @QtCore.Slot()

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -1151,6 +1151,11 @@ class _ActionsController:
                                         workspace_file_path=access.path,
                                     )
                                     workspace_dt_owned = False
+                                    loaded_workspace = (
+                                        self._manager._finish_workspace_file_load(
+                                            loaded_workspace
+                                        )
+                                    )
                                     if loaded_workspace:
                                         self._manager._associate_loaded_workspace_file(
                                             access.path,

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
+import traceback
 import typing
 
 import numpy as np
@@ -416,6 +417,11 @@ class _LineageController:
             raise _ScriptRebuildError(
                 "Could not reload data.",
                 details=str(exc),
+            ) from exc
+        except Exception as exc:
+            raise _ScriptRebuildError(
+                "Could not reload data.",
+                details=traceback.format_exc(),
             ) from exc
         return _ScriptRebuildResult(
             data=data,

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3161,8 +3161,8 @@ class ImageToolManager(_ImageToolManagerBase):
         manifest: dict[str, typing.Any] | None = None,
         workspace_file_path: str | os.PathLike[str] | None = None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
-    ) -> None:
-        self._workspace_controller._load_workspace_figures(
+    ) -> int:
+        return self._workspace_controller._load_workspace_figures(
             tree,
             manifest=manifest,
             workspace_file_path=workspace_file_path,
@@ -3251,6 +3251,27 @@ class ImageToolManager(_ImageToolManagerBase):
             loaded_targets_by_uid=loaded_targets_by_uid,
         )
 
+    def _load_workspace_node_or_warn(
+        self,
+        node_tree: xr.DataTree,
+        *,
+        parent_target: int | str | None = None,
+        selection_item: QtWidgets.QTreeWidgetItem | None = None,
+        manifest: dict[str, typing.Any] | None = None,
+        node_path: str | None = None,
+        workspace_file_path: str | os.PathLike[str] | None = None,
+        loaded_targets_by_uid: dict[str, int | str] | None = None,
+    ) -> int | str | None:
+        return self._workspace_controller._load_workspace_node_or_warn(
+            node_tree,
+            parent_target=parent_target,
+            selection_item=selection_item,
+            manifest=manifest,
+            node_path=node_path,
+            workspace_file_path=workspace_file_path,
+            loaded_targets_by_uid=loaded_targets_by_uid,
+        )
+
     def _load_workspace_roots(
         self,
         tree: xr.DataTree,
@@ -3260,8 +3281,8 @@ class ImageToolManager(_ImageToolManagerBase):
         manifest: dict[str, typing.Any] | None = None,
         workspace_file_path: str | os.PathLike[str] | None = None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
-    ) -> None:
-        self._workspace_controller._load_workspace_roots(
+    ) -> int:
+        return self._workspace_controller._load_workspace_roots(
             tree,
             root_keys,
             root_item=root_item,
@@ -3269,6 +3290,9 @@ class ImageToolManager(_ImageToolManagerBase):
             workspace_file_path=workspace_file_path,
             loaded_targets_by_uid=loaded_targets_by_uid,
         )
+
+    def _finish_workspace_file_load(self, loaded: bool) -> bool:
+        return self._workspace_controller._finish_workspace_file_load(loaded)
 
     def _from_h5py_workspace_file(
         self,

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pathlib
+import traceback
 import typing
 import uuid
 from collections.abc import Mapping
@@ -133,6 +134,7 @@ class _WorkspaceIOController:
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager = manager
         self._missing_workspace_colormaps: list[tuple[str, str]] = []
+        self._skipped_workspace_nodes: list[tuple[str, str, str]] = []
         self._loader_state = _manager_workspace.WorkspaceLoaderState()
 
     def _record_missing_workspace_colormap(
@@ -193,9 +195,54 @@ class _WorkspaceIOController:
         )
         dialog.exec()
 
+    def _record_skipped_workspace_node(
+        self, node_path: str | None, exc: Exception
+    ) -> None:
+        node_label = node_path if node_path is not None else "unknown workspace node"
+        exc_summary = f"{type(exc).__name__}: {exc}"
+        exc_text = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        )
+        logger.warning(
+            "Skipping workspace node %s during workspace load",
+            node_label,
+            exc_info=(type(exc), exc, exc.__traceback__),
+            extra={"suppress_ui_alert": True},
+        )
+        self._skipped_workspace_nodes.append((node_label, exc_summary, exc_text))
+
+    @staticmethod
+    def _raise_no_workspace_windows_loaded() -> typing.NoReturn:
+        raise ValueError("No workspace windows could be loaded")
+
+    def _show_skipped_workspace_node_warning(self) -> None:
+        if not self._skipped_workspace_nodes:
+            return
+        affected = "\n".join(
+            f"- {node_label}: {exc_summary}"
+            for node_label, exc_summary, _exc_text in self._skipped_workspace_nodes
+        )
+        tracebacks = "\n\n".join(
+            f"Workspace node {node_label}\n{exc_text}"
+            for node_label, _exc_summary, exc_text in self._skipped_workspace_nodes
+        )
+        dialog = erlab.interactive.utils.MessageDialog(
+            self._manager,
+            title="Workspace Partially Loaded",
+            text="Some workspace windows could not be loaded.",
+            informative_text=(
+                f"The rest of the workspace was loaded. Skipped nodes:\n{affected}"
+            ),
+            detailed_text=erlab.interactive.utils._format_traceback(tracebacks),
+            buttons=QtWidgets.QDialogButtonBox.StandardButton.Ok,
+            icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning,
+        )
+        dialog.exec()
+
     def _finish_workspace_file_load(self, loaded: bool) -> bool:
         if loaded:
             self._show_missing_workspace_colormap_warning()
+            self._show_skipped_workspace_node_warning()
         return loaded
 
     @staticmethod
@@ -1220,7 +1267,7 @@ class _WorkspaceIOController:
                     and child_item.checkState(0) == QtCore.Qt.CheckState.Unchecked
                 ):
                     continue
-                self._manager._load_workspace_node(
+                self._manager._load_workspace_node_or_warn(
                     child_node,
                     parent_target=target,
                     selection_item=child_item,
@@ -1235,6 +1282,31 @@ class _WorkspaceIOController:
                 )
         return target
 
+    def _load_workspace_node_or_warn(
+        self,
+        node_tree: xr.DataTree,
+        *,
+        parent_target: int | str | None = None,
+        selection_item: QtWidgets.QTreeWidgetItem | None = None,
+        manifest: dict[str, typing.Any] | None = None,
+        node_path: str | None = None,
+        workspace_file_path: str | os.PathLike[str] | None = None,
+        loaded_targets_by_uid: dict[str, int | str] | None = None,
+    ) -> int | str | None:
+        try:
+            return self._manager._load_workspace_node(
+                node_tree,
+                parent_target=parent_target,
+                selection_item=selection_item,
+                manifest=manifest,
+                node_path=node_path,
+                workspace_file_path=workspace_file_path,
+                loaded_targets_by_uid=loaded_targets_by_uid,
+            )
+        except Exception as exc:
+            self._record_skipped_workspace_node(node_path, exc)
+            return None
+
     def _load_workspace_roots(
         self,
         tree: xr.DataTree,
@@ -1244,14 +1316,15 @@ class _WorkspaceIOController:
         manifest: dict[str, typing.Any] | None = None,
         workspace_file_path: str | os.PathLike[str] | None = None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
-    ) -> None:
+    ) -> int:
+        loaded_count = 0
         for key in root_keys:
             if key not in tree:
                 continue
             node = typing.cast("xr.DataTree", tree[key])
             item = self._manager._tree_item_child_by_key(root_item, key)
             if item is None or item.checkState(0) != QtCore.Qt.CheckState.Unchecked:
-                self._manager._load_workspace_node(
+                target = self._manager._load_workspace_node_or_warn(
                     node,
                     selection_item=item,
                     manifest=manifest,
@@ -1259,6 +1332,9 @@ class _WorkspaceIOController:
                     node_path=key,
                     loaded_targets_by_uid=loaded_targets_by_uid,
                 )
+                if target is not None:
+                    loaded_count += 1
+        return loaded_count
 
     def _load_workspace_figures(
         self,
@@ -1267,9 +1343,9 @@ class _WorkspaceIOController:
         manifest: dict[str, typing.Any] | None = None,
         workspace_file_path: str | os.PathLike[str] | None = None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
-    ) -> None:
+    ) -> int:
         if "figures" not in tree:
-            return
+            return 0
         figures = typing.cast("xr.DataTree", tree["figures"])
         figure_keys: list[str] = []
         if manifest is not None:
@@ -1286,10 +1362,11 @@ class _WorkspaceIOController:
                         figure_keys.append(figure_key)
         figure_keys.extend(str(key) for key in figures if str(key) not in figure_keys)
 
+        loaded_count = 0
         for figure_key in figure_keys:
             if figure_key not in figures:
                 continue
-            self._manager._load_workspace_node(
+            target = self._manager._load_workspace_node_or_warn(
                 typing.cast("xr.DataTree", figures[figure_key]),
                 parent_target=None,
                 manifest=manifest,
@@ -1297,6 +1374,9 @@ class _WorkspaceIOController:
                 node_path=f"figures/{figure_key}",
                 loaded_targets_by_uid=loaded_targets_by_uid,
             )
+            if target is not None:
+                loaded_count += 1
+        return loaded_count
 
     def _from_h5py_workspace_file(
         self,
@@ -1306,6 +1386,7 @@ class _WorkspaceIOController:
         replace: bool,
         mark_dirty: bool,
     ) -> bool:
+        self._skipped_workspace_nodes = []
         nodes = manifest.get("nodes", ())
         root_order = manifest.get("root_order", ())
         if not isinstance(nodes, list) or not isinstance(root_order, list):
@@ -1415,8 +1496,17 @@ class _WorkspaceIOController:
                     loaded_targets_by_uid=loaded_targets_by_uid,
                 )
             for child_path in child_paths[path]:
-                _load_path(child_path, target)
+                _load_path_or_warn(child_path, target)
             return target
+
+        def _load_path_or_warn(
+            path: str, parent_target: int | str | None = None
+        ) -> int | str | None:
+            try:
+                return _load_path(path, parent_target)
+            except Exception as exc:
+                self._record_skipped_workspace_node(path, exc)
+                return None
 
         if replace:
             manifest_workspace_link_id = manifest.get("workspace_link_id")
@@ -1443,10 +1533,15 @@ class _WorkspaceIOController:
                     backup_tree = self._manager._to_datatree()
                     self._manager.remove_all_tools()
                     self._manager._drain_workspace_restore_events()
+                loaded_count = 0
                 for root_path in root_paths:
-                    _load_path(root_path)
+                    if _load_path_or_warn(root_path) is not None:
+                        loaded_count += 1
                 for figure_path in figure_paths:
-                    _load_path(figure_path)
+                    if _load_path_or_warn(figure_path) is not None:
+                        loaded_count += 1
+                if loaded_count == 0 and self._skipped_workspace_nodes:
+                    self._raise_no_workspace_windows_loaded()
                 self._manager._rebase_loaded_workspace_dependency_refs(
                     loaded_targets_by_uid
                 )
@@ -1498,6 +1593,7 @@ class _WorkspaceIOController:
         workspace_file_path: str | os.PathLike[str] | None = None,
     ) -> bool:
         """Restore the state of the manager from a DataTree object."""
+        self._skipped_workspace_nodes = []
         opened_tree = tree
         try:
             if not self._manager._is_datatree_workspace(tree):
@@ -1568,7 +1664,7 @@ class _WorkspaceIOController:
                         if dialog is None
                         else dialog._tree_widget.invisibleRootItem()
                     )
-                    self._manager._load_workspace_roots(
+                    loaded_count = self._manager._load_workspace_roots(
                         tree,
                         root_keys,
                         root_item=root_item,
@@ -1576,12 +1672,14 @@ class _WorkspaceIOController:
                         workspace_file_path=workspace_file_path,
                         loaded_targets_by_uid=loaded_targets_by_uid,
                     )
-                    self._manager._load_workspace_figures(
+                    loaded_count += self._manager._load_workspace_figures(
                         tree,
                         manifest=manifest,
                         workspace_file_path=workspace_file_path,
                         loaded_targets_by_uid=loaded_targets_by_uid,
                     )
+                    if loaded_count == 0 and self._skipped_workspace_nodes:
+                        self._raise_no_workspace_windows_loaded()
                     self._manager._rebase_loaded_workspace_dependency_refs(
                         loaded_targets_by_uid
                     )
@@ -2955,7 +3053,9 @@ class _WorkspaceIOController:
         native: bool = True,
     ) -> bool:
         previous_missing_colormaps = self._missing_workspace_colormaps
+        previous_skipped_nodes = self._skipped_workspace_nodes
         self._missing_workspace_colormaps = []
+        self._skipped_workspace_nodes = []
         try:
             with self._manager._workspace_document_access_context(fname) as access:
                 _manager_workspace._recover_workspace_transactions(access.path)
@@ -3026,6 +3126,7 @@ class _WorkspaceIOController:
                 return self._finish_workspace_file_load(loaded)
         finally:
             self._missing_workspace_colormaps = previous_missing_colormaps
+            self._skipped_workspace_nodes = previous_skipped_nodes
 
     def load(self, *, native: bool = True) -> bool:
         """Replace this manager with a workspace file."""

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -134,7 +134,7 @@ class _WorkspaceIOController:
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager = manager
         self._missing_workspace_colormaps: list[tuple[str, str]] = []
-        self._skipped_workspace_nodes: list[tuple[str, str, str]] = []
+        self._skipped_workspace_nodes: list[tuple[str, str, str, Exception]] = []
         self._loader_state = _manager_workspace.WorkspaceLoaderState()
 
     def _record_missing_workspace_colormap(
@@ -209,22 +209,30 @@ class _WorkspaceIOController:
             exc_info=(type(exc), exc, exc.__traceback__),
             extra={"suppress_ui_alert": True},
         )
-        self._skipped_workspace_nodes.append((node_label, exc_summary, exc_text))
+        self._skipped_workspace_nodes.append((node_label, exc_summary, exc_text, exc))
 
-    @staticmethod
-    def _raise_no_workspace_windows_loaded() -> typing.NoReturn:
-        raise ValueError("No workspace windows could be loaded")
+    def _raise_no_workspace_windows_loaded(self) -> typing.NoReturn:
+        skipped_nodes = self._skipped_workspace_nodes
+        details = "\n".join(
+            f"- {node_label}: {exc_summary}"
+            for node_label, exc_summary, _exc_text, _exc in skipped_nodes
+        )
+        exc = ValueError(f"No workspace windows could be loaded:\n{details}")
+        if skipped_nodes:
+            raise exc from skipped_nodes[0][3]
+        raise exc
 
     def _show_skipped_workspace_node_warning(self) -> None:
         if not self._skipped_workspace_nodes:
             return
+        skipped_nodes = self._skipped_workspace_nodes
         affected = "\n".join(
             f"- {node_label}: {exc_summary}"
-            for node_label, exc_summary, _exc_text in self._skipped_workspace_nodes
+            for node_label, exc_summary, _exc_text, _exc in skipped_nodes
         )
         tracebacks = "\n\n".join(
             f"Workspace node {node_label}\n{exc_text}"
-            for node_label, _exc_summary, exc_text in self._skipped_workspace_nodes
+            for node_label, _exc_summary, exc_text, _exc in skipped_nodes
         )
         dialog = erlab.interactive.utils.MessageDialog(
             self._manager,

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3489,13 +3489,20 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             )
         return normalized_id, definition
 
+    def _output_imagetool_target_map(self) -> dict[str, str | QtWidgets.QWidget]:
+        targets = getattr(self, "_output_imagetool_targets", None)
+        if targets is None:
+            targets = {}
+            self._output_imagetool_targets = targets
+        return targets
+
     def _clear_output_imagetool_target(self, key: str) -> None:
-        self._output_imagetool_targets.pop(key, None)
+        self._output_imagetool_target_map().pop(key, None)
 
     def _clear_output_imagetool_target_if_matches(
         self, key: str, expected: str | QtWidgets.QWidget
     ) -> None:
-        current = self._output_imagetool_targets.get(key)
+        current = self._output_imagetool_target_map().get(key)
         if isinstance(expected, str):
             if current == expected:
                 self._clear_output_imagetool_target(key)
@@ -3506,7 +3513,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def _register_output_imagetool_target(
         self, key: str, target: str | QtWidgets.QWidget
     ) -> None:
-        self._output_imagetool_targets[key] = target
+        self._output_imagetool_target_map()[key] = target
         if isinstance(target, QtWidgets.QWidget):
             target.destroyed.connect(
                 lambda _=None, target_key=key, widget=target: (
@@ -3515,7 +3522,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             )
 
     def _output_imagetool_target(self, key: str) -> str | QtWidgets.QWidget | None:
-        target = self._output_imagetool_targets.get(key)
+        target = self._output_imagetool_target_map().get(key)
         if target is None:
             return None
 
@@ -4658,11 +4665,20 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             self._save_tool_data_references = previous_enabled
             self._save_tool_data_reference_node_uids = previous_uids
 
+    @staticmethod
+    def _reference_resolves_current_tool_data(
+        resolved: xr.DataArray, data: xr.DataArray
+    ) -> bool:
+        if resolved.ndim != data.ndim:
+            return False
+        if resolved.sizes != data.sizes:
+            return False
+        return tuple(resolved.dims) == tuple(data.dims)
+
     def _tool_data_reference_payload(
         self, variable_name: str, data: xr.DataArray
     ) -> dict[str, typing.Any] | None:
         """Return a saved reference payload for a persistence data item."""
-        del data
         if (
             not self._save_tool_data_references
             or variable_name != _SAVED_TOOL_DATA_NAME
@@ -4673,8 +4689,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             return None
         try:
             parent_data = self._source_parent_fetcher()
-            self._materialized_source_spec(parent_data)
+            resolved = self._materialized_source_spec(parent_data).apply(parent_data)
+            resolved = self.validate_update_data(resolved)
         except Exception:
+            return None
+        if not self._reference_resolves_current_tool_data(resolved, data):
             return None
         return {"kind": "parent_source"}
 

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -2632,6 +2632,51 @@ def test_manager_reload_script_inputs_normalizes_derived_1d_stack_dim(
         assert manager._tool_graph.root_wrappers[1].snapshot_token != before_token
 
 
+def test_manager_reload_script_derived_target_reports_runtime_error(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(9.0).reshape(3, 3),
+        dims=("x", "y"),
+        coords={"x": np.arange(3.0), "y": np.arange(3.0)},
+    )
+    critical_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _critical(*args: object, **kwargs: object) -> int:
+        critical_calls.append((args, kwargs))
+        return 0
+
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        staticmethod(_critical),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        assert (
+            manager._show_multi_input_script_result(
+                data.copy(deep=True),
+                (0,),
+                operation_label="Runtime failure",
+                operation_code="derived = data_0.isel(not_a_dim=0)",
+            )
+            == 1
+        )
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        assert not manager._reload_script_derived_target(1)
+
+    assert len(critical_calls) == 1
+    assert "ValueError" in str(critical_calls[0][1].get("detailed_text", ""))
+
+
 def test_manager_reload_script_inputs_normalizes_nonuniform_idx_dims(
     qtbot,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -4177,6 +4177,57 @@ def test_manager_workspace_partially_loads_corrupted_child_with_warning(
         assert "Input DataArray must be 2D" in dialog.kwargs["detailed_text"]
 
 
+def test_manager_workspace_no_loaded_windows_error_without_skipped_nodes(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        controller._skipped_workspace_nodes = []
+        with pytest.raises(ValueError, match="No workspace windows") as exc_info:
+            controller._raise_no_workspace_windows_loaded()
+        assert exc_info.value.__cause__ is None
+
+
+def test_manager_load_workspace_figures_counts_loaded_and_skipped(
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    tree = xr.DataTree.from_dict(
+        {
+            "figures/loaded": xr.Dataset(),
+            "figures/skipped": xr.Dataset(),
+        }
+    )
+    manifest = {
+        "nodes": [
+            {"path": "figures/missing"},
+            {"path": "figures/loaded"},
+            {"path": "figures/skipped"},
+        ]
+    }
+    calls: list[str | None] = []
+
+    def _fake_load_workspace_node_or_warn(*_args, **kwargs):
+        calls.append(kwargs.get("node_path"))
+        if kwargs.get("node_path") == "figures/skipped":
+            return None
+        return "figure-target"
+
+    with manager_context() as manager:
+        monkeypatch.setattr(
+            manager,
+            "_load_workspace_node_or_warn",
+            _fake_load_workspace_node_or_warn,
+        )
+        assert manager._load_workspace_figures(tree, manifest=manifest) == 1
+
+    assert calls == ["figures/loaded", "figures/skipped"]
+
+
 def test_manager_from_h5py_workspace_manifest_validation(
     tmp_path,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -4257,6 +4257,7 @@ def test_manager_from_h5py_workspace_falls_back_after_fast_read_error(
 
 def test_manager_from_h5py_workspace_logs_restore_failure(
     qtbot,
+    caplog,
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -4285,10 +4286,17 @@ def test_manager_from_h5py_workspace_logs_restore_failure(
         monkeypatch.setattr(manager, "_load_workspace_imagetool_dataset", _raise_load)
         monkeypatch.setattr(manager, "_restore_replaced_workspace", _raise_restore)
 
-        with pytest.raises(RuntimeError, match="load failed"):
+        with (
+            caplog.at_level(logging.ERROR, logger=manager_workspace_io.logger.name),
+            pytest.raises(ValueError, match="No workspace windows") as exc_info,
+        ):
             manager._from_h5py_workspace_file(
                 fname, manifest, replace=True, mark_dirty=False
             )
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert str(exc_info.value.__cause__) == "load failed"
+        assert "Failed to restore previous workspace" in caplog.text
+        assert "restore failed" in caplog.text
 
 
 def test_manager_workspace_rebind_skips_missing_snapshot_and_keeps_chunks(
@@ -9609,7 +9617,7 @@ def test_manager_workspace_replace_load_failure_restores_previous_workspace(
             h5_file.attrs["imagetool_workspace_schema_version"] = 4
             h5_file.create_group("0")
 
-        with pytest.raises(ValueError, match="Workspace node"):
+        with pytest.raises(ValueError, match="No workspace windows") as exc_info:
             manager._load_workspace_file(
                 broken_fname,
                 replace=True,
@@ -9617,6 +9625,8 @@ def test_manager_workspace_replace_load_failure_restores_previous_workspace(
                 mark_dirty=False,
                 select=False,
             )
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "Workspace node" in str(exc_info.value.__cause__)
 
         assert manager.workspace_path == str(current_fname.resolve())
         assert manager.ntools == 1

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -4056,6 +4056,127 @@ def test_manager_workspace_tool_data_reference_roundtrip(
         xr.testing.assert_identical(loaded_child.tool_data, data)
 
 
+def test_manager_workspace_tool_data_reference_falls_back_on_shape_mismatch(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    parent_data = xr.DataArray(
+        np.arange(50.0).reshape(2, 5, 5),
+        dims=("z", "y", "x"),
+        name="source",
+    )
+    child_data = parent_data.isel(z=0, drop=True).rename("source")
+
+    with manager_context() as manager:
+        root = itool(parent_data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        child = DerivativeTool(child_data)
+        child.set_source_binding(provenance.full_data())
+        child_uid = manager.add_childtool(child, 0, show=False)
+
+        tree = manager._to_datatree()
+        try:
+            ds = typing.cast(
+                "xr.DataTree", tree[f"0/childtools/{child_uid}/tool"]
+            ).to_dataset(inherit=False)
+            assert erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR not in ds.attrs
+            xr.testing.assert_identical(
+                ds[imagetool_serialization.SAVED_TOOL_DATA_NAME].rename(
+                    child.tool_data.name
+                ),
+                child.tool_data,
+            )
+        finally:
+            tree.close()
+
+
+def test_manager_workspace_partially_loads_corrupted_child_with_warning(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    dialogs: list[typing.Any] = []
+
+    class _RecordingMessageDialog(QtWidgets.QDialog):
+        def __init__(self, parent=None, **kwargs) -> None:
+            super().__init__(parent)
+            self.parent = parent
+            self.kwargs = kwargs
+            dialogs.append(self)
+
+        def exec(self):
+            return QtWidgets.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "MessageDialog", _RecordingMessageDialog
+    )
+
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="source",
+    )
+    with manager_context() as manager:
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        child = DerivativeTool(data)
+        child_uid = manager.add_childtool(child, 0, show=False)
+
+        tree = manager._to_datatree()
+        try:
+            root_ds = typing.cast("xr.DataTree", tree["0/imagetool"]).to_dataset(
+                inherit=False
+            )
+            child_ds = typing.cast(
+                "xr.DataTree", tree[f"0/childtools/{child_uid}/tool"]
+            ).to_dataset(inherit=False)
+            child_ds = child_ds.copy(deep=True)
+            saved_data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
+            child_ds[saved_data_name] = xr.DataArray(
+                np.arange(50.0).reshape(2, 5, 5),
+                dims=("z", "y", "x"),
+                name=saved_data_name,
+            )
+            corrupted_tree = xr.DataTree.from_dict(
+                {
+                    "0/imagetool": root_ds,
+                    f"0/childtools/{child_uid}/tool": child_ds,
+                }
+            )
+            corrupted_tree.attrs.update(tree.attrs)
+        finally:
+            tree.close()
+
+        assert manager._from_datatree(
+            corrupted_tree,
+            replace=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        assert manager._tool_graph.root_wrappers[0]._childtool_indices == []
+
+        assert manager._finish_workspace_file_load(True)
+
+        partial_dialogs = [
+            dialog
+            for dialog in dialogs
+            if dialog.kwargs.get("title") == "Workspace Partially Loaded"
+        ]
+        assert len(partial_dialogs) == 1
+        dialog = partial_dialogs[0]
+        assert dialog.parent is manager
+        assert f"0/childtools/{child_uid}" in dialog.kwargs["informative_text"]
+        assert "Input DataArray must be 2D" in dialog.kwargs["detailed_text"]
+
+
 def test_manager_from_h5py_workspace_manifest_validation(
     tmp_path,
     manager_context: Callable[

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1877,6 +1877,66 @@ def test_fit2d_param_plot_save_dataarray_as_hdf5_branches(
     assert captured_dirs[-1] == os.path.join(os.getcwd(), "cwdname.h5")
 
 
+def test_fit2d_param_plot_save_dataarray_as_hdf5_handles_write_error(
+    qtbot, monkeypatch, tmp_path
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    class _DialogStub:
+        AcceptMode = QtWidgets.QFileDialog.AcceptMode
+        FileMode = QtWidgets.QFileDialog.FileMode
+        Option = QtWidgets.QFileDialog.Option
+
+        def __init__(self, *args, **kwargs) -> None:
+            self._init_args = (args, kwargs)
+
+        def setAcceptMode(self, mode) -> None:
+            self._accept_mode = mode
+
+        def setFileMode(self, mode) -> None:
+            self._file_mode = mode
+
+        def setNameFilters(self, name_filters) -> None:
+            self._name_filters = name_filters
+
+        def setDefaultSuffix(self, suffix) -> None:
+            self._suffix = suffix
+
+        def setOption(self, *args, **kwargs) -> None:
+            self._option = (args, kwargs)
+
+        def setDirectory(self, directory: str) -> None:
+            self._directory = directory
+
+        def exec(self) -> bool:
+            return True
+
+        def selectedFiles(self) -> list[str]:
+            return [str(tmp_path / "locked.h5")]
+
+    def _raise_write_error(self, *args, **kwargs) -> None:
+        raise BlockingIOError("locked")
+
+    critical_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    monkeypatch.setattr(QtWidgets, "QFileDialog", _DialogStub)
+    monkeypatch.setattr(xr.DataArray, "to_netcdf", _raise_write_error)
+    monkeypatch.setattr(pg.PlotItem, "lastFileDir", str(tmp_path / "previous"))
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        lambda *args, **kwargs: critical_calls.append((args, kwargs)) or 0,
+    )
+
+    win.param_plot._save_dataarray_as_hdf5(xr.DataArray([1.0], name="data"))
+
+    assert len(critical_calls) == 1
+    assert pg.PlotItem.lastFileDir == str(tmp_path / "previous")
+
+
 def test_fit2d_is_in_manager_false_when_no_manager(qtbot, monkeypatch) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1974,6 +1974,49 @@ def test_tool_window_dataset_prefers_source_spec_over_legacy_binding(qtbot) -> N
     assert legacy_restored.source_binding == source_binding
 
 
+def test_tool_window_saved_reference_requires_matching_resolved_data(qtbot) -> None:
+    parent_data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": range(4)})
+    tool_data = parent_data.isel(x=slice(0, 2))
+    tool = _PersistentTool(tool_data)
+    qtbot.addWidget(tool)
+
+    assert (
+        erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            tool_data.expand_dims("z"), tool_data
+        )
+        is False
+    )
+    assert (
+        erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            parent_data, tool_data
+        )
+        is False
+    )
+    assert (
+        erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            tool_data.rename({"x": "y"}), tool_data
+        )
+        is False
+    )
+    assert (
+        erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            tool_data, tool_data
+        )
+        is True
+    )
+
+    tool.set_source_parent_fetcher(lambda: parent_data)
+    tool.set_source_binding(provenance.full_data(), state="fresh")
+    with tool._save_tool_data_reference_context(available_node_uids=frozenset()):
+        assert (
+            tool._tool_data_reference_payload(
+                erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+                tool_data,
+            )
+            is None
+        )
+
+
 def test_tool_window_dataset_ignores_invalid_saved_provenance(
     qtbot,
     caplog,

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1828,6 +1828,10 @@ def test_tool_window_output_target_cleanup_branches(qtbot, monkeypatch) -> None:
     tool._output_imagetool_targets["out"] = "child"
     assert tool._output_imagetool_target("out") == "child"
 
+    del tool._output_imagetool_targets
+    tool._clear_output_imagetool_target_if_matches("out", "child")
+    assert tool._output_imagetool_targets == {}
+
 
 def test_tool_window_prompt_existing_output_choices(qtbot, monkeypatch) -> None:
     tool = _PersistentTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))


### PR DESCRIPTION
## Summary
- Catch Fit2D parameter export failures, log them, and show a user-facing error dialog without updating the recent save directory
- Continue loading valid workspace content when individual nodes fail, then surface a summary warning with tracebacks
- Preserve saved tool-data references only when the resolved data still matches the current shape and dimensions
- Improve script reload error reporting so runtime failures include full tracebacks

## Testing
- Added unit tests for Fit2D export failure handling
- Added unit tests for partial workspace recovery and skipped-node warnings
- Added unit tests for tool-data reference fallback and runtime script reload errors