### PR TITLE
Fix compatibility test Qt teardown crashes

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -127,11 +127,14 @@ jobs:
             -v
             -o faulthandler_timeout=300
             -o junit_family=legacy
+          )
+          xdist_args=(
             -n auto
             --dist=loadgroup
           )
           uv run pytest \
             "${common_args[@]}" \
+            "${xdist_args[@]}" \
             -m "not gui" \
             --junitxml "junit-${{ matrix.python-version }}-${{ matrix.qt-api }}-non-gui.xml"
           uv run pytest \

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -108,8 +108,7 @@ GUI_PREFIXES: tuple[str, ...] = ("tests/interactive/",)
 GUI_TARGETS: tuple[str, ...] = ()
 
 SERIAL_PREFIX_GROUPS: tuple[tuple[str, str | None], ...] = (
-    ("tests/interactive/imagetool/manager/", None),
-    ("tests/interactive/imagetool/", None),
+    ("tests/interactive/", None),
 )
 SERIAL_TARGET_GROUPS: dict[str, str] = {
     "tests/io/plugins/test_erpes.py": "hdf5-cache",

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -800,8 +800,12 @@ class ItoolColormapControls(ItoolControlsBase):
             return
         try:
             lock_levels_act = slicer_area.lock_levels_act
-        except (AttributeError, RuntimeError):  # pragma: no cover - teardown edge
+        except AttributeError:  # pragma: no cover - teardown edge
             return
+        except RuntimeError as exc:  # pragma: no cover - teardown edge
+            if erlab.interactive.utils._is_deleted_qt_wrapper_error(exc):
+                return
+            raise
         if not erlab.interactive.utils.qt_is_valid(lock_levels_act):  # pragma: no cover
             return
         super().update_content()
@@ -812,14 +816,15 @@ class ItoolColormapControls(ItoolControlsBase):
         try:
             colormap = slicer_area.colormap
             gamma = slicer_area.colormap_properties["gamma"]
-        except RuntimeError:  # pragma: no cover - teardown edge
-            return
+        except RuntimeError as exc:  # pragma: no cover - teardown edge
+            if erlab.interactive.utils._is_deleted_qt_wrapper_error(exc):
+                return
+            raise
         if isinstance(colormap, str):  # pragma: no branch
             with QtCore.QSignalBlocker(self.cb_colormap):
                 self.cb_colormap.setDefaultCmap(colormap)
-        self.gamma_widget.blockSignals(True)
-        self.gamma_widget.setValue(gamma)
-        self.gamma_widget.blockSignals(False)
+        with QtCore.QSignalBlocker(self.gamma_widget):
+            self.gamma_widget.setValue(gamma)
 
     def connect_signals(self) -> None:
         super().connect_signals()

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -790,20 +790,35 @@ class ItoolColormapControls(ItoolControlsBase):
         self.slicer_area.set_colormap(gamma=gamma)
 
     def update_content(self) -> None:
+        try:
+            slicer_area = self.slicer_area
+        except LookupError:  # pragma: no cover - teardown edge
+            return
         if not erlab.interactive.utils.qt_is_valid(
-            self, self.cb_colormap, self.gamma_widget, self.slicer_area
+            self, self.cb_colormap, self.gamma_widget, slicer_area
         ):  # pragma: no cover
             return
-        with contextlib.suppress(AttributeError):
-            if not erlab.interactive.utils.qt_is_valid(
-                self.slicer_area.lock_levels_act
-            ):  # pragma: no cover
-                return
+        try:
+            lock_levels_act = slicer_area.lock_levels_act
+        except (AttributeError, RuntimeError):  # pragma: no cover - teardown edge
+            return
+        if not erlab.interactive.utils.qt_is_valid(lock_levels_act):  # pragma: no cover
+            return
         super().update_content()
-        if isinstance(self.slicer_area.colormap, str):  # pragma: no branch
-            self.cb_colormap.setDefaultCmap(self.slicer_area.colormap)
+        if not erlab.interactive.utils.qt_is_valid(
+            self, self.cb_colormap, self.gamma_widget, slicer_area
+        ):  # pragma: no cover
+            return
+        try:
+            colormap = slicer_area.colormap
+            gamma = slicer_area.colormap_properties["gamma"]
+        except RuntimeError:  # pragma: no cover - teardown edge
+            return
+        if isinstance(colormap, str):  # pragma: no branch
+            with QtCore.QSignalBlocker(self.cb_colormap):
+                self.cb_colormap.setDefaultCmap(colormap)
         self.gamma_widget.blockSignals(True)
-        self.gamma_widget.setValue(self.slicer_area.colormap_properties["gamma"])
+        self.gamma_widget.setValue(gamma)
         self.gamma_widget.blockSignals(False)
 
     def connect_signals(self) -> None:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1116,7 +1116,15 @@ class ImageSlicerArea(QtWidgets.QWidget):
         entry = self._pending_history_entry
         if entry is None:
             return
-        if not erlab.interactive.utils.qt_is_valid(self, self.lock_levels_act):
+        if not erlab.interactive.utils.qt_is_valid(self):
+            self._discard_pending_history_entry()
+            return
+        try:
+            lock_levels_act = self.lock_levels_act
+        except RuntimeError:
+            self._discard_pending_history_entry()
+            return
+        if not erlab.interactive.utils.qt_is_valid(lock_levels_act):
             self._discard_pending_history_entry()
             return
 
@@ -1128,6 +1136,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 self._prev_states.remove(entry)
             self._pending_history_entry = None
             self._pending_history_committed = False
+            if not erlab.interactive.utils.qt_is_valid(self):
+                return
             self.sigHistoryChanged.emit()
             return
 
@@ -1139,6 +1149,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if not keep_pending:
             self._pending_history_entry = None
             self._pending_history_committed = False
+        if not erlab.interactive.utils.qt_is_valid(self):
+            return
         self.sigHistoryChanged.emit()
 
     def record_history_mutation(

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -1121,9 +1121,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
             return
         try:
             lock_levels_act = self.lock_levels_act
-        except RuntimeError:
-            self._discard_pending_history_entry()
-            return
+        except RuntimeError as exc:
+            if erlab.interactive.utils._is_deleted_qt_wrapper_error(exc):
+                self._discard_pending_history_entry()
+                return
+            raise
         if not erlab.interactive.utils.qt_is_valid(lock_levels_act):
             self._discard_pending_history_entry()
             return

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -176,7 +176,9 @@ def qt_is_valid(*objects: object) -> bool:
 
 def _is_deleted_qt_wrapper_error(exc: RuntimeError) -> bool:
     message = str(exc)
-    return "wrapped C/C++ object" in message and "has been deleted" in message
+    return ("wrapped C/C++ object" in message and "has been deleted" in message) or (
+        "Internal C++ object" in message and "already deleted" in message
+    )
 
 
 _ERLAB_CURSOR_SHAPE_PROPERTY = "_erlab_cursor_shape"
@@ -274,7 +276,7 @@ def single_shot(
         try:
             callback()
         except RuntimeError as exc:  # pragma: no cover
-            if "has been deleted" in str(exc):
+            if _is_deleted_qt_wrapper_error(exc):
                 return
             raise
 

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -174,6 +174,11 @@ def qt_is_valid(*objects: object) -> bool:
     return all(obj is None or _qt_object_is_valid(obj) for obj in objects)
 
 
+def _is_deleted_qt_wrapper_error(exc: RuntimeError) -> bool:
+    message = str(exc)
+    return "wrapped C/C++ object" in message and "has been deleted" in message
+
+
 _ERLAB_CURSOR_SHAPE_PROPERTY = "_erlab_cursor_shape"
 _ERLAB_CURSOR_UNSET = "unset"
 _MPL_QT_CURSOR_PATCH_ATTR = "_erlab_original_set_cursor"
@@ -2062,6 +2067,16 @@ class BetterSpinBox(QtWidgets.QAbstractSpinBox):
 class BetterAxisItem(pg.AxisItem):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+
+    def paint(self, painter, option, widget=None):
+        if not qt_is_valid(self):
+            return None
+        try:
+            return super().paint(painter, option, widget)
+        except RuntimeError as exc:
+            if _is_deleted_qt_wrapper_error(exc):
+                return None
+            raise
 
     def updateAutoSIPrefix(self) -> None:
         if self.label.isVisible():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,11 @@ import erlab
 import erlab.interactive.imagetool.manager as imagetool_manager
 import erlab.interactive.imagetool.manager._registry as imagetool_manager_registry
 import erlab.interactive.imagetool.manager._server as imagetool_manager_server
-from erlab.interactive.utils import _WaitDialog, qt_is_valid
+from erlab.interactive.utils import (
+    _is_deleted_qt_wrapper_error,
+    _WaitDialog,
+    qt_is_valid,
+)
 from erlab.io.dataloader import LoaderBase
 from erlab.io.exampledata import generate_data_angles, generate_gold_edge
 
@@ -63,11 +67,6 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _TEST_OPTIONS_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH"
 _TEST_OPTIONS_MANAGED_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH_TEST_MANAGED"
 _TEST_INTERACTIVE_OPTIONS_PATHS: list[pathlib.Path] = []
-_DELETED_QT_WRAPPER_PATTERN = re.compile(r"wrapped C/C\+\+ object .* has been deleted")
-
-
-def _is_deleted_qt_wrapper_error(exc: RuntimeError) -> bool:
-    return _DELETED_QT_WRAPPER_PATTERN.search(str(exc)) is not None
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -793,14 +793,13 @@ def serialize_hdf5_loads():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def patch_pyqtgraph_teardown_callbacks():
-    """Guard pyqtgraph callbacks during Qt teardown."""
+def patch_pyqtgraph_boundingrect():
+    """Guard pyqtgraph InfiniteLine boundingRect during Qt teardown."""
     mp = pytest.MonkeyPatch()
     import pyqtgraph as pg
     from qtpy import QtCore
 
     original_br = pg.InfiniteLine.boundingRect
-    original_graphics_view_close = pg.GraphicsView.closeEvent
 
     def safe_br(self):
         if not qt_is_valid(self):
@@ -820,36 +819,7 @@ def patch_pyqtgraph_teardown_callbacks():
                 return QtCore.QRectF()
             raise
 
-    def safe_graphics_view_close(self, event):
-        self.setProperty("_erlab_test_closing", True)
-        return original_graphics_view_close(self, event)
-
-    def safe_graphics_view_paint(self, event):
-        if (
-            self.property("_erlab_test_closing")
-            or not qt_is_valid(self)
-            or not self.isVisible()
-        ):
-            return
-        try:
-            scene = self.scene()
-        except RuntimeError as exc:
-            if _is_deleted_qt_wrapper_error(exc):
-                return
-            raise
-        if not qt_is_valid(scene):
-            return
-        try:
-            scene.prepareForPaint()
-        except RuntimeError as exc:
-            if _is_deleted_qt_wrapper_error(exc):
-                return
-            raise
-        return
-
     mp.setattr(pg.InfiniteLine, "boundingRect", safe_br, raising=False)
-    mp.setattr(pg.GraphicsView, "closeEvent", safe_graphics_view_close, raising=False)
-    mp.setattr(pg.GraphicsView, "paintEvent", safe_graphics_view_paint, raising=False)
     try:
         yield
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -793,13 +793,14 @@ def serialize_hdf5_loads():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def patch_pyqtgraph_boundingrect():
-    """Guard pyqtgraph InfiniteLine boundingRect during Qt teardown."""
+def patch_pyqtgraph_teardown_callbacks():
+    """Guard pyqtgraph callbacks during Qt teardown."""
     mp = pytest.MonkeyPatch()
     import pyqtgraph as pg
     from qtpy import QtCore
 
     original_br = pg.InfiniteLine.boundingRect
+    original_graphics_view_close = pg.GraphicsView.closeEvent
 
     def safe_br(self):
         if not qt_is_valid(self):
@@ -819,7 +820,36 @@ def patch_pyqtgraph_boundingrect():
                 return QtCore.QRectF()
             raise
 
+    def safe_graphics_view_close(self, event):
+        self.setProperty("_erlab_test_closing", True)
+        return original_graphics_view_close(self, event)
+
+    def safe_graphics_view_paint(self, event):
+        if (
+            self.property("_erlab_test_closing")
+            or not qt_is_valid(self)
+            or not self.isVisible()
+        ):
+            return
+        try:
+            scene = self.scene()
+        except RuntimeError as exc:
+            if _is_deleted_qt_wrapper_error(exc):
+                return
+            raise
+        if not qt_is_valid(scene):
+            return
+        try:
+            scene.prepareForPaint()
+        except RuntimeError as exc:
+            if _is_deleted_qt_wrapper_error(exc):
+                return
+            raise
+        return
+
     mp.setattr(pg.InfiniteLine, "boundingRect", safe_br, raising=False)
+    mp.setattr(pg.GraphicsView, "closeEvent", safe_graphics_view_close, raising=False)
+    mp.setattr(pg.GraphicsView, "paintEvent", safe_graphics_view_paint, raising=False)
     try:
         yield
     finally:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -38,6 +38,7 @@ import erlab.interactive._figurecomposer._widgets as figurecomposer_widgets
 import erlab.interactive._stylesheets
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._workspace as manager_workspace
+import erlab.interactive.imagetool.plot_items as imagetool_plot_items
 import erlab.plotting as eplt
 from erlab.interactive._figurecomposer import (
     FigureAxesSelectionState,
@@ -1464,17 +1465,8 @@ def test_imagetool_rejects_uneditable_plot_slices_selection(qtbot) -> None:
 def test_imagetool_plot_slices_selection_warning_shows_error_detail(
     qtbot, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    tool = erlab.interactive.itool(
-        _unsupported_plot_slices_data(), manager=False, execute=False
-    )
-    assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
-    qtbot.addWidget(tool)
-
-    _set_unsupported_plot_slices_cursor_state(tool)
-
-    with pytest.raises(FigureComposerPlotSlicesSelectionError) as exc_info:
-        tool.slicer_area.images[0].figure_composer_operation(source_name="data")
-
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
     messages: list[tuple[QtWidgets.QWidget | None, str, str]] = []
 
     def warning(
@@ -1485,12 +1477,15 @@ def test_imagetool_plot_slices_selection_warning_shows_error_detail(
 
     monkeypatch.setattr(QtWidgets.QMessageBox, "warning", warning)
 
-    tool.slicer_area.images[0]._show_plot_slices_selection_error(
-        tool.slicer_area, exc_info.value
+    imagetool_plot_items.ItoolPlotItem._show_plot_slices_selection_error(
+        parent,
+        FigureComposerPlotSlicesSelectionError(
+            "Cannot plot when more than one dimension"
+        ),
     )
 
     assert len(messages) == 1
-    assert messages[0][0] is tool.slicer_area
+    assert messages[0][0] is parent
     assert messages[0][1] == "Cannot Create Plot Slices Figure"
     assert "Details:" in messages[0][2]
     assert "Cannot plot when more than one dimension" in messages[0][2]

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1447,10 +1447,7 @@ def test_imagetool_main_image_seeds_plot_slices_selection_with_spaced_dim(
 
 
 def test_imagetool_rejects_uneditable_plot_slices_selection(qtbot) -> None:
-    tool = erlab.interactive.itool(
-        _unsupported_plot_slices_data(), manager=False, execute=False
-    )
-    assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+    tool = erlab.interactive.imagetool.ImageTool(_unsupported_plot_slices_data())
     qtbot.addWidget(tool)
 
     _set_unsupported_plot_slices_cursor_state(tool)
@@ -1467,6 +1464,7 @@ def test_imagetool_plot_slices_selection_warning_shows_error_detail(
 ) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
+
     messages: list[tuple[QtWidgets.QWidget | None, str, str]] = []
 
     def warning(

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 from qtpy import QtCore, QtWidgets
 
+import erlab.interactive.imagetool.viewer as imagetool_viewer
 import erlab.interactive.utils
 from erlab.interactive.imagetool import ImageTool, _history
 from erlab.interactive.imagetool.controls import (
@@ -740,6 +741,153 @@ def test_history_finalize_removes_committed_noop_entry_and_suppressed_write(qtbo
 
     assert entry not in area._prev_states
     assert area._pending_history_entry is None
+    win.close()
+
+
+def test_history_finalize_discards_when_area_invalid(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    area.begin_history_entry(None)
+
+    original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+
+    def qt_is_valid(*objects: object) -> bool:
+        if area in objects:
+            return False
+        return original_qt_is_valid(*objects)
+
+    with monkeypatch.context() as context:
+        context.setattr(erlab.interactive.utils, "qt_is_valid", qt_is_valid)
+        area.finalize_history_entry()
+
+    assert area._pending_history_entry is None
+    assert not area._pending_history_committed
+    win.close()
+
+
+def test_history_finalize_discards_deleted_lock_action_wrapper(monkeypatch) -> None:
+    class Area:
+        _pending_history_entry = object()
+        _pending_history_committed = True
+        discarded = False
+
+        @property
+        def lock_levels_act(self):
+            raise RuntimeError("wrapped C/C++ object has been deleted")
+
+        def _discard_pending_history_entry(self) -> None:
+            self.discarded = True
+            self._pending_history_entry = None
+            self._pending_history_committed = False
+
+    area = Area()
+    with monkeypatch.context() as context:
+        context.setattr(erlab.interactive.utils, "qt_is_valid", lambda *_args: True)
+        imagetool_viewer.ImageSlicerArea.finalize_history_entry(area)
+
+    assert area.discarded
+    assert area._pending_history_entry is None
+    assert not area._pending_history_committed
+
+
+def test_history_finalize_reraises_unexpected_lock_action_error(monkeypatch) -> None:
+    class Area:
+        _pending_history_entry = object()
+
+        @property
+        def lock_levels_act(self):
+            raise RuntimeError("unrelated failure")
+
+    with monkeypatch.context() as context:
+        context.setattr(erlab.interactive.utils, "qt_is_valid", lambda *_args: True)
+        with pytest.raises(RuntimeError, match="unrelated failure"):
+            imagetool_viewer.ImageSlicerArea.finalize_history_entry(Area())
+
+
+def test_history_finalize_discards_invalid_lock_action(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    area.begin_history_entry(None)
+    lock_levels_act = area.lock_levels_act
+    original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+
+    def qt_is_valid(*objects: object) -> bool:
+        if lock_levels_act in objects:
+            return False
+        return original_qt_is_valid(*objects)
+
+    with monkeypatch.context() as context:
+        context.setattr(erlab.interactive.utils, "qt_is_valid", qt_is_valid)
+        area.finalize_history_entry()
+
+    assert area._pending_history_entry is None
+    assert not area._pending_history_committed
+    win.close()
+
+
+def test_history_finalize_noop_skips_signal_when_invalid_before_emit(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    area.begin_history_entry(None)
+    emissions: list[None] = []
+    area.sigHistoryChanged.connect(lambda: emissions.append(None))
+    original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+    area_valid_calls = 0
+
+    def qt_is_valid(*objects: object) -> bool:
+        nonlocal area_valid_calls
+        if objects == (area,):
+            area_valid_calls += 1
+            return area_valid_calls == 1
+        return original_qt_is_valid(*objects)
+
+    with monkeypatch.context() as context:
+        context.setattr(erlab.interactive.utils, "qt_is_valid", qt_is_valid)
+        area.finalize_history_entry()
+
+    assert emissions == []
+    assert area._pending_history_entry is None
+    assert not area._pending_history_committed
+    win.close()
+
+
+def test_history_finalize_changed_skips_signal_when_invalid_before_emit(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+    win = ImageTool(data)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    area.begin_history_entry(None)
+    area.set_manual_limits({"x": [0.0, 1.0]})
+    emissions: list[None] = []
+    area.sigHistoryChanged.connect(lambda: emissions.append(None))
+    original_qt_is_valid = erlab.interactive.utils.qt_is_valid
+    area_valid_calls = 0
+
+    def qt_is_valid(*objects: object) -> bool:
+        nonlocal area_valid_calls
+        if objects == (area,):
+            area_valid_calls += 1
+            return area_valid_calls == 1
+        return original_qt_is_valid(*objects)
+
+    with monkeypatch.context() as context:
+        context.setattr(erlab.interactive.utils, "qt_is_valid", qt_is_valid)
+        area.finalize_history_entry()
+
+    assert emissions == []
+    assert area._pending_history_entry is None
+    assert not area._pending_history_committed
+    assert len(area._prev_states) == 1
     win.close()
 
 

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -83,6 +83,13 @@ def _make_da_ktool_data(anglemap) -> xr.DataArray:
     return data.assign_coords(xi=0.0, chi=0.0)
 
 
+def _add_kspace_conversion_dialog(qtbot, slicer_area) -> KspaceConversionDialog:
+    dialog = KspaceConversionDialog(slicer_area)
+    dialog.setParent(None)
+    qtbot.addWidget(dialog)
+    return dialog
+
+
 def _memory_budget(
     *,
     total: int = 64 * _GIB,
@@ -194,8 +201,7 @@ def test_kspace_conversion_dialog_requires_configuration(
 
     win = erlab.interactive.itool(data, execute=False)
     qtbot.addWidget(win)
-    dialog = KspaceConversionDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
 
     assert dialog._compatible is False
     assert not hasattr(dialog, "configuration_combo")
@@ -673,9 +679,7 @@ def test_kspace_memory_estimate_labels_wrap(qtbot, anglemap) -> None:
     qtbot.addWidget(win)
     dialog_host = erlab.interactive.itool(data, execute=False)
     qtbot.addWidget(dialog_host)
-    dialog = KspaceConversionDialog(dialog_host.slicer_area)
-    dialog.setParent(None)
-    qtbot.addWidget(dialog)
+    dialog = _add_kspace_conversion_dialog(qtbot, dialog_host.slicer_area)
 
     for label in (win._memory_estimate_label, dialog._memory_estimate_label):
         assert label.wordWrap()
@@ -923,8 +927,7 @@ def test_kspace_conversion_dialog_code_and_result(qtbot, anglemap, kind) -> None
 
     win = erlab.interactive.itool(data, execute=False)
     qtbot.addWidget(win)
-    dialog = KspaceConversionDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
 
     assert not {"delta", "xi", "beta", "chi"} & set(dialog._offset_spins)
     assert ("V0" in dialog._offset_spins) is data.kspace._has_hv
@@ -977,8 +980,7 @@ def test_kspace_conversion_dialog_unsafe_accept_shows_error(
     data = anglemap.qsel(eV=-0.1).copy(deep=True)
     win = erlab.interactive.itool(data, execute=False)
     qtbot.addWidget(win)
-    dialog = KspaceConversionDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
     messages: list[tuple[tuple, dict]] = []
     monkeypatch.setattr(
         erlab.interactive.utils.MessageDialog,
@@ -1015,9 +1017,7 @@ def test_kspace_conversion_dialog_estimate_defensive_paths(
     data = _make_da_ktool_data(anglemap)
     win = erlab.interactive.itool(data, execute=False)
     qtbot.addWidget(win)
-    dialog = KspaceConversionDialog(win.slicer_area)
-    dialog.setParent(None)
-    qtbot.addWidget(dialog)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
     dialog._set_control_configuration(int(AxesConfiguration.Type2DA))
 
     estimate = dialog.conversion_estimate_for_data(data)
@@ -1066,8 +1066,7 @@ def test_kspace_conversion_dialog_seeds_from_newest_ktool(qtbot, anglemap) -> No
     win.slicer_area.add_tool_window(first)
     win.slicer_area.add_tool_window(second)
 
-    dialog = KspaceConversionDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
 
     assert dialog._offset_spins["wf"].value() == pytest.approx(4.75)
     assert dialog._normal_delta == pytest.approx(12.5)
@@ -1098,8 +1097,7 @@ def test_kspace_conversion_dialog_seeds_hv_inner_potential_from_ktool(
     child._offset_spins["V0"].setValue(14.0)
     win.slicer_area.add_tool_window(child)
 
-    dialog = KspaceConversionDialog(win.slicer_area)
-    qtbot.addWidget(dialog)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
 
     assert dialog._offset_spins["V0"].value() == pytest.approx(14.0)
 
@@ -1138,9 +1136,7 @@ def test_kspace_conversion_dialog_restores_unordered_setup_group(
     data = anglemap.qsel(eV=-0.1).copy(deep=True)
     win = erlab.interactive.itool(data, execute=False)
     qtbot.addWidget(win)
-    dialog = KspaceConversionDialog(win.slicer_area)
-    dialog.setParent(None)
-    qtbot.addWidget(dialog)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
     axes = tuple(dialog._control_data.kspace.momentum_axes)
     bounds = dict.fromkeys(axes, (-0.03, 0.04))
     resolution = dict.fromkeys(axes, 0.02)

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -90,6 +90,12 @@ def _add_kspace_conversion_dialog(qtbot, slicer_area) -> KspaceConversionDialog:
     return dialog
 
 
+def _add_hidden_tool(qtbot, widget):
+    qtbot.addWidget(widget)
+    widget.hide()
+    return widget
+
+
 def _memory_budget(
     *,
     total: int = 64 * _GIB,
@@ -200,7 +206,7 @@ def test_kspace_conversion_dialog_requires_configuration(
     del data.attrs["configuration"]
 
     win = erlab.interactive.itool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
 
     assert dialog._compatible is False
@@ -460,7 +466,7 @@ def test_ktool(qtbot, anglemap, wf, kind, assignment) -> None:
         cmap="terrain_r",
         execute=False,
     )
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     win.centering_combo.setCurrentText("I")
     if not win.data.kspace._has_hv:
         win.kz_spin.setValue(0.5)
@@ -525,7 +531,7 @@ def test_ktool(qtbot, anglemap, wf, kind, assignment) -> None:
         win.to_file(filename)
 
         win_restored = erlab.interactive.utils.ToolWindow.from_file(filename)
-        qtbot.addWidget(win_restored)
+        _add_hidden_tool(qtbot, win_restored)
         assert isinstance(win_restored, KspaceTool)
 
         assert win.tool_status == win_restored.tool_status
@@ -537,7 +543,7 @@ def test_ktool_angle_energy_cut(qtbot, anglemap) -> None:
         anglemap.isel(alpha=slice(0, 4), eV=slice(0, 5)).qsel(beta=-8.3).copy(deep=True)
     )
     win = cut.kspace.interactive(data_name="cut", execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert isinstance(win, KspaceTool)
     assert win.energy_group.isEnabled() is False
@@ -580,7 +586,7 @@ def test_ktool_unsafe_preview_clears_kspace_image(
     data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
     data.kspace.work_function = 4.5
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     assert win.images[1].data_array is not None
 
     monkeypatch.setattr(
@@ -617,7 +623,7 @@ def test_ktool_preview_guard_estimates_full_output_data(
     data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
     data.kspace.work_function = 4.5
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     win.resolution_supergroup.setChecked(True)
 
     preview_data = win._preview_angle_data()
@@ -676,9 +682,9 @@ def test_kspace_memory_estimate_labels_wrap(qtbot, anglemap) -> None:
     data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
     data.kspace.work_function = 4.5
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     dialog_host = erlab.interactive.itool(data, execute=False)
-    qtbot.addWidget(dialog_host)
+    _add_hidden_tool(qtbot, dialog_host)
     dialog = _add_kspace_conversion_dialog(qtbot, dialog_host.slicer_area)
 
     for label in (win._memory_estimate_label, dialog._memory_estimate_label):
@@ -700,7 +706,7 @@ def test_ktool_unsafe_output_shows_blocking_error(
     data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
     data.kspace.work_function = 4.5
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     messages: list[tuple[tuple, dict]] = []
     monkeypatch.setattr(
         erlab.interactive.utils.MessageDialog,
@@ -761,7 +767,7 @@ def test_ktool_normal_emission_updates_offsets(
     )
 
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert win.normal_emission_group.title() == "Normal Emission"
 
@@ -806,7 +812,7 @@ def test_ktool_normal_emission_spins_follow_offsets(
     )
 
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     for key, value in reference_offsets.items():
         win._offset_spins[key].setValue(value)
@@ -827,7 +833,7 @@ def test_ktool_normal_emission_zero_offsets_are_finite_for_da(qtbot, anglemap) -
     )
 
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert np.isfinite(win._normal_emission_spins["alpha"].value())
     assert np.isfinite(win._normal_emission_spins["beta"].value())
@@ -874,7 +880,7 @@ def test_ktool_initial_normal_emission_seed(
         execute=False,
         initial_normal_emission=(alpha_normal, beta_normal),
     )
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert win._normal_emission_spins["alpha"].value() == pytest.approx(
         alpha_normal, abs=1e-3
@@ -905,7 +911,7 @@ def test_ktool_initial_delta_overrides_delta(qtbot, anglemap) -> None:
         initial_normal_emission=(alpha_normal, beta_normal),
         initial_delta=14.5,
     )
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert win._offset_spins["delta"].value() == pytest.approx(14.5)
     for key in expected.kspace._valid_offset_keys:
@@ -926,7 +932,7 @@ def test_kspace_conversion_dialog_code_and_result(qtbot, anglemap, kind) -> None
         data = generate_hvdep_cuts((8, 10, 7), hvrange=(20.0, 30.0), noise=False)
 
     win = erlab.interactive.itool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
 
     assert not {"delta", "xi", "beta", "chi"} & set(dialog._offset_spins)
@@ -979,7 +985,7 @@ def test_kspace_conversion_dialog_unsafe_accept_shows_error(
 ) -> None:
     data = anglemap.qsel(eV=-0.1).copy(deep=True)
     win = erlab.interactive.itool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
     messages: list[tuple[tuple, dict]] = []
     monkeypatch.setattr(
@@ -1016,7 +1022,7 @@ def test_kspace_conversion_dialog_estimate_defensive_paths(
 ) -> None:
     data = _make_da_ktool_data(anglemap)
     win = erlab.interactive.itool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
     dialog._set_control_configuration(int(AxesConfiguration.Type2DA))
 
@@ -1038,12 +1044,12 @@ def test_kspace_conversion_dialog_estimate_defensive_paths(
 def test_kspace_conversion_dialog_seeds_from_newest_ktool(qtbot, anglemap) -> None:
     data = anglemap.qsel(eV=-0.1).copy(deep=True)
     win = erlab.interactive.itool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     first = ktool(data, execute=False)
     second = ktool(data, execute=False)
-    qtbot.addWidget(first)
-    qtbot.addWidget(second)
+    _add_hidden_tool(qtbot, first)
+    _add_hidden_tool(qtbot, second)
     first._offset_spins["wf"].setValue(3.25)
     second._offset_spins["wf"].setValue(4.75)
     second._offset_spins["delta"].setValue(12.5)
@@ -1090,10 +1096,10 @@ def test_kspace_conversion_dialog_seeds_hv_inner_potential_from_ktool(
 ) -> None:
     data = generate_hvdep_cuts((8, 10, 7), hvrange=(20.0, 30.0), noise=False)
     win = erlab.interactive.itool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     child = ktool(data, execute=False)
-    qtbot.addWidget(child)
+    _add_hidden_tool(qtbot, child)
     child._offset_spins["V0"].setValue(14.0)
     win.slicer_area.add_tool_window(child)
 
@@ -1135,7 +1141,7 @@ def test_kspace_conversion_dialog_restores_unordered_setup_group(
 ) -> None:
     data = anglemap.qsel(eV=-0.1).copy(deep=True)
     win = erlab.interactive.itool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
     axes = tuple(dialog._control_data.kspace.momentum_axes)
     bounds = dict.fromkeys(axes, (-0.03, 0.04))
@@ -1278,7 +1284,7 @@ def test_ktool_copy_code_uses_set_normal(
 ) -> None:
     data = _make_ktool_data(anglemap, configuration, coords)
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     for key, value in reference_offsets.items():
         win._offset_spins[key].setValue(value)
@@ -1335,7 +1341,7 @@ def test_ktool_configuration_combo_rebuilds_controls_and_code(
 ) -> None:
     data = _make_da_ktool_data(anglemap)
     win = ktool(data, data_name="scan", execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert win.configuration_combo.count() == len(AxesConfiguration)
     index = win.configuration_combo.findData(int(target_configuration))
@@ -1364,7 +1370,7 @@ def test_ktool_configuration_combo_rebuilds_controls_and_code(
 def test_ktool_configuration_state_edges(qtbot, anglemap) -> None:
     data = _make_da_ktool_data(anglemap)
     win = ktool(data, data_name="scan", execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     with imagetool_dialogs.QtCore.QSignalBlocker(win.configuration_combo):
         win.configuration_combo.setCurrentIndex(-1)
@@ -1405,7 +1411,7 @@ def test_ktool_configuration_state_round_trip_output_provenance_and_update_data(
 ) -> None:
     data = _make_da_ktool_data(anglemap)
     win = ktool(data, data_name="scan", execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     target_configuration = AxesConfiguration.Type2DA
     win.configuration_combo.setCurrentIndex(
         win.configuration_combo.findData(int(target_configuration))
@@ -1431,7 +1437,7 @@ def test_ktool_configuration_state_round_trip_output_provenance_and_update_data(
         filename = f"{tmp_dir_name}/tool_save.h5"
         win.to_file(filename)
         win_restored = erlab.interactive.utils.ToolWindow.from_file(filename)
-        qtbot.addWidget(win_restored)
+        _add_hidden_tool(qtbot, win_restored)
         assert isinstance(win_restored, KspaceTool)
         assert win_restored.data.kspace.configuration == target_configuration
         assert win_restored.tool_status.configuration == int(target_configuration)
@@ -1450,7 +1456,7 @@ def test_ktool_configuration_state_round_trip_output_provenance_and_update_data(
 def test_ktool_output_provenance_uses_converted_output_name(qtbot) -> None:
     data = generate_hvdep_cuts((15, 30, 20), hvrange=(20.0, 30.0), noise=False)
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     converted = win.output_imagetool_data(KspaceTool.Output.CONVERTED)
     assert converted is not None
@@ -1472,7 +1478,7 @@ def test_ktool_output_provenance_uses_converted_output_name(qtbot) -> None:
 def test_ktool_copy_code_aliases_expression_input_names(qtbot) -> None:
     data = generate_hvdep_cuts((15, 30, 20), hvrange=(20.0, 30.0), noise=False)
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     win.set_input_provenance_spec(
         erlab.interactive.imagetool.provenance.script(
             start_label="Start from watched variable 'my_data'",
@@ -1503,7 +1509,7 @@ def test_ktool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> No
     )
     source_data = source.apply(data)
     win = ktool(source_data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     win.set_source_binding(source)
     win.set_input_provenance_parent_fetcher(lambda: parent_provenance)
 
@@ -1521,7 +1527,7 @@ def test_ktool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> No
 
 def test_ktool_update_rate_limited(qtbot, anglemap, monkeypatch) -> None:
     win = ktool(anglemap, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     # Allow any startup-triggered delayed update to finish before counting.
     wait_ms = int(1000 / win._UPDATE_LIMIT_HZ) + 50
@@ -1556,7 +1562,7 @@ def test_ktool_kinetic_energy_axis_preview(qtbot, anglemap) -> None:
     data = data.assign_coords(eV=data.hv - data.kspace.work_function + data.eV)
 
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     min0, max0 = win.center_spin.minimum(), win.center_spin.maximum()
     win._offset_spins["wf"].setValue(win._offset_spins["wf"].value() - 0.2)
@@ -1599,7 +1605,7 @@ def test_ktool_bounds_estimate_uses_current_inner_potential(qtbot) -> None:
     data.kspace.inner_potential = 10.0
 
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     initial_kz_bounds = (
         win._bound_spins["kz0"].value(),
@@ -1625,7 +1631,7 @@ def test_ktool_bounds_estimate_uses_current_inner_potential(qtbot) -> None:
 def test_ktool_resolution_estimate_uses_current_work_function(qtbot, anglemap) -> None:
     data = anglemap.copy().assign_coords(hv=6.0)
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     initial_kx_resolution = win._resolution_spins["kx"].value()
     win._offset_spins["wf"].setValue(3.0)
@@ -1651,7 +1657,7 @@ def test_ktool_suppresses_missing_kspace_parameter_warnings(qtbot) -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert not _missing_kspace_parameter_warnings(caught)
     assert win._offset_spins["wf"].value() == pytest.approx(4.5)
@@ -1681,7 +1687,7 @@ def test_ktool_shallow_copy_paths_do_not_mutate_tool_data_attrs(
 ) -> None:
     data = anglemap.copy().assign_coords(hv=21.2)
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     original_attrs = win.data.attrs.copy()
 
@@ -1707,7 +1713,7 @@ def test_ktool_nonphysical_kinetic_energy_raises_with_tool_context(
 ) -> None:
     data = anglemap.copy().assign_coords(hv=6.0)
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     wf_spin = win._offset_spins["wf"]
     wf_spin.blockSignals(True)
@@ -1727,7 +1733,7 @@ def test_ktool_descending_energy_axis_preview(qtbot, anglemap) -> None:
     data = data.assign_coords(eV=data.eV.values[::-1])
 
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert np.isclose(win.center_spin.minimum(), float(data.eV.min()))
     assert np.isclose(win.center_spin.maximum(), float(data.eV.max()))
@@ -1762,7 +1768,7 @@ def test_ktool_descending_energy_axis_preview(qtbot, anglemap) -> None:
 )
 def test_ktool_preview_symmetry_default_fold(qtbot, anglemap, avec, expected) -> None:
     win = ktool(anglemap.qsel(eV=-0.1), avec=avec, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert win.preview_symmetry_fold_spin.value() == expected
 
@@ -1772,7 +1778,7 @@ def test_ktool_preview_symmetry_is_preview_only(qtbot, anglemap) -> None:
     data.values[2, 7] += 500.0
 
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     raw_k = win.get_data()[1]
     raw_preview = raw_k.T
@@ -1796,7 +1802,7 @@ def test_ktool_preview_symmetry_rotates_and_averages(
     qtbot, anglemap, monkeypatch
 ) -> None:
     win = ktool(anglemap, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     dummy_ang = anglemap.qsel(eV=-0.1)
     raw_k = xr.DataArray(
@@ -1835,7 +1841,7 @@ def test_ktool_preview_symmetry_disabled_for_non_in_plane_preview(qtbot) -> None
     data = generate_hvdep_cuts((15, 30, 20), hvrange=(20.0, 30.0), noise=False)
 
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     assert not win.preview_symmetry_group.isEnabled()
     assert not win.preview_symmetry_group.isChecked()
@@ -1865,7 +1871,7 @@ def test_ktool_exact_hv_bz_overlay_uses_cache(qtbot, monkeypatch) -> None:
         rotate_bz=30.0,
         execute=False,
     )
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     converted = win.images[1].data_array
     assert converted is not None
@@ -1954,7 +1960,7 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
         deep=True
     )
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     win.center_spin.setValue(float(data.eV.values[2]))
     win.width_spin.setValue(3)
@@ -1982,7 +1988,7 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
 
 def test_ktool_undo_redo_colormap_state(qtbot, anglemap) -> None:
     win = ktool(anglemap.qsel(eV=-0.1), execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
     initial = win.tool_status
 
     win.gamma_widget.setValue(initial.cmap_gamma + 0.1)
@@ -2008,7 +2014,7 @@ def test_ktool_update_data_with_single_energy_disables_energy_group(
         deep=True
     )
     win = ktool(initial, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     win.update_data(data)
     fixed_energy = float(data.eV.values[0])
@@ -2027,7 +2033,7 @@ def test_ktool_update_data_reconnects_energy_controls_after_single_energy(
         deep=True
     )
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     update_calls: list[None] = []
     original_update = win.update
@@ -2057,7 +2063,7 @@ def test_ktool_update_data_rejects_noninteractive_replacement_for_cut(
         anglemap.isel(alpha=slice(0, 3), eV=slice(0, 5)).qsel(beta=-8.3).copy(deep=True)
     )
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     with pytest.raises(ValueError, match="not compatible with the interactive tool"):
         win.update_data(data.isel(eV=0))
@@ -2083,7 +2089,7 @@ def test_ktool_validate_update_data_rejects_incompatible_metadata(
         deep=True
     )
     win = ktool(data, execute=False)
-    qtbot.addWidget(win)
+    _add_hidden_tool(qtbot, win)
 
     fake_kspace = SimpleNamespace(
         _interactive_compatible=True,

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -608,6 +608,35 @@ def test_better_axis_item_paint_ignores_deleted_axis(qtbot) -> None:
         painter.end()
 
 
+def test_better_axis_item_paint_ignores_deleted_wrapper_error(
+    qtbot, monkeypatch
+) -> None:
+    import pyqtgraph as pg
+
+    axis = erlab.interactive.utils.BetterAxisItem("bottom")
+
+    def paint(self, painter, option, widget=None):
+        raise RuntimeError("wrapped C/C++ object has been deleted")
+
+    monkeypatch.setattr(pg.AxisItem, "paint", paint)
+
+    assert axis.paint(None, None, None) is None
+
+
+def test_better_axis_item_paint_reraises_unexpected_error(qtbot, monkeypatch) -> None:
+    import pyqtgraph as pg
+
+    axis = erlab.interactive.utils.BetterAxisItem("bottom")
+
+    def paint(self, painter, option, widget=None):
+        raise RuntimeError("unrelated failure")
+
+    monkeypatch.setattr(pg.AxisItem, "paint", paint)
+
+    with pytest.raises(RuntimeError, match="unrelated failure"):
+        axis.paint(None, None, None)
+
+
 def test_tool_window_reload_refresh_ignores_deleted_file_menu(qtbot) -> None:
     tool = erlab.interactive.utils.ToolWindow()
     qtbot.addWidget(tool)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -41,6 +41,7 @@ from erlab.interactive.utils import (
     load_ui,
     qt_is_valid,
     save_fit_ui,
+    single_shot,
     xImageItem,
 )
 
@@ -574,6 +575,23 @@ def test_qt_is_valid_rejects_deleted_widget(qtbot) -> None:
     QtWidgets.QApplication.processEvents()
 
     qtbot.wait_until(lambda: not qt_is_valid(widget), timeout=1000)
+
+
+def test_single_shot_ignores_pyside_deleted_wrapper_error(qtbot) -> None:
+    widget = QtWidgets.QWidget()
+    qtbot.addWidget(widget)
+    called = False
+
+    def callback() -> None:
+        nonlocal called
+        called = True
+        raise RuntimeError(
+            "Internal C++ object (PySide6.QtWidgets.QWidget) already deleted."
+        )
+
+    single_shot(widget, 0, callback)
+
+    qtbot.wait_until(lambda: called, timeout=1000)
 
 
 def test_better_axis_item_paint_ignores_deleted_axis(qtbot) -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -576,6 +576,20 @@ def test_qt_is_valid_rejects_deleted_widget(qtbot) -> None:
     qtbot.wait_until(lambda: not qt_is_valid(widget), timeout=1000)
 
 
+def test_better_axis_item_paint_ignores_deleted_axis(qtbot) -> None:
+    axis = erlab.interactive.utils.BetterAxisItem("bottom")
+    axis.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    qtbot.wait_until(lambda: not qt_is_valid(axis), timeout=1000)
+
+    pixmap = QtGui.QPixmap(8, 8)
+    painter = QtGui.QPainter(pixmap)
+    try:
+        assert axis.paint(painter, None, None) is None
+    finally:
+        painter.end()
+
+
 def test_tool_window_reload_refresh_ignores_deleted_file_menu(qtbot) -> None:
     tool = erlab.interactive.utils.ToolWindow()
     qtbot.addWidget(tool)

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -138,16 +138,3 @@ def test_pyqtgraph_boundingrect_ignores_deleted_infinite_line(qtbot) -> None:
     qtbot.waitUntil(lambda: not qt_is_valid(line), timeout=1000)
 
     assert line.boundingRect() == QtCore.QRectF()
-
-
-def test_pyqtgraph_graphics_view_skips_paint_after_close(qtbot) -> None:
-    import pyqtgraph as pg
-    from qtpy import QtCore, QtGui
-
-    view = pg.GraphicsView()
-    qtbot.addWidget(view)
-
-    view.close()
-    event = QtGui.QPaintEvent(QtCore.QRect(0, 0, 1, 1))
-
-    assert view.paintEvent(event) is None

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -111,12 +111,17 @@ def test_serial_xdist_group_serializes_manager_context_tests() -> None:
         "tests/interactive/imagetool/manager/test_console.py",
         "tests/interactive/imagetool/manager/test_console.py::test_console",
     )
+    kspace_group = _CONFTEST.serial_xdist_group(
+        "tests/interactive/test_kspace.py",
+        "tests/interactive/test_kspace.py::test_kspace_conversion_dialog_code_and_result",
+    )
 
     assert slicer_group == "qt-tests-interactive-imagetool-test_slicer"
     assert workspace_group == "qt-tests-interactive-imagetool-manager-test_workspace"
     assert explorer_group == "qt-tests-interactive-test_explorer"
     assert watcher_group == "qt-tests-interactive-imagetool-test_watcher"
     assert console_group == "qt-tests-interactive-imagetool-manager-test_console"
+    assert kspace_group == "qt-tests-interactive-test_kspace"
     assert slicer_group != workspace_group
     assert console_group != workspace_group
 
@@ -133,3 +138,16 @@ def test_pyqtgraph_boundingrect_ignores_deleted_infinite_line(qtbot) -> None:
     qtbot.waitUntil(lambda: not qt_is_valid(line), timeout=1000)
 
     assert line.boundingRect() == QtCore.QRectF()
+
+
+def test_pyqtgraph_graphics_view_skips_paint_after_close(qtbot) -> None:
+    import pyqtgraph as pg
+    from qtpy import QtCore, QtGui
+
+    view = pg.GraphicsView()
+    qtbot.addWidget(view)
+
+    view.close()
+    event = QtGui.QPaintEvent(QtCore.QRect(0, 0, 1, 1))
+
+    assert view.paintEvent(event) is None

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -80,8 +80,15 @@ def test_conftest_import_defaults_pyside6_to_offscreen() -> None:
 
 
 def test_is_deleted_qt_wrapper_error_matches_deleted_wrapper_message() -> None:
-    exc = RuntimeError("wrapped C/C++ object of type InfiniteLine has been deleted")
-    assert _CONFTEST._is_deleted_qt_wrapper_error(exc)
+    assert _CONFTEST._is_deleted_qt_wrapper_error(
+        RuntimeError("wrapped C/C++ object of type InfiniteLine has been deleted")
+    )
+    assert _CONFTEST._is_deleted_qt_wrapper_error(
+        RuntimeError("wrapped C/C++ object has been deleted")
+    )
+    assert _CONFTEST._is_deleted_qt_wrapper_error(
+        RuntimeError("Internal C++ object (PySide6.QtWidgets.QWidget) already deleted.")
+    )
     assert not _CONFTEST._is_deleted_qt_wrapper_error(RuntimeError("different error"))
 
 


### PR DESCRIPTION
## Summary

This PR hardens the compatibility test path against intermittent Qt/pyqtgraph lifetime crashes without masking native paint paths globally.

## Root Cause

The segfaults were caused by queued Qt/pyqtgraph paint/event work running after ImageTool/KspaceTool widgets had started teardown. The failures surfaced in pytest-qt post-test event processing, not in the Python assertion path. xdist was not the underlying cause; it only made ordering and timing problems easier to expose.

## Changes

- Keep compatibility GUI tests serial while allowing non-GUI compatibility tests to use xdist.
- Broaden serial xdist grouping to cover interactive tests by file, so xdist does not interleave tests from the same Qt-heavy module in one shared worker state.
- Remove the global pyqtgraph `GraphicsView.paintEvent` test monkeypatch that suppressed real painting and could hide the crash surface.
- Keep non-visual kspace tests from leaving visible pyqtgraph-backed tool windows around during pytest-qt post-test event processing.
- Guard ImageTool colormap and history deferred paths against deleted Qt wrappers while re-raising unrelated runtime errors.
- Add a shared deleted-wrapper detector that handles both PyQt-style and PySide-style error messages.
- Use that detector in `single_shot()` and the pyqtgraph `InfiniteLine.boundingRect` teardown guard.
- Add a `BetterAxisItem.paint()` guard for deleted axis wrappers.
- Keep plot-slices rejection coverage on the real ImageTool path, but keep warning text formatting coverage lightweight to avoid reintroducing the full-tool warning teardown crash.

## Validation

- `PYTEST_QT_API=pyqt6 QT_API=pyqt6 uv run pytest -q tests/interactive/test_kspace.py`
- `PYTEST_QT_API=pyqt6 QT_API=pyqt6 uv run pytest -q tests/test_conftest.py tests/interactive/test_utils.py::test_single_shot_ignores_pyside_deleted_wrapper_error tests/interactive/test_utils.py::test_better_axis_item_paint_ignores_deleted_axis`
- `PYTEST_QT_API=pyqt6 QT_API=pyqt6 uv run pytest -q tests/interactive/imagetool/manager/test_figurecomposer.py::test_imagetool_rejects_uneditable_plot_slices_selection tests/interactive/imagetool/manager/test_figurecomposer.py::test_imagetool_plot_slices_selection_warning_shows_error_detail`
- Repeated the figurecomposer rejection/warning pair 3 times locally.
- Targeted history/colormap tests for touched ImageTool paths.
- `uv run ruff check --fix ...`
- `uv run ruff format --check ...`
- `uv run python -m scripts.ci_test_groups --check-partition`
- Compatibility workflow YAML parse
- `git diff --check`

PySide6 is not installed locally in this worktree, so the PySide lanes still need CI confirmation.
