### PR TITLE
Speed up ITWS loading in ImageTool

### DIFF
--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -531,6 +531,7 @@ class BetterColorBarItem(pg.PlotItem):
         hoverBrush: QtGui.QBrush | str = "#FFFFFF33",
         *,
         show_colormap_edit_menu: bool = True,
+        _defer_context_menu_setup: bool = False,
         **kargs,
     ) -> None:
         super().__init__(parent, **kargs)
@@ -567,23 +568,18 @@ class BetterColorBarItem(pg.PlotItem):
         self._images: set[weakref.ref[BetterImageItem]] = set()
         self._primary_image: weakref.ref[BetterImageItem] | None = None
 
-        # Add colorbar limit editor to context menu
-        self.vb.menu.addSeparator()
-        self._clim_menu: QtWidgets.QMenu = self.vb.menu.addMenu("Edit color limits")
-        self._clim_widget = _ColorBarLimitWidget(self)
-        self._clim_action = QtWidgets.QWidgetAction(self._clim_menu)
-        self._clim_action.setDefaultWidget(self._clim_widget)
-        self._clim_menu.addAction(self._clim_action)
-
-        self._center_zero_action = self.vb.menu.addAction("Center zero")
-        self._center_zero_action.triggered.connect(self._clim_widget.center_zero)
-
-        if show_colormap_edit_menu:
-            self._cmap_menu: QtWidgets.QMenu = self.vb.menu.addMenu("Edit colormap")
-            self._cmap_widget = _ColorBarEditWidget(self)
-            self._cmap_action = QtWidgets.QWidgetAction(self._cmap_menu)
-            self._cmap_action.setDefaultWidget(self._cmap_widget)
-            self._cmap_menu.addAction(self._cmap_action)
+        self._context_menu: QtWidgets.QMenu | None = None
+        self._context_menu_ready = False
+        self._show_colormap_edit_menu = show_colormap_edit_menu
+        self._clim_menu: QtWidgets.QMenu | None = None
+        self._clim_widget: _ColorBarLimitWidget | None = None
+        self._clim_action: QtWidgets.QWidgetAction | None = None
+        self._center_zero_action: QtGui.QAction | None = None
+        self._cmap_menu: QtWidgets.QMenu | None = None
+        self._cmap_widget: _ColorBarEditWidget | None = None
+        self._cmap_action: QtWidgets.QWidgetAction | None = None
+        if not _defer_context_menu_setup:
+            self._ensure_context_menu()
 
         if image is not None:
             self.setImageItem(image)
@@ -591,6 +587,57 @@ class BetterColorBarItem(pg.PlotItem):
             self.setLimits(limits)
         self.setLabels(right=("", ""))
         self.set_dimensions()
+
+    def _menu_for_context_setup(self) -> QtWidgets.QMenu | None:
+        ensure_menu = getattr(self.vb, "_ensure_menu", None)
+        if callable(ensure_menu):
+            return ensure_menu()
+        return self.vb.getMenu(None)
+
+    def _ensure_context_menu(self) -> QtWidgets.QMenu | None:
+        menu = self._menu_for_context_setup()
+        if menu is None:
+            return None
+        if self._context_menu_ready and self._context_menu is menu:
+            return menu
+
+        menu.addSeparator()
+        clim_menu = typing.cast("QtWidgets.QMenu", menu.addMenu("Edit color limits"))
+        self._clim_menu = clim_menu
+        clim_widget = _ColorBarLimitWidget(self)
+        self._clim_widget = clim_widget
+        clim_action = QtWidgets.QWidgetAction(clim_menu)
+        self._clim_action = clim_action
+        clim_action.setDefaultWidget(clim_widget)
+        clim_menu.addAction(clim_action)
+        if self.primary_image is not None:
+            clim_widget.region_changed()
+
+        center_zero_action = typing.cast("QtGui.QAction", menu.addAction("Center zero"))
+        self._center_zero_action = center_zero_action
+        center_zero_action.triggered.connect(clim_widget.center_zero)
+
+        if self._show_colormap_edit_menu:
+            cmap_menu = typing.cast("QtWidgets.QMenu", menu.addMenu("Edit colormap"))
+            self._cmap_menu = cmap_menu
+            cmap_widget = _ColorBarEditWidget(self)
+            self._cmap_widget = cmap_widget
+            cmap_action = QtWidgets.QWidgetAction(cmap_menu)
+            self._cmap_action = cmap_action
+            cmap_action.setDefaultWidget(cmap_widget)
+            cmap_menu.addAction(cmap_action)
+
+        self._context_menu = menu
+        self._context_menu_ready = True
+        return menu
+
+    def getMenu(self) -> QtWidgets.QMenu:
+        self._ensure_context_menu()
+        return self.ctrlMenu
+
+    def getContextMenus(self, event) -> QtWidgets.QMenu | None:
+        self._ensure_context_menu()
+        return super().getContextMenus(event)
 
     @property
     def images(self):

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -100,10 +100,13 @@ class BaseImageTool(QtWidgets.QMainWindow):
             self.addDockWidget(QtCore.Qt.DockWidgetArea.TopDockWidgetArea, d)
         self.resize(720, 720)
 
-        if state is not None:
-            self.slicer_area.state = state
-        if transpose:
-            self.slicer_area.transpose_main_image()
+        try:
+            if state is not None:
+                self.slicer_area.state = state
+            if transpose:
+                self.slicer_area.transpose_main_image()
+        finally:
+            self.slicer_area._workspace_load_profiler = None
         self._sync_file_load_provenance()
 
         # Allow writing history after initialization

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -310,7 +310,9 @@ class ItoolCrosshairControls(ItoolControlsBase):
         try:
             with np.errstate(divide="ignore"), suppressnanwarning:
                 approx_abs_max = np.nanmax(
-                    np.abs(next(iter(self.slicer_area._imageitems)).image)
+                    np.abs(
+                        next(iter(self.slicer_area._materialized_imageitems())).image
+                    )
                 )
                 self.spin_dat.setDecimals(round(abs(np.log10(approx_abs_max)) + 1))
         except Exception:
@@ -637,7 +639,9 @@ class ItoolCrosshairControls(ItoolControlsBase):
         try:
             with np.errstate(divide="ignore"), suppressnanwarning:
                 approx_abs_max = np.nanmax(
-                    np.abs(next(iter(self.slicer_area._imageitems)).image)
+                    np.abs(
+                        next(iter(self.slicer_area._materialized_imageitems())).image
+                    )
                 )
                 self.spin_dat.setDecimals(round(abs(np.log10(approx_abs_max)) + 1))
         except Exception:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3519,12 +3519,14 @@ class ImageToolManager(_ImageToolManagerBase):
         parent_target: int | str | None,
         node_path: str | None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
+        profiler: typing.Any | None = None,
     ) -> int | str:
         return self._workspace_controller._load_workspace_imagetool_dataset(
             ds,
             parent_target=parent_target,
             node_path=node_path,
             loaded_targets_by_uid=loaded_targets_by_uid,
+            profiler=profiler,
         )
 
     def _load_workspace_tool_dataset(
@@ -3533,11 +3535,13 @@ class ImageToolManager(_ImageToolManagerBase):
         *,
         parent_target: int | str | None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
+        profiler: typing.Any | None = None,
     ) -> int | str:
         return self._workspace_controller._load_workspace_tool_dataset(
             ds,
             parent_target=parent_target,
             loaded_targets_by_uid=loaded_targets_by_uid,
+            profiler=profiler,
         )
 
     @staticmethod

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -107,6 +107,17 @@ class _WorkspaceLoadProfiler:
                 logger.debug("Workspace load stage %s: %.3fs", name, duration)
 
 
+@contextlib.contextmanager
+def _workspace_load_stage(
+    profiler: _WorkspaceLoadProfiler | None, name: str
+) -> Iterator[None]:
+    if profiler is None:
+        yield
+    else:
+        with profiler.stage(name):
+            yield
+
+
 class _WorkspaceReplaceBackup:
     __slots__ = ("file_path", "snapshot", "tree")
 
@@ -1090,139 +1101,152 @@ class _WorkspaceIOController:
         parent_target: int | str | None,
         node_path: str | None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
+        profiler: _WorkspaceLoadProfiler | None = None,
     ) -> int | str:
-        uid = ds.attrs.get("manager_node_uid")
-        provenance_spec = ds.attrs.get("manager_node_provenance_spec")
-        live_source_spec = ds.attrs.get("manager_node_live_source_spec")
-        live_source_binding = ds.attrs.get("manager_node_live_source_binding")
-        parse_provenance_spec = provenance.parse_tool_provenance_spec
-        parsed_provenance_spec = None
-        if provenance_spec is not None:
-            try:
-                provenance_payload = typing.cast(
-                    "Mapping[str, typing.Any]",
-                    json.loads(provenance_spec),
+        with _workspace_load_stage(profiler, "imagetool metadata restore"):
+            uid = ds.attrs.get("manager_node_uid")
+            provenance_spec = ds.attrs.get("manager_node_provenance_spec")
+            live_source_spec = ds.attrs.get("manager_node_live_source_spec")
+            live_source_binding = ds.attrs.get("manager_node_live_source_binding")
+            parse_provenance_spec = provenance.parse_tool_provenance_spec
+            parsed_provenance_spec = None
+            if provenance_spec is not None:
+                try:
+                    provenance_payload = typing.cast(
+                        "Mapping[str, typing.Any]",
+                        json.loads(provenance_spec),
+                    )
+                    parsed_provenance_spec = parse_provenance_spec(provenance_payload)
+                except Exception:
+                    logger.warning(
+                        "Ignoring invalid saved manager provenance for node %s",
+                        uid,
+                        exc_info=True,
+                    )
+            parsed_source_spec = None
+            if live_source_spec is not None:
+                try:
+                    source_payload = typing.cast(
+                        "Mapping[str, typing.Any]",
+                        json.loads(live_source_spec),
+                    )
+                    parsed_source_spec = provenance.require_live_source_spec(
+                        parse_provenance_spec(source_payload)
+                    )
+                except Exception:
+                    logger.warning(
+                        "Ignoring invalid saved manager source provenance for node %s",
+                        uid,
+                        exc_info=True,
+                    )
+            parsed_source_binding = None
+            if parsed_source_spec is None and live_source_binding is not None:
+                try:
+                    binding_payload = typing.cast(
+                        "Mapping[str, typing.Any]",
+                        json.loads(live_source_binding),
+                    )
+                    binding_type = provenance.ImageToolSelectionSourceBinding
+                    parsed_source_binding = binding_type.model_validate(binding_payload)
+                except Exception:
+                    logger.warning(
+                        "Ignoring invalid saved manager source binding for node %s",
+                        uid,
+                        exc_info=True,
+                    )
+            kwargs: dict[str, typing.Any] = {
+                "uid": uid,
+                "snapshot_token": ds.attrs.get("manager_node_snapshot_token"),
+                "created_time": ds.attrs.get("manager_node_added_at"),
+                "note": ds.attrs.get("manager_node_note"),
+                "provenance_spec": parsed_provenance_spec,
+                "source_spec": parsed_source_spec,
+                "source_binding": (
+                    parsed_source_binding if parsed_source_spec is None else None
+                ),
+                "output_id": ds.attrs.get("manager_node_output_id"),
+                "source_auto_update": bool(
+                    ds.attrs.get("manager_node_source_auto_update", False)
+                ),
+                "source_state": typing.cast(
+                    "_ManagedWindowNode._source_state_type",
+                    ds.attrs.get("manager_node_source_state", "fresh"),
+                ),
+            }
+            window_visible = _workspace_dataset_window_visible(ds, "itool")
+            tool_kwargs: dict[str, typing.Any] = {
+                "_in_manager": True,
+                "_defer_state_refresh": True,
+                "_defer_secondary_plots": not window_visible,
+            }
+            if profiler is not None:
+                tool_kwargs["_workspace_load_profiler"] = profiler
+            if _ITOOL_DATA_NAME in ds and ds[_ITOOL_DATA_NAME].chunks is not None:
+                tool_kwargs["auto_compute"] = False
+            legacy_name = _legacy_saved_title_data_name(ds, parsed_provenance_spec)
+            if legacy_name is not None:
+                ds = ds.copy(deep=False)
+                ds.attrs["itool_name"] = legacy_name
+            elif "itool_name" not in ds.attrs:
+                ds = ds.copy(deep=False)
+                ds.attrs["itool_name"] = ""
+            ds = self._dataset_without_missing_workspace_colormap(ds, node_path)
+
+        with _workspace_load_stage(profiler, "imagetool widget restore"):
+            tool = ImageTool.from_dataset(ds, **tool_kwargs)
+
+        with _workspace_load_stage(profiler, "imagetool manager registration"):
+            if parent_target is not None:
+                target = self._manager.add_imagetool_child(
+                    tool,
+                    parent_target,
+                    show=window_visible,
+                    **kwargs,
                 )
-                parsed_provenance_spec = parse_provenance_spec(provenance_payload)
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid saved manager provenance for node %s",
-                    uid,
-                    exc_info=True,
+                self._manager._record_workspace_loaded_imagetool_target(
+                    ds, target, loaded_targets_by_uid
                 )
-        parsed_source_spec = None
-        if live_source_spec is not None:
-            try:
-                source_payload = typing.cast(
-                    "Mapping[str, typing.Any]",
-                    json.loads(live_source_spec),
+                return target
+
+            kwargs.pop("output_id", None)
+            kwargs["source_input_ndim"] = typing.cast(
+                "int | None",
+                ds.attrs.get("manager_node_source_input_ndim"),
+            )
+            watched_varname = ds.attrs.get("manager_node_watched_varname")
+            watched_uid = ds.attrs.get("manager_node_watched_uid")
+            if watched_varname is not None and watched_uid is not None:
+                kwargs["watched_var"] = (str(watched_varname), str(watched_uid))
+                kwargs["watched_workspace_link_id"] = (
+                    None
+                    if ds.attrs.get("manager_node_watched_workspace_link_id") is None
+                    else str(ds.attrs["manager_node_watched_workspace_link_id"])
                 )
-                parsed_source_spec = provenance.require_live_source_spec(
-                    parse_provenance_spec(source_payload)
+                kwargs["watched_source_label"] = (
+                    None
+                    if ds.attrs.get("manager_node_watched_source_label") is None
+                    else str(ds.attrs["manager_node_watched_source_label"])
                 )
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid saved manager source provenance for node %s",
-                    uid,
-                    exc_info=True,
+                kwargs["watched_source_uid"] = (
+                    None
+                    if ds.attrs.get("manager_node_watched_source_uid") is None
+                    else str(ds.attrs["manager_node_watched_source_uid"])
                 )
-        parsed_source_binding = None
-        if parsed_source_spec is None and live_source_binding is not None:
-            try:
-                binding_payload = typing.cast(
-                    "Mapping[str, typing.Any]",
-                    json.loads(live_source_binding),
-                )
-                binding_type = provenance.ImageToolSelectionSourceBinding
-                parsed_source_binding = binding_type.model_validate(binding_payload)
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid saved manager source binding for node %s",
-                    uid,
-                    exc_info=True,
-                )
-        kwargs: dict[str, typing.Any] = {
-            "uid": uid,
-            "snapshot_token": ds.attrs.get("manager_node_snapshot_token"),
-            "created_time": ds.attrs.get("manager_node_added_at"),
-            "note": ds.attrs.get("manager_node_note"),
-            "provenance_spec": parsed_provenance_spec,
-            "source_spec": parsed_source_spec,
-            "source_binding": (
-                parsed_source_binding if parsed_source_spec is None else None
-            ),
-            "output_id": ds.attrs.get("manager_node_output_id"),
-            "source_auto_update": bool(
-                ds.attrs.get("manager_node_source_auto_update", False)
-            ),
-            "source_state": typing.cast(
-                "_ManagedWindowNode._source_state_type",
-                ds.attrs.get("manager_node_source_state", "fresh"),
-            ),
-        }
-        tool_kwargs: dict[str, typing.Any] = {"_in_manager": True}
-        if _ITOOL_DATA_NAME in ds and ds[_ITOOL_DATA_NAME].chunks is not None:
-            tool_kwargs["auto_compute"] = False
-        legacy_name = _legacy_saved_title_data_name(ds, parsed_provenance_spec)
-        if legacy_name is not None:
-            ds = ds.copy(deep=False)
-            ds.attrs["itool_name"] = legacy_name
-        elif "itool_name" not in ds.attrs:
-            ds = ds.copy(deep=False)
-            ds.attrs["itool_name"] = ""
-        ds = self._dataset_without_missing_workspace_colormap(ds, node_path)
-        tool = ImageTool.from_dataset(ds, **tool_kwargs)
-        if parent_target is not None:
-            target = self._manager.add_imagetool_child(
+                # Loaded watched rows stay watched, but are disconnected until
+                # a notebook explicitly reconnects them.
+                kwargs["watched_connected"] = False
+            preferred_index: int | None = None
+            if node_path is not None and "/" not in node_path:
+                with contextlib.suppress(ValueError):
+                    preferred_index = int(node_path)
+                if preferred_index is not None and preferred_index < 0:
+                    preferred_index = None
+            target = self._manager.add_imagetool(
                 tool,
-                parent_target,
-                show=_workspace_dataset_window_visible(ds, "itool"),
+                show=window_visible,
+                index=preferred_index,
                 **kwargs,
             )
-            self._manager._record_workspace_loaded_imagetool_target(
-                ds, target, loaded_targets_by_uid
-            )
-            return target
-
-        kwargs.pop("output_id", None)
-        kwargs["source_input_ndim"] = typing.cast(
-            "int | None",
-            ds.attrs.get("manager_node_source_input_ndim"),
-        )
-        watched_varname = ds.attrs.get("manager_node_watched_varname")
-        watched_uid = ds.attrs.get("manager_node_watched_uid")
-        if watched_varname is not None and watched_uid is not None:
-            kwargs["watched_var"] = (str(watched_varname), str(watched_uid))
-            kwargs["watched_workspace_link_id"] = (
-                None
-                if ds.attrs.get("manager_node_watched_workspace_link_id") is None
-                else str(ds.attrs["manager_node_watched_workspace_link_id"])
-            )
-            kwargs["watched_source_label"] = (
-                None
-                if ds.attrs.get("manager_node_watched_source_label") is None
-                else str(ds.attrs["manager_node_watched_source_label"])
-            )
-            kwargs["watched_source_uid"] = (
-                None
-                if ds.attrs.get("manager_node_watched_source_uid") is None
-                else str(ds.attrs["manager_node_watched_source_uid"])
-            )
-            # Loaded watched rows stay watched, but are disconnected until
-            # a notebook explicitly reconnects them.
-            kwargs["watched_connected"] = False
-        preferred_index: int | None = None
-        if node_path is not None and "/" not in node_path:
-            with contextlib.suppress(ValueError):
-                preferred_index = int(node_path)
-            if preferred_index is not None and preferred_index < 0:
-                preferred_index = None
-        target = self._manager.add_imagetool(
-            tool,
-            show=_workspace_dataset_window_visible(ds, "itool"),
-            index=preferred_index,
-            **kwargs,
-        )
         self._manager._record_workspace_loaded_imagetool_target(
             ds, target, loaded_targets_by_uid
         )
@@ -1234,55 +1258,59 @@ class _WorkspaceIOController:
         *,
         parent_target: int | str | None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
+        profiler: _WorkspaceLoadProfiler | None = None,
     ) -> int | str:
-        source_parent_data: xr.DataArray | None = None
-        if parent_target is not None:
-            source_parent_data = self._manager._node_for_target(
-                parent_target
-            ).current_source_data()
+        with _workspace_load_stage(profiler, "tool reference restore"):
+            source_parent_data: xr.DataArray | None = None
+            if parent_target is not None:
+                source_parent_data = self._manager._node_for_target(
+                    parent_target
+                ).current_source_data()
 
-        def _tool_data_reference_resolver(
-            payload: Mapping[str, typing.Any],
-        ) -> xr.DataArray | None:
-            node_uid = payload.get("node_uid")
-            if not isinstance(node_uid, str) or not node_uid:
-                return None
-            target: int | str = node_uid
-            if loaded_targets_by_uid is not None:
-                target = loaded_targets_by_uid.get(node_uid, node_uid)
-            try:
-                return self._manager._node_for_target(target).current_source_data()
-            except (KeyError, ValueError):
-                return None
+            def _tool_data_reference_resolver(
+                payload: Mapping[str, typing.Any],
+            ) -> xr.DataArray | None:
+                node_uid = payload.get("node_uid")
+                if not isinstance(node_uid, str) or not node_uid:
+                    return None
+                target: int | str = node_uid
+                if loaded_targets_by_uid is not None:
+                    target = loaded_targets_by_uid.get(node_uid, node_uid)
+                try:
+                    return self._manager._node_for_target(target).current_source_data()
+                except (KeyError, ValueError):
+                    return None
 
-        tool: erlab.interactive.utils.ToolWindow = (
-            erlab.interactive.utils.ToolWindow.from_dataset(
-                ds,
-                _source_parent_data=source_parent_data,
-                _tool_data_reference_resolver=_tool_data_reference_resolver,
+        with _workspace_load_stage(profiler, "tool widget restore"):
+            tool: erlab.interactive.utils.ToolWindow = (
+                erlab.interactive.utils.ToolWindow.from_dataset(
+                    ds,
+                    _source_parent_data=source_parent_data,
+                    _tool_data_reference_resolver=_tool_data_reference_resolver,
+                )
             )
-        )
-        if parent_target is None:
-            if tool.manager_collection != "figures":
-                raise ValueError("Workspace tool node has no parent")
-            target = self._manager.add_figuretool(
-                tool,
-                show=_workspace_dataset_window_visible(ds, "tool"),
-                uid=ds.attrs.get("manager_node_uid"),
-                snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
-                created_time=ds.attrs.get("manager_node_added_at"),
-                note=ds.attrs.get("manager_node_note"),
-            )
-        else:
-            target = self._manager.add_childtool(
-                tool,
-                parent_target,
-                show=_workspace_dataset_window_visible(ds, "tool"),
-                uid=ds.attrs.get("manager_node_uid"),
-                snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
-                created_time=ds.attrs.get("manager_node_added_at"),
-                note=ds.attrs.get("manager_node_note"),
-            )
+        with _workspace_load_stage(profiler, "tool manager registration"):
+            if parent_target is None:
+                if tool.manager_collection != "figures":
+                    raise ValueError("Workspace tool node has no parent")
+                target = self._manager.add_figuretool(
+                    tool,
+                    show=_workspace_dataset_window_visible(ds, "tool"),
+                    uid=ds.attrs.get("manager_node_uid"),
+                    snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
+                    created_time=ds.attrs.get("manager_node_added_at"),
+                    note=ds.attrs.get("manager_node_note"),
+                )
+            else:
+                target = self._manager.add_childtool(
+                    tool,
+                    parent_target,
+                    show=_workspace_dataset_window_visible(ds, "tool"),
+                    uid=ds.attrs.get("manager_node_uid"),
+                    snapshot_token=ds.attrs.get("manager_node_snapshot_token"),
+                    created_time=ds.attrs.get("manager_node_added_at"),
+                    note=ds.attrs.get("manager_node_note"),
+                )
         self._manager._record_workspace_loaded_tool_target(
             ds, target, loaded_targets_by_uid
         )
@@ -1719,25 +1747,21 @@ class _WorkspaceIOController:
             payload_path = f"{path}/{'imagetool' if is_imagetool else 'tool'}"
             with profiler.stage("payload read"):
                 ds = _load_dataset(payload_path, entry=entry, imagetool=is_imagetool)
-            stage_name = (
-                "figure restore"
-                if path.startswith("figures/") and not is_imagetool
-                else "tool construction"
-            )
-            with profiler.stage(stage_name):
-                if is_imagetool:
-                    target = self._manager._load_workspace_imagetool_dataset(
-                        ds,
-                        parent_target=parent_target,
-                        node_path=path,
-                        loaded_targets_by_uid=loaded_targets_by_uid,
-                    )
-                else:
-                    target = self._manager._load_workspace_tool_dataset(
-                        ds,
-                        parent_target=parent_target,
-                        loaded_targets_by_uid=loaded_targets_by_uid,
-                    )
+            if is_imagetool:
+                target = self._manager._load_workspace_imagetool_dataset(
+                    ds,
+                    parent_target=parent_target,
+                    node_path=path,
+                    loaded_targets_by_uid=loaded_targets_by_uid,
+                    profiler=profiler,
+                )
+            else:
+                target = self._manager._load_workspace_tool_dataset(
+                    ds,
+                    parent_target=parent_target,
+                    loaded_targets_by_uid=loaded_targets_by_uid,
+                    profiler=profiler,
+                )
             for child_path in child_paths[path]:
                 _load_path_or_warn(child_path, target)
             return target

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -422,7 +422,7 @@ class _ManagedWindowNode(QtCore.QObject):
             )
             value.slicer_area._in_manager = True
             value.remove_act.setVisible(True)
-            for plot in value.slicer_area.axes:
+            for plot in value.slicer_area._materialized_axes():
                 plot.ensure_manager_figure_actions()
             return
 
@@ -1297,6 +1297,9 @@ class _ManagedWindowNode(QtCore.QObject):
         )
         if obj == self.window and event_type in tracked_event_types:
             if self.imagetool is not None and event_type == QtCore.QEvent.Type.Show:
+                erlab.interactive.utils.single_shot(
+                    self.slicer_area, 0, self.slicer_area._ensure_secondary_plots
+                )
                 erlab.interactive.utils.single_shot(
                     self.slicer_area, 0, self.slicer_area._update_if_delayed
                 )

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -379,6 +379,57 @@ class _OptionKeyMenuFilter(QtCore.QObject):
         return super().eventFilter(obj, event)
 
 
+class ItoolViewBox(pg.ViewBox):
+    """ViewBox that defers expensive menu construction until first use."""
+
+    def __init__(self, *args, enableMenu: bool = True, **kwargs) -> None:
+        super().__init__(*args, enableMenu=False, **kwargs)
+        self.state["enableMenu"] = enableMenu
+        self._itool_menu_populator: collections.abc.Callable[[], object] | None = None
+        self._itool_menu_resetters: list[collections.abc.Callable[[], None]] = []
+        self._itool_populating_menu = False
+
+    def _ensure_menu(self) -> QtWidgets.QMenu | None:
+        menu = typing.cast("QtWidgets.QMenu | None", getattr(self, "menu", None))
+        if menu is None and self.menuEnabled():
+            pg.ViewBox._applyMenuEnabled(self)
+            menu = typing.cast("QtWidgets.QMenu | None", getattr(self, "menu", None))
+        return menu
+
+    def _populate_itool_menu(self) -> None:
+        populator = self._itool_menu_populator
+        if populator is None or self._itool_populating_menu:
+            return
+        self._itool_populating_menu = True
+        try:
+            populator()
+        finally:
+            self._itool_populating_menu = False
+
+    def _reset_itool_menu_state(self) -> None:
+        for resetter in tuple(self._itool_menu_resetters):
+            resetter()
+
+    def _applyMenuEnabled(self) -> None:
+        menu = typing.cast("QtWidgets.QMenu | None", getattr(self, "menu", None))
+        if not self.menuEnabled() and menu is not None:
+            self._reset_itool_menu_state()
+            menu.setParent(None)
+            self.menu = None
+
+    def getMenu(self, ev=None) -> QtWidgets.QMenu | None:
+        menu = self._ensure_menu()
+        if menu is not None:
+            self._populate_itool_menu()
+        return menu
+
+    def getContextMenus(self, event) -> list[QtGui.QAction]:
+        menu = self.getMenu(event)
+        if menu is None or not self.menuEnabled():
+            return []
+        return menu.actions()
+
+
 class ItoolPlotItem(pg.PlotItem):
     """A subclass of :class:`pyqtgraph.PlotItem` used in ImageTool.
 
@@ -400,11 +451,13 @@ class ItoolPlotItem(pg.PlotItem):
         plotdata_cls=None,
         **item_kw,
     ) -> None:
+        view_box = ItoolViewBox(enableMenu=True)
         super().__init__(
+            viewBox=view_box,
             axisItems={
                 a: erlab.interactive.utils.BetterAxisItem(a)
                 for a in ("left", "right", "top", "bottom")
-            }
+            },
         )
         self._axis_enabled = axis_enabled
 
@@ -416,7 +469,21 @@ class ItoolPlotItem(pg.PlotItem):
         self.is_image = image
         self._item_kw = item_kw
 
-        self.setup_actions()
+        self._context_menu: QtWidgets.QMenu | None = None
+        self._context_menu_ready = False
+        self._manager_figure_actions_requested = False
+        self._associated_coord_menu: QtWidgets.QMenu | None = None
+        self._associated_coord_menu_separator_above: QtGui.QAction | None = None
+        self._associated_coord_menu_separator_below: QtGui.QAction | None = None
+        self._plot_with_matplotlib_action: QtGui.QAction | None = None
+        self._append_to_figure_action: QtGui.QAction | None = None
+        self._new_window_separator: QtGui.QAction | None = None
+        self._new_window_action: QtGui.QAction | None = None
+        self._menu_filter: _OptionKeyMenuFilter | None = None
+        view_box._itool_menu_populator = self._ensure_context_menu
+        view_box._itool_menu_resetters.append(self._reset_context_menu)
+        for act in ["Transforms", "Downsample", "Average", "Alpha", "Points"]:
+            self.setContextMenuActionVisible(act, False)
 
         if image_cls is None:  # pragma: no branch
             self.image_cls = ItoolImageItem
@@ -503,44 +570,56 @@ class ItoolPlotItem(pg.PlotItem):
         self._last_axis_inversions = self._viewbox_axis_inversions()
 
     def setup_actions(self) -> None:
-        self._associated_coord_menu: QtWidgets.QMenu | None = None
-        self._associated_coord_menu_separator_above: QtGui.QAction | None = None
-        self._associated_coord_menu_separator_below: QtGui.QAction | None = None
-        self._plot_with_matplotlib_action: QtGui.QAction | None = None
-        self._append_to_figure_action: QtGui.QAction | None = None
-        self._new_window_separator: QtGui.QAction | None = None
-        self._new_window_action: QtGui.QAction | None = None
-        for act in ["Transforms", "Downsample", "Average", "Alpha", "Points"]:
-            self.setContextMenuActionVisible(act, False)
+        self._ensure_context_menu()
+
+    def _reset_context_menu(self) -> None:
+        self._context_menu = None
+        self._context_menu_ready = False
+        self._associated_coord_menu = None
+        self._associated_coord_menu_separator_above = None
+        self._associated_coord_menu_separator_below = None
+        self._plot_with_matplotlib_action = None
+        self._append_to_figure_action = None
+        self._new_window_separator = None
+        self._new_window_action = None
+        self._menu_filter = None
+
+    def _ensure_context_menu(self) -> QtWidgets.QMenu | None:
+        raw_menu = typing.cast("ItoolViewBox", self.vb)._ensure_menu()
+        if raw_menu is None:
+            return None
+        if self._context_menu_ready and self._context_menu is raw_menu:
+            return raw_menu
+        menu = typing.cast("typing.Any", raw_menu)
 
         for i in (0, 1):
             # Hide unnecessary menu items
-            self.vb.menu.ctrl[i].linkCombo.setVisible(False)
-            self.vb.menu.ctrl[i].label.setVisible(False)
+            menu.ctrl[i].linkCombo.setVisible(False)
+            menu.ctrl[i].label.setVisible(False)
 
         if self.is_image:
             # ROI actions
-            self.vb.menu.addSeparator()
-            poly_roi_action = self.vb.menu.addAction("Add Polygon ROI")
+            menu.addSeparator()
+            poly_roi_action = menu.addAction("Add Polygon ROI")
             poly_roi_action.setObjectName("itool_add_polygon_roi_action")
             poly_roi_action.triggered.connect(self.add_roi)
 
-        self.vb.menu.addSeparator()
+        menu.addSeparator()
 
-        save_action = self.vb.menu.addAction("Save data as HDF5…")
+        save_action = menu.addAction("Save data as HDF5…")
         save_action.triggered.connect(self.save_current_data)
 
-        copy_code_action = self.vb.menu.addAction("Copy selection code")
+        copy_code_action = menu.addAction("Copy selection code")
         copy_code_action.triggered.connect(self.copy_selection_code)
 
-        self.vb.menu.addSeparator()
+        menu.addSeparator()
 
-        if self.slicer_area._in_manager:
-            self.ensure_manager_figure_actions()
+        if self.slicer_area._in_manager or self._manager_figure_actions_requested:
+            self._add_manager_figure_actions(menu)
 
-        self._new_window_separator = self.vb.menu.addSeparator()
+        self._new_window_separator = menu.addSeparator()
 
-        itool_action = self.vb.menu.addAction("New Window")
+        itool_action = menu.addAction("New Window")
         itool_action.triggered.connect(self.open_in_new_window)
         itool_action.setIcon(qtawesome.icon("mdi6.export"))
         itool_action.setIconVisibleInMenu(True)
@@ -555,26 +634,26 @@ class ItoolPlotItem(pg.PlotItem):
 
         if self.is_image:
             # Actions that open new windows
-            goldtool_action = self.vb.menu.addAction("goldtool")
+            goldtool_action = menu.addAction("goldtool")
             goldtool_action.triggered.connect(self.open_in_goldtool)
 
-            restool_action = self.vb.menu.addAction("restool")
+            restool_action = menu.addAction("restool")
             restool_action.triggered.connect(self.open_in_restool)
 
-            dtool_action = self.vb.menu.addAction("dtool")
+            dtool_action = menu.addAction("dtool")
             dtool_action.triggered.connect(self.open_in_dtool)
 
-            ftool_action = self.vb.menu.addAction("ftool")
+            ftool_action = menu.addAction("ftool")
             ftool_action.triggered.connect(self.open_in_ftool)
 
             croppable_actions.extend(
                 (goldtool_action, restool_action, dtool_action, ftool_action)
             )
 
-            self.vb.menu.addSeparator()
+            menu.addSeparator()
 
             # Aspect ratio lock checkbox
-            equal_aspect_action = self.vb.menu.addAction("Equal aspect ratio")
+            equal_aspect_action = menu.addAction("Equal aspect ratio")
             equal_aspect_action.setCheckable(True)
             equal_aspect_action.setChecked(False)
             equal_aspect_action.toggled.connect(self.toggle_aspect_equal)
@@ -589,7 +668,7 @@ class ItoolPlotItem(pg.PlotItem):
             self.getViewBox().sigStateChanged.connect(_update_aspect_lock_state)
 
             # AdjustCT-like action
-            adjust_color_action = self.vb.menu.addAction("Normalize to View")
+            adjust_color_action = menu.addAction("Normalize to View")
             adjust_color_action.setToolTip(
                 "Set color limits from the currently visible area of this image.\n"
                 "Similar to 'AdjustCT' in Igor Pro."
@@ -610,53 +689,61 @@ class ItoolPlotItem(pg.PlotItem):
             _set_icons()
 
         else:
-            ftool_action = self.vb.menu.addAction("ftool")
+            ftool_action = menu.addAction("ftool")
             ftool_action.triggered.connect(self.open_in_ftool)
             ftool_action.setIcon(qtawesome.icon("mdi6.export"))
             ftool_action.setIconVisibleInMenu(True)
             croppable_actions.append(ftool_action)
 
-            self.vb.menu.addSeparator()
+            menu.addSeparator()
 
-            norm_action = self.vb.menu.addAction("Normalize by mean")
+            norm_action = menu.addAction("Normalize by mean")
             norm_action.setCheckable(True)
             norm_action.setChecked(False)
             norm_action.toggled.connect(self.set_normalize)
 
-            self._associated_coord_menu_separator_above = self.vb.menu.addSeparator()
+            self._associated_coord_menu_separator_above = menu.addSeparator()
             self._associated_coord_menu_separator_above.setVisible(False)
-            self._associated_coord_menu = self.vb.menu.addMenu(
-                "Open Associated Coordinate"
-            )
+            self._associated_coord_menu = menu.addMenu("Open Associated Coordinate")
             typing.cast(
                 "QtGui.QAction", self._associated_coord_menu.menuAction()
             ).setVisible(False)
-            self._associated_coord_menu_separator_below = self.vb.menu.addSeparator()
+            self._associated_coord_menu_separator_below = menu.addSeparator()
             self._associated_coord_menu_separator_below.setVisible(False)
-            self.vb.menu.aboutToShow.connect(self._refresh_associated_coord_menu)
+            menu.aboutToShow.connect(self._refresh_associated_coord_menu)
 
         if self.is_image:
-            self.vb.menu.addSeparator()
+            menu.addSeparator()
 
-        self._menu_filter = _OptionKeyMenuFilter(self.vb.menu, croppable_actions)
-        self.vb.menu.installEventFilter(self._menu_filter)
+        self._menu_filter = _OptionKeyMenuFilter(menu, croppable_actions)
+        menu.installEventFilter(self._menu_filter)
+        self._context_menu = raw_menu
+        self._context_menu_ready = True
+        return raw_menu
 
     def ensure_manager_figure_actions(self) -> None:
+        self._manager_figure_actions_requested = True
+        if self._plot_with_matplotlib_action is not None:
+            return
+        if self._context_menu_ready and self._context_menu is not None:
+            self._add_manager_figure_actions(self._context_menu)
+
+    def _add_manager_figure_actions(self, menu: QtWidgets.QMenu) -> None:
         if self._plot_with_matplotlib_action is not None:
             return
         insert_before = self._new_window_separator or self._new_window_action
-        plot_action = QtGui.QAction("New Figure", self.vb.menu)
+        plot_action = QtGui.QAction("New Figure", menu)
         plot_action.setObjectName("itool_plot_with_matplotlib_action")
         plot_action.triggered.connect(self.plot_with_matplotlib)
-        append_action = QtGui.QAction("Append to Figure", self.vb.menu)
+        append_action = QtGui.QAction("Append to Figure", menu)
         append_action.setObjectName("itool_append_to_figure_action")
         append_action.triggered.connect(self.append_to_matplotlib_figure)
         if insert_before is None:
-            self.vb.menu.addAction(plot_action)
-            self.vb.menu.addAction(append_action)
+            menu.addAction(plot_action)
+            menu.addAction(append_action)
         else:
-            self.vb.menu.insertAction(insert_before, plot_action)
-            self.vb.menu.insertAction(insert_before, append_action)
+            menu.insertAction(insert_before, plot_action)
+            menu.insertAction(insert_before, append_action)
         self._plot_with_matplotlib_action = plot_action
         self._append_to_figure_action = append_action
 
@@ -792,6 +879,7 @@ class ItoolPlotItem(pg.PlotItem):
 
     @QtCore.Slot()
     def _refresh_associated_coord_menu(self) -> None:
+        self._ensure_context_menu()
         menu = self._associated_coord_menu
         if menu is None:
             return
@@ -2760,7 +2848,12 @@ class ItoolPlotItem(pg.PlotItem):
             vb.setAspectLocked(False)
 
     def getMenu(self) -> QtWidgets.QMenu:
+        self._ensure_context_menu()
         return self.ctrlMenu
+
+    def getContextMenus(self, event) -> QtWidgets.QMenu | None:
+        self._ensure_context_menu()
+        return super().getContextMenus(event)
 
     def getViewBox(self) -> pg.ViewBox:
         # override for type hinting
@@ -3296,11 +3389,39 @@ class ItoolColorBarItem(erlab.interactive.colors.BetterColorBarItem):
                 for a in ("left", "right", "top", "bottom")
             },
         )
+        kwargs.setdefault("viewBox", ItoolViewBox(enableMenu=True))
         kwargs["show_colormap_edit_menu"] = False
+        kwargs["_defer_context_menu_setup"] = True
         super().__init__(**kwargs)
 
-        copy_action = self.vb.menu.addAction("Copy color limits to clipboard")
+        self._copy_limits_action: QtGui.QAction | None = None
+        if isinstance(self.vb, ItoolViewBox):
+            self.vb._itool_menu_populator = self._ensure_context_menu
+            self.vb._itool_menu_resetters.append(self._reset_context_menu)
+
+    def _ensure_context_menu(self) -> QtWidgets.QMenu | None:
+        menu = super()._ensure_context_menu()
+        if menu is None or self._copy_limits_action is not None:
+            return menu
+        copy_action = typing.cast(
+            "QtGui.QAction", menu.addAction("Copy color limits to clipboard")
+        )
+        copy_action.setObjectName("itool_copy_color_limits_action")
         copy_action.triggered.connect(self._copy_limits)
+        self._copy_limits_action = copy_action
+        return menu
+
+    def _reset_context_menu(self) -> None:
+        self._context_menu = None
+        self._context_menu_ready = False
+        self._clim_menu = None
+        self._clim_widget = None
+        self._clim_action = None
+        self._center_zero_action = None
+        self._cmap_menu = None
+        self._cmap_widget = None
+        self._cmap_action = None
+        self._copy_limits_action = None
 
     @property
     def slicer_area(self) -> ImageSlicerArea:
@@ -3315,7 +3436,7 @@ class ItoolColorBarItem(erlab.interactive.colors.BetterColorBarItem):
 
     @property
     def images(self):
-        return [weakref.ref(x) for x in self.slicer_area._imageitems]
+        return [weakref.ref(x) for x in self.slicer_area._materialized_imageitems()]
 
     @property
     def primary_image(self):

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -480,6 +480,10 @@ class ItoolPlotItem(pg.PlotItem):
         self._new_window_separator: QtGui.QAction | None = None
         self._new_window_action: QtGui.QAction | None = None
         self._menu_filter: _OptionKeyMenuFilter | None = None
+        self._equal_aspect_action: QtGui.QAction | None = None
+        self._equal_aspect_state_changed_slot: (
+            collections.abc.Callable[[], None] | None
+        ) = None
         view_box._itool_menu_populator = self._ensure_context_menu
         view_box._itool_menu_resetters.append(self._reset_context_menu)
         for act in ["Transforms", "Downsample", "Average", "Alpha", "Points"]:
@@ -572,7 +576,17 @@ class ItoolPlotItem(pg.PlotItem):
     def setup_actions(self) -> None:
         self._ensure_context_menu()
 
+    def _disconnect_equal_aspect_state_changed(self) -> None:
+        slot = self._equal_aspect_state_changed_slot
+        if slot is None:
+            return
+        with contextlib.suppress(TypeError, RuntimeError):
+            self.getViewBox().sigStateChanged.disconnect(slot)
+        self._equal_aspect_state_changed_slot = None
+        self._equal_aspect_action = None
+
     def _reset_context_menu(self) -> None:
+        self._disconnect_equal_aspect_state_changed()
         self._context_menu = None
         self._context_menu_ready = False
         self._associated_coord_menu = None
@@ -659,12 +673,17 @@ class ItoolPlotItem(pg.PlotItem):
             equal_aspect_action.toggled.connect(self.toggle_aspect_equal)
 
             def _update_aspect_lock_state() -> None:
+                if not erlab.interactive.utils.qt_is_valid(equal_aspect_action):
+                    self._disconnect_equal_aspect_state_changed()
+                    return
                 locked: bool = self.getViewBox().state["aspectLocked"] is not False
                 if equal_aspect_action.isChecked() != locked:
                     equal_aspect_action.blockSignals(True)
                     equal_aspect_action.setChecked(locked)
                     equal_aspect_action.blockSignals(False)
 
+            self._equal_aspect_action = equal_aspect_action
+            self._equal_aspect_state_changed_slot = _update_aspect_lock_state
             self.getViewBox().sigStateChanged.connect(_update_aspect_lock_state)
 
             # AdjustCT-like action

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -547,6 +547,12 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if plotitem_state is not None:
             plot._serializable_state = plotitem_state
 
+    def _apply_pending_plotitem_states_to_materialized_axes(self) -> None:
+        for index, ax in zip(
+            self._axes_indices(), self._materialized_axes(), strict=False
+        ):
+            self._apply_pending_plotitem_state(index, ax)
+
     def _sync_materialized_plot(self, index: int, plot: ItoolPlotItem) -> None:
         if not hasattr(self, "_array_slicer") or not self._axes_index_valid(index):
             return
@@ -604,6 +610,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
                     self._build_axes_widget(index)
                 if hasattr(self, "_array_slicer"):
                     self.adjust_layout()
+                    self._apply_pending_plotitem_states_to_materialized_axes()
                     if self._pending_splitter_sizes is not None:
                         self._apply_splitter_sizes(self._pending_splitter_sizes)
                         self._pending_splitter_sizes = None
@@ -774,10 +781,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
                         "Saved ImageTool plot state does not match current layout"
                     )
                 self._pending_plotitem_states = list(plotitem_states)
-                for index, ax in zip(
-                    self._axes_indices(), self._materialized_axes(), strict=False
-                ):
-                    self._apply_pending_plotitem_state(index, ax)
+                self._apply_pending_plotitem_states_to_materialized_axes()
             logger.debug("Restored plotitem states")
 
         with self._workspace_load_stage("imagetool state restore: cursors"):

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -15,6 +15,7 @@ import logging
 import os
 import pathlib
 import threading
+import time
 import typing
 import uuid
 import weakref
@@ -34,7 +35,7 @@ from erlab.interactive.imagetool._viewer_dialogs import (
 
 if typing.TYPE_CHECKING:
     import datetime
-    from collections.abc import Callable, Hashable, Iterable, Mapping
+    from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
 
     import qtawesome
 
@@ -245,16 +246,16 @@ class ImageSlicerArea(QtWidgets.QWidget):
         plotdata_cls=None,
         options_model: AppOptions | None = None,
         _in_manager: bool = False,
+        _defer_state_refresh: bool = False,
+        _defer_secondary_plots: bool = False,
+        _workspace_load_profiler: typing.Any = None,
     ) -> None:
         super().__init__(parent)
         self._options_model = options_model or erlab.interactive.options.model
         self.qapp = typing.cast(
             "QtWidgets.QApplication", QtWidgets.QApplication.instance()
         )
-        from erlab.interactive.imagetool.plot_items import (
-            ItoolColorBar,
-            ItoolGraphicsLayoutWidget,
-        )
+        from erlab.interactive.imagetool.plot_items import ItoolColorBar
 
         # Handle default values
         opts = self._options_model
@@ -269,6 +270,16 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         self._in_manager: bool = _in_manager  #: Internal flag for tools inside manager
         self._update_delayed: bool = _in_manager  #: Internal flag for delayed updates
+        self._defer_state_refresh = _defer_state_refresh
+        self._defer_secondary_plots = _defer_secondary_plots
+        self._secondary_plots_materialized = False
+        self._secondary_plot_materialization_duration = 0.0
+        self._plot_widgets_constructed = 0
+        self._pending_plotitem_states: list[PlotItemState] | None = None
+        self._pending_splitter_sizes: list[list[int]] | None = None
+        self._axes_signals_connected = False
+        self._axes_signal_connected_indices: set[int] = set()
+        self._workspace_load_profiler = _workspace_load_profiler
 
         self._linking_proxy: SlicerLinkProxy | None = None
 
@@ -373,69 +384,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self.axis_inversions: dict[str, bool] = {}
         # Dictionary of inverted view state for each plotted data dimension.
 
-        pkw = {"image_cls": image_cls, "plotdata_cls": plotdata_cls}
-        self._plots: tuple[ItoolGraphicsLayoutWidget, ...] = (
-            ItoolGraphicsLayoutWidget(
-                self,
-                display_axis=(0, 1),
-                axis_enabled=(1, 0, 0, 1),
-                image=True,
-                **pkw,
-            ),
-            ItoolGraphicsLayoutWidget(
-                self,
-                display_axis=(0,),
-                axis_enabled=(1, 1, 0, 0),
-                **pkw,
-            ),
-            ItoolGraphicsLayoutWidget(
-                self,
-                display_axis=(1,),
-                axis_enabled=(0, 0, 1, 1),
-                is_vertical=True,
-                **pkw,
-            ),
-            ItoolGraphicsLayoutWidget(
-                self,
-                display_axis=(2,),
-                axis_enabled=(0, 1, 1, 0),
-                **pkw,
-            ),
-            ItoolGraphicsLayoutWidget(
-                self,
-                image=True,
-                display_axis=(0, 2),
-                axis_enabled=(1, 0, 0, 0),
-                **pkw,
-            ),
-            ItoolGraphicsLayoutWidget(
-                self,
-                display_axis=(2, 1),
-                axis_enabled=(0, 0, 0, 1),
-                image=True,
-                **pkw,
-            ),
-            ItoolGraphicsLayoutWidget(
-                self,
-                display_axis=(3,),
-                axis_enabled=(0, 1, 1, 0),
-                **pkw,
-            ),
-            ItoolGraphicsLayoutWidget(
-                self,
-                display_axis=(3, 2),
-                axis_enabled=(0, 1, 1, 0),
-                image=True,
-                **pkw,
-            ),
-        )
-        for i in (1, 4):
-            self._splitters[2].addWidget(self._plots[i])
-        for i in (6, 3, 7):
-            self._splitters[3].addWidget(self._plots[i])
-        self._splitters[5].addWidget(self._plots[0])
-        for i in (5, 2):
-            self._splitters[6].addWidget(self._plots[i])
+        self._plot_item_kw = {"image_cls": image_cls, "plotdata_cls": plotdata_cls}
+        self._plots: list[ItoolGraphicsLayoutWidget | None] = [None] * 8
+        self._build_axes_widget(0)
+        if not self._defer_secondary_plots:
+            self._ensure_secondary_plots()
 
         self._file_path: pathlib.Path | None = None
         self._load_func: _LoadFunc | None = None
@@ -470,16 +423,234 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 vmax = self.array_slicer.nanmax
             self.set_colormap(levels_locked=True, levels=(vmin, vmax))
 
-        if state is not None:
-            self.state = state
+        try:
+            if state is not None:
+                self.state = state
 
-        if transpose:
-            self.transpose_main_image()
+            if transpose:
+                self.transpose_main_image()
+        finally:
+            if state is not None:
+                self._workspace_load_profiler = None
 
     @property
     def _associated_tools_list(self) -> list[QtWidgets.QWidget]:
         with self._assoc_tools_lock:
             return list(self._associated_tools.values())
+
+    @staticmethod
+    def _axes_widget_kwargs(index: int) -> dict[str, typing.Any]:
+        specs: tuple[dict[str, typing.Any], ...] = (
+            {
+                "display_axis": (0, 1),
+                "axis_enabled": (1, 0, 0, 1),
+                "image": True,
+            },
+            {"display_axis": (0,), "axis_enabled": (1, 1, 0, 0)},
+            {
+                "display_axis": (1,),
+                "axis_enabled": (0, 0, 1, 1),
+                "is_vertical": True,
+            },
+            {"display_axis": (2,), "axis_enabled": (0, 1, 1, 0)},
+            {
+                "image": True,
+                "display_axis": (0, 2),
+                "axis_enabled": (1, 0, 0, 0),
+            },
+            {
+                "display_axis": (2, 1),
+                "axis_enabled": (0, 0, 0, 1),
+                "image": True,
+            },
+            {"display_axis": (3,), "axis_enabled": (0, 1, 1, 0)},
+            {
+                "display_axis": (3, 2),
+                "axis_enabled": (0, 1, 1, 0),
+                "image": True,
+            },
+        )
+        return specs[index].copy()
+
+    def _slice_axes_indices(self) -> tuple[int, ...]:
+        match self.data.ndim:
+            case 2:
+                return ()
+            case 3:
+                return (4, 5)
+            case 4:
+                return (4, 5, 7)
+            case _:
+                raise ValueError("Data must have 2 to 4 dimensions")
+
+    def _profile_axes_indices(self) -> tuple[int, ...]:
+        match self.data.ndim:
+            case 2:
+                return (1, 2)
+            case 3:
+                return (1, 2, 3)
+            case 4:
+                return (1, 2, 3, 6)
+            case _:
+                raise ValueError("Data must have 2 to 4 dimensions")
+
+    def _image_axes_indices(self) -> tuple[int, ...]:
+        return (0, *self._slice_axes_indices())
+
+    def _axes_indices(self) -> tuple[int, ...]:
+        return (*self._image_axes_indices(), *self._profile_axes_indices())
+
+    @staticmethod
+    def _secondary_plot_construction_order() -> tuple[int, ...]:
+        return (1, 4, 6, 3, 7, 5, 2)
+
+    def _secondary_plot_indices(self) -> tuple[int, ...]:
+        if not hasattr(self, "_data"):
+            return self._secondary_plot_construction_order()
+        valid_indices = set(self._axes_indices())
+        return tuple(
+            index
+            for index in self._secondary_plot_construction_order()
+            if index in valid_indices
+        )
+
+    def _axes_index_valid(self, index: int) -> bool:
+        return not hasattr(self, "_data") or index in self._axes_indices()
+
+    def _add_axes_widget_to_splitter(
+        self, index: int, widget: ItoolGraphicsLayoutWidget
+    ) -> None:
+        if index in (1, 4):
+            self._splitters[2].addWidget(widget)
+        elif index in (6, 3, 7):
+            self._splitters[3].addWidget(widget)
+        elif index == 0:
+            self._splitters[5].addWidget(widget)
+        elif index in (5, 2):
+            self._splitters[6].addWidget(widget)
+        else:
+            raise IndexError(f"Invalid ImageTool axes index {index}")
+
+    def _pending_plotitem_state(self, index: int) -> PlotItemState | None:
+        if self._pending_plotitem_states is None:
+            return None
+        try:
+            state_index = self._axes_indices().index(index)
+        except ValueError:
+            return None
+        if state_index >= len(self._pending_plotitem_states):
+            return None
+        return self._pending_plotitem_states[state_index]
+
+    def _apply_pending_plotitem_state(self, index: int, plot: ItoolPlotItem) -> None:
+        plotitem_state = self._pending_plotitem_state(index)
+        if plotitem_state is not None:
+            plot._serializable_state = plotitem_state
+
+    def _sync_materialized_plot(self, index: int, plot: ItoolPlotItem) -> None:
+        if not hasattr(self, "_array_slicer") or not self._axes_index_valid(index):
+            return
+        while len(plot.slicer_data_items) < self.n_cursors:
+            plot.add_cursor(update=False)
+        while len(plot.slicer_data_items) > self.n_cursors:
+            plot.remove_cursor(len(plot.slicer_data_items) - 1)
+        self._apply_pending_plotitem_state(index, plot)
+        plot.set_cursor_colors(self.cursor_colors)
+        plot.set_active_cursor(self.current_cursor)
+        plot.set_cursor_visible(self.toggle_cursor_act.isChecked())
+        plot.refresh_labels()
+        plot.update_manual_range()
+        plot.update_axis_inversions()
+
+    def _connect_plot_signals(self, index: int, plot: ItoolPlotItem) -> None:
+        if index in self._axes_signal_connected_indices:
+            return
+        plot.connect_signals()
+        self._axes_signal_connected_indices.add(index)
+
+    def _build_axes_widget(self, index: int) -> ItoolGraphicsLayoutWidget:
+        plot = self._plots[index]
+        if plot is None:
+            from erlab.interactive.imagetool.plot_items import ItoolGraphicsLayoutWidget
+
+            plot_kwargs = self._axes_widget_kwargs(index)
+            plot_kwargs.update(self._plot_item_kw)
+            plot = ItoolGraphicsLayoutWidget(self, **plot_kwargs)
+            self._plots[index] = plot
+            self._plot_widgets_constructed += 1
+            self._add_axes_widget_to_splitter(index, plot)
+        valid_index = self._axes_index_valid(index)
+        self._sync_materialized_plot(index, plot.plotItem)
+        if self._axes_signals_connected and valid_index:
+            self._connect_plot_signals(index, plot.plotItem)
+        if not valid_index:
+            plot.setVisible(False)
+        if self._in_manager:
+            plot.plotItem.ensure_manager_figure_actions()
+        return plot
+
+    def _ensure_secondary_plots(self) -> None:
+        if self._secondary_plots_materialized:
+            return
+        start = time.perf_counter()
+        self._secondary_plots_materialized = True
+        try:
+            with (
+                self.history_suppressed(),
+                self.link_sync_suppressed(),
+                self._workspace_load_stage("imagetool secondary plot materialize"),
+            ):
+                for index in self._secondary_plot_indices():
+                    self._build_axes_widget(index)
+                if hasattr(self, "_array_slicer"):
+                    self.adjust_layout()
+                    if self._pending_splitter_sizes is not None:
+                        self._apply_splitter_sizes(self._pending_splitter_sizes)
+                        self._pending_splitter_sizes = None
+                    self.refresh_all(only_plots=True)
+                    self.set_colormap(**self.colormap_properties, update=False)
+                    self.lock_levels(self.levels_locked)
+        except Exception:
+            self._secondary_plots_materialized = False
+            raise
+        finally:
+            self._secondary_plot_materialization_duration += time.perf_counter() - start
+
+    def _plot_widget_for_index(self, index: int) -> ItoolGraphicsLayoutWidget:
+        if not 0 <= index < len(self._plots):
+            raise IndexError(f"Invalid ImageTool axes index {index}")
+        if index != 0:
+            self._ensure_secondary_plots()
+        plot = self._plots[index]
+        if plot is None:
+            plot = self._build_axes_widget(index)
+        return plot
+
+    def _materialized_axes_for_indices(
+        self, indices: tuple[int, ...]
+    ) -> tuple[ItoolPlotItem, ...]:
+        return tuple(
+            plot.plotItem
+            for index in indices
+            if (plot := self._plots[index]) is not None
+        )
+
+    def _materialized_slices(self) -> tuple[ItoolPlotItem, ...]:
+        return self._materialized_axes_for_indices(self._slice_axes_indices())
+
+    def _materialized_profiles(self) -> tuple[ItoolPlotItem, ...]:
+        return self._materialized_axes_for_indices(self._profile_axes_indices())
+
+    def _materialized_images(self) -> tuple[ItoolPlotItem, ...]:
+        return self._materialized_axes_for_indices(self._image_axes_indices())
+
+    def _materialized_axes(self) -> tuple[ItoolPlotItem, ...]:
+        return self._materialized_axes_for_indices(self._axes_indices())
+
+    def _materialized_imageitems(self) -> tuple[ItoolImageItem, ...]:
+        return tuple(
+            im for ax in self._materialized_images() for im in ax.slicer_data_items
+        )
 
     @property
     def parent_title(self) -> str:
@@ -567,6 +738,18 @@ class ImageSlicerArea(QtWidgets.QWidget):
         with self.history_suppressed(), self.link_sync_suppressed():
             self._restore_state(state)
 
+    @contextlib.contextmanager
+    def _workspace_load_stage(self, name: str) -> Iterator[None]:
+        stage = getattr(self._workspace_load_profiler, "stage", None)
+        if callable(stage):
+            with stage(name):
+                yield
+        else:
+            yield
+
+    def _state_refresh_deferred(self) -> bool:
+        return self._defer_state_refresh and self._update_delayed
+
     def _restore_state(
         self,
         state: ImageSlicerState,
@@ -574,108 +757,135 @@ class ImageSlicerArea(QtWidgets.QWidget):
         emit_filter_edited: bool = False,
     ) -> None:
         logger.debug("Restoring state...")
-        parent = self.parent()
-        if hasattr(parent, "_set_controls_visible"):
-            typing.cast("typing.Any", parent)._set_controls_visible(
-                bool(state.get("controls_visible", True))
-            )
+        with self._workspace_load_stage("imagetool state restore: layout"):
+            parent = self.parent()
+            if hasattr(parent, "_set_controls_visible"):
+                typing.cast("typing.Any", parent)._set_controls_visible(
+                    bool(state.get("controls_visible", True))
+                )
 
-        if "splitter_sizes" in state:
-            self.splitter_sizes = state["splitter_sizes"]
+            if "splitter_sizes" in state:
+                self.splitter_sizes = state["splitter_sizes"]
 
-        plotitem_states = state.get("plotitem_states", None)
-        if plotitem_states is not None:  # pragma: no branch
-            for ax, plotitem_state in zip(self.axes, plotitem_states, strict=True):
-                ax._serializable_state = plotitem_state
-        logger.debug("Restored plotitem states")
-
-        self.make_cursors(state["cursor_colors"], update=False)
-        self.sigCursorCountChanged.emit(self.n_cursors)
-        self.sigCursorColorsChanged.emit()
-        logger.debug("Restored cursor number and colors")
-
-        self.set_current_cursor(state["current_cursor"], update=False)
-        logger.debug("Restored current cursor")
-
-        self.array_slicer.state = state["slice"]
-        self.sigBinChanged.emit(self.current_cursor, tuple(range(self.data.ndim)))
-        for ax in self.axes:
-            if ax.is_image:
-                ax.sync_guidelines_to_active_cursor()
-        logger.debug("Restored array slicer state")
-
-        self.set_manual_limits(state.get("manual_limits", {}))
-        logger.debug("Restored manual limits")
-
-        axis_inversions = state.get("axis_inversions", None)
-        if axis_inversions is None:
-            axis_inversions = self._axis_inversions_from_plotitem_states(
-                plotitem_states
-            )
-        self.axis_inversions = self._normalized_axis_inversions(axis_inversions)
-        self.apply_axis_inversions()
-        logger.debug("Restored axis inversions")
-
-        file_path = state.get("file_path", None)
-        if file_path is not None:
-            self._file_path = pathlib.Path(file_path)
-
-        load_func = state.get("load_func", None)
-        if load_func is not None:
-            fn: str = load_func[0]
-            if ":" in fn:
-                self._load_func = load_func
-                try:
-                    mod_name, qual = fn.split(":")
-                    mod = importlib.import_module(mod_name)
-                    func_obj = mod
-                    for attr in qual.split("."):
-                        func_obj = getattr(func_obj, attr)
-                    self._load_func = (
-                        typing.cast("Callable", func_obj),
-                        *load_func[1:],
+            plotitem_states = state.get("plotitem_states", None)
+            if plotitem_states is not None:  # pragma: no branch
+                if len(plotitem_states) != len(self._axes_indices()):
+                    raise ValueError(
+                        "Saved ImageTool plot state does not match current layout"
                     )
-                except Exception:
+                self._pending_plotitem_states = list(plotitem_states)
+                for index, ax in zip(
+                    self._axes_indices(), self._materialized_axes(), strict=False
+                ):
+                    self._apply_pending_plotitem_state(index, ax)
+            logger.debug("Restored plotitem states")
+
+        with self._workspace_load_stage("imagetool state restore: cursors"):
+            self.make_cursors(state["cursor_colors"], update=False)
+            self.sigCursorCountChanged.emit(self.n_cursors)
+            self.sigCursorColorsChanged.emit()
+            logger.debug("Restored cursor number and colors")
+
+            self.set_current_cursor(state["current_cursor"], update=False)
+            logger.debug("Restored current cursor")
+
+            self.array_slicer.state = state["slice"]
+            self.sigBinChanged.emit(self.current_cursor, tuple(range(self.data.ndim)))
+            for ax in self._materialized_axes():
+                if ax.is_image:
+                    ax.sync_guidelines_to_active_cursor()
+            logger.debug("Restored array slicer state")
+
+        with self._workspace_load_stage("imagetool state restore: axes"):
+            self.set_manual_limits(state.get("manual_limits", {}))
+            logger.debug("Restored manual limits")
+
+            axis_inversions = state.get("axis_inversions", None)
+            if axis_inversions is None:
+                self._ensure_secondary_plots()
+                axis_inversions = self._axis_inversions_from_plotitem_states(
+                    plotitem_states
+                )
+            self.axis_inversions = self._normalized_axis_inversions(axis_inversions)
+            self.apply_axis_inversions()
+            logger.debug("Restored axis inversions")
+
+        with self._workspace_load_stage("imagetool state restore: source"):
+            file_path = state.get("file_path", None)
+            if file_path is not None:
+                self._file_path = pathlib.Path(file_path)
+
+            load_func = state.get("load_func", None)
+            if load_func is not None:
+                fn: str = load_func[0]
+                if ":" in fn:
+                    self._load_func = load_func
+                    try:
+                        mod_name, qual = fn.split(":")
+                        mod = importlib.import_module(mod_name)
+                        func_obj = mod
+                        for attr in qual.split("."):
+                            func_obj = getattr(func_obj, attr)
+                        self._load_func = (
+                            typing.cast("Callable", func_obj),
+                            *load_func[1:],
+                        )
+                    except Exception:
+                        self._load_func = None
+                elif fn in erlab.io.loaders:
+                    self._load_func = (fn, *load_func[1:])
+                else:
                     self._load_func = None
-            elif fn in erlab.io.loaders:
-                self._load_func = (fn, *load_func[1:])
-            else:
-                self._load_func = None
 
-        if file_path is not None:
-            self.sigDataChanged.emit()
-            logger.debug("Restored file path")
+            if file_path is not None and not self._state_refresh_deferred():
+                self.sigDataChanged.emit()
+                logger.debug("Restored file path")
 
-        self._restore_filter_operation_from_state(
-            state.get("filter_operation", None),
-            emit_edited=emit_filter_edited,
-        )
-        logger.debug("Restored filter operation")
-
-        # Restore colormap settings
-        try:
-            self.set_colormap(**state.get("color", {}), update=False)
-        except Exception:
-            erlab.utils.misc.emit_user_level_warning(
-                "Failed to restore colormap settings, skipping"
+        with self._workspace_load_stage("imagetool state restore: filter"):
+            self._restore_filter_operation_from_state(
+                state.get("filter_operation", None),
+                emit_edited=emit_filter_edited,
             )
-        logger.debug("Restored colormap settings")
+            logger.debug("Restored filter operation")
 
-        self.refresh_all()
-        logger.debug("Refreshed after state restoration")
+        with self._workspace_load_stage("imagetool state restore: color"):
+            try:
+                self.set_colormap(**state.get("color", {}), update=False)
+            except Exception:
+                erlab.utils.misc.emit_user_level_warning(
+                    "Failed to restore colormap settings, skipping"
+                )
+            logger.debug("Restored colormap settings")
 
-        self.cursor_colors = [pg.mkColor(c) for c in state["cursor_colors"]]
-        for ax in self.axes:
-            ax.set_cursor_colors(self.cursor_colors)
-        self.sigCursorColorsChanged.emit()
-        logger.debug("Reapplied saved cursor colors")
+        if self._state_refresh_deferred():
+            logger.debug("Deferred refresh after state restoration")
+        else:
+            with self._workspace_load_stage("imagetool state refresh"):
+                self.refresh_all()
+            logger.debug("Refreshed after state restoration")
+
+        with self._workspace_load_stage("imagetool state restore: cursor colors"):
+            self.cursor_colors = [pg.mkColor(c) for c in state["cursor_colors"]]
+            for ax in self._materialized_axes():
+                ax.set_cursor_colors(self.cursor_colors)
+            self.sigCursorColorsChanged.emit()
+            logger.debug("Reapplied saved cursor colors")
 
     @property
     def splitter_sizes(self) -> list[list[int]]:
+        if self._pending_splitter_sizes is not None:
+            return copy.deepcopy(self._pending_splitter_sizes)
         return [s.sizes() for s in self._splitters]
 
     @splitter_sizes.setter
     def splitter_sizes(self, sizes: list[list[int]]) -> None:
+        if self._secondary_plots_materialized:
+            self._apply_splitter_sizes(sizes)
+            self._pending_splitter_sizes = None
+        else:
+            self._pending_splitter_sizes = copy.deepcopy(sizes)
+
+    def _apply_splitter_sizes(self, sizes: list[list[int]]) -> None:
         for s, size in zip(self._splitters, sizes, strict=True):
             s.setSizes(size)
 
@@ -726,33 +936,19 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._colorbar.cb.setLimits(requested_levels)
         self._colorbar.cb.setSpanRegion(requested_levels)
         if self.levels_locked:
-            for im in self._imageitems:
+            for im in self._materialized_imageitems():
                 im.setLevels(requested_levels, update=False)
                 im.updateImage()
 
     @property
     def slices(self) -> tuple[ItoolPlotItem, ...]:
-        match self.data.ndim:
-            case 2:
-                return ()
-            case 3:
-                return tuple(self.get_axes(ax) for ax in (4, 5))
-            case 4:  # pragma: no branch
-                return tuple(self.get_axes(ax) for ax in (4, 5, 7))
-            case _:
-                raise ValueError("Data must have 2 to 4 dimensions")
+        self._ensure_secondary_plots()
+        return tuple(self.get_axes(ax) for ax in self._slice_axes_indices())
 
     @property
     def profiles(self) -> tuple[ItoolPlotItem, ...]:
-        match self.data.ndim:
-            case 2:
-                profile_axes: tuple[int, ...] = (1, 2)
-            case 3:
-                profile_axes = (1, 2, 3)
-            case _:
-                profile_axes = (1, 2, 3, 6)
-
-        return tuple(self.get_axes(ax) for ax in profile_axes)
+        self._ensure_secondary_plots()
+        return tuple(self.get_axes(ax) for ax in self._profile_axes_indices())
 
     @property
     def main_image(self) -> ItoolPlotItem:
@@ -761,12 +957,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     @property
     def images(self) -> tuple[ItoolPlotItem, ...]:
-        return (self.main_image, *self.slices)
+        self._ensure_secondary_plots()
+        return tuple(self.get_axes(ax) for ax in self._image_axes_indices())
 
     @property
     def axes(self) -> tuple[ItoolPlotItem, ...]:
         """Currently valid subset of self._plots."""
-        return self.images + self.profiles
+        self._ensure_secondary_plots()
+        return tuple(self.get_axes(ax) for ax in self._axes_indices())
 
     @property
     def _imageitems(self) -> tuple[ItoolImageItem, ...]:
@@ -1548,12 +1746,19 @@ class ImageSlicerArea(QtWidgets.QWidget):
         )
 
     def connect_axes_signals(self) -> None:
-        for ax in self.axes:
-            ax.connect_signals()
+        self._axes_signals_connected = True
+        for index in self._axes_indices():
+            plot = self._plots[index]
+            if plot is not None:
+                self._connect_plot_signals(index, plot.plotItem)
 
     def disconnect_axes_signals(self) -> None:
-        for ax in self.axes:
-            ax.disconnect_signals()
+        for index in tuple(self._axes_signal_connected_indices):
+            plot = self._plots[index]
+            if plot is not None:
+                plot.plotItem.disconnect_signals()
+        self._axes_signal_connected_indices.clear()
+        self._axes_signals_connected = False
 
     def connect_signals(self) -> None:
         self.connect_axes_signals()
@@ -1608,7 +1813,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 if reverse:
                     value = 1 - value
                 color = cmap.map(value, mode=cmap.QCOLOR)
-                for ax in self.axes:
+                for ax in self._materialized_axes():
                     self.cursor_colors[cursor_idx] = color
                     ax.set_cursor_color(cursor_idx, color)
             self.sigCursorColorsChanged.emit()
@@ -1654,7 +1859,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         coord_or_rect_list = []
         arrays_list_flat = []
 
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             objs, coord_or_rects, arrays = ax.collect_dask_objects(cursor, axes)
             if objs:
                 obj_list.append(objs)
@@ -1672,7 +1877,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         arrays_it = iter(arrays_list_flat)
 
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             for c in cursor:
                 ax.refresh_cursor(c)
 
@@ -1704,10 +1909,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
         return self.array_slicer.get_value(self.current_cursor, axis, uniform=uniform)
 
     def get_axes_widget(self, index: int) -> ItoolGraphicsLayoutWidget:
-        return self._plots[index]
+        return self._plot_widget_for_index(index)
 
     def get_axes(self, index: int) -> ItoolPlotItem:
-        return self._plots[index].plotItem
+        return self._plot_widget_for_index(index).plotItem
 
     @QtCore.Slot()
     def close_associated_windows(self) -> None:
@@ -1723,7 +1928,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
     ) -> None:
         self.sigIndexChanged.emit(tuple(c for c in range(self.n_cursors)), axes)
         if not only_plots:
-            for ax in self.axes:
+            for ax in self._materialized_axes():
                 ax.refresh_labels()
                 ax.update_manual_range()  # Handle axis limits (in case of transpose)
                 ax.update_axis_inversions()
@@ -1893,8 +2098,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         ndim_changed: bool = True
         cursors_reset: bool = True
+        had_array_slicer = hasattr(self, "_array_slicer")
+        secondary_plots_were_materialized = self._secondary_plots_materialized
         try:
-            if hasattr(self, "_array_slicer"):
+            if had_array_slicer:
                 if self._array_slicer._obj.ndim == _processed_ndim(self._data):
                     ndim_changed = False
                 cursors_reset = self._array_slicer.set_array(
@@ -1925,9 +2132,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         self.connect_signals()
         self.axis_inversions = self._normalized_axis_inversions(self.axis_inversions)
+        if had_array_slicer and ndim_changed:
+            self._secondary_plots_materialized = False
 
         if ndim_changed:
-            self.adjust_layout()
+            if secondary_plots_were_materialized:
+                self._ensure_secondary_plots()
+            else:
+                self.adjust_layout()
 
         if self.current_cursor > self.n_cursors - 1:
             self.set_current_cursor(self.n_cursors - 1, update=False)
@@ -1992,10 +2204,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def _update_if_delayed(self) -> None:
         if self._update_delayed:
             self._update_delayed = False
-            self.sigDataChanged.emit()
-            logger.debug("Data refresh triggered (delayed)")
+            with self.history_suppressed(), self.link_sync_suppressed():
+                self.sigDataChanged.emit()
+                logger.debug("Data refresh triggered (delayed)")
 
-            self.refresh_colormap()
+                self.refresh_colormap()
 
     @property
     def reloadable(self) -> bool:
@@ -2530,7 +2743,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             for dim, limits in manual_limits.items()
             if dim in valid_dims
         }
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             ax.update_manual_range()
 
     def _normalized_axis_inversions(
@@ -2560,7 +2773,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         return axis_inversions
 
     def apply_axis_inversions(self) -> None:
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             ax.update_axis_inversions()
 
     @link_slicer
@@ -2593,7 +2806,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 target.set_manual_limits(self.manual_limits)
 
         # Set manual limits for all other axes
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             if ax is not axes:
                 ax.update_manual_range()
 
@@ -2798,7 +3011,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             # is expensive and can be flaky on some Qt backends.
             color = pg.mkColor(colors[0])
             self.cursor_colors[0] = color
-            for ax in self.axes:
+            for ax in self._materialized_axes():
                 ax.set_cursor_colors(self.cursor_colors)
             if update:
                 self.refresh_all()
@@ -2828,7 +3041,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.cursor_colors.append(QtGui.QColor(color))
 
         self.current_cursor = self.n_cursors - 1
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             ax.add_cursor(update=False)
         if update:
             self._colorbar.cb.level_change()  # <- why is this required?
@@ -2852,7 +3065,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         elif self.current_cursor > index:  # pragma: no branch
             self.current_cursor -= 1
 
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             ax.remove_cursor(index)
         if update:
             self.refresh_current()
@@ -2866,7 +3079,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
     @QtCore.Slot()
     def toggle_cursor_visibility(self) -> None:
         """Toggle the visibility of the cursor lines."""
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             ax.set_cursor_visible(self.toggle_cursor_act.isChecked())
 
     def color_for_cursor(self, index: int) -> QtGui.QColor:
@@ -2892,7 +3105,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """
         self.array_slicer._cursor_color_params = None
         self.cursor_colors = [pg.mkColor(c) for c in colors]
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             ax.set_cursor_colors(self.cursor_colors)
         self.sigCursorColorsChanged.emit()
 
@@ -2981,7 +3194,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if levels is not None:
             self.levels = levels
 
-        for im in self._imageitems:
+        for im in self._materialized_imageitems():
             im.set_pg_colormap(pg_colormap, update=update)
         self.sigViewOptionChanged.emit()
 
@@ -3004,7 +3217,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if self.levels_locked:
             levels = self.array_slicer.limits
             self._colorbar.cb.setLimits(levels)
-        for im in self._imageitems:
+        for im in self._materialized_imageitems():
             if self.levels_locked:
                 im.setLevels(levels, update=False)
             else:
@@ -3239,10 +3452,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         for i in range(8):
             visible: bool = i not in invalid
-            self.get_axes_widget(i).setVisible(visible)
+            plot = self._plots[i]
+            if plot is not None:
+                plot.setVisible(visible)
 
         # reserve space, only hide plotItem
-        self.get_axes(3).setVisible(self.data.ndim != 2)
+        if self._plots[3] is not None:
+            self.get_axes(3).setVisible(self.data.ndim != 2)
 
         self._colorbar.set_dimensions(
             width=self.HORIZ_PAD + 30,
@@ -3252,7 +3468,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         )
 
         # Remove all ROI since they may not be valid anymore
-        for ax in self.axes:
+        for ax in self._materialized_axes():
             ax.clear_rois()
 
     def _cursor_name(self, i: int) -> str:
@@ -3284,3 +3500,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             if style is not None:
                 self.qapp.setStyle(style.name())
         super().changeEvent(evt)
+
+    def showEvent(self, event: QtGui.QShowEvent | None) -> None:
+        self._ensure_secondary_plots()
+        super().showEvent(event)

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -552,6 +552,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._axes_indices(), self._materialized_axes(), strict=False
         ):
             self._apply_pending_plotitem_state(index, ax)
+        if self._secondary_plots_materialized:
+            self._pending_plotitem_states = None
 
     def _sync_materialized_plot(self, index: int, plot: ItoolPlotItem) -> None:
         if not hasattr(self, "_array_slicer") or not self._axes_index_valid(index):
@@ -2138,6 +2140,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self.axis_inversions = self._normalized_axis_inversions(self.axis_inversions)
         if had_array_slicer and ndim_changed:
             self._secondary_plots_materialized = False
+            if not secondary_plots_were_materialized:
+                self._pending_plotitem_states = None
+                self._pending_splitter_sizes = None
 
         if ndim_changed:
             if secondary_plots_were_materialized:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -26499,11 +26499,12 @@ def test_manager_child_imagetool_gets_figure_context_actions(
     ],
 ) -> None:
     def action_names(tool: erlab.interactive.imagetool.ImageTool) -> set[str]:
-        return {
-            action.objectName()
-            for plot in tool.slicer_area.axes
-            for action in plot.vb.menu.actions()
-        }
+        names: set[str] = set()
+        for plot in tool.slicer_area.axes:
+            menu = plot.vb.getMenu(None)
+            assert menu is not None
+            names.update(action.objectName() for action in menu.actions())
+        return names
 
     with manager_context() as manager:
         itool(
@@ -26527,12 +26528,27 @@ def test_manager_child_imagetool_gets_figure_context_actions(
             execute=False,
         )
         assert isinstance(child, erlab.interactive.imagetool.ImageTool)
-        assert "itool_plot_with_matplotlib_action" not in action_names(child)
+        assert all(plot.vb.menu is None for plot in child.slicer_area.axes)
+        assert all(
+            plot._plot_with_matplotlib_action is None for plot in child.slicer_area.axes
+        )
 
         manager.add_imagetool_child(child, 0, show=False)
 
+        assert all(plot.vb.menu is None for plot in child.slicer_area.axes)
         assert "itool_plot_with_matplotlib_action" in action_names(child)
         assert "itool_append_to_figure_action" in action_names(child)
+        main_plot = child.slicer_area.axes[0]
+        main_plot.vb.setMenuEnabled(False)
+        assert main_plot.vb.menu is None
+        main_plot.vb.setMenuEnabled(True)
+        rebuilt_menu = main_plot.vb.getMenu(None)
+        assert rebuilt_menu is not None
+        rebuilt_action_names = {
+            action.objectName() for action in rebuilt_menu.actions()
+        }
+        assert "itool_plot_with_matplotlib_action" in rebuilt_action_names
+        assert "itool_append_to_figure_action" in rebuilt_action_names
 
 
 def test_manager_workspace_restores_figures_ui(

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -4123,6 +4123,25 @@ def test_manager_load_workspace_dataset_ignores_invalid_saved_metadata(
         assert target in manager._tool_graph.root_wrappers
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
+        binding = provenance.ImageToolSelectionSourceBinding(
+            selection_mode="isel",
+            selection_indexers={"x": 0},
+        )
+        bound_ds = saved.to_dataset()
+        bound_ds.attrs["manager_node_uid"] = "bound"
+        bound_ds.attrs.pop("manager_node_live_source_spec", None)
+        bound_ds.attrs["manager_node_live_source_binding"] = json.dumps(
+            binding.model_dump(mode="json")
+        )
+        bound_ds.attrs.pop("itool_name", None)
+
+        bound_target = manager._load_workspace_imagetool_dataset(
+            bound_ds, parent_target=None, node_path="-2"
+        )
+
+        assert manager._node_for_target(bound_target).source_binding == binding
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
 
 def test_manager_load_workspace_tool_dataset_rejects_root_tool(
     qtbot,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -30,7 +30,10 @@ import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace as manager_workspace
 import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
+import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.imagetool.manager._xarray as manager_xarray
+import erlab.interactive.imagetool.plot_items as imagetool_plot_items
+import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive.derivative import DerivativeTool
@@ -9745,6 +9748,227 @@ def test_manager_workspace_load_uses_h5py_fast_path(
         assert not loaded.data_chunked
         assert not loaded.data_file_backed
         np.testing.assert_array_equal(loaded._data.values, data.values)
+
+
+def test_manager_h5py_workspace_load_defers_hidden_imagetool_refresh_and_profiles(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25, dtype=np.float64).reshape((5, 5)),
+            dims=["x", "y"],
+            coords={"x": np.arange(5), "y": np.arange(5)},
+        )
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "profiled-h5py-load.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        root_attrs = manager_workspace._read_workspace_root_attrs_h5py(fname)
+        _, _, manifest = manager_workspace._workspace_file_metadata_from_attrs(
+            root_attrs
+        )
+        assert manifest is not None
+
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+        original_restore_state = imagetool_viewer.ImageSlicerArea._restore_state
+        original_refresh_all = imagetool_viewer.ImageSlicerArea.refresh_all
+        restoring_state: list[imagetool_viewer.ImageSlicerArea] = []
+        refresh_during_restore: list[imagetool_viewer.ImageSlicerArea] = []
+
+        def _record_restore_state(self, *args, **kwargs):
+            restoring_state.append(self)
+            try:
+                return original_restore_state(self, *args, **kwargs)
+            finally:
+                restoring_state.pop()
+
+        def _record_refresh_all(self):
+            if restoring_state and restoring_state[-1] is self:
+                refresh_during_restore.append(self)
+            return original_refresh_all(self)
+
+        monkeypatch.setattr(
+            imagetool_viewer.ImageSlicerArea,
+            "_restore_state",
+            _record_restore_state,
+        )
+        monkeypatch.setattr(
+            imagetool_viewer.ImageSlicerArea,
+            "refresh_all",
+            _record_refresh_all,
+        )
+
+        profiler = manager_workspace_io._WorkspaceLoadProfiler(fname)
+        assert manager._from_h5py_workspace_file(
+            fname,
+            manifest,
+            replace=True,
+            mark_dirty=False,
+            profiler=profiler,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        loaded = manager.get_imagetool(0).slicer_area
+        assert loaded not in refresh_during_restore
+
+        assert profiler._durations["imagetool widget restore"] > 0.0
+        assert profiler._durations["imagetool manager registration"] > 0.0
+        assert "imagetool state restore: layout" in profiler._durations
+        assert "imagetool state refresh" not in profiler._durations
+
+
+def test_manager_h5py_workspace_load_defers_hidden_secondary_plot_widgets(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for index in range(4):
+            manager.add_imagetool(
+                erlab.interactive.imagetool.ImageTool(
+                    _workspace_sweep_data(f"window_{index}"),
+                    _in_manager=True,
+                ),
+                show=False,
+            )
+
+        fname = tmp_path / "lazy-secondary-plots.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+        constructed_display_axes: list[tuple[int, ...] | tuple[int, int]] = []
+        original_init = imagetool_plot_items.ItoolGraphicsLayoutWidget.__init__
+
+        def _record_graphics_layout_init(self, *args, **kwargs) -> None:
+            constructed_display_axes.append(tuple(kwargs["display_axis"]))
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(
+            imagetool_plot_items.ItoolGraphicsLayoutWidget,
+            "__init__",
+            _record_graphics_layout_init,
+        )
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 4, timeout=5000)
+
+        loaded_areas = [
+            manager.get_imagetool(index).slicer_area for index in range(manager.ntools)
+        ]
+        assert constructed_display_axes == [(0, 1)] * 4
+        assert all(area._plot_widgets_constructed == 1 for area in loaded_areas)
+        assert not any(area._secondary_plots_materialized for area in loaded_areas)
+
+        first_tool = manager.get_imagetool(0)
+        first_tool.show()
+        qtbot.wait_until(
+            lambda: first_tool.slicer_area._secondary_plots_materialized,
+            timeout=5000,
+        )
+        first_area = first_tool.slicer_area
+        assert first_area._plot_widgets_constructed == 8
+        assert first_area._secondary_plot_materialization_duration > 0.0
+        assert len(first_area.axes) == 8
+        assert constructed_display_axes == [
+            (0, 1),
+            (0, 1),
+            (0, 1),
+            (0, 1),
+            (0,),
+            (0, 2),
+            (3,),
+            (2,),
+            (3, 2),
+            (2, 1),
+            (1,),
+        ]
+
+
+def test_hidden_2d_workspace_preview_does_not_build_invalid_secondary_plots(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25, dtype=np.float64).reshape((5, 5)),
+            dims=["x", "y"],
+            coords={"x": np.arange(5), "y": np.arange(5)},
+        )
+
+        root = erlab.interactive.imagetool.ImageTool(data, _in_manager=True)
+        qtbot.addWidget(root)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "hidden-2d-preview.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+        constructed_display_axes: list[tuple[int, ...] | tuple[int, int]] = []
+        original_init = imagetool_plot_items.ItoolGraphicsLayoutWidget.__init__
+
+        def _record_graphics_layout_init(self, *args, **kwargs) -> None:
+            constructed_display_axes.append(tuple(kwargs["display_axis"]))
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(
+            imagetool_plot_items.ItoolGraphicsLayoutWidget,
+            "__init__",
+            _record_graphics_layout_init,
+        )
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        loaded = manager.get_imagetool(0).slicer_area
+        loaded_node = manager._node_for_target(0)
+
+        assert constructed_display_axes == [(0, 1)]
+        assert loaded._plot_widgets_constructed == 1
+        assert not loaded._secondary_plots_materialized
+
+        ratio, pixmap = manager_wrapper._preview_image_for_node(loaded_node)
+        assert isinstance(ratio, float)
+        assert isinstance(pixmap, QtGui.QPixmap)
+        assert not loaded._update_delayed
+        assert constructed_display_axes == [(0, 1)]
+        assert not loaded._secondary_plots_materialized
+
+        assert len(loaded.axes) == 3
+        assert loaded._plot_widgets_constructed == 3
+        assert constructed_display_axes == [(0, 1), (0,), (1,)]
 
 
 def test_manager_workspace_load_preserves_transposed_inverted_axis_limits(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -389,9 +389,11 @@ def test_itool_tools(qtbot, test_data_type, condition, use_dask) -> None:
                 win.array_slicer.set_bin(0, axis=2, value=3, update=True)
 
         logger.info("Test alt key menu")
-        main_image.vb.menu.popup(QtCore.QPoint(0, 0))
-        main_image.vb.menu.eventFilter(
-            main_image.vb.menu,
+        viewbox_menu = main_image.vb.getMenu(None)
+        assert viewbox_menu is not None
+        viewbox_menu.popup(QtCore.QPoint(0, 0))
+        viewbox_menu.eventFilter(
+            viewbox_menu,
             QtGui.QKeyEvent(
                 QtCore.QEvent.KeyPress, QtCore.Qt.Key_Alt, QtCore.Qt.AltModifier
             ),
@@ -2006,6 +2008,142 @@ def test_point_value_context_menu_selects_associated_coord(qtbot) -> None:
     win.close()
 
 
+def test_itool_plot_item_viewbox_menu_is_lazy_and_idempotent(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    plot = win.slicer_area.main_image
+    assert plot.vb.menu is None
+    colorbar = win.slicer_area._colorbar.cb
+    assert colorbar.vb.menu is None
+
+    plot.getMenu()
+    menu = plot.vb.menu
+    assert menu is not None
+    first_actions = tuple(menu.actions())
+
+    assert (
+        sum(
+            action.objectName() == "itool_add_polygon_roi_action"
+            for action in first_actions
+        )
+        == 1
+    )
+
+    assert plot.vb.getMenu(None) is menu
+    assert tuple(menu.actions()) == first_actions
+
+    plot.getMenu()
+    assert tuple(menu.actions()) == first_actions
+
+    plot.vb.setMenuEnabled(False)
+    assert plot.vb.menu is None
+    plot.vb.setMenuEnabled(True)
+    rebuilt_menu = plot.vb.getMenu(None)
+    assert rebuilt_menu is not None
+    assert rebuilt_menu is not menu
+    assert (
+        sum(
+            action.objectName() == "itool_add_polygon_roi_action"
+            for action in rebuilt_menu.actions()
+        )
+        == 1
+    )
+
+    colorbar_menu = colorbar.vb.getMenu(None)
+    assert colorbar_menu is not None
+    assert (
+        sum(
+            action.objectName() == "itool_copy_color_limits_action"
+            for action in colorbar_menu.actions()
+        )
+        == 1
+    )
+    colorbar.vb.setMenuEnabled(False)
+    assert colorbar.vb.menu is None
+    colorbar.vb.setMenuEnabled(True)
+    rebuilt_colorbar_menu = colorbar.vb.getMenu(None)
+    assert rebuilt_colorbar_menu is not None
+    assert rebuilt_colorbar_menu is not colorbar_menu
+    assert (
+        sum(
+            action.objectName() == "itool_copy_color_limits_action"
+            for action in rebuilt_colorbar_menu.actions()
+        )
+        == 1
+    )
+    win.close()
+
+
+def test_lazy_secondary_plots_reset_after_dimensionality_change(qtbot) -> None:
+    data_2d = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    win = ImageTool(data_2d, _in_manager=True, _defer_secondary_plots=True)
+    qtbot.addWidget(win)
+
+    area = win.slicer_area
+    assert area._plot_widgets_constructed == 1
+    assert [index for index, plot in enumerate(area._plots) if plot is not None] == [0]
+
+    assert len(area.axes) == 3
+    assert area._secondary_plots_materialized
+    assert area._plot_widgets_constructed == 3
+    assert [index for index, plot in enumerate(area._plots) if plot is not None] == [
+        0,
+        1,
+        2,
+    ]
+
+    data_3d = xr.DataArray(np.arange(8.0).reshape(2, 2, 2), dims=("x", "y", "z"))
+    area.set_data(data_3d)
+    assert area._secondary_plots_materialized
+    assert area._plot_widgets_constructed == 6
+
+    axes = area.axes
+    assert len(axes) == 6
+    assert area._secondary_plots_materialized
+    assert area._plot_widgets_constructed == 6
+    assert {tuple(ax.display_axis) for ax in axes} == {
+        (0, 1),
+        (0, 2),
+        (2, 1),
+        (0,),
+        (1,),
+        (2,),
+    }
+    win.close()
+
+
+def test_lazy_secondary_plot_fixed_index_access_allows_hidden_invalid_plot(
+    qtbot,
+) -> None:
+    data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    win = ImageTool(data, _in_manager=True, _defer_secondary_plots=True)
+    qtbot.addWidget(win)
+
+    area = win.slicer_area
+    plot = area.get_axes(7)
+    assert tuple(plot.display_axis) == (3, 2)
+    assert area._plot_widgets_constructed == 4
+    assert area._secondary_plots_materialized
+    assert [index for index, item in enumerate(area._plots) if item is not None] == [
+        0,
+        1,
+        2,
+        7,
+    ]
+    assert 7 not in area._axes_signal_connected_indices
+
+    data_4d = xr.DataArray(
+        np.arange(16.0).reshape(2, 2, 2, 2), dims=("x", "y", "z", "t")
+    )
+    area.set_data(data_4d)
+    assert area._secondary_plots_materialized
+    assert len(area.axes) == 8
+    assert 7 in area._axes_signal_connected_indices
+    win.close()
+
+
 def test_profile_menu_opens_associated_coord_targets(
     qtbot, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2044,7 +2182,9 @@ def test_profile_menu_opens_associated_coord_targets(
     profile._refresh_associated_coord_menu()
     assert profile._associated_coord_menu is not None
     assert profile._associated_coord_menu.menuAction().isVisible()
-    plot_actions = profile.vb.menu.actions()
+    plot_menu = profile.vb.getMenu(None)
+    assert plot_menu is not None
+    plot_actions = plot_menu.actions()
     menu_index = plot_actions.index(profile._associated_coord_menu.menuAction())
     assert plot_actions[menu_index - 1].isSeparator()
     assert plot_actions[menu_index - 1].isVisible()
@@ -3458,7 +3598,11 @@ def test_itool_general(qtbot, move_and_compare_values, use_dask) -> None:
     assert win.slicer_area._colorbar.cb._copy_limits() == str((1.0, 23.0))
 
     # Test color limits editor
-    clw = win.slicer_area._colorbar.cb._clim_menu.actions()[0].defaultWidget()
+    colorbar_menu = win.slicer_area._colorbar.cb.vb.getMenu(None)
+    assert colorbar_menu is not None
+    clim_menu = win.slicer_area._colorbar.cb._clim_menu
+    assert clim_menu is not None
+    clw = clim_menu.actions()[0].defaultWidget()
     assert clw.min_spin.value() == win.slicer_area.levels[0]
     assert clw.max_spin.value() == win.slicer_area.levels[1]
     clw.min_spin.setValue(1.0)
@@ -6527,9 +6671,11 @@ def test_itool_roi_lifecycle(qtbot) -> None:
     qtbot.addWidget(win)
 
     plot_item = win.slicer_area.main_image
+    menu = plot_item.vb.getMenu(None)
+    assert menu is not None
     add_roi_action = next(
         act
-        for act in plot_item.vb.menu.actions()
+        for act in menu.actions()
         if act.objectName() == "itool_add_polygon_roi_action"
     )
     add_roi_action.trigger()

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2152,6 +2152,39 @@ def test_lazy_secondary_plots_reset_after_dimensionality_change(qtbot) -> None:
     win.close()
 
 
+def test_lazy_secondary_pending_plot_state_cleared_on_dimensionality_change(
+    qtbot,
+) -> None:
+    data_4d = xr.DataArray(
+        np.arange(16.0).reshape(2, 2, 2, 2), dims=("x", "y", "z", "t")
+    )
+    source = ImageTool(data_4d, _in_manager=True)
+    qtbot.addWidget(source)
+    source.slicer_area.get_axes(4).add_roi()
+    state = copy.deepcopy(source.slicer_area.state)
+    source.close()
+
+    restored = ImageTool(
+        data_4d,
+        _in_manager=True,
+        _defer_secondary_plots=True,
+        state=state,
+    )
+    qtbot.addWidget(restored)
+    area = restored.slicer_area
+    assert area._pending_plotitem_states is not None
+
+    data_2d = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    area.set_data(data_2d)
+
+    assert area._pending_plotitem_states is None
+    assert area._pending_splitter_sizes is None
+    axes = area.axes
+    assert len(axes) == 3
+    assert all(not ax._roi_list for ax in axes)
+    restored.close()
+
+
 def test_lazy_secondary_plot_fixed_index_access_allows_hidden_invalid_plot(
     qtbot,
 ) -> None:

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -67,7 +67,11 @@ from erlab.interactive.imagetool.dialogs import (
     SymmetrizeNfoldDialog,
     ThinDialog,
 )
-from erlab.interactive.imagetool.plot_items import ItoolPlotItem, _PolyROIEditDialog
+from erlab.interactive.imagetool.plot_items import (
+    ItoolPlotItem,
+    ItoolViewBox,
+    _PolyROIEditDialog,
+)
 from erlab.interactive.imagetool.slicer import ArraySlicerState
 from erlab.interactive.imagetool.viewer import ImageSlicerArea
 from erlab.interactive.imagetool.viewer_state import (
@@ -2008,16 +2012,26 @@ def test_point_value_context_menu_selects_associated_coord(qtbot) -> None:
     win.close()
 
 
-def test_itool_plot_item_viewbox_menu_is_lazy_and_idempotent(qtbot) -> None:
+def test_itool_plot_item_viewbox_menu_is_lazy_and_idempotent(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    viewbox = ItoolViewBox(enableMenu=False)
+    assert viewbox.getContextMenus(None) == []
+    viewbox._populate_itool_menu()
+
     data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
     win = itool(data, execute=False)
     qtbot.addWidget(win)
 
     plot = win.slicer_area.main_image
     assert plot.vb.menu is None
+    plot.vb.setMenuEnabled(False)
+    assert plot._ensure_context_menu() is None
+    plot.vb.setMenuEnabled(True)
     colorbar = win.slicer_area._colorbar.cb
     assert colorbar.vb.menu is None
 
+    plot.setup_actions()
     plot.getMenu()
     menu = plot.vb.menu
     assert menu is not None
@@ -2032,10 +2046,32 @@ def test_itool_plot_item_viewbox_menu_is_lazy_and_idempotent(qtbot) -> None:
     )
 
     assert plot.vb.getMenu(None) is menu
+    assert plot.vb.getContextMenus(None)
     assert tuple(menu.actions()) == first_actions
 
     plot.getMenu()
     assert tuple(menu.actions()) == first_actions
+    assert plot.getContextMenus(None)
+
+    plot.ensure_manager_figure_actions()
+    manager_action_names = {action.objectName() for action in menu.actions()}
+    assert "itool_plot_with_matplotlib_action" in manager_action_names
+    assert "itool_append_to_figure_action" in manager_action_names
+    plot.ensure_manager_figure_actions()
+    assert (
+        sum(
+            action.objectName() == "itool_plot_with_matplotlib_action"
+            for action in menu.actions()
+        )
+        == 1
+    )
+
+    aspect_slot = plot._equal_aspect_state_changed_slot
+    assert aspect_slot is not None
+    with monkeypatch.context() as patch:
+        patch.setattr(erlab.interactive.utils, "qt_is_valid", lambda *_: False)
+        aspect_slot()
+    assert plot._equal_aspect_state_changed_slot is None
 
     plot.vb.setMenuEnabled(False)
     assert plot.vb.menu is None
@@ -2053,6 +2089,7 @@ def test_itool_plot_item_viewbox_menu_is_lazy_and_idempotent(qtbot) -> None:
 
     colorbar_menu = colorbar.vb.getMenu(None)
     assert colorbar_menu is not None
+    assert colorbar._ensure_context_menu() is colorbar_menu
     assert (
         sum(
             action.objectName() == "itool_copy_color_limits_action"
@@ -2073,6 +2110,7 @@ def test_itool_plot_item_viewbox_menu_is_lazy_and_idempotent(qtbot) -> None:
         )
         == 1
     )
+    assert colorbar.getContextMenus(None) is None
     win.close()
 
 
@@ -2142,6 +2180,61 @@ def test_lazy_secondary_plot_fixed_index_access_allows_hidden_invalid_plot(
     assert len(area.axes) == 8
     assert 7 in area._axes_signal_connected_indices
     win.close()
+
+
+def test_lazy_secondary_plot_helper_edge_paths(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    win = ImageTool(data, _in_manager=True, _defer_secondary_plots=True)
+    qtbot.addWidget(win)
+
+    area = win.slicer_area
+    assert area._pending_plotitem_state(99) is None
+    area._pending_plotitem_states = []
+    assert area._pending_plotitem_state(0) is None
+
+    with pytest.raises(IndexError, match="Invalid ImageTool axes index"):
+        area._add_axes_widget_to_splitter(99, QtWidgets.QWidget())
+    with pytest.raises(IndexError, match="Invalid ImageTool axes index"):
+        area.get_axes_widget(99)
+
+    assert area._materialized_slices() == ()
+    assert area._materialized_profiles() == ()
+    assert area.slices == ()
+    assert area.get_axes_widget(0) is area._plots[0]
+
+    original_data = area.array_slicer._obj
+    area.array_slicer._obj = xr.DataArray(np.arange(2.0), dims=("x",))
+    try:
+        with pytest.raises(ValueError, match="Data must have 2 to 4 dimensions"):
+            area._slice_axes_indices()
+        with pytest.raises(ValueError, match="Data must have 2 to 4 dimensions"):
+            area._profile_axes_indices()
+    finally:
+        area.array_slicer._obj = original_data
+
+    bad_state = copy.deepcopy(area.state)
+    bad_state["plotitem_states"] = []
+    with pytest.raises(ValueError, match="plot state does not match"):
+        area.state = bad_state
+    win.close()
+
+    failing = ImageTool(data, _in_manager=True, _defer_secondary_plots=True)
+    qtbot.addWidget(failing)
+
+    def _raise_build_error(index: int) -> typing.NoReturn:
+        raise RuntimeError(f"cannot build {index}")
+
+    monkeypatch.setattr(
+        failing.slicer_area,
+        "_build_axes_widget",
+        _raise_build_error,
+    )
+    with pytest.raises(RuntimeError, match="cannot build"):
+        failing.slicer_area._ensure_secondary_plots()
+    assert not failing.slicer_area._secondary_plots_materialized
+    failing.close()
 
 
 def test_profile_menu_opens_associated_coord_targets(

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -273,6 +273,23 @@ def test_colorbar_keeps_menu_widget_action_references() -> None:
     assert colorbar._cmap_action.defaultWidget() is colorbar._cmap_widget
 
 
+def test_colorbar_lazy_context_menu_access_paths(qtbot, monkeypatch) -> None:
+    image = BetterImageItem(np.arange(16, dtype=float).reshape(4, 4))
+    image.set_colormap("viridis", gamma=1.0)
+    colorbar = BetterColorBarItem(image=image, _defer_context_menu_setup=True)
+    widget = pg.PlotWidget(plotItem=colorbar)
+    qtbot.addWidget(widget)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(colorbar, "_menu_for_context_setup", lambda: None)
+        assert colorbar._ensure_context_menu() is None
+
+    menu = colorbar.getMenu()
+    assert menu is colorbar.ctrlMenu
+    assert colorbar._ensure_context_menu() is colorbar._context_menu
+    assert colorbar.getContextMenus(None) is None
+
+
 def test_colorbar_edit_widget_applies_changes_to_images(qtbot):
     data = np.linspace(0, 1, 25, dtype=float).reshape(5, 5)
     images = [BetterImageItem(data + offset) for offset in (0.0, 1.0)]


### PR DESCRIPTION
## Summary
- Reduce ImageTool ITWS load overhead across the main window, manager, viewer, and workspace I/O paths
- Update related color, plot item, and control handling to fit the faster load flow
- Add coverage for manager workspace handling and ImageTool restore behavior

## Testing
- Added and updated unit tests for manager workspace and ImageTool paths
- UI behavior validated through targeted tests for the affected load and restore flows