### PR TITLE
Load modern BCS tables without payload columns

### DIFF
--- a/src/erlab/io/plugins/_merlin_bcs.py
+++ b/src/erlab/io/plugins/_merlin_bcs.py
@@ -58,9 +58,8 @@ def load_bcs(path: str | os.PathLike) -> xr.DataArray | xr.Dataset | xr.DataTree
     xarray.DataArray, xarray.Dataset, or xarray.DataTree
         A data array containing the compiled payload stack for BCS files with one
         payload column. If a file contains multiple payload columns, each payload stream
-        is loaded into a separate child node of a data tree. Legacy tabular BCS scans
-        without payload columns are returned as a dataset with one data variable per
-        measured channel.
+        is loaded into a separate child node of a data tree. BCS scans without payload
+        columns are returned as a dataset with one data variable per measured channel.
     """
     path = pathlib.Path(path)
     lines = path.read_text(encoding="utf-8-sig").splitlines()
@@ -72,7 +71,7 @@ def load_bcs(path: str | os.PathLike) -> xr.DataArray | xr.Dataset | xr.DataTree
 
     payload_columns = _find_payload_columns(columns, rows)
     if not payload_columns:
-        raise ValueError(f"{path} contains no BCS payload columns")
+        return _load_modern_bcs_table(path, header, columns, rows)
 
     payload_kinds = {column: _payload_kind(column, rows) for column in payload_columns}
     numeric_columns = _numeric_columns(columns, rows, payload_columns)
@@ -145,6 +144,56 @@ def _parse_bcs_table(
         raise ValueError(f"{path} contains no BCS data rows")
 
     return header, columns, rows
+
+
+def _load_modern_bcs_table(
+    path: pathlib.Path,
+    header: _BCSHeader,
+    columns: list[str],
+    rows: list[_BCSRow],
+) -> xr.Dataset:
+    numeric_columns = _modern_numeric_columns(path, columns, rows)
+    scan_dim, scan_values, goal_column = _scan_axis(header, numeric_columns, rows)
+    coords, attrs = _attach_bcs_metadata(
+        {scan_dim: scan_values}, header, scan_dim, {}, {}
+    )
+
+    existing_names = set(coords)
+    data_vars = {}
+    for column in columns:
+        if column == goal_column:
+            continue
+
+        data_vars[_unique_name(column, existing_names)] = (
+            scan_dim,
+            numeric_columns[column],
+        )
+
+    return xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs)
+
+
+def _modern_numeric_columns(
+    path: pathlib.Path, columns: list[str], rows: list[_BCSRow]
+) -> dict[str, _FloatArray]:
+    numeric_columns: dict[str, _FloatArray] = {}
+    for row in rows:
+        if None in row or any(row.get(column) is None for column in columns):
+            raise ValueError(f"{path} contains ragged BCS data rows")
+
+    for column in columns:
+        values: list[float] = []
+        for row in rows:
+            value = row[column]
+            if value == "":
+                raise ValueError(f"{path} contains non-numeric BCS data rows")
+            try:
+                values.append(float(value))
+            except ValueError as err:
+                raise ValueError(f"{path} contains non-numeric BCS data rows") from err
+
+        numeric_columns[column] = np.asarray(values, dtype=np.float64)
+
+    return numeric_columns
 
 
 def _has_modern_bcs_markers(lines: list[str]) -> bool:

--- a/tests/io/plugins/test_merlin.py
+++ b/tests/io/plugins/test_merlin.py
@@ -307,6 +307,53 @@ def test_load_bcs_unsupported_legacy_tabular_scan(tmp_path) -> None:
         load_bcs(scan_path)
 
 
+def test_load_bcs_modern_numeric_single_motor_scan(tmp_path) -> None:
+    scan_path = tmp_path / "numeric.txt"
+    _write_bcs_text(
+        scan_path,
+        {
+            "Scan Type": "Single Motor Scan",
+            "Version": "3",
+            "Single Motor Scan": {"X Motor": "EPU Gap"},
+            "Motors": {"EPU Gap": 999.0, "Beamline Energy": 30.0},
+            "Notes": {"operator": "test"},
+        },
+        [
+            "Time (s)",
+            "EPU Gap Goal",
+            "EPU Gap Actual",
+            "EPU Gap",
+            "Beam Current",
+            "Const Trace",
+        ],
+        [
+            ["0.0", "20.0", "20.01", "999.0", "500.0", "7.0"],
+            ["1.0", "20.2", "20.21", "999.0", "501.0", "7.0"],
+        ],
+    )
+
+    data = load_bcs(scan_path)
+
+    assert isinstance(data, xr.Dataset)
+    assert data.sizes == {"EPU Gap": 2}
+    assert set(data.data_vars) == {
+        "Time (s)",
+        "EPU Gap Actual",
+        "EPU Gap raw",
+        "Beam Current",
+        "Const Trace",
+    }
+    assert "EPU Gap Goal" not in data.data_vars
+    np.testing.assert_allclose(data["EPU Gap"].values, [20.0, 20.2])
+    np.testing.assert_allclose(data["EPU Gap Actual"].values, [20.01, 20.21])
+    np.testing.assert_allclose(data["EPU Gap raw"].values, [999.0, 999.0])
+    assert data["Beamline Energy"].dims == ()
+    assert float(data["Beamline Energy"]) == 30.0
+    assert "Motors" not in data.attrs
+    assert data.attrs["Scan Type"] == "Single Motor Scan"
+    assert data.attrs["Notes"] == {"operator": "test"}
+
+
 def test_load_bcs_dataarray(tmp_path) -> None:
     scan_path, expected_images = _write_bcs_scan(tmp_path)
 
@@ -560,7 +607,8 @@ def test_load_bcs_text_payload_mismatched_axes(tmp_path) -> None:
         ("DATA\nx\n1\n", "not a valid BCS data file"),
         ("HEADER\n{}\nDATA\n", "missing BCS data table"),
         ("HEADER\n{}\nDATA\nx\n", "contains no BCS data rows"),
-        ("HEADER\n{}\nDATA\nx\n1\n", "contains no BCS payload columns"),
+        ("HEADER\n{}\nDATA\nx\nbad\n", "contains non-numeric BCS data rows"),
+        ("HEADER\n{}\nDATA\nx\ty\n1\n", "contains ragged BCS data rows"),
     ],
 )
 def test_load_bcs_invalid_files(tmp_path, text, match) -> None:


### PR DESCRIPTION
## Summary
- Return a dataset for modern BCS tables that omit payload columns instead of raising an error
- Parse numeric columns directly for these scans, preserving scan metadata and motor values
- Add coverage for a valid single-motor scan plus numeric and ragged data validation cases

## Testing
- Added unit tests for modern tabular BCS loading and error handling
- Not run (not requested)