### PR TITLE
Explain why ImageTool reload is unavailable

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -259,6 +259,11 @@ and right-click context menus:
   conducting experiments, where you can repeat analysis on a continually updated file
   source with a single click.
 
+  If the selected data cannot currently be reloaded, the action remains available and
+  explains what is missing. Common fixes are reconnecting the drive that contains the
+  source file, restoring a moved or deleted file, or reopening the ImageTool inputs that
+  created the result.
+
   :::{note}
 
   This action is also available inside each ImageTool window, and is associated with the

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -878,7 +878,14 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
 
     @QtCore.Slot()
     def _file_menu_visibility(self) -> None:
-        self.slicer_area.reload_act.setVisible(self.slicer_area.reloadable)
+        reload_unavailable_reason = self.slicer_area._reload_unavailable_reason()
+        self.slicer_area.reload_act.setVisible(True)
+        self.slicer_area.reload_act.setEnabled(True)
+        self.slicer_area.reload_act.setToolTip(
+            "Reload data from its saved files, parent, or inputs"
+            if reload_unavailable_reason is None
+            else reload_unavailable_reason
+        )
 
         if self.slicer_area._in_manager:
             visible: bool = False

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -1029,7 +1029,7 @@ class _DetailsPanelController:
         imagetool_targets = self._manager._selected_imagetool_targets()
         promotable_child_uid = self._manager._selected_promotable_child_imagetool_uid()
         source_update_child_uid = self._manager._selected_source_update_child_uid()
-        reload_targets = self._manager._selected_reload_targets()
+        reload_candidates = self._manager._selected_reload_candidates()
 
         selection_watched: list[int] = []
         selection_offloadable: list[int | str] = []
@@ -1078,9 +1078,13 @@ class _DetailsPanelController:
             bool(self._manager.tree_view.selected_imagetool_indices)
         )
 
-        reload_available = reload_targets is not None
-        self._manager.reload_action.setVisible(reload_available)
-        self._manager.reload_action.setEnabled(reload_available)
+        reload_relevant = reload_candidates is not None
+        self._manager.reload_action.setVisible(reload_relevant)
+        self._manager.reload_action.setEnabled(reload_relevant)
+        reload_tooltip = "Reload selected data from its saved files, parent, or inputs"
+        if reload_candidates is not None and reload_candidates[2] is not None:
+            reload_tooltip = reload_candidates[2]
+        self._manager.reload_action.setToolTip(reload_tooltip)
         self._manager.unwatch_action.setVisible(
             bool(imagetool_targets)
             and len(selection_watched) == len(imagetool_targets)

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -374,9 +374,16 @@ class _LineageController:
         if spec is None:
             return False
         if spec.kind == "file":
+            if spec.file_load_source is None:
+                return False
+            replay_call = spec.file_load_source.replay_call
             return (
-                spec.file_load_source is not None
+                replay_call is not None
                 and pathlib.Path(spec.file_load_source.path).exists()
+                and (
+                    replay_call.kind != "erlab_loader"
+                    or replay_call.target in erlab.io.loaders
+                )
             )
         if spec.kind != "script":
             return False
@@ -387,6 +394,84 @@ class _LineageController:
             )
             for nested_input in spec.script_inputs
         )
+
+    def _script_input_unavailable_reason(
+        self,
+        script_input: provenance.ScriptInput,
+        *,
+        target_node_uid: str | None = None,
+    ) -> str | None:
+        spec = script_input.parsed_provenance_spec()
+        is_target_input = (
+            target_node_uid is not None and script_input.node_uid == target_node_uid
+        )
+        if script_input.node_uid is not None and not is_target_input:
+            node = self._manager._tool_graph.nodes.get(script_input.node_uid)
+            if node is not None and (
+                spec is None
+                or spec.kind != "script"
+                or self._manager._script_provenance_inputs_current(spec)
+            ):
+                return None
+        if spec is None:
+            return (
+                f"{script_input.label} has no recorded reload source. Reopen the "
+                "input or recreate the result from reloadable inputs, then try "
+                "again."
+            )
+        if spec.kind == "file":
+            if spec.file_load_source is None:
+                return (
+                    f"{script_input.label} has no recorded source file. Reopen "
+                    "the input or recreate the result from reloadable inputs, "
+                    "then try again."
+                )
+            file_path = pathlib.Path(spec.file_load_source.path)
+            if not file_path.exists():
+                return (
+                    f"The source file for {script_input.label} is not available:\n"
+                    f"{file_path}\n\n"
+                    "Reconnect the drive or restore the file, then try again."
+                )
+            replay_call = spec.file_load_source.replay_call
+            if replay_call is None:
+                return (
+                    f"{script_input.label} has file provenance, but the loader "
+                    "information needed to read it is missing. Reopen the input "
+                    "or recreate the result from reloadable inputs, then try "
+                    "again."
+                )
+            if (
+                replay_call.kind == "erlab_loader"
+                and replay_call.target not in erlab.io.loaders
+            ):
+                return (
+                    f"The saved loader {replay_call.target!r} for "
+                    f"{script_input.label} is not available in this ImageTool "
+                    "session. Reopen the input from its file with an available "
+                    "loader."
+                )
+            return None
+        if spec.kind != "script":
+            return (
+                f"{script_input.label} has recorded provenance that cannot be "
+                "reloaded. Reopen the input or recreate the result from "
+                "reloadable inputs, then try again."
+            )
+        if not provenance.script_provenance_replayable(spec):
+            return (
+                f"{script_input.label} was created from recorded code that "
+                "cannot be replayed automatically. Recreate the result from "
+                "reloadable inputs to enable reload."
+            )
+        for nested_input in spec.script_inputs:
+            reason = self._manager._script_input_unavailable_reason(
+                nested_input,
+                target_node_uid=target_node_uid,
+            )
+            if reason is not None:
+                return reason
+        return None
 
     def _rebuild_script_provenance(
         self,
@@ -448,6 +533,49 @@ class _LineageController:
             )
         )
 
+    def _node_reload_unavailable_reason(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> str | None:
+        if not node.is_imagetool:
+            return (
+                "This tool cannot be reloaded directly. Recreate it from a "
+                "reloadable ImageTool input to enable reload."
+            )
+        if node.imagetool is None:
+            return (
+                "This ImageTool window is not open. Show or reopen the data, "
+                "then try again."
+            )
+        if (
+            node.slicer_area._direct_reloadable()
+            or node.slicer_area._provenance_reloadable()
+        ):
+            return None
+
+        spec = node.provenance_spec
+        if spec is not None and spec.kind == "script":
+            if not spec.script_inputs:
+                return (
+                    "This result has no recorded inputs. Reopen or recreate it "
+                    "from reloadable inputs to enable reload."
+                )
+            if not provenance.script_provenance_replayable(spec):
+                return (
+                    "This result was created from recorded code that cannot be "
+                    "replayed automatically. Recreate it from reloadable inputs "
+                    "to enable reload."
+                )
+            for script_input in spec.script_inputs:
+                reason = self._manager._script_input_unavailable_reason(
+                    script_input,
+                    target_node_uid=node.uid,
+                )
+                if reason is not None:
+                    return reason
+            return None
+
+        return node.slicer_area._local_reload_unavailable_reason()
+
     def _script_reload_from_slicer_area(
         self,
         slicer_area: erlab.interactive.imagetool.viewer.ImageSlicerArea,
@@ -503,6 +631,17 @@ class _LineageController:
     def _selected_reload_targets(
         self,
     ) -> tuple[list[int | str], dict[int | str, list[str]]] | None:
+        selected_reload_candidates = self._manager._selected_reload_candidates()
+        if selected_reload_candidates is None:
+            return None
+        reload_targets, child_targets, unavailable_reason = selected_reload_candidates
+        if unavailable_reason is not None:
+            return None
+        return reload_targets, child_targets
+
+    def _selected_reload_candidates(
+        self,
+    ) -> tuple[list[int | str], dict[int | str, list[str]], str | None] | None:
         selected_roots = self._manager.tree_view.selected_imagetool_indices
         selected_children = self._manager.tree_view.selected_childtool_uids
         if not selected_roots and not selected_children:
@@ -519,18 +658,21 @@ class _LineageController:
             reload_targets.append(target)
 
         for index in selected_roots:
-            if not self._manager._node_for_target(index).reloadable:
-                return None
+            unavailable_reason = self._manager._reload_unavailable_reason_for_target(
+                index
+            )
+            if unavailable_reason is not None:
+                return [], {}, unavailable_reason
             _add_reload_target(index)
 
         for uid in selected_children:
             reload_target = self._manager._reload_target_for_child(uid)
             if reload_target is None:
-                return None
+                return [], {}, self._manager._reload_unavailable_reason_for_child(uid)
             _add_reload_target(reload_target)
             child_targets.setdefault(reload_target, []).append(uid)
 
-        return reload_targets, child_targets
+        return reload_targets, child_targets, None
 
     def _reload_target_for_child(self, uid: str) -> int | str | None:
         try:
@@ -558,6 +700,32 @@ class _LineageController:
                 break
             current = parent
         return reload_target
+
+    def _reload_unavailable_reason_for_child(self, uid: str) -> str:
+        try:
+            current = self._manager._child_node(uid)
+        except KeyError:
+            return "The selected tool is no longer available. Select an open item."
+        if not current.has_source_binding:
+            return (
+                "This tool does not have a recorded source input. Reopen or "
+                "recreate it from reloadable ImageTool data to enable reload."
+            )
+        return (
+            "This tool cannot reload because its source chain has no reloadable "
+            "ImageTool. Restore or reopen the source data, then try again."
+        )
+
+    def _reload_unavailable_reason_for_target(self, target: int | str) -> str | None:
+        try:
+            node = self._manager._node_for_target(target)
+        except KeyError:
+            return "The selected item is no longer available. Select an open item."
+        if isinstance(target, str):
+            if self._manager._reload_target_for_child(target) is not None:
+                return None
+            return self._manager._reload_unavailable_reason_for_child(target)
+        return self._node_reload_unavailable_reason(node)
 
     def _reload_source_chain_for_child(self, uid: str) -> bool:
         """Reload the nearest reloadable ancestor, then refresh a child node."""
@@ -699,11 +867,18 @@ class _LineageController:
 
     def reload_selected(self) -> None:
         """Reload data in selected ImageTool windows."""
-        selected_reload_targets = self._manager._selected_reload_targets()
-        if selected_reload_targets is None:
+        selected_reload_candidates = self._manager._selected_reload_candidates()
+        if selected_reload_candidates is None:
             return
 
-        reload_targets, child_targets = selected_reload_targets
+        reload_targets, child_targets, unavailable_reason = selected_reload_candidates
+        if unavailable_reason is not None:
+            erlab.interactive.utils._show_reload_unavailable_dialog(
+                self._manager,
+                unavailable_reason,
+            )
+            return
+
         reloaded_targets: set[int | str] = set()
         for target in reload_targets:
             node = self._manager._node_for_target(target)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3883,6 +3883,17 @@ class ImageToolManager(_ImageToolManagerBase):
             target_node_uid=target_node_uid,
         )
 
+    def _script_input_unavailable_reason(
+        self,
+        script_input: provenance.ScriptInput,
+        *,
+        target_node_uid: str | None = None,
+    ) -> str | None:
+        return self._lineage_controller._script_input_unavailable_reason(
+            script_input,
+            target_node_uid=target_node_uid,
+        )
+
     def _rebuild_script_provenance(
         self,
         spec: provenance.ToolProvenanceSpec,
@@ -3927,8 +3938,19 @@ class ImageToolManager(_ImageToolManagerBase):
     ) -> tuple[list[int | str], dict[int | str, list[str]]] | None:
         return self._lineage_controller._selected_reload_targets()
 
+    def _selected_reload_candidates(
+        self,
+    ) -> tuple[list[int | str], dict[int | str, list[str]], str | None] | None:
+        return self._lineage_controller._selected_reload_candidates()
+
     def _reload_target_for_child(self, uid: str) -> int | str | None:
         return self._lineage_controller._reload_target_for_child(uid)
+
+    def _reload_unavailable_reason_for_child(self, uid: str) -> str:
+        return self._lineage_controller._reload_unavailable_reason_for_child(uid)
+
+    def _reload_unavailable_reason_for_target(self, target: int | str) -> str | None:
+        return self._lineage_controller._reload_unavailable_reason_for_target(target)
 
     def _reload_source_chain_for_child(self, uid: str) -> bool:
         return self._lineage_controller._reload_source_chain_for_child(uid)

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -427,7 +427,9 @@ class _ManagedWindowNode(QtCore.QObject):
         tool.destroyed.connect(self._handle_tool_window_destroyed)
         tool._set_managed_source_update_dialog(self.show_source_update_dialog)
         tool._set_managed_source_reload(
-            self.reload_source_data, self.can_reload_source_data
+            self.reload_source_data,
+            self.can_reload_source_data,
+            self.reload_unavailable_reason,
         )
 
     def _handle_tool_window_destroyed(self, _obj: QtCore.QObject | None = None) -> None:
@@ -1284,6 +1286,11 @@ class _ManagedWindowNode(QtCore.QObject):
             self.tool_window is not None
             and self.manager._reload_target_for_child(self.uid) is not None
         )
+
+    def reload_unavailable_reason(self) -> str | None:
+        if self.tool_window is None:
+            return "The selected tool is no longer available. Select an open item."
+        return self.manager._reload_unavailable_reason_for_child(self.uid)
 
     @QtCore.Slot()
     def _refresh_node_info(self) -> None:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1347,6 +1347,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def initialize_actions(self) -> None:
         """Initialize :class:`QtWidgets.QAction` instances."""
         self.reload_act = QtWidgets.QAction("&Reload Data", self)
+        self.reload_act.setObjectName("itool_reload_data_action")
         self.reload_act.setShortcut(QtGui.QKeySequence.StandardKey.Refresh)
         self.reload_act.triggered.connect(self.reload)
         self.reload_act.setToolTip(
@@ -2026,12 +2027,120 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def _provenance_reloadable(self) -> bool:
         """Return whether replay provenance can rebuild the displayed data from file."""
         provenance_spec = self.provenance_spec
-        return not (
+        if (
             provenance_spec is None
             or provenance_spec.kind != "file"
             or provenance_spec.file_load_source is None
             or not pathlib.Path(provenance_spec.file_load_source.path).exists()
+        ):
+            return False
+        replay_call = provenance_spec.file_load_source.replay_call
+        return replay_call is not None and (
+            replay_call.kind != "erlab_loader" or replay_call.target in erlab.io.loaders
         )
+
+    def _direct_reload_unavailable_reason(self) -> str | None:
+        """Return why direct file metadata cannot reload, if it is relevant."""
+        if self._file_path is None and self._load_func is None:
+            return None
+        if self._file_path is None:
+            return (
+                "This data has loader information but no recorded source file. "
+                "Reopen the data from its file to enable reload."
+            )
+        if not self._file_path.exists():
+            return (
+                "The source file is not available:\n"
+                f"{self._file_path}\n\n"
+                "Reconnect the drive or restore the file, then try again."
+            )
+        if self._load_func is None:
+            return (
+                "This data has a recorded source file, but the loader information "
+                "needed to read it is missing. Reopen the data from its file to "
+                "enable reload."
+            )
+        loader = self._load_func[0]
+        if not callable(loader) and loader not in erlab.io.loaders:
+            return (
+                f"The saved loader {loader!r} is not available in this ImageTool "
+                "session. Reopen the data from its file with an available loader."
+            )
+        return None
+
+    def _provenance_reload_unavailable_reason(self) -> str | None:
+        """Return why file provenance cannot reload, if it is relevant."""
+        provenance_spec = self.provenance_spec
+        if provenance_spec is None:
+            return None
+        if provenance_spec.kind == "file":
+            load_source = provenance_spec.file_load_source
+            if load_source is None:
+                return (
+                    "This data has file provenance, but it does not include the "
+                    "source file needed for reload. Reopen the data from its file "
+                    "to enable reload."
+                )
+            file_path = pathlib.Path(load_source.path)
+            if not file_path.exists():
+                return (
+                    "The source file is not available:\n"
+                    f"{file_path}\n\n"
+                    "Reconnect the drive or restore the file, then try again."
+                )
+            replay_call = load_source.replay_call
+            if replay_call is None:
+                return (
+                    "This data has file provenance, but the loader information "
+                    "needed to read it is missing. Reopen the data from its file "
+                    "to enable reload."
+                )
+            if (
+                replay_call.kind == "erlab_loader"
+                and replay_call.target not in erlab.io.loaders
+            ):
+                return (
+                    f"The saved loader {replay_call.target!r} is not available "
+                    "in this ImageTool session. Reopen the data from its file "
+                    "with an available loader."
+                )
+            return None
+        if provenance_spec.kind == "script":
+            return (
+                "This data was created from recorded script steps that cannot be "
+                "reloaded outside ImageTool Manager. Reopen or recreate it from "
+                "reloadable inputs to enable reload."
+            )
+        return None
+
+    def _local_reload_unavailable_reason(self) -> str | None:
+        """Return why this slicer area cannot reload without manager routing."""
+        if self._direct_reloadable() or self._provenance_reloadable():
+            return None
+        reason = self._direct_reload_unavailable_reason()
+        if reason is not None:
+            return reason
+        reason = self._provenance_reload_unavailable_reason()
+        if reason is not None:
+            return reason
+        return (
+            "This data was not opened from a reloadable file or recorded input. "
+            "Reopen it from a file, or recreate it from reloadable ImageTool "
+            "inputs, to enable reload."
+        )
+
+    def _reload_unavailable_reason(self) -> str | None:
+        """Return why Reload Data cannot run, or `None` when reload is available."""
+        if self._managed_source_chain_reload_target() is not None:
+            return None
+        if self._direct_reloadable() or self._provenance_reloadable():
+            return None
+        manager = self._manager_instance if self._in_manager else None
+        if manager is not None:
+            target = manager.target_from_slicer_area(self)
+            if target is not None:
+                return manager._reload_unavailable_reason_for_target(target)
+        return self._local_reload_unavailable_reason()
 
     def _fetch_for_reload(self) -> xr.DataArray:
         file_path = self._file_path
@@ -2145,13 +2254,22 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def reload(self) -> None:
         """Reload the displayed data from recorded source information.
 
-        Silently fails if the data cannot be reloaded. If an error occurs while
-        reloading the data, a message is shown to the user.
+        Shows an explanation if the data cannot be reloaded. If an error occurs
+        while reloading the data, a message is shown to the user.
+
+        .. versionchanged:: 3.24.0
+
+           User-triggered reload now explains why reload is unavailable instead
+           of silently doing nothing.
 
         See Also
         --------
         :attr:`reloadable`
         """
+        reason = self._reload_unavailable_reason()
+        if reason is not None:
+            erlab.interactive.utils._show_reload_unavailable_dialog(self, reason)
+            return
         self._reload()
 
     def update_values(

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -834,6 +834,22 @@ class MessageDialog(QtWidgets.QDialog):
         return dialog.exec()
 
 
+def _show_reload_unavailable_dialog(
+    parent: QtWidgets.QWidget | None,
+    reason: str,
+) -> int:
+    """Show a non-error dialog explaining why Reload Data cannot run."""
+    dialog = MessageDialog(
+        parent=parent,
+        title="Reload Data",
+        text="This data cannot be reloaded yet.",
+        informative_text=reason,
+        icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_MessageBoxInformation,
+    )
+    dialog.adjustSize()
+    return dialog.exec()
+
+
 def array_rect(data):
     data_coords = tuple(data[dim].values for dim in data.dims)
     data_incs = tuple(
@@ -3232,6 +3248,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._managed_source_update_dialog: Callable[..., int] | None = None
         self._managed_source_reload: Callable[[], bool] | None = None
         self._managed_source_reload_available: Callable[[], bool] | None = None
+        self._managed_source_reload_unavailable_reason: (
+            Callable[[], str | None] | None
+        ) = None
         self._output_imagetool_targets: dict[str, str | QtWidgets.QWidget] = {}
         self._save_tool_data_references = False
         self._save_tool_data_reference_node_uids: frozenset[str] | None = None
@@ -4279,11 +4298,16 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self,
         callback: Callable[[], bool] | None,
         available: Callable[[], bool] | None = None,
+        unavailable_reason: Callable[[], str | None] | None = None,
     ) -> None:
         """Set the manager-owned reload callback for this tool source."""
         self._managed_source_reload = callback
         self._managed_source_reload_available = available
+        self._managed_source_reload_unavailable_reason = unavailable_reason
         self._refresh_reload_data_action()
+
+    def _source_reload_relevant(self) -> bool:
+        return self._managed_source_reload is not None
 
     def _source_reloadable(self) -> bool:
         if self._managed_source_reload is None:
@@ -4295,18 +4319,42 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         except Exception:
             return False
 
+    def _source_reload_unavailable_reason(self) -> str:
+        if self._managed_source_reload is None:
+            return (
+                "This tool does not have a recorded reload source. Reopen or "
+                "recreate it from reloadable ImageTool data to enable reload."
+            )
+        if self._managed_source_reload_unavailable_reason is not None:
+            try:
+                reason = self._managed_source_reload_unavailable_reason()
+            except Exception:
+                reason = None
+            if reason:
+                return reason
+        return (
+            "This tool cannot reload because its source chain has no reloadable "
+            "ImageTool. Restore or reopen the source data, then try again."
+        )
+
     @QtCore.Slot()
     def _refresh_reload_data_action(self) -> None:
         if not qt_is_valid(self.reload_data_action):
             return
+        relevant = self._source_reload_relevant()
         reloadable = self._source_reloadable()
-        self.reload_data_action.setVisible(reloadable)
-        self.reload_data_action.setEnabled(reloadable)
+        self.reload_data_action.setVisible(relevant)
+        self.reload_data_action.setEnabled(relevant)
+        self.reload_data_action.setToolTip(
+            "Reload data from its saved files, parent, or inputs"
+            if reloadable
+            else self._source_reload_unavailable_reason()
+        )
         if not qt_is_valid(self._tool_file_menu):
             return
         menu_action = self._tool_file_menu.menuAction()
         if menu_action is not None and qt_is_valid(menu_action):
-            menu_action.setVisible(reloadable)
+            menu_action.setVisible(relevant)
 
     def finalize_source_refresh(self) -> None:
         """Record that the current source refresh has been applied to the tool."""
@@ -4380,6 +4428,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             or not qt_is_valid(self.reload_data_action)
             or not self.reload_data_action.isEnabled()
         ):
+            return False
+        if not self._source_reloadable():
+            _show_reload_unavailable_dialog(
+                self,
+                self._source_reload_unavailable_reason(),
+            )
             return False
         return self._managed_source_reload()
 

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -46,6 +46,16 @@ if typing.TYPE_CHECKING:
     )
 
 
+def _record_reload_unavailable_dialog(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_show_reload_unavailable_dialog",
+        lambda _parent, reason: reasons.append(reason),
+    )
+    return reasons
+
+
 def test_manager_console(
     qtbot,
     accept_dialog,
@@ -3291,6 +3301,7 @@ def test_manager_reload_script_inputs_missing_parent_without_source_noops(
     )
     data1 = data0 + 1.0
     errors: list[tuple[str, str, str, str]] = []
+    unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
 
     def _critical(
         parent, title, text, informative_text="", detailed_text=None, buttons=None
@@ -3321,10 +3332,12 @@ def test_manager_reload_script_inputs_missing_parent_without_source_noops(
         select_tools(manager, [2])
         manager._update_actions()
 
-        assert not manager.reload_action.isVisible()
+        assert manager.reload_action.isVisible()
+        assert manager.reload_action.isEnabled()
         manager.reload_selected()
 
         xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, original)
+        assert unavailable_reasons
         assert not errors
 
 
@@ -3465,6 +3478,35 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             ).model_dump(mode="json"),
         )
         assert not manager._script_input_has_recorded_file(missing_file_input)
+        load_source = file_spec.file_load_source
+        assert load_source is not None
+        replay_call = load_source.replay_call
+        assert replay_call is not None
+        missing_loader = "definitely-missing-erlab-loader"
+        missing_loader_input = provenance.ScriptInput(
+            name="missing_loader",
+            label="Missing loader",
+            provenance_spec=file_spec.model_copy(
+                update={
+                    "file_load_source": load_source.model_copy(
+                        update={
+                            "loader_label": "Loader",
+                            "loader_text": missing_loader,
+                            "replay_call": replay_call.model_copy(
+                                update={
+                                    "kind": "erlab_loader",
+                                    "target": missing_loader,
+                                }
+                            ),
+                        }
+                    )
+                }
+            ).model_dump(mode="json"),
+        )
+        assert not manager._script_input_can_reload(missing_loader_input)
+        reason = manager._script_input_unavailable_reason(missing_loader_input)
+        assert reason is not None
+        assert missing_loader in reason
 
         file_marker = "file-marker"
         child_marker = "child-marker"
@@ -3679,10 +3721,12 @@ def test_manager_reload_self_replacement_uses_recorded_source(
 
 def test_manager_reload_raw_self_replacement_unavailable(
     qtbot,
+    monkeypatch,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
     data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
         dims=("x", "y"),
@@ -3706,10 +3750,12 @@ def test_manager_reload_raw_self_replacement_unavailable(
         select_tools(manager, [0])
         manager._update_actions()
         assert not manager._node_can_reload_script_inputs(wrapper)
-        assert not manager.reload_action.isVisible()
+        assert manager.reload_action.isVisible()
+        assert manager.reload_action.isEnabled()
 
         manager.reload_selected()
 
+        assert unavailable_reasons
         xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
 
 
@@ -3772,7 +3818,7 @@ def test_unavailable_replay_code_traceback_ignores_successful_emit(
     assert calls == [(("graph", spec, True), "derived")]
 
 
-def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
+def test_manager_reload_data_explains_non_replayable_script_provenance(
     qtbot,
     monkeypatch,
     manager_context: Callable[
@@ -3822,7 +3868,8 @@ def test_manager_reload_data_hidden_for_non_replayable_script_provenance(
         select_tools(manager, [0])
         manager._update_actions()
 
-        assert not manager.reload_action.isVisible()
+        assert manager.reload_action.isVisible()
+        assert manager.reload_action.isEnabled()
         copied: list[str] = []
         monkeypatch.setattr(erlab.interactive.utils, "copy_to_clipboard", copied.append)
         manager._set_metadata_node(wrapper)

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -3466,6 +3466,19 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             provenance_spec=provenance.full_data().model_dump(mode="json"),
         )
         assert not manager._script_input_can_reload(full_data_input)
+        assert manager._script_input_unavailable_reason(full_data_input) is not None
+        file_without_source_input = types.SimpleNamespace(
+            node_uid=None,
+            label="File without source",
+            parsed_provenance_spec=lambda: file_spec.model_copy(
+                update={"file_load_source": None}
+            ),
+        )
+        assert not manager._script_input_can_reload(file_without_source_input)
+        assert (
+            manager._script_input_unavailable_reason(file_without_source_input)
+            is not None
+        )
         missing_file_input = provenance.ScriptInput(
             name="missing_file",
             label="Missing file",
@@ -3478,10 +3491,35 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             ).model_dump(mode="json"),
         )
         assert not manager._script_input_has_recorded_file(missing_file_input)
+        missing_file_reason = manager._script_input_unavailable_reason(
+            missing_file_input
+        )
+        assert missing_file_reason is not None
+        assert str(tmp_path / "missing.nc") in missing_file_reason
         load_source = file_spec.file_load_source
         assert load_source is not None
         replay_call = load_source.replay_call
         assert replay_call is not None
+        no_replay_call_input = types.SimpleNamespace(
+            node_uid=None,
+            label="No replay call",
+            parsed_provenance_spec=lambda: file_spec.model_copy(
+                update={
+                    "file_load_source": load_source.model_copy(
+                        update={"replay_call": None}
+                    )
+                }
+            ),
+        )
+        assert not manager._script_input_can_reload(no_replay_call_input)
+        assert manager._script_input_unavailable_reason(no_replay_call_input)
+        valid_file_input = provenance.ScriptInput(
+            name="valid_file",
+            label="Valid file",
+            provenance_spec=file_spec.model_dump(mode="json"),
+        )
+        assert manager._script_input_can_reload(valid_file_input)
+        assert manager._script_input_unavailable_reason(valid_file_input) is None
         missing_loader = "definitely-missing-erlab-loader"
         missing_loader_input = provenance.ScriptInput(
             name="missing_loader",
@@ -3507,6 +3545,50 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         reason = manager._script_input_unavailable_reason(missing_loader_input)
         assert reason is not None
         assert missing_loader in reason
+
+        nonreplayable_script_input = provenance.ScriptInput(
+            name="nonreplayable",
+            label="Nonreplayable script",
+            provenance_spec=provenance.script(
+                provenance.ScriptCodeOperation(label="Opaque", code=None),
+                start_label="Run script",
+                active_name="derived",
+                script_inputs=(valid_file_input,),
+            ).model_dump(mode="json"),
+        )
+        assert not manager._script_input_can_reload(nonreplayable_script_input)
+        assert (
+            manager._script_input_unavailable_reason(nonreplayable_script_input)
+            is not None
+        )
+        nested_missing_input = provenance.ScriptInput(
+            name="nested_missing",
+            label="Nested missing file",
+            provenance_spec=provenance.script(
+                provenance.ScriptCodeOperation(
+                    label="Use missing", code="derived = missing_file"
+                ),
+                start_label="Run script",
+                active_name="derived",
+                script_inputs=(missing_file_input,),
+            ).model_dump(mode="json"),
+        )
+        nested_reason = manager._script_input_unavailable_reason(nested_missing_input)
+        assert nested_reason is not None
+        assert str(tmp_path / "missing.nc") in nested_reason
+        nested_valid_input = provenance.ScriptInput(
+            name="nested_valid",
+            label="Nested valid file",
+            provenance_spec=provenance.script(
+                provenance.ScriptCodeOperation(
+                    label="Use valid", code="derived = valid_file"
+                ),
+                start_label="Run script",
+                active_name="derived",
+                script_inputs=(valid_file_input,),
+            ).model_dump(mode="json"),
+        )
+        assert manager._script_input_unavailable_reason(nested_valid_input) is None
 
         file_marker = "file-marker"
         child_marker = "child-marker"
@@ -3627,6 +3709,85 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             patch.setattr(manager, "target_from_slicer_area", lambda _area: 0)
             patch.setattr(manager, "_node_can_reload_script_inputs", lambda _node: True)
             assert manager._script_reload_from_slicer_area(object(), execute=False)
+
+        lineage = manager._lineage_controller
+        non_imagetool_node = types.SimpleNamespace(is_imagetool=False)
+        assert lineage._node_reload_unavailable_reason(non_imagetool_node)
+        closed_imagetool_node = types.SimpleNamespace(
+            is_imagetool=True,
+            imagetool=None,
+        )
+        assert lineage._node_reload_unavailable_reason(closed_imagetool_node)
+        script_no_inputs_node = types.SimpleNamespace(
+            uid="script-no-inputs",
+            is_imagetool=True,
+            imagetool=object(),
+            slicer_area=types.SimpleNamespace(
+                _direct_reloadable=lambda: False,
+                _provenance_reloadable=lambda: False,
+                _local_reload_unavailable_reason=lambda: "local reason",
+            ),
+            provenance_spec=provenance.script(
+                provenance.ScriptCodeOperation(
+                    label="Use input", code="derived = data"
+                ),
+                start_label="Run script",
+                active_name="derived",
+            ),
+        )
+        assert lineage._node_reload_unavailable_reason(script_no_inputs_node)
+        script_file_input_node = types.SimpleNamespace(
+            uid="script-file-input",
+            is_imagetool=True,
+            imagetool=object(),
+            slicer_area=script_no_inputs_node.slicer_area,
+            provenance_spec=provenance.script(
+                provenance.ScriptCodeOperation(
+                    label="Use file", code="derived = valid_file"
+                ),
+                start_label="Run script",
+                active_name="derived",
+                script_inputs=(valid_file_input,),
+            ),
+        )
+        assert lineage._node_reload_unavailable_reason(script_file_input_node) is None
+
+        with monkeypatch.context() as patch:
+            patch.setattr(manager, "_selected_reload_candidates", lambda: None)
+            assert manager._selected_reload_targets() is None
+            manager.reload_selected()
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager,
+                "_selected_reload_candidates",
+                lambda: ([0], {}, "blocked"),
+            )
+            assert manager._selected_reload_targets() is None
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager,
+                "_selected_reload_candidates",
+                lambda: ([0], {}, None),
+            )
+            assert manager._selected_reload_targets() == ([0], {})
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager,
+                "_node_for_target",
+                lambda _target: (_ for _ in ()).throw(KeyError("missing")),
+            )
+            assert manager._reload_unavailable_reason_for_target(0)
+        with monkeypatch.context() as patch:
+            patch.setattr(manager, "_node_for_target", lambda _target: object())
+            patch.setattr(manager, "_reload_target_for_child", lambda _uid: 0)
+            assert manager._reload_unavailable_reason_for_target("child") is None
+            patch.setattr(manager, "_reload_target_for_child", lambda _uid: None)
+            patch.setattr(
+                manager,
+                "_reload_unavailable_reason_for_child",
+                lambda _uid: "child reason",
+            )
+            assert manager._reload_unavailable_reason_for_target("child")
 
         old_parent_uid = "saved-parent"
         derived_wrapper.set_displayed_provenance(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -20,6 +20,7 @@ import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
+import erlab.interactive.utils
 from erlab.interactive._figurecomposer import FigureComposerTool
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool
@@ -65,6 +66,16 @@ if typing.TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+
+def _record_reload_unavailable_dialog(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_show_reload_unavailable_dialog",
+        lambda _parent, reason: reasons.append(reason),
+    )
+    return reasons
 
 
 def _batch_data(
@@ -3363,6 +3374,60 @@ def test_imagetool_source_chain_reload_target_falls_back_without_managed_source(
         assert child_tool.slicer_area._managed_source_chain_reload_target() is None
 
 
+def test_managed_child_imagetool_file_menu_reload_uses_own_file_source(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = test_data.rename("scan")
+    file_path = tmp_path / "child_scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+    unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(source, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child_tool = itool(
+            source.copy(deep=True),
+            manager=False,
+            execute=False,
+            file_path=file_path,
+            load_func=(xr.load_dataarray, {"engine": "h5netcdf"}, 0),
+        )
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(child_tool, 0, show=False)
+        assert manager._reload_target_for_child(child_uid) is None
+        assert child_tool.slicer_area._reload_unavailable_reason() is None
+
+        child_menu_bar = typing.cast(
+            "erlab.interactive.imagetool._mainwindow.ItoolMenuBar",
+            child_tool.menuBar(),
+        )
+        child_file_menu = child_menu_bar.menu_dict["fileMenu"]
+        child_file_menu.aboutToShow.emit()
+        assert child_tool.slicer_area.reload_act.isVisible()
+        assert child_tool.slicer_area.reload_act.isEnabled()
+
+        updated = source.copy(deep=True)
+        updated.data = np.asarray(updated.data) + 100.0
+        updated.to_netcdf(file_path, engine="h5netcdf")
+
+        with qtbot.wait_signal(child_tool.slicer_area.sigDataChanged, timeout=5000):
+            child_tool.slicer_area.reload_act.trigger()
+
+        assert unavailable_reasons == []
+        xr.testing.assert_identical(fetch(child_uid), updated)
+        xr.testing.assert_identical(child_tool.slicer_area.data, updated)
+
+
 def test_manager_workspace_reload_preserves_manual_root_name(
     qtbot,
     tmp_path: pathlib.Path,
@@ -3797,13 +3862,16 @@ def test_managed_nested_child_tool_file_menu_reload_refreshes_file_ancestor(
         )
 
 
-def test_managed_child_tool_hides_reload_without_reloadable_ancestor(
+def test_managed_child_tool_shows_reload_reason_without_reloadable_ancestor(
     qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
     test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
     with manager_context() as manager:
         manager.show()
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -3825,11 +3893,34 @@ def test_managed_child_tool_hides_reload_without_reloadable_ancestor(
         reload_action = child.findChild(QtGui.QAction, "tool_reload_data_action")
         assert reload_action is not None
         child._tool_file_menu.aboutToShow.emit()
-        assert not child._tool_file_menu.menuAction().isVisible()
-        assert not reload_action.isVisible()
-        assert not reload_action.isEnabled()
+        assert child._tool_file_menu.menuAction().isVisible()
+        assert reload_action.isVisible()
+        assert reload_action.isEnabled()
         assert not child.reload_source_data()
+        assert unavailable_reasons
         assert not manager._reload_source_chain_for_child(child_uid)
+
+        updated = test_data.copy(deep=True)
+        updated.data = np.asarray(updated.data) + 100.0
+        file_path = tmp_path / "scan.h5"
+        updated.to_netcdf(file_path, engine="h5netcdf")
+        parent_tool.slicer_area._file_path = file_path
+        parent_tool.slicer_area._load_func = (
+            xr.load_dataarray,
+            {"engine": "h5netcdf"},
+            0,
+        )
+
+        unavailable_reasons.clear()
+        child._tool_file_menu.aboutToShow.emit()
+        assert reload_action.isVisible()
+        assert reload_action.isEnabled()
+        with qtbot.wait_signal(child.sigDataChanged, timeout=5000):
+            reload_action.trigger()
+
+        assert not unavailable_reasons
+        xr.testing.assert_identical(fetch(0), updated)
+        xr.testing.assert_identical(child.tool_data, updated.transpose("eV", "alpha"))
 
 
 def test_manager_reload_selected_nested_child_refreshes_from_file_ancestor(
@@ -3999,6 +4090,7 @@ def test_manager_reload_mixed_child_selection_requires_all_children_eligible(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
     source = xr.DataArray(
         np.arange(12, dtype=float).reshape((3, 4)),
         dims=["x", "y"],
@@ -4050,10 +4142,12 @@ def test_manager_reload_mixed_child_selection_requires_all_children_eligible(
         select_child_tool(manager, eligible_uid)
         select_child_tool(manager, unbound_uid)
         manager._update_actions()
-        assert not manager.reload_action.isVisible()
+        assert manager.reload_action.isVisible()
+        assert manager.reload_action.isEnabled()
 
         manager.reload_selected()
 
+        assert unavailable_reasons
         assert reload_calls == []
         xr.testing.assert_identical(fetch(0), source)
         xr.testing.assert_identical(fetch(eligible_uid), source.isel(x=slice(0, 2)))

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -3889,6 +3889,10 @@ def test_managed_child_tool_shows_reload_reason_without_reloadable_ancestor(
         child_uid = manager._tool_graph.root_wrappers[0]._childtool_indices[0]
         child = manager.get_childtool(child_uid)
         assert isinstance(child, DerivativeTool)
+        child_node = manager._child_node(child_uid)
+        with monkeypatch.context() as patch:
+            patch.setattr(child_node, "_tool_window", None)
+            assert child_node.reload_unavailable_reason()
 
         reload_action = child.findChild(QtGui.QAction, "tool_reload_data_action")
         assert reload_action is not None

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -6136,7 +6136,9 @@ def test_manager_detached_file_provenance_metadata_and_reload_roundtrip(
         file_path.unlink()
         manager._update_actions()
         assert not detached.reloadable
-        assert not manager.reload_action.isVisible()
+        assert manager.reload_action.isVisible()
+        assert manager.reload_action.isEnabled()
+        assert str(file_path) in manager.reload_action.toolTip()
 
 
 def test_manager_workspace_loads_legacy_321_provenance_payload(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -79,6 +79,16 @@ from erlab.io.dataloader import LoaderBase
 logger = logging.getLogger(__name__)
 
 
+def _record_reload_unavailable_dialog(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_show_reload_unavailable_dialog",
+        lambda _parent, reason: reasons.append(reason),
+    )
+    return reasons
+
+
 @pytest.fixture(autouse=True)
 def isolate_pyperclip(monkeypatch) -> None:
     clipboard_text = ""
@@ -2929,10 +2939,12 @@ def test_itool_file_open_selection_branches(
 
 def test_itool_provenance_reload_rejects_incomplete_or_invalid_replay(
     qtbot,
+    monkeypatch,
     tmp_path: pathlib.Path,
 ) -> None:
     win = itool(xr.DataArray(np.arange(4.0), dims=("x",)), execute=False)
     qtbot.addWidget(win)
+    unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
 
     with pytest.raises(RuntimeError, match="cannot be reloaded"):
         win.slicer_area._fetch_for_provenance_reload()
@@ -2961,6 +2973,8 @@ def test_itool_provenance_reload_rejects_incomplete_or_invalid_replay(
         )
     )
     assert not win.slicer_area.reloadable
+    win.slicer_area.reload()
+    assert str(missing_file) in unavailable_reasons[-1]
     with pytest.raises(FileNotFoundError):
         win.slicer_area._fetch_for_provenance_reload()
 
@@ -2969,6 +2983,30 @@ def test_itool_provenance_reload_rejects_incomplete_or_invalid_replay(
         source_file,
         engine="h5netcdf",
     )
+    missing_loader = "definitely-missing-erlab-loader"
+    win.set_provenance_spec(
+        provenance.file_load(
+            start_label="Load with missing loader",
+            seed_code="derived = erlab.io.load(source_file)",
+            file_load_source=_file_source(source_file).model_copy(
+                update={
+                    "loader_label": "Loader",
+                    "loader_text": missing_loader,
+                    "replay_call": provenance.FileReplayCall(
+                        kind="erlab_loader",
+                        target=missing_loader,
+                        kwargs={},
+                        selected_index=0,
+                    ),
+                }
+            ),
+        )
+    )
+    assert not win.slicer_area.reloadable
+    unavailable_reasons.clear()
+    win.slicer_area.reload()
+    assert missing_loader in unavailable_reasons[-1]
+
     win.set_provenance_spec(
         provenance.script(
             start_label="Needs external data",
@@ -3026,12 +3064,42 @@ def test_itool_provenance_reload_rejects_incomplete_or_invalid_replay(
     win.close()
 
 
-def test_itool_reload_reports_failure_and_nonreloadable_noop(qtbot, monkeypatch):
+def test_itool_reload_reports_failure_and_nonreloadable_noop(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+):
     win = itool(xr.DataArray(np.arange(4.0), dims=("x",)), execute=False)
     qtbot.addWidget(win)
+    unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
+    original = win.slicer_area.data.copy()
 
     assert not win.slicer_area.reloadable
     assert not win.slicer_area._reload()
+    menu_bar = typing.cast(
+        "erlab.interactive.imagetool._mainwindow.ItoolMenuBar", win.menuBar()
+    )
+    menu_bar._file_menu_visibility()
+    assert win.slicer_area.reload_act.isVisible()
+    assert win.slicer_area.reload_act.isEnabled()
+    win.slicer_area.reload()
+    assert unavailable_reasons
+    xr.testing.assert_identical(win.slicer_area.data, original)
+
+    missing_file = tmp_path / "missing.h5"
+    win.slicer_area._file_path = missing_file
+    win.slicer_area._load_func = (xr.load_dataarray, {"engine": "h5netcdf"}, 0)
+    unavailable_reasons.clear()
+    win.slicer_area.reload()
+    assert str(missing_file) in unavailable_reasons[-1]
+
+    existing_file = tmp_path / "data.h5"
+    win.slicer_area.data.to_netcdf(existing_file, engine="h5netcdf")
+    win.slicer_area._file_path = existing_file
+    win.slicer_area._load_func = ("missing-loader", {}, 0)
+    unavailable_reasons.clear()
+    win.slicer_area.reload()
+    assert "missing-loader" in unavailable_reasons[-1]
 
     errors: list[tuple[str, str]] = []
     monkeypatch.setattr(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -3095,11 +3095,21 @@ def test_itool_reload_reports_failure_and_nonreloadable_noop(
 
     existing_file = tmp_path / "data.h5"
     win.slicer_area.data.to_netcdf(existing_file, engine="h5netcdf")
+    win.slicer_area._file_path = None
+    win.slicer_area._load_func = (xr.load_dataarray, {"engine": "h5netcdf"}, 0)
+    assert win.slicer_area._direct_reload_unavailable_reason() is not None
+
     win.slicer_area._file_path = existing_file
+    win.slicer_area._load_func = None
+    assert win.slicer_area._direct_reload_unavailable_reason() is not None
+
     win.slicer_area._load_func = ("missing-loader", {}, 0)
     unavailable_reasons.clear()
     win.slicer_area.reload()
     assert "missing-loader" in unavailable_reasons[-1]
+    win.slicer_area._load_func = (xr.load_dataarray, {"engine": "h5netcdf"}, 0)
+    assert win.slicer_area._direct_reload_unavailable_reason() is None
+    assert win.slicer_area._local_reload_unavailable_reason() is None
 
     errors: list[tuple[str, str]] = []
     monkeypatch.setattr(
@@ -3118,6 +3128,81 @@ def test_itool_reload_reports_failure_and_nonreloadable_noop(
 
     assert not win.slicer_area._reload()
     assert errors == [("Error", "An error occurred while reloading data.")]
+    win.close()
+
+
+def test_itool_reload_unavailable_reason_metadata_branches(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    win = itool(xr.DataArray(np.arange(4.0), dims=("x",)), execute=False)
+    qtbot.addWidget(win)
+    unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
+
+    source_file = tmp_path / "source.h5"
+    win.slicer_area.data.to_netcdf(source_file, engine="h5netcdf")
+    load_source = provenance.FileLoadSource(
+        path=str(source_file),
+        loader_label="xarray.load_dataarray",
+        loader_text="xarray.load_dataarray",
+        kwargs_text="",
+        replay_call=provenance.FileReplayCall(
+            kind="callable",
+            target="xarray.load_dataarray",
+            selected_index=0,
+        ),
+    )
+
+    valid_file_spec = provenance.file_load(
+        start_label="Load valid file",
+        seed_code="derived = xr.load_dataarray(path)",
+        file_load_source=load_source,
+    )
+    win.set_provenance_spec(
+        valid_file_spec.model_copy(update={"file_load_source": None})
+    )
+    win.slicer_area.reload()
+    assert unavailable_reasons[-1]
+
+    win.set_provenance_spec(
+        valid_file_spec.model_copy(
+            update={
+                "file_load_source": load_source.model_copy(update={"replay_call": None})
+            }
+        )
+    )
+    win.slicer_area.reload()
+    assert unavailable_reasons[-1]
+
+    win.set_provenance_spec(valid_file_spec)
+    assert win.slicer_area._provenance_reload_unavailable_reason() is None
+    win.set_provenance_spec(provenance.full_data())
+    assert win.slicer_area._provenance_reload_unavailable_reason() is None
+
+    win.set_provenance_spec(
+        provenance.script(
+            provenance.ScriptCodeOperation(label="Use input", code="derived = data"),
+            start_label="Run script",
+            active_name="derived",
+        )
+    )
+    assert win.slicer_area._provenance_reload_unavailable_reason() is not None
+
+    manager = types.SimpleNamespace(
+        target_from_slicer_area=lambda _area: "target",
+        _reload_target_for_child=lambda _target: None,
+        _reload_unavailable_reason_for_target=lambda _target: "manager reason",
+    )
+    with monkeypatch.context() as patch:
+        patch.setattr(win.slicer_area, "_in_manager", True)
+        patch.setattr(
+            type(win.slicer_area), "_manager_instance", property(lambda _: manager)
+        )
+        assert win.slicer_area._reload_unavailable_reason() == "manager reason"
+        manager.target_from_slicer_area = lambda _area: None
+        assert win.slicer_area._reload_unavailable_reason()
+
     win.close()
 
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -591,6 +591,68 @@ def test_tool_window_reload_refresh_ignores_deleted_file_menu(qtbot) -> None:
     assert not tool.reload_source_data()
 
 
+def test_reload_unavailable_dialog_executes_information_message(
+    qtbot,
+    monkeypatch,
+) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    exec_calls: list[MessageDialog] = []
+
+    def _exec(dialog: MessageDialog) -> int:
+        exec_calls.append(dialog)
+        return int(QtWidgets.QDialog.DialogCode.Accepted)
+
+    monkeypatch.setattr(erlab.interactive.utils.MessageDialog, "exec", _exec)
+
+    result = erlab.interactive.utils._show_reload_unavailable_dialog(
+        parent,
+        "specific reason",
+    )
+
+    assert result == int(QtWidgets.QDialog.DialogCode.Accepted)
+    assert exec_calls
+    assert exec_calls[0].informativeText() == "specific reason"
+
+
+def test_tool_window_reload_unavailable_reason_falls_back_after_callback_error(
+    qtbot,
+    monkeypatch,
+) -> None:
+    tool = erlab.interactive.utils.ToolWindow()
+    qtbot.addWidget(tool)
+    unavailable_reasons: list[str] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_show_reload_unavailable_dialog",
+        lambda _parent, reason: unavailable_reasons.append(reason),
+    )
+
+    tool._set_managed_source_reload(
+        lambda: True,
+        lambda: False,
+        lambda: "custom reason",
+    )
+    assert tool._source_reload_unavailable_reason() == "custom reason"
+    assert tool.reload_data_action.isVisible()
+    assert tool.reload_data_action.isEnabled()
+    tool._set_managed_source_reload(lambda: True, lambda: False)
+    assert tool._source_reload_unavailable_reason()
+
+    def _raise_reason() -> str:
+        raise RuntimeError("boom")
+
+    tool._set_managed_source_reload(
+        lambda: True,
+        lambda: False,
+        _raise_reason,
+    )
+    assert not tool.reload_source_data()
+    assert unavailable_reasons
+    assert unavailable_reasons[-1]
+    assert unavailable_reasons[-1] == tool.reload_data_action.toolTip()
+
+
 def test_close_shortcut_reaches_child_line_edit(qtbot) -> None:
     window = QtWidgets.QMainWindow()
     line_edit = QtWidgets.QLineEdit(window)


### PR DESCRIPTION
## Summary
- Keep Reload Data actions visible when reload is relevant, and surface a tooltip or dialog explaining why it cannot run yet.
- Add manager and slicer-area reasoning for missing files, unavailable loaders, and non-replayable provenance.
- Update the manager docs to describe the new behavior when source data cannot be reloaded.

## Testing
- Added manager and ImageTool tests covering unavailable reload reasons, dialog paths, and successful child reloads through the manager.
- Existing reload behavior is still covered for reloadable sources and provenance-backed inputs.