### PR TITLE
Add user stylesheet support to Figure Composer

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -177,8 +177,14 @@ To add custom Matplotlib stylesheets:
 1. Open {menuselection}`File --> Settings`.
 2. In {menuselection}`Figure --> Stylesheets`, select {guilabel}`Open Folder`.
 3. Copy `*.mplstyle` files into that folder.
-4. Select {guilabel}`Reload` in the settings dialog to update the stylesheet list. The
-   stylesheet name shown in settings is the file name without the `.mplstyle` suffix.
+4. Select {guilabel}`Reload` to update the stylesheet list.
+5. Add the stylesheet by name. The name shown in settings is the file name without the
+   `.mplstyle` suffix.
+
+Saved stylesheet names are kept even if the corresponding style is not currently
+available. Unavailable styles remain visible in Settings, are skipped while rendering
+and when copying generated code, and become active again after the `.mplstyle` file is
+restored and the list is reloaded.
 
 In addition to the default stylesheets provided with Matplotlib, the list includes some
 stylesheets provided by ERLab, such as `khan`, `times`, and `nature`. Try them out to

--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -171,3 +171,16 @@ settings dialog in {guilabel}`File → Settings`. These stylesheets affect new f
 defaults such as size, dpi, and export settings, as well as the styling of all figure
 elements. If a saved stylesheet is unavailable on the current computer, it remains
 visible in settings but is skipped when rendering or generating code.
+
+To add custom Matplotlib stylesheets:
+
+1. Open {menuselection}`File --> Settings`.
+2. In {menuselection}`Figure --> Stylesheets`, select {guilabel}`Open Folder`.
+3. Copy `*.mplstyle` files into that folder. The stylesheet name shown in settings is
+   the file name without the `.mplstyle` suffix.
+4. Select {guilabel}`Reload`, then add the stylesheet by name.
+
+Saved stylesheets that are no longer available stay in the configured list and are
+marked unavailable. Figure Composer skips unavailable styles during rendering and code
+generation, and uses them again after the `.mplstyle` file is restored and stylesheets
+are reloaded.

--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -166,21 +166,20 @@ replay code that includes all analysis steps.
 
 ## Stylesheets and export
 
-Figure Composer applies the Matplotlib stylesheets configured in the interactive
-settings dialog in {guilabel}`File → Settings`. These stylesheets affect new figure
-defaults such as size, dpi, and export settings, as well as the styling of all figure
-elements. If a saved stylesheet is unavailable on the current computer, it remains
-visible in settings but is skipped when rendering or generating code.
+[Matplotlib stylesheets](https://matplotlib.org/stable/users/explain/customizing.html)
+are a powerful way to control the styling of all figure elements. Figure Composer
+applies the Matplotlib stylesheets configured in the interactive settings dialog in
+{menuselection}`File --> Settings`. These stylesheets affect new figure defaults such as
+size, dpi, and export settings, as well as the styling of all figure elements.
 
 To add custom Matplotlib stylesheets:
 
 1. Open {menuselection}`File --> Settings`.
 2. In {menuselection}`Figure --> Stylesheets`, select {guilabel}`Open Folder`.
-3. Copy `*.mplstyle` files into that folder. The stylesheet name shown in settings is
-   the file name without the `.mplstyle` suffix.
-4. Select {guilabel}`Reload`, then add the stylesheet by name.
+3. Copy `*.mplstyle` files into that folder.
+4. Select {guilabel}`Reload` in the settings dialog to update the stylesheet list. The
+   stylesheet name shown in settings is the file name without the `.mplstyle` suffix.
 
-Saved stylesheets that are no longer available stay in the configured list and are
-marked unavailable. Figure Composer skips unavailable styles during rendering and code
-generation, and uses them again after the `.mplstyle` file is restored and stylesheets
-are reloaded.
+In addition to the default stylesheets provided with Matplotlib, the list includes some
+stylesheets provided by ERLab, such as `khan`, `times`, and `nature`. Try them out to
+see how they affect the figures.

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -78,7 +78,7 @@ non-empty 2D, 3D, or 4D array. Canceling the dialog leaves the original data uno
   such as `-m` or `--manager` which sends the window straight to the {ref}`manager
   <imagetool-manager>`. Type `%itool --help` or `%itool?` to list all supported flags.
 
-- Need to open a file quickly? Use {guilabel}`File → Open…` inside ImageTool. The dialog
+- Need to open a file quickly? Use {menuselection}`File --> Open…` inside ImageTool. The dialog
   lists every available loader, including those from data loader plugins, so you can
   switch between formats without writing code.
 
@@ -165,23 +165,23 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
 - Non-uniform coordinates are converted with a `_idx` suffix for plotting. Their true values are displayed in the cursor readouts.
 
-- Use {guilabel}`Edit → Edit Coordinates` to open the {guilabel}`Coordinate Editor`
+- Use {menuselection}`Edit --> Edit Coordinates` to open the {guilabel}`Coordinate Editor`
   dialog. This is a GUI for {meth}`xarray.DataArray.assign_coords` that lets you specify
   start/end values, edit per-point values, scale and offset a numeric scalar or 1D
   coordinate with `new = scale * old + offset`, add a scalar coordinate, or add a 1D
   associated coordinate along an existing dimension.
 
-- Use {guilabel}`Edit → Edit Attributes` to open the {guilabel}`Attribute Editor`
+- Use {menuselection}`Edit --> Edit Attributes` to open the {guilabel}`Attribute Editor`
   dialog. This is a GUI for {meth}`xarray.DataArray.assign_attrs` that lets you change
   existing attributes or add new typed attributes while leaving untouched attributes in
   place. Choose {guilabel}`String`, {guilabel}`Int`, {guilabel}`Float`,
   {guilabel}`Bool`, or {guilabel}`Python literal` when entering values.
 
-- Use {guilabel}`Edit → Rename…` to open the {guilabel}`Rename Coordinates and
+- Use {menuselection}`Edit --> Rename…` to open the {guilabel}`Rename Coordinates and
   Dimensions` dialog. This is a GUI for {meth}`xarray.DataArray.rename` that lets you
   rename coordinates and dimensions.
 
-- Use {guilabel}`Edit → Swap Dimensions` to open the {guilabel}`Swap Dimensions` dialog.
+- Use {menuselection}`Edit --> Swap Dimensions` to open the {guilabel}`Swap Dimensions` dialog.
   This is an interface for {meth}`xarray.DataArray.swap_dims`.
 
 - Dask-backed arrays are fully supported. The dedicated {guilabel}`Dask` menu exposes
@@ -189,12 +189,12 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
   chunk shapes within ImageTool.
 
 - Overlay plots of numeric non-dimensional coordinates (e.g., temperature) on profile
-  plots from {guilabel}`View → Plot Associated Coordinates`. Multi-dimensional
+  plots from {menuselection}`View --> Plot Associated Coordinates`. Multi-dimensional
   coordinates are sliced with the active cursor and averaged over binned hidden
   dimensions. Right-click a profile plot to open associated coordinates in a new
   ImageTool window.
 
-- Use {guilabel}`View → Set Cursor Colors by Coordinate…` to color cursors by a
+- Use {menuselection}`View --> Set Cursor Colors by Coordinate…` to color cursors by a
   dimension coordinate or numeric associated coordinate value at each cursor position.
 
 (imagetool-slicing)=
@@ -206,7 +206,7 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
 - To change the slicing position, drag on a cursor line to move it, or drag on the plots
   while holding {kbd}`Ctrl`. You can also use the keyboard shortcuts listed in the
-  {guilabel}`View → Cursor Control` submenu which allow precise nudging of the active
+  {menuselection}`View --> Cursor Control` submenu which allow precise nudging of the active
   cursor with arrow keys.
 
 - When binning is enabled, the data shown are an average over the specified bin widths,
@@ -215,7 +215,7 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
   :::{hint}
 
   To reduce the underlying data instead of displaying binned slices, use the
-  {guilabel}`Edit → Aggregate…` dialog or the {guilabel}`Coarsen` dialog for more
+  {menuselection}`Edit --> Aggregate…` dialog or the {guilabel}`Coarsen` dialog for more
   options.
 
   :::
@@ -267,24 +267,24 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
   Holding {kbd}`Alt` while opening the menu switches many actions to cropped mode, which crops the data to what is currently visible in the plot before performing the action. This is useful for conducting analysis on a specific region.
   :::
 
-- Use {guilabel}`View → Rotation Guidelines` to add guidelines for azimuthal offsets or
+- Use {menuselection}`View --> Rotation Guidelines` to add guidelines for azimuthal offsets or
   symmetry operations.
 
   The guideline center moves together with the cursor. The center and the angle of the
   guidelines feed directly into the {guilabel}`Rotate` dialog and {guilabel}`ktool` for
   fast alignment.
 
-- Use {guilabel}`View → Open ktool` and {guilabel}`View → Open meshtool` for tools
+- Use {menuselection}`View --> Open ktool` and {menuselection}`View --> Open meshtool` for tools
   launched from the main menu rather than the plot context menu.
 
 - The default color cycle of cursors is user configurable. See [](./options.md).
 
-- Colors can be changed individually from {guilabel}`View → Edit Cursor Colors…`, where
+- Colors can be changed individually from {menuselection}`View --> Edit Cursor Colors…`, where
   you can choose from a colormap or edit each cursor's color separately.
 
 - Alternatively, the colors of the cursors can be set to follow a specific coordinate
-  dynamically based on their positions. This can be enabled from {guilabel}`View → Set
-  Cursor Colors by Coordinate…`.
+  dynamically based on their positions. This can be enabled from
+  {menuselection}`View --> Set Cursor Colors by Coordinate…`.
 
 (imagetool-color)=
 
@@ -319,53 +319,53 @@ ImageTool; see {ref}`imagetool-manager-result-placement`. When {guilabel}`Copy C
 available, the generated snippet is placed on your clipboard, ready to paste into a
 script or notebook for reproducibility.
 
-- {guilabel}`Edit → Rotate` opens the {guilabel}`Rotate` dialog. Enter the angle,
+- {menuselection}`Edit --> Rotate` opens the {guilabel}`Rotate` dialog. Enter the angle,
   center, interpolation order, and whether to reshape the image. If a rotation guideline
   is active, the dialog pre-fills the angle and center from the guideline.
-- {guilabel}`Edit → Select Data…` opens the {guilabel}`Select Data` dialog. Use it to
+- {menuselection}`Edit --> Select Data…` opens the {guilabel}`Select Data` dialog. Use it to
   build {meth}`xarray.DataArray.qsel`, {meth}`xarray.DataArray.sel`, and
   {meth}`xarray.DataArray.isel` selections from a table of dimensions. Each row can
   select a scalar point or a contiguous range.
-- {guilabel}`Edit → Aggregate…` opens the {guilabel}`Aggregate Over Dimensions` dialog.
+- {menuselection}`Edit --> Aggregate…` opens the {guilabel}`Aggregate Over Dimensions` dialog.
   Select any set of dimensions and reduce them with mean, minimum, maximum, or sum via
   {meth}`xarray.DataArray.qsel.mean`, {meth}`xarray.DataArray.qsel.min`,
   {meth}`xarray.DataArray.qsel.max`, or {meth}`xarray.DataArray.qsel.sum`.
-- {guilabel}`Edit → Interpolate…` opens the {guilabel}`Interpolate` dialog. Choose one
+- {menuselection}`Edit --> Interpolate…` opens the {guilabel}`Interpolate` dialog. Choose one
   dimension, enter the target coordinate values, and interpolate with
   {meth}`xarray.DataArray.interp` using `linear` or `nearest`.
-- {guilabel}`Edit → Sort By…` opens the {guilabel}`Sort By` dialog. Choose one or
+- {menuselection}`Edit --> Sort By…` opens the {guilabel}`Sort By` dialog. Choose one or
   more dimension or 1D coordinate keys, order them by priority, and sort with
   {meth}`xarray.DataArray.sortby`.
-- {guilabel}`Edit → Leading Edge…` opens the {guilabel}`Leading Edge` dialog. Choose the
+- {menuselection}`Edit --> Leading Edge…` opens the {guilabel}`Leading Edge` dialog. Choose the
   dimension to extract the leading edge from, set the fraction of the curve maximum, and
   choose whether the edge is searched toward larger or smaller coordinate values with
   {func}`erlab.analysis.interpolate.leading_edge`.
-- {guilabel}`Edit → Coarsen` opens the {guilabel}`Coarsen` dialog. Select window sizes
+- {menuselection}`Edit --> Coarsen` opens the {guilabel}`Coarsen` dialog. Select window sizes
   for one or more dimensions, choose the `boundary`, `side`, and coordinate reduction
   function for {meth}`xarray.DataArray.coarsen`, then apply a reducer such as `mean`,
   `sum`, or `median`.
-- {guilabel}`Edit → Thin` opens the {guilabel}`Thin Data` dialog which uses
+- {menuselection}`Edit --> Thin` opens the {guilabel}`Thin Data` dialog which uses
   {meth}`xarray.DataArray.thin`.
-- {guilabel}`Edit → Symmetrize → Mirror…` opens the {guilabel}`Symmetrize` dialog.
+- {menuselection}`Edit --> Symmetrize --> Mirror…` opens the {guilabel}`Symmetrize` dialog.
   Mirror a selected dimension about a specified center with additive or subtractive
   symmetry, `valid` or `full` overlap, and one-sided or two-sided output.
-- {guilabel}`Edit → Symmetrize → Rotational…` opens the rotational symmetrization
+- {menuselection}`Edit --> Symmetrize --> Rotational…` opens the rotational symmetrization
   dialog. If a rotation guideline is visible, the dialog pre-fills the center and fold
   count based on the guideline.
-- {guilabel}`Edit → Crop` opens the {guilabel}`Crop Between Cursors` dialog, while
-  {guilabel}`Edit → Crop to View` opens the {guilabel}`Crop to View` dialog.
-- {guilabel}`Edit → Correct With Edge…` opens the {guilabel}`Edge Correction` dialog. If
+- {menuselection}`Edit --> Crop` opens the {guilabel}`Crop Between Cursors` dialog, while
+  {menuselection}`Edit --> Crop to View` opens the {guilabel}`Crop to View` dialog.
+- {menuselection}`Edit --> Correct With Edge…` opens the {guilabel}`Edge Correction` dialog. If
   your data exposes an `eV` axis, ImageTool can import a previously fitted edge via
   {func}`xarray_lmfit.load_fit` and shift the spectrum accordingly.
-- {guilabel}`View → Normalize` opens the {guilabel}`Normalize` dialog, which applies a
+- {menuselection}`View --> Normalize` opens the {guilabel}`Normalize` dialog, which applies a
   reversible filter that supports area normalization, min-max scaling, and baseline
   subtraction.
-- {guilabel}`View → Gaussian Filter` opens the {guilabel}`Gaussian Filter` dialog, which
+- {menuselection}`View --> Gaussian Filter` opens the {guilabel}`Gaussian Filter` dialog, which
   applies a reversible coordinate-aware Gaussian broadening filter along selected
   dimensions.
 
-Use {guilabel}`Edit → Undo` and {guilabel}`Edit → Redo` to walk changes back, and
-{guilabel}`View → Reset` to remove any currently applied filter. Reopening the dialog
+Use {menuselection}`Edit --> Undo` and {menuselection}`Edit --> Redo` to walk changes back, and
+{menuselection}`View --> Reset` to remove any currently applied filter. Reopening the dialog
 for the active filter starts from the current filter settings and replaces that active
 filter when accepted.
 
@@ -408,11 +408,11 @@ Note that both procedures work on the entire data volume, not just the visible s
 
 ## Exporting and settings
 
-- {guilabel}`File → Save As…` exports the current data to NetCDF, HDF5, or Igor Binary Wave (`.ibw`).
+- {menuselection}`File --> Save As…` exports the current data to NetCDF, HDF5, or Igor Binary Wave (`.ibw`).
 
-- {guilabel}`File → Move to Manager` hands the window off to the {ref}`ImageTool manager <imagetool-manager>`.
+- {menuselection}`File --> Move to Manager` hands the window off to the {ref}`ImageTool manager <imagetool-manager>`.
 
-- {guilabel}`File → Settings` opens the shared settings dialog described in [](./options.md).
+- {menuselection}`File --> Settings` opens the shared settings dialog described in [](./options.md).
 
 (imagetool-shortcuts)=
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -100,11 +100,11 @@ Once the manager is running, you can open ImageTools in several ways:
   %itool -m 1 darr
   ```
 
-- The {guilabel}`File → Move to Manager` ({kbd}`Ctrl+Shift+M`) action from an ImageTool
+- The {menuselection}`File --> Move to Manager` ({kbd}`Ctrl+Shift+M`) action from an ImageTool
   window opened outside the manager. This action moves the active ImageTool to the
   manager.
 
-- Use the manager’s {guilabel}`File → Add Data Files…` action to load data in a new
+- Use the manager’s {menuselection}`File --> Add Data Files…` action to load data in a new
   ImageTool.
 
 - Drag and drop supported ARPES data into the manager window.
@@ -124,7 +124,7 @@ Once the manager is running, you can open ImageTools in several ways:
 
   :::
 
-- Launch the built-in data explorer from {guilabel}`File → Data Explorer` or
+- Launch the built-in data explorer from {menuselection}`File --> Data Explorer` or
   {kbd}`Ctrl+E` when you want directory browsing and metadata preview before opening
   selected files in the manager. Use the loader options button next to the loader
   selector to apply the same `loader_extensions=` settings when opening selected files.
@@ -160,7 +160,7 @@ shows a non-empty 2D, 3D, or 4D result, or cancel to skip opening that data.
 Multiple ImageTool Manager windows can run at the same time. The first live manager is
 manager `#0`, and later managers receive 0-based indexes in the order they start.
 
-To start a new manager instance, choose {guilabel}`File → New Manager Window` from an
+To start a new manager instance, choose {menuselection}`File --> New Manager Window` from an
 existing manager window.
 
 When more than one manager is running, either pass the index like `manager=2` or set a
@@ -197,7 +197,7 @@ list, and a preview of the main image.
 
 :::{note}
 
-Enable {guilabel}`View → Preview on Hover` to see thumbnails while moving the mouse over
+Enable {menuselection}`View --> Preview on Hover` to see thumbnails while moving the mouse over
 the list.
 
 :::
@@ -238,7 +238,7 @@ and right-click context menus:
 - {guilabel}`Offload to Workspace`
 
   Reloads the data as dask-backed data from the workspace file, freeing up memory but
-  slowing down indexing. Use {guilabel}`Dask → Load Into Memory` in ImageTool to load it
+  slowing down indexing. Use {menuselection}`Dask --> Load Into Memory` in ImageTool to load it
   back into memory when needed.
 
 - {guilabel}`Concatenate`
@@ -309,20 +309,20 @@ the entire manager workspace, including all windows and their state.
 Manager row notes are workspace metadata. They are saved with the row they describe and
 do not modify the data attributes of the underlying `DataArray`.
 
-{guilabel}`File → Add Windows From Workspace…` lets you choose windows from another
+{menuselection}`File --> Add Windows From Workspace…` lets you choose windows from another
 workspace file to import into the current one.
 
-Saved ImageTool workspaces can be reloaded via {guilabel}`File → Open Workspace…`
+Saved ImageTool workspaces can be reloaded via {menuselection}`File --> Open Workspace…`
 ({kbd}`Ctrl+O`) or by dragging the `.itws` file back into the manager to recreate your
 windows exactly as they were. A list of recent workspaces is available in
-{guilabel}`File → Open Recent`.
+{menuselection}`File --> Open Recent`.
 
-To check where the open manager is saved, choose {guilabel}`File → Workspace Properties`
+To check where the open manager is saved, choose {menuselection}`File --> Workspace Properties`
 ({kbd}`Alt+Return`).
 
-Use {guilabel}`File → Offload to Workspace` to make the selected data lazy-loaded from
+Use {menuselection}`File --> Offload to Workspace` to make the selected data lazy-loaded from
 the workspace file. This frees up memory but will slow down indexing and slicing. Use
-{guilabel}`Dask → Load Into Memory` in ImageTool to bring it back into memory.
+{menuselection}`Dask --> Load Into Memory` in ImageTool to bring it back into memory.
 
 If the workspace contains watched notebook variables, the watched rows reopen with
 their variable-name badges. The rows stay disconnected until a notebook defines the
@@ -442,7 +442,7 @@ also launch standalone apps that stay outside the tree view and workspace files.
 
 ### Data Explorer
 
-Open the explorer from {guilabel}`File → Data Explorer` or {kbd}`Ctrl+E`.
+Open the explorer from {menuselection}`File --> Data Explorer` or {kbd}`Ctrl+E`.
 
 Use it when you want to browse folders, preview metadata, queue batch loads, and then
 open selected files into the manager without writing code. For most day-to-day browsing
@@ -458,7 +458,7 @@ For the standalone tool page, see {ref}`guide-data-explorer`.
 
 ### Periodic Table
 
-Open the periodic table from {guilabel}`Apps → Periodic Table` or {kbd}`Ctrl+Shift+P`.
+Open the periodic table from {menuselection}`Apps --> Periodic Table` or {kbd}`Ctrl+Shift+P`.
 
 Use it when you want quick reference for core-level energies photoionization cross
 sections.
@@ -667,7 +667,7 @@ Because `fetch` returns a copy, you can safely modify it without touching the li
 
 ### Sharing data via `%store`
 
-The [%store](https://ipython.readthedocs.io/en/stable/config/extensions/storemagic.html) magic can persist variables between notebook sessions. Select tools in the manager and run {guilabel}`File → Store with IPython` (or the matching context-menu command) to push their `DataArray` objects into the `%store` database. Internally, this executes:
+The [%store](https://ipython.readthedocs.io/en/stable/config/extensions/storemagic.html) magic can persist variables between notebook sessions. Select tools in the manager and run {menuselection}`File --> Store with IPython` (or the matching context-menu command) to push their `DataArray` objects into the `%store` database. Internally, this executes:
 
 ```python
 my_data = tools[0].data

--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -47,7 +47,7 @@ There are four ways to start `ktool`.
 
 3. From the ImageTool View menu
 
-   Click {guilabel}`View → Open ktool`.
+   Click {menuselection}`View --> Open ktool`.
 
    The button will be disabled if the data is not compatible with {func}`ktool <erlab.interactive.ktool>`.
 
@@ -520,7 +520,7 @@ import erlab.interactive as eri
 eri.meshtool(data)
 ```
 
-It can also be opened from the ImageTool View menu with {guilabel}`View → Open meshtool`.
+It can also be opened from the ImageTool View menu with {menuselection}`View --> Open meshtool`.
 
 The `%meshtool` magic (see {ref}`interactive-misc-magics`) provides a quick way to launch it from IPython.
 
@@ -592,7 +592,7 @@ you want the overview as a DataFrame inside Python or when you are implementing 
 You can open the explorer in several ways:
 
 1. From the {ref}`ImageTool manager <imagetool-manager-data-explorer>` with
-   {guilabel}`File → Data Explorer` or {kbd}`Ctrl+E`.
+   {menuselection}`File --> Data Explorer` or {kbd}`Ctrl+E`.
 2. From Python with {func}`erlab.interactive.data_explorer`.
 3. From the command line with `python -m erlab.interactive.explorer`.
 
@@ -641,7 +641,7 @@ python -m erlab.interactive.ptable
 ```
 
 In the {ref}`ImageTool manager <imagetool-manager>`, you can open it from
-{guilabel}`Apps → Periodic Table` or with the keyboard shortcut {kbd}`Ctrl+Shift+P`.
+{menuselection}`Apps --> Periodic Table` or with the keyboard shortcut {kbd}`Ctrl+Shift+P`.
 
 - The search bar highlights matching elements by symbol or name and offers autocomplete
   suggestions that select the chosen element. Entering a comma- or space-separated

--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -3,7 +3,7 @@
 The interactive tools in {mod}`erlab.interactive` provide several options to customize
 their behavior and appearance.
 
-Open the shared settings dialog from {guilabel}`File → Settings`. The standard
+Open the shared settings dialog from {menuselection}`File --> Settings`. The standard
 preferences shortcut also opens the same window on platforms that support it.
 
 Once saved, the settings will be applied the next time you open a new interactive tool.

--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -3,7 +3,30 @@
 The interactive tools in {mod}`erlab.interactive` provide several options to customize
 their behavior and appearance.
 
-Open the shared settings dialog from {menuselection}`File --> Settings`. The standard
-preferences shortcut also opens the same window on platforms that support it.
+Open the shared settings window from {menuselection}`File --> Settings`.
 
-Once saved, the settings will be applied the next time you open a new interactive tool.
+Changes are saved immediately. The bottom of the window reports the save status, and
+{guilabel}`Revert Changes` restores all user and workspace changes made since the
+Settings window was opened. Closing the window does not discard changes that have
+already been saved.
+
+Use the sidebar to switch between setting groups:
+
+- {guilabel}`Visualization` controls default colormap, gamma, cursor colors, and
+  related display defaults.
+- {guilabel}`I/O` controls default loader behavior.
+- {guilabel}`ktool` controls defaults for newly opened momentum-conversion tools.
+- {guilabel}`Figure Composer` controls default Matplotlib stylesheets for newly
+  created figures.
+
+Rows in the {guilabel}`User` scope include a reset action that restores the application
+default for that setting. Broadly resetting all user settings still asks for
+confirmation.
+
+When Settings is opened from ImageTool Manager, a {guilabel}`Workspace` scope is also
+available. Workspace settings are sparse overrides saved inside the manager's `.itws`
+workspace file, so they travel with that workspace. Turn on {guilabel}`Override` for a
+row to store a workspace value; turn it off, or use the row action, to inherit the user
+setting again. Clearing all workspace overrides asks for confirmation. Workspace
+overrides affect newly opened tools and new Figure Composer defaults, but do not mutate
+tools that are already open.

--- a/docs/source/user-guide/io.ipynb
+++ b/docs/source/user-guide/io.ipynb
@@ -429,7 +429,7 @@
     "\n",
     "For routine browsing and loading, the {ref}`data explorer <guide-data-explorer>` is\n",
     "usually faster than the interactive summary widget. Open it from the {ref}`ImageTool\n",
-    "manager <imagetool-manager-data-explorer>` with {guilabel}`File → Data Explorer` or\n",
+    "manager <imagetool-manager-data-explorer>` with {menuselection}`File --> Data Explorer` or\n",
     "{kbd}`Ctrl+E`, or launch it directly with {func}`erlab.interactive.data_explorer` for\n",
     "standalone browsing.\n"
    ]

--- a/docs/source/user-guide/workflow-bridge.md
+++ b/docs/source/user-guide/workflow-bridge.md
@@ -40,7 +40,7 @@ code for reproducibility and batch processing.
   - {ref}`Figure Composer <figure-composer>`
   - Matplotlib API and {mod}`erlab.plotting` functions
 - - Select a point or range from multidimensional data
-  - {guilabel}`Edit → Select Data…` or the right-click context menu of each plot
+  - {menuselection}`Edit --> Select Data…` or the right-click context menu of each plot
   - {meth}`xarray.DataArray.qsel`, {meth}`xarray.DataArray.sel`, and
     {meth}`xarray.DataArray.isel`
 - - Aggregate over dimensions
@@ -61,19 +61,19 @@ code for reproducibility and batch processing.
   - {ref}`Crop dialogs <imagetool-editing>`
   - {meth}`xarray.DataArray.sel`, {meth}`xarray.DataArray.isel`
 - - Rotate or symmetrize
-  - {ref}`Transform dialogs <imagetool-editing>` including {guilabel}`Edit → Rotate` and
-    {guilabel}`Edit → Symmetrize`
+  - {ref}`Transform dialogs <imagetool-editing>` including {menuselection}`Edit --> Rotate` and
+    {menuselection}`Edit --> Symmetrize`
   - {func}`erlab.analysis.transform.rotate`,
     {func}`erlab.analysis.transform.symmetrize`,
     {func}`erlab.analysis.transform.symmetrize_nfold`
 - - Edit or add coordinates
-  - {guilabel}`Edit → Edit Coordinates` in {ref}`ImageTool data controls <imagetool-data>`
+  - {menuselection}`Edit --> Edit Coordinates` in {ref}`ImageTool data controls <imagetool-data>`
   - {meth}`xarray.DataArray.assign_coords`, such as
     `data.assign_coords(y=scale * data.y + offset)`,
     `data.assign_coords(temperature=20.0)`, or
     `data.assign_coords(label=("x", labels))`
 - - Edit or add attributes
-  - {guilabel}`Edit → Edit Attributes` in {ref}`ImageTool data controls <imagetool-data>`
+  - {menuselection}`Edit --> Edit Attributes` in {ref}`ImageTool data controls <imagetool-data>`
   - {meth}`xarray.DataArray.assign_attrs`, such as
     `data.assign_attrs(sample_temp=20.0, note="checked")`
 - - Swap dimensions

--- a/src/erlab/accessors/general.py
+++ b/src/erlab/accessors/general.py
@@ -688,7 +688,7 @@ class SelectionAccessor(ERLabDataArrayAccessor):
                 )
             }
 
-            out = self._obj.copy()
+            out = self._obj.copy(deep=False)
             for dim, slice_list in slice_collections.items():
                 lost_dims_extend: list[Hashable] = [
                     k for k, v in self._obj.coords.items() if dim in v.dims
@@ -714,7 +714,7 @@ class SelectionAccessor(ERLabDataArrayAccessor):
                 )
         else:
             out = self._qsel_scalar(
-                self._obj.copy(), scalars, slices, avg_dims, lost_dims, func
+                self._obj.copy(deep=False), scalars, slices, avg_dims, lost_dims, func
             )
 
         return erlab.utils.array.sort_coord_order(

--- a/src/erlab/interactive/_figurecomposer/_defaults.py
+++ b/src/erlab/interactive/_figurecomposer/_defaults.py
@@ -127,8 +127,15 @@ def _style_code_lines() -> list[str]:
 
 
 def _style_required_imports() -> tuple[str, ...]:
-    if erlab.interactive._stylesheets.stylesheets_require_erlab_plotting(
-        _configured_stylesheets()
-    ):
-        return ("import erlab.plotting  # registers ERLab matplotlib stylesheets",)
-    return ()
+    configured = _configured_stylesheets()
+    lines: list[str] = []
+    if erlab.interactive._stylesheets.stylesheets_require_erlab_plotting(configured):
+        lines.append("import erlab.plotting  # registers ERLab matplotlib stylesheets")
+    if erlab.interactive._stylesheets.stylesheets_require_user_stylesheets(configured):
+        lines.extend(
+            [
+                "import erlab.interactive._stylesheets as _erlab_stylesheets",
+                "_erlab_stylesheets.load_user_stylesheets()",
+            ]
+        )
+    return tuple(lines)

--- a/src/erlab/interactive/_figurecomposer/_defaults.py
+++ b/src/erlab/interactive/_figurecomposer/_defaults.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import typing
 import warnings
 
@@ -16,18 +17,44 @@ if typing.TYPE_CHECKING:
 
     from matplotlib.figure import Figure
 
+    from erlab.interactive._options.schema import AppOptions
+
 _MM_PER_INCH = 25.4
 _LAYOUT_COLLAPSED_WARNING = (
     r"constrained_layout not applied because axes sizes collapsed to zero\."
 )
+_OPTIONS_MODEL_CONTEXT: contextvars.ContextVar[AppOptions | None] = (
+    contextvars.ContextVar("figure_composer_options_model", default=None)
+)
 
 
-def _configured_stylesheets() -> tuple[str, ...]:
+def _current_options() -> AppOptions:
+    context_options = _OPTIONS_MODEL_CONTEXT.get()
+    if context_options is not None:
+        return context_options
     with contextlib.suppress(Exception):
         from erlab.interactive._options import options
 
-        return tuple(options.model.figure.stylesheets)
-    return ()
+        return options.model
+    from erlab.interactive._options.schema import AppOptions
+
+    return AppOptions()
+
+
+@contextlib.contextmanager
+def figure_options_context(options_model: AppOptions | None) -> Iterator[None]:
+    if options_model is None:
+        yield
+        return
+    token = _OPTIONS_MODEL_CONTEXT.set(options_model)
+    try:
+        yield
+    finally:
+        _OPTIONS_MODEL_CONTEXT.reset(token)
+
+
+def _configured_stylesheets() -> tuple[str, ...]:
+    return tuple(_current_options().figure.stylesheets)
 
 
 def _available_configured_stylesheets() -> tuple[str, ...]:

--- a/src/erlab/interactive/_figurecomposer/_norms.py
+++ b/src/erlab/interactive/_figurecomposer/_norms.py
@@ -9,6 +9,7 @@ import matplotlib.colors as mcolors
 import erlab
 import erlab.interactive.utils
 import erlab.plotting as eplt
+from erlab.interactive._figurecomposer._defaults import _current_options
 from erlab.interactive._figurecomposer._state import (
     _POWER_NORM_NAME,
     FigureOperationState,
@@ -132,7 +133,7 @@ def _norm_updates_from_kwargs(
 
 def _cmap_base_and_reverse(cmap: str | None) -> tuple[str, bool]:
     if cmap is None:
-        return erlab.interactive.options.model.colors.cmap.name, False
+        return _current_options().colors.cmap.name, False
     if cmap.endswith("_r"):
         return cmap[:-2], True
     return cmap, False

--- a/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
@@ -7,6 +7,7 @@ import typing
 
 from qtpy import QtCore, QtWidgets
 
+import erlab.interactive.utils
 from erlab.interactive._figurecomposer._gridspec import (
     _gridspec_all_axes_ids,
     _gridspec_axis_code_tuple,
@@ -33,6 +34,71 @@ if typing.TYPE_CHECKING:
 
     from erlab.interactive._figurecomposer._tool import FigureComposerTool
 
+_CUSTOM_CODE_UPDATE_DELAY_MS = 250
+
+
+def _connect_custom_code_editor(
+    tool: FigureComposerTool, code_edit: erlab.interactive.utils.PythonCodeEditor
+) -> None:
+    timer = QtCore.QTimer(tool)
+    timer.setSingleShot(True)
+    timer.setInterval(_CUSTOM_CODE_UPDATE_DELAY_MS)
+    code_edit_any = typing.cast("typing.Any", code_edit)
+    code_edit_any._figure_composer_custom_code_commit_timer = timer
+    pending_code = [code_edit.toPlainText()]
+    pending_operation_ids: list[tuple[str, ...]] = [()]
+    pending_dirty = [False]
+
+    def queue_commit() -> None:
+        if not tool._editor_control_signal_allowed(code_edit):
+            return
+        pending_code[0] = code_edit.toPlainText()
+        pending_operation_ids[0] = tuple(
+            operation.operation_id for _index, operation in tool._editable_operations()
+        )
+        pending_dirty[0] = True
+        timer.start()
+
+    def queue_contents_change(
+        _position: int, chars_removed: int, chars_added: int
+    ) -> None:
+        if chars_removed or chars_added:
+            queue_commit()
+
+    def commit_code() -> None:
+        if not pending_dirty[0]:
+            return
+        if tool._closing or not erlab.interactive.utils.qt_is_valid(tool):
+            return
+        operation_ids = pending_operation_ids[0]
+        if not operation_ids:
+            return
+        pending_dirty[0] = False
+        timer.stop()
+        code = pending_code[0]
+        tool._update_operations_by_ids(
+            operation_ids,
+            lambda _index, target: target.model_copy(update={"code": code}),
+        )
+
+    def flush_pending_commit() -> None:
+        if timer.isActive():
+            timer.stop()
+        commit_code()
+
+    tool._mark_editor_control(code_edit)
+    document = code_edit.document()
+    document.contentsChange.connect(queue_contents_change)
+    timer.timeout.connect(commit_code)
+    code_edit_any._figure_composer_custom_code_commit_handlers = (
+        queue_contents_change,
+        commit_code,
+        flush_pending_commit,
+    )
+    code_edit_any._figure_composer_custom_code_flush_pending_commit = (
+        flush_pending_commit
+    )
+
 
 def _build_custom_code_editor(
     tool: FigureComposerTool, operation: FigureOperationState
@@ -51,15 +117,19 @@ def _build_custom_code_editor(
         "Allow this custom Python step to execute during rendering.",
     )
 
-    code_edit = QtWidgets.QPlainTextEdit(tool.operation_editor)
+    code_edit = erlab.interactive.utils.PythonCodeEditor(tool.operation_editor)
+    code_edit.setObjectName("figureComposerCustomCodeEdit")
     code_edit.setPlainText(operation.code)
-    code_edit.setMinimumHeight(160)
-    code_edit.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-    code_edit.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-    tool._connect_plain_text_changed(
-        code_edit,
-        lambda text: tool._update_current_operation(code=text),
+    code_edit.setPlaceholderText("# Write Python code here")
+    code_edit.setMinimumHeight(220)
+    code_edit.setLineWrapMode(QtWidgets.QTextEdit.LineWrapMode.NoWrap)
+    code_edit.setSizePolicy(
+        QtWidgets.QSizePolicy.Policy.Expanding,
+        QtWidgets.QSizePolicy.Policy.Expanding,
     )
+    code_edit.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+    code_edit.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+    _connect_custom_code_editor(tool, code_edit)
     tool._add_form_row(
         tool.operation_editor_layout,
         "Code",

--- a/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
@@ -34,30 +34,31 @@ if typing.TYPE_CHECKING:
 
     from erlab.interactive._figurecomposer._tool import FigureComposerTool
 
-_CUSTOM_CODE_UPDATE_DELAY_MS = 250
+_CUSTOM_CODE_SETTLE_DELAY_MS = 900
 
 
 def _connect_custom_code_editor(
     tool: FigureComposerTool, code_edit: erlab.interactive.utils.PythonCodeEditor
 ) -> None:
-    timer = QtCore.QTimer(tool)
-    timer.setSingleShot(True)
-    timer.setInterval(_CUSTOM_CODE_UPDATE_DELAY_MS)
+    code_edit.set_text_editing_settle_delay(_CUSTOM_CODE_SETTLE_DELAY_MS)
+    code_edit.reset_text_editing_activity()
     code_edit_any = typing.cast("typing.Any", code_edit)
-    code_edit_any._figure_composer_custom_code_commit_timer = timer
     pending_code = [code_edit.toPlainText()]
     pending_operation_ids: list[tuple[str, ...]] = [()]
     pending_dirty = [False]
 
-    def queue_commit() -> None:
-        if not tool._editor_control_signal_allowed(code_edit):
-            return
+    def capture_pending_code(*, refresh_operation_ids: bool) -> None:
         pending_code[0] = code_edit.toPlainText()
-        pending_operation_ids[0] = tuple(
-            operation.operation_id for _index, operation in tool._editable_operations()
-        )
+        if refresh_operation_ids:
+            pending_operation_ids[0] = tuple(
+                operation.operation_id
+                for _index, operation in tool._editable_operations()
+            )
         pending_dirty[0] = True
-        timer.start()
+
+    def queue_commit() -> None:
+        if tool._editor_control_signal_allowed(code_edit):
+            capture_pending_code(refresh_operation_ids=True)
 
     def queue_contents_change(
         _position: int, chars_removed: int, chars_added: int
@@ -65,7 +66,7 @@ def _connect_custom_code_editor(
         if chars_removed or chars_added:
             queue_commit()
 
-    def commit_code() -> None:
+    def commit_code(*, render: bool) -> None:
         if not pending_dirty[0]:
             return
         if tool._closing or not erlab.interactive.utils.qt_is_valid(tool):
@@ -74,25 +75,33 @@ def _connect_custom_code_editor(
         if not operation_ids:
             return
         pending_dirty[0] = False
-        timer.stop()
         code = pending_code[0]
-        tool._update_operations_by_ids(
+        render_valid_code = render and code_edit.has_valid_python_syntax(code)
+        changed = tool._update_operations_by_ids(
             operation_ids,
             lambda _index, target: target.model_copy(update={"code": code}),
+            render=render_valid_code,
         )
+        if changed and not render_valid_code:
+            tool.sigInfoChanged.emit()
 
-    def flush_pending_commit() -> None:
-        if timer.isActive():
-            timer.stop()
-        commit_code()
+    def commit_settled_code(_code: str) -> None:
+        commit_code(render=True)
+
+    def flush_pending_commit(*, render: bool = False) -> None:
+        if code_edit.text_editing_active():
+            code_edit.reset_text_editing_activity()
+            if pending_dirty[0]:
+                pending_code[0] = code_edit.toPlainText()
+        commit_code(render=render)
 
     tool._mark_editor_control(code_edit)
     document = code_edit.document()
     document.contentsChange.connect(queue_contents_change)
-    timer.timeout.connect(commit_code)
+    code_edit.sigTextEditingSettled.connect(commit_settled_code)
     code_edit_any._figure_composer_custom_code_commit_handlers = (
         queue_contents_change,
-        commit_code,
+        commit_settled_code,
         flush_pending_commit,
     )
     code_edit_any._figure_composer_custom_code_flush_pending_commit = (

--- a/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
@@ -97,8 +97,14 @@ def _connect_custom_code_editor(
 
     tool._mark_editor_control(code_edit)
     document = code_edit.document()
-    document.contentsChange.connect(queue_contents_change)
-    code_edit.sigTextEditingSettled.connect(commit_settled_code)
+    if document is None:
+        raise RuntimeError("Custom code editor has no text document")
+    tool._connect_editor_signal(
+        code_edit, document.contentsChange, queue_contents_change
+    )
+    tool._connect_editor_signal(
+        code_edit, code_edit.sigTextEditingSettled, commit_settled_code
+    )
     code_edit_any._figure_composer_custom_code_commit_handlers = (
         queue_contents_change,
         commit_settled_code,

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -3163,6 +3163,12 @@ def _render_plot_slices(
     if _plot_slices_uses_transformed_line_maps(tool, operation):
         maps = _plot_slices_transformed_maps(tool, operation, maps)
         kwargs = _plot_slices_transformed_kwargs(tool, operation)
+    selection_cache = getattr(tool, "_plot_slices_selection_cache", None)
+    if selection_cache is not None:
+        kwargs["_selection_cache"] = selection_cache
+        kwargs["_selection_cache_key"] = _plot_slices_selection_cache_key(
+            operation, maps
+        )
     axes = _plot_slices_axes(
         operation,
         maps,
@@ -3232,6 +3238,26 @@ def _plot_slices_axes(
     if axes.size != math.prod(shape):
         return axes
     return axes.reshape(shape)
+
+
+def _plot_slices_selection_cache_key(
+    operation: FigureOperationState, maps: Sequence[xr.DataArray]
+) -> tuple[object, ...]:
+    source_key = tuple(
+        (
+            selection.source,
+            repr(selection.isel),
+            repr(selection.qsel),
+            tuple(selection.mean_dims),
+        )
+        for selection in operation.map_selections
+    )
+    if not source_key:
+        source_key = tuple((source,) for source in operation.sources)
+    map_key = tuple(
+        (id(data.data), tuple(data.dims), tuple(data.shape)) for data in maps
+    )
+    return (source_key, map_key)
 
 
 def _operation_maps(

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -565,6 +565,8 @@ def _plot_slices_transformed_maps(
             xr.concat(
                 ordered_profiles,
                 dim=operation.slice_dim,
+                coords="different",
+                compat="equals",
             ).assign_coords({operation.slice_dim: slice_values})
         )
     return transformed_maps
@@ -3321,6 +3323,8 @@ def _plot_slices_transformed_maps_code(
                 "xr.concat(",
                 f"    [{profile_items}],",
                 f"    dim={dim_code},",
+                '    coords="different",',
+                '    compat="equals",',
                 f").assign_coords({coords_code})",
             ]
         )

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -16,6 +16,7 @@ from erlab.interactive._figurecomposer._code import (
     _maybe_squeeze_drop_code,
     _selection_code,
 )
+from erlab.interactive._figurecomposer._defaults import _current_options
 from erlab.interactive._figurecomposer._line_style import (
     CONTROLLED_LINE_KW_KEYS,
     LINE_MARKER_OPTIONS,
@@ -336,7 +337,7 @@ def _effective_panel_cmap(
 ) -> str:
     if style.cmap is not None:
         return style.cmap
-    return operation.cmap or erlab.interactive.options.model.colors.cmap.name
+    return operation.cmap or _current_options().colors.cmap.name
 
 
 def _operation_with_panel_norm_style(
@@ -978,9 +979,7 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
         if self._updating or check_state == QtCore.Qt.CheckState.PartiallyChecked:
             return
         if check_state == QtCore.Qt.CheckState.Checked:
-            cmap = (
-                self._operation.cmap or erlab.interactive.options.model.colors.cmap.name
-            )
+            cmap = self._operation.cmap or _current_options().colors.cmap.name
             self._update_selected_styles({"cmap": cmap})
         else:
             self._update_selected_styles({"cmap": None})
@@ -1009,9 +1008,7 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
             return
         base = self.cmap_combo.currentText()
         if self.cmap_combo.currentData() is _MISSING:
-            base = (
-                self._operation.cmap or erlab.interactive.options.model.colors.cmap.name
-            )
+            base = self._operation.cmap or _current_options().colors.cmap.name
         reverse = check_state == QtCore.Qt.CheckState.Checked
         self._update_selected_styles({"cmap": _cmap_with_reverse(base, reverse)})
 

--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -320,20 +320,29 @@ def _render_into_figure(
     from erlab.interactive._figurecomposer._operations import _registry
 
     render_errors: dict[str, str] = {}
-    with _tool_figure_options_context(tool), _figure_style_context():
-        axs = _make_axes(tool, figure, sync_visible=sync_visible)
-        for operation in tool._recipe.operations:
-            if not operation.enabled:
-                continue
-            spec = _registry.spec_for(operation.kind)
-            if spec.has_invalid_target(
-                tool, operation
-            ) or tool._operation_has_invalid_input(operation):
-                continue
-            try:
-                spec.render(tool, operation, figure, axs)
-            except Exception as exc:
-                render_errors[operation.operation_id] = _render_error_text(exc)
+    previous_plot_slices_cache = getattr(tool, "_plot_slices_selection_cache", None)
+    tool._plot_slices_selection_cache = {}
+    try:
+        with _tool_figure_options_context(tool), _figure_style_context():
+            axs = _make_axes(tool, figure, sync_visible=sync_visible)
+            for operation in tool._recipe.operations:
+                if not operation.enabled:
+                    continue
+                spec = _registry.spec_for(operation.kind)
+                if spec.has_invalid_target(
+                    tool, operation
+                ) or tool._operation_has_invalid_input(operation):
+                    continue
+                try:
+                    spec.render(tool, operation, figure, axs)
+                except Exception as exc:
+                    render_errors[operation.operation_id] = _render_error_text(exc)
+    finally:
+        if previous_plot_slices_cache is None:
+            with contextlib.suppress(AttributeError):
+                del tool._plot_slices_selection_cache
+        else:
+            tool._plot_slices_selection_cache = previous_plot_slices_cache
     tool._set_operation_render_errors(render_errors)
 
 

--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -320,7 +320,7 @@ def _render_into_figure(
     from erlab.interactive._figurecomposer._operations import _registry
 
     render_errors: dict[str, str] = {}
-    previous_plot_slices_cache = getattr(tool, "_plot_slices_selection_cache", None)
+    previous_plot_slices_cache = tool._plot_slices_selection_cache
     tool._plot_slices_selection_cache = {}
     try:
         with _tool_figure_options_context(tool), _figure_style_context():
@@ -338,11 +338,7 @@ def _render_into_figure(
                 except Exception as exc:
                     render_errors[operation.operation_id] = _render_error_text(exc)
     finally:
-        if previous_plot_slices_cache is None:
-            with contextlib.suppress(AttributeError):
-                del tool._plot_slices_selection_cache
-        else:
-            tool._plot_slices_selection_cache = previous_plot_slices_cache
+        tool._plot_slices_selection_cache = previous_plot_slices_cache
     tool._set_operation_render_errors(render_errors)
 
 

--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -181,12 +181,21 @@ def _make_gridspec_axes(
 
 def _new_offscreen_figure(tool: FigureComposerTool) -> Figure:
     setup = tool._recipe.setup
-    with _figure_style_context():
+    with _tool_figure_options_context(tool), _figure_style_context():
         return Figure(
             figsize=setup.figsize,
             dpi=setup.dpi,
             layout=typing.cast("typing.Any", setup.layout),
         )
+
+
+def _tool_figure_options_context(
+    tool: FigureComposerTool,
+) -> contextlib.AbstractContextManager[None]:
+    options_context = getattr(tool, "_figure_options_context", None)
+    if callable(options_context):
+        return options_context()
+    return contextlib.nullcontext()
 
 
 def _valid_figure_window(tool: FigureComposerTool) -> typing.Any | None:
@@ -311,7 +320,7 @@ def _render_into_figure(
     from erlab.interactive._figurecomposer._operations import _registry
 
     render_errors: dict[str, str] = {}
-    with _figure_style_context():
+    with _tool_figure_options_context(tool), _figure_style_context():
         axs = _make_axes(tool, figure, sync_visible=sync_visible)
         for operation in tool._recipe.operations:
             if not operation.enabled:

--- a/src/erlab/interactive/_figurecomposer/_seeding.py
+++ b/src/erlab/interactive/_figurecomposer/_seeding.py
@@ -6,7 +6,7 @@ import typing
 
 import numpy as np
 
-import erlab
+from erlab.interactive._figurecomposer._defaults import _current_options
 from erlab.interactive._figurecomposer._state import (
     FigureAxesSelectionState,
     FigureOperationState,
@@ -142,7 +142,7 @@ def plot_slices_operation_with_source_styles(
 
 
 def _default_bz_updates() -> dict[str, typing.Any]:
-    opts = erlab.interactive.options.model.ktool.bz
+    opts = _current_options().ktool.bz
     return {
         "bz_a": opts.default_a,
         "bz_b": opts.default_b,

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -893,7 +893,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if event is not None:
             super().hideEvent(event)
 
-    def _flush_pending_editor_commits(self) -> None:
+    def _flush_pending_editor_commits(self, *, render: bool = False) -> None:
         for widget in self.findChildren(QtWidgets.QWidget):
             flush = getattr(
                 widget,
@@ -902,7 +902,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
             if callable(flush):
                 with contextlib.suppress(RuntimeError):
-                    flush()
+                    flush(render=render)
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         self._flush_pending_editor_commits()
@@ -2754,10 +2754,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         rebuild_editor: bool = False,
         defer_editor_rebuild: bool = False,
         sync_axes: bool = True,
-    ) -> None:
+    ) -> bool:
         operation_id_set = set(operation_ids)
         if not operation_id_set:
-            return
+            return False
         current = self._current_operation()
         operations = list(self._recipe.operations)
         changed = False
@@ -2768,7 +2768,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             changed = changed or updated != operation
             operations[index] = updated
         if not changed:
-            return
+            return False
         self._recipe = self._recipe.model_copy(update={"operations": tuple(operations)})
         self._refresh_operation_list()
         if current is not None:
@@ -2788,6 +2788,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             _render_preview(self)
             self.sigInfoChanged.emit()
         self._write_state()
+        return True
 
     def _replace_operation(
         self,
@@ -4322,6 +4323,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 self._retire_editor_widget(widget)
 
     def _clear_operation_editor(self) -> None:
+        self._flush_pending_editor_commits()
         for page in self._operation_editor_pages:
             self.step_editor_stack.removeWidget(page)
             self._retire_editor_widget(page)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -124,7 +124,15 @@ from erlab.interactive._figurecomposer._widgets import (
 from erlab.interactive.imagetool import provenance
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+    from collections.abc import (
+        Callable,
+        Hashable,
+        Iterable,
+        Iterator,
+        Mapping,
+        MutableMapping,
+        Sequence,
+    )
 
     import xarray as xr
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
@@ -327,6 +335,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._retired_editor_widgets: list[QtWidgets.QWidget] = []
         self._operation_render_errors: dict[str, str] = {}
         self._operation_input_errors: dict[str, dict[str, str]] = {}
+        self._plot_slices_selection_cache: (
+            MutableMapping[Hashable, tuple[xr.DataArray, ...]] | None
+        ) = None
         self._operation_editor_generation = 0
         self._active_editor_signal_widget: QtWidgets.QWidget | None = None
         self._figure_resize_render_generation = 0

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -124,7 +124,7 @@ from erlab.interactive._figurecomposer._widgets import (
 from erlab.interactive.imagetool import provenance
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Mapping, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 
     import xarray as xr
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
@@ -893,7 +893,19 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if event is not None:
             super().hideEvent(event)
 
+    def _flush_pending_editor_commits(self) -> None:
+        for widget in self.findChildren(QtWidgets.QWidget):
+            flush = getattr(
+                widget,
+                "_figure_composer_custom_code_flush_pending_commit",
+                None,
+            )
+            if callable(flush):
+                with contextlib.suppress(RuntimeError):
+                    flush()
+
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        self._flush_pending_editor_commits()
         self._closing = True
         self._cancel_queued_show_figure_window()
         self._figure_resize_render_generation += 1
@@ -2724,10 +2736,39 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         editable = self._editable_operations()
         if not editable:
             return
+        self._update_operations_by_ids(
+            (operation.operation_id for _index, operation in editable),
+            updater,
+            render=render,
+            rebuild_editor=rebuild_editor,
+            defer_editor_rebuild=defer_editor_rebuild,
+            sync_axes=sync_axes,
+        )
+
+    def _update_operations_by_ids(
+        self,
+        operation_ids: Iterable[str],
+        updater: Callable[[int, FigureOperationState], FigureOperationState],
+        *,
+        render: bool = True,
+        rebuild_editor: bool = False,
+        defer_editor_rebuild: bool = False,
+        sync_axes: bool = True,
+    ) -> None:
+        operation_id_set = set(operation_ids)
+        if not operation_id_set:
+            return
         current = self._current_operation()
         operations = list(self._recipe.operations)
-        for index, operation in editable:
-            operations[index] = updater(index, operation)
+        changed = False
+        for index, operation in enumerate(operations):
+            if operation.operation_id not in operation_id_set:
+                continue
+            updated = updater(index, operation)
+            changed = changed or updated != operation
+            operations[index] = updated
+        if not changed:
+            return
         self._recipe = self._recipe.model_copy(update={"operations": tuple(operations)})
         self._refresh_operation_list()
         if current is not None:
@@ -4911,6 +4952,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return row_widget
 
     def generated_code(self) -> str:
+        self._flush_pending_editor_commits()
         with self._figure_options_context():
             return erlab.interactive._figurecomposer._codegen.generated_code(self)
 
@@ -4938,6 +4980,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def export_figure(self) -> None:
         if self._warn_invalid_operation_targets():
             return
+        self._flush_pending_editor_commits()
         filename, _filter = QtWidgets.QFileDialog.getSaveFileName(
             self,
             "Export Figure",

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -29,6 +29,7 @@ from erlab.interactive._figurecomposer._defaults import (
     _MM_PER_INCH,
     _figure_draw_context,
     _figure_style_context,
+    figure_options_context,
 )
 from erlab.interactive._figurecomposer._editor_controls import (
     MIXED_VALUE as _MIXED_VALUE,
@@ -123,10 +124,12 @@ from erlab.interactive._figurecomposer._widgets import (
 from erlab.interactive.imagetool import provenance
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
     import xarray as xr
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+
+    from erlab.interactive._options.schema import AppOptions
 
 
 _OPERATION_EDITOR_UPDATE_DELAY_MS = 25
@@ -307,6 +310,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         source_data: Mapping[str, xr.DataArray] | None = None,
     ) -> None:
         super().__init__()
+        self._options_getter: Callable[[], AppOptions] | None = None
         self._updating_controls = False
         self._rendering = False
         self._operation_editor_update_pending = False
@@ -377,6 +381,18 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._build_ui()
         self._apply_recipe_to_controls()
         self._write_state()
+
+    def set_options_getter(self, getter: Callable[[], AppOptions] | None) -> None:
+        self._options_getter = getter
+
+    @contextlib.contextmanager
+    def _figure_options_context(self) -> Iterator[None]:
+        options_model = None
+        if self._options_getter is not None:
+            with contextlib.suppress(Exception):
+                options_model = self._options_getter()
+        with figure_options_context(options_model):
+            yield
 
     @staticmethod
     def _default_recipe(data: xr.DataArray) -> FigureRecipeState:
@@ -4909,7 +4925,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return row_widget
 
     def generated_code(self) -> str:
-        return erlab.interactive._figurecomposer._codegen.generated_code(self)
+        with self._figure_options_context():
+            return erlab.interactive._figurecomposer._codegen.generated_code(self)
 
     @QtCore.Slot()
     def copy_code(self) -> None:
@@ -4943,7 +4960,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         if not filename:
             return
-        with _rendered_output_figure(self) as figure, _figure_draw_context():
+        with (
+            self._figure_options_context(),
+            _rendered_output_figure(self) as figure,
+            _figure_draw_context(),
+        ):
             figure.savefig(
                 filename,
                 dpi=self._recipe.export.dpi,
@@ -5161,7 +5182,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             canvas = window.canvas
             if not erlab.interactive.utils.qt_is_valid(canvas):
                 return None
-            with _figure_style_context():
+            with self._figure_options_context(), _figure_style_context():
                 canvas.draw()
             width, height = canvas.get_width_height(physical=True)
             if width <= 0 or height <= 0:
@@ -5181,7 +5202,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             return None
         from matplotlib.backends.backend_agg import FigureCanvasAgg
 
-        with _figure_style_context():
+        with self._figure_options_context(), _figure_style_context():
             figure = Figure(
                 figsize=self._recipe.setup.figsize,
                 dpi=self._recipe.setup.dpi,

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -481,6 +481,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
             self._figure_window.destroyed.connect(figure_window_destroyed)
         self._figure_window.setWindowTitle(self._figure_window_title())
+        self._configure_managed_secondary_window(self._figure_window)
         return self._figure_window
 
     def _figure_window_destroyed(
@@ -509,6 +510,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         title = self.windowTitle()
         return title if title and title != self.tool_name else "Figure"
 
+    def _managed_secondary_windows(
+        self,
+    ) -> tuple[tuple[QtWidgets.QWidget, str], ...]:
+        if self._figure_window is None or not erlab.interactive.utils.qt_is_valid(
+            self._figure_window
+        ):
+            return ()
+        return ((self._figure_window, self._figure_window_title()),)
+
     @QtCore.Slot()
     def _show_figure_window_requested(self) -> None:
         self._request_show_figure_window(activate=True)
@@ -524,9 +534,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.activateWindow()
 
     def show_figure_window(self, *, activate: bool = True) -> None:
-        self.figure_window.show_for_setup(
+        figure_window = self.figure_window
+        figure_window.show_for_setup(
             self._recipe.setup, self._figure_window_title(), activate=activate
         )
+        self._configure_managed_secondary_window(figure_window)
         self._cancel_preview_render_update()
         _render_preview(self, show_window=True)
 

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -142,8 +142,9 @@ _COMBO_INTERACTION_REBUILD_GRACE_MS = 250
 _COMBO_TRACKED_PROPERTY = "figure_composer_combo_tracked"
 _COMBO_POPUP_GUARD_ID_PROPERTY = "figure_composer_combo_popup_guard_id"
 _SOURCE_LIST_SOURCE_COLUMN = 0
-_SOURCE_LIST_SHAPE_COLUMN = 1
-_SOURCE_LIST_ACTION_COLUMN = 2
+_SOURCE_LIST_ALIAS_COLUMN = 1
+_SOURCE_LIST_SHAPE_COLUMN = 2
+_SOURCE_LIST_ACTION_COLUMN = 3
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
@@ -1139,8 +1140,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         sources_layout.addWidget(self.source_actions)
         self.source_list = QtWidgets.QTreeWidget(self.step_sources_page)
         self.source_list.setObjectName("figureComposerSourceList")
-        self.source_list.setColumnCount(3)
-        self.source_list.setHeaderLabels(("Source", "Shape", ""))
+        self.source_list.setColumnCount(4)
+        self.source_list.setHeaderLabels(("Source", "Alias", "Shape", ""))
         self.source_list.setRootIsDecorated(False)
         self.source_list.setIndentation(0)
         self.source_list.setUniformRowHeights(True)
@@ -1154,17 +1155,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.source_list.setHorizontalScrollBarPolicy(
             QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
         )
-        self.source_list.setToolTip("Data available to the selected step.")
         source_header = self.source_list.header()
         if source_header is not None:
             source_header.setStretchLastSection(False)
             source_header.setSectionResizeMode(
                 _SOURCE_LIST_SOURCE_COLUMN,
+                QtWidgets.QHeaderView.ResizeMode.Stretch,
+            )
+            source_header.setSectionResizeMode(
+                _SOURCE_LIST_ALIAS_COLUMN,
                 QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
             )
             source_header.setSectionResizeMode(
                 _SOURCE_LIST_SHAPE_COLUMN,
-                QtWidgets.QHeaderView.ResizeMode.Stretch,
+                QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
             )
             source_header.setSectionResizeMode(
                 _SOURCE_LIST_ACTION_COLUMN,
@@ -1699,7 +1703,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._add_source_list_row(
                 display,
                 name,
-                _source_display_tooltip(source, name),
                 data=data,
                 missing=source is None,
                 used=name in used_sources,
@@ -1719,11 +1722,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._add_source_list_row(
                 display,
                 source.name,
-                _source_display_tooltip(source, source.name),
                 missing=True,
                 used=source.name in used_sources,
             )
-        self.source_list.resizeColumnToContents(_SOURCE_LIST_SOURCE_COLUMN)
+        self.source_list.resizeColumnToContents(_SOURCE_LIST_ALIAS_COLUMN)
+        self.source_list.resizeColumnToContents(_SOURCE_LIST_SHAPE_COLUMN)
         self.source_list.resizeColumnToContents(_SOURCE_LIST_ACTION_COLUMN)
         self._refresh_source_controls()
 
@@ -1746,23 +1749,22 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self,
         display: str,
         name: str,
-        tooltip: str,
         *,
         data: xr.DataArray | None = None,
         missing: bool = False,
         used: bool = False,
     ) -> None:
         item = QtWidgets.QTreeWidgetItem(
-            [display, "missing" if data is None else "", ""]
+            [display, name, "missing" if data is None else "", ""]
         )
         item.setData(_SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole, name)
-        item.setData(
-            _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole + 2, tooltip
-        )
         item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
         if missing:
             item.setForeground(
                 _SOURCE_LIST_SOURCE_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
+            )
+            item.setForeground(
+                _SOURCE_LIST_ALIAS_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
             )
             item.setForeground(
                 _SOURCE_LIST_SHAPE_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
@@ -1789,7 +1791,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             QtCore.Qt.TextInteractionFlag.NoTextInteraction
         )
         shape_label.setContentsMargins(4, 0, 4, 0)
-        shape_label.setToolTip(item.toolTip(_SOURCE_LIST_SOURCE_COLUMN))
         if missing:
             palette = shape_label.palette()
             palette.setColor(
@@ -1991,16 +1992,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         item.setData(
             _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole + 1, used
         )
-        base_tooltip = item.data(
-            _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole + 2
-        )
-        tooltip = (
-            base_tooltip
-            if isinstance(base_tooltip, str)
-            else item.toolTip(_SOURCE_LIST_SOURCE_COLUMN)
-        )
-        if used:
-            tooltip = f"Used by selected step.\n{tooltip}"
         font = item.font(_SOURCE_LIST_SOURCE_COLUMN)
         font.setBold(used)
         item.setFont(_SOURCE_LIST_SOURCE_COLUMN, font)
@@ -2015,11 +2006,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 self._set_source_remove_button_state(
                     remove_button, source_name, item.text(_SOURCE_LIST_SOURCE_COLUMN)
                 )
-        for column in (_SOURCE_LIST_SOURCE_COLUMN, _SOURCE_LIST_SHAPE_COLUMN):
-            item.setToolTip(column, tooltip)
-            widget = self.source_list.itemWidget(item, column)
-            if widget is not None:
-                widget.setToolTip(tooltip)
 
     def _sync_source_list_used_state(self) -> None:
         current = self._current_operation()

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 _LMFIT_CALLABLE_WARNING_RE = re.compile(
     r"^Could not unpack dill-encoded callable '([^']+)', saved with Python version .+$"
 )
+_PythonCodeEditor = erlab.interactive.utils.PythonCodeEditor
 
 _fit_worker_gc_lock = threading.Lock()
 _fit_worker_gc_depth = 0
@@ -174,106 +175,6 @@ def _suspend_gc_in_fit_worker():
                 _fit_worker_gc_restore_enabled = False
             if should_enable:
                 gc.enable()
-
-
-class _PythonCodeEditor(QtWidgets.QTextEdit):
-    TAB_SPACES = 4
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self.setFont(
-            QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
-        )
-        self.highlighter = erlab.interactive.utils.PythonHighlighter(self.document())
-
-    def keyPressEvent(self, e: QtGui.QKeyEvent | None) -> None:
-        if e is not None:
-            key = e.key()
-            mods = e.modifiers()
-
-            is_tab = key == QtCore.Qt.Key.Key_Tab
-            is_backtab = key == QtCore.Qt.Key.Key_Backtab
-            shift = bool(mods & QtCore.Qt.KeyboardModifier.ShiftModifier)
-
-            if (is_tab or is_backtab) and not (
-                mods & QtCore.Qt.KeyboardModifier.ControlModifier
-            ):
-                cursor = self.textCursor()
-                if is_backtab or (is_tab and shift):
-                    self._unindent(cursor, self.TAB_SPACES)
-                else:
-                    self._indent(cursor, self.TAB_SPACES)
-                e.accept()
-                return
-
-        super().keyPressEvent(e)
-
-    def _indent(self, cursor: QtGui.QTextCursor, n: int) -> None:
-        text = " " * n
-        cursor.beginEditBlock()
-        if cursor.hasSelection():
-            self._for_each_selected_block(cursor, lambda c: c.insertText(text))
-        else:
-            cursor.insertText(text)
-        cursor.endEditBlock()
-
-    def _unindent(self, cursor: QtGui.QTextCursor, n: int) -> None:
-        cursor.beginEditBlock()
-
-        def unindent_block(c: QtGui.QTextCursor):
-            c.movePosition(QtGui.QTextCursor.MoveOperation.StartOfBlock)
-
-            # Remove one literal tab if present
-            c.movePosition(
-                QtGui.QTextCursor.MoveOperation.Right,
-                QtGui.QTextCursor.MoveMode.KeepAnchor,
-                1,
-            )
-            if c.selectedText() == "\t":
-                c.removeSelectedText()
-                return
-            c.clearSelection()
-
-            # Otherwise remove up to n leading spaces
-            removed = 0
-            while removed < n:
-                c.movePosition(QtGui.QTextCursor.MoveOperation.StartOfBlock)
-                c.movePosition(
-                    QtGui.QTextCursor.MoveOperation.Right,
-                    QtGui.QTextCursor.MoveMode.KeepAnchor,
-                    1,
-                )
-                if c.selectedText() == " ":
-                    c.removeSelectedText()
-                    removed += 1
-                else:
-                    c.clearSelection()
-                    break
-
-        if cursor.hasSelection():
-            self._for_each_selected_block(cursor, unindent_block)
-        else:
-            unindent_block(cursor)
-
-        cursor.endEditBlock()
-
-    def _for_each_selected_block(self, cursor: QtGui.QTextCursor, fn):
-        start = cursor.selectionStart()
-        end = cursor.selectionEnd()
-
-        c = QtGui.QTextCursor(cursor.document())
-        c.setPosition(start)
-        start_block = c.blockNumber()
-
-        c.setPosition(end)
-        end_block = c.blockNumber()
-
-        c.setPosition(start)
-        c.movePosition(QtGui.QTextCursor.MoveOperation.StartOfBlock)
-
-        for _ in range(start_block, end_block + 1):
-            fn(c)
-            c.movePosition(QtGui.QTextCursor.MoveOperation.NextBlock)
 
 
 class _ExpressionInitScriptDialog(QtWidgets.QDialog):

--- a/src/erlab/interactive/_options/core.py
+++ b/src/erlab/interactive/_options/core.py
@@ -10,6 +10,7 @@ import os
 import threading
 import typing
 
+import pydantic
 from qtpy import QtCore
 
 from erlab.interactive._options.schema import AppOptions
@@ -109,6 +110,99 @@ def write_settings(opts: AppOptions, qsettings: QtCore.QSettings) -> None:
         The QSettings object to write to.
     """
     _dict_to_qsettings(opts.model_dump(), qsettings)
+
+
+def option_value(model: AppOptions, name: str) -> typing.Any:
+    """Return an option value by slash-separated path."""
+    value: typing.Any = model
+    for key in name.split("/"):
+        value = getattr(value, key)
+    return value
+
+
+def option_model_with_value(
+    model: AppOptions, name: str, value: typing.Any
+) -> AppOptions:
+    """Return a copy of *model* with one slash-separated option path changed."""
+    data = model.model_dump()
+    target = data
+    keys = name.split("/")
+    for key in keys[:-1]:
+        child = target[key]
+        if not isinstance(child, dict):
+            raise KeyError(name)
+        target = child
+    target[keys[-1]] = value
+    return AppOptions.model_validate(data)
+
+
+def option_paths(model_cls: type[pydantic.BaseModel] = AppOptions) -> tuple[str, ...]:
+    """Return all leaf option paths in schema order."""
+    paths: list[str] = []
+
+    def collect(cls: type[pydantic.BaseModel], prefix: str = "") -> None:
+        default_instance = cls()
+        for field_name in cls.model_fields:
+            path = f"{prefix}/{field_name}" if prefix else field_name
+            value = getattr(default_instance, field_name)
+            if isinstance(value, pydantic.BaseModel):
+                collect(type(value), path)
+            else:
+                paths.append(path)
+
+    collect(model_cls)
+    return tuple(paths)
+
+
+def workspace_overridable_option_paths() -> tuple[str, ...]:
+    """Return option paths allowed in ImageTool Manager workspace overrides."""
+    paths: list[str] = []
+
+    def collect(cls: type[pydantic.BaseModel], prefix: str = "") -> None:
+        default_instance = cls()
+        for field_name, field_info in cls.model_fields.items():
+            path = f"{prefix}/{field_name}" if prefix else field_name
+            value = getattr(default_instance, field_name)
+            if isinstance(value, pydantic.BaseModel):
+                collect(type(value), path)
+                continue
+            extra = getattr(field_info, "json_schema_extra", None) or {}
+            if isinstance(extra, dict) and extra.get("workspace_overridable"):
+                paths.append(path)
+
+    collect(AppOptions)
+    return tuple(paths)
+
+
+def normalize_workspace_option_overrides(
+    overrides: typing.Mapping[str, typing.Any] | None,
+) -> dict[str, typing.Any]:
+    """Keep only workspace-overridable option paths.
+
+    Values are intentionally not fully validated here. A workspace may contain a loader
+    or stylesheet that is unavailable on this computer; such values must remain in the
+    saved override payload so they can become active again when available.
+    """
+    if not isinstance(overrides, typing.Mapping):
+        return {}
+    allowed = set(workspace_overridable_option_paths())
+    return {
+        str(path): value for path, value in overrides.items() if str(path) in allowed
+    }
+
+
+def model_with_workspace_overrides(
+    user_options: AppOptions,
+    overrides: typing.Mapping[str, typing.Any] | None,
+) -> AppOptions:
+    """Merge valid workspace overrides over user settings."""
+    model = user_options
+    for path, value in normalize_workspace_option_overrides(overrides).items():
+        try:
+            model = option_model_with_value(model, path, value)
+        except (KeyError, TypeError, ValueError):
+            continue
+    return model
 
 
 class OptionManager:

--- a/src/erlab/interactive/_options/parameters.py
+++ b/src/erlab/interactive/_options/parameters.py
@@ -220,6 +220,22 @@ class StylesheetListWidget(QtWidgets.QWidget):
         self.add_button.clicked.connect(self.add_stylesheet)
         layout.addWidget(self.add_button, 0, 1)
 
+        self.open_folder_button = QtWidgets.QToolButton(self)
+        self.open_folder_button.setObjectName("matplotlibStylesheetOpenFolderButton")
+        self.open_folder_button.setText("Open Folder")
+        self.open_folder_button.setToolTip(
+            "Open the ERLab custom Matplotlib stylesheet folder."
+        )
+        self.open_folder_button.clicked.connect(self.open_stylesheet_directory)
+        layout.addWidget(self.open_folder_button, 0, 2)
+
+        self.reload_button = QtWidgets.QToolButton(self)
+        self.reload_button.setObjectName("matplotlibStylesheetReloadButton")
+        self.reload_button.setText("Reload")
+        self.reload_button.setToolTip("Reload Matplotlib stylesheets.")
+        self.reload_button.clicked.connect(self.reload_stylesheets)
+        layout.addWidget(self.reload_button, 0, 3)
+
         self.list_widget = QtWidgets.QListWidget(self)
         self.list_widget.setObjectName("matplotlibStylesheetList")
         self.list_widget.setSelectionMode(
@@ -227,7 +243,7 @@ class StylesheetListWidget(QtWidgets.QWidget):
         )
         self.list_widget.setFixedHeight(88)
         self.list_widget.currentRowChanged.connect(self._update_button_state)
-        layout.addWidget(self.list_widget, 1, 0, 1, 2)
+        layout.addWidget(self.list_widget, 1, 0, 1, 4)
 
         button_layout = QtWidgets.QHBoxLayout()
         button_layout.setContentsMargins(0, 0, 0, 0)
@@ -253,7 +269,7 @@ class StylesheetListWidget(QtWidgets.QWidget):
         self.down_button.clicked.connect(lambda: self.move_selected_stylesheet(1))
         button_layout.addWidget(self.down_button)
         button_layout.addStretch(1)
-        layout.addLayout(button_layout, 2, 0, 1, 2)
+        layout.addLayout(button_layout, 2, 0, 1, 4)
 
         self._refresh()
 
@@ -309,11 +325,29 @@ class StylesheetListWidget(QtWidgets.QWidget):
     @QtCore.Slot()
     def _load_available_stylesheets(self) -> None:
         current = self.add_combo.currentText()
-        erlab.interactive._stylesheets.load_erlab_plotting_stylesheets()
+        erlab.interactive._stylesheets.reload_stylesheets()
         self._refresh_list()
         self._refresh_add_combo()
         if current:
             self.add_combo.setCurrentText(current)
+
+    @QtCore.Slot()
+    def open_stylesheet_directory(self) -> None:
+        try:
+            style_dir = erlab.interactive._stylesheets.user_stylesheet_directory()
+        except RuntimeError as exc:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Stylesheet folder unavailable",
+                str(exc),
+            )
+            return
+        QtGui.QDesktopServices.openUrl(QtCore.QUrl.fromLocalFile(str(style_dir)))
+
+    @QtCore.Slot()
+    def reload_stylesheets(self) -> None:
+        erlab.interactive._stylesheets.reload_stylesheets()
+        self._refresh()
 
     def _update_button_state(self, *_args) -> None:
         row = self.list_widget.currentRow()

--- a/src/erlab/interactive/_options/parameters.py
+++ b/src/erlab/interactive/_options/parameters.py
@@ -189,6 +189,7 @@ class StylesheetListWidget(QtWidgets.QWidget):
     """Widget for editing an ordered list of Matplotlib stylesheets."""
 
     sigStylesheetsChanged = QtCore.Signal(list)
+    _VISIBLE_LIST_ROWS = 4
 
     def __init__(
         self,
@@ -198,27 +199,31 @@ class StylesheetListWidget(QtWidgets.QWidget):
         super().__init__(parent)
         self.stylesheets = _stylesheet_names(stylesheets)
 
-        layout = QtWidgets.QGridLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setHorizontalSpacing(4)
-        layout.setVerticalSpacing(3)
+        layout = QtWidgets.QVBoxLayout(self)
+
+        add_layout = QtWidgets.QHBoxLayout()
+        add_layout.setContentsMargins(0, 0, 0, 0)
 
         self.add_combo = _StylesheetComboBox(self)
         self.add_combo.setObjectName("matplotlibStylesheetCombo")
         self.add_combo.setSizeAdjustPolicy(
             QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
         )
-        self.add_combo.setMinimumContentsLength(18)
+        self.add_combo.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
         self.add_combo.setToolTip("Available Matplotlib stylesheet to add.")
         self.add_combo.sigPopupAboutToShow.connect(self._load_available_stylesheets)
-        layout.addWidget(self.add_combo, 0, 0)
+        add_layout.addWidget(self.add_combo, 1)
 
         self.add_button = QtWidgets.QToolButton(self)
         self.add_button.setObjectName("matplotlibStylesheetAddButton")
         self.add_button.setText("Add")
         self.add_button.setToolTip("Add the selected stylesheet.")
         self.add_button.clicked.connect(self.add_stylesheet)
-        layout.addWidget(self.add_button, 0, 1)
+        add_layout.addWidget(self.add_button)
+        layout.addLayout(add_layout)
 
         self.open_folder_button = QtWidgets.QToolButton(self)
         self.open_folder_button.setObjectName("matplotlibStylesheetOpenFolderButton")
@@ -227,27 +232,31 @@ class StylesheetListWidget(QtWidgets.QWidget):
             "Open the ERLab custom Matplotlib stylesheet folder."
         )
         self.open_folder_button.clicked.connect(self.open_stylesheet_directory)
-        layout.addWidget(self.open_folder_button, 0, 2)
 
         self.reload_button = QtWidgets.QToolButton(self)
         self.reload_button.setObjectName("matplotlibStylesheetReloadButton")
         self.reload_button.setText("Reload")
         self.reload_button.setToolTip("Reload Matplotlib stylesheets.")
         self.reload_button.clicked.connect(self.reload_stylesheets)
-        layout.addWidget(self.reload_button, 0, 3)
 
         self.list_widget = QtWidgets.QListWidget(self)
         self.list_widget.setObjectName("matplotlibStylesheetList")
         self.list_widget.setSelectionMode(
             QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
         )
-        self.list_widget.setFixedHeight(88)
+        self.list_widget.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
         self.list_widget.currentRowChanged.connect(self._update_button_state)
-        layout.addWidget(self.list_widget, 1, 0, 1, 4)
+        layout.addWidget(self.list_widget)
 
         button_layout = QtWidgets.QHBoxLayout()
         button_layout.setContentsMargins(0, 0, 0, 0)
-        button_layout.setSpacing(3)
+        button_layout.addWidget(self.open_folder_button)
+        button_layout.addWidget(self.reload_button)
+        button_layout.addStretch(1)
+
         self.remove_button = QtWidgets.QToolButton(self)
         self.remove_button.setObjectName("matplotlibStylesheetRemoveButton")
         self.remove_button.setText("Remove")
@@ -268,8 +277,7 @@ class StylesheetListWidget(QtWidgets.QWidget):
         self.down_button.setToolTip("Move the selected stylesheet later.")
         self.down_button.clicked.connect(lambda: self.move_selected_stylesheet(1))
         button_layout.addWidget(self.down_button)
-        button_layout.addStretch(1)
-        layout.addLayout(button_layout, 2, 0, 1, 4)
+        layout.addLayout(button_layout)
 
         self._refresh()
 
@@ -303,6 +311,28 @@ class StylesheetListWidget(QtWidgets.QWidget):
                     "This saved stylesheet is unavailable here and will be skipped."
                 )
             self.list_widget.addItem(item)
+        self._update_list_height()
+
+    def _update_list_height(self) -> None:
+        row_height = self.list_widget.sizeHintForRow(0)
+        if row_height <= 0:
+            style = self.list_widget.style()
+            vertical_margin = (
+                style.pixelMetric(
+                    QtWidgets.QStyle.PixelMetric.PM_FocusFrameVMargin,
+                    None,
+                    self.list_widget,
+                )
+                if style is not None
+                else 0
+            )
+            row_height = self.list_widget.fontMetrics().height() + 2 * vertical_margin
+        frame_width = self.list_widget.frameWidth()
+        spacing = self.list_widget.spacing()
+        rows = self._VISIBLE_LIST_ROWS
+        self.list_widget.setFixedHeight(
+            row_height * rows + spacing * max(0, rows - 1) + frame_width * 2
+        )
 
     def _refresh_add_combo(self) -> None:
         current = self.add_combo.currentText()

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -83,6 +83,11 @@ def _str_list(value: typing.Any) -> list[str]:
     return _unique_seq([str(item).strip() for item in value if str(item).strip()])
 
 
+def _workspace_extra(**extra: typing.Any) -> dict[str, typing.Any]:
+    """Return UI metadata for settings that may be saved in workspaces."""
+    return {"workspace_overridable": True, **extra}
+
+
 class KToolBZOptions(BaseModel):
     default_a: float = Field(
         default=3.54,
@@ -90,7 +95,7 @@ class KToolBZOptions(BaseModel):
         description="Default lattice constant a in Ångström.",
         ge=0.01,
         le=99.99,
-        json_schema_extra={"ui_step": 0.01, "ui_suffix": "Å"},
+        json_schema_extra=_workspace_extra(ui_step=0.01, ui_suffix="Å"),
     )
     default_b: float = Field(
         default=3.54,
@@ -98,7 +103,7 @@ class KToolBZOptions(BaseModel):
         description="Default lattice constant b in Ångström.",
         ge=0.01,
         le=99.99,
-        json_schema_extra={"ui_step": 0.01, "ui_suffix": "Å"},
+        json_schema_extra=_workspace_extra(ui_step=0.01, ui_suffix="Å"),
     )
     default_c: float = Field(
         default=6.01,
@@ -106,7 +111,7 @@ class KToolBZOptions(BaseModel):
         description="Default lattice constant c in Ångström.",
         ge=0.01,
         le=99.99,
-        json_schema_extra={"ui_step": 0.01, "ui_suffix": "Å"},
+        json_schema_extra=_workspace_extra(ui_step=0.01, ui_suffix="Å"),
     )
     default_alpha: float = Field(
         default=90.0,
@@ -114,7 +119,7 @@ class KToolBZOptions(BaseModel):
         description="Default lattice angle α in degrees.",
         ge=1.0,
         le=179.0,
-        json_schema_extra={"ui_step": 1.0, "ui_suffix": "°"},
+        json_schema_extra=_workspace_extra(ui_step=1.0, ui_suffix="°"),
     )
     default_beta: float = Field(
         default=90.0,
@@ -122,7 +127,7 @@ class KToolBZOptions(BaseModel):
         description="Default lattice angle β in degrees.",
         ge=1.0,
         le=179.0,
-        json_schema_extra={"ui_step": 1.0, "ui_suffix": "°"},
+        json_schema_extra=_workspace_extra(ui_step=1.0, ui_suffix="°"),
     )
     default_gamma: float = Field(
         default=120.0,
@@ -130,17 +135,17 @@ class KToolBZOptions(BaseModel):
         description="Default lattice angle γ in degrees.",
         ge=1.0,
         le=179.0,
-        json_schema_extra={"ui_step": 1.0, "ui_suffix": "°"},
+        json_schema_extra=_workspace_extra(ui_step=1.0, ui_suffix="°"),
     )
     default_centering: typing.Literal["P", "A", "B", "C", "F", "I", "R"] = Field(
         default="P",
         title="Centering",
         description="Default centering used to transform the conventional cell "
         "into a primitive cell.",
-        json_schema_extra={
-            "ui_type": "list",
-            "ui_limits": ["P", "A", "B", "C", "F", "I", "R"],
-        },
+        json_schema_extra=_workspace_extra(
+            ui_type="list",
+            ui_limits=["P", "A", "B", "C", "F", "I", "R"],
+        ),
     )
 
     default_rot: float = Field(
@@ -149,7 +154,7 @@ class KToolBZOptions(BaseModel):
         description="Default rotation of the Brillouin zone about kz in degrees.",
         ge=-360.0,
         le=360.0,
-        json_schema_extra={"ui_step": 1.0, "ui_suffix": "°"},
+        json_schema_extra=_workspace_extra(ui_step=1.0, ui_suffix="°"),
     )
 
 
@@ -218,8 +223,10 @@ class IOOptions(BaseModel):
         title="Default loader",
         description="Loader to pre-select in the data explorer.",
         json_schema_extra={
-            "ui_type": "list",
-            "ui_limits": ["None", *list(erlab.io.loaders.keys())],
+            **_workspace_extra(
+                ui_type="list",
+                ui_limits=["None", *list(erlab.io.loaders.keys())],
+            )
         },
     )
 
@@ -249,7 +256,7 @@ class ColorMapOptions(BaseModel):
         default="magma",
         title="Name",
         description="Name of the default colormap.",
-        json_schema_extra={"ui_type": "erlabpy_colormap"},
+        json_schema_extra=_workspace_extra(ui_type="erlabpy_colormap"),
     )
     gamma: float = Field(
         default=0.5,
@@ -257,12 +264,13 @@ class ColorMapOptions(BaseModel):
         le=99.99,
         title="Default γ",
         description="Default gamma exponent.",
-        json_schema_extra={"ui_step": 0.01},
+        json_schema_extra=_workspace_extra(ui_step=0.01),
     )
     reverse: bool = Field(
         default=False,
         title="Reverse",
         description="Display the colormap reversed by default.",
+        json_schema_extra=_workspace_extra(),
     )
     exclude: list[str] = Field(
         default=[
@@ -323,7 +331,7 @@ class ColorOptions(BaseModel):
         ),
         ge=1.0,
         le=1e308,
-        json_schema_extra={"ui_step": 1e30},
+        json_schema_extra=_workspace_extra(ui_step=1e30),
     )
     cursors: list[str] = Field(
         default=[
@@ -337,7 +345,7 @@ class ColorOptions(BaseModel):
         ],
         title="Cursor colors",
         description="Base list of colors used for different cursors in the ImageTool.",
-        json_schema_extra={"ui_type": "colorlist"},
+        json_schema_extra=_workspace_extra(ui_type="colorlist"),
     )
 
     @field_validator("cursors", mode="before")
@@ -358,7 +366,7 @@ class FigureOptions(BaseModel):
             "Ordered Matplotlib stylesheets applied to Figure Composer plots. "
             "Unavailable saved styles are kept and skipped until available again."
         ),
-        json_schema_extra={"ui_type": "matplotlib_stylesheets"},
+        json_schema_extra=_workspace_extra(ui_type="matplotlib_stylesheets"),
     )
 
     @field_validator("stylesheets", mode="before")

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -1,155 +1,771 @@
-import pyqtgraph.parametertree
-from qtpy import QtCore, QtWidgets
+from __future__ import annotations
+
+import contextlib
+import typing
+
+import pydantic
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+from erlab.interactive._options.core import (
+    model_with_workspace_overrides,
+    normalize_workspace_option_overrides,
+    option_model_with_value,
+    option_paths,
+    option_value,
+    workspace_overridable_option_paths,
+)
+from erlab.interactive._options.parameters import ColorListWidget, StylesheetListWidget
 from erlab.interactive._options.schema import AppOptions
-from erlab.interactive._options.tree import make_parameter, parameter_to_options
+
+_Scope = typing.Literal["user", "workspace"]
+_CATEGORY_ORDER = ("colors", "io", "ktool", "figure")
 
 
-class _CustomParameterTree(pyqtgraph.parametertree.ParameterTree):
-    """Custom ParameterTree that keeps a handle to the parameter it is displaying."""
+def _object_path(path: str) -> str:
+    return path.replace("/", "__")
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self._parameter: pyqtgraph.parametertree.Parameter | None = None
 
-    def setParameters(self, *args, **kwargs):
-        self._parameter = args[0] if args else None
-        super().setParameters(*args, **kwargs)
-        if self._parameter is not None:
-            self._apply_parameter_tooltips(self._parameter)
+def _field_constraints(field: pydantic.fields.FieldInfo) -> dict[str, typing.Any]:
+    constraints: dict[str, typing.Any] = {}
+    for item in field.metadata:
+        for name in ("ge", "gt", "le", "lt"):
+            value = getattr(item, name, None)
+            if value is not None:
+                constraints[name] = value
+    return constraints
 
-    @property
-    def parameter(self) -> pyqtgraph.parametertree.Parameter | None:
-        return self._parameter
 
-    def _apply_parameter_tooltips(
-        self, parameter: pyqtgraph.parametertree.Parameter
+def _model_field(path: str) -> pydantic.fields.FieldInfo:
+    model_type: type[pydantic.BaseModel] = AppOptions
+    field: pydantic.fields.FieldInfo | None = None
+    for key in path.split("/"):
+        field = model_type.model_fields[key]
+        annotation = field.annotation
+        if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
+            model_type = annotation
+    if field is None:  # pragma: no cover
+        raise KeyError(path)
+    return field
+
+
+def _path_title(path: str) -> str:
+    model_type: type[pydantic.BaseModel] = AppOptions
+    titles: list[str] = []
+    for index, key in enumerate(path.split("/")):
+        field = model_type.model_fields[key]
+        if index > 0:
+            titles.append(str(field.title or key.replace("_", " ").title()))
+        annotation = field.annotation
+        if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
+            model_type = annotation
+    if len(titles) <= 1:
+        return titles[0] if titles else path
+    return " / ".join(titles)
+
+
+def _path_description(path: str) -> str:
+    description = _model_field(path).description
+    return "" if description is None else str(description)
+
+
+def _field_extra(path: str) -> dict[str, typing.Any]:
+    extra = _model_field(path).json_schema_extra or {}
+    return dict(extra) if isinstance(extra, dict) else {}
+
+
+def _category_title(key: str) -> str:
+    field = AppOptions.model_fields[key]
+    return str(field.title or key.replace("_", " ").title())
+
+
+def _leaf_paths_for_category(category: str, *, workspace_only: bool) -> tuple[str, ...]:
+    prefix = f"{category}/"
+    allowed = set(workspace_overridable_option_paths()) if workspace_only else None
+    return tuple(
+        path
+        for path in option_paths()
+        if path.startswith(prefix) and (allowed is None or path in allowed)
+    )
+
+
+def _is_bool_path(path: str) -> bool:
+    value = option_value(AppOptions(), path)
+    return isinstance(value, bool)
+
+
+def _is_int_path(path: str) -> bool:
+    value = option_value(AppOptions(), path)
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_float_path(path: str) -> bool:
+    value = option_value(AppOptions(), path)
+    return isinstance(value, float)
+
+
+def _stylesheet_names(value: typing.Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = value.split(",")
+    if not isinstance(value, list | tuple):
+        value = [value]
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        name = str(item).strip()
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+class _SettingsRow(QtWidgets.QFrame):
+    def __init__(
+        self,
+        *,
+        scope: _Scope,
+        path: str,
+        control: QtWidgets.QWidget,
+        parent: QtWidgets.QWidget,
     ) -> None:
-        tip = parameter.opts.get("tip")
-        if tip:
-            for item in parameter.items:
-                item.setToolTip(0, tip)
-                item.setToolTip(1, tip)
-                for attr in ("layoutWidget", "displayLabel", "widget", "defaultBtn"):
-                    widget = getattr(item, attr, None)
-                    if widget is not None:
-                        widget.setToolTip(tip)
+        super().__init__(parent)
+        self.scope = scope
+        self.path = path
+        self.control = control
+        object_path = _object_path(path)
+        self.setObjectName(f"settingsRow_{scope}_{object_path}")
+        self.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        multiline_control = isinstance(control, StylesheetListWidget)
 
-        for child in parameter:
-            self._apply_parameter_tooltips(child)
+        layout = QtWidgets.QGridLayout(self)
+        layout.setContentsMargins(0, 8, 0, 8)
+        layout.setHorizontalSpacing(12)
+        layout.setVerticalSpacing(3)
+        layout.setColumnStretch(1, 1)
+
+        label = QtWidgets.QLabel(_path_title(path), self)
+        label.setObjectName(f"settingsLabel_{scope}_{object_path}")
+        label.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        layout.addWidget(label, 0, 0)
+
+        description = _path_description(path)
+        description_label = QtWidgets.QLabel(description, self)
+        description_label.setObjectName(f"settingsDescription_{scope}_{object_path}")
+        description_label.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        description_label.setWordWrap(True)
+        description_label.setEnabled(False)
+        layout.addWidget(description_label, 1, 0, 1, 4 if multiline_control else 2)
+
+        control.setObjectName(f"settingsControl_{scope}_{object_path}")
+        control.setToolTip(description)
+        label.setBuddy(control)
+        if multiline_control:
+            layout.addWidget(control, 2, 0, 1, 4)
+        else:
+            layout.addWidget(control, 0, 1)
+
+        self.override_check: QtWidgets.QCheckBox | None = None
+        if scope == "workspace":
+            self.override_check = QtWidgets.QCheckBox(self)
+            self.override_check.setObjectName(f"settingsOverride_{object_path}")
+            self.override_check.setToolTip("Store this value as a workspace override.")
+            layout.addWidget(self.override_check, 0, 2)
+
+        self.action_button = QtWidgets.QToolButton(self)
+        self.action_button.setObjectName(f"settingsReset_{scope}_{object_path}")
+        self.action_button.setAutoRaise(True)
+        self.action_button.setToolTip(
+            "Reset this setting to its default value."
+            if scope == "user"
+            else "Use the user setting for this workspace."
+        )
+        icon_name = "edit-undo" if scope == "user" else "edit-clear"
+        self.action_button.setIcon(QtGui.QIcon.fromTheme(icon_name))
+        self.action_button.setText("Reset" if scope == "user" else "Inherit")
+        layout.addWidget(self.action_button, 0, 3)
 
 
 class OptionDialog(QtWidgets.QDialog):
+    """Native settings dialog with immediate save and session revert."""
+
     def __init__(self, parent: QtWidgets.QWidget | None = None):
         super().__init__(parent)
+        self.setObjectName("settingsDialog")
         self.setWindowTitle("Settings")
+        self.setWindowModality(QtCore.Qt.WindowModality.NonModal)
+        self.setSizeGripEnabled(True)
 
-        self.tree = _CustomParameterTree()
-        self.setup_ui()
-        self.update()
+        self._workspace_manager = self._find_workspace_manager(parent)
+        self._baseline_user = erlab.interactive.options.model
+        self._baseline_workspace = self._workspace_overrides()
+        self._rows: dict[tuple[_Scope, str], _SettingsRow] = {}
+        self._page_indexes: dict[tuple[_Scope, str], int] = {}
+        self._updating = False
+        self._current_scope: _Scope = "user"
 
-    def setup_ui(self):
-        """Set up the UI for the settings dialog."""
-        buttons = QtWidgets.QDialogButtonBox()
-        self.btn_ok = buttons.addButton(
-            QtWidgets.QDialogButtonBox.StandardButton.Ok,
+        self._setup_ui()
+        self._refresh_all()
+
+    def showEvent(self, event: QtGui.QShowEvent | None) -> None:
+        self.reset_session_baseline()
+        super().showEvent(event)
+
+    @staticmethod
+    def _find_workspace_manager(parent: QtWidgets.QWidget | None) -> typing.Any | None:
+        current: QtCore.QObject | None = parent
+        required = (
+            "workspace_option_overrides",
+            "_set_workspace_option_overrides",
+            "set_workspace_option_override",
+            "clear_workspace_option_override",
+            "effective_interactive_options",
         )
-        self.btn_cancel = buttons.addButton(
-            QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+        while current is not None:
+            if all(hasattr(current, name) for name in required):
+                return current
+            current = current.parent()
+        return None
+
+    def _setup_ui(self) -> None:
+        main_layout = QtWidgets.QVBoxLayout(self)
+        main_layout.setContentsMargins(12, 12, 12, 12)
+        main_layout.setSpacing(8)
+
+        self.scope_tabs = QtWidgets.QTabBar(self)
+        self.scope_tabs.setObjectName("settingsScopeTabs")
+        self.scope_tabs.setExpanding(False)
+        self.scope_tabs.addTab("User")
+        if self._workspace_manager is not None:
+            self.scope_tabs.addTab("Workspace")
+        self.scope_tabs.currentChanged.connect(self._scope_changed)
+        main_layout.addWidget(self.scope_tabs)
+
+        content = QtWidgets.QWidget(self)
+        content_layout = QtWidgets.QHBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(12)
+        main_layout.addWidget(content, 1)
+
+        self.category_list = QtWidgets.QListWidget(content)
+        self.category_list.setObjectName("settingsCategoryList")
+        self.category_list.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
         )
-        self.btn_apply = buttons.addButton(
-            QtWidgets.QDialogButtonBox.StandardButton.Apply,
+        self.category_list.setHorizontalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
         )
-        self.btn_restore = buttons.addButton(
-            QtWidgets.QDialogButtonBox.StandardButton.RestoreDefaults,
+        self.category_list.setFixedWidth(170)
+        self.category_list.currentRowChanged.connect(self._category_changed)
+        content_layout.addWidget(self.category_list)
+
+        self.page_stack = QtWidgets.QStackedWidget(content)
+        self.page_stack.setObjectName("settingsPageStack")
+        content_layout.addWidget(self.page_stack, 1)
+
+        self._build_pages()
+        self.category_list.setCurrentRow(0)
+
+        bottom_bar = QtWidgets.QWidget(self)
+        bottom_layout = QtWidgets.QHBoxLayout(bottom_bar)
+        bottom_layout.setContentsMargins(0, 0, 0, 0)
+        bottom_layout.setSpacing(8)
+        main_layout.addWidget(bottom_bar)
+
+        self.status_label = QtWidgets.QLabel("Saved", bottom_bar)
+        self.status_label.setObjectName("settingsStatusLabel")
+        self.status_label.setEnabled(False)
+        bottom_layout.addWidget(self.status_label)
+        bottom_layout.addStretch(1)
+
+        self.reset_scope_button = QtWidgets.QPushButton(bottom_bar)
+        self.reset_scope_button.setObjectName("settingsResetScopeButton")
+        self.reset_scope_button.clicked.connect(self._reset_current_scope)
+        bottom_layout.addWidget(self.reset_scope_button)
+
+        self.revert_button = QtWidgets.QPushButton("Revert Changes", bottom_bar)
+        self.revert_button.setObjectName("settingsRevertButton")
+        self.revert_button.clicked.connect(self.revert_changes)
+        bottom_layout.addWidget(self.revert_button)
+
+        self.close_button = QtWidgets.QPushButton("Close", bottom_bar)
+        self.close_button.setObjectName("settingsCloseButton")
+        self.close_button.clicked.connect(self.close)
+        bottom_layout.addWidget(self.close_button)
+
+        close_shortcut = QtGui.QShortcut(QtGui.QKeySequence.StandardKey.Close, self)
+        close_shortcut.activated.connect(self.close)
+        escape_shortcut = QtGui.QShortcut(
+            QtGui.QKeySequence(QtCore.Qt.Key.Key_Escape), self
+        )
+        escape_shortcut.activated.connect(self.close)
+
+        self.resize(780, 560)
+        self.setMinimumSize(640, 420)
+
+    def _build_pages(self) -> None:
+        self.category_list.clear()
+        while self.page_stack.count():
+            widget = self.page_stack.widget(0)
+            self.page_stack.removeWidget(widget)
+            if widget is not None:
+                widget.deleteLater()
+        self._page_indexes.clear()
+        self._rows.clear()
+
+        for category in _CATEGORY_ORDER:
+            item = QtWidgets.QListWidgetItem(_category_title(category))
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, category)
+            self.category_list.addItem(item)
+
+        for scope in self._scopes():
+            for category in _CATEGORY_ORDER:
+                page = self._make_category_page(scope, category)
+                self._page_indexes[(scope, category)] = self.page_stack.addWidget(page)
+
+    def _scopes(self) -> tuple[_Scope, ...]:
+        if self._workspace_manager is None:
+            return ("user",)
+        return ("user", "workspace")
+
+    def _make_category_page(self, scope: _Scope, category: str) -> QtWidgets.QWidget:
+        container = QtWidgets.QWidget(self.page_stack)
+        container.setObjectName(f"settingsPageContainer_{scope}_{category}")
+        container_layout = QtWidgets.QVBoxLayout(container)
+        style = container.style()
+        right_margin = (
+            style.pixelMetric(
+                QtWidgets.QStyle.PixelMetric.PM_DefaultFrameWidth,
+                None,
+                container,
+            )
+            if style is not None
+            else 0
+        )
+        container_layout.setContentsMargins(0, 0, right_margin, 0)
+
+        scroll = QtWidgets.QScrollArea(container)
+        scroll.setObjectName(f"settingsPage_{scope}_{category}")
+        scroll.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        scroll.setWidgetResizable(True)
+        container_layout.addWidget(scroll)
+
+        page = QtWidgets.QWidget(scroll)
+        layout = QtWidgets.QVBoxLayout(page)
+        layout.setSpacing(0)
+
+        paths = _leaf_paths_for_category(category, workspace_only=scope == "workspace")
+        if not paths:
+            empty = QtWidgets.QLabel(page)
+            empty.setObjectName(f"settingsEmpty_{scope}_{category}")
+            empty.setWordWrap(True)
+            empty.setEnabled(False)
+            empty.setText(
+                "Workspace overrides are saved with ImageTool workspace files."
+            )
+            layout.addWidget(empty)
+            layout.addStretch(1)
+            scroll.setWidget(page)
+            return container
+
+        for path in paths:
+            control = self._make_control(path)
+            row = _SettingsRow(scope=scope, path=path, control=control, parent=page)
+            self._rows[(scope, path)] = row
+            self._connect_control(row)
+            row.action_button.clicked.connect(
+                lambda _checked=False, row=row: self._row_action(row)
+            )
+            if row.override_check is not None:
+                row.override_check.stateChanged.connect(
+                    lambda _state, row=row: self._override_changed(row)
+                )
+            layout.addWidget(row)
+            if path != paths[-1]:
+                line = QtWidgets.QFrame(page)
+                line.setFrameShape(QtWidgets.QFrame.Shape.HLine)
+                line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+                layout.addWidget(line)
+        layout.addStretch(1)
+        scroll.setWidget(page)
+        return container
+
+    def _make_control(self, path: str) -> QtWidgets.QWidget:
+        extra = _field_extra(path)
+        ui_type = extra.get("ui_type")
+        if ui_type == "erlabpy_colormap":
+            widget = erlab.interactive.colors.ColorMapComboBox(self)
+            widget.ensure_populated()
+            return widget
+        if ui_type == "colorlist":
+            return ColorListWidget(parent=self)
+        if ui_type == "matplotlib_stylesheets":
+            return StylesheetListWidget(parent=self)
+        if ui_type == "list" or "ui_limits" in extra:
+            combo = QtWidgets.QComboBox(self)
+            for choice in extra.get("ui_limits", ()):
+                combo.addItem(str(choice), choice)
+            return combo
+        if _is_bool_path(path):
+            return QtWidgets.QCheckBox(self)
+        if _is_int_path(path):
+            spin = QtWidgets.QSpinBox(self)
+            self._configure_spinbox(spin, path)
+            return spin
+        if _is_float_path(path):
+            spin = QtWidgets.QDoubleSpinBox(self)
+            self._configure_spinbox(spin, path)
+            return spin
+        return QtWidgets.QLineEdit(self)
+
+    def _configure_spinbox(
+        self, spin: QtWidgets.QSpinBox | QtWidgets.QDoubleSpinBox, path: str
+    ) -> None:
+        def set_minimum(value: float) -> None:
+            if isinstance(spin, QtWidgets.QDoubleSpinBox):
+                spin.setMinimum(float(value))
+            else:
+                spin.setMinimum(int(value))
+
+        def set_maximum(value: float) -> None:
+            if isinstance(spin, QtWidgets.QDoubleSpinBox):
+                spin.setMaximum(float(value))
+            else:
+                spin.setMaximum(int(value))
+
+        constraints = _field_constraints(_model_field(path))
+        if "ge" in constraints:
+            set_minimum(constraints["ge"])
+        elif "gt" in constraints:
+            set_minimum(constraints["gt"])
+        else:
+            minimum = -2147483648 if isinstance(spin, QtWidgets.QSpinBox) else -1e12
+            set_minimum(minimum)
+        if "le" in constraints:
+            set_maximum(constraints["le"])
+        elif "lt" in constraints:
+            set_maximum(constraints["lt"])
+        else:
+            maximum = 2147483647 if isinstance(spin, QtWidgets.QSpinBox) else 1e12
+            set_maximum(maximum)
+        extra = _field_extra(path)
+        if "ui_step" in extra:
+            if isinstance(spin, QtWidgets.QDoubleSpinBox):
+                spin.setSingleStep(float(extra["ui_step"]))
+            else:
+                spin.setSingleStep(int(extra["ui_step"]))
+        if isinstance(spin, QtWidgets.QDoubleSpinBox):
+            spin.setDecimals(6)
+        suffix = extra.get("ui_suffix")
+        if suffix:
+            spin.setSuffix(f" {suffix}")
+
+    def _connect_control(self, row: _SettingsRow) -> None:
+        control = row.control
+        if isinstance(control, QtWidgets.QCheckBox):
+            control.stateChanged.connect(
+                lambda _state, row=row: self._control_changed(row)
+            )
+        elif isinstance(control, QtWidgets.QSpinBox | QtWidgets.QDoubleSpinBox):
+            control.valueChanged.connect(
+                lambda _value, row=row: self._control_changed(row)
+            )
+        elif isinstance(control, QtWidgets.QComboBox):
+            control.currentIndexChanged.connect(
+                lambda _index, row=row: self._control_changed(row)
+            )
+        elif isinstance(control, ColorListWidget):
+            control.sigColorChanged.connect(
+                lambda _colors, row=row: self._control_changed(row)
+            )
+        elif isinstance(control, StylesheetListWidget):
+            control.sigStylesheetsChanged.connect(
+                lambda _stylesheets, row=row: self._control_changed(row)
+            )
+        elif isinstance(control, QtWidgets.QLineEdit):
+            control.editingFinished.connect(lambda row=row: self._control_changed(row))
+
+    def _scope_changed(self, index: int) -> None:
+        self._current_scope = "workspace" if index == 1 else "user"
+        self._update_visible_page()
+        self._refresh_all()
+
+    def _category_changed(self, _row: int) -> None:
+        self._update_visible_page()
+
+    def _update_visible_page(self) -> None:
+        item = self.category_list.currentItem()
+        if item is None:
+            return
+        category = item.data(QtCore.Qt.ItemDataRole.UserRole)
+        index = self._page_indexes.get((self._current_scope, str(category)))
+        if index is not None:
+            self.page_stack.setCurrentIndex(index)
+        if not hasattr(self, "reset_scope_button"):
+            return
+        button_text = (
+            "Reset User Settings…"
+            if self._current_scope == "user"
+            else "Clear Workspace Overrides…"
+        )
+        self.reset_scope_button.setText(button_text)
+        self.reset_scope_button.setToolTip(
+            "Reset all user settings to their defaults."
+            if self._current_scope == "user"
+            else "Remove every workspace-specific setting override."
         )
 
-        self.btn_ok.clicked.connect(self.accept)
-        self.btn_cancel.clicked.connect(self.reject)
-        self.btn_apply.clicked.connect(self.apply)
-        self.btn_restore.clicked.connect(self.restore)
+    def _workspace_overrides(self) -> dict[str, typing.Any]:
+        if self._workspace_manager is None:
+            return {}
+        overrides = self._workspace_manager.workspace_option_overrides()
+        return normalize_workspace_option_overrides(overrides)
 
-        self.btn_apply.setEnabled(False)
+    def _effective_options(self) -> AppOptions:
+        if self._workspace_manager is None:
+            return erlab.interactive.options.model
+        return model_with_workspace_overrides(
+            erlab.interactive.options.model,
+            self._workspace_overrides(),
+        )
 
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.addWidget(self.tree)
-        layout.addWidget(buttons)
-        self.setLayout(layout)
+    def _value_for_row(self, row: _SettingsRow) -> typing.Any:
+        if row.scope == "user":
+            return option_value(erlab.interactive.options.model, row.path)
+        overrides = self._workspace_overrides()
+        if row.path in overrides:
+            return overrides[row.path]
+        return option_value(erlab.interactive.options.model, row.path)
 
-        self.setMinimumSize(487, 301)
+    def _control_value(self, control: QtWidgets.QWidget, path: str) -> typing.Any:
+        if isinstance(control, QtWidgets.QCheckBox):
+            return control.isChecked()
+        if isinstance(control, QtWidgets.QSpinBox | QtWidgets.QDoubleSpinBox):
+            return control.value()
+        if isinstance(control, erlab.interactive.colors.ColorMapComboBox):
+            return control.currentText()
+        if isinstance(control, QtWidgets.QComboBox):
+            value = control.currentData()
+            return control.currentText() if value is None else value
+        if isinstance(control, ColorListWidget):
+            return control.get_colors()
+        if isinstance(control, StylesheetListWidget):
+            return control.get_stylesheets()
+        if isinstance(control, QtWidgets.QLineEdit):
+            text = control.text()
+            default_value = option_value(AppOptions(), path)
+            if isinstance(default_value, list):
+                return [item.strip() for item in text.split(",") if item.strip()]
+            return text
+        return None
+
+    def _set_control_value(
+        self, control: QtWidgets.QWidget, path: str, value: typing.Any
+    ) -> None:
+        if isinstance(control, QtWidgets.QCheckBox):
+            control.setChecked(bool(value))
+            return
+        if isinstance(control, QtWidgets.QSpinBox):
+            control.setValue(int(value))
+            return
+        if isinstance(control, QtWidgets.QDoubleSpinBox):
+            control.setValue(float(value))
+            return
+        if isinstance(control, erlab.interactive.colors.ColorMapComboBox):
+            control.ensure_populated()
+            control.setCurrentText(str(value))
+            return
+        if isinstance(control, QtWidgets.QComboBox):
+            index = control.findData(value)
+            if index < 0:
+                index = control.findText(str(value))
+            if index < 0:
+                control.addItem(f"{value} (unavailable)", value)
+                index = control.count() - 1
+            control.setCurrentIndex(index)
+            return
+        if isinstance(control, ColorListWidget):
+            control.set_colors(list(value or []))
+            return
+        if isinstance(control, StylesheetListWidget):
+            control.set_stylesheets(_stylesheet_names(value))
+            return
+        if isinstance(control, QtWidgets.QLineEdit):
+            if isinstance(value, list):
+                control.setText(", ".join(str(item) for item in value))
+            else:
+                control.setText(str(value))
+
+    def _refresh_all(self) -> None:
+        self._updating = True
+        try:
+            overrides = self._workspace_overrides()
+            for row in self._rows.values():
+                value = self._value_for_row(row)
+                self._set_control_value(row.control, row.path, value)
+                if row.scope == "workspace":
+                    active = row.path in overrides
+                    if row.override_check is not None:
+                        row.override_check.setChecked(active)
+                    row.control.setEnabled(active)
+                    row.action_button.setEnabled(active)
+                else:
+                    default_value = option_value(AppOptions(), row.path)
+                    row.action_button.setEnabled(value != default_value)
+        finally:
+            self._updating = False
+        self._update_status()
+        self._update_visible_page()
+
+    def _control_changed(self, row: _SettingsRow) -> None:
+        if self._updating:
+            return
+        value = self._control_value(row.control, row.path)
+        if row.scope == "workspace":
+            if row.override_check is None or not row.override_check.isChecked():
+                return
+            self._set_workspace_override(row.path, value)
+        else:
+            self._set_user_option(row.path, value)
+        self._refresh_all()
+
+    def _set_user_option(self, path: str, value: typing.Any) -> None:
+        with contextlib.suppress(pydantic.ValidationError, ValueError, TypeError):
+            erlab.interactive.options.model = option_model_with_value(
+                erlab.interactive.options.model, path, value
+            )
+
+    def _set_workspace_override(self, path: str, value: typing.Any) -> None:
+        if self._workspace_manager is None:
+            return
+        self._workspace_manager.set_workspace_option_override(path, value)
+
+    def _clear_workspace_override(self, path: str) -> None:
+        if self._workspace_manager is not None:
+            self._workspace_manager.clear_workspace_option_override(path)
+
+    def _override_changed(self, row: _SettingsRow) -> None:
+        if self._updating or row.override_check is None:
+            return
+        if row.override_check.isChecked():
+            value = self._control_value(row.control, row.path)
+            self._set_workspace_override(row.path, value)
+        else:
+            self._clear_workspace_override(row.path)
+        self._refresh_all()
+
+    def _row_action(self, row: _SettingsRow) -> None:
+        if row.scope == "workspace":
+            self._clear_workspace_override(row.path)
+        else:
+            self._set_user_option(row.path, option_value(AppOptions(), row.path))
+        self._refresh_all()
+
+    def _reset_current_scope(self) -> None:
+        if self._current_scope == "workspace":
+            if self._workspace_manager is None or not self._workspace_overrides():
+                return
+            reply = QtWidgets.QMessageBox.question(
+                self,
+                "Clear Workspace Overrides",
+                "Clear all workspace-specific settings?",
+                QtWidgets.QMessageBox.StandardButton.Yes
+                | QtWidgets.QMessageBox.StandardButton.Cancel,
+            )
+            if reply == QtWidgets.QMessageBox.StandardButton.Yes:
+                self._workspace_manager._set_workspace_option_overrides({})
+                self._refresh_all()
+            return
+
+        reply = QtWidgets.QMessageBox.question(
+            self,
+            "Reset User Settings",
+            "Reset all user settings to their defaults?",
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
+            erlab.interactive.options.restore()
+            self._refresh_all()
+
+    def _change_count(self) -> int:
+        count = 0
+        current_user = erlab.interactive.options.model
+        for path in option_paths():
+            if option_value(current_user, path) != option_value(
+                self._baseline_user, path
+            ):
+                count += 1
+        current_workspace = self._workspace_overrides()
+        keys = set(current_workspace) | set(self._baseline_workspace)
+        count += sum(
+            current_workspace.get(key) != self._baseline_workspace.get(key)
+            for key in keys
+        )
+        return count
+
+    def _update_status(self) -> None:
+        count = self._change_count()
+        if count == 0:
+            self.status_label.setText("Saved")
+            self.revert_button.setEnabled(False)
+        elif count == 1:
+            self.status_label.setText("1 change saved")
+            self.revert_button.setEnabled(True)
+        else:
+            self.status_label.setText(f"{count} changes saved")
+            self.revert_button.setEnabled(True)
 
     @property
     def current_options(self) -> AppOptions:
-        """Get the currently displayed settings from the parameter tree."""
-        if self.tree.parameter is None:
-            return AppOptions()
-        return parameter_to_options(self.tree.parameter)
+        """Return the currently saved user settings."""
+        return erlab.interactive.options.model
 
     @property
     def modified(self) -> bool:
-        """Check if the current settings differ from the saved settings."""
-        return self.current_options != erlab.interactive.options.model
+        """Whether settings changed since this window opened."""
+        return self._change_count() > 0
 
     @property
     def is_default(self) -> bool:
-        """Check if the current settings are the default settings."""
+        """Whether current user settings equal built-in defaults."""
         return self.current_options.model_dump() == AppOptions().model_dump()
 
     @QtCore.Slot()
-    def apply(self):
-        erlab.interactive.options.model = self.current_options
-        self.update()
-
-    def _set_parameters(self, opts: AppOptions) -> None:
-        """Update the parameter tree with the given options dictionary."""
-        if self.tree.parameter is not None:
-            self.tree.parameter.sigTreeStateChanged.disconnect(self._tree_changed)
-
-        parameter: pyqtgraph.parametertree.Parameter = make_parameter(opts)
-        parameter.sigTreeStateChanged.connect(self._tree_changed)
-        self.tree.setParameters(parameter, showTop=False)
-        self._tree_changed()
+    def apply(self) -> None:
+        """Compatibility no-op; edits are saved immediately."""
+        self._refresh_all()
 
     @QtCore.Slot()
-    def update(self):
-        """Update the parameter tree with current settings."""
-        self._set_parameters(erlab.interactive.options.model)
+    def update(self) -> None:
+        """Refresh displayed settings from the saved models."""
+        self._refresh_all()
 
     @QtCore.Slot()
-    def _tree_changed(self):
-        """Update button states when the tree changes."""
-        self.btn_restore.setDisabled(self.is_default)
-        if self.modified:
-            self.setWindowTitle("Settings (Unsaved Changes)")
-            self.btn_apply.setEnabled(True)
-        else:
-            self.setWindowTitle("Settings")
-            self.btn_apply.setEnabled(False)
+    def restore(self) -> None:
+        """Reset user settings to defaults immediately."""
+        erlab.interactive.options.restore()
+        self._refresh_all()
 
     @QtCore.Slot()
-    def restore(self):
-        """Populate the parameter tree with default settings."""
-        self._set_parameters(AppOptions())
+    def reset_session_baseline(self) -> None:
+        """Start a new revert session from the currently saved settings."""
+        self._baseline_user = erlab.interactive.options.model
+        self._baseline_workspace = self._workspace_overrides()
+        self._refresh_all()
 
-    def accept(self):
-        """Apply changes and close the dialog."""
-        self.apply()
-        super().accept()
+    @QtCore.Slot()
+    def revert_changes(self) -> None:
+        erlab.interactive.options.model = self._baseline_user
+        if self._workspace_manager is not None:
+            self._workspace_manager._set_workspace_option_overrides(
+                dict(self._baseline_workspace)
+            )
+        self._refresh_all()
 
-    def reject(self):
-        """Ask the user if they want to save changes before closing."""
-        if self.modified:
-            match QtWidgets.QMessageBox.question(
-                self,
-                "Unsaved Changes",
-                "You have unsaved changes. Do you want to save them before closing?",
-                QtWidgets.QMessageBox.StandardButton.Ok
-                | QtWidgets.QMessageBox.StandardButton.Discard
-                | QtWidgets.QMessageBox.StandardButton.Cancel,
-            ):
-                case QtWidgets.QMessageBox.StandardButton.Cancel:
-                    return
-                case QtWidgets.QMessageBox.StandardButton.Ok:
-                    self.apply()
+    def reject(self) -> None:
         super().reject()
+
+    def accept(self) -> None:
+        super().accept()

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -530,13 +530,29 @@ class OptionDialog(QtWidgets.QDialog):
             self._workspace_overrides(),
         )
 
+    @staticmethod
+    def _keeps_raw_workspace_value(control: QtWidgets.QWidget) -> bool:
+        if isinstance(control, StylesheetListWidget):
+            return True
+        return isinstance(control, QtWidgets.QComboBox) and not isinstance(
+            control, erlab.interactive.colors.ColorMapComboBox
+        )
+
     def _value_for_row(self, row: _SettingsRow) -> typing.Any:
         if row.scope == "user":
             return option_value(erlab.interactive.options.model, row.path)
         overrides = self._workspace_overrides()
         if row.path in overrides:
-            return overrides[row.path]
+            if self._keeps_raw_workspace_value(row.control):
+                return overrides[row.path]
+            return option_value(self._effective_options(), row.path)
         return option_value(erlab.interactive.options.model, row.path)
+
+    def _fallback_value_for_row(self, row: _SettingsRow) -> typing.Any:
+        for model in (erlab.interactive.options.model, AppOptions()):
+            with contextlib.suppress(Exception):
+                return option_value(model, row.path)
+        return None  # pragma: no cover
 
     def _control_value(self, control: QtWidgets.QWidget, path: str) -> typing.Any:
         if isinstance(control, QtWidgets.QCheckBox):
@@ -603,7 +619,16 @@ class OptionDialog(QtWidgets.QDialog):
             overrides = self._workspace_overrides()
             for row in self._rows.values():
                 value = self._value_for_row(row)
-                self._set_control_value(row.control, row.path, value)
+                try:
+                    self._set_control_value(row.control, row.path, value)
+                except (TypeError, ValueError):
+                    if row.scope != "workspace" or row.path not in overrides:
+                        raise
+                    self._set_control_value(
+                        row.control,
+                        row.path,
+                        self._fallback_value_for_row(row),
+                    )
                 if row.scope == "workspace":
                     active = row.path in overrides
                     if row.override_check is not None:

--- a/src/erlab/interactive/_stylesheets.py
+++ b/src/erlab/interactive/_stylesheets.py
@@ -7,13 +7,20 @@ import functools
 import importlib
 import pathlib
 import typing
+import warnings
 
+import matplotlib as mpl
 from matplotlib import style as mpl_style
+from qtpy import QtCore
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 
 _ERLAB_REGISTERED_STYLESHEETS: set[str] = set()
+_USER_REGISTERED_STYLESHEETS: set[str] = set()
+_USER_STYLESHEET_NAMES: frozenset[str] = frozenset()
+
+_STYLE_APPLICATION_NAME = "ImageTool Manager"
 
 
 @functools.cache
@@ -26,6 +33,100 @@ def _stylesheet_name_set() -> frozenset[str]:
     return frozenset(str(name) for name in mpl_style.available)
 
 
+def _style_library_paths() -> list[str]:
+    paths: list[str] | None = getattr(mpl_style, "USER_LIBRARY_PATHS", None)
+    if paths is not None:
+        return paths
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=mpl.MatplotlibDeprecationWarning)
+        from matplotlib.style import core as mpl_style_core  # pragma: no cover
+
+    return mpl_style_core.USER_LIBRARY_PATHS  # pragma: no cover
+
+
+@contextlib.contextmanager
+def _style_path_application_context():
+    application_name = QtCore.QCoreApplication.applicationName()
+    try:
+        QtCore.QCoreApplication.setApplicationName(_STYLE_APPLICATION_NAME)
+        yield
+    finally:
+        QtCore.QCoreApplication.setApplicationName(application_name)
+
+
+def _app_data_directory() -> pathlib.Path | None:
+    with _style_path_application_context():
+        location = QtCore.QStandardPaths.writableLocation(
+            QtCore.QStandardPaths.StandardLocation.AppDataLocation
+        )
+    return pathlib.Path(location) if location else None
+
+
+def _generic_data_directory() -> pathlib.Path | None:
+    location = QtCore.QStandardPaths.writableLocation(
+        QtCore.QStandardPaths.StandardLocation.GenericDataLocation
+    )
+    if not location:
+        return None
+    return pathlib.Path(location) / "erlabpy" / _STYLE_APPLICATION_NAME
+
+
+def user_stylesheet_directory(*, create: bool = True) -> pathlib.Path:
+    """Return the ERLab user stylesheet directory."""
+    base_path = _app_data_directory() or _generic_data_directory()
+    if base_path is None:
+        raise RuntimeError(
+            "Could not determine a writable application data directory for "
+            "custom Matplotlib stylesheets."
+        )
+    style_dir = base_path / "stylelib"
+    if create:
+        try:
+            style_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise RuntimeError(
+                "Could not create the custom Matplotlib stylesheet directory "
+                f"at {style_dir}."
+            ) from exc
+    return style_dir
+
+
+def _stylesheet_names_in_directory(style_dir: pathlib.Path) -> frozenset[str]:
+    if not style_dir.is_dir():
+        return frozenset()
+    return frozenset(path.stem for path in style_dir.glob("*.mplstyle"))
+
+
+def load_user_stylesheets(*, reload: bool = False) -> None:
+    """Register and load user-provided Matplotlib stylesheets."""
+    global _USER_STYLESHEET_NAMES
+
+    style_dir = user_stylesheet_directory()
+    library_paths = _style_library_paths()
+    style_dir_str = str(style_dir)
+    path_added = style_dir_str not in library_paths
+    if path_added:
+        library_paths.append(style_dir_str)
+
+    stylesheet_names = _stylesheet_names_in_directory(style_dir)
+    if path_added or reload or stylesheet_names != _USER_STYLESHEET_NAMES:
+        mpl_style.reload_library()
+        stylesheet_names = _stylesheet_names_in_directory(style_dir)
+
+    _USER_STYLESHEET_NAMES = stylesheet_names
+    available = _stylesheet_name_set()
+    _USER_REGISTERED_STYLESHEETS.clear()
+    _USER_REGISTERED_STYLESHEETS.update(
+        name for name in stylesheet_names if name in available
+    )
+
+
+def reload_stylesheets() -> None:
+    """Reload bundled and user-provided Matplotlib stylesheets."""
+    load_erlab_plotting_stylesheets()
+    load_user_stylesheets(reload=True)
+
+
 @functools.cache
 def load_erlab_plotting_stylesheets() -> None:
     """Import ERLab plotting once so its bundled stylesheets are registered."""
@@ -36,6 +137,7 @@ def load_erlab_plotting_stylesheets() -> None:
 def available_stylesheets(names: Iterable[str] = ()) -> frozenset[str]:
     """Return available stylesheets, loading ERLab plotting if requested names miss."""
     names = tuple(names)
+    load_user_stylesheets()
     available = _stylesheet_name_set()
     if names and any(name not in available for name in names):
         before_load = available
@@ -45,6 +147,17 @@ def available_stylesheets(names: Iterable[str] = ()) -> frozenset[str]:
             name for name in names if name not in before_load and name in available
         )
     return available
+
+
+def stylesheets_require_user_stylesheets(names: Iterable[str]) -> bool:
+    """Return whether a requested stylesheet is registered from the user directory."""
+    names = tuple(names)
+    if not names:
+        return False
+    if any(name in _USER_REGISTERED_STYLESHEETS for name in names):
+        return True
+    load_user_stylesheets()
+    return any(name in _USER_REGISTERED_STYLESHEETS for name in names)
 
 
 def stylesheets_require_erlab_plotting(names: Iterable[str]) -> bool:

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -500,8 +500,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
         self._position_readout_source_indicator()
         self._readout_source_indicator.show()
 
-    @staticmethod
-    def _readout_value_to_float(value: object) -> float | None:
+    def _readout_value_to_float(self, value: object) -> float | None:
         if value is None:
             return None
         compute = getattr(value, "compute", None)
@@ -510,7 +509,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
         arr = np.asarray(value)
         if arr.size == 0:
             return None
-        return erlab.interactive.imagetool.slicer._display_safe_float(arr)
+        return self.slicer_area.array_slicer.display_safe_float(arr)
 
     def _set_spin_dat_value(self, value: object) -> None:
         readout_value = self._readout_value_to_float(value)

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -777,9 +777,11 @@ class DataTransformDialog(_DataManipulationDialog):
             "execute": False,
         }
 
+        if slicer_area is None:
+            slicer_area = self.slicer_area
+        itool_kw["options_model"] = getattr(slicer_area, "_options_model", None)
+
         if self.keep_colors:
-            if slicer_area is None:
-                slicer_area = self.slicer_area
             color_props: ColorMapState = slicer_area.colormap_properties
 
             itool_kw["cmap"] = color_props["cmap"]

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -707,8 +707,12 @@ class _ActionsController:
         else:
             tool = typing.cast("erlab.interactive.utils.ToolWindow", node.tool_window)
             if node.parent_uid is None and self._manager._is_figure_node(node):
+                duplicated_tool = tool.duplicate()
+                duplicated_tool._tool_display_name = (
+                    self._manager._duplicated_figure_display_name(node.display_text)
+                )
                 new_target = self._manager.add_figuretool(
-                    tool.duplicate(), note=node.note
+                    duplicated_tool, note=node.note
                 )
             else:
                 parent_target = (

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -11,6 +11,7 @@ import weakref
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive._options.core
 from erlab.interactive import _qt_state
 from erlab.interactive.imagetool.manager._dialogs import _NameFilterDialog
 
@@ -20,6 +21,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
     from erlab.interactive._dask import DaskMenu
+    from erlab.interactive._options.schema import AppOptions
     from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
     from erlab.interactive.imagetool._mainwindow import ImageTool
     from erlab.interactive.imagetool.manager._actions import _ActionsController
@@ -227,6 +229,51 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     def _mark_workspace_layout_dirty(self) -> None:
         self._workspace_controller._mark_workspace_layout_dirty()
 
+    def _mark_workspace_options_dirty(self) -> None:
+        self._workspace_controller._mark_workspace_options_dirty()
+
+    def workspace_option_overrides(self) -> dict[str, typing.Any]:
+        """Return manager-local workspace option overrides."""
+        return dict(self._workspace_state.option_overrides)
+
+    def _set_workspace_option_overrides(
+        self,
+        overrides: typing.Mapping[str, typing.Any],
+        *,
+        mark_dirty: bool = True,
+    ) -> None:
+        normalized = (
+            erlab.interactive._options.core.normalize_workspace_option_overrides(
+                overrides
+            )
+        )
+        if self._workspace_state.option_overrides == normalized:
+            return
+        self._workspace_state.option_overrides = normalized
+        if mark_dirty:
+            self._mark_workspace_options_dirty()
+
+    def set_workspace_option_override(self, path: str, value: typing.Any) -> None:
+        overrides = self.workspace_option_overrides()
+        overrides[str(path)] = value
+        self._set_workspace_option_overrides(overrides)
+
+    def clear_workspace_option_override(self, path: str) -> None:
+        overrides = self.workspace_option_overrides()
+        try:
+            del overrides[str(path)]
+        except KeyError:
+            return
+        self._set_workspace_option_overrides(overrides)
+
+    @property
+    def effective_interactive_options(self) -> AppOptions:
+        """Return user settings with this manager's workspace overrides applied."""
+        return erlab.interactive._options.core.model_with_workspace_overrides(
+            erlab.interactive.options.model,
+            self._workspace_state.option_overrides,
+        )
+
     def _node_for_target(
         self, target: int | str
     ) -> _ImageToolWrapper | _ManagedWindowNode:
@@ -358,8 +405,12 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     def _create_explorer_window(self) -> QtWidgets.QWidget:
         from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
 
+        loader_name = self._recent_loader_name
+        if loader_name is None:
+            loader_name = self.effective_interactive_options.io.default_loader
         explorer = _TabbedExplorer(
-            root_path=self._recent_directory, loader_name=self._recent_loader_name
+            root_path=self._recent_directory,
+            loader_name=loader_name,
         )
         loader_kwargs, loader_extensions = (
             self._workspace_controller._explorer_loader_state()
@@ -392,7 +443,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         if self._recent_name_filter in valid_loaders:
             return self._recent_name_filter
 
-        default_loader = erlab.interactive.options.model.io.default_loader
+        default_loader = self.effective_interactive_options.io.default_loader
         if default_loader == "None" or default_loader not in erlab.io.loaders:
             return None
 

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1932,6 +1932,22 @@ class ImageToolManager(_ImageToolManagerBase):
                 highest = max(highest, int(match.group(1)))
         return f"Figure {highest + 1}"
 
+    def _duplicated_figure_display_name(self, display_name: str) -> str:
+        if re.fullmatch(r"Figure \d+", display_name):
+            return self._next_figure_display_name()
+
+        existing_names = {
+            self._child_node(uid).display_text for uid in self._figure_uids()
+        }
+        base_name = f"{display_name} copy"
+        if base_name not in existing_names:
+            return base_name
+
+        suffix = 2
+        while f"{base_name} {suffix}" in existing_names:
+            suffix += 1
+        return f"{base_name} {suffix}"
+
     def _sync_figures_ui(self, *, select_uid: str | None = None) -> None:
         figure_uids = self._figure_uids()
         selected_uids = (

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2488,6 +2488,7 @@ class ImageToolManager(_ImageToolManagerBase):
             FigureOperationState,
             FigureSourceState,
         )
+        from erlab.interactive._figurecomposer._defaults import figure_options_context
         from erlab.interactive._figurecomposer._sources import _public_source_data
 
         resolved_targets = tuple(dict.fromkeys(targets))
@@ -2527,60 +2528,63 @@ class ImageToolManager(_ImageToolManagerBase):
             except FigureComposerPlotSlicesSelectionError as exc:
                 self._show_figure_plot_slices_selection_error(exc)
                 return None
-        setup = self._figure_setup_for_operation(
-            None if custom_code is not None else operation or auto_operation,
-            source_data,
-        )
-        all_axes = FigureAxesSelectionState(
-            axes=self._figure_all_axes(setup.nrows, setup.ncols)
-        )
-        bz_operation = (
-            None
-            if operation is not None or custom_code is not None
-            else self._figure_bz_overlay_operation_from_targets(
-                resolved_targets,
+        with figure_options_context(self.effective_interactive_options):
+            setup = self._figure_setup_for_operation(
+                None if custom_code is not None else operation or auto_operation,
                 source_data,
-                axes=all_axes,
             )
-        )
-        operations: tuple[FigureOperationState, ...]
-        if operation is not None:
-            if (
-                operation.kind == FigureOperationKind.PLOT_SLICES
-                and not operation.axes.expression
-            ):
-                operation = operation.model_copy(update={"axes": all_axes})
-            operations = (operation,)
-        elif custom_code is not None:
-            operations = (
-                FigureOperationState.custom(
-                    label=title or "custom code",
-                    code=custom_code,
-                    trusted=True,
-                ),
+            all_axes = FigureAxesSelectionState(
+                axes=self._figure_all_axes(setup.nrows, setup.ncols)
             )
-        elif auto_operation is not None:
-            if not auto_operation.axes.expression:
-                auto_operation = auto_operation.model_copy(update={"axes": all_axes})
-            operations = (auto_operation,)
-        else:
-            operations = typing.cast(
-                "tuple[FigureOperationState, ...]",
-                self._make_figure_operations_for_sources(
+            bz_operation = (
+                None
+                if operation is not None or custom_code is not None
+                else self._figure_bz_overlay_operation_from_targets(
+                    resolved_targets,
                     source_data,
-                    setup=setup,
-                ),
+                    axes=all_axes,
+                )
             )
-        if bz_operation is not None:
-            operations = (*operations, bz_operation)
+            operations: tuple[FigureOperationState, ...]
+            if operation is not None:
+                if (
+                    operation.kind == FigureOperationKind.PLOT_SLICES
+                    and not operation.axes.expression
+                ):
+                    operation = operation.model_copy(update={"axes": all_axes})
+                operations = (operation,)
+            elif custom_code is not None:
+                operations = (
+                    FigureOperationState.custom(
+                        label=title or "custom code",
+                        code=custom_code,
+                        trusted=True,
+                    ),
+                )
+            elif auto_operation is not None:
+                if not auto_operation.axes.expression:
+                    auto_operation = auto_operation.model_copy(
+                        update={"axes": all_axes}
+                    )
+                operations = (auto_operation,)
+            else:
+                operations = typing.cast(
+                    "tuple[FigureOperationState, ...]",
+                    self._make_figure_operations_for_sources(
+                        source_data,
+                        setup=setup,
+                    ),
+                )
+            if bz_operation is not None:
+                operations = (*operations, bz_operation)
 
-        tool = FigureComposerTool.from_sources(
-            source_data,
-            sources=tuple(sources),
-            operations=operations,
-            setup=setup,
-            primary_source=primary_source,
-        )
+            tool = FigureComposerTool.from_sources(
+                source_data,
+                sources=tuple(sources),
+                operations=operations,
+                setup=setup,
+                primary_source=primary_source,
+            )
         tool._tool_display_name = (
             title if title is not None else self._next_figure_display_name()
         )
@@ -2718,6 +2722,7 @@ class ImageToolManager(_ImageToolManagerBase):
             FigureComposerTool,
             FigureSourceState,
         )
+        from erlab.interactive._figurecomposer._defaults import figure_options_context
         from erlab.interactive._figurecomposer._sources import _public_source_data
 
         resolved_targets = tuple(dict.fromkeys(targets))
@@ -2771,23 +2776,24 @@ class ImageToolManager(_ImageToolManagerBase):
             return False
 
         tool.add_sources(tuple(sources), source_data)
-        operations = (
-            (operation,)
-            if operation is not None
-            else (auto_operation,)
-            if auto_operation is not None
-            else self._make_figure_operations_for_sources(
-                source_data, setup=tool.tool_status.setup
+        with figure_options_context(self.effective_interactive_options):
+            operations = (
+                (operation,)
+                if operation is not None
+                else (auto_operation,)
+                if auto_operation is not None
+                else self._make_figure_operations_for_sources(
+                    source_data, setup=tool.tool_status.setup
+                )
             )
-        )
-        if operation is None:
-            bz_operation = self._figure_bz_overlay_operation_from_targets(
-                resolved_targets,
-                source_data,
-                axes=axes_selection,
-            )
-            if bz_operation is not None:
-                operations = (*operations, bz_operation)
+            if operation is None:
+                bz_operation = self._figure_bz_overlay_operation_from_targets(
+                    resolved_targets,
+                    source_data,
+                    axes=axes_selection,
+                )
+                if bz_operation is not None:
+                    operations = (*operations, bz_operation)
         for appended in operations:
             tool.add_operation(appended.model_copy(update={"axes": axes_selection}))
 
@@ -4263,6 +4269,7 @@ class ImageToolManager(_ImageToolManagerBase):
             tool._tool_display_name = self._next_figure_display_name()
         self._register_figure_node(node)
         if isinstance(tool, FigureComposerTool):
+            tool.set_options_getter(lambda: self.effective_interactive_options)
             self._install_figure_source_refresh_callbacks(node.uid, tool)
         self._mark_node_added(node.uid)
         self._sync_figures_ui(select_uid=node.uid if show else None)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1895,18 +1895,35 @@ class ImageToolManager(_ImageToolManagerBase):
         thumbnail_size = self._figure_gallery_thumbnail_size()
         canvas = QtGui.QPixmap(thumbnail_size)
         canvas.fill(self.palette().color(QtGui.QPalette.ColorRole.Base))
-        scaled = source_pixmap
-        if source_pixmap.size() != thumbnail_size:
-            scaled = source_pixmap.scaled(
-                thumbnail_size,
-                QtCore.Qt.AspectRatioMode.KeepAspectRatio,
-                QtCore.Qt.TransformationMode.SmoothTransformation,
-            )
+        dpr = source_pixmap.devicePixelRatioF()
+        if dpr <= 0.0:
+            dpr = 1.0
+        source_size = QtCore.QSizeF(
+            source_pixmap.width() / dpr,
+            source_pixmap.height() / dpr,
+        )
+        if source_size.isEmpty():
+            return canvas
+        target_size = QtCore.QSizeF(source_size)
+        target_size.scale(
+            QtCore.QSizeF(thumbnail_size),
+            QtCore.Qt.AspectRatioMode.KeepAspectRatio,
+        )
+        target_rect = QtCore.QRectF(
+            QtCore.QPointF(
+                (thumbnail_size.width() - target_size.width()) / 2.0,
+                (thumbnail_size.height() - target_size.height()) / 2.0,
+            ),
+            target_size,
+        )
         painter = QtGui.QPainter(canvas)
         try:
-            x_pos = (thumbnail_size.width() - scaled.width()) // 2
-            y_pos = (thumbnail_size.height() - scaled.height()) // 2
-            painter.drawPixmap(x_pos, y_pos, scaled)
+            painter.setRenderHint(QtGui.QPainter.RenderHint.SmoothPixmapTransform)
+            painter.drawPixmap(
+                target_rect,
+                source_pixmap,
+                QtCore.QRectF(QtCore.QPointF(0.0, 0.0), source_size),
+            )
         finally:
             painter.end()
         return canvas

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -1597,8 +1597,19 @@ class _WidgetsController:
 
     def open_settings(self) -> None:
         """Open the settings dialog for the ImageTool manager."""
-        dialog = erlab.interactive._options.OptionDialog(self._manager)
-        dialog.exec()
+        dialog = self._manager._additional_windows.get("settings")
+        if dialog is None or not erlab.interactive.utils.qt_is_valid(dialog):
+            dialog = erlab.interactive._options.OptionDialog(self._manager)
+            self._manager._additional_windows["settings"] = dialog
+
+            def cleanup(_obj: QtCore.QObject | None = None) -> None:
+                if self._manager._additional_windows.get("settings") is dialog:
+                    self._manager._additional_windows.pop("settings", None)
+
+            dialog.destroyed.connect(cleanup)
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
 
     def open_new_manager_instance(self) -> None:
         """Open another ImageTool Manager window."""

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -117,6 +117,13 @@ class StandaloneAppsState(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="ignore")
 
 
+class WorkspaceOptionOverridesState(pydantic.BaseModel):
+    schema_version: int = 1
+    overrides: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+
 @dataclass
 class _WorkspaceSaveSnapshot:
     generation: int
@@ -397,6 +404,7 @@ def _workspace_root_attrs_payload(
     manager_layout: Mapping[str, typing.Any] | None = None,
     loader_state: Mapping[str, typing.Any] | None = None,
     standalone_apps: Mapping[str, typing.Any] | None = None,
+    option_overrides: Mapping[str, typing.Any] | None = None,
 ) -> dict[str, typing.Any]:
     manifest: dict[str, typing.Any] = {
         "schema_version": _WORKSPACE_SCHEMA_VERSION,
@@ -418,6 +426,9 @@ def _workspace_root_attrs_payload(
     if standalone_apps is not None:
         # Restored on full workspace open; imports intentionally ignore app windows.
         manifest["standalone_apps"] = dict(standalone_apps)
+    if option_overrides is not None:
+        # Sparse interactive settings overrides portable with this workspace.
+        manifest["interactive_option_overrides"] = dict(option_overrides)
     if delta_save_count > 0:
         # Marks files written through the recoverable in-place delta-save protocol.
         manifest["transaction_protocol"] = _WORKSPACE_TRANSACTION_PROTOCOL

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -613,8 +613,6 @@ class _WorkspaceIOController:
         if node is None:
             return
         window = node.window
-        if window is None or not erlab.interactive.utils.qt_is_valid(window):
-            return
         if node.tool_window is not None:
             display_name = node.tool_window._tool_display_name
             base_title = (
@@ -624,10 +622,18 @@ class _WorkspaceIOController:
             )
         else:
             base_title = node.label_text
-        title = _window_title_with_modified_placeholder(base_title)
-        if title != window.windowTitle():
-            window.setWindowTitle(title)
-        window.setWindowModified(modified)
+        windows: list[tuple[QtWidgets.QWidget | None, str]] = [(window, base_title)]
+        if node.tool_window is not None:
+            windows.extend(node.tool_window._managed_secondary_windows())
+        for target_window, target_title in windows:
+            if target_window is None or not erlab.interactive.utils.qt_is_valid(
+                target_window
+            ):
+                continue
+            title = _window_title_with_modified_placeholder(target_title)
+            if title != target_window.windowTitle():
+                target_window.setWindowTitle(title)
+            target_window.setWindowModified(modified)
 
     def _apply_workspace_dirty_event(
         self, event: _manager_workspace._WorkspaceDirtyEvent

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -660,10 +660,21 @@ class _WorkspaceIOController:
             removed=removed,
             structure=structure,
         )
-        if event.uid is not None and (event.added or event.data or event.state):
+        was_modified = self._manager.is_workspace_modified
+        node_was_modified = event.uid is not None and event.uid in (
+            self._manager._workspace_state.dirty_added
+            | self._manager._workspace_state.dirty_data
+            | self._manager._workspace_state.dirty_state
+        )
+        if (
+            event.uid is not None
+            and (event.added or event.data or event.state)
+            and not node_was_modified
+        ):
             self._manager._set_node_window_modified(event.uid, True)
         self._manager._workspace_state.mark_dirty(event)
-        self._manager._update_workspace_window_title()
+        if not was_modified and self._manager.is_workspace_modified:
+            self._manager._update_workspace_window_title()
 
     def _mark_node_added(self, uid: str) -> None:
         self._manager._mark_workspace_dirty(

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -15,6 +15,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive._options.core
 import erlab.interactive.imagetool.slicer
 from erlab.interactive import _qt_state
 from erlab.interactive.imagetool import provenance
@@ -594,6 +595,12 @@ class _WorkspaceIOController:
                 if self._manager._workspace_state.layout_modified
                 else (),
             ),
+            (
+                "Settings modified",
+                ("Workspace settings",)
+                if self._manager._workspace_state.options_modified
+                else (),
+            ),
         )
         blocks: list[str] = []
         for label, items in sections:
@@ -686,6 +693,16 @@ class _WorkspaceIOController:
         ):
             return
         if self._manager._workspace_state.mark_layout_dirty():
+            self._manager._update_workspace_window_title()
+
+    def _mark_workspace_options_dirty(self) -> None:
+        if (
+            self._manager._workspace_state.loading_depth > 0
+            or self._manager._workspace_state.saving_depth > 0
+            or self._manager._workspace_state.closing_document
+        ):
+            return
+        if self._manager._workspace_state.mark_options_dirty():
             self._manager._update_workspace_window_title()
 
     def _mark_workspace_clean(self) -> None:
@@ -1565,6 +1582,7 @@ class _WorkspaceIOController:
                 )
                 if replace:
                     self._manager._restore_workspace_layout(manifest)
+                    self._restore_workspace_option_overrides(manifest)
                     self._restore_workspace_loader_state(manifest)
                     self._restore_standalone_apps_state(manifest)
                 if not mark_dirty:
@@ -1703,6 +1721,7 @@ class _WorkspaceIOController:
                     )
                     if replace:
                         self._manager._restore_workspace_layout(manifest)
+                        self._restore_workspace_option_overrides(manifest)
                         self._restore_workspace_loader_state(manifest)
                         self._restore_standalone_apps_state(manifest)
                     if not mark_dirty:
@@ -1863,6 +1882,7 @@ class _WorkspaceIOController:
             manager_layout=self._manager._workspace_layout_snapshot(),
             loader_state=self._workspace_loader_state_snapshot(),
             standalone_apps=self._workspace_standalone_apps_snapshot(),
+            option_overrides=self._workspace_option_overrides_snapshot(),
         )
 
     def _workspace_layout_snapshot(self) -> dict[str, typing.Any]:
@@ -1899,6 +1919,35 @@ class _WorkspaceIOController:
         )
         if right_splitter is not None:
             self._manager.right_splitter.restoreState(right_splitter)
+
+    def _workspace_option_overrides_snapshot(self) -> dict[str, typing.Any]:
+        return _manager_workspace.WorkspaceOptionOverridesState(
+            overrides=erlab.interactive._options.core.normalize_workspace_option_overrides(
+                self._manager._workspace_state.option_overrides
+            )
+        ).model_dump(mode="json")
+
+    def _restore_workspace_option_overrides(
+        self, manifest: Mapping[str, typing.Any] | None
+    ) -> None:
+        if manifest is None:
+            return
+        payload = manifest.get("interactive_option_overrides")
+        if not isinstance(payload, dict):
+            self._manager._set_workspace_option_overrides({}, mark_dirty=False)
+            return
+        try:
+            state = _manager_workspace.WorkspaceOptionOverridesState.model_validate(
+                payload
+            )
+        except Exception:
+            logger.warning(
+                "Ignoring invalid workspace interactive option overrides",
+                exc_info=True,
+            )
+            self._manager._set_workspace_option_overrides({}, mark_dirty=False)
+            return
+        self._manager._set_workspace_option_overrides(state.overrides, mark_dirty=False)
 
     def _workspace_loader_state_snapshot(self) -> dict[str, typing.Any]:
         manager_loader_kwargs = self._manager._recent_loader_kwargs_by_filter
@@ -2514,8 +2563,8 @@ class _WorkspaceIOController:
     def _workspace_layout_only_modified(self) -> bool:
         return (
             self._manager._workspace_state.layout_modified
-            and not self._workspace_has_non_layout_modifications()
-        )
+            or self._manager._workspace_state.options_modified
+        ) and not self._workspace_has_non_layout_modifications()
 
     def _workspace_rewrite_group_snapshot(
         self, uid: str
@@ -3105,6 +3154,7 @@ class _WorkspaceIOController:
                                     rebind_data=False,
                                 )
                                 if replace:
+                                    self._restore_workspace_option_overrides(manifest)
                                     self._restore_workspace_loader_state(
                                         manifest, apply_explorer=False
                                     )
@@ -3135,6 +3185,7 @@ class _WorkspaceIOController:
                         rebind_data=False,
                     )
                     if replace:
+                        self._restore_workspace_option_overrides(manifest)
                         self._restore_workspace_loader_state(
                             manifest, apply_explorer=False
                         )
@@ -3331,7 +3382,12 @@ class _WorkspaceIOController:
             for ds in data:
                 try:
                     self._manager.add_imagetool(
-                        ImageTool.from_dataset(ds, _in_manager=True), activate=True
+                        ImageTool.from_dataset(
+                            ds,
+                            _in_manager=True,
+                            options_model=self._manager.effective_interactive_options,
+                        ),
+                        activate=True,
                     )
                 except Exception:
                     flags.append(False)
@@ -3366,6 +3422,7 @@ class _WorkspaceIOController:
         link_colors = kwargs.pop("link_colors", True)
         indices: list[int] = []
         kwargs["_in_manager"] = True
+        kwargs.setdefault("options_model", self._manager.effective_interactive_options)
 
         load_func = kwargs.pop("load_func", None)
         load_indices = kwargs.pop("load_indices", None)

--- a/src/erlab/interactive/imagetool/manager/_workspace_state.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_state.py
@@ -29,6 +29,8 @@ class _WorkspaceStateSnapshot(typing.TypedDict):
     dirty_removed: tuple[str, ...]
     structure_reasons: tuple[str, ...]
     layout_modified: bool
+    options_modified: bool
+    option_overrides: dict[str, typing.Any]
     dirty_generation: int
     dirty_events: tuple[_manager_workspace._WorkspaceDirtyEvent, ...]
     delta_save_count: int
@@ -50,6 +52,8 @@ class _ManagerWorkspaceState:
         self.dirty_removed: list[str] = []
         self.structure_reasons: list[str] = []
         self.layout_modified: bool = False
+        self.options_modified: bool = False
+        self.option_overrides: dict[str, typing.Any] = {}
         self.needs_full_save: bool = False
         self.dirty_generation: int = 0
         self.dirty_events: list[_manager_workspace._WorkspaceDirtyEvent] = []
@@ -71,6 +75,7 @@ class _ManagerWorkspaceState:
             or bool(self.dirty_data)
             or bool(self.dirty_state)
             or bool(self.dirty_removed)
+            or self.options_modified
         )
 
     def apply_dirty_event(self, event: _manager_workspace._WorkspaceDirtyEvent) -> bool:
@@ -108,9 +113,17 @@ class _ManagerWorkspaceState:
         self.dirty_generation += 1
         return True
 
+    def mark_options_dirty(self) -> bool:
+        if self.options_modified:
+            return False
+        self.options_modified = True
+        self.dirty_generation += 1
+        return True
+
     def mark_clean(self) -> None:
         self.structure_modified = False
         self.layout_modified = False
+        self.options_modified = False
         self.dirty_added.clear()
         self.dirty_data.clear()
         self.dirty_state.clear()
@@ -147,6 +160,8 @@ class _ManagerWorkspaceState:
             "dirty_removed": tuple(self.dirty_removed),
             "structure_reasons": tuple(self.structure_reasons),
             "layout_modified": self.layout_modified,
+            "options_modified": self.options_modified,
+            "option_overrides": dict(self.option_overrides),
             "dirty_generation": self.dirty_generation,
             "dirty_events": tuple(self.dirty_events),
             "delta_save_count": self.delta_save_count,
@@ -164,6 +179,8 @@ class _ManagerWorkspaceState:
         self.dirty_removed = list(snapshot["dirty_removed"])
         self.structure_reasons = list(snapshot["structure_reasons"])
         self.layout_modified = snapshot["layout_modified"]
+        self.options_modified = snapshot["options_modified"]
+        self.option_overrides = dict(snapshot["option_overrides"])
         self.dirty_generation = snapshot["dirty_generation"]
         self.dirty_events = list(snapshot["dirty_events"])
         self.delta_save_count = snapshot["delta_save_count"]

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -382,6 +382,7 @@ class _ManagedWindowNode(QtCore.QObject):
             old.removeEventFilter(self)
             old._set_managed_source_update_dialog(None)
             old._set_managed_source_reload(None)
+            old._set_managed_secondary_window_callback(None)
             old.set_source_parent_fetcher(None)
             old.set_input_provenance_parent_fetcher(None)
             old.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
@@ -431,6 +432,27 @@ class _ManagedWindowNode(QtCore.QObject):
             self.can_reload_source_data,
             self.reload_unavailable_reason,
         )
+        tool._set_managed_secondary_window_callback(
+            self._configure_tool_secondary_window
+        )
+        for secondary_window, _title in tool._managed_secondary_windows():
+            self._configure_tool_secondary_window(secondary_window)
+
+    def _configure_tool_secondary_window(self, window: QtWidgets.QWidget) -> None:
+        manager = self._manager()
+        if manager is None or not erlab.interactive.utils.qt_is_valid(manager):
+            return
+        manager._install_workspace_save_shortcut(window)
+        if manager._tool_graph.nodes.get(self.uid) is self:
+            manager._set_node_window_modified(
+                self.uid,
+                self.uid
+                in (
+                    manager._workspace_state.dirty_added
+                    | manager._workspace_state.dirty_data
+                    | manager._workspace_state.dirty_state
+                ),
+            )
 
     def _handle_tool_window_destroyed(self, _obj: QtCore.QObject | None = None) -> None:
         manager = self._manager()

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -263,13 +263,13 @@ class ItoolPlotDataItem(ItoolDisplayObject, pg.PlotDataItem):
     def update_data(self, coord, vals) -> None:
         mask_display = not self.array_slicer.display_values_known_safe
         if mask_display:
-            vals = erlab.interactive.imagetool.slicer._display_safe_values(vals)
+            vals = self.array_slicer.display_safe_values(vals)
         if self.normalize:
             avg = np.nan if np.isnan(np.asarray(vals)).all() else np.nanmean(vals)
             if not np.isnan(avg):  # pragma: no branch
                 with np.errstate(all="ignore"):
                     vals = vals / avg
-            vals = erlab.interactive.imagetool.slicer._display_safe_values(vals)
+            vals = self.array_slicer.display_safe_values(vals)
 
         coord, vals = _pad_1d_plot(coord, vals)
 
@@ -314,7 +314,7 @@ class ItoolImageItem(ItoolDisplayObject, erlab.interactive.colors.BetterImageIte
     @suppressnanwarning
     def update_data(self, rect, img) -> None:
         if not self.array_slicer.display_values_known_safe:
-            img = erlab.interactive.imagetool.slicer._display_safe_values(img)
+            img = self.array_slicer.display_safe_values(img)
         self.setImage(
             image=img, rect=rect, autoLevels=not self.slicer_area.levels_locked
         )
@@ -2565,10 +2565,8 @@ class ItoolPlotItem(pg.PlotItem):
         """
         if self.is_image:  # pragma: no branch
             self.slicer_area.lock_levels(True)
-            self.slicer_area.levels = (
-                erlab.interactive.imagetool.slicer._display_safe_minmax(
-                    self._current_data_cropped
-                )
+            self.slicer_area.levels = self.array_slicer.display_safe_minmax(
+                self._current_data_cropped
             )
 
     @QtCore.Slot()

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -208,28 +208,33 @@ def _display_safe_values(values, limit: float | None = None):
         return np.where(np.isfinite(arr) & (np.abs(arr) <= limit), arr, np.nan)
 
 
-def _display_safe_float(value) -> float:
+def _display_safe_float(value, limit: float | None = None) -> float:
     """Return a scalar display value after applying ImageTool display masking."""
     arr = np.asarray(value)
     if arr.size == 0:
         return np.nan
+    if limit is None:
+        limit = _display_value_abs_limit()
     if arr.size == 1:
         out = float(arr.reshape(()))
-        if np.isfinite(out) and abs(out) <= _display_value_abs_limit():
+        if np.isfinite(out) and abs(out) <= limit:
             return out
         return np.nan
 
-    arr = np.asarray(_display_safe_values(arr))
+    arr = np.asarray(_display_safe_values(arr, limit))
     if np.isnan(arr).all():
         return np.nan
     return float(np.nanmean(arr))
 
 
 def _display_safe_minmax(
-    data: xr.DataArray, raw_limits: tuple[float, float] | None = None
+    data: xr.DataArray,
+    raw_limits: tuple[float, float] | None = None,
+    limit: float | None = None,
 ) -> tuple[float, float]:
     """Return display-safe finite limits for an ImageTool DataArray."""
-    limit = _display_value_abs_limit()
+    if limit is None:
+        limit = _display_value_abs_limit()
     mn, mx = raw_limits if raw_limits is not None else _minmax_darr_quiet(data)
     if _limits_require_display_mask(mn, mx, limit):
         if data.chunks is None:
@@ -382,8 +387,19 @@ class ArraySlicer(QtCore.QObject):
     sigShapeChanged = QtCore.Signal()  #: :meta private:
     sigTwinChanged = QtCore.Signal()  #: :meta private:
 
-    def __init__(self, xarray_obj: xr.DataArray, parent: QtCore.QObject) -> None:
+    def __init__(
+        self,
+        xarray_obj: xr.DataArray,
+        parent: QtCore.QObject,
+        *,
+        display_value_abs_limit: float | None = None,
+    ) -> None:
         super().__init__(parent)
+        self.display_value_abs_limit = float(
+            display_value_abs_limit
+            if display_value_abs_limit is not None
+            else _display_value_abs_limit()
+        )
         self.snap_act = QtWidgets.QAction("&Snap to Pixels", self)
         self.snap_act.setShortcut("S")
         self.snap_act.setCheckable(True)
@@ -696,19 +712,33 @@ class ArraySlicer(QtCore.QObject):
     def _raw_limits(self) -> tuple[float, float]:
         return _minmax_darr_quiet(self._obj)
 
+    def display_safe_values(self, values):
+        """Return values safe for Qt rendering for this slicer instance."""
+        return _display_safe_values(values, self.display_value_abs_limit)
+
+    def display_safe_float(self, value) -> float:
+        """Return a scalar display value for this slicer instance."""
+        return _display_safe_float(value, self.display_value_abs_limit)
+
+    def display_safe_minmax(
+        self, data: xr.DataArray, raw_limits: tuple[float, float] | None = None
+    ) -> tuple[float, float]:
+        """Return display-safe finite limits for this slicer instance."""
+        return _display_safe_minmax(data, raw_limits, self.display_value_abs_limit)
+
     @property
     def display_values_known_safe(self) -> bool:
         if self._obj.chunks is not None:
             return False
         raw_limits = self.__dict__.get("_raw_limits")
         return raw_limits is not None and not _limits_require_display_mask(
-            raw_limits[0], raw_limits[1], _display_value_abs_limit()
+            raw_limits[0], raw_limits[1], self.display_value_abs_limit
         )
 
     @functools.cached_property
     def limits(self) -> tuple[float, float]:
         """Return the display-safe global minimum and maximum of the data."""
-        return _display_safe_minmax(self._obj, self._raw_limits)
+        return self.display_safe_minmax(self._obj, self._raw_limits)
 
     @property
     def n_cursors(self) -> int:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -38,6 +38,7 @@ if typing.TYPE_CHECKING:
 
     import qtawesome
 
+    from erlab.interactive._options.schema import AppOptions
     from erlab.interactive.imagetool.plot_items import (
         ItoolGraphicsLayoutWidget,
         ItoolImageItem,
@@ -169,9 +170,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
     @property
     def COLORS(self) -> tuple[QtGui.QColor, ...]:
         r""":class:`PySide6.QtGui.QColor`\ s for multiple cursors."""
-        return tuple(
-            QtGui.QColor(c) for c in erlab.interactive.options.model.colors.cursors
-        )
+        return tuple(QtGui.QColor(c) for c in self._options_model.colors.cursors)
 
     TWIN_COLORS: tuple[QtGui.QColor, ...] = (
         pg.mkColor("#ffa500"),
@@ -244,9 +243,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
         auto_compute: bool = True,
         image_cls=None,
         plotdata_cls=None,
+        options_model: AppOptions | None = None,
         _in_manager: bool = False,
     ) -> None:
         super().__init__(parent)
+        self._options_model = options_model or erlab.interactive.options.model
         self.qapp = typing.cast(
             "QtWidgets.QApplication", QtWidgets.QApplication.instance()
         )
@@ -256,7 +257,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         )
 
         # Handle default values
-        opts = erlab.interactive.options.model
+        opts = self._options_model
         if cmap is None:
             cmap = opts.colors.cmap.name
             if opts.colors.cmap.reverse:
@@ -1684,7 +1685,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             ax.vb.blockSignals(False)
 
         self.sigPointValueChanged.emit(
-            erlab.interactive.imagetool.slicer._display_safe_float(next(arrays_it))
+            self.array_slicer.display_safe_float(next(arrays_it))
         )
 
     def link(self, proxy: SlicerLinkProxy) -> None:
@@ -1900,7 +1901,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
             else:
                 self._array_slicer = erlab.interactive.imagetool.slicer.ArraySlicer(
-                    self._data, self
+                    self._data,
+                    self,
+                    display_value_abs_limit=(
+                        self._options_model.colors.max_rendered_abs_value
+                    ),
                 )
                 logger.debug("Initialized ArraySlicer")
         except Exception:
@@ -3150,6 +3155,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             data_name=self.watched_data_name,
             initial_normal_emission=initial_normal_emission,
             initial_delta=initial_delta,
+            options_model=self._options_model,
             execute=False,
         )
         if isinstance(tool, erlab.interactive.utils.ToolWindow):

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -36,6 +36,8 @@ if typing.TYPE_CHECKING:
     import matplotlib
     import varname
     import xarray as xr
+
+    from erlab.interactive._options.schema import AppOptions
 else:
     import lazy_loader as _lazy
 
@@ -151,6 +153,7 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
         centering: typing.Literal["P", "A", "B", "C", "F", "I", "R"] | None = None,
         cmap: str | None = None,
         gamma: float | None = None,
+        options_model: AppOptions | None = None,
     ) -> None:
         # Initialize UI
         super().__init__()
@@ -172,7 +175,7 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
             plot.addItem(self.images[i])
             plot.showGrid(x=True, y=True, alpha=0.5)
 
-        opts = erlab.interactive.options.model
+        opts = options_model or erlab.interactive.options.model
 
         if cmap is None:
             cmap = opts.colors.cmap.name
@@ -716,9 +719,15 @@ class KspaceTool(KspaceToolGUI):
         data_name: str | None = None,
         initial_normal_emission: tuple[float, float] | None = None,
         initial_delta: float | None = None,
+        options_model: AppOptions | None = None,
     ) -> None:
         super().__init__(
-            avec=avec, rotate_bz=rotate_bz, centering=centering, cmap=cmap, gamma=gamma
+            avec=avec,
+            rotate_bz=rotate_bz,
+            centering=centering,
+            cmap=cmap,
+            gamma=gamma,
+            options_model=options_model,
         )
 
         self._argnames: dict[str, str] = {}
@@ -1613,6 +1622,7 @@ def ktool(
     data_name: str | None = None,
     initial_normal_emission: tuple[float, float] | None = None,
     initial_delta: float | None = None,
+    options_model: AppOptions | None = None,
     execute: bool | None = None,
 ) -> KspaceTool:
     """Interactive momentum conversion tool.
@@ -1668,6 +1678,7 @@ def ktool(
             data_name=data_name,
             initial_normal_emission=initial_normal_emission,
             initial_delta=initial_delta,
+            options_model=options_model,
         )
         win.show()
         win.raise_()

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -6378,7 +6378,11 @@ class _PythonCodeLineNumberArea(QtWidgets.QWidget):
 class PythonCodeEditor(QtWidgets.QTextEdit):
     """Python code editor with syntax highlighting and block indentation."""
 
+    sigTextEditingStarted = QtCore.Signal()  #: :meta private:
+    sigTextEditingSettled = QtCore.Signal(str)  #: :meta private:
+
     TAB_SPACES = 4
+    TEXT_EDITING_SETTLE_DELAY_MS = 800
     _PAIR_DELIMITERS: typing.ClassVar[dict[str, str]] = {
         "(": ")",
         "[": "]",
@@ -6392,11 +6396,19 @@ class PythonCodeEditor(QtWidgets.QTextEdit):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._line_number_area = _PythonCodeLineNumberArea(self)
+        self._text_editing_active = False
+        self._text_editing_settle_timer = QtCore.QTimer(self)
+        self._text_editing_settle_timer.setSingleShot(True)
+        self._text_editing_settle_timer.setInterval(self.TEXT_EDITING_SETTLE_DELAY_MS)
+        self._text_editing_settle_timer.timeout.connect(
+            self._finish_text_editing_activity
+        )
         self.setAcceptRichText(False)
         self.setFont(
             QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
         )
         self.highlighter = PythonHighlighter(self.document())
+        self.document().contentsChange.connect(self._mark_text_editing_activity)
         self.document().blockCountChanged.connect(
             lambda _count: self._update_line_number_area_width()
         )
@@ -6488,6 +6500,58 @@ class PythonCodeEditor(QtWidgets.QTextEdit):
             else QtWidgets.QTextEdit.LineWrapMode.NoWrap
         )
         self.setLineWrapMode(mode)
+
+    def set_text_editing_settle_delay(self, delay_ms: int) -> None:
+        """Set the quiet interval used to mark text editing as settled."""
+        self._text_editing_settle_timer.setInterval(max(0, delay_ms))
+
+    def text_editing_settle_delay(self) -> int:
+        """Return the quiet interval used to mark text editing as settled."""
+        return self._text_editing_settle_timer.interval()
+
+    def text_editing_active(self) -> bool:
+        """Return whether the document is in an active editing burst."""
+        return self._text_editing_active
+
+    def reset_text_editing_activity(self) -> None:
+        """Clear pending editing activity without emitting settled-text signals."""
+        self._text_editing_settle_timer.stop()
+        self._text_editing_active = False
+
+    @staticmethod
+    def python_syntax_error_for_text(code: str) -> SyntaxError | None:
+        """Return the Python syntax error for *code*, or ``None`` if it parses."""
+        try:
+            ast.parse(code)
+        except SyntaxError as exc:
+            return exc
+        return None
+
+    def python_syntax_error(self, code: str | None = None) -> SyntaxError | None:
+        """Return the Python syntax error for *code* or the editor contents."""
+        return self.python_syntax_error_for_text(
+            self.toPlainText() if code is None else code
+        )
+
+    def has_valid_python_syntax(self, code: str | None = None) -> bool:
+        """Return whether *code* or the editor contents parse as Python."""
+        return self.python_syntax_error(code) is None
+
+    def _mark_text_editing_activity(
+        self, _position: int, chars_removed: int, chars_added: int
+    ) -> None:
+        if not chars_removed and not chars_added:
+            return
+        if not self._text_editing_active:
+            self._text_editing_active = True
+            self.sigTextEditingStarted.emit()
+        self._text_editing_settle_timer.start()
+
+    def _finish_text_editing_activity(self) -> None:
+        if not self._text_editing_active:
+            return
+        self._text_editing_active = False
+        self.sigTextEditingSettled.emit(self.toPlainText())
 
     @staticmethod
     def _plain_edit_modifiers(mods: QtCore.Qt.KeyboardModifier) -> bool:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -70,6 +70,7 @@ __all__ = [
     "KeyboardEventFilter",
     "MessageDialog",
     "ParameterGroup",
+    "PythonCodeEditor",
     "PythonHighlighter",
     "ResizingLineEdit",
     "RotatableLine",
@@ -6358,3 +6359,615 @@ class PythonHighlighter(QtGui.QSyntaxHighlighter):
         bi = self.currentBlock().blockNumber()
         for start, length, f in self._block_spans.get(bi, ()):
             self.setFormat(start, length, f)
+
+
+class _PythonCodeLineNumberArea(QtWidgets.QWidget):
+    def __init__(self, editor: PythonCodeEditor) -> None:
+        super().__init__(editor)
+        self._editor = editor
+        self.setObjectName("pythonCodeEditorLineNumberArea")
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(self._editor._line_number_area_width(), 0)
+
+    def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
+        if event is not None:
+            self._editor._paint_line_number_area(event)
+
+
+class PythonCodeEditor(QtWidgets.QTextEdit):
+    """Python code editor with syntax highlighting and block indentation."""
+
+    TAB_SPACES = 4
+    _PAIR_DELIMITERS: typing.ClassVar[dict[str, str]] = {
+        "(": ")",
+        "[": "]",
+        "{": "}",
+        '"': '"',
+        "'": "'",
+    }
+    _CLOSING_DELIMITERS: typing.ClassVar[set[str]] = {")", "]", "}", '"', "'"}
+    _QUOTE_DELIMITERS: typing.ClassVar[set[str]] = {'"', "'"}
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._line_number_area = _PythonCodeLineNumberArea(self)
+        self.setAcceptRichText(False)
+        self.setFont(
+            QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
+        )
+        self.highlighter = PythonHighlighter(self.document())
+        self.document().blockCountChanged.connect(
+            lambda _count: self._update_line_number_area_width()
+        )
+        self.document().contentsChanged.connect(self._line_number_area.update)
+        self.cursorPositionChanged.connect(self._line_number_area.update)
+        self.verticalScrollBar().valueChanged.connect(
+            lambda _value: self._line_number_area.update()
+        )
+        self._update_line_number_area_width()
+
+    def keyPressEvent(self, e: QtGui.QKeyEvent | None) -> None:
+        if e is not None:
+            key = e.key()
+            mods = e.modifiers()
+
+            is_tab = key == QtCore.Qt.Key.Key_Tab
+            is_backtab = key == QtCore.Qt.Key.Key_Backtab
+            shift = bool(mods & QtCore.Qt.KeyboardModifier.ShiftModifier)
+
+            if self._handle_line_shortcut(key, mods):
+                e.accept()
+                return
+
+            if (
+                key == QtCore.Qt.Key.Key_Z
+                and bool(mods & QtCore.Qt.KeyboardModifier.AltModifier)
+                and not bool(
+                    mods
+                    & (
+                        QtCore.Qt.KeyboardModifier.ControlModifier
+                        | QtCore.Qt.KeyboardModifier.MetaModifier
+                    )
+                )
+            ):
+                self.toggle_line_wrap()
+                e.accept()
+                return
+
+            if (
+                key == QtCore.Qt.Key.Key_Backspace
+                and self._plain_edit_modifiers(mods)
+                and self._delete_empty_pair()
+            ):
+                e.accept()
+                return
+
+            if self._text_input_modifiers(mods) and self._handle_pair_text(e.text()):
+                e.accept()
+                return
+
+            if (is_tab or is_backtab) and not (
+                mods & QtCore.Qt.KeyboardModifier.ControlModifier
+            ):
+                cursor = self.textCursor()
+                if is_backtab or (is_tab and shift):
+                    self._unindent(cursor, self.TAB_SPACES)
+                else:
+                    self._indent(cursor, self.TAB_SPACES)
+                e.accept()
+                return
+
+        super().keyPressEvent(e)
+
+    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
+        super().resizeEvent(event)
+        self._update_line_number_area_geometry()
+
+    def changeEvent(self, event: QtCore.QEvent | None) -> None:
+        super().changeEvent(event)
+        if not hasattr(self, "_line_number_area"):
+            return
+        if event is not None and event.type() in {
+            QtCore.QEvent.Type.FontChange,
+            QtCore.QEvent.Type.PaletteChange,
+            QtCore.QEvent.Type.StyleChange,
+        }:
+            self._update_line_number_area_width()
+
+    def setLineWrapMode(self, mode: QtWidgets.QTextEdit.LineWrapMode) -> None:
+        super().setLineWrapMode(mode)
+        if hasattr(self, "_line_number_area"):
+            self._line_number_area.update()
+
+    def toggle_line_wrap(self) -> None:
+        """Toggle editor line wrapping."""
+        mode = (
+            QtWidgets.QTextEdit.LineWrapMode.WidgetWidth
+            if self.lineWrapMode() == QtWidgets.QTextEdit.LineWrapMode.NoWrap
+            else QtWidgets.QTextEdit.LineWrapMode.NoWrap
+        )
+        self.setLineWrapMode(mode)
+
+    @staticmethod
+    def _plain_edit_modifiers(mods: QtCore.Qt.KeyboardModifier) -> bool:
+        return not bool(
+            mods
+            & (
+                QtCore.Qt.KeyboardModifier.ControlModifier
+                | QtCore.Qt.KeyboardModifier.AltModifier
+                | QtCore.Qt.KeyboardModifier.MetaModifier
+            )
+        )
+
+    @staticmethod
+    def _text_input_modifiers(mods: QtCore.Qt.KeyboardModifier) -> bool:
+        return not bool(
+            mods
+            & (
+                QtCore.Qt.KeyboardModifier.ControlModifier
+                | QtCore.Qt.KeyboardModifier.AltModifier
+                | QtCore.Qt.KeyboardModifier.MetaModifier
+            )
+        )
+
+    def _handle_line_shortcut(self, key: int, mods: QtCore.Qt.KeyboardModifier) -> bool:
+        ctrl_or_meta = bool(
+            mods
+            & (
+                QtCore.Qt.KeyboardModifier.ControlModifier
+                | QtCore.Qt.KeyboardModifier.MetaModifier
+            )
+        )
+        alt = bool(mods & QtCore.Qt.KeyboardModifier.AltModifier)
+        shift = bool(mods & QtCore.Qt.KeyboardModifier.ShiftModifier)
+        if (
+            key == QtCore.Qt.Key.Key_Slash
+            and ctrl_or_meta
+            and not alt
+            and self._toggle_line_comments()
+        ):
+            return True
+        if (
+            key in (QtCore.Qt.Key.Key_Up, QtCore.Qt.Key.Key_Down)
+            and alt
+            and not ctrl_or_meta
+        ):
+            offset = -1 if key == QtCore.Qt.Key.Key_Up else 1
+            if shift:
+                return self._duplicate_selected_lines(offset)
+            return self._move_selected_lines(offset)
+        return False
+
+    def _handle_pair_text(self, text: str) -> bool:
+        if len(text) != 1:
+            return False
+        if text in self._CLOSING_DELIMITERS and self._skip_closing_delimiter(text):
+            return True
+        close = self._PAIR_DELIMITERS.get(text)
+        if close is None:
+            return False
+        cursor = self.textCursor()
+        if (
+            text in self._QUOTE_DELIMITERS
+            and not cursor.hasSelection()
+            and not self._should_auto_pair_quote(cursor)
+        ):
+            return False
+        if cursor.hasSelection():
+            self._surround_selection(text, close)
+        else:
+            self._insert_pair(text, close)
+        return True
+
+    def _insert_pair(self, open_text: str, close_text: str) -> None:
+        cursor = self.textCursor()
+        position = cursor.position()
+        cursor.beginEditBlock()
+        cursor.insertText(open_text + close_text)
+        cursor.setPosition(position + len(open_text))
+        cursor.endEditBlock()
+        self.setTextCursor(cursor)
+
+    def _surround_selection(self, open_text: str, close_text: str) -> None:
+        cursor = self.textCursor()
+        start = cursor.selectionStart()
+        end = cursor.selectionEnd()
+        cursor_at_start = cursor.position() == start
+        cursor.beginEditBlock()
+        cursor.setPosition(start)
+        cursor.insertText(open_text)
+        cursor.setPosition(end + len(open_text))
+        cursor.insertText(close_text)
+        if cursor_at_start:
+            cursor.setPosition(end + len(open_text))
+            cursor.setPosition(
+                start + len(open_text), QtGui.QTextCursor.MoveMode.KeepAnchor
+            )
+        else:
+            cursor.setPosition(start + len(open_text))
+            cursor.setPosition(
+                end + len(open_text), QtGui.QTextCursor.MoveMode.KeepAnchor
+            )
+        cursor.endEditBlock()
+        self.setTextCursor(cursor)
+
+    def _skip_closing_delimiter(self, text: str) -> bool:
+        cursor = self.textCursor()
+        if cursor.hasSelection() or self._next_character(cursor) != text:
+            return False
+        cursor.movePosition(QtGui.QTextCursor.MoveOperation.NextCharacter)
+        self.setTextCursor(cursor)
+        return True
+
+    def _delete_empty_pair(self) -> bool:
+        cursor = self.textCursor()
+        if cursor.hasSelection():
+            return False
+        previous = self._previous_character(cursor)
+        next_character = self._next_character(cursor)
+        if not previous or self._PAIR_DELIMITERS.get(previous) != next_character:
+            return False
+        position = cursor.position()
+        cursor.beginEditBlock()
+        cursor.setPosition(position - 1)
+        cursor.setPosition(position + 1, QtGui.QTextCursor.MoveMode.KeepAnchor)
+        cursor.removeSelectedText()
+        cursor.endEditBlock()
+        self.setTextCursor(cursor)
+        return True
+
+    def _previous_character(self, cursor: QtGui.QTextCursor) -> str:
+        position = cursor.position()
+        if position <= 0:
+            return ""
+        return self.toPlainText()[position - 1]
+
+    def _next_character(self, cursor: QtGui.QTextCursor) -> str:
+        position = cursor.position()
+        text = self.toPlainText()
+        if position >= len(text):
+            return ""
+        return text[position]
+
+    def _should_auto_pair_quote(self, cursor: QtGui.QTextCursor) -> bool:
+        previous = self._previous_character(cursor)
+        next_character = self._next_character(cursor)
+        if previous == "\\":
+            return False
+        return not (
+            self._identifier_character(previous)
+            or self._identifier_character(next_character)
+        )
+
+    @staticmethod
+    def _identifier_character(text: str) -> bool:
+        return bool(text) and (text.isalnum() or text == "_")
+
+    def _toggle_line_comments(self) -> bool:
+        cursor = self.textCursor()
+        cursor_at_start = cursor.hasSelection() and (
+            cursor.position() == cursor.selectionStart()
+        )
+        lines, offsets = self._document_lines_and_offsets()
+        start_line, end_line, start_col, end_col, has_selection = (
+            self._selected_line_range(cursor, lines, offsets)
+        )
+        selected_lines = lines[start_line : end_line + 1]
+        non_empty = [line for line in selected_lines if line.strip()]
+        uncomment = bool(non_empty) and all(
+            self._line_comment_column(line) is not None for line in non_empty
+        )
+        new_lines = list(lines)
+        deltas: dict[int, tuple[int, int]] = {}
+        for line_number in range(start_line, end_line + 1):
+            line = new_lines[line_number]
+            indent = len(line) - len(line.lstrip(" \t"))
+            if uncomment:
+                comment_column = self._line_comment_column(line)
+                if comment_column is None:
+                    continue
+                remove_count = 2 if line[comment_column:].startswith("# ") else 1
+                new_lines[line_number] = (
+                    line[:comment_column] + line[comment_column + remove_count :]
+                )
+                deltas[line_number] = (comment_column, -remove_count)
+            else:
+                new_lines[line_number] = line[:indent] + "# " + line[indent:]
+                deltas[line_number] = (indent, 2)
+
+        self._replace_document_text("\n".join(new_lines))
+        self._restore_line_cursor(
+            start_line,
+            end_line,
+            self._adjust_line_column(start_line, start_col, deltas),
+            self._adjust_line_column(end_line, end_col, deltas),
+            has_selection,
+            cursor_at_start,
+        )
+        return True
+
+    @staticmethod
+    def _line_comment_column(line: str) -> int | None:
+        indent = len(line) - len(line.lstrip(" \t"))
+        return indent if line[indent:].startswith("#") else None
+
+    @staticmethod
+    def _adjust_line_column(
+        line_number: int,
+        column: int,
+        deltas: dict[int, tuple[int, int]],
+    ) -> int:
+        edit = deltas.get(line_number)
+        if edit is None:
+            return column
+        edit_column, delta = edit
+        if column < edit_column:
+            return column
+        return max(edit_column, column + delta)
+
+    def _move_selected_lines(self, offset: int) -> bool:
+        cursor = self.textCursor()
+        cursor_at_start = cursor.hasSelection() and (
+            cursor.position() == cursor.selectionStart()
+        )
+        lines, offsets = self._document_lines_and_offsets()
+        start_line, end_line, start_col, end_col, has_selection = (
+            self._selected_line_range(cursor, lines, offsets)
+        )
+        if offset < 0:
+            if start_line == 0:
+                return True
+            block = lines[start_line : end_line + 1]
+            new_lines = [
+                *lines[: start_line - 1],
+                *block,
+                lines[start_line - 1],
+                *lines[end_line + 1 :],
+            ]
+            new_start = start_line - 1
+            new_end = end_line - 1
+        else:
+            if end_line >= len(lines) - 1:
+                return True
+            block = lines[start_line : end_line + 1]
+            new_lines = [
+                *lines[:start_line],
+                lines[end_line + 1],
+                *block,
+                *lines[end_line + 2 :],
+            ]
+            new_start = start_line + 1
+            new_end = end_line + 1
+        self._replace_document_text("\n".join(new_lines))
+        self._restore_line_cursor(
+            new_start,
+            new_end,
+            start_col,
+            end_col,
+            has_selection,
+            cursor_at_start,
+        )
+        return True
+
+    def _duplicate_selected_lines(self, offset: int) -> bool:
+        cursor = self.textCursor()
+        cursor_at_start = cursor.hasSelection() and (
+            cursor.position() == cursor.selectionStart()
+        )
+        lines, offsets = self._document_lines_and_offsets()
+        start_line, end_line, start_col, end_col, has_selection = (
+            self._selected_line_range(cursor, lines, offsets)
+        )
+        block = lines[start_line : end_line + 1]
+        if offset < 0:
+            new_lines = [*lines[:start_line], *block, *lines[start_line:]]
+            new_start = start_line
+            new_end = start_line + len(block) - 1
+        else:
+            new_lines = [*lines[: end_line + 1], *block, *lines[end_line + 1 :]]
+            new_start = end_line + 1
+            new_end = end_line + len(block)
+        self._replace_document_text("\n".join(new_lines))
+        self._restore_line_cursor(
+            new_start,
+            new_end,
+            start_col,
+            end_col,
+            has_selection,
+            cursor_at_start,
+        )
+        return True
+
+    def _document_lines_and_offsets(self) -> tuple[list[str], list[int]]:
+        lines = self.toPlainText().split("\n")
+        offsets: list[int] = []
+        position = 0
+        for index, line in enumerate(lines):
+            offsets.append(position)
+            position += len(line)
+            if index < len(lines) - 1:
+                position += 1
+        return lines, offsets
+
+    @staticmethod
+    def _line_column_for_position(
+        position: int, lines: list[str], offsets: list[int]
+    ) -> tuple[int, int]:
+        line_number = bisect.bisect_right(offsets, position) - 1
+        line_number = max(0, min(line_number, len(lines) - 1))
+        return line_number, min(
+            position - offsets[line_number], len(lines[line_number])
+        )
+
+    def _selected_line_range(
+        self,
+        cursor: QtGui.QTextCursor,
+        lines: list[str],
+        offsets: list[int],
+    ) -> tuple[int, int, int, int, bool]:
+        start = cursor.selectionStart()
+        end = cursor.selectionEnd()
+        start_line, start_col = self._line_column_for_position(start, lines, offsets)
+        end_line, end_col = self._line_column_for_position(end, lines, offsets)
+        has_selection = cursor.hasSelection()
+        if has_selection and end > start and end_col == 0 and end_line > start_line:
+            end_line -= 1
+            end_col = len(lines[end_line])
+        return start_line, end_line, start_col, end_col, has_selection
+
+    def _replace_document_text(self, text: str) -> None:
+        cursor = QtGui.QTextCursor(self.document())
+        cursor.beginEditBlock()
+        cursor.select(QtGui.QTextCursor.SelectionType.Document)
+        cursor.insertText(text)
+        cursor.endEditBlock()
+
+    def _restore_line_cursor(
+        self,
+        start_line: int,
+        end_line: int,
+        start_col: int,
+        end_col: int,
+        has_selection: bool,
+        cursor_at_start: bool,
+    ) -> None:
+        lines, offsets = self._document_lines_and_offsets()
+        start_line = max(0, min(start_line, len(lines) - 1))
+        end_line = max(0, min(end_line, len(lines) - 1))
+        start_position = offsets[start_line] + min(start_col, len(lines[start_line]))
+        end_position = offsets[end_line] + min(end_col, len(lines[end_line]))
+        cursor = self.textCursor()
+        if has_selection and cursor_at_start:
+            cursor.setPosition(end_position)
+            cursor.setPosition(start_position, QtGui.QTextCursor.MoveMode.KeepAnchor)
+        else:
+            cursor.setPosition(start_position)
+        if has_selection and not cursor_at_start:
+            cursor.setPosition(end_position, QtGui.QTextCursor.MoveMode.KeepAnchor)
+        self.setTextCursor(cursor)
+
+    def _line_number_area_width(self) -> int:
+        digits = len(str(max(1, self.document().blockCount())))
+        font_width = self.fontMetrics().horizontalAdvance("9")
+        style = self.style()
+        frame_width = (
+            style.pixelMetric(QtWidgets.QStyle.PixelMetric.PM_DefaultFrameWidth)
+            if style is not None
+            else 0
+        )
+        return frame_width + 8 + font_width * digits
+
+    def _update_line_number_area_width(self) -> None:
+        self.setViewportMargins(self._line_number_area_width(), 0, 0, 0)
+        self._update_line_number_area_geometry()
+        self._line_number_area.update()
+
+    def _update_line_number_area_geometry(self) -> None:
+        contents = self.contentsRect()
+        self._line_number_area.setGeometry(
+            QtCore.QRect(
+                contents.left(),
+                contents.top(),
+                self._line_number_area_width(),
+                contents.height(),
+            )
+        )
+
+    def _paint_line_number_area(self, event: QtGui.QPaintEvent) -> None:
+        painter = QtGui.QPainter(self._line_number_area)
+        palette = self.palette()
+        painter.fillRect(event.rect(), palette.color(QtGui.QPalette.ColorRole.Window))
+        painter.setPen(
+            palette.color(
+                QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text
+            )
+        )
+
+        block = self.cursorForPosition(QtCore.QPoint(0, 0)).block()
+        bottom = event.rect().bottom()
+        width = self._line_number_area.width() - 4
+        height = self.fontMetrics().height()
+        while block.isValid():
+            cursor = QtGui.QTextCursor(block)
+            rect = self.cursorRect(cursor)
+            if rect.top() > bottom:
+                break
+            if block.isVisible() and rect.bottom() >= event.rect().top():
+                painter.drawText(
+                    0,
+                    rect.top(),
+                    width,
+                    height,
+                    QtCore.Qt.AlignmentFlag.AlignRight,
+                    str(block.blockNumber() + 1),
+                )
+            block = block.next()
+        painter.end()
+
+    def _indent(self, cursor: QtGui.QTextCursor, n: int) -> None:
+        text = " " * n
+        cursor.beginEditBlock()
+        if cursor.hasSelection():
+            self._for_each_selected_block(cursor, lambda c: c.insertText(text))
+        else:
+            cursor.insertText(text)
+        cursor.endEditBlock()
+
+    def _unindent(self, cursor: QtGui.QTextCursor, n: int) -> None:
+        cursor.beginEditBlock()
+
+        def unindent_block(c: QtGui.QTextCursor) -> None:
+            c.movePosition(QtGui.QTextCursor.MoveOperation.StartOfBlock)
+
+            c.movePosition(
+                QtGui.QTextCursor.MoveOperation.Right,
+                QtGui.QTextCursor.MoveMode.KeepAnchor,
+                1,
+            )
+            if c.selectedText() == "\t":
+                c.removeSelectedText()
+                return
+            c.clearSelection()
+
+            removed = 0
+            while removed < n:
+                c.movePosition(QtGui.QTextCursor.MoveOperation.StartOfBlock)
+                c.movePosition(
+                    QtGui.QTextCursor.MoveOperation.Right,
+                    QtGui.QTextCursor.MoveMode.KeepAnchor,
+                    1,
+                )
+                if c.selectedText() == " ":
+                    c.removeSelectedText()
+                    removed += 1
+                else:
+                    c.clearSelection()
+                    break
+
+        if cursor.hasSelection():
+            self._for_each_selected_block(cursor, unindent_block)
+        else:
+            unindent_block(cursor)
+
+        cursor.endEditBlock()
+
+    def _for_each_selected_block(
+        self, cursor: QtGui.QTextCursor, fn: Callable[[QtGui.QTextCursor], None]
+    ) -> None:
+        start = cursor.selectionStart()
+        end = cursor.selectionEnd()
+
+        c = QtGui.QTextCursor(cursor.document())
+        c.setPosition(start)
+        start_block = c.blockNumber()
+
+        c.setPosition(end)
+        end_block = c.blockNumber()
+
+        c.setPosition(start)
+        c.movePosition(QtGui.QTextCursor.MoveOperation.StartOfBlock)
+
+        for _ in range(start_block, end_block + 1):
+            fn(c)
+            c.movePosition(QtGui.QTextCursor.MoveOperation.NextBlock)

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -6427,17 +6427,25 @@ class PythonCodeEditor(QtWidgets.QTextEdit):
         self.setFont(
             QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
         )
-        self.highlighter = PythonHighlighter(self.document())
-        self.document().contentsChange.connect(self._mark_text_editing_activity)
-        self.document().blockCountChanged.connect(
+        document = self._text_document()
+        self.highlighter = PythonHighlighter(document)
+        document.contentsChange.connect(self._mark_text_editing_activity)
+        document.blockCountChanged.connect(
             lambda _count: self._update_line_number_area_width()
         )
-        self.document().contentsChanged.connect(self._line_number_area.update)
+        document.contentsChanged.connect(self._line_number_area.update)
         self.cursorPositionChanged.connect(self._line_number_area.update)
-        self.verticalScrollBar().valueChanged.connect(
-            lambda _value: self._line_number_area.update()
-        )
+        scroll_bar = self.verticalScrollBar()
+        if scroll_bar is None:
+            raise RuntimeError("PythonCodeEditor has no vertical scroll bar")
+        scroll_bar.valueChanged.connect(lambda _value: self._line_number_area.update())
         self._update_line_number_area_width()
+
+    def _text_document(self) -> QtGui.QTextDocument:
+        document = self.document()
+        if document is None:
+            raise RuntimeError("PythonCodeEditor has no text document")
+        return document
 
     def keyPressEvent(self, e: QtGui.QKeyEvent | None) -> None:
         if e is not None:
@@ -6932,7 +6940,7 @@ class PythonCodeEditor(QtWidgets.QTextEdit):
         self.setTextCursor(cursor)
 
     def _line_number_area_width(self) -> int:
-        digits = len(str(max(1, self.document().blockCount())))
+        digits = len(str(max(1, self._text_document().blockCount())))
         font_width = self.fontMetrics().horizontalAdvance("9")
         style = self.style()
         frame_width = (

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3269,6 +3269,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._managed_source_reload_unavailable_reason: (
             Callable[[], str | None] | None
         ) = None
+        self._managed_secondary_window_callback: (
+            Callable[[QtWidgets.QWidget], None] | None
+        ) = None
         self._output_imagetool_targets: dict[str, str | QtWidgets.QWidget] = {}
         self._save_tool_data_references = False
         self._save_tool_data_reference_node_uids: frozenset[str] | None = None
@@ -4323,6 +4326,23 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._managed_source_reload_available = available
         self._managed_source_reload_unavailable_reason = unavailable_reason
         self._refresh_reload_data_action()
+
+    def _set_managed_secondary_window_callback(
+        self, callback: Callable[[QtWidgets.QWidget], None] | None
+    ) -> None:
+        """Set the manager-owned callback for secondary tool windows."""
+        self._managed_secondary_window_callback = callback
+
+    def _configure_managed_secondary_window(self, window: QtWidgets.QWidget) -> None:
+        """Apply manager-owned behavior to a secondary tool window."""
+        if self._managed_secondary_window_callback is not None:
+            self._managed_secondary_window_callback(window)
+
+    def _managed_secondary_windows(
+        self,
+    ) -> tuple[tuple[QtWidgets.QWidget, str], ...]:
+        """Return secondary managed windows with their base titles."""
+        return ()
 
     def _source_reload_relevant(self) -> bool:
         return self._managed_source_reload is not None

--- a/src/erlab/plotting/general.py
+++ b/src/erlab/plotting/general.py
@@ -16,7 +16,15 @@ __all__ = [
 import contextlib
 import copy
 import typing
-from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
+from collections.abc import (
+    Callable,
+    Collection,
+    Hashable,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Sequence,
+)
 
 import matplotlib
 import matplotlib.colorbar
@@ -652,6 +660,71 @@ _LINE_KWARG_ALIASES = {
 }
 
 
+def _hashable_plot_slices_value(value: typing.Any) -> Hashable:
+    if isinstance(value, slice):
+        return (
+            "slice",
+            _hashable_plot_slices_value(value.start),
+            _hashable_plot_slices_value(value.stop),
+            _hashable_plot_slices_value(value.step),
+        )
+    if isinstance(value, np.ndarray):
+        return ("array", tuple(_hashable_plot_slices_value(v) for v in value.tolist()))
+    if isinstance(value, Mapping):
+        return (
+            "mapping",
+            tuple(
+                sorted(
+                    (
+                        _hashable_plot_slices_value(key),
+                        _hashable_plot_slices_value(val),
+                    )
+                    for key, val in value.items()
+                )
+            ),
+        )
+    if isinstance(value, str | bytes) or not isinstance(value, Iterable):
+        with contextlib.suppress(TypeError):
+            hash(value)
+            return typing.cast("Hashable", value)
+        return repr(value)
+    return ("iterable", tuple(_hashable_plot_slices_value(v) for v in value))
+
+
+def _plot_slices_selection_cache_key(
+    maps: Sequence[xr.DataArray],
+    qsel_kw: Mapping[str, typing.Any],
+    cache_key: Hashable | None,
+) -> Hashable:
+    map_key = tuple((id(m.data), tuple(m.dims), tuple(m.shape)) for m in maps)
+    qsel_key = tuple(
+        sorted(
+            (key, _hashable_plot_slices_value(value)) for key, value in qsel_kw.items()
+        )
+    )
+    return (cache_key, map_key, qsel_key)
+
+
+def _plot_slices_selected_maps(
+    maps: Sequence[xr.DataArray],
+    qsel_kw: Mapping[str, typing.Any],
+    *,
+    selection_cache: MutableMapping[Hashable, tuple[xr.DataArray, ...]] | None,
+    selection_cache_key: Hashable | None,
+) -> tuple[xr.DataArray, ...]:
+    cache_key: Hashable | None = None
+    if selection_cache is not None:
+        cache_key = _plot_slices_selection_cache_key(maps, qsel_kw, selection_cache_key)
+        cached = selection_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+    selected = tuple(m.qsel(**qsel_kw) for m in maps)
+    if selection_cache is not None and cache_key is not None:
+        selection_cache[cache_key] = selected
+    return selected
+
+
 def plot_slices(
     maps: xr.DataArray | Sequence[xr.DataArray],
     figsize: tuple[float, float] | None = None,
@@ -690,6 +763,8 @@ def plot_slices(
     annotate_kw: dict | None = None,
     colorbar_kw: dict | None = None,
     axes: Iterable[matplotlib.axes.Axes] | None = None,
+    _selection_cache: MutableMapping[Hashable, tuple[xr.DataArray, ...]] | None = None,
+    _selection_cache_key: Hashable | None = None,
     **values,
 ) -> tuple[matplotlib.figure.Figure, Iterable[matplotlib.axes.Axes]]:
     """Automated comparison plot of slices.
@@ -952,14 +1027,23 @@ def plot_slices(
         else:
             qsel_kw[slice_dim + "_width"] = slice_width
 
-    for i in range(len(slice_levels)):
-        if slice_dim is not None:
-            qsel_kw[slice_dim] = slice_levels[i]
-            if isinstance(slice_width, Collection):
-                qsel_kw[slice_dim + "_width"] = slice_width[i]
+    qsel_stack_kw = dict(qsel_kw)
+    if slice_dim is not None:
+        qsel_stack_kw[slice_dim] = list(slice_levels)
+        if isinstance(slice_width, Collection):
+            qsel_stack_kw[slice_dim + "_width"] = slice_width
+    selected_maps = _plot_slices_selected_maps(
+        maps,
+        qsel_stack_kw,
+        selection_cache=_selection_cache,
+        selection_cache_key=_selection_cache_key,
+    )
 
+    for i in range(len(slice_levels)):
         for j in range(len(maps)):
-            dat_sel = maps[j].qsel(**qsel_kw)
+            dat_sel = selected_maps[j]
+            if slice_dim is not None:
+                dat_sel = dat_sel.isel({slice_dim: i})
 
             if order == "F":
                 ax = axes[i, j]

--- a/src/erlab/plotting/stylelib/fira.mplstyle
+++ b/src/erlab/plotting/stylelib/fira.mplstyle
@@ -77,7 +77,7 @@ mathtext.rm: "Fira Sans:style=normal:variant=normal:weight=regular:stretch=norma
 mathtext.sf: "Fira Sans:style=normal:variant=normal:weight=regular:stretch=normal"
 mathtext.tt: monospace
 mathtext.fallback: stixsans
-mathtext.default: it
+mathtext.default: normal
 
 # ***************************************************************************
 # * AXES                                                                    *

--- a/src/erlab/plotting/stylelib/fira.mplstyle
+++ b/src/erlab/plotting/stylelib/fira.mplstyle
@@ -71,7 +71,7 @@ text.latex.preamble:
 # The following settings allow you to select the fonts in math mode.
 mathtext.fontset: custom
 mathtext.bf: "Fira Sans:style=normal:variant=normal:weight=bold:stretch=normal"
-mathtext.cal: cursive
+mathtext.cal: cmsy10
 mathtext.it: "Fira Sans:style=italic:variant=normal:weight=regular:stretch=normal"
 mathtext.rm: "Fira Sans:style=normal:variant=normal:weight=regular:stretch=normal"
 mathtext.sf: "Fira Sans:style=normal:variant=normal:weight=regular:stretch=normal"

--- a/src/erlab/plotting/stylelib/firalight.mplstyle
+++ b/src/erlab/plotting/stylelib/firalight.mplstyle
@@ -77,7 +77,7 @@ mathtext.rm: "Fira Sans:style=normal:variant=normal:weight=300:stretch=normal"
 mathtext.sf: "Fira Sans:style=normal:variant=normal:weight=300:stretch=normal"
 mathtext.tt: monospace
 mathtext.fallback: stixsans
-mathtext.default: it
+mathtext.default: normal
 
 # ***************************************************************************
 # * AXES                                                                    *

--- a/src/erlab/plotting/stylelib/firalight.mplstyle
+++ b/src/erlab/plotting/stylelib/firalight.mplstyle
@@ -54,10 +54,10 @@
 # relative to font.size, using the following values: xx-small, x-small,
 # small, medium, large, x-large, xx-large, larger, or smaller
 
-font.family: Fira Sans, sans-serif
+font.family: Fira Sans Light, Fira Sans, sans-serif
 font.style: normal
 font.variant: normal
-font.weight: 300
+font.weight: normal
 font.stretch: normal
 
 # ***************************************************************************
@@ -71,7 +71,7 @@ text.latex.preamble:
 # The following settings allow you to select the fonts in math mode.
 mathtext.fontset: custom
 mathtext.bf: "Fira Sans:style=normal:variant=normal:weight=regular:stretch=normal"
-mathtext.cal: cursive
+mathtext.cal: cmsy10
 mathtext.it: "Fira Sans:style=italic:variant=normal:weight=300:stretch=normal"
 mathtext.rm: "Fira Sans:style=normal:variant=normal:weight=300:stretch=normal"
 mathtext.sf: "Fira Sans:style=normal:variant=normal:weight=300:stretch=normal"
@@ -85,16 +85,16 @@ mathtext.default: it
 # Following are default face and edge colors, default tick sizes,
 # default font sizes for tick labels, and so on.  See
 # https://matplotlib.org/api/axes_api.html#module-matplotlib.axes
-axes.titleweight: 300
-axes.labelweight: 300
+axes.titleweight: normal
+axes.labelweight: normal
 axes.unicode_minus: True
 
 # ***************************************************************************
 # * FIGURE                                                                  *
 # ***************************************************************************
 # See https://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
-figure.titleweight: 300
-figure.labelweight: 300
+figure.titleweight: normal
+figure.labelweight: normal
 
 # ***************************************************************************
 # * SAVING FIGURES                                                          *

--- a/src/erlab/plotting/stylelib/nature.mplstyle
+++ b/src/erlab/plotting/stylelib/nature.mplstyle
@@ -101,7 +101,7 @@ mathtext.rm: Arial:style=normal:variant=normal:weight=normal:stretch=normal,Symb
 mathtext.sf: Arial:style=normal:variant=normal:weight=normal:stretch=normal
 mathtext.tt: monospace
 mathtext.fallback: None
-mathtext.default: it
+mathtext.default: normal
 
 # ***************************************************************************
 # * AXES                                                                    *

--- a/src/erlab/plotting/stylelib/nature.mplstyle
+++ b/src/erlab/plotting/stylelib/nature.mplstyle
@@ -95,7 +95,7 @@ text.latex.preamble:
 # The following settings allow you to select the fonts in math mode.
 mathtext.fontset: custom
 mathtext.bf: Arial:style=normal:variant=normal:weight=bold:stretch=normal
-mathtext.cal: cursive
+mathtext.cal: cmsy10
 mathtext.it: Arial:style=italic:variant=normal:weight=normal:stretch=normal,Symbol
 mathtext.rm: Arial:style=normal:variant=normal:weight=normal:stretch=normal,Symbol
 mathtext.sf: Arial:style=normal:variant=normal:weight=normal:stretch=normal

--- a/src/erlab/plotting/stylelib/times.mplstyle
+++ b/src/erlab/plotting/stylelib/times.mplstyle
@@ -83,7 +83,7 @@ mathtext.fontset: stix
 # mathtext.sf: "Fira Sans:style=normal:variant=normal:weight=300:stretch=normal"
 # mathtext.tt: monospace
 # mathtext.fallback: stixsans
-# mathtext.default: it
+# mathtext.default: normal
 
 # ***************************************************************************
 # * AXES                                                                    *

--- a/tests/accessors/test_general.py
+++ b/tests/accessors/test_general.py
@@ -175,6 +175,46 @@ def test_qsel_collection() -> None:
     )
 
 
+def test_qsel_shallow_copy_preserves_selection_semantics() -> None:
+    dat = xr.DataArray(np.arange(25).reshape(5, 5), dims=("x", "y"))
+
+    scalar = dat.qsel(x=2.0)
+    xr.testing.assert_equal(scalar, dat.isel(x=2))
+    assert "x" not in dat.coords
+
+    xr.testing.assert_identical(
+        dat.qsel(x=2.0, x_width=3.0),
+        xr.DataArray(np.array([10.0, 11.0, 12.0, 13.0, 14.0]), dims=("y",)),
+    )
+    xr.testing.assert_identical(
+        dat.qsel(x=[1.0, 3.0], x_width=[2.0, 2.0]),
+        xr.DataArray(
+            np.array([[5.0, 6.0, 7.0, 8.0, 9.0], [15.0, 16.0, 17.0, 18.0, 19.0]]),
+            dims=("x", "y"),
+        ),
+    )
+
+
+def test_qsel_shallow_copy_preserves_dask_backing() -> None:
+    dask_array = pytest.importorskip("dask.array")
+    dat = xr.DataArray(
+        dask_array.arange(25, chunks=5).reshape((5, 5)),
+        dims=("x", "y"),
+    )
+
+    result = dat.qsel(x=[1.0, 3.0], x_width=[2.0, 2.0])
+
+    assert hasattr(result.data, "compute")
+    assert "x" not in dat.coords
+    xr.testing.assert_equal(
+        result.compute(),
+        xr.DataArray(
+            np.array([[5.0, 6.0, 7.0, 8.0, 9.0], [15.0, 16.0, 17.0, 18.0, 19.0]]),
+            dims=("x", "y"),
+        ),
+    )
+
+
 def test_qsel_slice_with_width() -> None:
     dat = xr.DataArray(np.arange(25).reshape(5, 5), dims=("x", "y"))
     with pytest.raises(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -658,9 +658,11 @@ def test_figure_composer_source_ui_keeps_aliases_as_internal_keys(qtbot) -> None
     assert first_item.data(0, QtCore.Qt.ItemDataRole.UserRole) == "data_0"
     assert first_item.data(0, QtCore.Qt.ItemDataRole.UserRole + 1) is True
     assert first_item.font(0).bold()
+    assert first_item.text(1) == "data_0"
     second_item = tool.source_list.topLevelItem(1)
     assert second_item is not None
     assert second_item.data(0, QtCore.Qt.ItemDataRole.UserRole + 1) is False
+    assert second_item.text(1) == "data_1"
 
     tool._select_step_section("sources")
     checks = _plot_source_checks(tool)
@@ -690,11 +692,14 @@ def test_figure_composer_source_ui_uses_shared_shape_formatter(
 
     first_item = tool.source_list.topLevelItem(0)
     assert first_item is not None
-    shape_widget = tool.source_list.itemWidget(first_item, 1)
+    shape_widget = tool.source_list.itemWidget(first_item, 2)
     assert isinstance(shape_widget, QtWidgets.QLabel)
     assert shape_widget.text() == "<p>formatted shape</p>"
-    assert shape_widget.toolTip() == first_item.toolTip(0)
-    assert first_item.toolTip(1) == first_item.toolTip(0)
+    assert tool.source_list.toolTip() == ""
+    assert first_item.toolTip(0) == ""
+    assert first_item.toolTip(1) == ""
+    assert first_item.toolTip(2) == ""
+    assert shape_widget.toolTip() == ""
     assert calls == [(tuple(str(dim) for dim in data.dims), False, None)]
 
 
@@ -843,11 +848,11 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
     )
     assert tool._source_refresh_label("data_0") is None
 
-    direct_item = QtWidgets.QTreeWidgetItem(["direct", "", ""])
+    direct_item = QtWidgets.QTreeWidgetItem(["direct", "", "", ""])
     tool.source_list.addTopLevelItem(direct_item)
     direct_button = QtWidgets.QToolButton(tool.source_list)
     direct_button.setObjectName("figureComposerRefreshSourceButton")
-    tool.source_list.setItemWidget(direct_item, 2, direct_button)
+    tool.source_list.setItemWidget(direct_item, 3, direct_button)
     assert (
         tool._source_list_row_button(direct_item, "figureComposerRefreshSourceButton")
         is direct_button
@@ -1520,7 +1525,7 @@ def test_figure_composer_raw_sources_use_public_nonuniform_dims(qtbot) -> None:
     assert "sample_temp_idx" not in shape.source_text
     shape_item = tool.source_list.topLevelItem(0)
     assert shape_item is not None
-    shape_label = tool.source_list.itemWidget(shape_item, 1)
+    shape_label = tool.source_list.itemWidget(shape_item, 2)
     assert isinstance(shape_label, QtWidgets.QLabel)
     assert "sample_temp_idx" not in shape_label.text()
 

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -22,6 +22,7 @@ from matplotlib.figure import Figure
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.accessors.general as accessor_general
 import erlab.interactive._figurecomposer._axes as figurecomposer_axes
 import erlab.interactive._figurecomposer._code as figurecomposer_code
 import erlab.interactive._figurecomposer._defaults as figurecomposer_defaults
@@ -626,6 +627,65 @@ def test_figure_composer_plot_slices_source_selector_updates_sources(
     }
     exec(tool.generated_code(), namespace)  # noqa: S102
     assert captured_maps == [("second", "first")]
+
+
+def test_figure_composer_plot_slices_reuses_selection_cache_per_render(
+    qtbot, monkeypatch
+) -> None:
+    data = _figure_composer_image_source("data")
+    axes = FigureAxesSelectionState(axes=((0, 0), (0, 1)))
+    first_operation = FigureOperationState.plot_slices(
+        label="first",
+        sources=("data",),
+        axes=axes,
+        slice_dim="eV",
+        slice_values=(0.0, 0.5),
+    ).model_copy(update={"cmap": "viridis"})
+    second_operation = FigureOperationState.plot_slices(
+        label="second",
+        sources=("data",),
+        axes=axes,
+        slice_dim="eV",
+        slice_values=(0.0, 0.5),
+    ).model_copy(update={"cmap": "magma"})
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=2),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(first_operation, second_operation),
+            primary_source="data",
+        ),
+        source_data={"data": data},
+    )
+    qtbot.addWidget(tool)
+
+    calls: list[dict[str, object]] = []
+    original_qsel = accessor_general.SelectionAccessor.__call__
+
+    def counted_qsel(self, *args, **kwargs):
+        calls.append(dict(kwargs))
+        return original_qsel(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        accessor_general.SelectionAccessor,
+        "__call__",
+        counted_qsel,
+    )
+
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+
+    assert len(calls) == 1
+    assert calls[0]["eV"] == [0.0, 0.5]
+    assert [len(axis.images) for axis in tool.figure.axes] == [2, 2]
+    assert [image.get_cmap().name for image in tool.figure.axes[0].images] == [
+        "viridis",
+        "magma",
+    ]
+
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+
+    assert len(calls) == 2
 
 
 def test_figure_composer_source_ui_keeps_aliases_as_internal_keys(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -3,6 +3,8 @@ import contextlib
 import functools
 import gc
 import json
+import sys
+import types
 import typing
 import warnings
 from collections.abc import Callable, Sequence
@@ -39,6 +41,7 @@ import erlab.interactive._figurecomposer._widgets as figurecomposer_widgets
 import erlab.interactive._stylesheets
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._workspace as manager_workspace
+import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
 import erlab.interactive.imagetool.plot_items as imagetool_plot_items
 import erlab.plotting as eplt
 from erlab.interactive._figurecomposer import (
@@ -4871,6 +4874,69 @@ def test_figure_display_window_close_and_canvas_size_contracts(qtbot) -> None:
     assert not app_quit_window.isVisible()
     app_quit_window.deleteLater()
     QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+
+
+def test_figure_composer_managed_display_window_configures_save_shortcut(
+    qtbot, monkeypatch
+) -> None:
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+    monkeypatch.setattr(
+        figurecomposer_tool_module,
+        "_render_preview",
+        lambda *_args, **_kwargs: None,
+    )
+    save_calls: list[bool] = []
+    controller = object.__new__(manager_workspace_io._WorkspaceIOController)
+    controller._manager = types.SimpleNamespace(
+        save=lambda *, native=True: save_calls.append(native) or True
+    )
+    tool._set_managed_secondary_window_callback(
+        controller._install_workspace_save_shortcut
+    )
+
+    tool.show_figure_window(activate=False)
+    figure_window = tool.figure_window
+
+    save_shortcuts = [
+        shortcut
+        for shortcut in figure_window.findChildren(QtWidgets.QShortcut)
+        if shortcut.objectName() == "managerWorkspaceSaveShortcut"
+    ]
+    assert len(save_shortcuts) == 1
+    save_shortcuts[0].activated.emit()
+    assert save_calls == [True]
+
+
+def test_workspace_modified_state_updates_figure_display_window(qtbot) -> None:
+    primary_window = QtWidgets.QMainWindow()
+    secondary_window = QtWidgets.QMainWindow()
+    qtbot.addWidget(primary_window)
+    qtbot.addWidget(secondary_window)
+    tool = types.SimpleNamespace(
+        tool_name="Figure Composer",
+        _tool_display_name="Figure 1",
+        _managed_secondary_windows=lambda: (
+            (secondary_window, "Figure Composer: Figure 1"),
+        ),
+    )
+    node = types.SimpleNamespace(window=primary_window, tool_window=tool)
+    controller = object.__new__(manager_workspace_io._WorkspaceIOController)
+    controller._manager = types.SimpleNamespace(
+        _tool_graph=types.SimpleNamespace(nodes={"figure_uid": node})
+    )
+
+    controller._set_node_window_modified("figure_uid", True)
+
+    assert primary_window.isWindowModified()
+    assert secondary_window.isWindowModified()
+    if sys.platform != "darwin":
+        assert "[*]" in secondary_window.windowTitle()
+
+    controller._set_node_window_modified("figure_uid", False)
+
+    assert not primary_window.isWindowModified()
+    assert not secondary_window.isWindowModified()
 
 
 def test_figure_composer_canvas_resize_defers_draw(qtbot, monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -5826,6 +5826,32 @@ def test_figure_composer_defaults_follow_stylesheet_rcparams(
     assert export.bbox_inches == expected_bbox
 
 
+def test_figure_composer_defaults_skip_unavailable_stylesheets(
+    monkeypatch,
+    restore_interactive_options,
+) -> None:
+    monkeypatch.setattr(
+        figurecomposer_defaults,
+        "_configured_stylesheets",
+        lambda: ("classic", "missing-style"),
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "available_stylesheets",
+        lambda names=(): frozenset({"classic"}),
+    )
+    with mpl_style.context(["classic"]):
+        expected_figsize = tuple(
+            float(value) for value in mpl.rcParams["figure.figsize"]
+        )
+
+    assert figurecomposer_defaults._available_configured_stylesheets() == ("classic",)
+    assert figurecomposer_defaults._unavailable_configured_stylesheets() == (
+        "missing-style",
+    )
+    assert figurecomposer_defaults._default_figsize() == expected_figsize
+
+
 @pytest.mark.parametrize("dpi", [0, -1])
 def test_figure_composer_export_dpi_must_be_positive(dpi: int) -> None:
     with pytest.raises(ValueError, match="export dpi must be positive"):
@@ -5878,6 +5904,57 @@ def test_figure_composer_generated_code_uses_available_stylesheets(
     finally:
         mpl_style_core.USER_LIBRARY_PATHS.remove(str(style_dir))
         mpl_style.reload_library()
+
+
+def test_figure_composer_generated_code_loads_user_stylesheets(
+    qtbot,
+    monkeypatch,
+    restore_interactive_options,
+) -> None:
+    @contextlib.contextmanager
+    def style_context(_stylesheets):
+        yield
+
+    monkeypatch.setattr(
+        figurecomposer_defaults,
+        "_configured_stylesheets",
+        lambda: ("user-style", "missing-style"),
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "available_stylesheets",
+        lambda names=(): frozenset({"user-style"}),
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "stylesheets_require_erlab_plotting",
+        lambda names: False,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "stylesheets_require_user_stylesheets",
+        lambda names: "user-style" in names,
+    )
+    monkeypatch.setattr(figurecomposer_defaults.mpl_style, "context", style_context)
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="data",
+    )
+    tool = FigureComposerTool(data)
+    qtbot.addWidget(tool)
+
+    code = tool.generated_code()
+
+    user_import = "import erlab.interactive._stylesheets as _erlab_stylesheets"
+    user_load = "_erlab_stylesheets.load_user_stylesheets()"
+    style_use = "plt.style.use(['user-style'])"
+    assert user_import in code
+    assert user_load in code
+    assert style_use in code
+    assert code.index(user_import) < code.index(user_load) < code.index(style_use)
+    assert "# Skipped unavailable stylesheets: 'missing-style'" in code
 
 
 def test_figure_composer_preview_uses_live_canvas_without_rerender(
@@ -6053,6 +6130,11 @@ def test_figure_composer_rechecks_configured_stylesheets_after_erlab_import(
     monkeypatch.setattr("erlab.interactive._stylesheets.mpl_style.available", available)
     monkeypatch.setattr(
         erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
         "load_erlab_plotting_stylesheets",
         lambda: available.append("classic"),
     )
@@ -6107,6 +6189,16 @@ def test_figure_composer_generated_code_imports_erlab_for_erlab_stylesheet(
         "load_erlab_plotting_stylesheets",
         load_stylesheets,
     )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "stylesheets_require_user_stylesheets",
+        lambda names: False,
+    )
     erlab.interactive._stylesheets._ERLAB_REGISTERED_STYLESHEETS.clear()
     monkeypatch.setattr(figurecomposer_defaults.mpl_style, "context", style_context)
     monkeypatch.setattr(
@@ -6145,6 +6237,11 @@ def test_figure_composer_generated_code_imports_erlab_for_preloaded_erlab_style(
     monkeypatch,
     restore_interactive_options,
 ) -> None:
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "stylesheets_require_user_stylesheets",
+        lambda names: False,
+    )
     monkeypatch.setattr(
         figurecomposer_defaults,
         "_configured_stylesheets",

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -20027,6 +20027,29 @@ def test_manager_figures_gallery_helpers_handle_invalid_sources(
         fallback = QtGui.QPixmap(40, 20)
         fallback.fill(QtGui.QColor("red"))
 
+        high_dpi_preview = QtGui.QPixmap(400, 100)
+        high_dpi_preview.setDevicePixelRatio(2.0)
+        high_dpi_preview.fill(QtGui.QColor("red"))
+        high_dpi_thumbnail = manager._figure_gallery_thumbnail_pixmap(high_dpi_preview)
+        high_dpi_image = high_dpi_thumbnail.toImage().convertToFormat(
+            QtGui.QImage.Format.Format_ARGB32
+        )
+        red_pixels: list[tuple[int, int]] = []
+        for y_pos in range(high_dpi_image.height()):
+            for x_pos in range(high_dpi_image.width()):
+                color = high_dpi_image.pixelColor(x_pos, y_pos)
+                if color.red() > 220 and color.green() < 40 and color.blue() < 40:
+                    red_pixels.append((x_pos, y_pos))
+        assert red_pixels
+        min_x = min(x_pos for x_pos, _y_pos in red_pixels)
+        max_x = max(x_pos for x_pos, _y_pos in red_pixels)
+        min_y = min(y_pos for _x_pos, y_pos in red_pixels)
+        max_y = max(y_pos for _x_pos, y_pos in red_pixels)
+        assert high_dpi_thumbnail.size() == manager._figure_gallery_thumbnail_size()
+        assert max_x - min_x + 1 == high_dpi_thumbnail.width()
+        assert abs((max_y - min_y + 1) - round(high_dpi_thumbnail.width() / 4)) <= 1
+        assert abs(((min_y + max_y) / 2) - ((high_dpi_thumbnail.height() - 1) / 2)) <= 1
+
         class NullThumbnailProvider:
             preview_pixmap = fallback
 

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -2516,8 +2516,8 @@ def test_figure_composer_plot_slices_panel_helpers_cover_style_contract(
     )
     with warnings.catch_warnings():
         warnings.filterwarnings(
-            "ignore",
-            message="In a future version of xarray the default value for coords",
+            "error",
+            message="In a future version of xarray the default value for .*",
             category=FutureWarning,
         )
         transformed_maps = figurecomposer_plot_slices._plot_slices_transformed_maps(
@@ -2543,8 +2543,8 @@ def test_figure_composer_plot_slices_panel_helpers_cover_style_contract(
     }
     with warnings.catch_warnings():
         warnings.filterwarnings(
-            "ignore",
-            message="In a future version of xarray the default value for coords",
+            "error",
+            message="In a future version of xarray the default value for .*",
             category=FutureWarning,
         )
         exec(  # noqa: S102
@@ -18194,6 +18194,8 @@ def test_figure_composer_plot_slices_line_transforms_codegen_executes(
     assert "plot_maps" not in code
     assert "eplt.plot_slices(\n    xr.concat(" in code
     assert 'dim="eV"' in code
+    assert 'coords="different"' in code
+    assert 'compat="equals"' in code
     assert '.assign_coords({"eV": [0.0, 1.0]})' in code
     assert "eV_width" not in code.split("eplt.plot_slices(", maxsplit=1)[1]
 

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -2390,6 +2390,138 @@ def test_figure_composer_custom_code_helpers_cover_codegen_paths(qtbot) -> None:
     assert figurecomposer_custom_code._custom_first_axis_code(grid_tool) == "ax0"
 
 
+def test_figure_composer_custom_code_editor_is_multiline_and_debounced(
+    qtbot,
+    monkeypatch,
+) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    operation = FigureOperationState.custom(
+        label="code",
+        code="ax.set_title('old')",
+        trusted=True,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("code")
+
+    current_page = tool.step_editor_stack.currentWidget()
+    assert current_page is not None
+    code_edit = current_page.findChild(
+        erlab.interactive.utils.PythonCodeEditor, "figureComposerCustomCodeEdit"
+    )
+    assert code_edit is not None
+    assert isinstance(code_edit.highlighter, erlab.interactive.utils.PythonHighlighter)
+    assert code_edit.lineWrapMode() == QtWidgets.QTextEdit.LineWrapMode.NoWrap
+
+    render_calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        figurecomposer_tool_module,
+        "_render_preview",
+        lambda *args, **_kwargs: render_calls.append(args),
+    )
+
+    first_code = "ax.set_title('first')"
+    second_code = "ax.set_title('second')\nax.set_xlabel('energy')"
+    code_edit.setPlainText(first_code)
+    code_edit.setPlainText(second_code)
+
+    assert tool.tool_status.operations[0].code == "ax.set_title('old')"
+    assert render_calls == []
+
+    qtbot.waitUntil(
+        lambda: tool.tool_status.operations[0].code == second_code,
+        timeout=1000,
+    )
+    assert render_calls == [(tool,)]
+
+
+def test_figure_composer_custom_code_pending_edit_survives_step_switch(
+    qtbot,
+) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    first_operation = FigureOperationState.custom(
+        label="first",
+        code="ax.set_title('old')",
+        trusted=True,
+    )
+    second_operation = FigureOperationState.custom(
+        label="second",
+        code="ax.set_xlabel('other')",
+        trusted=True,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(first_operation, second_operation),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("code")
+
+    current_page = tool.step_editor_stack.currentWidget()
+    assert current_page is not None
+    code_edit = current_page.findChild(
+        erlab.interactive.utils.PythonCodeEditor, "figureComposerCustomCodeEdit"
+    )
+    assert code_edit is not None
+
+    new_code = "ax.set_title('pending')\nax.set_ylabel('counts')"
+    code_edit.setPlainText(new_code)
+    tool.operation_list.setCurrentRow(1)
+
+    qtbot.waitUntil(
+        lambda: tool.tool_status.operations[0].code == new_code,
+        timeout=1000,
+    )
+    assert tool.tool_status.operations[1].code == "ax.set_xlabel('other')"
+
+
+def test_figure_composer_custom_code_pending_edit_flushes_on_close(qtbot) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    operation = FigureOperationState.custom(
+        label="code",
+        code="ax.set_title('old')",
+        trusted=True,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("code")
+
+    current_page = tool.step_editor_stack.currentWidget()
+    assert current_page is not None
+    code_edit = current_page.findChild(
+        erlab.interactive.utils.PythonCodeEditor, "figureComposerCustomCodeEdit"
+    )
+    assert code_edit is not None
+
+    new_code = "ax.set_title('pending close')\nax.set_ylabel('counts')"
+    code_edit.setPlainText(new_code)
+
+    assert tool.tool_status.operations[0].code == "ax.set_title('old')"
+    tool.close()
+
+    assert tool.tool_status.operations[0].code == new_code
+
+
 def test_figure_composer_custom_code_uses_public_nonuniform_dims(qtbot) -> None:
     public = xr.DataArray(
         np.arange(8.0).reshape(4, 2),

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -20208,6 +20208,75 @@ def test_manager_auto_names_figures_numerically(
         assert manager._child_node(unnamed_uid).display_text == "Figure 6"
 
 
+def test_manager_duplicate_figure_assigns_unique_display_name_and_keeps_state(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    def uid_for_name(
+        manager: erlab.interactive.imagetool.manager.ImageToolManager, name: str
+    ) -> str:
+        matches = [
+            uid
+            for uid in manager._tool_graph.figure_uids
+            if manager._child_node(uid).display_text == name
+        ]
+        assert len(matches) == 1
+        return matches[0]
+
+    with manager_context() as manager:
+        data = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="map",
+        )
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        first_uid = manager.create_figure_from_targets((0,), show=False)
+        assert first_uid is not None
+        assert manager._child_node(first_uid).display_text == "Figure 1"
+
+        original_tool = manager._child_node(first_uid).tool_window
+        assert isinstance(original_tool, FigureComposerTool)
+        original_status = original_tool.tool_status
+
+        manager._select_figure_uid(first_uid)
+        manager.duplicate_selected()
+        qtbot.wait_until(
+            lambda: len(manager._tool_graph.figure_uids) == 2, timeout=5000
+        )
+
+        auto_copy_uid = uid_for_name(manager, "Figure 2")
+        assert manager._selected_figure_uids() == [auto_copy_uid]
+        auto_copy_tool = manager._child_node(auto_copy_uid).tool_window
+        assert isinstance(auto_copy_tool, FigureComposerTool)
+        assert auto_copy_tool.tool_status == original_status
+        assert auto_copy_tool.tool_data.identical(original_tool.tool_data)
+
+        manager._child_node(first_uid).name = "Band map"
+
+        manager._select_figure_uid(first_uid)
+        manager.duplicate_selected()
+        qtbot.wait_until(
+            lambda: len(manager._tool_graph.figure_uids) == 3, timeout=5000
+        )
+
+        first_custom_copy_uid = uid_for_name(manager, "Band map copy")
+        assert manager._selected_figure_uids() == [first_custom_copy_uid]
+
+        manager._select_figure_uid(first_uid)
+        manager.duplicate_selected()
+        qtbot.wait_until(
+            lambda: len(manager._tool_graph.figure_uids) == 4, timeout=5000
+        )
+
+        second_custom_copy_uid = uid_for_name(manager, "Band map copy 2")
+        assert manager._selected_figure_uids() == [second_custom_copy_uid]
+
+
 def test_manager_create_figure_uses_first_selected_main_image_state(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -9439,7 +9439,6 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
             tool.width_ratios_edit,
             tool.height_ratios_edit,
             tool.operation_list,
-            tool.source_list,
             tool.use_all_axes_button,
             tool.keep_valid_axes_button,
             tool.axes_expression_edit,

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -2491,6 +2491,10 @@ def test_figure_composer_custom_code_editor_is_multiline_and_debounced(
     first_code = "ax.set_title('first')"
     second_code = "ax.set_title('second')\nax.set_xlabel('energy')"
     code_edit.setPlainText(first_code)
+    qtbot.wait(300)
+    assert tool.tool_status.operations[0].code == "ax.set_title('old')"
+    assert render_calls == []
+
     code_edit.setPlainText(second_code)
 
     assert tool.tool_status.operations[0].code == "ax.set_title('old')"
@@ -2501,6 +2505,65 @@ def test_figure_composer_custom_code_editor_is_multiline_and_debounced(
         timeout=1000,
     )
     assert render_calls == [(tool,)]
+
+
+def test_figure_composer_custom_code_editor_skips_render_until_valid_python(
+    qtbot,
+    monkeypatch,
+) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    operation = FigureOperationState.custom(
+        label="code",
+        code="ax.set_title('old')",
+        trusted=True,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("code")
+
+    current_page = tool.step_editor_stack.currentWidget()
+    assert current_page is not None
+    code_edit = current_page.findChild(
+        erlab.interactive.utils.PythonCodeEditor, "figureComposerCustomCodeEdit"
+    )
+    assert code_edit is not None
+
+    render_calls: list[tuple[object, ...]] = []
+    info_changed: list[None] = []
+    tool.sigInfoChanged.connect(lambda: info_changed.append(None))
+    monkeypatch.setattr(
+        figurecomposer_tool_module,
+        "_render_preview",
+        lambda *args, **_kwargs: render_calls.append(args),
+    )
+
+    invalid_code = "ax.set_title("
+    code_edit.setPlainText(invalid_code)
+
+    qtbot.waitUntil(
+        lambda: tool.tool_status.operations[0].code == invalid_code,
+        timeout=2000,
+    )
+    assert render_calls == []
+    assert info_changed == [None]
+
+    valid_code = "ax.set_title('valid')"
+    code_edit.setPlainText(valid_code)
+
+    qtbot.waitUntil(
+        lambda: tool.tool_status.operations[0].code == valid_code,
+        timeout=2000,
+    )
+    assert render_calls == [(tool,)]
+    assert info_changed == [None, None]
 
 
 def test_figure_composer_custom_code_pending_edit_survives_step_switch(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -141,6 +141,31 @@ def _selection_shortcut_sequences(
     }
 
 
+def test_manager_open_settings_reuses_live_dialog(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager.open_settings()
+
+        dialog = manager._additional_windows.get("settings")
+        if dialog is None:
+            raise AssertionError("Settings dialog was not registered")
+        assert isinstance(dialog, erlab.interactive._options.OptionDialog)
+        assert dialog.isVisible()
+
+        manager.open_settings()
+
+        assert manager._additional_windows.get("settings") is dialog
+
+        dialog.deleteLater()
+        qtbot.wait_until(lambda: "settings" not in manager._additional_windows)
+
+
 @pytest.mark.parametrize(
     ("platform", "rename_shortcut", "show_shortcut", "expected_shortcuts"),
     [

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -15,6 +15,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive._options.core
 import erlab.interactive.imagetool.manager._base as manager_base
 import erlab.interactive.imagetool.manager._io as manager_io
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state
@@ -633,6 +634,13 @@ def _set_default_loader_option(monkeypatch, loader_name: str) -> None:
     )
 
 
+def _manager_for_loader_preference(recent_filter: str | None = None):
+    return types.SimpleNamespace(
+        _recent_name_filter=recent_filter,
+        effective_interactive_options=erlab.interactive.options.model,
+    )
+
+
 @pytest.mark.parametrize(
     ("default_loader", "recent_filter", "expected_filter"),
     [
@@ -656,7 +664,7 @@ def test_preferred_name_filter_precedence(
         xarray_filter: (xr.load_dataarray, {"engine": "h5netcdf"}),
         example_filter: erlab.io.loaders["example"].file_dialog_methods[example_filter],
     }
-    manager = types.SimpleNamespace(_recent_name_filter=recent_filter)
+    manager = _manager_for_loader_preference(recent_filter)
 
     assert (
         ImageToolManager._preferred_name_filter(manager, valid_loaders)
@@ -673,11 +681,87 @@ def test_preferred_name_filter_uses_default_loader_method_order(monkeypatch) -> 
         second_filter: loader_methods[second_filter],
         first_filter: loader_methods[first_filter],
     }
-    manager = types.SimpleNamespace(_recent_name_filter=None)
+    manager = _manager_for_loader_preference()
 
     assert (
         ImageToolManager._preferred_name_filter(manager, valid_loaders) == first_filter
     )
+
+
+def test_preferred_name_filter_uses_workspace_default_loader(example_loader) -> None:
+    example_filter = "Example Raw Data (*.h5)"
+    valid_loaders = {
+        example_filter: erlab.io.loaders["example"].file_dialog_methods[example_filter],
+    }
+    manager = types.SimpleNamespace(
+        _recent_name_filter=None,
+        effective_interactive_options=(
+            erlab.interactive._options.core.model_with_workspace_overrides(
+                erlab.interactive.options.model,
+                {"io/default_loader": "example"},
+            )
+        ),
+    )
+
+    assert (
+        ImageToolManager._preferred_name_filter(manager, valid_loaders)
+        == example_filter
+    )
+
+
+def test_manager_new_imagetool_uses_workspace_options(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager._set_workspace_option_overrides(
+            {
+                "colors/cmap/name": "viridis",
+                "colors/max_rendered_abs_value": 12.0,
+            }
+        )
+        data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+
+        assert manager._data_recv([data], {}, show=False) == [True]
+
+        tool = manager.get_imagetool(0)
+        assert tool.slicer_area._options_model.colors.cmap.name == "viridis"
+        assert tool.slicer_area.colormap_properties["cmap"] == "viridis"
+        assert tool.array_slicer.display_value_abs_limit == 12.0
+
+
+def test_manager_figure_generated_code_uses_workspace_stylesheets(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager._set_workspace_option_overrides(
+            {"figure/stylesheets": ["classic", "missing-style"]}
+        )
+        data = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            name="data",
+        )
+        assert manager._data_recv([data], {}, show=False) == [True]
+
+        uid = manager.create_figure_from_targets((0,), show=False)
+        if uid is None:
+            raise AssertionError("Figure Composer tool was not created")
+        tool = manager._child_node(uid).tool_window
+        if tool is None:
+            raise AssertionError("Figure Composer tool window is missing")
+
+        code = tool.generated_code()
+
+        assert "plt.style.use(['classic'])" in code
+        assert "# Skipped unavailable stylesheets: 'missing-style'" in code
 
 
 def test_open_multiple_files_preselects_default_loader_filter(
@@ -712,6 +796,7 @@ def test_open_multiple_files_preselects_default_loader_filter(
         _recent_loader_kwargs_by_filter={},
         _recent_loader_extensions_by_filter={},
         _recent_name_filter=None,
+        effective_interactive_options=erlab.interactive.options.model,
         _add_from_multiple_files=lambda *_args, **_kwargs: None,
         open_multiple_files=lambda *_args, **_kwargs: None,
     )
@@ -776,6 +861,7 @@ def test_manager_open_preselects_default_loader_filter(
             super().__init__()
             self._recent_name_filter = None
             self._recent_directory = None
+            self.effective_interactive_options = erlab.interactive.options.model
 
     manager = _FakeManager()
     manager._preferred_name_filter = types.MethodType(
@@ -1110,6 +1196,7 @@ def test_manager_open_loader_selection_branches(
             super().__init__()
             self._recent_name_filter = None
             self._recent_directory = None
+            self.effective_interactive_options = erlab.interactive.options.model
             self._select_loader_options = _select_loader_options
             self._add_from_multiple_files = lambda *args, **kwargs: add_calls.append(
                 (args, kwargs)

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -5340,6 +5340,44 @@ def test_manager_workspace_window_title_sets_file_path(
         assert manager.isWindowModified()
 
 
+@pytest.mark.parametrize("dirty_kw", [{"data": True}, {"state": True}])
+def test_manager_repeated_tool_dirty_event_updates_document_metadata_once(
+    monkeypatch,
+    tmp_path,
+    dirty_kw: dict[str, bool],
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        workspace = tmp_path / "normal.itws"
+        manager._workspace_state.path = workspace
+        file_path_calls: list[str] = []
+        node_modified_calls: list[tuple[str, bool]] = []
+
+        monkeypatch.setattr(
+            ImageToolManager,
+            "setWindowFilePath",
+            lambda _manager, path: file_path_calls.append(path),
+        )
+        monkeypatch.setattr(
+            manager,
+            "_set_node_window_modified",
+            lambda uid, modified: node_modified_calls.append((uid, modified)),
+        )
+
+        manager._mark_workspace_dirty(uid="n1", **dirty_kw)
+        manager._mark_workspace_dirty(uid="n1", **dirty_kw)
+
+        assert file_path_calls == [str(workspace)]
+        assert node_modified_calls == [("n1", True)]
+        assert [event.uid for event in manager._workspace_state.dirty_events] == [
+            "n1",
+            "n1",
+        ]
+        assert manager._workspace_state.dirty_generation == 2
+
+
 def test_manager_workspace_window_title_clears_file_path_without_workspace(
     monkeypatch,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -682,6 +682,51 @@ def test_manager_workspace_load_preserves_added_time(
         assert manager._child_node(tool_uid).created_time == tool_added
 
 
+def test_manager_workspace_option_overrides_roundtrip_and_mark_dirty(
+    qtbot,
+    tmp_path: pathlib.Path,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    overrides = {
+        "colors/cmap/name": "viridis",
+        "colors/max_rendered_abs_value": 12.0,
+        "figure/stylesheets": ["classic", "missing-style"],
+    }
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+        )
+        manager._mark_workspace_clean()
+
+        manager._set_workspace_option_overrides(overrides)
+
+        assert manager.is_workspace_modified
+        assert manager._workspace_state.options_modified
+        assert manager.workspace_option_overrides() == overrides
+
+        fname = tmp_path / "option-overrides.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._set_workspace_option_overrides({})
+        manager._mark_workspace_clean()
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        assert manager.workspace_option_overrides() == overrides
+        assert not manager._workspace_state.options_modified
+        assert not manager.is_workspace_modified
+
+
 def test_manager_workspace_load_warns_for_unavailable_colormap(
     qtbot,
     tmp_path: pathlib.Path,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -727,6 +727,31 @@ def test_manager_workspace_option_overrides_roundtrip_and_mark_dirty(
         assert not manager.is_workspace_modified
 
 
+def test_manager_workspace_option_override_helpers(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager._workspace_state.path = tmp_path / "workspace.itws"
+        manager._mark_workspace_clean()
+
+        manager.set_workspace_option_override("colors/cmap/name", "viridis")
+
+        assert manager.workspace_option_overrides() == {"colors/cmap/name": "viridis"}
+        assert manager.is_workspace_modified
+        assert manager._workspace_state.options_modified
+
+        manager.clear_workspace_option_override("colors/cmap/name")
+        assert manager.workspace_option_overrides() == {}
+
+        manager.clear_workspace_option_override("colors/cmap/name")
+        assert manager.workspace_option_overrides() == {}
+
+
 def test_manager_workspace_load_warns_for_unavailable_colormap(
     qtbot,
     tmp_path: pathlib.Path,

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -13,7 +13,7 @@ from erlab.interactive._options.core import (
     option_paths,
     workspace_overridable_option_paths,
 )
-from erlab.interactive._options.parameters import StylesheetListWidget
+from erlab.interactive._options.parameters import ColorListWidget, StylesheetListWidget
 from erlab.interactive._options.schema import AppOptions
 
 
@@ -262,6 +262,50 @@ def test_workspace_row_action_removes_override(qtbot):
     dlg = OptionDialog(manager)
     qtbot.addWidget(dlg)
     dlg.scope_tabs.setCurrentIndex(1)
+
+    _button(dlg, "workspace", path).click()
+
+    assert path not in manager.overrides
+
+
+def test_workspace_invalid_numeric_override_remains_removable(qtbot):
+    path = "colors/max_rendered_abs_value"
+    manager = _WorkspaceManagerStub({path: "not-a-number"})
+    qtbot.addWidget(manager)
+
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+
+    spin = typing.cast(
+        "QtWidgets.QDoubleSpinBox",
+        _control(dlg, "workspace", path, QtWidgets.QDoubleSpinBox),
+    )
+    assert spin.value() == pytest.approx(options.model.colors.max_rendered_abs_value)
+    assert _override(dlg, path).isChecked()
+    assert manager.overrides[path] == "not-a-number"
+
+    _button(dlg, "workspace", path).click()
+
+    assert path not in manager.overrides
+
+
+def test_workspace_invalid_color_list_override_remains_removable(qtbot):
+    path = "colors/cursors"
+    manager = _WorkspaceManagerStub({path: ["not-a-color"]})
+    qtbot.addWidget(manager)
+
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+
+    control = typing.cast(
+        "ColorListWidget",
+        _control(dlg, "workspace", path, ColorListWidget),
+    )
+    assert control.get_colors() == options.model.colors.cursors
+    assert _override(dlg, path).isChecked()
+    assert manager.overrides[path] == ["not-a-color"]
 
     _button(dlg, "workspace", path).click()
 

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -5,6 +5,7 @@ import typing
 import pytest
 from qtpy import QtWidgets
 
+import erlab.interactive._options.ui as options_ui
 from erlab.interactive._options import OptionDialog, options
 from erlab.interactive._options.core import (
     OptionManager,
@@ -15,6 +16,7 @@ from erlab.interactive._options.core import (
 )
 from erlab.interactive._options.parameters import ColorListWidget, StylesheetListWidget
 from erlab.interactive._options.schema import AppOptions
+from erlab.interactive.colors import ColorMapComboBox
 
 
 @pytest.fixture(autouse=True)
@@ -120,6 +122,47 @@ def test_dialog_native_structure(dialog: OptionDialog):
     assert container.layout().contentsMargins().right() > 0
 
 
+def test_dialog_rebuild_pages_replaces_existing_pages(dialog: OptionDialog):
+    old_pages = dialog.findChild(QtWidgets.QStackedWidget, "settingsPageStack").count()
+
+    dialog._build_pages()
+
+    assert (
+        dialog.findChild(QtWidgets.QStackedWidget, "settingsPageStack").count()
+        == old_pages
+    )
+    assert ("user", "colors/cmap/name") in dialog._rows
+
+
+def test_dialog_empty_category_page(
+    monkeypatch: pytest.MonkeyPatch, dialog: OptionDialog
+):
+    monkeypatch.setattr(
+        options_ui,
+        "_leaf_paths_for_category",
+        lambda _category, *, workspace_only: (),
+    )
+
+    container = dialog._make_category_page("workspace", "empty")
+
+    assert (
+        container.findChild(QtWidgets.QLabel, "settingsEmpty_workspace_empty")
+        is not None
+    )
+
+
+def test_dialog_finds_workspace_manager_through_parent(qtbot):
+    manager = _WorkspaceManagerStub()
+    intermediate = QtWidgets.QWidget(manager)
+    qtbot.addWidget(manager)
+    qtbot.addWidget(intermediate)
+
+    dlg = OptionDialog(intermediate)
+    qtbot.addWidget(dlg)
+
+    assert dlg.findChild(QtWidgets.QTabBar, "settingsScopeTabs").count() == 2
+
+
 def test_dialog_close_button_closes_window(qtbot):
     dlg = OptionDialog()
     qtbot.addWidget(dlg)
@@ -132,6 +175,14 @@ def test_dialog_close_button_closes_window(qtbot):
     close_button.click()
 
     qtbot.waitUntil(lambda: not dlg.isVisible())
+
+
+def test_dialog_update_visible_page_ignores_missing_selection(dialog: OptionDialog):
+    dialog.category_list.setCurrentRow(-1)
+
+    dialog._update_visible_page()
+
+    assert dialog.category_list.currentItem() is None
 
 
 def test_stylesheet_editor_fits_settings_page(dialog: OptionDialog, qtbot):
@@ -153,6 +204,15 @@ def test_stylesheet_editor_fits_settings_page(dialog: OptionDialog, qtbot):
     )
 
     qtbot.waitUntil(lambda: page.horizontalScrollBar().maximum() == 0)
+
+
+def test_stylesheet_names_normalize_saved_values() -> None:
+    assert options_ui._stylesheet_names(None) == []
+    assert options_ui._stylesheet_names("classic, ggplot, classic") == [
+        "classic",
+        "ggplot",
+    ]
+    assert options_ui._stylesheet_names(42) == ["42"]
 
 
 def test_user_edit_saves_immediately(dialog: OptionDialog):
@@ -221,6 +281,96 @@ def test_user_row_reset_restores_default(qtbot):
     assert options.model.colors.cmap.name == AppOptions().colors.cmap.name
 
 
+def test_dialog_control_value_helpers(dialog: OptionDialog):
+    checkbox = QtWidgets.QCheckBox()
+    checkbox.setChecked(True)
+    assert dialog._control_value(checkbox, "colors/cmap/reverse") is True
+
+    spin = QtWidgets.QSpinBox()
+    spin.setValue(42)
+    assert dialog._control_value(spin, "io/dask/compute_threshold") == 42
+
+    color_combo = ColorMapComboBox()
+    color_combo.ensure_populated()
+    color_combo.setCurrentText("bwr")
+    assert dialog._control_value(color_combo, "colors/cmap/name") == "bwr"
+
+    combo = QtWidgets.QComboBox()
+    combo.addItem("Visible text")
+    assert dialog._control_value(combo, "io/default_loader") == "Visible text"
+
+    combo_with_data = QtWidgets.QComboBox()
+    combo_with_data.addItem("Visible text", "stored-value")
+    assert dialog._control_value(combo_with_data, "io/default_loader") == "stored-value"
+
+    colors = ColorListWidget()
+    colors.set_colors(["#ff0000", "#00ff00"])
+    assert colors.get_colors() == ["#ff0000", "#00ff00"]
+    assert dialog._control_value(colors, "colors/cursors") == [
+        "#ff0000",
+        "#00ff00",
+    ]
+
+    stylesheets = StylesheetListWidget(["classic", "ggplot"])
+    assert dialog._control_value(stylesheets, "figure/stylesheets") == [
+        "classic",
+        "ggplot",
+    ]
+
+    list_line = QtWidgets.QLineEdit("one, two,, ")
+    assert dialog._control_value(list_line, "colors/cmap/exclude") == ["one", "two"]
+
+    text_line = QtWidgets.QLineEdit("example")
+    assert dialog._control_value(text_line, "io/default_loader") == "example"
+    assert dialog._control_value(QtWidgets.QWidget(), "io/default_loader") is None
+
+
+def test_dialog_set_control_value_helpers(dialog: OptionDialog):
+    combo = QtWidgets.QComboBox()
+    combo.addItem("Known", "known")
+
+    dialog._set_control_value(combo, "io/default_loader", "missing")
+
+    assert combo.currentData() == "missing"
+    assert combo.currentText() == "missing (unavailable)"
+
+    list_line = QtWidgets.QLineEdit()
+    dialog._set_control_value(list_line, "colors/cmap/exclude", ["one", "two"])
+    assert list_line.text() == "one, two"
+
+    text_line = QtWidgets.QLineEdit()
+    dialog._set_control_value(text_line, "io/default_loader", "example")
+    assert text_line.text() == "example"
+
+
+def test_dialog_spinbox_constraint_variants(
+    monkeypatch: pytest.MonkeyPatch, dialog: OptionDialog
+):
+    int_spin = QtWidgets.QSpinBox()
+    monkeypatch.setattr(options_ui, "_field_constraints", lambda _field: {"gt": 2})
+    dialog._configure_spinbox(int_spin, "io/dask/compute_threshold")
+    assert int_spin.minimum() == 2
+
+    double_spin = QtWidgets.QDoubleSpinBox()
+    monkeypatch.setattr(options_ui, "_field_constraints", lambda _field: {"lt": 3.5})
+    dialog._configure_spinbox(double_spin, "colors/cmap/gamma")
+    assert double_spin.maximum() == pytest.approx(3.5)
+
+    unconstrained_int = QtWidgets.QSpinBox()
+    monkeypatch.setattr(options_ui, "_field_constraints", lambda _field: {})
+    dialog._configure_spinbox(unconstrained_int, "io/dask/compute_threshold")
+    assert unconstrained_int.minimum() == -2147483648
+    assert unconstrained_int.maximum() == 2147483647
+
+
+def test_dialog_workspace_helpers_without_manager_are_noops(dialog: OptionDialog):
+    dialog._set_workspace_override("colors/cmap/name", "bwr")
+    dialog._clear_workspace_override("colors/cmap/name")
+
+    assert dialog._workspace_overrides() == {}
+    assert dialog._effective_options().model_dump() == options.model.model_dump()
+
+
 def test_workspace_scope_shows_only_overridable_settings(qtbot):
     manager = _WorkspaceManagerStub()
     qtbot.addWidget(manager)
@@ -232,6 +382,20 @@ def test_workspace_scope_shows_only_overridable_settings(qtbot):
         row.path for (scope, _path), row in dlg._rows.items() if scope == "workspace"
     }
     assert workspace_paths == set(workspace_overridable_option_paths())
+
+
+def test_workspace_stylesheet_override_keeps_raw_saved_names(qtbot):
+    path = "figure/stylesheets"
+    saved = ["classic", "missing-style"]
+    manager = _WorkspaceManagerStub({path: saved})
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+
+    row = dlg._rows[("workspace", path)]
+
+    assert dlg._keeps_raw_workspace_value(row.control)
+    assert dlg._value_for_row(row) == saved
 
 
 def test_workspace_override_switch_saves_sparse_override(qtbot):
@@ -253,6 +417,55 @@ def test_workspace_override_switch_saves_sparse_override(qtbot):
 
     assert manager.overrides[path] == "bwr"
     assert combo.isEnabled()
+
+
+def test_workspace_control_change_without_override_is_ignored(qtbot):
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+
+    row = dlg._rows[("workspace", "colors/cmap/name")]
+    dlg._control_changed(row)
+
+    assert manager.overrides == {}
+
+
+def test_workspace_override_switch_can_clear_existing_override(qtbot):
+    path = "colors/cmap/name"
+    manager = _WorkspaceManagerStub({path: "bwr"})
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+
+    _override(dlg, path).setChecked(False)
+
+    assert path not in manager.overrides
+
+
+def test_workspace_override_changed_ignores_user_rows(qtbot):
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+
+    dlg._override_changed(dlg._rows[("user", "colors/cmap/name")])
+
+    assert manager.overrides == {}
+
+
+def test_refresh_all_reraises_invalid_user_values(
+    monkeypatch: pytest.MonkeyPatch, dialog: OptionDialog
+) -> None:
+    def raise_value_error(*_args, **_kwargs) -> None:
+        raise ValueError("invalid user setting")
+
+    monkeypatch.setattr(dialog, "_set_control_value", raise_value_error)
+
+    with pytest.raises(ValueError, match="invalid user setting"):
+        dialog._refresh_all()
 
 
 def test_workspace_row_action_removes_override(qtbot):
@@ -339,6 +552,84 @@ def test_session_revert_restores_user_and_workspace(qtbot):
     assert options.model.colors.cmap.name == AppOptions().colors.cmap.name
     assert manager.overrides == {path: "viridis"}
     assert not dlg.modified
+
+
+def test_reset_current_scope_confirms_user_reset(
+    monkeypatch: pytest.MonkeyPatch, dialog: OptionDialog
+):
+    combo = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(dialog, "user", "colors/cmap/name", QtWidgets.QComboBox),
+    )
+    combo.setCurrentText("bwr")
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Cancel,
+    )
+
+    dialog._reset_current_scope()
+
+    assert options.model.colors.cmap.name == "bwr"
+
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+
+    dialog._reset_current_scope()
+
+    assert options.model.colors.cmap.name == AppOptions().colors.cmap.name
+
+
+def test_reset_current_scope_confirms_workspace_clear(
+    monkeypatch: pytest.MonkeyPatch, qtbot
+):
+    path = "colors/cmap/name"
+    manager = _WorkspaceManagerStub({path: "bwr"})
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+
+    dlg._reset_current_scope()
+
+    assert manager.overrides == {}
+
+
+def test_reset_current_scope_workspace_without_overrides_is_noop(qtbot):
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+
+    dlg._reset_current_scope()
+
+    assert manager.dirty_marks == []
+
+
+def test_dialog_compatibility_slots(dialog: OptionDialog):
+    combo = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(dialog, "user", "colors/cmap/name", QtWidgets.QComboBox),
+    )
+    combo.setCurrentText("bwr")
+
+    dialog.apply()
+    dialog.update()
+    dialog.restore()
+
+    assert options.model.colors.cmap.name == AppOptions().colors.cmap.name
+
+    dialog.accept()
+    dialog.reject()
 
 
 def test_workspace_override_helpers_filter_to_curated_subset() -> None:

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -1,8 +1,19 @@
+from __future__ import annotations
+
+import typing
+
 import pytest
 from qtpy import QtWidgets
 
 from erlab.interactive._options import OptionDialog, options
-from erlab.interactive._options.core import OptionManager
+from erlab.interactive._options.core import (
+    OptionManager,
+    model_with_workspace_overrides,
+    normalize_workspace_option_overrides,
+    option_paths,
+    workspace_overridable_option_paths,
+)
+from erlab.interactive._options.parameters import StylesheetListWidget
 from erlab.interactive._options.schema import AppOptions
 
 
@@ -22,118 +33,298 @@ def dialog(qtbot):
     return dlg
 
 
+class _WorkspaceManagerStub(QtWidgets.QWidget):
+    def __init__(
+        self,
+        overrides: dict[str, typing.Any] | None = None,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.overrides = normalize_workspace_option_overrides(overrides)
+        self.dirty_marks: list[bool] = []
+
+    def workspace_option_overrides(self) -> dict[str, typing.Any]:
+        return dict(self.overrides)
+
+    def _set_workspace_option_overrides(
+        self,
+        overrides: typing.Mapping[str, typing.Any],
+        *,
+        mark_dirty: bool = True,
+    ) -> None:
+        self.overrides = normalize_workspace_option_overrides(overrides)
+        self.dirty_marks.append(mark_dirty)
+
+    def set_workspace_option_override(self, path: str, value: typing.Any) -> None:
+        overrides = self.workspace_option_overrides()
+        overrides[path] = value
+        self._set_workspace_option_overrides(overrides)
+
+    def clear_workspace_option_override(self, path: str) -> None:
+        overrides = self.workspace_option_overrides()
+        overrides.pop(path, None)
+        self._set_workspace_option_overrides(overrides)
+
+    @property
+    def effective_interactive_options(self) -> AppOptions:
+        return model_with_workspace_overrides(options.model, self.overrides)
+
+
+def _control(
+    dialog: OptionDialog, scope: str, path: str, cls: type[QtWidgets.QWidget]
+) -> QtWidgets.QWidget:
+    widget = dialog.findChild(cls, f"settingsControl_{scope}_{path.replace('/', '__')}")
+    if widget is None:
+        raise AssertionError(f"Missing control for {scope}:{path}")
+    return widget
+
+
+def _button(dialog: OptionDialog, scope: str, path: str) -> QtWidgets.QToolButton:
+    widget = dialog.findChild(
+        QtWidgets.QToolButton,
+        f"settingsReset_{scope}_{path.replace('/', '__')}",
+    )
+    if widget is None:
+        raise AssertionError(f"Missing action for {scope}:{path}")
+    return widget
+
+
+def _override(dialog: OptionDialog, path: str) -> QtWidgets.QCheckBox:
+    widget = dialog.findChild(
+        QtWidgets.QCheckBox,
+        f"settingsOverride_{path.replace('/', '__')}",
+    )
+    if widget is None:
+        raise AssertionError(f"Missing override switch for {path}")
+    return widget
+
+
 def test_dialog_initial_settings(dialog: OptionDialog):
-    # Should match current OptionManager settings
     assert dialog.current_options.model_dump() == options.model.model_dump()
-
-
-def test_dialog_modified_property(dialog: OptionDialog):
-    # Should be False initially
     assert not dialog.modified
-    # Change a value in the parameter tree
-    param = dialog.tree.parameter.child("colors").child("cmap").child("name")
-    param.setValue("bwr")
+
+
+def test_dialog_native_structure(dialog: OptionDialog):
+    assert dialog.findChild(QtWidgets.QDialogButtonBox) is None
+    assert dialog.findChild(QtWidgets.QTabBar, "settingsScopeTabs").count() == 1
+    assert dialog.findChild(QtWidgets.QListWidget, "settingsCategoryList").count() == 4
+    assert dialog.findChild(QtWidgets.QStackedWidget, "settingsPageStack").count() == 4
+    assert dialog.findChild(QtWidgets.QPushButton, "settingsRevertButton") is not None
+    page = dialog.findChild(QtWidgets.QScrollArea, "settingsPage_user_colors")
+    if page is None:
+        raise AssertionError("Missing settings page")
+    assert page.frameShape() == QtWidgets.QFrame.Shape.NoFrame
+    container = dialog.findChild(QtWidgets.QWidget, "settingsPageContainer_user_colors")
+    if container is None or container.layout() is None:
+        raise AssertionError("Missing settings page container")
+    assert container.layout().contentsMargins().right() > 0
+
+
+def test_dialog_close_button_closes_window(qtbot):
+    dlg = OptionDialog()
+    qtbot.addWidget(dlg)
+    dlg.show()
+    assert dlg.isVisible()
+
+    close_button = dlg.findChild(QtWidgets.QPushButton, "settingsCloseButton")
+    if close_button is None:
+        raise AssertionError("Missing close button")
+    close_button.click()
+
+    qtbot.waitUntil(lambda: not dlg.isVisible())
+
+
+def test_stylesheet_editor_fits_settings_page(dialog: OptionDialog, qtbot):
+    category_list = dialog.findChild(QtWidgets.QListWidget, "settingsCategoryList")
+    if category_list is None:
+        raise AssertionError("Missing settings category list")
+    category_list.setCurrentRow(3)
+    dialog.resize(dialog.minimumSize())
+    dialog.show()
+
+    page = dialog.findChild(QtWidgets.QScrollArea, "settingsPage_user_figure")
+    if page is None:
+        raise AssertionError("Missing figure settings page")
+    _control(
+        dialog,
+        "user",
+        "figure/stylesheets",
+        StylesheetListWidget,
+    )
+
+    qtbot.waitUntil(lambda: page.horizontalScrollBar().maximum() == 0)
+
+
+def test_user_edit_saves_immediately(dialog: OptionDialog):
+    combo = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(dialog, "user", "colors/cmap/name", QtWidgets.QComboBox),
+    )
+    combo.setCurrentText("bwr")
+
+    assert options.model.colors.cmap.name == "bwr"
     assert dialog.modified
 
 
-def test_apply_button_enables_on_change(dialog: OptionDialog, qtbot):
-    param = dialog.tree.parameter.child("colors").child("cmap").child("name")
-    param.setValue("bwr")
-    assert dialog.btn_apply.isEnabled()
-
-
-def test_dialog_parameter_tips_apply_to_label_and_row_widgets(
-    dialog: OptionDialog,
-):
-    param = dialog.tree.parameter.child("io").child("dask").child("compute_threshold")
-    tip = param.opts["tip"]
-    (item,) = tuple(param.items)
-
-    assert item.toolTip(0) == tip
-    assert item.toolTip(1) == tip
-    assert item.layoutWidget.toolTip() == tip
-    assert item.displayLabel.toolTip() == tip
-    assert item.widget.toolTip() == tip
-
-
-def test_apply_saves_settings(dialog: OptionDialog, qtbot):
-    dialog.tree.parameter.child("colors").child("cmap").child("name").setValue("bwr")
-    dialog.apply()
-
-    # Test with igor colormap that requires combobox repopulation
-    dialog.tree.parameter.child("colors").child("cmap").child("name").setValue(
-        "RainbowLight"
+def test_session_revert_restores_user_baseline(dialog: OptionDialog):
+    combo = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(dialog, "user", "colors/cmap/name", QtWidgets.QComboBox),
     )
-    dialog.tree.parameter.child("colors").child("cmap").child("reverse").setValue(True)
-    dialog.apply()
+    combo.setCurrentText("bwr")
 
-    assert options.model.colors.cmap.name == "RainbowLight"
-    assert options.model.colors.cmap.reverse
+    dialog.revert_changes()
+
+    assert options.model.colors.cmap.name == AppOptions().colors.cmap.name
     assert not dialog.modified
 
-    options.restore()  # Reset settings after test
 
+def test_reused_dialog_revert_uses_reopen_baseline(qtbot):
+    dlg = OptionDialog()
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitUntil(dlg.isVisible)
+    combo = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(dlg, "user", "colors/cmap/name", QtWidgets.QComboBox),
+    )
+    combo.setCurrentText("bwr")
+    dlg.close()
+    qtbot.waitUntil(lambda: not dlg.isVisible())
 
-def test_restore_defaults(dialog: OptionDialog, qtbot):
-    # Change a value
-    param = dialog.tree.parameter.child("colors").child("cmap").child("name")
-    param.setValue("bwr")
-    dialog.restore()
-    # Should restore to DEFAULT_OPTIONS
-    assert dialog.current_options.model_dump() == AppOptions().model_dump()
+    dlg.show()
+    qtbot.waitUntil(dlg.isVisible)
+    assert not dlg.modified
+    combo.setCurrentText("viridis")
 
-    # Accept dialog to save changes
-    dialog.accept()
+    dlg.revert_changes()
 
-
-def test_reject_with_modifications(dialog: OptionDialog, qtbot, accept_dialog):
-    # Reset to defaults first
-    dialog.restore()
-    dialog.apply()
-    assert options.model.colors.cmap.name != "bwr"
-
-    # Change a value
-    param = dialog.tree.parameter.child("colors").child("cmap").child("name")
-    param.setValue("bwr")
-    # Patch QMessageBox to simulate user clicking "No"
-
-    def _msgbox_close(dialog: QtWidgets.QMessageBox):
-        dialog.button(QtWidgets.QMessageBox.StandardButton.Cancel).click()
-
-    accept_dialog(dialog.reject, accept_call=_msgbox_close)
-
-    # Dialog should remain open, and changes should not be saved
-    assert dialog.current_options.colors.cmap.name == "bwr"
-    assert options.model.model_dump() == AppOptions().model_dump()
-
-    def _msgbox_savechanges(dialog: QtWidgets.QMessageBox):
-        dialog.button(QtWidgets.QMessageBox.StandardButton.Ok).click()
-
-    accept_dialog(dialog.reject, accept_call=_msgbox_savechanges)
-
-    # Changes should be saved now
     assert options.model.colors.cmap.name == "bwr"
+    assert not dlg.modified
 
-    options.restore()  # Reset settings after test
+
+def test_user_row_reset_restores_default(qtbot):
+    options.model = AppOptions().model_copy(
+        update={
+            "colors": AppOptions().colors.model_copy(
+                update={
+                    "cmap": AppOptions().colors.cmap.model_copy(update={"name": "bwr"})
+                }
+            )
+        }
+    )
+    dlg = OptionDialog()
+    qtbot.addWidget(dlg)
+
+    _button(dlg, "user", "colors/cmap/name").click()
+
+    assert options.model.colors.cmap.name == AppOptions().colors.cmap.name
+
+
+def test_workspace_scope_shows_only_overridable_settings(qtbot):
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+
+    assert dlg.findChild(QtWidgets.QTabBar, "settingsScopeTabs").count() == 2
+    workspace_paths = {
+        row.path for (scope, _path), row in dlg._rows.items() if scope == "workspace"
+    }
+    assert workspace_paths == set(workspace_overridable_option_paths())
+
+
+def test_workspace_override_switch_saves_sparse_override(qtbot):
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+
+    path = "colors/cmap/name"
+    combo = typing.cast(
+        "QtWidgets.QComboBox", _control(dlg, "workspace", path, QtWidgets.QComboBox)
+    )
+    override = _override(dlg, path)
+
+    assert not combo.isEnabled()
+    override.setChecked(True)
+    combo.setCurrentText("bwr")
+
+    assert manager.overrides[path] == "bwr"
+    assert combo.isEnabled()
+
+
+def test_workspace_row_action_removes_override(qtbot):
+    path = "colors/cmap/name"
+    manager = _WorkspaceManagerStub({path: "bwr"})
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+
+    _button(dlg, "workspace", path).click()
+
+    assert path not in manager.overrides
+
+
+def test_session_revert_restores_user_and_workspace(qtbot):
+    path = "colors/cmap/name"
+    manager = _WorkspaceManagerStub({path: "viridis"})
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+
+    user_combo = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(dlg, "user", "colors/cmap/name", QtWidgets.QComboBox),
+    )
+    user_combo.setCurrentText("bwr")
+    dlg.scope_tabs.setCurrentIndex(1)
+    workspace_combo = typing.cast(
+        "QtWidgets.QComboBox", _control(dlg, "workspace", path, QtWidgets.QComboBox)
+    )
+    workspace_combo.setCurrentText("magma")
+
+    dialog_workspace_before_revert = manager.workspace_option_overrides()
+    assert options.model.colors.cmap.name == "bwr"
+    assert dialog_workspace_before_revert[path] == "magma"
+
+    dlg.revert_changes()
+
+    assert options.model.colors.cmap.name == AppOptions().colors.cmap.name
+    assert manager.overrides == {path: "viridis"}
+    assert not dlg.modified
+
+
+def test_workspace_override_helpers_filter_to_curated_subset() -> None:
+    paths = set(workspace_overridable_option_paths())
+
+    assert "colors/cmap/name" in paths
+    assert "colors/cmap/packages" not in paths
+    assert "io/workspace/compress" not in paths
+    assert normalize_workspace_option_overrides(
+        {
+            "colors/cmap/name": "bwr",
+            "io/workspace/compress": False,
+        }
+    ) == {"colors/cmap/name": "bwr"}
 
 
 def test_options_get_set():
     options.restore()
 
-    # Check initial values
     assert options["colors/cmap/name"] == AppOptions().colors.cmap.name
     assert options["io/workspace/compress"] is True
     assert options["io/workspace/use_incremental"] is True
     assert options["io/workspace/incremental_save_on_remote"] is False
 
-    # Set a new value
     options["colors/cmap/name"] = "viridis"
     options["io/workspace/compress"] = False
     options["io/workspace/use_incremental"] = False
     options["io/workspace/incremental_save_on_remote"] = True
     options["figure/stylesheets"] = ["classic", "missing-style"]
 
-    # Check if the value was set correctly
     assert options["colors/cmap/name"] == "viridis"
     assert options["io/workspace/compress"] is False
     assert options["io/workspace/use_incremental"] is False
@@ -144,7 +335,7 @@ def test_options_get_set():
     assert options.model.io.workspace.incremental_save_on_remote
     assert options.model.figure.stylesheets == ["classic", "missing-style"]
 
-    options.restore()  # Reset settings after test
+    options.restore()
 
 
 def test_option_manager_uses_configured_settings_path(monkeypatch, tmp_path):
@@ -161,3 +352,7 @@ def test_option_manager_uses_configured_settings_path(monkeypatch, tmp_path):
     monkeypatch.setenv("ERLAB_INTERACTIVE_OPTIONS_PATH", str(other_settings_path))
 
     assert OptionManager()["figure/stylesheets"] == AppOptions().figure.stylesheets
+
+
+def test_workspace_overridable_paths_are_existing_option_paths() -> None:
+    assert set(workspace_overridable_option_paths()) <= set(option_paths())

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -281,29 +281,35 @@ def test_user_row_reset_restores_default(qtbot):
     assert options.model.colors.cmap.name == AppOptions().colors.cmap.name
 
 
-def test_dialog_control_value_helpers(dialog: OptionDialog):
+def test_dialog_control_value_helpers(dialog: OptionDialog, qtbot):
     checkbox = QtWidgets.QCheckBox()
+    qtbot.addWidget(checkbox)
     checkbox.setChecked(True)
     assert dialog._control_value(checkbox, "colors/cmap/reverse") is True
 
     spin = QtWidgets.QSpinBox()
+    qtbot.addWidget(spin)
     spin.setValue(42)
     assert dialog._control_value(spin, "io/dask/compute_threshold") == 42
 
     color_combo = ColorMapComboBox()
+    qtbot.addWidget(color_combo)
     color_combo.ensure_populated()
     color_combo.setCurrentText("bwr")
     assert dialog._control_value(color_combo, "colors/cmap/name") == "bwr"
 
     combo = QtWidgets.QComboBox()
+    qtbot.addWidget(combo)
     combo.addItem("Visible text")
     assert dialog._control_value(combo, "io/default_loader") == "Visible text"
 
     combo_with_data = QtWidgets.QComboBox()
+    qtbot.addWidget(combo_with_data)
     combo_with_data.addItem("Visible text", "stored-value")
     assert dialog._control_value(combo_with_data, "io/default_loader") == "stored-value"
 
     colors = ColorListWidget()
+    qtbot.addWidget(colors)
     colors.set_colors(["#ff0000", "#00ff00"])
     assert colors.get_colors() == ["#ff0000", "#00ff00"]
     assert dialog._control_value(colors, "colors/cursors") == [
@@ -312,21 +318,27 @@ def test_dialog_control_value_helpers(dialog: OptionDialog):
     ]
 
     stylesheets = StylesheetListWidget(["classic", "ggplot"])
+    qtbot.addWidget(stylesheets)
     assert dialog._control_value(stylesheets, "figure/stylesheets") == [
         "classic",
         "ggplot",
     ]
 
     list_line = QtWidgets.QLineEdit("one, two,, ")
+    qtbot.addWidget(list_line)
     assert dialog._control_value(list_line, "colors/cmap/exclude") == ["one", "two"]
 
     text_line = QtWidgets.QLineEdit("example")
+    qtbot.addWidget(text_line)
     assert dialog._control_value(text_line, "io/default_loader") == "example"
-    assert dialog._control_value(QtWidgets.QWidget(), "io/default_loader") is None
+    unknown_widget = QtWidgets.QWidget()
+    qtbot.addWidget(unknown_widget)
+    assert dialog._control_value(unknown_widget, "io/default_loader") is None
 
 
-def test_dialog_set_control_value_helpers(dialog: OptionDialog):
+def test_dialog_set_control_value_helpers(dialog: OptionDialog, qtbot):
     combo = QtWidgets.QComboBox()
+    qtbot.addWidget(combo)
     combo.addItem("Known", "known")
 
     dialog._set_control_value(combo, "io/default_loader", "missing")
@@ -335,28 +347,33 @@ def test_dialog_set_control_value_helpers(dialog: OptionDialog):
     assert combo.currentText() == "missing (unavailable)"
 
     list_line = QtWidgets.QLineEdit()
+    qtbot.addWidget(list_line)
     dialog._set_control_value(list_line, "colors/cmap/exclude", ["one", "two"])
     assert list_line.text() == "one, two"
 
     text_line = QtWidgets.QLineEdit()
+    qtbot.addWidget(text_line)
     dialog._set_control_value(text_line, "io/default_loader", "example")
     assert text_line.text() == "example"
 
 
 def test_dialog_spinbox_constraint_variants(
-    monkeypatch: pytest.MonkeyPatch, dialog: OptionDialog
+    monkeypatch: pytest.MonkeyPatch, dialog: OptionDialog, qtbot
 ):
     int_spin = QtWidgets.QSpinBox()
+    qtbot.addWidget(int_spin)
     monkeypatch.setattr(options_ui, "_field_constraints", lambda _field: {"gt": 2})
     dialog._configure_spinbox(int_spin, "io/dask/compute_threshold")
     assert int_spin.minimum() == 2
 
     double_spin = QtWidgets.QDoubleSpinBox()
+    qtbot.addWidget(double_spin)
     monkeypatch.setattr(options_ui, "_field_constraints", lambda _field: {"lt": 3.5})
     dialog._configure_spinbox(double_spin, "colors/cmap/gamma")
     assert double_spin.maximum() == pytest.approx(3.5)
 
     unconstrained_int = QtWidgets.QSpinBox()
+    qtbot.addWidget(unconstrained_int)
     monkeypatch.setattr(options_ui, "_field_constraints", lambda _field: {})
     dialog._configure_spinbox(unconstrained_int, "io/dask/compute_threshold")
     assert unconstrained_int.minimum() == -2147483648

--- a/tests/interactive/test_options_parameters.py
+++ b/tests/interactive/test_options_parameters.py
@@ -1,4 +1,5 @@
-from qtpy import QtGui, QtWidgets
+import pytest
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab.interactive._stylesheets
 from erlab.interactive._options.parameters import (
@@ -70,10 +71,99 @@ def test_colorlistparameter_save_state() -> None:
     assert state["value"][0][:3] == (1, 2, 3)
 
 
+def test_user_stylesheet_directory_uses_generic_data_fallback(
+    tmp_path, monkeypatch
+) -> None:
+    data_dir = tmp_path / "erlabpy" / "ImageTool Manager"
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets, "_app_data_directory", lambda: None
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "_generic_data_directory",
+        lambda: data_dir,
+    )
+
+    style_dir = erlab.interactive._stylesheets.user_stylesheet_directory()
+
+    assert style_dir == data_dir / "stylelib"
+    assert style_dir.is_dir()
+
+
+def test_user_stylesheet_directory_raises_without_qt_data_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets, "_app_data_directory", lambda: None
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "_generic_data_directory",
+        lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="custom Matplotlib stylesheets"):
+        erlab.interactive._stylesheets.user_stylesheet_directory()
+
+
+def test_load_user_stylesheets_tracks_added_and_removed_files(
+    tmp_path, monkeypatch
+) -> None:
+    library_paths = erlab.interactive._stylesheets._style_library_paths()
+    old_library_paths = list(library_paths)
+    user_registered = erlab.interactive._stylesheets._USER_REGISTERED_STYLESHEETS
+    old_registered = set(user_registered)
+    old_names = erlab.interactive._stylesheets._USER_STYLESHEET_NAMES
+    user_registered.clear()
+    erlab.interactive._stylesheets._USER_STYLESHEET_NAMES = frozenset()
+    data_dir = tmp_path / "app-data"
+    style_dir = data_dir / "stylelib"
+    style_name = "erlab-test-user-style"
+
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "_app_data_directory",
+        lambda: data_dir,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "_generic_data_directory",
+        lambda: None,
+    )
+    try:
+        (style_dir / f"{style_name}.mplstyle").parent.mkdir(parents=True)
+        (style_dir / f"{style_name}.mplstyle").write_text("axes.facecolor: white\n")
+
+        erlab.interactive._stylesheets.load_user_stylesheets(reload=True)
+
+        assert str(style_dir) in library_paths
+        assert style_name in erlab.interactive._stylesheets.available_stylesheets()
+        assert erlab.interactive._stylesheets.stylesheets_require_user_stylesheets(
+            [style_name]
+        )
+
+        (style_dir / f"{style_name}.mplstyle").unlink()
+        erlab.interactive._stylesheets.load_user_stylesheets(reload=True)
+
+        assert style_name not in erlab.interactive._stylesheets.available_stylesheets()
+        assert not erlab.interactive._stylesheets.stylesheets_require_user_stylesheets(
+            [style_name]
+        )
+    finally:
+        library_paths[:] = old_library_paths
+        erlab.interactive._stylesheets.mpl_style.reload_library()
+        user_registered.clear()
+        user_registered.update(old_registered)
+        erlab.interactive._stylesheets._USER_STYLESHEET_NAMES = old_names
+
+
 def test_stylesheetlistwidget_preserves_unavailable_styles(qtbot, monkeypatch):
     monkeypatch.setattr(
         "erlab.interactive._stylesheets.mpl_style.available",
         ["classic", "ggplot"],
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
     )
     monkeypatch.setattr(
         erlab.interactive._stylesheets,
@@ -86,6 +176,12 @@ def test_stylesheetlistwidget_preserves_unavailable_styles(qtbot, monkeypatch):
     assert widget.get_stylesheets() == ["classic", "missing-style"]
     assert widget.list_widget.item(1).data(_STYLESHEET_AVAILABLE_ROLE) is False
     assert "unavailable" in widget.list_widget.item(1).toolTip()
+    widget.list_widget.setCurrentRow(1)
+    assert widget.remove_button.isEnabled()
+    assert widget.up_button.isEnabled()
+    assert not widget.down_button.isEnabled()
+    widget.remove_selected_stylesheet()
+    assert widget.get_stylesheets() == ["classic"]
 
 
 def test_stylesheet_names_normalizes_and_deduplicates_values() -> None:
@@ -106,6 +202,11 @@ def test_stylesheetlistwidget_add_remove_and_reorder(qtbot, monkeypatch):
     monkeypatch.setattr(
         "erlab.interactive._stylesheets.mpl_style.available",
         ["classic", "ggplot", "bmh"],
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
     )
     widget = StylesheetListWidget(stylesheets=["classic"])
     qtbot.addWidget(widget)
@@ -129,6 +230,11 @@ def test_stylesheetlistwidget_ignores_invalid_actions_and_preserves_roles(
     monkeypatch.setattr(
         "erlab.interactive._stylesheets.mpl_style.available",
         ["classic", "ggplot"],
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
     )
     widget = StylesheetListWidget(stylesheets=["classic", "ggplot"])
     qtbot.addWidget(widget)
@@ -172,7 +278,12 @@ def test_stylesheetlistwidget_loads_erlab_styles_on_popup(qtbot, monkeypatch):
     )
     monkeypatch.setattr(
         erlab.interactive._stylesheets,
-        "load_erlab_plotting_stylesheets",
+        "load_user_stylesheets",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "reload_stylesheets",
         lambda: calls.append(None),
     )
     widget = StylesheetListWidget(stylesheets=[])
@@ -191,6 +302,11 @@ def test_stylesheetlistwidget_rechecks_saved_styles_after_erlab_import(
     monkeypatch.setattr("erlab.interactive._stylesheets.mpl_style.available", available)
     monkeypatch.setattr(
         erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
         "load_erlab_plotting_stylesheets",
         lambda: available.append("nature"),
     )
@@ -199,6 +315,69 @@ def test_stylesheetlistwidget_rechecks_saved_styles_after_erlab_import(
     qtbot.addWidget(widget)
 
     assert widget.list_widget.item(0).data(_STYLESHEET_AVAILABLE_ROLE) is True
+
+
+def test_stylesheetlistwidget_reload_updates_saved_style_availability(
+    qtbot, monkeypatch
+) -> None:
+    available = ["classic"]
+    monkeypatch.setattr("erlab.interactive._stylesheets.mpl_style.available", available)
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_erlab_plotting_stylesheets",
+        lambda: None,
+    )
+
+    def reload_stylesheets() -> None:
+        available.append("restored-style")
+
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "reload_stylesheets",
+        reload_stylesheets,
+    )
+    widget = StylesheetListWidget(stylesheets=["restored-style"])
+    qtbot.addWidget(widget)
+
+    assert widget.get_stylesheets() == ["restored-style"]
+    assert widget.list_widget.item(0).data(_STYLESHEET_AVAILABLE_ROLE) is False
+
+    widget.reload_button.click()
+
+    assert widget.get_stylesheets() == ["restored-style"]
+    assert widget.list_widget.item(0).data(_STYLESHEET_AVAILABLE_ROLE) is True
+
+
+def test_stylesheetlistwidget_open_folder_uses_custom_style_directory(
+    qtbot, monkeypatch, tmp_path
+) -> None:
+    opened_urls: list[QtCore.QUrl] = []
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "user_stylesheet_directory",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        QtGui.QDesktopServices,
+        "openUrl",
+        lambda url: opened_urls.append(url) or True,
+    )
+    widget = StylesheetListWidget(stylesheets=[])
+    qtbot.addWidget(widget)
+
+    widget.open_folder_button.click()
+
+    assert opened_urls[0].toLocalFile() == str(tmp_path)
 
 
 def test_stylesheetlistparameter_value_roundtrip() -> None:

--- a/tests/interactive/test_options_parameters.py
+++ b/tests/interactive/test_options_parameters.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -71,6 +73,47 @@ def test_colorlistparameter_save_state() -> None:
     assert state["value"][0][:3] == (1, 2, 3)
 
 
+def test_style_library_paths_falls_back_to_matplotlib_core(monkeypatch) -> None:
+    paths = ["stylelib"]
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The matplotlib.style.core module was deprecated",
+            category=DeprecationWarning,
+        )
+        from matplotlib.style import core as mpl_style_core
+
+    monkeypatch.delattr(
+        erlab.interactive._stylesheets.mpl_style,
+        "USER_LIBRARY_PATHS",
+        raising=False,
+    )
+    monkeypatch.setattr(mpl_style_core, "USER_LIBRARY_PATHS", paths)
+
+    assert erlab.interactive._stylesheets._style_library_paths() is paths
+
+
+def test_generic_data_directory_uses_qstandardpaths(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets.QtCore.QStandardPaths,
+        "writableLocation",
+        lambda location: "",
+    )
+
+    assert erlab.interactive._stylesheets._generic_data_directory() is None
+
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets.QtCore.QStandardPaths,
+        "writableLocation",
+        lambda location: str(tmp_path),
+    )
+
+    assert (
+        erlab.interactive._stylesheets._generic_data_directory()
+        == tmp_path / "erlabpy" / "ImageTool Manager"
+    )
+
+
 def test_user_stylesheet_directory_uses_generic_data_fallback(
     tmp_path, monkeypatch
 ) -> None:
@@ -102,6 +145,76 @@ def test_user_stylesheet_directory_raises_without_qt_data_path(monkeypatch) -> N
 
     with pytest.raises(RuntimeError, match="custom Matplotlib stylesheets"):
         erlab.interactive._stylesheets.user_stylesheet_directory()
+
+
+def test_user_stylesheet_directory_reports_create_failure(
+    tmp_path, monkeypatch
+) -> None:
+    file_path = tmp_path / "not-a-directory"
+    file_path.write_text("")
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "_app_data_directory",
+        lambda: file_path,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "_generic_data_directory",
+        lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="Could not create"):
+        erlab.interactive._stylesheets.user_stylesheet_directory()
+
+
+def test_user_stylesheet_directory_can_skip_creation(tmp_path, monkeypatch) -> None:
+    data_dir = tmp_path / "app-data"
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "_app_data_directory",
+        lambda: data_dir,
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "_generic_data_directory",
+        lambda: None,
+    )
+
+    style_dir = erlab.interactive._stylesheets.user_stylesheet_directory(create=False)
+
+    assert style_dir == data_dir / "stylelib"
+    assert not style_dir.exists()
+
+
+def test_stylesheet_names_in_directory_handles_missing_directory(tmp_path) -> None:
+    assert (
+        erlab.interactive._stylesheets._stylesheet_names_in_directory(
+            tmp_path / "missing"
+        )
+        == frozenset()
+    )
+
+
+def test_reload_stylesheets_loads_bundled_and_user_styles(monkeypatch) -> None:
+    calls: list[object] = []
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_erlab_plotting_stylesheets",
+        lambda: calls.append("erlab"),
+    )
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *, reload=False: calls.append(reload),
+    )
+
+    erlab.interactive._stylesheets.reload_stylesheets()
+
+    assert calls == ["erlab", True]
+
+
+def test_stylesheets_require_user_stylesheets_ignores_empty_values() -> None:
+    assert not erlab.interactive._stylesheets.stylesheets_require_user_stylesheets([])
 
 
 def test_load_user_stylesheets_tracks_added_and_removed_files(
@@ -378,6 +491,44 @@ def test_stylesheetlistwidget_open_folder_uses_custom_style_directory(
     widget.open_folder_button.click()
 
     assert opened_urls[0].toLocalFile() == str(tmp_path)
+
+
+def test_stylesheetlistwidget_open_folder_reports_unavailable_directory(
+    qtbot, monkeypatch
+) -> None:
+    warnings: list[tuple[str, str]] = []
+    opened_urls: list[QtCore.QUrl] = []
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "load_user_stylesheets",
+        lambda *_, **__: None,
+    )
+
+    def raise_no_style_directory():
+        raise RuntimeError("no stylesheet directory")
+
+    monkeypatch.setattr(
+        erlab.interactive._stylesheets,
+        "user_stylesheet_directory",
+        raise_no_style_directory,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda parent, title, text: warnings.append((title, text)),
+    )
+    monkeypatch.setattr(
+        QtGui.QDesktopServices,
+        "openUrl",
+        lambda url: opened_urls.append(url) or True,
+    )
+    widget = StylesheetListWidget(stylesheets=[])
+    qtbot.addWidget(widget)
+
+    widget.open_folder_button.click()
+
+    assert warnings == [("Stylesheet folder unavailable", "no stylesheet directory")]
+    assert opened_urls == []
 
 
 def test_stylesheetlistparameter_value_roundtrip() -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -33,6 +33,7 @@ from erlab.interactive.utils import (
     IconActionButton,
     IdentifierValidator,
     MessageDialog,
+    PythonCodeEditor,
     PythonHighlighter,
     SingleLinePlainTextEdit,
     array_rect,
@@ -1119,6 +1120,241 @@ def test_python_highlighter_formats_operator(qtbot) -> None:
         for start, length, fmt in spans
     )
     assert has_operator_format
+
+
+def test_python_code_editor_has_line_number_area(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setPlainText("\n".join(f"line_{i}" for i in range(120)))
+    editor.resize(320, 180)
+    editor.show()
+
+    area = editor.findChild(QtWidgets.QWidget, "pythonCodeEditorLineNumberArea")
+    if area is None:
+        raise AssertionError("Missing line number area")
+
+    qtbot.waitUntil(lambda: area.width() > editor.fontMetrics().horizontalAdvance("99"))
+    assert editor.viewport().geometry().left() >= area.width()
+
+
+def test_python_code_editor_alt_z_toggles_line_wrap(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setLineWrapMode(QtWidgets.QTextEdit.LineWrapMode.NoWrap)
+
+    qtbot.keyClick(editor, QtCore.Qt.Key.Key_Z, QtCore.Qt.KeyboardModifier.AltModifier)
+    assert editor.lineWrapMode() == QtWidgets.QTextEdit.LineWrapMode.WidgetWidth
+
+    qtbot.keyClick(editor, QtCore.Qt.Key.Key_Z, QtCore.Qt.KeyboardModifier.AltModifier)
+    assert editor.lineWrapMode() == QtWidgets.QTextEdit.LineWrapMode.NoWrap
+
+
+def _press_editor_key(
+    editor: PythonCodeEditor,
+    key: QtCore.Qt.Key,
+    text: str = "",
+    modifiers: QtCore.Qt.KeyboardModifier = QtCore.Qt.KeyboardModifier.NoModifier,
+) -> None:
+    event = QtGui.QKeyEvent(QtCore.QEvent.Type.KeyPress, key, modifiers, text)
+    editor.keyPressEvent(event)
+
+
+def _set_editor_cursor(
+    editor: PythonCodeEditor,
+    position: int,
+    anchor: int | None = None,
+) -> None:
+    cursor = editor.textCursor()
+    cursor.setPosition(position)
+    if anchor is not None:
+        cursor.setPosition(anchor, QtGui.QTextCursor.MoveMode.KeepAnchor)
+    editor.setTextCursor(cursor)
+
+
+def test_python_code_editor_auto_pairs_delimiters(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+
+    _press_editor_key(editor, QtCore.Qt.Key.Key_ParenLeft, "(")
+
+    assert editor.toPlainText() == "()"
+    assert editor.textCursor().position() == 1
+
+
+def test_python_code_editor_surrounds_selection_with_delimiters(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setPlainText("value")
+    _set_editor_cursor(editor, 0, 5)
+
+    _press_editor_key(editor, QtCore.Qt.Key.Key_BracketLeft, "[")
+
+    assert editor.toPlainText() == "[value]"
+    assert editor.textCursor().selectionStart() == 1
+    assert editor.textCursor().selectionEnd() == 6
+    assert editor.textCursor().selectedText() == "value"
+
+    editor.setPlainText("value")
+    _set_editor_cursor(editor, 5, 0)
+
+    _press_editor_key(editor, QtCore.Qt.Key.Key_BraceLeft, "{")
+
+    assert editor.toPlainText() == "{value}"
+    assert editor.textCursor().selectionStart() == 1
+    assert editor.textCursor().selectionEnd() == 6
+    assert editor.textCursor().position() == 1
+
+
+def test_python_code_editor_skips_and_deletes_empty_pairs(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+
+    _press_editor_key(editor, QtCore.Qt.Key.Key_ParenLeft, "(")
+    _press_editor_key(editor, QtCore.Qt.Key.Key_ParenRight, ")")
+
+    assert editor.toPlainText() == "()"
+    assert editor.textCursor().position() == 2
+
+    _set_editor_cursor(editor, 1)
+    _press_editor_key(editor, QtCore.Qt.Key.Key_Backspace)
+
+    assert editor.toPlainText() == ""
+
+
+def test_python_code_editor_quotes_pair_conservatively(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setPlainText("x = ")
+    _set_editor_cursor(editor, len("x = "))
+
+    _press_editor_key(editor, QtCore.Qt.Key.Key_Apostrophe, "'")
+
+    assert editor.toPlainText() == "x = ''"
+    assert editor.textCursor().position() == len("x = '")
+
+    editor.setPlainText("spam eggs")
+    _set_editor_cursor(editor, 4)
+
+    _press_editor_key(editor, QtCore.Qt.Key.Key_Apostrophe, "'")
+
+    assert editor.toPlainText() == "spam' eggs"
+
+
+def test_python_code_editor_toggle_comments_current_and_selected_lines(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setPlainText("alpha\n    beta")
+    _set_editor_cursor(editor, len("alpha\n    be"))
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Slash,
+        "/",
+        QtCore.Qt.KeyboardModifier.ControlModifier,
+    )
+
+    assert editor.toPlainText() == "alpha\n    # beta"
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Slash,
+        "/",
+        QtCore.Qt.KeyboardModifier.ControlModifier,
+    )
+
+    assert editor.toPlainText() == "alpha\n    beta"
+
+    _set_editor_cursor(editor, 0, len(editor.toPlainText()))
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Slash,
+        "/",
+        QtCore.Qt.KeyboardModifier.MetaModifier,
+    )
+
+    assert editor.toPlainText() == "# alpha\n    # beta"
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Slash,
+        "/",
+        QtCore.Qt.KeyboardModifier.MetaModifier,
+    )
+
+    assert editor.toPlainText() == "alpha\n    beta"
+
+
+def test_python_code_editor_moves_lines_with_alt_up_down(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setPlainText("a\nb\nc")
+    _set_editor_cursor(editor, len("a\nb"))
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Up,
+        modifiers=QtCore.Qt.KeyboardModifier.AltModifier,
+    )
+
+    assert editor.toPlainText() == "b\na\nc"
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Up,
+        modifiers=QtCore.Qt.KeyboardModifier.AltModifier,
+    )
+
+    assert editor.toPlainText() == "b\na\nc"
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Down,
+        modifiers=QtCore.Qt.KeyboardModifier.AltModifier,
+    )
+
+    assert editor.toPlainText() == "a\nb\nc"
+
+    editor.setPlainText("a\nb\nc\nd")
+    _set_editor_cursor(editor, len("a\n"), len("a\nb\nc"))
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Down,
+        modifiers=QtCore.Qt.KeyboardModifier.AltModifier,
+    )
+
+    assert editor.toPlainText() == "a\nd\nb\nc"
+    assert editor.textCursor().selectedText().replace("\u2029", "\n") == "b\nc"
+
+
+def test_python_code_editor_duplicates_lines_with_shift_alt_up_down(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setPlainText("a\nb\nc")
+    _set_editor_cursor(editor, len("a\nb"))
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Down,
+        modifiers=(
+            QtCore.Qt.KeyboardModifier.ShiftModifier
+            | QtCore.Qt.KeyboardModifier.AltModifier
+        ),
+    )
+
+    assert editor.toPlainText() == "a\nb\nb\nc"
+
+    editor.setPlainText("a\nb\nc")
+    _set_editor_cursor(editor, 0, len("a\nb"))
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Up,
+        modifiers=(
+            QtCore.Qt.KeyboardModifier.ShiftModifier
+            | QtCore.Qt.KeyboardModifier.AltModifier
+        ),
+    )
+
+    assert editor.toPlainText() == "a\nb\na\nb\nc"
 
 
 def test_generate_code_multiple_assignment() -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1149,6 +1149,32 @@ def test_python_code_editor_alt_z_toggles_line_wrap(qtbot) -> None:
     assert editor.lineWrapMode() == QtWidgets.QTextEdit.LineWrapMode.NoWrap
 
 
+def test_python_code_editor_reports_python_syntax(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+
+    assert editor.has_valid_python_syntax("ax.set_title('ok')")
+    assert editor.python_syntax_error("ax.set_title(") is not None
+
+
+def test_python_code_editor_tracks_settled_text(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.set_text_editing_settle_delay(20)
+    started: list[bool] = []
+    settled: list[str] = []
+    editor.sigTextEditingStarted.connect(lambda: started.append(True))
+    editor.sigTextEditingSettled.connect(settled.append)
+
+    editor.setPlainText("first")
+    editor.setPlainText("second")
+
+    assert editor.text_editing_active()
+    assert started == [True]
+    qtbot.waitUntil(lambda: settled == ["second"], timeout=1000)
+    assert not editor.text_editing_active()
+
+
 def _press_editor_key(
     editor: PythonCodeEditor,
     key: QtCore.Qt.Key,

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1135,6 +1135,7 @@ def test_python_code_editor_has_line_number_area(qtbot) -> None:
 
     qtbot.waitUntil(lambda: area.width() > editor.fontMetrics().horizontalAdvance("99"))
     assert editor.viewport().geometry().left() >= area.width()
+    assert area.sizeHint().width() > 0
 
 
 def test_python_code_editor_alt_z_toggles_line_wrap(qtbot) -> None:
@@ -1172,6 +1173,20 @@ def test_python_code_editor_tracks_settled_text(qtbot) -> None:
     assert editor.text_editing_active()
     assert started == [True]
     qtbot.waitUntil(lambda: settled == ["second"], timeout=1000)
+    assert not editor.text_editing_active()
+
+
+def test_python_code_editor_editing_activity_edges(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.set_text_editing_settle_delay(-10)
+
+    assert editor.text_editing_settle_delay() == 0
+
+    editor._mark_text_editing_activity(0, 0, 0)
+    assert not editor.text_editing_active()
+
+    editor._finish_text_editing_activity()
     assert not editor.text_editing_active()
 
 
@@ -1266,6 +1281,29 @@ def test_python_code_editor_quotes_pair_conservatively(qtbot) -> None:
     assert editor.toPlainText() == "spam' eggs"
 
 
+def test_python_code_editor_pair_helper_edges(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+
+    assert not editor._handle_pair_text("ab")
+    assert not editor._handle_pair_text("x")
+
+    editor.setPlainText("abc")
+    _set_editor_cursor(editor, 0)
+    assert editor._previous_character(editor.textCursor()) == ""
+    assert not editor._delete_empty_pair()
+
+    _set_editor_cursor(editor, 0, 2)
+    assert not editor._delete_empty_pair()
+
+    editor.setPlainText("x = \\")
+    _set_editor_cursor(editor, len(editor.toPlainText()))
+
+    _press_editor_key(editor, QtCore.Qt.Key.Key_Apostrophe, "'")
+
+    assert editor.toPlainText() == "x = \\'"
+
+
 def test_python_code_editor_toggle_comments_current_and_selected_lines(qtbot) -> None:
     editor = PythonCodeEditor()
     qtbot.addWidget(editor)
@@ -1310,6 +1348,36 @@ def test_python_code_editor_toggle_comments_current_and_selected_lines(qtbot) ->
     assert editor.toPlainText() == "alpha\n    beta"
 
 
+def test_python_code_editor_toggle_comments_edge_selections(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setPlainText("# a\n\n# b")
+    _set_editor_cursor(editor, 0, len(editor.toPlainText()))
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Slash,
+        "/",
+        QtCore.Qt.KeyboardModifier.ControlModifier,
+    )
+
+    assert editor.toPlainText() == "a\n\nb"
+
+    editor.setPlainText("a\nb\nc")
+    _set_editor_cursor(editor, 0, len("a\n"))
+
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Slash,
+        "/",
+        QtCore.Qt.KeyboardModifier.ControlModifier,
+    )
+
+    assert editor.toPlainText() == "# a\nb\nc"
+    assert editor._adjust_line_column(0, 3, {}) == 3
+    assert editor._adjust_line_column(0, 1, {0: (2, 2)}) == 1
+
+
 def test_python_code_editor_moves_lines_with_alt_up_down(qtbot) -> None:
     editor = PythonCodeEditor()
     qtbot.addWidget(editor)
@@ -1351,6 +1419,27 @@ def test_python_code_editor_moves_lines_with_alt_up_down(qtbot) -> None:
     assert editor.toPlainText() == "a\nd\nb\nc"
     assert editor.textCursor().selectedText().replace("\u2029", "\n") == "b\nc"
 
+    editor.setPlainText("a\nb")
+    _set_editor_cursor(editor, len("a\nb"))
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Down,
+        modifiers=QtCore.Qt.KeyboardModifier.AltModifier,
+    )
+
+    assert editor.toPlainText() == "a\nb"
+
+    editor.setPlainText("a\nb\nc")
+    _set_editor_cursor(editor, len("a\nb"), 0)
+    _press_editor_key(
+        editor,
+        QtCore.Qt.Key.Key_Down,
+        modifiers=QtCore.Qt.KeyboardModifier.AltModifier,
+    )
+
+    assert editor.toPlainText() == "c\na\nb"
+    assert editor.textCursor().selectedText().replace("\u2029", "\n") == "a\nb"
+
 
 def test_python_code_editor_duplicates_lines_with_shift_alt_up_down(qtbot) -> None:
     editor = PythonCodeEditor()
@@ -1381,6 +1470,17 @@ def test_python_code_editor_duplicates_lines_with_shift_alt_up_down(qtbot) -> No
     )
 
     assert editor.toPlainText() == "a\nb\na\nb\nc"
+
+
+def test_python_code_editor_unindent_handles_tabs_and_plain_lines(qtbot) -> None:
+    editor = PythonCodeEditor()
+    qtbot.addWidget(editor)
+    editor.setPlainText("\tfoo\nbar")
+    _set_editor_cursor(editor, 0, len(editor.toPlainText()))
+
+    _press_editor_key(editor, QtCore.Qt.Key.Key_Backtab)
+
+    assert editor.toPlainText() == "foo\nbar"
 
 
 def test_generate_code_multiple_assignment() -> None:

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -27,6 +27,7 @@ def test_custom_mathtext_styles_use_concrete_calligraphic_font(style) -> None:
     with matplotlib.style.context(style):
         assert plt.rcParams["mathtext.fontset"] == "custom"
         assert plt.rcParams["mathtext.cal"] == "cmsy10"
+        assert plt.rcParams["mathtext.default"] == "normal"
 
 
 def test_firalight_selects_light_face_without_numeric_global_weight() -> None:

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -22,6 +22,19 @@ def test_plotting_import_registration_is_idempotent() -> None:
         assert plt.rcParams["pcolor.shading"] == "auto"
 
 
+@pytest.mark.parametrize("style", ["nature", "fira", "firalight"])
+def test_custom_mathtext_styles_use_concrete_calligraphic_font(style) -> None:
+    with matplotlib.style.context(style):
+        assert plt.rcParams["mathtext.fontset"] == "custom"
+        assert plt.rcParams["mathtext.cal"] == "cmsy10"
+
+
+def test_firalight_selects_light_face_without_numeric_global_weight() -> None:
+    with matplotlib.style.context("firalight"):
+        assert plt.rcParams["font.family"][0] == "Fira Sans Light"
+        assert plt.rcParams["font.weight"] == "normal"
+
+
 def sample_plot(norms, kw0, kw1, cmap):
     if isinstance(kw0, dict):
         kw0 = (kw0,) * len(norms)

--- a/tests/plotting/test_general.py
+++ b/tests/plotting/test_general.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+import erlab.accessors.general as accessor_general
 from erlab.plotting.general import (
     clean_labels,
     fermiline,
@@ -11,6 +12,63 @@ from erlab.plotting.general import (
     plot_array,
     plot_slices,
 )
+
+
+def test_plot_slices_selects_slice_stack_once_per_map(monkeypatch) -> None:
+    eV = np.array([0.0, 1.0, 2.0])
+    y = np.array([0.0, 1.0, 2.0, 3.0])
+    x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    data0 = xr.DataArray(
+        np.arange(eV.size * y.size * x.size, dtype=float).reshape(
+            eV.size, y.size, x.size
+        ),
+        dims=("eV", "y", "x"),
+        coords={"eV": eV, "y": y, "x": x},
+    )
+    data1 = data0 + 100.0
+    expected0 = data0.qsel(
+        eV=[0.0, 2.0],
+        eV_width=[0.1, 0.1],
+        y=slice(1.0, 3.0),
+        x=slice(1.0, 3.0),
+    )
+    expected1 = data1.qsel(
+        eV=[0.0, 2.0],
+        eV_width=[0.1, 0.1],
+        y=slice(1.0, 3.0),
+        x=slice(1.0, 3.0),
+    )
+    calls: list[dict[str, object]] = []
+    original_qsel = accessor_general.SelectionAccessor.__call__
+
+    def counted_qsel(self, *args, **kwargs):
+        calls.append(dict(kwargs))
+        return original_qsel(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        accessor_general.SelectionAccessor,
+        "__call__",
+        counted_qsel,
+    )
+
+    fig, axes = plot_slices(
+        [data0, data1],
+        eV=[0.0, 2.0],
+        eV_width=[0.1, 0.1],
+        xlim=(1.0, 3.0),
+        ylim=(1.0, 3.0),
+    )
+
+    assert len(calls) == 2
+    assert calls[0]["eV"] == [0.0, 2.0]
+    assert calls[0]["eV_width"] == [0.1, 0.1]
+    assert axes.shape == (2, 2)
+    assert all(len(axis.images) == 1 for axis in axes.ravel())
+    np.testing.assert_allclose(axes[0, 0].images[0].get_array(), expected0[0].values)
+    np.testing.assert_allclose(axes[0, 1].images[0].get_array(), expected0[1].values)
+    np.testing.assert_allclose(axes[1, 0].images[0].get_array(), expected1[0].values)
+    np.testing.assert_allclose(axes[1, 1].images[0].get_array(), expected1[1].values)
+    plt.close(fig)
 
 
 def test_plot_slices_general(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Document how to add custom Matplotlib stylesheets for Figure Composer
- Add Open Folder and Reload controls to the stylesheet settings widget
- Load user stylesheets during code generation and skip unavailable saved styles cleanly
- Refresh bundled style defaults for the Fira and Nature stylesheets

## Testing
- Added unit tests for user stylesheet directory handling, reload behavior, and unavailable stylesheet preservation
- Added Figure Composer coverage for generated code that references user stylesheets