### PR TITLE
Harden compat manager teardown

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -575,14 +575,21 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         self._standalone_app_pending_states[key] = state
 
     def _close_standalone_app(self, key: str) -> None:
-        widget = self._standalone_app_windows.pop(key, None)
-        event_filter = self._standalone_app_event_filters.pop(key, None)
+        widget = self._standalone_app_windows.get(key)
+        event_filter = self._standalone_app_event_filters.get(key)
         if widget is None or not erlab.interactive.utils.qt_is_valid(widget):
+            self._standalone_app_windows.pop(key, None)
+            self._standalone_app_event_filters.pop(key, None)
             self._standalone_app_pending_states.pop(key, None)
             return
         if event_filter is not None:
             widget.removeEventFilter(event_filter)
-        widget.close()
+        if not widget.close():
+            if event_filter is not None and erlab.interactive.utils.qt_is_valid(widget):
+                widget.installEventFilter(event_filter)
+            return
+        self._standalone_app_windows.pop(key, None)
+        self._standalone_app_event_filters.pop(key, None)
         widget.deleteLater()
         self._standalone_app_pending_states.pop(key, None)
 

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1478,6 +1478,14 @@ class ImageToolManager(_ImageToolManagerBase):
                     for handler in list(self._file_handlers):
                         handler.wait()
 
+            if self._standalone_app_windows:
+                logger.debug("Closing standalone apps...")
+                self._close_standalone_apps()
+                if self._standalone_app_windows:
+                    if event:
+                        event.ignore()
+                    return
+
             logger.debug("Stopping servers...")
             self._registry_heartbeat_timer.stop()
             self._registry_heartbeat.stop()
@@ -1521,10 +1529,6 @@ class ImageToolManager(_ImageToolManagerBase):
                 self.console._console_widget.shutdown_kernel()
                 self.console.close()
                 self.console.deleteLater()
-
-            if self._standalone_app_windows:
-                logger.debug("Closing standalone apps...")
-                self._close_standalone_apps()
 
             logger.debug("Releasing workspace lock...")
             self._release_workspace_lock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,6 +419,8 @@ def manager_context() -> Callable[
                     clipboard = QtWidgets.QApplication.clipboard()
                     if clipboard is not None:
                         clipboard.clear()
+                    manager._close_standalone_apps()
+                    _drain_qt_events()
                     manager.remove_all_tools()
                     manager._mark_workspace_clean()
                     manager.close()

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -1301,3 +1301,93 @@ def test_manager_close_event_closes_standalone_apps(
 
         assert manager._standalone_app_windows == {}
         assert not erlab.interactive.utils.qt_is_valid(explorer, ptable)
+
+
+def test_manager_close_standalone_app_keeps_ignored_close(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    class _BusyStandaloneWindow(QtWidgets.QWidget):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_event_count = 0
+            self.delete_later_count = 0
+            self.refuse_close = True
+
+        def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+            self.close_event_count += 1
+            if self.refuse_close and event is not None:
+                event.ignore()
+                return
+            super().closeEvent(event)
+
+        def deleteLater(self) -> None:
+            self.delete_later_count += 1
+            super().deleteLater()
+
+    with manager_context() as manager:
+        spec = manager._standalone_app_specs["explorer"]
+        manager._standalone_app_specs["explorer"] = dataclasses.replace(
+            spec,
+            factory=_BusyStandaloneWindow,
+        )
+        manager.show_explorer()
+        standalone = manager.explorer
+        event_filter = manager._standalone_app_event_filters["explorer"]
+
+        assert isinstance(standalone, _BusyStandaloneWindow)
+        qtbot.wait_until(standalone.isVisible)
+
+        manager._close_standalone_app("explorer")
+
+        assert manager._standalone_app_windows["explorer"] is standalone
+        assert manager._standalone_app_event_filters["explorer"] is event_filter
+        assert standalone.close_event_count == 1
+        assert standalone.delete_later_count == 0
+
+        standalone.refuse_close = False
+        manager._close_standalone_app("explorer")
+
+        assert "explorer" not in manager._standalone_app_windows
+        assert standalone.delete_later_count == 1
+
+
+def test_manager_close_event_waits_for_busy_standalone_app(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    class _BusyStandaloneWindow(QtWidgets.QWidget):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_event_count = 0
+            self.refuse_close = True
+
+        def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+            self.close_event_count += 1
+            if self.refuse_close and event is not None:
+                event.ignore()
+                return
+            super().closeEvent(event)
+
+    with manager_context() as manager:
+        spec = manager._standalone_app_specs["explorer"]
+        manager._standalone_app_specs["explorer"] = dataclasses.replace(
+            spec,
+            factory=_BusyStandaloneWindow,
+        )
+        manager.show_explorer()
+        standalone = manager.explorer
+
+        assert isinstance(standalone, _BusyStandaloneWindow)
+        qtbot.wait_until(standalone.isVisible)
+
+        assert not manager.close()
+        assert manager.isVisible()
+        assert manager._standalone_app_windows["explorer"] is standalone
+        assert standalone.close_event_count == 1
+
+        standalone.refuse_close = False

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -1340,11 +1340,27 @@ def test_manager_close_standalone_app_keeps_ignored_close(
         assert isinstance(standalone, _BusyStandaloneWindow)
         qtbot.wait_until(standalone.isVisible)
 
+        manager._standalone_app_event_filters["stale"] = QtCore.QObject(manager)
+        manager._standalone_app_pending_states["stale"] = {}
+        manager._close_standalone_app("stale")
+
+        assert "stale" not in manager._standalone_app_windows
+        assert "stale" not in manager._standalone_app_event_filters
+        assert "stale" not in manager._standalone_app_pending_states
+
         manager._close_standalone_app("explorer")
 
         assert manager._standalone_app_windows["explorer"] is standalone
         assert manager._standalone_app_event_filters["explorer"] is event_filter
         assert standalone.close_event_count == 1
+        assert standalone.delete_later_count == 0
+
+        manager._standalone_app_event_filters.pop("explorer")
+        manager._close_standalone_app("explorer")
+
+        assert manager._standalone_app_windows["explorer"] is standalone
+        assert "explorer" not in manager._standalone_app_event_filters
+        assert standalone.close_event_count == 2
         assert standalone.delete_later_count == 0
 
         standalone.refuse_close = False
@@ -1389,5 +1405,9 @@ def test_manager_close_event_waits_for_busy_standalone_app(
         assert manager.isVisible()
         assert manager._standalone_app_windows["explorer"] is standalone
         assert standalone.close_event_count == 1
+
+        manager.closeEvent(None)
+        assert manager._standalone_app_windows["explorer"] is standalone
+        assert standalone.close_event_count == 2
 
         standalone.refuse_close = False

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -21119,12 +21119,12 @@ def test_figure_composer_plot_slices_label_codegen_helper_variants() -> None:
     single = figurecomposer_plot_slices._plot_slices_label_line_kw_comprehension_code(
         operation, single_key, ("alpha",), "slice_values", fields
     )
-    assert eval(single, {}, namespace) == {"label": "alpha:1:0.1"}  # noqa: S307
+    assert eval(single, namespace) == {"label": "alpha:1:0.1"}  # noqa: S307
 
     by_slice = figurecomposer_plot_slices._plot_slices_label_line_kw_comprehension_code(
         operation, by_slice_keys, ("alpha",), "slice_values", fields
     )
-    assert eval(by_slice, {}, namespace) == [  # noqa: S307
+    assert eval(by_slice, namespace) == [  # noqa: S307
         {"label": "alpha:1:0.1"},
         {"label": "alpha:2:0.2"},
     ]
@@ -21134,7 +21134,7 @@ def test_figure_composer_plot_slices_label_codegen_helper_variants() -> None:
             operation, by_source_keys, ("alpha", "beta"), "slice_values", fields
         )
     )
-    assert eval(by_source, {}, namespace) == [  # noqa: S307
+    assert eval(by_source, namespace) == [  # noqa: S307
         {"label": "alpha:1:0.1"},
         {"label": "beta:2:0.1"},
     ]
@@ -21142,7 +21142,7 @@ def test_figure_composer_plot_slices_label_codegen_helper_variants() -> None:
     grid = figurecomposer_plot_slices._plot_slices_label_line_kw_comprehension_code(
         operation, grid_keys, ("alpha", "beta"), "slice_values", fields
     )
-    assert eval(grid, {}, namespace) == [  # noqa: S307
+    assert eval(grid, namespace) == [  # noqa: S307
         [{"label": "alpha:1:0.1"}, {"label": "alpha:2:0.2"}],
         [{"label": "beta:3:0.1"}, {"label": "beta:4:0.2"}],
     ]
@@ -21156,7 +21156,7 @@ def test_figure_composer_plot_slices_label_codegen_helper_variants() -> None:
             fields,
         )
     )
-    assert eval(fortran_grid, {}, namespace) == [  # noqa: S307
+    assert eval(fortran_grid, namespace) == [  # noqa: S307
         [{"label": "alpha:1:0.1"}, {"label": "beta:2:0.1"}],
         [{"label": "alpha:3:0.2"}, {"label": "beta:4:0.2"}],
     ]
@@ -21182,7 +21182,7 @@ def test_figure_composer_plot_slices_label_codegen_helper_variants() -> None:
         },
         fields,
     )
-    styled_value = eval(styled, {}, namespace)  # noqa: S307
+    styled_value = eval(styled, namespace)  # noqa: S307
     assert styled_value[1][1]["label"] == "beta:4:0.2"
     assert styled_value[1][1]["color"] == "red"
     assert styled_value[0][0]["linewidth"] == 1.5

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -3924,8 +3924,6 @@ def test_manager_provenance_recorded_operation_dialog_handles_empty_operations(
 
 def test_manager_provenance_operation_title_falls_back_on_label_failure() -> None:
     class _BrokenTitleOperation(provenance.ToolProvenanceOperation):
-        op: typing.Literal["broken_title"] = "broken_title"
-
         def derivation_label(self) -> str:
             raise RuntimeError("label failed")
 
@@ -8903,23 +8901,20 @@ def test_manager_copy_selected_derivation_code_fallbacks(
 
 def test_manager_derivation_context_menu_ignores_empty_space(
     qtbot,
-    monkeypatch,
 ) -> None:
     list_widget = QtWidgets.QListWidget()
     qtbot.addWidget(list_widget)
     calls: list[bool] = []
-    menus: list[QtWidgets.QMenu] = []
     exec_positions: list[QtCore.QPoint] = []
+
+    class _Menu:
+        def exec(self, pos: QtCore.QPoint) -> None:
+            exec_positions.append(pos)
 
     def build_menu(*, include_row_actions: bool) -> QtWidgets.QMenu:
         calls.append(include_row_actions)
-        menu = QtWidgets.QMenu()
-        menus.append(menu)
-        return menu
+        return typing.cast("QtWidgets.QMenu", _Menu())
 
-    monkeypatch.setattr(
-        QtWidgets.QMenu, "exec", lambda _self, pos: exec_positions.append(pos)
-    )
     manager = types.SimpleNamespace(
         metadata_derivation_list=list_widget,
         _build_metadata_derivation_menu=build_menu,

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -1433,7 +1433,9 @@ def test_fit1d_multi_fit_history_and_sync_edges(qtbot, monkeypatch) -> None:
     assert not win._fit_multi_live_refresh_due()
 
     replaced: list[bool] = []
-    monkeypatch.setattr(win, "_replace_last_state", lambda: replaced.append(True))
+    monkeypatch.setattr(
+        win, "_replace_last_state", lambda *_args: replaced.append(True)
+    )
     win._write_history = True
     win._begin_fit_multi_history()
     assert win._fit_multi_sequence_write_history is True
@@ -1449,9 +1451,9 @@ def test_fit1d_multi_fit_history_and_sync_edges(qtbot, monkeypatch) -> None:
     assert win._fit_multi_refresh_pending is True
 
     events: list[str] = []
-    monkeypatch.setattr(win, "_update_fit_curve", lambda: events.append("curve"))
+    monkeypatch.setattr(win, "_update_fit_curve", lambda *_args: events.append("curve"))
     monkeypatch.setattr(
-        win, "_refresh_slider_from_model", lambda: events.append("slider")
+        win, "_refresh_slider_from_model", lambda *_args: events.append("slider")
     )
     monkeypatch.setattr(
         win,
@@ -1463,14 +1465,16 @@ def test_fit1d_multi_fit_history_and_sync_edges(qtbot, monkeypatch) -> None:
     monkeypatch.setattr(
         win,
         "_sync_fit_result_state",
-        lambda *, notify=True: events.append(f"sync-{notify}"),
+        lambda *_args, notify=True: events.append(f"sync-{notify}"),
     )
     monkeypatch.setattr(
         win,
         "_mark_fit_fresh",
-        lambda *, emit_info=True: events.append(f"fresh-{emit_info}"),
+        lambda *_args, emit_info=True: events.append(f"fresh-{emit_info}"),
     )
-    monkeypatch.setattr(win, "finalize_source_refresh", lambda: events.append("source"))
+    monkeypatch.setattr(
+        win, "finalize_source_refresh", lambda *_args: events.append("source")
+    )
 
     win._fit_multi_refresh_pending = False
     win._sync_multi_fit_view(full=True)


### PR DESCRIPTION
## Summary

- Fix Python 3.11 compat test evaluation by using one namespace for generated-code `eval()` calls that contain comprehensions.
- Keep the broken-title provenance test operation local to that test so it does not register a global operation type and leak into later provenance tests.
- Update PySide-sensitive test doubles to match the actual Qt signal/menu call contracts.
- Harden manager shutdown around standalone app windows: ignored standalone close events now keep manager ownership instead of scheduling deletion, and manager close waits for standalone apps before tearing down ImageTool windows.

## Root Cause

The deterministic compat failures were test-contract issues exposed by Python 3.11 and PySide. The crash-adjacent weak spot was in shutdown ordering: standalone app windows such as Data Explorer could be deleted after an ignored close, or left until after managed ImageTool windows were already being removed. That is risky when preview workers or other Qt-owned work are still active.

## Validation

- `UV_PYTHON=3.11 QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/manager/test_app.py::test_manager_close_event_closes_standalone_apps tests/interactive/imagetool/manager/test_app.py::test_manager_close_standalone_app_keeps_ignored_close tests/interactive/imagetool/manager/test_app.py::test_manager_close_event_waits_for_busy_standalone_app tests/interactive/imagetool/manager/test_provenance.py::test_manager_provenance_operation_title_falls_back_on_label_failure tests/interactive/imagetool/test_provenance.py::test_registered_provenance_define_operation_code_api tests/interactive/imagetool/test_provenance.py::test_current_structured_operations_round_trip_without_script_fallback tests/interactive/imagetool/manager/test_figurecomposer.py::test_figure_composer_plot_slices_label_codegen_helper_variants -q`
- `UV_PYTHON=3.11 QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/manager/test_provenance.py::test_manager_derivation_context_menu_ignores_empty_space tests/interactive/test_fit1d.py::test_fit1d_multi_fit_history_and_sync_edges -q`
- `UV_PYTHON=3.11 QT_API=pyside6 PYTEST_QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/manager/test_app.py::test_manager_close_event_closes_standalone_apps tests/interactive/imagetool/manager/test_app.py::test_manager_close_standalone_app_keeps_ignored_close tests/interactive/imagetool/manager/test_app.py::test_manager_close_event_waits_for_busy_standalone_app tests/interactive/imagetool/manager/test_provenance.py::test_manager_derivation_context_menu_ignores_empty_space tests/interactive/test_fit1d.py::test_fit1d_multi_fit_history_and_sync_edges -q`
- `UV_PYTHON=3.11 uv run ruff format --check src/erlab/interactive/imagetool/manager/_base.py src/erlab/interactive/imagetool/manager/_mainwindow.py tests/conftest.py tests/interactive/imagetool/manager/test_app.py tests/interactive/imagetool/manager/test_provenance.py tests/interactive/imagetool/manager/test_figurecomposer.py tests/interactive/test_fit1d.py`
- `UV_PYTHON=3.11 uv run ruff check src/erlab/interactive/imagetool/manager/_base.py src/erlab/interactive/imagetool/manager/_mainwindow.py tests/conftest.py tests/interactive/imagetool/manager/test_app.py tests/interactive/imagetool/manager/test_provenance.py tests/interactive/imagetool/manager/test_figurecomposer.py tests/interactive/test_fit1d.py`
- `UV_PYTHON=3.11 uv run mypy src`
- `git diff --check`
