### PR TITLE
Add notes editing to the ImageTool manager

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -154,6 +154,11 @@ kept and the source is marked missing until it can be restored or replaced.
 Use {guilabel}`Copy Code` in the composer for recipe code that assumes the figure
 sources already exist as Python variables.
 
+To record the intent for the whole figure, select the Figure Composer row in the
+manager's {guilabel}`Figures` tab and use the inspector's {guilabel}`Notes` tab. The
+note is saved with the manager workspace as figure metadata and is separate from the
+generated Python recipe code.
+
 Use the manager side panel's {guilabel}`Copy Full Code` action when you want recursive
 replay code that includes all analysis steps.
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -266,6 +266,12 @@ and right-click context menus:
 
   :::
 
+- {guilabel}`Edit Note` / {guilabel}`Copy Note`
+
+  Add plain-text notes to the selected row from the right-side inspector or the
+  right-click context menu. Notes are saved with the manager workspace for ImageTool
+  rows, analysis tools, child ImageTool outputs, and Figure Composer windows.
+
 Icons next to each entry indicate special states: linked windows share a colored badge,
 chunked Dask arrays show the dask icon, watched variables display their variable name,
 rows opened from another row can show the state badges described in
@@ -294,6 +300,9 @@ See {ref}`Figure Composer <figure-composer>` for details.
 Windows in an ImageTool Manager instance can be saved to a workspace file (`.itws`),
 similar to Igor Pro experiment files. Pressing {kbd}`Ctrl+S` in any child window saves
 the entire manager workspace, including all windows and their state.
+
+Manager row notes are workspace metadata. They are saved with the row they describe and
+do not modify the data attributes of the underlying `DataArray`.
 
 {guilabel}`File → Add Windows From Workspace…` lets you choose windows from another
 workspace file to import into the current one.

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -159,6 +159,7 @@ class _ActionsController:
 
     def promote_child_imagetool(self, uid: str) -> int:
         """Promote the nested ImageTool identified by ``uid`` to a top-level row."""
+        self._manager._commit_note_editor()
         node = self._manager._child_node(uid)
         if not node.is_imagetool:
             raise KeyError(f"Target {uid!r} is not an ImageTool")
@@ -179,6 +180,7 @@ class _ActionsController:
         persistence = node.persistence_view()
         provenance_spec = persistence.provenance_spec
         snapshot_token = node.snapshot_token
+        note = node.note
 
         self._manager.tree_view.childtool_removed(uid)
         self._manager._unregister_node(uid)
@@ -191,6 +193,7 @@ class _ActionsController:
                 provenance_spec=provenance_spec,
                 snapshot_token=snapshot_token,
                 created_time=created_time,
+                note=note,
             )
         wrapper = self._manager._tool_graph.root_wrappers[new_index]
         wrapper._recent_geometry = recent_geometry
@@ -627,6 +630,7 @@ class _ActionsController:
                     source_binding=persistence.source_binding,
                     source_auto_update=persistence.source_auto_update,
                     source_state=persistence.source_state,
+                    note=node.note,
                 )
             else:
                 parent_target = (
@@ -644,11 +648,14 @@ class _ActionsController:
                     source_auto_update=persistence.source_auto_update,
                     source_state=persistence.source_state,
                     output_id=persistence.output_id,
+                    note=node.note,
                 )
         else:
             tool = typing.cast("erlab.interactive.utils.ToolWindow", node.tool_window)
             if node.parent_uid is None and self._manager._is_figure_node(node):
-                new_target = self._manager.add_figuretool(tool.duplicate())
+                new_target = self._manager.add_figuretool(
+                    tool.duplicate(), note=node.note
+                )
             else:
                 parent_target = (
                     parent_override
@@ -656,7 +663,7 @@ class _ActionsController:
                     else self._manager._parent_node(node).uid
                 )
                 new_target = self._manager.add_childtool(
-                    tool.duplicate(), parent_target
+                    tool.duplicate(), parent_target, note=node.note
                 )
 
         for child_uid in node._childtool_indices:
@@ -676,6 +683,7 @@ class _ActionsController:
         int
             Index of the newly created ImageTool window.
         """
+        self._manager._commit_note_editor()
         return self._manager._duplicate_subtree(index)
 
     def duplicate_childtool(self, uid: str) -> str:
@@ -691,6 +699,7 @@ class _ActionsController:
         str
             UID of the newly created child tool.
         """
+        self._manager._commit_note_editor()
         duplicated = self._manager._duplicate_subtree(uid)
         if isinstance(duplicated, str):
             return duplicated
@@ -1337,6 +1346,7 @@ class _ActionsController:
         uid: str | None = None,
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
     ) -> str:
         """Register a child tool window.
 
@@ -1359,6 +1369,7 @@ class _ActionsController:
                 uid=uid,
                 snapshot_token=snapshot_token,
                 created_time=created_time,
+                note=note,
             )
 
         parent = self._manager._node_for_target(index)
@@ -1369,6 +1380,7 @@ class _ActionsController:
             tool,
             snapshot_token=snapshot_token,
             created_time=created_time,
+            note=note,
         )
         if not tool._tool_display_name:
             tool._tool_display_name = parent.name
@@ -1408,6 +1420,7 @@ class _ActionsController:
         output_id: str | None = None,
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
     ) -> str:
         parent_node = self._manager._node_for_target(parent)
         if source_spec is None and source_binding is not None:
@@ -1436,6 +1449,7 @@ class _ActionsController:
             output_id=output_id,
             snapshot_token=snapshot_token,
             created_time=created_time,
+            note=note,
         )
         self._manager._register_child_node(node)
         if output_id is not None and parent_node.tool_window is not None:

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -100,6 +100,9 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     compact_workspace_action: QtGui.QAction
     create_figure_action: QtGui.QAction
     duplicate_action: QtGui.QAction
+    edit_note_action: QtGui.QAction
+    copy_note_action: QtGui.QAction
+    clear_note_action: QtGui.QAction
     figure_list: QtWidgets.QListWidget
     figure_tab: QtWidgets.QWidget
     figure_view_button_group: QtWidgets.QButtonGroup
@@ -115,7 +118,16 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     metadata_derivation_list: _MetadataDerivationListWidget
     metadata_details_layout: QtWidgets.QGridLayout
     metadata_details_widget: _HeightForWidthFrame
+    metadata_details_page: QtWidgets.QWidget
     metadata_group: QtWidgets.QFrame
+    metadata_provenance_page: QtWidgets.QWidget
+    inspector_tabs: QtWidgets.QTabWidget
+    notes_page: QtWidgets.QWidget
+    notes_title_label: QtWidgets.QLabel
+    notes_kind_label: QtWidgets.QLabel
+    notes_editor: QtWidgets.QPlainTextEdit
+    notes_copy_button: QtWidgets.QToolButton
+    notes_clear_button: QtWidgets.QToolButton
     offload_action: QtGui.QAction
     open_recent_menu: QtWidgets.QMenu
     preview_widget: _SingleImagePreview
@@ -165,6 +177,9 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     _metadata_full_code_available: bool
     _metadata_monospace_font: QtGui.QFont
     _metadata_node_uid: str | None
+    _notes_node_uid: str | None
+    _note_commit_timer: QtCore.QTimer
+    _updating_note_editor: bool
     _previous_excepthook: Callable[
         [type[BaseException], BaseException, types.TracebackType | None], typing.Any
     ]

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -17,6 +17,7 @@ from erlab.interactive.imagetool.manager._widgets import (
     _METADATA_DERIVATION_CODE_ROLE,
     _METADATA_DERIVATION_COPYABLE_ROLE,
     _METADATA_DERIVATION_ROW_ROLE,
+    _QWIDGETSIZE_MAX,
     _CenteredIconToolButton,
     _ElidedValueLabel,
     _LoadSourceDetailsDialog,
@@ -102,15 +103,145 @@ class _DetailsPanelController:
     def _node_info_html(self, node: _ImageToolWrapper | _ManagedWindowNode) -> str:
         return node.info_text
 
+    def _notes_ui_available(self) -> bool:
+        return hasattr(self._manager, "notes_editor")
+
+    def _selected_note_node(self) -> _ImageToolWrapper | _ManagedWindowNode | None:
+        targets: list[int | str] = []
+        targets.extend(self._manager._selected_imagetool_targets())
+        targets.extend(self._manager._selected_tool_uids())
+        if len(targets) != 1:
+            return None
+        return self._manager._node_for_target(targets[0])
+
+    def _current_note_node(self) -> _ImageToolWrapper | _ManagedWindowNode | None:
+        uid = self._manager._notes_node_uid
+        if uid is None:
+            return None
+        return self._manager._tool_graph.nodes.get(uid)
+
+    def _selected_or_current_note_node(
+        self,
+    ) -> _ImageToolWrapper | _ManagedWindowNode | None:
+        return self._selected_note_node() or self._current_note_node()
+
+    def _note_kind_text(self, node: _ImageToolWrapper | _ManagedWindowNode) -> str:
+        if self._manager._is_figure_uid(node.uid):
+            return "Figure Composer"
+        if node.is_imagetool:
+            return "ImageTool"
+        return node.type_badge_text or "Analysis Tool"
+
+    def _set_notes_node(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode | None,
+    ) -> None:
+        if not self._notes_ui_available():
+            return
+        if node is None:
+            self._manager._commit_note_editor()
+            self._manager._notes_node_uid = None
+            self._manager._updating_note_editor = True
+            try:
+                self._manager.notes_title_label.setText("")
+                self._manager.notes_kind_label.clear()
+                self._manager.notes_editor.clear()
+            finally:
+                self._manager._updating_note_editor = False
+            self._manager.notes_editor.setEnabled(False)
+            self._update_note_actions()
+            return
+
+        if self._manager._notes_node_uid != node.uid:
+            self._manager._commit_note_editor()
+        self._manager._notes_node_uid = node.uid
+        self._manager.notes_title_label.setText(node.display_text)
+        self._manager.notes_kind_label.setText(self._note_kind_text(node))
+        self._manager._updating_note_editor = True
+        try:
+            if self._manager.notes_editor.toPlainText() != node.note:
+                self._manager.notes_editor.setPlainText(node.note)
+        finally:
+            self._manager._updating_note_editor = False
+        self._manager.notes_editor.setEnabled(True)
+        self._update_note_actions()
+
+    def _update_note_actions(self) -> None:
+        if not self._notes_ui_available():
+            return
+        node = self._selected_or_current_note_node()
+        can_edit = node is not None
+        has_note = bool(node is not None and node.has_note)
+        self._manager.edit_note_action.setEnabled(can_edit)
+        self._manager.copy_note_action.setEnabled(has_note)
+        self._manager.clear_note_action.setEnabled(has_note)
+
+    def _schedule_note_commit(self) -> None:
+        if not self._notes_ui_available():
+            return
+        if self._manager._updating_note_editor:
+            return
+        self._manager._note_commit_timer.start()
+
+    def _commit_note_editor(self) -> None:
+        if not self._notes_ui_available():
+            return
+        self._manager._note_commit_timer.stop()
+        if self._manager._updating_note_editor:
+            return
+        node = self._current_note_node()
+        if node is None:
+            return
+        note = self._manager.notes_editor.toPlainText()
+        if node.note == note:
+            self._update_note_actions()
+            return
+        node.note = note
+        self._manager._mark_node_state_dirty(node.uid)
+        self._manager.tree_view.refresh(node.uid)
+        self._update_note_actions()
+
+    def _edit_selected_note(self) -> None:
+        if not self._notes_ui_available():
+            return
+        node = self._selected_note_node()
+        if node is None:
+            return
+        self._set_notes_node(node)
+        self._manager.inspector_tabs.setCurrentWidget(self._manager.notes_page)
+        self._manager.notes_editor.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+
+    def _copy_selected_note(self) -> None:
+        if not self._notes_ui_available():
+            return
+        self._commit_note_editor()
+        node = self._selected_or_current_note_node()
+        if node is None or not node.note:
+            return
+        erlab.interactive.utils.copy_to_clipboard(node.note)
+
+    def _clear_selected_note(self) -> None:
+        if not self._notes_ui_available():
+            return
+        self._commit_note_editor()
+        node = self._selected_or_current_note_node()
+        if node is None:
+            return
+        self._set_notes_node(node)
+        self._manager.notes_editor.clear()
+        self._commit_note_editor()
+
     def _clear_metadata(self) -> None:
         self._manager._metadata_full_code_available = False
         self._manager._metadata_node_uid = None
+        self._set_notes_node(None)
         with QtCore.QSignalBlocker(self._manager.metadata_derivation_list):
             self._manager.metadata_derivation_list.clear()
         self._manager._set_metadata_fields([])
         self._manager._update_metadata_pane()
 
     def _set_metadata_node(self, node: _ImageToolWrapper | _ManagedWindowNode) -> None:
+        self._set_notes_node(node)
         self._manager._metadata_full_code_available = (
             node.displayed_provenance_spec is not None
         )
@@ -393,11 +524,56 @@ class _DetailsPanelController:
     def _update_metadata_pane(self) -> None:
         has_details = bool(self._manager._metadata_detail_labels)
         derivation_count = self._manager.metadata_derivation_list.count()
-        has_metadata = has_details or derivation_count > 0
+        has_note_target = self._manager._notes_node_uid is not None
+        has_metadata = has_details or derivation_count > 0 or has_note_target
 
         self._manager.metadata_group.setVisible(has_metadata)
         self._manager.metadata_details_widget.setVisible(has_details)
         self._manager.metadata_derivation_list.setVisible(derivation_count > 0)
+        details_index = self._manager.inspector_tabs.indexOf(
+            self._manager.metadata_details_page
+        )
+        provenance_index = self._manager.inspector_tabs.indexOf(
+            self._manager.metadata_provenance_page
+        )
+        notes_index = self._manager.inspector_tabs.indexOf(self._manager.notes_page)
+        if details_index >= 0:
+            self._manager.inspector_tabs.setTabEnabled(
+                details_index, has_details or not has_metadata
+            )
+        if provenance_index >= 0:
+            self._manager.inspector_tabs.setTabEnabled(
+                provenance_index, derivation_count > 0
+            )
+        if notes_index >= 0:
+            self._manager.inspector_tabs.setTabEnabled(notes_index, has_note_target)
+        current_widget = self._manager.inspector_tabs.currentWidget()
+        if current_widget is self._manager.metadata_details_page and not has_details:
+            if derivation_count > 0:
+                self._manager.inspector_tabs.setCurrentWidget(
+                    self._manager.metadata_provenance_page
+                )
+            elif has_note_target:
+                self._manager.inspector_tabs.setCurrentWidget(self._manager.notes_page)
+        elif (
+            current_widget is self._manager.metadata_provenance_page
+            and derivation_count == 0
+        ):
+            if has_details:
+                self._manager.inspector_tabs.setCurrentWidget(
+                    self._manager.metadata_details_page
+                )
+            elif has_note_target:
+                self._manager.inspector_tabs.setCurrentWidget(self._manager.notes_page)
+        elif current_widget is self._manager.notes_page and not has_note_target:
+            if has_details:
+                self._manager.inspector_tabs.setCurrentWidget(
+                    self._manager.metadata_details_page
+                )
+            elif derivation_count > 0:
+                self._manager.inspector_tabs.setCurrentWidget(
+                    self._manager.metadata_provenance_page
+                )
 
         if derivation_count == 0:
             self._manager.metadata_derivation_list.setMinimumHeight(0)
@@ -410,9 +586,7 @@ class _DetailsPanelController:
             frame = self._manager.metadata_derivation_list.frameWidth() * 2
             height = visible_rows * row_height + frame + 4
             self._manager.metadata_derivation_list.setMinimumHeight(height)
-            self._manager.metadata_derivation_list.setMaximumHeight(
-                QtWidgets.QWIDGETSIZE_MAX
-            )
+            self._manager.metadata_derivation_list.setMaximumHeight(_QWIDGETSIZE_MAX)
 
         self._manager.metadata_details_widget.updateGeometry()
         self._manager.metadata_derivation_list.updateGeometry()
@@ -923,6 +1097,7 @@ class _DetailsPanelController:
         self._manager.source_update_action.setEnabled(
             source_update_child_uid is not None
         )
+        self._update_note_actions()
 
         if not imagetool_targets or selection_children:
             self._manager.link_action.setDisabled(True)

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -537,17 +537,14 @@ class _DetailsPanelController:
             self._manager.metadata_provenance_page
         )
         notes_index = self._manager.inspector_tabs.indexOf(self._manager.notes_page)
-        if details_index >= 0:
-            self._manager.inspector_tabs.setTabEnabled(
-                details_index, has_details or not has_metadata
-            )
-        if provenance_index >= 0:
-            self._manager.inspector_tabs.setTabEnabled(
-                provenance_index, derivation_count > 0
-            )
-        if notes_index >= 0:
-            self._manager.inspector_tabs.setTabEnabled(notes_index, has_note_target)
         current_widget = self._manager.inspector_tabs.currentWidget()
+        self._manager.inspector_tabs.setTabEnabled(
+            details_index, has_details or not has_metadata
+        )
+        self._manager.inspector_tabs.setTabEnabled(
+            provenance_index, derivation_count > 0
+        )
+        self._manager.inspector_tabs.setTabEnabled(notes_index, has_note_target)
         if current_widget is self._manager.metadata_details_page and not has_details:
             if derivation_count > 0:
                 self._manager.inspector_tabs.setCurrentWidget(

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -37,6 +37,7 @@ from erlab.interactive.imagetool.manager._widgets import (
     _SHM_NAME,
     _WORKSPACE_REBIND_KEEP_CHUNKS,
     _ApplicationQuitFilter,
+    _ElidedValueLabel,
     _HeightForWidthFrame,
     _manager_settings,
     _MetadataDerivationListWidget,
@@ -102,6 +103,15 @@ _FIGURE_GALLERY_THUMBNAIL_SIZES = {
     _FIGURE_GALLERY_SIZE_MEDIUM: (152, 114),
     "large": (216, 162),
 }
+_NOTE_COMMIT_DELAY_MS = 400
+
+
+class _NotesPlainTextEdit(QtWidgets.QPlainTextEdit):
+    focus_lost = QtCore.Signal()
+
+    def focusOutEvent(self, event: QtGui.QFocusEvent | None) -> None:
+        super().focusOutEvent(event)
+        self.focus_lost.emit()
 
 
 class _AppendFigureTargetDialog(QtWidgets.QDialog):
@@ -894,6 +904,24 @@ class ImageToolManager(_ImageToolManagerBase):
         self.source_update_action.setIcon(QtGui.QIcon.fromTheme("sync-synchronizing"))
         self.source_update_action.setVisible(False)
 
+        self.edit_note_action = QtWidgets.QAction("Edit Note", self)
+        self.edit_note_action.setObjectName("manager_edit_note_action")
+        self.edit_note_action.triggered.connect(self.edit_selected_note)
+        self.edit_note_action.setToolTip("Edit the note for the selected window")
+        self.edit_note_action.setIcon(QtGui.QIcon.fromTheme("accessories-text-editor"))
+
+        self.copy_note_action = QtWidgets.QAction("Copy Note", self)
+        self.copy_note_action.setObjectName("manager_copy_note_action")
+        self.copy_note_action.triggered.connect(self.copy_selected_note)
+        self.copy_note_action.setToolTip("Copy the selected window note")
+        self.copy_note_action.setIcon(QtGui.QIcon.fromTheme("edit-copy"))
+
+        self.clear_note_action = QtWidgets.QAction("Clear Note", self)
+        self.clear_note_action.setObjectName("manager_clear_note_action")
+        self.clear_note_action.triggered.connect(self.clear_selected_note)
+        self.clear_note_action.setToolTip("Clear the selected window note")
+        self.clear_note_action.setIcon(QtGui.QIcon.fromTheme("edit-clear"))
+
         self.about_action = QtWidgets.QAction("About", self)
         self.about_action.setIcon(QtGui.QIcon.fromTheme("help-about"))
         self.about_action.triggered.connect(self.about)
@@ -964,6 +992,10 @@ class ImageToolManager(_ImageToolManagerBase):
         self.edit_menu.addAction(self.rename_action)
         self.edit_menu.addAction(self.link_action)
         self.edit_menu.addAction(self.unlink_action)
+        self.edit_menu.addSeparator()
+        self.edit_menu.addAction(self.edit_note_action)
+        self.edit_menu.addAction(self.copy_note_action)
+        self.edit_menu.addAction(self.clear_note_action)
 
         self.view_menu: QtWidgets.QMenu = typing.cast(
             "QtWidgets.QMenu", self.menu_bar.addMenu("&View")
@@ -1101,7 +1133,33 @@ class ImageToolManager(_ImageToolManagerBase):
         metadata_layout.setSpacing(4)
         self.metadata_group.setLayout(metadata_layout)
 
-        self.metadata_details_widget = _HeightForWidthFrame(self.metadata_group)
+        self.inspector_tabs = QtWidgets.QTabWidget(self.metadata_group)
+        self.inspector_tabs.setObjectName("manager_inspector_tabs")
+        self.inspector_tabs.setDocumentMode(True)
+        metadata_layout.addWidget(self.inspector_tabs, 1)
+
+        inspector_margin = max(
+            6,
+            self._style_pixel_metric(QtWidgets.QStyle.PixelMetric.PM_LayoutTopMargin),
+        )
+        inspector_spacing = max(
+            4,
+            self._style_pixel_metric(
+                QtWidgets.QStyle.PixelMetric.PM_LayoutVerticalSpacing
+            ),
+        )
+
+        self.metadata_details_page = QtWidgets.QWidget(self.inspector_tabs)
+        metadata_details_page_layout = QtWidgets.QVBoxLayout(self.metadata_details_page)
+        metadata_details_page_layout.setContentsMargins(
+            inspector_margin,
+            inspector_spacing,
+            inspector_margin,
+            inspector_spacing,
+        )
+        metadata_details_page_layout.setSpacing(inspector_spacing)
+
+        self.metadata_details_widget = _HeightForWidthFrame(self.metadata_details_page)
         self.metadata_details_layout = QtWidgets.QGridLayout(
             self.metadata_details_widget
         )
@@ -1115,14 +1173,22 @@ class ImageToolManager(_ImageToolManagerBase):
             QtWidgets.QSizePolicy.Policy.Maximum,
         )
         self.metadata_details_widget.setVisible(False)
-        metadata_layout.addWidget(self.metadata_details_widget, 0)
+        metadata_details_page_layout.addWidget(self.metadata_details_widget, 0)
+        metadata_details_page_layout.addStretch(1)
         self._metadata_detail_labels: dict[str, QtWidgets.QLabel] = {}
         self._metadata_monospace_font = QtGui.QFontDatabase.systemFont(
             QtGui.QFontDatabase.SystemFont.FixedFont
         )
 
+        self.metadata_provenance_page = QtWidgets.QWidget(self.inspector_tabs)
+        metadata_provenance_page_layout = QtWidgets.QVBoxLayout(
+            self.metadata_provenance_page
+        )
+        metadata_provenance_page_layout.setContentsMargins(0, 0, 0, 0)
+        metadata_provenance_page_layout.setSpacing(0)
+
         self.metadata_derivation_list = _MetadataDerivationListWidget(
-            self.metadata_group
+            self.metadata_provenance_page
         )
         self.metadata_derivation_list.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Preferred,
@@ -1156,7 +1222,55 @@ class ImageToolManager(_ImageToolManagerBase):
             lambda _item, _column: self._activate_selected_derivation_step()
         )
         self.metadata_derivation_list.setVisible(False)
-        metadata_layout.addWidget(self.metadata_derivation_list, 1)
+        metadata_provenance_page_layout.addWidget(self.metadata_derivation_list, 1)
+
+        self.notes_page = QtWidgets.QWidget(self.inspector_tabs)
+        notes_page_layout = QtWidgets.QVBoxLayout(self.notes_page)
+        notes_page_layout.setContentsMargins(0, 0, 0, 0)
+        notes_page_layout.setSpacing(4)
+        notes_header_layout = QtWidgets.QHBoxLayout()
+        notes_header_layout.setContentsMargins(0, 0, 0, 0)
+        notes_header_layout.setSpacing(4)
+        self.notes_title_label = _ElidedValueLabel(
+            "",
+            self.notes_page,
+            elide_mode=QtCore.Qt.TextElideMode.ElideMiddle,
+        )
+        self.notes_title_label.setObjectName("manager_notes_title_label")
+        self.notes_title_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Preferred,
+        )
+        self.notes_kind_label = QtWidgets.QLabel(self.notes_page)
+        self.notes_kind_label.setObjectName("manager_notes_kind_label")
+        self.notes_kind_label.setEnabled(False)
+        self.notes_kind_label.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        self.notes_copy_button = QtWidgets.QToolButton(self.notes_page)
+        self.notes_copy_button.setObjectName("manager_notes_copy_button")
+        self.notes_copy_button.setDefaultAction(self.copy_note_action)
+        self.notes_copy_button.setAutoRaise(True)
+        self.notes_clear_button = QtWidgets.QToolButton(self.notes_page)
+        self.notes_clear_button.setObjectName("manager_notes_clear_button")
+        self.notes_clear_button.setDefaultAction(self.clear_note_action)
+        self.notes_clear_button.setAutoRaise(True)
+        notes_header_layout.addWidget(self.notes_title_label, 1)
+        notes_header_layout.addWidget(self.notes_kind_label, 0)
+        notes_header_layout.addWidget(self.notes_copy_button, 0)
+        notes_header_layout.addWidget(self.notes_clear_button, 0)
+        notes_page_layout.addLayout(notes_header_layout)
+        self.notes_editor = _NotesPlainTextEdit(self.notes_page)
+        self.notes_editor.setObjectName("manager_notes_editor")
+        self.notes_editor.setPlaceholderText("Notes")
+        self.notes_editor.setLineWrapMode(
+            QtWidgets.QPlainTextEdit.LineWrapMode.WidgetWidth
+        )
+        self.notes_editor.textChanged.connect(self._schedule_note_commit)
+        self.notes_editor.focus_lost.connect(self._commit_note_editor)
+        notes_page_layout.addWidget(self.notes_editor, 1)
+
+        self.inspector_tabs.addTab(self.metadata_details_page, "Details")
+        self.inspector_tabs.addTab(self.metadata_provenance_page, "Provenance")
+        self.inspector_tabs.addTab(self.notes_page, "Notes")
         self.right_splitter.addWidget(self.metadata_group)
         self.right_splitter.setStretchFactor(0, 2)
         self.right_splitter.setStretchFactor(1, 1)
@@ -1173,6 +1287,12 @@ class ImageToolManager(_ImageToolManagerBase):
         self._recent_loader_extensions_by_filter: dict[str, dict[str, typing.Any]] = {}
         self._metadata_full_code_available = False
         self._metadata_node_uid: str | None = None
+        self._notes_node_uid: str | None = None
+        self._updating_note_editor = False
+        self._note_commit_timer = QtCore.QTimer(self)
+        self._note_commit_timer.setSingleShot(True)
+        self._note_commit_timer.setInterval(_NOTE_COMMIT_DELAY_MS)
+        self._note_commit_timer.timeout.connect(self._commit_note_editor)
         self._refreshing_figure_list = False
         self._figure_menu: QtWidgets.QMenu | None = None
         self._metadata_copy_selected_action = QtGui.QAction("Copy", self)
@@ -1232,6 +1352,7 @@ class ImageToolManager(_ImageToolManagerBase):
         for widget in (
             self.text_box,
             self.metadata_derivation_list,
+            self.notes_editor,
         ):
             widget.installEventFilter(self._kb_filter)
 
@@ -1255,6 +1376,7 @@ class ImageToolManager(_ImageToolManagerBase):
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """Handle proper termination of resources before closing the application."""
         logger.debug("Closing ImageTool Manager...")
+        self._commit_note_editor()
         previous_closing_workspace_document = self._workspace_state.closing_document
         self._workspace_state.closing_document = True
         try:
@@ -1300,6 +1422,7 @@ class ImageToolManager(_ImageToolManagerBase):
             for widget in (
                 self.text_box,
                 self.metadata_derivation_list,
+                self.notes_editor,
             ):
                 widget.removeEventFilter(self._kb_filter)
             self.tree_view._delegate._cleanup_filter()
@@ -1943,6 +2066,9 @@ class ImageToolManager(_ImageToolManagerBase):
         menu.addAction(self.duplicate_action)
         menu.addAction(self.remove_action)
         menu.addAction(self.rename_action)
+        menu.addSeparator()
+        menu.addAction(self.edit_note_action)
+        menu.addAction(self.copy_note_action)
         viewport = self.figure_list.viewport()
         if viewport is None:  # pragma: no cover
             self._release_figure_menu(menu)
@@ -2885,6 +3011,21 @@ class ImageToolManager(_ImageToolManagerBase):
     def _delete_selected_derivation_step(self) -> None:
         self._details_panel._delete_selected_derivation_step()
 
+    def edit_selected_note(self) -> None:
+        self._details_panel._edit_selected_note()
+
+    def copy_selected_note(self) -> None:
+        self._details_panel._copy_selected_note()
+
+    def clear_selected_note(self) -> None:
+        self._details_panel._clear_selected_note()
+
+    def _schedule_note_commit(self) -> None:
+        self._details_panel._schedule_note_commit()
+
+    def _commit_note_editor(self) -> None:
+        self._details_panel._commit_note_editor()
+
     def _update_info(self, *, uid: str | None = None) -> None:
         self._details_panel._update_info(uid=uid)
 
@@ -3529,15 +3670,18 @@ class ImageToolManager(_ImageToolManagerBase):
         )
 
     def save(self, *, native: bool = True) -> bool:
+        self._commit_note_editor()
         return self._workspace_controller.save(native=native)
 
     def save_as(self, *, native: bool = True) -> bool:
+        self._commit_note_editor()
         return self._workspace_controller.save_as(native=native)
 
     def _compact_workspace_before_shutdown(self) -> None:
         self._workspace_controller._compact_workspace_before_shutdown()
 
     def compact_workspace(self) -> bool:
+        self._commit_note_editor()
         return self._workspace_controller.compact_workspace()
 
     def _save_to_file(self, fname: str) -> None:
@@ -3563,6 +3707,7 @@ class ImageToolManager(_ImageToolManagerBase):
         )
 
     def load(self, *, native: bool = True) -> bool:
+        self._commit_note_editor()
         return self._workspace_controller.load(native=native)
 
     def import_workspace(self, *, native: bool = True) -> bool:
@@ -4035,6 +4180,7 @@ class ImageToolManager(_ImageToolManagerBase):
         uid: str | None = None,
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
     ) -> str:
         return self._actions_controller.add_childtool(
             tool,
@@ -4043,6 +4189,7 @@ class ImageToolManager(_ImageToolManagerBase):
             uid=uid,
             snapshot_token=snapshot_token,
             created_time=created_time,
+            note=note,
         )
 
     def add_figuretool(
@@ -4053,6 +4200,7 @@ class ImageToolManager(_ImageToolManagerBase):
         uid: str | None = None,
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
     ) -> str:
         from erlab.interactive._figurecomposer import FigureComposerTool
 
@@ -4063,6 +4211,7 @@ class ImageToolManager(_ImageToolManagerBase):
             tool,
             snapshot_token=snapshot_token,
             created_time=created_time,
+            note=note,
         )
         if not tool._tool_display_name:
             tool._tool_display_name = self._next_figure_display_name()
@@ -4091,6 +4240,7 @@ class ImageToolManager(_ImageToolManagerBase):
         output_id: str | None = None,
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
     ) -> str:
         return self._actions_controller.add_imagetool_child(
             tool,
@@ -4106,6 +4256,7 @@ class ImageToolManager(_ImageToolManagerBase):
             output_id=output_id,
             snapshot_token=snapshot_token,
             created_time=created_time,
+            note=note,
         )
 
     def index_from_slicer_area(self, slicer_area: ImageSlicerArea) -> int | None:
@@ -4174,6 +4325,7 @@ class ImageToolManager(_ImageToolManagerBase):
         index: int | None = None,
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
     ) -> int:
         """Add a new ImageTool window to the manager and show it.
 
@@ -4222,6 +4374,7 @@ class ImageToolManager(_ImageToolManagerBase):
             source_state=source_state,
             snapshot_token=snapshot_token,
             created_time=created_time,
+            note=note,
         )
         self._register_root_wrapper(wrapper)
         wrapper.update_title()

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -34,7 +34,12 @@ logger = logging.getLogger(__name__)
 _NODE_UID_ROLE = int(QtCore.Qt.ItemDataRole.UserRole) + 128
 _TOOL_TYPE_ROLE = int(QtCore.Qt.ItemDataRole.UserRole) + 129
 _RowBadgeKind = typing.Literal[
-    "dask", "link", "watched", "tool_type", "source_status", "dependency_status"
+    "dask",
+    "link",
+    "watched",
+    "tool_type",
+    "source_status",
+    "dependency_status",
 ]
 
 
@@ -176,17 +181,15 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                     status_rect, _, _ = self._compute_child_status_info(
                         option,
                         child_node,
-                        right_edge=dask_rect.left() if dask_rect is not None else None,
+                        right_edge=self._right_badge_edge(dask_rect),
                     )
                     if status_rect is None:
                         status_rect, _, _ = self._compute_dependency_status_info(
                             option,
                             child_node,
-                            right_edge=(
-                                dask_rect.left() if dask_rect is not None else None
-                            ),
+                            right_edge=self._right_badge_edge(dask_rect),
                         )
-                    right_badge_rect = status_rect or dask_rect
+                    right_badge_rect = self._leftmost_rect(status_rect, dask_rect)
                     if right_badge_rect is not None:
                         rect.setRight(right_badge_rect.left() - self.icon_right_pad)
             rect.setTop(rect.center().y() - editor.sizeHint().height() / 2)
@@ -290,6 +293,16 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
 
         return icons_width, dask_rect, link_rect, watched_rect
 
+    @staticmethod
+    def _right_badge_edge(*rects: QtCore.QRect | None) -> int | None:
+        visible = [rect.left() for rect in rects if rect is not None]
+        return min(visible) if visible else None
+
+    @staticmethod
+    def _leftmost_rect(*rects: QtCore.QRect | None) -> QtCore.QRect | None:
+        visible = [rect for rect in rects if rect is not None]
+        return min(visible, key=lambda rect: rect.left()) if visible else None
+
     def _paint_icon(
         self,
         painter: QtGui.QPainter,
@@ -367,7 +380,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         )
 
         # Precompute icon geometry
-        icons_width, dask_rect, link_rect, watched_rect = self._compute_icons_info(
+        _icons_width, dask_rect, link_rect, watched_rect = self._compute_icons_info(
             option, tool_wrapper
         )
         icon_rects = [
@@ -401,16 +414,13 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             fm = QtGui.QFontMetrics(option.font)
             text = index.data(role=QtCore.Qt.ItemDataRole.DisplayRole)
             text_rect = QtCore.QRect(option.rect)
-            if dependency_rect is not None:
-                text_rect.setRight(dependency_rect.left() - self.icon_right_pad)
+            right_badge_rect = self._leftmost_rect(dependency_rect, *icon_rects)
+            if right_badge_rect is not None:
+                text_rect.setRight(right_badge_rect.left() - self.icon_right_pad)
             elided = fm.elidedText(
                 text,
                 view.textElideMode(),
-                (
-                    max(text_rect.width(), 0)
-                    if dependency_rect is not None
-                    else option.rect.width() - self.icon_right_pad - icons_width
-                ),
+                max(text_rect.width(), 0),
             )
             painter.setPen(palette.color(color_group, role))
             painter.drawText(
@@ -530,14 +540,14 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             status_rect, status_text, status_color = self._compute_child_status_info(
                 option,
                 child_node,
-                right_edge=dask_rect.left() if dask_rect is not None else None,
+                right_edge=self._right_badge_edge(dask_rect),
             )
             if status_rect is None:
                 status_rect, status_text, status_color = (
                     self._compute_dependency_status_info(
                         option,
                         child_node,
-                        right_edge=dask_rect.left() if dask_rect is not None else None,
+                        right_edge=self._right_badge_edge(dask_rect),
                     )
                 )
 
@@ -574,7 +584,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             text_rect = QtCore.QRect(option.rect)
             if type_rect is not None:
                 text_rect.setLeft(type_rect.right() + self.tool_type_rect_gap + 1)
-            right_badge_rect = status_rect or dask_rect
+            right_badge_rect = self._leftmost_rect(status_rect, dask_rect)
             if right_badge_rect is not None:
                 text_rect.setRight(right_badge_rect.left() - self.icon_right_pad)
 
@@ -875,14 +885,14 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         status_rect, _, _ = self._compute_child_status_info(
             option,
             child_node,
-            right_edge=dask_rect.left() if dask_rect is not None else None,
+            right_edge=self._right_badge_edge(dask_rect),
         )
         source_status = status_rect is not None
         if status_rect is None:
             status_rect, _, _ = self._compute_dependency_status_info(
                 option,
                 child_node,
-                right_edge=dask_rect.left() if dask_rect is not None else None,
+                right_edge=self._right_badge_edge(dask_rect),
             )
         if dask_rect is not None and dask_rect.contains(pos):
             tooltip = (
@@ -1708,6 +1718,9 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
         self._menu.addAction(manager.rename_action)
         self._menu.addAction(manager.link_action)
         self._menu.addAction(manager.unlink_action)
+        self._menu.addSeparator()
+        self._menu.addAction(manager.edit_note_action)
+        self._menu.addAction(manager.copy_note_action)
         self._menu.addSeparator()
         self._menu.addAction(manager.store_action)
 

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -708,6 +708,10 @@ class _WorkspaceIOController:
         ds.attrs["manager_node_kind"] = kind
         ds.attrs["manager_node_snapshot_token"] = node.snapshot_token
         ds.attrs["manager_node_added_at"] = node.added_time_iso
+        if node.note:
+            ds.attrs["manager_node_note"] = node.note
+        else:
+            ds.attrs.pop("manager_node_note", None)
         persistence = node.persistence_view()
         provenance_spec = persistence.provenance_spec
         if provenance_spec is not None:
@@ -888,6 +892,7 @@ class _WorkspaceIOController:
             "uid": uid,
             "snapshot_token": ds.attrs.get("manager_node_snapshot_token"),
             "created_time": ds.attrs.get("manager_node_added_at"),
+            "note": ds.attrs.get("manager_node_note"),
             "provenance_spec": parsed_provenance_spec,
             "source_spec": parsed_source_spec,
             "source_binding": (
@@ -1013,6 +1018,7 @@ class _WorkspaceIOController:
                 uid=ds.attrs.get("manager_node_uid"),
                 snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
                 created_time=ds.attrs.get("manager_node_added_at"),
+                note=ds.attrs.get("manager_node_note"),
             )
         else:
             target = self._manager.add_childtool(
@@ -1022,6 +1028,7 @@ class _WorkspaceIOController:
                 uid=ds.attrs.get("manager_node_uid"),
                 snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
                 created_time=ds.attrs.get("manager_node_added_at"),
+                note=ds.attrs.get("manager_node_note"),
             )
         self._manager._record_workspace_loaded_tool_target(
             ds, target, loaded_targets_by_uid

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -89,6 +89,23 @@ def _format_added_time(value: datetime.datetime) -> str:
     return value.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z (%z)")
 
 
+def _coerce_note(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        try:
+            return value.decode()
+        except UnicodeDecodeError:
+            logger.warning("Ignoring invalid saved manager note", exc_info=True)
+            return ""
+    if isinstance(value, str):
+        return value
+    logger.warning(
+        "Ignoring invalid saved manager note of type %s", type(value).__name__
+    )
+    return ""
+
+
 def _preview_from_imagetool(
     imagetool: ImageTool | None,
     fallback_ratio: float,
@@ -279,6 +296,7 @@ class _ManagedWindowNode(QtCore.QObject):
         output_id: str | None = None,
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
     ) -> None:
         super().__init__(manager)
         self._manager = weakref.ref(manager)
@@ -307,6 +325,7 @@ class _ManagedWindowNode(QtCore.QObject):
         self._snapshot_token = (
             str(snapshot_token) if snapshot_token else uuid.uuid4().hex
         )
+        self._note = _coerce_note(note)
         self._suspend_snapshot_token_updates = True
 
         self.window = window
@@ -588,6 +607,20 @@ class _ManagedWindowNode(QtCore.QObject):
     @property
     def created_time(self) -> datetime.datetime:
         return self._created_time
+
+    @property
+    def note(self) -> str:
+        return self._note
+
+    @note.setter
+    def note(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("note must be a string")
+        self._note = value
+
+    @property
+    def has_note(self) -> bool:
+        return bool(self._note.strip())
 
     @property
     def added_time_iso(self) -> str:
@@ -1453,6 +1486,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
         source_state: _ManagedWindowNode._source_state_type = "fresh",
         snapshot_token: str | None = None,
         created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
     ) -> None:
         self._index = index
         self._watched_varname: str | None = None
@@ -1486,6 +1520,7 @@ class _ImageToolWrapper(_ManagedWindowNode):
             source_state=source_state,
             snapshot_token=snapshot_token,
             created_time=created_time,
+            note=note,
         )
 
     @property

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -14,6 +14,7 @@ import erlab
 import erlab.interactive.imagetool.manager._console as manager_console
 import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
+import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.utils
 from erlab.interactive.imagetool import _provenance_framework, itool, provenance
 from erlab.interactive.imagetool.manager import fetch
@@ -2969,23 +2970,32 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
             == QtWidgets.QSizePolicy.Policy.Preferred
         )
         assert manager.metadata_group.parentWidget() is manager.right_splitter
-        assert manager.metadata_details_widget.parentWidget() is manager.metadata_group
-        assert manager.metadata_derivation_list.parentWidget() is manager.metadata_group
+        assert (
+            manager.metadata_details_widget.parentWidget()
+            is manager.metadata_details_page
+        )
+        assert (
+            manager.metadata_derivation_list.parentWidget()
+            is manager.metadata_provenance_page
+        )
         assert not isinstance(
             manager.metadata_details_widget.parentWidget(), QtWidgets.QSplitter
         )
         handle = manager.right_splitter.handle(2)
         assert handle is not None
         qtbot.wait_until(handle.isVisible, timeout=5000)
-        assert manager.metadata_group.maximumHeight() == QtWidgets.QWIDGETSIZE_MAX
         assert (
-            manager.metadata_details_widget.maximumHeight() == QtWidgets.QWIDGETSIZE_MAX
+            manager.metadata_group.maximumHeight() == manager_widgets._QWIDGETSIZE_MAX
+        )
+        assert (
+            manager.metadata_details_widget.maximumHeight()
+            == manager_widgets._QWIDGETSIZE_MAX
         )
         manager.resize(640, 700)
         manager.right_splitter.setSizes([180, 120, 280])
+        manager.inspector_tabs.setCurrentWidget(manager.metadata_provenance_page)
         QtWidgets.QApplication.processEvents()
         before_right_sizes = manager.right_splitter.sizes()
-        before_details_height = manager.metadata_details_widget.height()
         before_list_height = manager.metadata_derivation_list.height()
         manager.right_splitter.moveSplitter(
             before_right_sizes[0] + before_right_sizes[1] - 40, 2
@@ -2993,7 +3003,6 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
         QtWidgets.QApplication.processEvents()
         after_right_sizes = manager.right_splitter.sizes()
         assert after_right_sizes[2] > before_right_sizes[2]
-        assert manager.metadata_details_widget.height() == before_details_height
         assert manager.metadata_derivation_list.height() > before_list_height
         assert "\n" in details["Inputs"]
         assert "\n\n" not in details["Inputs"]

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -20,6 +20,7 @@ import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
+from erlab.interactive._figurecomposer import FigureComposerTool
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import itool, provenance
@@ -2014,6 +2015,94 @@ def test_workspace_properties_dialog_file_detail_branches(
     )
 
 
+def test_manager_notes_editor_actions(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    copied: list[str] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "copy_to_clipboard",
+        lambda content: copied.append(str(content)) or str(content),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        manager.resize(640, 700)
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        wrapper = manager._tool_graph.root_wrappers[0]
+        manager._mark_workspace_clean()
+
+        select_tools(manager, [0])
+        manager._update_info()
+        assert manager.inspector_tabs.count() == 3
+        assert manager.metadata_group.parentWidget() is manager.right_splitter
+        assert (
+            manager.metadata_details_widget.parentWidget()
+            is manager.metadata_details_page
+        )
+        assert (
+            manager.metadata_derivation_list.parentWidget()
+            is manager.metadata_provenance_page
+        )
+        assert manager.metadata_details_page.layout().contentsMargins().left() > 0
+
+        manager.edit_note_action.trigger()
+        assert manager.inspector_tabs.currentWidget() is manager.notes_page
+        assert isinstance(manager.notes_title_label, manager_widgets._ElidedValueLabel)
+        assert manager.notes_title_label.minimumSizeHint().width() == 0
+        assert manager.notes_title_label.full_text == wrapper.display_text
+        manager.notes_editor.setPlainText("root intent\nsecond line")
+
+        qtbot.wait_until(
+            lambda: wrapper.note == "root intent\nsecond line",
+            timeout=1500,
+        )
+        assert manager._workspace_state.dirty_state == {wrapper.uid}
+        assert manager._workspace_state.dirty_data == set()
+
+        manager.copy_note_action.trigger()
+        assert copied == ["root intent\nsecond line"]
+
+        manager.clear_note_action.trigger()
+        assert wrapper.note == ""
+
+        compact_notes: list[str] = []
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "compact_workspace",
+            lambda: compact_notes.append(wrapper.note) or True,
+        )
+        manager.notes_editor.setPlainText("pending compact note")
+        manager._note_commit_timer.stop()
+        assert manager.compact_workspace()
+        assert compact_notes == ["pending compact note"]
+
+        load_notes: list[tuple[str, bool]] = []
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "load",
+            lambda *, native=True: load_notes.append((wrapper.note, native)) or True,
+        )
+        manager.notes_editor.setPlainText("pending load note")
+        manager._note_commit_timer.stop()
+        assert manager.load(native=False)
+        assert load_notes == [("pending load note", False)]
+
+        manager.tree_view.clearSelection()
+        manager._update_info()
+        assert manager.notes_title_label.full_text == ""
+        assert manager.notes_title_label.toolTip() == ""
+        assert manager.notes_title_label.accessibleName() == ""
+
+
 @pytest.mark.parametrize("use_socket", [False, True], ids=["no_socket", "socket"])
 def test_manager(
     qtbot,
@@ -3198,6 +3287,118 @@ def test_manager_workspace_reload_preserves_manual_child_imagetool_name(
         assert loaded_child_node.name == "saved manual child"
         xr.testing.assert_identical(
             fetch(loaded_child_uid), updated.rename("saved manual child")
+        )
+
+
+def test_manager_notes_persist_workspace_roundtrip(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = xr.DataArray(
+        np.arange(24, dtype=float).reshape((6, 4)),
+        dims=["x", "y"],
+        coords={"x": np.arange(6), "y": np.arange(4)},
+        name="scan",
+    )
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(source, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        root = manager._tool_graph.root_wrappers[0]
+        root.note = "root note"
+
+        child_tool = itool(source.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=provenance.full_data(),
+            note="child note",
+        )
+        figure_uid = manager.add_figuretool(
+            FigureComposerTool(source),
+            show=False,
+            note="figure note",
+        )
+
+        workspace_path = tmp_path / "notes.itws"
+        manager._save_workspace_document(workspace_path, force_full=True)
+
+        assert manager._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        loaded_root = manager._tool_graph.root_wrappers[0]
+        loaded_child_uid = loaded_root._childtool_indices[0]
+        assert loaded_root.note == "root note"
+        assert manager._child_node(loaded_child_uid).note == "child note"
+        assert loaded_child_uid == child_uid
+        assert manager._tool_graph.figure_uids == [figure_uid]
+        assert manager._child_node(figure_uid).note == "figure note"
+
+
+def test_manager_notes_preserved_by_duplicate_and_promote(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        manager._tool_graph.root_wrappers[0].note = "root note"
+
+        child_tool = itool(test_data.copy(deep=False), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=provenance.full_data(),
+            note="child note",
+        )
+
+        select_tools(manager, [0])
+        manager.edit_note_action.trigger()
+        manager.notes_editor.setPlainText("pending duplicate root note")
+        manager._note_commit_timer.stop()
+        duplicated_target = manager.duplicate_imagetool(0)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        duplicated = manager._node_for_target(duplicated_target)
+        assert duplicated.note == "pending duplicate root note"
+        duplicated_child_uid = duplicated._childtool_indices[0]
+        assert manager._child_node(duplicated_child_uid).note == "child note"
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        manager.edit_note_action.trigger()
+        manager.notes_editor.setPlainText("pending promoted child note")
+        manager._note_commit_timer.stop()
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "exec",
+            lambda _: QtWidgets.QMessageBox.StandardButton.Yes,
+        )
+        manager.promote_selected()
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+        assert (
+            manager._tool_graph.nodes[child_uid].note == "pending promoted child note"
         )
 
 

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -2103,6 +2103,140 @@ def test_manager_notes_editor_actions(
         assert manager.notes_title_label.accessibleName() == ""
 
 
+def test_manager_notes_controller_guard_branches(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    copied: list[str] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "copy_to_clipboard",
+        lambda content: copied.append(str(content)) or str(content),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(test_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        wrapper = manager._tool_graph.root_wrappers[0]
+
+        select_tools(manager, [0])
+        manager.edit_note_action.trigger()
+        manager.notes_editor.setPlainText(wrapper.note)
+        manager._updating_note_editor = True
+        try:
+            manager._commit_note_editor()
+        finally:
+            manager._updating_note_editor = False
+
+        manager.tree_view.clearSelection()
+        manager._update_info()
+        manager.edit_selected_note()
+        manager.copy_selected_note()
+        manager.clear_selected_note()
+        assert copied == []
+
+        monkeypatch.setattr(
+            manager._details_panel,
+            "_notes_ui_available",
+            lambda: False,
+        )
+        manager._details_panel._update_note_actions()
+        manager._schedule_note_commit()
+        manager._commit_note_editor()
+        manager.edit_selected_note()
+        manager.copy_selected_note()
+        manager.clear_selected_note()
+
+
+def test_manager_inspector_tabs_fallback_between_pages(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        def enable_inspector_tabs() -> None:
+            for page in (
+                manager.metadata_details_page,
+                manager.metadata_provenance_page,
+                manager.notes_page,
+            ):
+                manager.inspector_tabs.setTabEnabled(
+                    manager.inspector_tabs.indexOf(page), True
+                )
+
+        manager._set_metadata_fields([])
+        manager.metadata_derivation_list.clear()
+        manager.metadata_derivation_list.addTopLevelItem(QtWidgets.QTreeWidgetItem())
+        manager._notes_node_uid = None
+        enable_inspector_tabs()
+        manager.inspector_tabs.setCurrentWidget(manager.metadata_details_page)
+        manager._update_metadata_pane()
+        assert (
+            manager.inspector_tabs.currentWidget() is manager.metadata_provenance_page
+        )
+
+        manager.metadata_derivation_list.clear()
+        manager._notes_node_uid = None
+        enable_inspector_tabs()
+        manager.inspector_tabs.setCurrentWidget(manager.notes_page)
+        manager._update_metadata_pane()
+        assert manager.inspector_tabs.currentWidget() is manager.metadata_details_page
+
+        manager.metadata_derivation_list.clear()
+        manager._notes_node_uid = "note-target"
+        enable_inspector_tabs()
+        manager.inspector_tabs.setCurrentWidget(manager.metadata_details_page)
+        manager._update_metadata_pane()
+        assert manager.inspector_tabs.currentWidget() is manager.notes_page
+
+        manager._set_metadata_fields(
+            [manager_wrapper._MetadataField("Kind", "ImageTool")]
+        )
+        manager._notes_node_uid = None
+        enable_inspector_tabs()
+        manager.inspector_tabs.setCurrentWidget(manager.metadata_provenance_page)
+        manager._update_metadata_pane()
+        assert manager.inspector_tabs.currentWidget() is manager.metadata_details_page
+
+        manager._set_metadata_fields([])
+        manager._notes_node_uid = "note-target"
+        enable_inspector_tabs()
+        manager.inspector_tabs.setCurrentWidget(manager.metadata_provenance_page)
+        manager._update_metadata_pane()
+        assert manager.inspector_tabs.currentWidget() is manager.notes_page
+
+        manager._set_metadata_fields(
+            [manager_wrapper._MetadataField("Kind", "ImageTool")]
+        )
+        manager._notes_node_uid = None
+        enable_inspector_tabs()
+        manager.inspector_tabs.setCurrentWidget(manager.notes_page)
+        manager._update_metadata_pane()
+        assert manager.inspector_tabs.currentWidget() is manager.metadata_details_page
+
+        manager._set_metadata_fields([])
+        manager.metadata_derivation_list.clear()
+        manager.metadata_derivation_list.addTopLevelItem(QtWidgets.QTreeWidgetItem())
+        manager._notes_node_uid = None
+        enable_inspector_tabs()
+        manager.inspector_tabs.setCurrentWidget(manager.notes_page)
+        manager._update_metadata_pane()
+        assert (
+            manager.inspector_tabs.currentWidget() is manager.metadata_provenance_page
+        )
+
+
 @pytest.mark.parametrize("use_socket", [False, True], ids=["no_socket", "socket"])
 def test_manager(
     qtbot,
@@ -3400,6 +3534,14 @@ def test_manager_notes_preserved_by_duplicate_and_promote(
         assert (
             manager._tool_graph.nodes[child_uid].note == "pending promoted child note"
         )
+
+        figure_uid = manager.add_figuretool(
+            FigureComposerTool(test_data),
+            show=False,
+            note="figure note",
+        )
+        duplicated_figure_uid = manager.duplicate_childtool(figure_uid)
+        assert manager._child_node(duplicated_figure_uid).note == "figure note"
 
 
 @pytest.mark.parametrize("auto_update", [False, True], ids=["manual", "auto"])

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -2776,8 +2776,14 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         assert manager.right_splitter.count() == 3
         assert manager.right_splitter.widget(2) is manager.metadata_group
-        assert manager.metadata_details_widget.parentWidget() is manager.metadata_group
-        assert manager.metadata_derivation_list.parentWidget() is manager.metadata_group
+        assert (
+            manager.metadata_details_widget.parentWidget()
+            is manager.metadata_details_page
+        )
+        assert (
+            manager.metadata_derivation_list.parentWidget()
+            is manager.metadata_provenance_page
+        )
         assert not isinstance(
             manager.metadata_derivation_list.parentWidget(), QtWidgets.QSplitter
         )
@@ -2787,6 +2793,11 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
                 "typing.Any",
                 types.SimpleNamespace(
                     uid="node",
+                    display_text="Node",
+                    note="",
+                    has_note=False,
+                    is_imagetool=True,
+                    type_badge_text="",
                     displayed_provenance_spec=provenance.full_data(),
                     metadata_fields=[
                         manager_wrapper._MetadataField("Kind", "ImageTool")
@@ -2797,7 +2808,11 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
         )
 
         assert manager.metadata_group.isVisible()
+        assert manager.inspector_tabs.currentWidget() is manager.metadata_details_page
         assert manager.metadata_details_widget.isVisible()
+        assert not manager.metadata_derivation_list.isVisible()
+        manager.inspector_tabs.setCurrentWidget(manager.metadata_provenance_page)
+        QtWidgets.QApplication.processEvents()
         assert manager.metadata_derivation_list.isVisible()
         handle = manager.right_splitter.handle(2)
         assert handle is not None
@@ -2805,7 +2820,7 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
         assert manager.metadata_derivation_list.minimumHeight() > 0
         assert (
             manager.metadata_derivation_list.maximumHeight()
-            == QtWidgets.QWIDGETSIZE_MAX
+            == manager_widgets._QWIDGETSIZE_MAX
         )
 
         manager.resize(640, 700)
@@ -2815,7 +2830,6 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
             manager.metadata_derivation_list.minimumHeight()
         )
         before_right_sizes = manager.right_splitter.sizes()
-        before_details_height = manager.metadata_details_widget.height()
         before_list_height = manager.metadata_derivation_list.height()
         manager.right_splitter.moveSplitter(
             before_right_sizes[0] + before_right_sizes[1] - 40, 2
@@ -2823,7 +2837,6 @@ def test_manager_metadata_derivation_list_has_visible_splitter(
         QtWidgets.QApplication.processEvents()
         after_right_sizes = manager.right_splitter.sizes()
         assert after_right_sizes[2] > before_right_sizes[2]
-        assert manager.metadata_details_widget.height() == before_details_height
         assert manager.metadata_derivation_list.height() > before_list_height
 
 

--- a/tests/interactive/imagetool/manager/test_wrapper.py
+++ b/tests/interactive/imagetool/manager/test_wrapper.py
@@ -5,6 +5,7 @@ import typing
 from collections.abc import Callable
 
 import numpy as np
+import pytest
 import xarray as xr
 from qtpy import QtCore, QtGui
 
@@ -18,6 +19,7 @@ from erlab.interactive.imagetool._load_source import (
 )
 from erlab.interactive.imagetool.manager._wrapper import (
     _coerce_added_time,
+    _coerce_note,
     _format_added_time,
     _format_chunk_summary,
     _preview_from_imagetool,
@@ -127,6 +129,38 @@ def test_wrapper_preview_fallback_branches(monkeypatch) -> None:
     ratio, pixmap = _preview(_FakeSlicerArea(_FakeMainImage()))
     assert ratio == 4.0
     assert not pixmap.isNull()
+
+
+def test_wrapper_note_coercion_and_setter_validation(
+    caplog,
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    assert _coerce_note(None) == ""
+    assert _coerce_note(b"encoded note") == "encoded note"
+    assert _coerce_note("plain note") == "plain note"
+
+    with caplog.at_level(logging.WARNING):
+        assert _coerce_note(b"\xff") == ""
+        assert _coerce_note(1) == ""
+    assert "Ignoring invalid saved manager note" in caplog.text
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        tool = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        index = manager.add_imagetool(tool, show=False, note=b"stored note")
+        wrapper = manager._tool_graph.root_wrappers[index]
+        assert wrapper.note == "stored note"
+        assert wrapper.has_note
+        wrapper.note = "   "
+        assert not wrapper.has_note
+        with pytest.raises(TypeError, match="note must be a string"):
+            wrapper.note = typing.cast("str", object())
 
 
 def test_preview_image_for_node_handles_legacy_preview_nodes(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add a Notes tab to the manager inspector for ImageTool, analysis, and Figure Composer rows
- Persist row notes in workspace metadata and carry them through duplicate, promote, save, and load flows
- Document how figure notes differ from generated recipe code

## Testing
- Not run (not requested)