### PR TITLE
Debounce kspace manager state updates and preview memory checks

### DIFF
--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -80,6 +80,10 @@ parameters. The image is updated in real time as you change the parameters. For
 angle-energy cuts, the preview keeps the full energy axis and displays the converted
 `k`/`eV` cut.
 
+Use the `alpha scale` and `beta scale` controls only to compensate known extrinsic
+warping in the angle coordinates. The scales multiply the `alpha` and `beta` coordinates
+before momentum conversion. In most cases, these should be left at 1.0.
+
 Clicking {guilabel}`Copy to clipboard` will copy the code for conversion to the
 clipboard, including any selected configuration change and momentum-conversion
 settings.

--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -1,6 +1,6 @@
 """Defines an accessor for momentum conversion related utilities."""
 
-__all__ = ["IncompleteDataError", "MomentumAccessor", "OffsetView"]
+__all__ = ["AngleScaleView", "IncompleteDataError", "MomentumAccessor", "OffsetView"]
 
 import functools
 import time
@@ -13,6 +13,8 @@ import xarray as xr
 import erlab
 from erlab.accessors.utils import ERLabDataArrayAccessor
 from erlab.constants import AxesConfiguration
+
+_ANGLE_SCALE_KEYS = ("alpha", "beta")
 
 
 class IncompleteDataError(ValueError):
@@ -29,6 +31,13 @@ class IncompleteDataError(ValueError):
     def _make_message(kind: typing.Literal["attr", "coord"], name: str) -> str:
         kind_str = "Attribute" if kind == "attr" else "Coordinate"
         return f"{kind_str} '{name}' is required for momentum conversion."
+
+
+def _validate_angle_scale(value: float, name: str) -> float:
+    scale = np.asarray(value, dtype=float)
+    if scale.ndim != 0 or not np.isfinite(scale) or scale <= 0:
+        raise ValueError(f"`{name}` must be a finite positive scalar.")
+    return float(scale)
 
 
 def _kxy_components(
@@ -324,6 +333,76 @@ class OffsetView:
         return self
 
 
+class AngleScaleView:
+    r"""A view of angle-scale compensation factors for momentum conversion.
+
+    The scale factors compensate extrinsic warping in the stored angle coordinates.
+    Missing scale attributes default to ``1.0``.
+    """
+
+    def __init__(self, xarray_obj: xr.DataArray) -> None:
+        self._obj = xarray_obj
+
+    def __iter__(self) -> Iterator[tuple[str, float]]:
+        for key in _ANGLE_SCALE_KEYS:
+            yield key, self.__getitem__(key)
+
+    def __getitem__(self, key: str) -> float:
+        if key not in _ANGLE_SCALE_KEYS:
+            raise KeyError(
+                f"Invalid angle scale key `{key}`. Valid keys are: {_ANGLE_SCALE_KEYS}."
+            )
+        attr_key = f"{key}_scale"
+        if attr_key not in self._obj.attrs:
+            return 1.0
+        return _validate_angle_scale(self._obj.attrs[attr_key], attr_key)
+
+    def __setitem__(self, key: str, value: float) -> None:
+        if key not in _ANGLE_SCALE_KEYS:
+            raise KeyError(
+                f"Invalid angle scale key '{key}'. Valid keys are: {_ANGLE_SCALE_KEYS}."
+            )
+        self._obj.attrs[f"{key}_scale"] = _validate_angle_scale(value, f"{key}_scale")
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Mapping):
+            return dict(self) == dict(other)
+        return False
+
+    def __repr__(self) -> str:
+        return dict(self).__repr__()
+
+    def _repr_html_(self) -> str:
+        return erlab.utils.formatting.format_html_table(
+            [(k, str(v)) for k, v in self.items()], header_cols=1
+        )
+
+    def update(
+        self,
+        other: Mapping[str, float] | Iterable[tuple[str, float]] | None = None,
+        **kwargs,
+    ) -> typing.Self:
+        """Update angle-scale compensation factors."""
+        if other is not None:
+            for k, v in other.items() if isinstance(other, Mapping) else other:
+                self[str(k)] = v
+        for k, v in kwargs.items():
+            self[k] = v
+        return self
+
+    def items(self) -> ItemsView[str, float]:
+        """Return a view of angle-scale factors as key-value pairs."""
+        return dict(self).items()
+
+    def reset(self) -> typing.Self:
+        """Reset all angle-scale compensation factors."""
+        for key in _ANGLE_SCALE_KEYS:
+            attr_key = f"{key}_scale"
+            if attr_key in self._obj.attrs:
+                del self._obj.attrs[attr_key]
+        return self
+
+
 @xr.register_dataarray_accessor("kspace")
 class MomentumAccessor(ERLabDataArrayAccessor):
     """`xarray.DataArray.kspace` accessor for momentum conversion related utilities.
@@ -463,6 +542,42 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         self._obj.attrs["angle_resolution"] = float(value)
 
     @property
+    def angle_scales(self) -> AngleScaleView:
+        """Angle-scale compensation factors used in momentum conversion.
+
+        .. versionadded:: 3.24.0
+        """
+        if not hasattr(self, "_anglescaleview"):
+            self._anglescaleview = AngleScaleView(self._obj)
+        return self._anglescaleview
+
+    @angle_scales.setter
+    def angle_scales(self, scales: Mapping[str, float]) -> None:
+        if not hasattr(self, "_anglescaleview"):
+            self._anglescaleview = AngleScaleView(self._obj)
+
+        self._anglescaleview.reset()
+        self._anglescaleview.update(scales)
+
+    @property
+    def alpha_scale(self) -> float:
+        """Alpha-axis scale compensation factor."""
+        return self.angle_scales["alpha"]
+
+    @alpha_scale.setter
+    def alpha_scale(self, value: float) -> None:
+        self.angle_scales["alpha"] = value
+
+    @property
+    def beta_scale(self) -> float:
+        """Beta-axis scale compensation factor."""
+        return self.angle_scales["beta"]
+
+    @beta_scale.setter
+    def beta_scale(self, value: float) -> None:
+        self.angle_scales["beta"] = value
+
+    @property
     def slit_axis(self) -> typing.Literal["kx", "ky"]:
         """Momentum axis parallel to the analyzer slit.
 
@@ -535,17 +650,37 @@ class MomentumAccessor(ERLabDataArrayAccessor):
 
     @property
     @_only_angles
-    def _alpha(self) -> xr.DataArray:
+    def _raw_alpha(self) -> xr.DataArray:
         if "alpha" not in self._obj.coords:
             raise IncompleteDataError("coord", "alpha")
         return self._obj.alpha
 
     @property
     @_only_angles
-    def _beta(self) -> xr.DataArray:
+    def _raw_beta(self) -> xr.DataArray:
         if "beta" not in self._obj.coords:
             raise IncompleteDataError("coord", "beta")
         return self._obj.beta
+
+    def _scaled_angle_coord(
+        self,
+        axis: typing.Literal["alpha", "beta"],
+        coord: xr.DataArray,
+    ) -> xr.DataArray:
+        scale = self.angle_scales[axis]
+        if np.isclose(scale, 1.0):
+            return coord
+        return coord * scale
+
+    @property
+    @_only_angles
+    def _alpha(self) -> xr.DataArray:
+        return self._scaled_angle_coord("alpha", self._raw_alpha)
+
+    @property
+    @_only_angles
+    def _beta(self) -> xr.DataArray:
+        return self._scaled_angle_coord("beta", self._raw_beta)
 
     @property
     def _hv(self) -> xr.DataArray:
@@ -763,13 +898,19 @@ class MomentumAccessor(ERLabDataArrayAccessor):
 
     @_only_angles
     def set_normal(
-        self, alpha: float, beta: float, *, delta: float | None = None
+        self,
+        alpha: float,
+        beta: float,
+        *,
+        delta: float | None = None,
+        alpha_scale: float | None = None,
+        beta_scale: float | None = None,
     ) -> None:
         r"""Set offsets from normal emission angles.
 
         This method sets the angle offsets so that the provided normal emission angles
-        :math:`(\alpha, \beta)` in the data map to :math:`(k_x, k_y) = (0, 0)` in
-        momentum space.
+        :math:`(\alpha, \beta)` in the raw data map to :math:`(k_x, k_y) = (0, 0)` in
+        momentum space after angle-scale compensation is applied.
 
         Parameters
         ----------
@@ -780,6 +921,10 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         delta
             Optional azimuthal offset :math:`\delta` in degrees. If omitted, the
             existing ``delta`` offset is preserved.
+        alpha_scale, beta_scale
+            Optional angle-scale compensation factors. If provided, the factors are
+            stored before solving the offsets. Omitted factors use the currently stored
+            scale values.
 
         Examples
         --------
@@ -787,13 +932,22 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         >>> dict(data.kspace.offsets)
         {'delta': 0.0, 'xi': -1.2, 'beta': -0.4}
 
+        .. versionchanged:: 3.24.0
+            Added ``alpha_scale`` and ``beta_scale`` compensation factors. The
+            provided normal-emission angles are interpreted in raw data coordinates.
+
         See Also
         --------
         :attr:`offsets <xarray.DataArray.kspace.offsets>`
             Attribute used to manipulate angle offsets directly.
         """
-        alpha_normal = self._require_finite_scalar(alpha, "alpha")
-        beta_normal = self._require_finite_scalar(beta, "beta")
+        if alpha_scale is not None:
+            self.alpha_scale = alpha_scale
+        if beta_scale is not None:
+            self.beta_scale = beta_scale
+
+        alpha_normal = self._require_finite_scalar(alpha, "alpha") * self.alpha_scale
+        beta_normal = self._require_finite_scalar(beta, "beta") * self.beta_scale
 
         if delta is not None:
             self.offsets["delta"] = self._require_finite_scalar(delta, "delta")
@@ -828,7 +982,8 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         This method reads the normal emission angles implied by another DataArray's
         current offsets and applies the same normal emission angles to the current data.
 
-        The azimuthal offset :math:`\delta` is copied as well.
+        The azimuthal offset :math:`\delta` and angle-scale compensation factors
+        are copied as well.
 
         Parameters
         ----------
@@ -846,15 +1001,19 @@ class MomentumAccessor(ERLabDataArrayAccessor):
             raise TypeError("`other` must be an xarray.DataArray.")
 
         self.set_normal(
-            *other.kspace._normal_emission_angles(), delta=other.kspace.offsets["delta"]
+            *other.kspace._normal_emission_angles(),
+            delta=other.kspace.offsets["delta"],
+            alpha_scale=other.kspace.alpha_scale,
+            beta_scale=other.kspace.beta_scale,
         )
 
     @_only_angles
     def _normal_emission_angles(self) -> tuple[float, float]:
         """Calculate the normal emission angles based on the current offsets."""
-        return erlab.analysis.kspace._normal_emission_from_angle_params(
+        alpha, beta = erlab.analysis.kspace._normal_emission_from_angle_params(
             self.configuration, self.angle_params
         )
+        return alpha / self.alpha_scale, beta / self.beta_scale
 
     @property
     @_only_angles
@@ -868,6 +1027,9 @@ class MomentumAccessor(ERLabDataArrayAccessor):
             \Delta k_{\parallel} \sim \sqrt{2 m_e E_k/\hbar^2} \cos(\alpha) \Delta\alpha
 
         """
+        return self._best_kp_resolution(self.slit_axis)
+
+    def _best_kp_resolution(self, axis: typing.Literal["kx", "ky"]) -> float:
         self._check_kinetic_energy(context="estimating in-plane momentum resolution")
         kinetic = np.asarray(self._kinetic_energy.values, dtype=float)
         finite_positive = kinetic[np.isfinite(kinetic) & (kinetic > 0)]
@@ -877,12 +1039,21 @@ class MomentumAccessor(ERLabDataArrayAccessor):
                 "contains no positive values."
             )
         min_Ek = np.amin(finite_positive)
-        max_angle = max(np.abs(self._alpha.values))
+        if axis == self.slit_axis:
+            angle_coord = self._alpha
+            angle_scale = self.alpha_scale
+        elif axis == self.other_axis:
+            angle_coord = self._beta
+            angle_scale = self.beta_scale
+        else:
+            raise ValueError(f"`{axis}` is not a valid in-plane momentum axis.")
+
+        max_angle = max(np.abs(angle_coord.values))
         return float(
             erlab.constants.rel_kconv
             * np.sqrt(min_Ek)
             * np.cos(np.deg2rad(max_angle))
-            * np.deg2rad(self.angle_resolution)
+            * np.deg2rad(self.angle_resolution * angle_scale)
         )
 
     @property
@@ -1021,7 +1192,7 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         if axis == "kz":
             return self.best_kz_resolution
 
-        return self.best_kp_resolution
+        return self._best_kp_resolution(axis)
 
     def _forward_func(self, alpha, beta):
         return erlab.analysis.kspace.get_kconv_forward(self.configuration)(
@@ -1171,6 +1342,10 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         """
         if name == "eV":
             return self._binding_energy
+        if name == "alpha":
+            return self._alpha
+        if name == "beta":
+            return self._beta
         return self._obj[name]
 
     @_only_angles

--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -1030,15 +1030,11 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         return self._best_kp_resolution(self.slit_axis)
 
     def _best_kp_resolution(self, axis: typing.Literal["kx", "ky"]) -> float:
-        self._check_kinetic_energy(context="estimating in-plane momentum resolution")
-        kinetic = np.asarray(self._kinetic_energy.values, dtype=float)
-        finite_positive = kinetic[np.isfinite(kinetic) & (kinetic > 0)]
-        if finite_positive.size == 0:
-            raise ValueError(
-                "Cannot estimate in-plane momentum resolution: kinetic energy "
-                "contains no positive values."
-            )
-        min_Ek = np.amin(finite_positive)
+        kinetic_energy = self._check_kinetic_energy(
+            context="estimating in-plane momentum resolution"
+        )
+        kinetic = np.asarray(kinetic_energy, dtype=float)
+        min_Ek = np.amin(kinetic[np.isfinite(kinetic)])
         if axis == self.slit_axis:
             angle_coord = self._alpha
             angle_scale = self.alpha_scale

--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -337,7 +337,8 @@ class AngleScaleView:
     r"""A view of angle-scale compensation factors for momentum conversion.
 
     The scale factors compensate extrinsic warping in the stored angle coordinates.
-    Missing scale attributes default to ``1.0``.
+    Missing scale attributes default to ``1.0``. Momentum conversion uses ``raw angle *
+    scale`` for each axis.
     """
 
     def __init__(self, xarray_obj: xr.DataArray) -> None:
@@ -545,6 +546,11 @@ class MomentumAccessor(ERLabDataArrayAccessor):
     def angle_scales(self) -> AngleScaleView:
         """Angle-scale compensation factors used in momentum conversion.
 
+        The mapping has ``"alpha"`` and ``"beta"`` keys. Values are stored in the
+        DataArray attributes ``alpha_scale`` and ``beta_scale`` and must be finite
+        positive scalars. Use these factors sparingly to compensate known extrinsic
+        angle-coordinate warping.
+
         .. versionadded:: 3.24.0
         """
         if not hasattr(self, "_anglescaleview"):
@@ -561,7 +567,10 @@ class MomentumAccessor(ERLabDataArrayAccessor):
 
     @property
     def alpha_scale(self) -> float:
-        """Alpha-axis scale compensation factor."""
+        """Alpha-axis scale compensation factor.
+
+        .. versionadded:: 3.24.0
+        """
         return self.angle_scales["alpha"]
 
     @alpha_scale.setter
@@ -570,7 +579,10 @@ class MomentumAccessor(ERLabDataArrayAccessor):
 
     @property
     def beta_scale(self) -> float:
-        """Beta-axis scale compensation factor."""
+        """Beta-axis scale compensation factor.
+
+        .. versionadded:: 3.24.0
+        """
         return self.angle_scales["beta"]
 
     @beta_scale.setter

--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -557,7 +557,9 @@ class MomentumAccessor(ERLabDataArrayAccessor):
     def _is_energy_kinetic(self) -> bool:
         """Check if the energy axis is in binding energy."""
         # If scalar, may be a constant energy contour above EF
-        return self._obj.eV.values.size > 1 and (self._obj.eV.values.min() > 0)
+        values = np.asarray(self._obj.eV.values, dtype=float)
+        finite = values[np.isfinite(values)]
+        return values.size > 1 and finite.size > 0 and np.min(finite) > 0.0
 
     @property
     def _binding_energy(self) -> xr.DataArray:
@@ -867,7 +869,14 @@ class MomentumAccessor(ERLabDataArrayAccessor):
 
         """
         self._check_kinetic_energy(context="estimating in-plane momentum resolution")
-        min_Ek = np.amin(self._kinetic_energy.values)
+        kinetic = np.asarray(self._kinetic_energy.values, dtype=float)
+        finite_positive = kinetic[np.isfinite(kinetic) & (kinetic > 0)]
+        if finite_positive.size == 0:
+            raise ValueError(
+                "Cannot estimate in-plane momentum resolution: kinetic energy "
+                "contains no positive values."
+            )
+        min_Ek = np.amin(finite_positive)
         max_angle = max(np.abs(self._alpha.values))
         return float(
             erlab.constants.rel_kconv

--- a/src/erlab/interactive/imagetool/_kspace_conversion.py
+++ b/src/erlab/interactive/imagetool/_kspace_conversion.py
@@ -428,7 +428,10 @@ def normal_emission_angles(
     alpha, beta = erlab.analysis.kspace._normal_emission_from_angle_params(
         data.kspace.configuration, angle_params
     )
-    return float(np.round(alpha, 5)), float(np.round(beta, 5))
+    return (
+        float(np.round(alpha / data.kspace.alpha_scale, 5)),
+        float(np.round(beta / data.kspace.beta_scale, 5)),
+    )
 
 
 def apply_kspace_parameters(
@@ -442,11 +445,19 @@ def apply_kspace_parameters(
     offsets: Mapping[str, float] | None = None,
     normal_emission: tuple[float, float] | None = None,
     delta: float | None = None,
+    alpha_scale: float | None = None,
+    beta_scale: float | None = None,
 ) -> xr.DataArray:
     if offsets is not None:
         data.kspace.offsets = offsets
     elif normal_emission is not None:
-        data.kspace.set_normal(normal_emission[0], normal_emission[1], delta=delta)
+        data.kspace.set_normal(
+            normal_emission[0],
+            normal_emission[1],
+            delta=delta,
+            alpha_scale=alpha_scale,
+            beta_scale=beta_scale,
+        )
 
     if data.kspace._has_hv and inner_potential is not None:
         with ignore_missing_kspace_parameter_warnings():
@@ -481,6 +492,8 @@ def kspace_conversion_operations(
     bounds: dict[str, tuple[float, float]] | None,
     resolution: dict[str, float] | None,
     force_scalars: bool,
+    alpha_scale: float | None = None,
+    beta_scale: float | None = None,
 ) -> tuple[provenance.ToolProvenanceOperation, ...]:
     operations: list[provenance.ToolProvenanceOperation] = []
     focuses: list[str] = []
@@ -517,11 +530,18 @@ def kspace_conversion_operations(
         )
         focuses.append(_FOCUS_WORK_FUNCTION)
 
+    if alpha_scale is None:
+        alpha_scale = configured_data.kspace.alpha_scale
+    if beta_scale is None:
+        beta_scale = configured_data.kspace.beta_scale
+
     operations.append(
         provenance.KspaceSetNormalOperation(
             alpha=float(normal_emission[0]),
             beta=float(normal_emission[1]),
             delta=None if delta is None else float(delta),
+            alpha_scale=None if np.isclose(alpha_scale, 1.0) else float(alpha_scale),
+            beta_scale=None if np.isclose(beta_scale, 1.0) else float(beta_scale),
         )
     )
     focuses.append(_FOCUS_NORMAL)

--- a/src/erlab/interactive/imagetool/_kspace_conversion.py
+++ b/src/erlab/interactive/imagetool/_kspace_conversion.py
@@ -75,7 +75,7 @@ class KspaceConversionEstimate:
 
     @property
     def is_safe(self) -> bool:
-        return self.peak_bytes <= self.memory.safe_budget_bytes
+        return self.final_bytes <= self.memory.available_bytes
 
 
 class KspaceConversionMemoryError(MemoryError):
@@ -84,7 +84,7 @@ class KspaceConversionMemoryError(MemoryError):
     def __init__(self, estimate: KspaceConversionEstimate) -> None:
         self.estimate = estimate
         super().__init__(
-            "The requested momentum grid is too large for the current memory budget."
+            "The requested momentum grid is too large for currently available memory."
         )
 
 
@@ -351,7 +351,7 @@ def kspace_conversion_estimate_text(
     estimate_summary = (
         f"Output: {_format_sizes(estimate.output_sizes)}\n"
         f"Final array: {_format_bytes(estimate.final_bytes)}\n"
-        f"Peak memory: {_format_bytes(estimate.peak_bytes)}"
+        f"Available memory: {_format_bytes(estimate.memory.available_bytes)}"
     )
     if estimate.is_safe:
         return estimate_summary
@@ -373,14 +373,15 @@ def kspace_conversion_memory_dialog_title() -> str:
 
 
 def kspace_conversion_memory_dialog_text() -> str:
-    return "The requested momentum grid is too large for the current memory budget."
+    return "The requested momentum grid is too large for currently available memory."
 
 
 def kspace_conversion_memory_dialog_info(
     estimate: KspaceConversionEstimate,
 ) -> str:
     return (
-        f"Estimated memory required: {_format_bytes(estimate.peak_bytes)}. "
+        f"Final array estimate: {_format_bytes(estimate.final_bytes)}. "
+        f"Available physical memory: {_format_bytes(estimate.memory.available_bytes)}. "
         "Increase the resolution value or reduce the bounds."
     )
 
@@ -394,10 +395,9 @@ def kspace_conversion_memory_dialog_details(
         f"Bounds: {_format_numeric_mapping(estimate.bounds)}",
         f"Resolution: {_format_numeric_mapping(estimate.resolution)}",
         f"Final array estimate: {_format_bytes(estimate.final_bytes)}",
-        f"Peak estimate: {_format_bytes(estimate.peak_bytes)}",
         f"Available physical memory: {_format_bytes(estimate.memory.available_bytes)}",
+        f"Peak estimate: {_format_bytes(estimate.peak_bytes)}",
         f"Reserve: {_format_bytes(estimate.memory.reserve_bytes)}",
-        f"Safe budget: {_format_bytes(estimate.memory.safe_budget_bytes)}",
         "Swap is intentionally not treated as usable memory.",
     ]
     return "<br>".join(html.escape(line) for line in lines)

--- a/src/erlab/interactive/imagetool/_kspace_conversion.py
+++ b/src/erlab/interactive/imagetool/_kspace_conversion.py
@@ -259,17 +259,27 @@ def estimate_kspace_conversion(
     effective_bounds: dict[str, tuple[float, float]] = {}
     effective_resolution: dict[str, float] = {}
     axis_sizes: dict[str, int] = {}
-    estimated_bounds = data.kspace.estimate_bounds()
-    for axis, estimated_lims in estimated_bounds.items():
-        if axis not in data.kspace.momentum_axes:
+    momentum_axes = tuple(data.kspace.momentum_axes)
+    estimated_bounds: dict[str, tuple[float, float]] = {}
+    if any(axis not in bounds for axis in momentum_axes):
+        estimated_bounds = data.kspace.estimate_bounds()
+
+    for axis in momentum_axes:
+        if axis in bounds:
+            lims = _validated_bounds(axis, bounds[axis])
+        elif axis in estimated_bounds:
+            lims = _validated_bounds(axis, estimated_bounds[axis])
+        else:
             continue
 
-        lims = _validated_bounds(axis, bounds.get(axis, estimated_lims))
-        res = data.kspace.estimate_resolution(axis, lims, from_numpoints=False)
-        if axis == "kz":
-            res_n = data.kspace.estimate_resolution(axis, lims, from_numpoints=True)
-            res = min(res, res_n)
-        res = _validated_resolution(axis, resolution.get(axis, res))
+        if axis in resolution:
+            res = _validated_resolution(axis, resolution[axis])
+        else:
+            res = data.kspace.estimate_resolution(axis, lims, from_numpoints=False)
+            if axis == "kz":
+                res_n = data.kspace.estimate_resolution(axis, lims, from_numpoints=True)
+                res = min(res, res_n)
+            res = _validated_resolution(axis, res)
 
         effective_bounds[axis] = lims
         effective_resolution[axis] = res
@@ -350,8 +360,7 @@ def kspace_conversion_estimate_text(
     """Return concise inline feedback for a conversion estimate."""
     estimate_summary = (
         f"Output: {_format_sizes(estimate.output_sizes)}\n"
-        f"Final array: {_format_bytes(estimate.final_bytes)}\n"
-        f"Available memory: {_format_bytes(estimate.memory.available_bytes)}"
+        f"Final array: {_format_bytes(estimate.final_bytes)}"
     )
     if estimate.is_safe:
         return estimate_summary
@@ -362,18 +371,18 @@ def kspace_conversion_estimate_text(
             "Increase resolution or reduce bounds."
         )
     return (
-        "Conversion unavailable.\n"
+        "Open in ImageTool unavailable.\n"
         f"{estimate_summary}\n"
         "Increase resolution or reduce bounds."
     )
 
 
 def kspace_conversion_memory_dialog_title() -> str:
-    return "Conversion Cannot Be Completed Safely"
+    return "Momentum Conversion Is Too Large"
 
 
 def kspace_conversion_memory_dialog_text() -> str:
-    return "The requested momentum grid is too large for currently available memory."
+    return "The full converted volume would not fit in available memory."
 
 
 def kspace_conversion_memory_dialog_info(
@@ -381,8 +390,8 @@ def kspace_conversion_memory_dialog_info(
 ) -> str:
     return (
         f"Final array estimate: {_format_bytes(estimate.final_bytes)}. "
-        f"Available physical memory: {_format_bytes(estimate.memory.available_bytes)}. "
-        "Increase the resolution value or reduce the bounds."
+        "Increase the resolution value, reduce the bounds, or convert a smaller "
+        "source volume."
     )
 
 
@@ -390,15 +399,9 @@ def kspace_conversion_memory_dialog_details(
     estimate: KspaceConversionEstimate,
 ) -> str:
     lines = [
-        f"Axis sizes: {_format_sizes(estimate.axis_sizes)}",
-        f"Output sizes: {_format_sizes(estimate.output_sizes)}",
+        f"Output grid: {_format_sizes(estimate.output_sizes)}",
         f"Bounds: {_format_numeric_mapping(estimate.bounds)}",
         f"Resolution: {_format_numeric_mapping(estimate.resolution)}",
-        f"Final array estimate: {_format_bytes(estimate.final_bytes)}",
-        f"Available physical memory: {_format_bytes(estimate.memory.available_bytes)}",
-        f"Peak estimate: {_format_bytes(estimate.peak_bytes)}",
-        f"Reserve: {_format_bytes(estimate.memory.reserve_bytes)}",
-        "Swap is intentionally not treated as usable memory.",
     ]
     return "<br>".join(html.escape(line) for line in lines)
 

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -1398,6 +1398,7 @@ class KspaceConversionDialog(DataTransformDialog):
             return False
         configuration = int(ktool.current_configuration)
         self._set_control_configuration(configuration)
+        self._control_data.kspace.angle_scales = ktool.data.kspace.angle_scales
         self._rebuild_kspace_controls(
             initial_normal_emission=ktool._current_normal_emission_angles(),
             initial_delta=ktool.offset_dict["delta"],
@@ -1496,6 +1497,8 @@ class KspaceConversionDialog(DataTransformDialog):
             force_inner_potential=True,
             normal_emission=self.normal_emission,
             delta=self._normal_delta,
+            alpha_scale=self._control_data.kspace.alpha_scale,
+            beta_scale=self._control_data.kspace.beta_scale,
         )
 
     def _conversion_input_for_data(self, data: xr.DataArray) -> xr.DataArray:
@@ -1620,6 +1623,8 @@ class KspaceConversionDialog(DataTransformDialog):
             inner_potential=self._inner_potential,
             normal_emission=self.normal_emission,
             delta=self._normal_delta,
+            alpha_scale=self._control_data.kspace.alpha_scale,
+            beta_scale=self._control_data.kspace.beta_scale,
             bounds=self.bounds,
             resolution=self.resolution,
             force_scalars=True,
@@ -1675,6 +1680,7 @@ class KspaceConversionDialog(DataTransformDialog):
         delta: float | None = None
         bounds: dict[str, tuple[float, float]] | None = None
         resolution: dict[str, float] | None = None
+        restored_angle_scales = False
         for operation in operations:
             if isinstance(operation, provenance.KspaceConfigurationOperation):
                 self._set_control_configuration(operation.configuration)
@@ -1689,6 +1695,12 @@ class KspaceConversionDialog(DataTransformDialog):
             elif isinstance(operation, provenance.KspaceSetNormalOperation):
                 normal = (operation.alpha, operation.beta)
                 delta = operation.delta
+                if operation.alpha_scale is not None:
+                    self._control_data.kspace.alpha_scale = operation.alpha_scale
+                    restored_angle_scales = True
+                if operation.beta_scale is not None:
+                    self._control_data.kspace.beta_scale = operation.beta_scale
+                    restored_angle_scales = True
             elif isinstance(operation, provenance.KspaceConvertOperation):
                 bounds = operation.bounds
                 resolution = operation.resolution
@@ -1696,6 +1708,9 @@ class KspaceConversionDialog(DataTransformDialog):
         if normal is not None:
             self._normal_delta = delta
             self._set_normal_emission_spins(normal)
+        if restored_angle_scales:
+            self.calculate_bounds()
+            self.calculate_resolution()
         self.bounds_supergroup.setChecked(bounds is not None)
         if bounds is not None:
             for axis, values in bounds.items():

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -388,6 +388,8 @@ class _ManagedWindowNode(QtCore.QObject):
             with contextlib.suppress(TypeError, RuntimeError):
                 old.sigInfoChanged.disconnect(self._handle_tool_info_changed)
             with contextlib.suppress(TypeError, RuntimeError):
+                old.sigStateChanged.disconnect(self._handle_tool_state_changed)
+            with contextlib.suppress(TypeError, RuntimeError):
                 old.sigDataChanged.disconnect(self._handle_tool_data_changed)
             old.removeEventFilter(self)
             old._set_managed_source_update_dialog(None)
@@ -436,6 +438,7 @@ class _ManagedWindowNode(QtCore.QObject):
         self.manager._register_interaction_window(tool)
         tool.installEventFilter(self)
         tool.sigInfoChanged.connect(self._handle_tool_info_changed)
+        tool.sigStateChanged.connect(self._handle_tool_state_changed)
         tool.sigDataChanged.connect(self._handle_tool_data_changed)
         tool.destroyed.connect(self._handle_tool_window_destroyed)
         tool._set_managed_source_update_dialog(self.show_source_update_dialog)
@@ -1419,6 +1422,16 @@ class _ManagedWindowNode(QtCore.QObject):
             return
         manager._update_figure_gallery_icon(self.uid)
         manager._update_info(uid=self.uid)
+
+    @QtCore.Slot()
+    def _handle_tool_state_changed(self) -> None:
+        manager = self._manager()
+        if manager is None or not erlab.interactive.utils.qt_is_valid(manager):
+            return
+        if manager._tool_graph.nodes.get(self.uid) is not self:
+            return
+        manager._note_interaction_activity()
+        manager._mark_node_state_dirty(self.uid)
 
     @QtCore.Slot()
     def _handle_imagetool_state_changed(self) -> None:

--- a/src/erlab/interactive/imagetool/provenance.py
+++ b/src/erlab/interactive/imagetool/provenance.py
@@ -1913,19 +1913,25 @@ class KspaceSetNormalOperation(_MutatingKspaceOperation):
     console_patterns: typing.ClassVar[tuple[ConsoleOperationPattern, ...]] = (
         ConsoleOperationPattern(
             accessor_path=("kspace", "set_normal"),
-            fields=("alpha", "beta"),
-            defaults={"delta": None},
+            fields=("alpha", "beta", "alpha_scale", "beta_scale"),
+            defaults={"delta": None, "alpha_scale": None, "beta_scale": None},
         ),
     )
     alpha: float
     beta: float
     delta: float | None = None
+    alpha_scale: float | None = None
+    beta_scale: float | None = None
 
     @property
     def kwargs(self) -> dict[str, float]:
         kwargs = {"alpha": self.alpha, "beta": self.beta}
         if self.delta is not None:
             kwargs["delta"] = self.delta
+        if self.alpha_scale is not None and not np.isclose(self.alpha_scale, 1.0):
+            kwargs["alpha_scale"] = self.alpha_scale
+        if self.beta_scale is not None and not np.isclose(self.beta_scale, 1.0):
+            kwargs["beta_scale"] = self.beta_scale
         return kwargs
 
     def derivation_label(self) -> str:

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -913,7 +913,9 @@ class KspaceTool(KspaceToolGUI):
 
         self._angle_scale_spins = {}
         for axis in ("alpha", "beta"):
-            if axis not in self.data.coords:
+            if axis not in self.data.coords:  # pragma: no cover
+                # Kept defensive for externally supplied tool data; supported ktool
+                # inputs currently require both angle coordinates during conversion.
                 continue
             spin = QtWidgets.QDoubleSpinBox()
             spin.setObjectName(f"ktool{axis.title()}Scale")

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -1435,7 +1435,12 @@ class KspaceTool(KspaceToolGUI):
         )
 
     def _sync_angle_scales(self) -> None:
-        self.data.kspace.angle_scales = self.angle_scale_dict
+        for axis, scale in self.angle_scale_dict.items():
+            attr_key = f"{axis}_scale"
+            if scale == 1.0:
+                self.data.attrs.pop(attr_key, None)
+            else:
+                self.data.kspace.angle_scales[axis] = scale
 
     @QtCore.Slot(float)
     def _handle_angle_scale_changed(self, _value: float) -> None:

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 __all__ = ["ktool"]
 
+import dataclasses
 import enum
 import hashlib
 import importlib.resources
@@ -394,6 +395,7 @@ class KspaceTool(KspaceToolGUI):
     }
     _sigTriggerUpdate = QtCore.Signal()
     _UPDATE_LIMIT_HZ = 10.0
+    _MANAGER_NOTIFY_DELAY_MS = 250
     data: xr.DataArray
     _source_configuration: int
     _offset_spins: dict[str, QtWidgets.QDoubleSpinBox]
@@ -402,6 +404,8 @@ class KspaceTool(KspaceToolGUI):
     _resolution_spins: dict[str, QtWidgets.QDoubleSpinBox]
     _bz_cache_key: typing.Any
     _bz_cache_value: typing.Any
+    _preview_memory_estimate_key_value: tuple[typing.Any, ...] | None
+    _preview_memory_estimate: _kspace_conversion.KspaceConversionEstimate | None
 
     @property
     def preview_imageitem(self) -> pg.ImageItem:
@@ -536,6 +540,7 @@ class KspaceTool(KspaceToolGUI):
         self.data = self.data.kspace.as_configuration(configuration)
         self._bz_cache_key = None
         self._bz_cache_value = None
+        self._invalidate_preview_memory_estimate()
         with self._history_suppressed():
             self._rebuild_kspace_controls()
             self._sync_aspect_lock()
@@ -735,6 +740,8 @@ class KspaceTool(KspaceToolGUI):
         self._itool: QtWidgets.QWidget | None = None
         self._bz_cache_key = None
         self._bz_cache_value = None
+        self._preview_memory_estimate_key_value = None
+        self._preview_memory_estimate = None
 
         if data_name is None:
             try:
@@ -759,6 +766,12 @@ class KspaceTool(KspaceToolGUI):
             delay=1 / self._UPDATE_LIMIT_HZ,
             rateLimit=self._UPDATE_LIMIT_HZ,
             slot=self._flush_debounced_update,
+        )
+        self._manager_notify_timer = QtCore.QTimer(self)
+        self._manager_notify_timer.setSingleShot(True)
+        self._manager_notify_timer.setInterval(self._MANAGER_NOTIFY_DELAY_MS)
+        self._manager_notify_timer.timeout.connect(
+            self._flush_debounced_manager_notification
         )
         self._energy_controls_connected: bool = False
 
@@ -974,6 +987,7 @@ class KspaceTool(KspaceToolGUI):
         self._source_configuration = source_configuration
         self._bz_cache_key = None
         self._bz_cache_value = None
+        self._invalidate_preview_memory_estimate()
         self._set_configuration_combo(self.data.kspace.configuration)
         with self._history_suppressed():
             self._rebuild_kspace_controls()
@@ -1095,6 +1109,17 @@ class KspaceTool(KspaceToolGUI):
     def _flush_debounced_update(self, _args: object) -> None:
         self.update()
 
+    def _queue_debounced_manager_notification(self) -> None:
+        self._manager_notify_timer.start()
+
+    @QtCore.Slot()
+    def _flush_debounced_manager_notification(self) -> None:
+        self._notify_data_changed()
+
+    def _notify_ktool_state_changed(self) -> None:
+        self.sigStateChanged.emit()
+        self._queue_debounced_manager_notification()
+
     @property
     def _work_function(self) -> float:
         return float(
@@ -1110,6 +1135,83 @@ class KspaceTool(KspaceToolGUI):
                 self._offset_spins["V0"].value(), self._offset_spins["V0"].decimals()
             )
         )
+
+    def _invalidate_preview_memory_estimate(self) -> None:
+        self._preview_memory_estimate_key_value = None
+        self._preview_memory_estimate = None
+
+    @staticmethod
+    def _mapping_token(
+        mapping: dict[str, float] | dict[str, tuple[float, float]] | None,
+        axes: tuple[str, ...],
+    ) -> tuple[typing.Any, ...] | None:
+        if mapping is None:
+            return None
+        return tuple((axis, mapping[axis]) for axis in axes if axis in mapping)
+
+    def _preview_slice_token(self) -> tuple[typing.Any, ...] | None:
+        if not self.data.kspace._has_eV:
+            return None
+        if self._shows_full_energy_cut():
+            return ("full",)
+        return (
+            "slice",
+            float(np.round(self.center_spin.value(), self.center_spin.decimals())),
+            int(self.width_spin.value()),
+        )
+
+    def _preview_memory_estimate_key(
+        self,
+        data: xr.DataArray,
+        bounds: dict[str, tuple[float, float]] | None,
+        resolution: dict[str, float] | None,
+    ) -> tuple[typing.Any, ...]:
+        momentum_axes = tuple(self.data.kspace.momentum_axes)
+        return (
+            id(self.data),
+            id(self.data.data),
+            tuple(str(dim) for dim in self.data.dims),
+            tuple(int(self.data.sizes[dim]) for dim in self.data.dims),
+            self._preview_slice_token(),
+            tuple(str(dim) for dim in data.dims),
+            tuple(int(data.sizes[dim]) for dim in data.dims),
+            int(self.current_configuration),
+            tuple((key, self.offset_dict[key]) for key in sorted(self.offset_dict)),
+            self._work_function,
+            self._inner_potential if self.data.kspace._has_hv else None,
+            self.bounds_supergroup.isChecked(),
+            self._mapping_token(bounds, momentum_axes),
+            self.resolution_supergroup.isChecked(),
+            self._mapping_token(resolution, momentum_axes),
+        )
+
+    def _preview_conversion_estimate(
+        self,
+        data: xr.DataArray,
+    ) -> _kspace_conversion.KspaceConversionEstimate:
+        bounds = self.bounds
+        resolution = self.resolution
+        key = self._preview_memory_estimate_key(data, bounds, resolution)
+        if key == self._preview_memory_estimate_key_value:
+            estimate = self._preview_memory_estimate
+            if estimate is not None:
+                estimate = dataclasses.replace(
+                    estimate,
+                    memory=_kspace_conversion.system_memory_budget(),
+                )
+                self._preview_memory_estimate = estimate
+                self._set_memory_estimate(estimate, preview=True)
+                return estimate
+
+        estimate = _kspace_conversion.estimate_kspace_conversion(
+            data,
+            bounds=bounds,
+            resolution=resolution,
+        )
+        self._set_memory_estimate(estimate, preview=True)
+        self._preview_memory_estimate_key_value = key
+        self._preview_memory_estimate = estimate
+        return estimate
 
     def _set_memory_estimate(
         self,
@@ -1417,7 +1519,9 @@ class KspaceTool(KspaceToolGUI):
         return data_ang
 
     def _preview_kspace_data(self, data_ang: xr.DataArray) -> xr.DataArray:
-        self._validate_conversion_memory(self._prepared_output_data(), preview=True)
+        estimate = self._preview_conversion_estimate(data_ang)
+        if not estimate.is_safe:
+            raise _kspace_conversion.KspaceConversionMemoryError(estimate)
         return data_ang.kspace.convert(
             bounds=self.bounds, resolution=self.resolution, silent=True
         )
@@ -1427,18 +1531,26 @@ class KspaceTool(KspaceToolGUI):
         data_k = self._preview_kspace_data(data_ang)
         return data_ang, data_k
 
+    def _clear_kspace_preview_for_memory_refusal(
+        self,
+        angle_data: xr.DataArray | None = None,
+    ) -> None:
+        if angle_data is None:
+            angle_data = self._preview_angle_data()
+        self.images[0].setDataArray(angle_data.T)
+        self.images[1].clear()
+        self.images[1].data_array = None
+        self._set_preview_symmetry_available(False)
+        self._set_bz_available(False)
+        self._notify_ktool_state_changed()
+
     @QtCore.Slot()
     def update(self) -> None:
         try:
             ang, k = self.get_data()
         except _kspace_conversion.KspaceConversionMemoryError:
             ang = self._preview_angle_data()
-            self.images[0].setDataArray(ang.T)
-            self.images[1].clear()
-            self.images[1].data_array = None
-            self._set_preview_symmetry_available(False)
-            self._set_bz_available(False)
-            self._notify_data_changed()
+            self._clear_kspace_preview_for_memory_refusal(ang)
             self._write_state()
             return
         k_preview = k.T
@@ -1450,7 +1562,7 @@ class KspaceTool(KspaceToolGUI):
         self._set_bz_available(bz_available)
         self.images[0].setDataArray(ang.T)
         self.images[1].setDataArray(k_preview)
-        self._notify_data_changed()
+        self._notify_ktool_state_changed()
         if bz_available and self.bz_group.isChecked():
             self.update_bz()
         self._write_state()

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -395,6 +395,7 @@ class KspaceTool(KspaceToolGUI):
     }
     _sigTriggerUpdate = QtCore.Signal()
     _UPDATE_LIMIT_HZ = 10.0
+    _OUTPUT_MEMORY_ESTIMATE_DELAY_MS = 250
     _MANAGER_NOTIFY_DELAY_MS = 250
     data: xr.DataArray
     _source_configuration: int
@@ -407,6 +408,9 @@ class KspaceTool(KspaceToolGUI):
     _bz_cache_value: typing.Any
     _preview_memory_estimate_key_value: tuple[typing.Any, ...] | None
     _preview_memory_estimate: _kspace_conversion.KspaceConversionEstimate | None
+    _output_memory_estimate_key_value: tuple[typing.Any, ...] | None
+    _output_memory_estimate: _kspace_conversion.KspaceConversionEstimate | None
+    _pending_output_memory_preview_unavailable: bool
 
     @property
     def preview_imageitem(self) -> pg.ImageItem:
@@ -756,6 +760,9 @@ class KspaceTool(KspaceToolGUI):
         self._bz_cache_value = None
         self._preview_memory_estimate_key_value = None
         self._preview_memory_estimate = None
+        self._output_memory_estimate_key_value = None
+        self._output_memory_estimate = None
+        self._pending_output_memory_preview_unavailable = False
 
         if data_name is None:
             try:
@@ -786,6 +793,14 @@ class KspaceTool(KspaceToolGUI):
         self._manager_notify_timer.setInterval(self._MANAGER_NOTIFY_DELAY_MS)
         self._manager_notify_timer.timeout.connect(
             self._flush_debounced_manager_notification
+        )
+        self._output_memory_estimate_timer = QtCore.QTimer(self)
+        self._output_memory_estimate_timer.setSingleShot(True)
+        self._output_memory_estimate_timer.setInterval(
+            self._OUTPUT_MEMORY_ESTIMATE_DELAY_MS
+        )
+        self._output_memory_estimate_timer.timeout.connect(
+            self._flush_output_memory_estimate
         )
         self._energy_controls_connected: bool = False
 
@@ -925,7 +940,8 @@ class KspaceTool(KspaceToolGUI):
             spin.setValue(self.data.kspace.angle_scales[axis])
             spin.valueChanged.connect(self._handle_angle_scale_changed)
             self._angle_scale_spins[axis] = spin
-            self.offsets_group.layout().addRow(f"{axis} scale", spin)
+            axis_label = self._NORMAL_EMISSION_LABELS.get(axis, axis)
+            self.offsets_group.layout().addRow(f"{axis_label} scale", spin)
 
         self._normal_emission_spins = {}
         for axis, label in self._NORMAL_EMISSION_LABELS.items():
@@ -1160,6 +1176,8 @@ class KspaceTool(KspaceToolGUI):
     def _invalidate_preview_memory_estimate(self) -> None:
         self._preview_memory_estimate_key_value = None
         self._preview_memory_estimate = None
+        self._output_memory_estimate_key_value = None
+        self._output_memory_estimate = None
 
     @staticmethod
     def _mapping_token(
@@ -1210,6 +1228,31 @@ class KspaceTool(KspaceToolGUI):
             self._mapping_token(resolution, momentum_axes),
         )
 
+    def _output_memory_estimate_key(
+        self,
+        bounds: dict[str, tuple[float, float]] | None,
+        resolution: dict[str, float] | None,
+    ) -> tuple[typing.Any, ...]:
+        momentum_axes = tuple(self.data.kspace.momentum_axes)
+        return (
+            id(self.data),
+            id(self.data.data),
+            tuple(str(dim) for dim in self.data.dims),
+            tuple(int(self.data.sizes[dim]) for dim in self.data.dims),
+            tuple(
+                (axis, round(spin.value(), spin.decimals()))
+                for axis, spin in self._angle_scale_spins.items()
+            ),
+            int(self.current_configuration),
+            tuple((key, self.offset_dict[key]) for key in sorted(self.offset_dict)),
+            self._work_function,
+            self._inner_potential if self.data.kspace._has_hv else None,
+            self.bounds_supergroup.isChecked(),
+            self._mapping_token(bounds, momentum_axes),
+            self.resolution_supergroup.isChecked(),
+            self._mapping_token(resolution, momentum_axes),
+        )
+
     def _preview_conversion_estimate(
         self,
         data: xr.DataArray,
@@ -1225,7 +1268,6 @@ class KspaceTool(KspaceToolGUI):
                     memory=_kspace_conversion.system_memory_budget(),
                 )
                 self._preview_memory_estimate = estimate
-                self._set_memory_estimate(estimate, preview=True)
                 return estimate
 
         estimate = _kspace_conversion.estimate_kspace_conversion(
@@ -1233,9 +1275,38 @@ class KspaceTool(KspaceToolGUI):
             bounds=bounds,
             resolution=resolution,
         )
-        self._set_memory_estimate(estimate, preview=True)
         self._preview_memory_estimate_key_value = key
         self._preview_memory_estimate = estimate
+        return estimate
+
+    def _output_conversion_estimate(
+        self,
+    ) -> _kspace_conversion.KspaceConversionEstimate:
+        bounds = self.bounds
+        resolution = self.resolution
+        key = self._output_memory_estimate_key(bounds, resolution)
+        if key == self._output_memory_estimate_key_value:
+            estimate = self._output_memory_estimate
+            if estimate is not None:
+                estimate = dataclasses.replace(
+                    estimate,
+                    memory=_kspace_conversion.system_memory_budget(),
+                )
+                self._output_memory_estimate = estimate
+                return estimate
+
+        data = self._assign_params(self.data.copy(deep=False))
+        self._validate_kinetic_energy(
+            data,
+            context="estimating converted ktool output",
+        )
+        estimate = _kspace_conversion.estimate_kspace_conversion(
+            data,
+            bounds=bounds,
+            resolution=resolution,
+        )
+        self._output_memory_estimate_key_value = key
+        self._output_memory_estimate = estimate
         return estimate
 
     def _set_memory_estimate(
@@ -1255,12 +1326,51 @@ class KspaceTool(KspaceToolGUI):
         self._memory_estimate_label.updateGeometry()
         self._memory_estimate_label.setProperty(
             "kspaceMemoryUnsafe",
-            not estimate.is_safe,
+            preview or not estimate.is_safe,
         )
         style = self._memory_estimate_label.style()
         if style is not None:
             style.unpolish(self._memory_estimate_label)
             style.polish(self._memory_estimate_label)
+
+    def _set_memory_estimate_error(self, message: str) -> None:
+        if not hasattr(self, "_memory_estimate_label"):
+            return
+        self._memory_estimate_label.setText(message)
+        self._memory_estimate_label.updateGeometry()
+        self._memory_estimate_label.setProperty("kspaceMemoryUnsafe", True)
+        style = self._memory_estimate_label.style()
+        if style is not None:
+            style.unpolish(self._memory_estimate_label)
+            style.polish(self._memory_estimate_label)
+
+    def _update_output_memory_estimate(
+        self,
+        *,
+        preview_unavailable: bool = False,
+    ) -> None:
+        try:
+            estimate = self._output_conversion_estimate()
+        except Exception as exc:
+            self._set_memory_estimate_error(str(exc))
+            return
+        self._set_memory_estimate(estimate, preview=preview_unavailable)
+
+    def _queue_output_memory_estimate(
+        self,
+        *,
+        preview_unavailable: bool = False,
+    ) -> None:
+        self._pending_output_memory_preview_unavailable = preview_unavailable
+        self._output_memory_estimate_timer.start()
+
+    @QtCore.Slot()
+    def _flush_output_memory_estimate(self) -> None:
+        preview_unavailable = self._pending_output_memory_preview_unavailable
+        self._pending_output_memory_preview_unavailable = False
+        self._update_output_memory_estimate(
+            preview_unavailable=preview_unavailable,
+        )
 
     def _conversion_estimate(
         self,
@@ -1596,6 +1706,7 @@ class KspaceTool(KspaceToolGUI):
         except _kspace_conversion.KspaceConversionMemoryError:
             ang = self._preview_angle_data()
             self._clear_kspace_preview_for_memory_refusal(ang)
+            self._queue_output_memory_estimate(preview_unavailable=True)
             self._write_state()
             return
         k_preview = k.T
@@ -1608,6 +1719,7 @@ class KspaceTool(KspaceToolGUI):
         self.images[0].setDataArray(ang.T)
         self.images[1].setDataArray(k_preview)
         self._notify_ktool_state_changed()
+        self._queue_output_memory_estimate()
         if bz_available and self.bz_group.isChecked():
             self.update_bz()
         self._write_state()

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -399,6 +399,7 @@ class KspaceTool(KspaceToolGUI):
     data: xr.DataArray
     _source_configuration: int
     _offset_spins: dict[str, QtWidgets.QDoubleSpinBox]
+    _angle_scale_spins: dict[str, QtWidgets.QDoubleSpinBox]
     _normal_emission_spins: dict[str, QtWidgets.QDoubleSpinBox]
     _bound_spins: dict[str, QtWidgets.QDoubleSpinBox]
     _resolution_spins: dict[str, QtWidgets.QDoubleSpinBox]
@@ -416,6 +417,7 @@ class KspaceTool(KspaceToolGUI):
         center: float
         width: int
         offsets: dict[str, float]
+        angle_scales: dict[str, float] = pydantic.Field(default_factory=dict)
         bounds_enabled: bool
         bounds: dict[str, float]
         resolution_enabled: bool
@@ -558,6 +560,10 @@ class KspaceTool(KspaceToolGUI):
                 k: round(spin.value(), spin.decimals())
                 for k, spin in self._offset_spins.items()
             },
+            angle_scales={
+                k: round(spin.value(), spin.decimals())
+                for k, spin in self._angle_scale_spins.items()
+            },
             bounds_enabled=self.bounds_supergroup.isChecked(),
             bounds={k: spin.value() for k, spin in self._bound_spins.items()},
             resolution_enabled=self.resolution_supergroup.isChecked(),
@@ -608,6 +614,14 @@ class KspaceTool(KspaceToolGUI):
             self._offset_spins[k].blockSignals(True)
             self._offset_spins[k].setValue(v)
             self._offset_spins[k].blockSignals(False)
+
+        for k, v in status.angle_scales.items():
+            if k not in self._angle_scale_spins:
+                continue
+            self._angle_scale_spins[k].blockSignals(True)
+            self._angle_scale_spins[k].setValue(v)
+            self._angle_scale_spins[k].blockSignals(False)
+        self._sync_angle_scales()
         self._sync_normal_emission_spins()
 
         self.bounds_supergroup.blockSignals(True)
@@ -798,15 +812,6 @@ class KspaceTool(KspaceToolGUI):
         self.preview_symmetry_group.toggled.connect(self.queue_update)
         self.preview_symmetry_fold_spin.valueChanged.connect(self.queue_update)
 
-        # Temporary customization for beta scaling
-        # self._beta_scale_spin = QtWidgets.QDoubleSpinBox()
-        # self._beta_scale_spin.setValue(1.0)
-        # self._beta_scale_spin.setDecimals(2)
-        # self._beta_scale_spin.setSingleStep(0.01)
-        # self._beta_scale_spin.setRange(0.01, 10)
-        # self.offsets_group.layout().addRow("scale", self._beta_scale_spin)
-        # self._beta_scale_spin.valueChanged.connect(self.update)
-
         self._rebuild_kspace_controls(
             initial_normal_emission=initial_normal_emission,
             initial_delta=initial_delta,
@@ -905,6 +910,20 @@ class KspaceTool(KspaceToolGUI):
         self.offsets_group.layout().addRow(
             self._OFFSET_LABELS["wf"], self._offset_spins["wf"]
         )
+
+        self._angle_scale_spins = {}
+        for axis in ("alpha", "beta"):
+            if axis not in self.data.coords:
+                continue
+            spin = QtWidgets.QDoubleSpinBox()
+            spin.setObjectName(f"ktool{axis.title()}Scale")
+            spin.setRange(0.01, 10.0)
+            spin.setSingleStep(0.01)
+            spin.setDecimals(3)
+            spin.setValue(self.data.kspace.angle_scales[axis])
+            spin.valueChanged.connect(self._handle_angle_scale_changed)
+            self._angle_scale_spins[axis] = spin
+            self.offsets_group.layout().addRow(f"{axis} scale", spin)
 
         self._normal_emission_spins = {}
         for axis, label in self._NORMAL_EMISSION_LABELS.items():
@@ -1173,6 +1192,10 @@ class KspaceTool(KspaceToolGUI):
             tuple(str(dim) for dim in self.data.dims),
             tuple(int(self.data.sizes[dim]) for dim in self.data.dims),
             self._preview_slice_token(),
+            tuple(
+                (axis, round(spin.value(), spin.decimals()))
+                for axis, spin in self._angle_scale_spins.items()
+            ),
             tuple(str(dim) for dim in data.dims),
             tuple(int(data.sizes[dim]) for dim in data.dims),
             int(self.current_configuration),
@@ -1346,6 +1369,8 @@ class KspaceTool(KspaceToolGUI):
             inner_potential=self._inner_potential if self.data.kspace._has_hv else None,
             normal_emission=(alpha_normal, beta_normal),
             delta=self.offset_dict["delta"],
+            alpha_scale=self.data.kspace.alpha_scale,
+            beta_scale=self.data.kspace.beta_scale,
             bounds=self.bounds,
             resolution=self.resolution,
             force_scalars=False,
@@ -1396,11 +1421,28 @@ class KspaceTool(KspaceToolGUI):
             for k in self.data.kspace._valid_offset_keys
         }
 
+    @property
+    def angle_scale_dict(self) -> dict[str, float]:
+        return {
+            k: float(np.round(spin.value(), spin.decimals()))
+            for k, spin in self._angle_scale_spins.items()
+        }
+
     def _current_normal_emission_angles(self) -> tuple[float, float]:
         return _kspace_conversion.normal_emission_angles(
             self.data,
             self.offset_dict,
         )
+
+    def _sync_angle_scales(self) -> None:
+        self.data.kspace.angle_scales = self.angle_scale_dict
+
+    @QtCore.Slot(float)
+    def _handle_angle_scale_changed(self, _value: float) -> None:
+        self._sync_angle_scales()
+        self._sync_normal_emission_spins()
+        self._invalidate_preview_memory_estimate()
+        self.queue_update()
 
     @QtCore.Slot()
     def _sync_normal_emission_spins(self) -> None:
@@ -1512,10 +1554,6 @@ class KspaceTool(KspaceToolGUI):
         # Set angle offsets
         data_ang = self._assign_params(self._angle_data())
         self._validate_kinetic_energy(data_ang, context="updating ktool preview")
-        # if "beta" in data_ang.dims:
-        #     data_ang = data_ang.assign_coords(
-        #         beta=data_ang.beta * self._beta_scale_spin.value()
-        #     )
         return data_ang
 
     def _preview_kspace_data(self, data_ang: xr.DataArray) -> xr.DataArray:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3205,6 +3205,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
       ``sigInfoChanged`` without any arguments whenever the content of these properties
       changes. This will ensure that the ImageTool manager updates its display.
 
+    - Emit ``sigStateChanged`` whenever tool settings changed and the manager should
+      mark the workspace state dirty, but preview/info/output refreshes can wait.
+
     - Emit ``sigDataChanged`` whenever the displayed tool data or any manager-visible
       ImageTool outputs have changed. Managed descendants use this to become stale or
       auto-refresh from the current tool state.
@@ -3222,6 +3225,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     StateModel: type[M]
 
     sigInfoChanged = QtCore.Signal()  #: :meta private:
+    sigStateChanged = QtCore.Signal()  #: :meta private:
     sigDataChanged = QtCore.Signal()  #: :meta private:
 
     def __init__(self, *args, **kwargs) -> None:

--- a/tests/accessors/test_kspace.py
+++ b/tests/accessors/test_kspace.py
@@ -479,6 +479,63 @@ def test_offsets(data_type, request) -> None:
         data.kspace.offsets["invalid"] = 10.0
 
 
+def test_angle_scales_round_trip_and_do_not_extend_offsets(anglemap) -> None:
+    data = anglemap.copy(deep=True)
+
+    assert dict(data.kspace.angle_scales) == {"alpha": 1.0, "beta": 1.0}
+
+    data.kspace.alpha_scale = 1.25
+    data.kspace.beta_scale = 0.75
+
+    assert data.attrs["alpha_scale"] == pytest.approx(1.25)
+    assert data.attrs["beta_scale"] == pytest.approx(0.75)
+    assert dict(data.kspace.angle_scales) == {"alpha": 1.25, "beta": 0.75}
+    assert "alpha_scale" not in dict(data.kspace.offsets)
+    assert "beta_scale" not in dict(data.kspace.offsets)
+
+    data.kspace.angle_scales.reset()
+    assert "alpha_scale" not in data.attrs
+    assert "beta_scale" not in data.attrs
+    assert dict(data.kspace.angle_scales) == {"alpha": 1.0, "beta": 1.0}
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, np.nan, np.inf])
+def test_angle_scales_validate_positive_finite_values(anglemap, value: float) -> None:
+    data = anglemap.copy(deep=True)
+
+    with pytest.raises(ValueError, match="finite positive scalar"):
+        data.kspace.alpha_scale = value
+
+    with pytest.raises(ValueError, match="finite positive scalar"):
+        data.kspace.angle_scales["beta"] = value
+
+    with pytest.raises(KeyError, match="Invalid angle scale key"):
+        data.kspace.angle_scales["gamma"] = 1.0
+
+
+def test_angle_scales_match_manual_scaled_coordinates(anglemap) -> None:
+    data = anglemap.isel(alpha=slice(0, 4), beta=slice(0, 4), eV=slice(0, 4)).copy(
+        deep=True
+    )
+    manual = data.assign_coords(alpha=data.alpha * 1.2, beta=data.beta * 0.8)
+
+    data.kspace.alpha_scale = 1.2
+    data.kspace.beta_scale = 0.8
+
+    scaled_bounds = data.kspace.estimate_bounds()
+    expected_bounds = manual.kspace.estimate_bounds()
+    for axis, bounds in expected_bounds.items():
+        assert scaled_bounds[axis] == pytest.approx(bounds)
+
+    bounds = {"kx": (-0.1, 0.1), "ky": (-0.1, 0.1)}
+    resolution = {"kx": 0.1, "ky": 0.1}
+    scaled = data.kspace.convert(bounds=bounds, resolution=resolution, silent=True)
+    expected = manual.kspace.convert(bounds=bounds, resolution=resolution, silent=True)
+    xarray.testing.assert_allclose(scaled, expected)
+    xarray.testing.assert_allclose(data.alpha, anglemap.isel(alpha=slice(0, 4)).alpha)
+    xarray.testing.assert_allclose(data.beta, anglemap.isel(beta=slice(0, 4)).beta)
+
+
 @pytest.mark.parametrize(
     ("configuration", "coords", "true_offsets", "initial_guess"),
     _NORMAL_EMISSION_CASES,
@@ -561,6 +618,53 @@ def test_set_normal(
 
     kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
         alpha_normal, beta_normal, 1.0, **data.kspace.angle_params
+    )
+
+    assert float(kx) == pytest.approx(0.0, abs=1e-10)
+    assert float(ky) == pytest.approx(0.0, abs=1e-10)
+
+
+@pytest.mark.parametrize(
+    ("configuration", "coords", "true_offsets", "initial_guess"),
+    _NORMAL_EMISSION_CASES,
+)
+def test_set_normal_accepts_angle_scales_in_raw_data_coordinates(
+    anglemap,
+    configuration: AxesConfiguration,
+    coords: dict[str, float],
+    true_offsets: dict[str, float],
+    initial_guess: list[float],
+) -> None:
+    data = _make_normal_emission_data(anglemap, configuration, coords)
+    alpha_physical, beta_physical = _solve_normal_emission_angles(
+        configuration, coords, true_offsets, initial_guess
+    )
+    alpha_scale = 1.25
+    beta_scale = 0.75
+    alpha_raw = alpha_physical / alpha_scale
+    beta_raw = beta_physical / beta_scale
+
+    data.kspace.set_normal(
+        alpha_raw,
+        beta_raw,
+        delta=true_offsets["delta"],
+        alpha_scale=alpha_scale,
+        beta_scale=beta_scale,
+    )
+
+    assert data.kspace.alpha_scale == pytest.approx(alpha_scale)
+    assert data.kspace.beta_scale == pytest.approx(beta_scale)
+    for key, expected in true_offsets.items():
+        assert data.kspace.offsets[key] == pytest.approx(expected)
+
+    assert data.kspace._normal_emission_angles() == pytest.approx(
+        (alpha_raw, beta_raw), abs=1e-10
+    )
+    kx, ky = erlab.analysis.kspace.get_kconv_forward(configuration)(
+        alpha_raw * alpha_scale,
+        beta_raw * beta_scale,
+        1.0,
+        **data.kspace.angle_params,
     )
 
     assert float(kx) == pytest.approx(0.0, abs=1e-10)
@@ -650,12 +754,23 @@ def test_set_normal_like(
 
     source = _make_normal_emission_data(anglemap, source_configuration, source_coords)
     source.kspace.offsets = source_offsets
+    source.kspace.alpha_scale = 1.25
+    source.kspace.beta_scale = 0.75
     alpha_normal, beta_normal = _solve_normal_emission_angles(
         source_configuration, source_coords, source_offsets, [3.5, -4.5]
     )
 
     target = _make_normal_emission_data(anglemap, target_configuration, target_coords)
     target.kspace.set_normal_like(source)
+
+    assert target.kspace.alpha_scale == pytest.approx(source.kspace.alpha_scale)
+    assert target.kspace.beta_scale == pytest.approx(source.kspace.beta_scale)
+    assert target.kspace._normal_emission_angles() == pytest.approx(
+        (
+            alpha_normal / source.kspace.alpha_scale,
+            beta_normal / source.kspace.beta_scale,
+        )
+    )
 
     expected_offsets = erlab.analysis.kspace._offsets_from_normal_emission(
         target_configuration,

--- a/tests/accessors/test_kspace.py
+++ b/tests/accessors/test_kspace.py
@@ -499,8 +499,31 @@ def test_angle_scales_round_trip_and_do_not_extend_offsets(anglemap) -> None:
     assert dict(data.kspace.angle_scales) == {"alpha": 1.0, "beta": 1.0}
 
 
-@pytest.mark.parametrize("value", [0.0, -1.0, np.nan, np.inf])
-def test_angle_scales_validate_positive_finite_values(anglemap, value: float) -> None:
+def test_angle_scales_mapping_helpers_and_setter(anglemap) -> None:
+    data = anglemap.copy(deep=True)
+
+    data.kspace.angle_scales.update([("alpha", 1.25)], beta=0.75)
+
+    assert data.kspace.angle_scales == {"alpha": 1.25, "beta": 0.75}
+    assert data.kspace.angle_scales != object()
+    assert repr(data.kspace.angle_scales) == repr({"alpha": 1.25, "beta": 0.75})
+    assert list(data.kspace.angle_scales.items()) == [("alpha", 1.25), ("beta", 0.75)]
+    assert isinstance(data.kspace.angle_scales._repr_html_(), str)
+
+    data.kspace.angle_scales.update(alpha=1.1)
+    assert data.kspace.alpha_scale == pytest.approx(1.1)
+
+    data.kspace.angle_scales = {"alpha": 1.25, "beta": 0.75}
+    assert dict(data.kspace.angle_scales) == {"alpha": 1.25, "beta": 0.75}
+
+    fresh = anglemap.copy(deep=True)
+    fresh.kspace.angle_scales = {"beta": 1.5}
+
+    assert dict(fresh.kspace.angle_scales) == {"alpha": 1.0, "beta": 1.5}
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, np.nan, np.inf, np.array([1.0])])
+def test_angle_scales_validate_positive_finite_values(anglemap, value: object) -> None:
     data = anglemap.copy(deep=True)
 
     with pytest.raises(ValueError, match="finite positive scalar"):
@@ -511,6 +534,9 @@ def test_angle_scales_validate_positive_finite_values(anglemap, value: float) ->
 
     with pytest.raises(KeyError, match="Invalid angle scale key"):
         data.kspace.angle_scales["gamma"] = 1.0
+
+    with pytest.raises(KeyError, match="Invalid angle scale key"):
+        _ = data.kspace.angle_scales["gamma"]
 
 
 def test_angle_scales_match_manual_scaled_coordinates(anglemap) -> None:
@@ -1088,6 +1114,18 @@ def test_resolution_raises_nonpositive_kinetic_energy(anglemap) -> None:
         r"space: min\(E_k\)=",
     ):
         _ = data.kspace.convert(silent=True)
+
+
+def test_best_kp_resolution_handles_other_axis_and_rejects_invalid_axis(
+    anglemap,
+) -> None:
+    data = anglemap.copy(deep=True)
+    data.kspace.beta_scale = 0.75
+
+    assert np.isfinite(data.kspace._best_kp_resolution(data.kspace.other_axis))
+
+    with pytest.raises(ValueError, match="not a valid in-plane momentum axis"):
+        data.kspace._best_kp_resolution("bad")  # type: ignore[arg-type]
 
 
 def test_estimate_resolution_from_numpoints_kz_uses_adjacent_spacing(hvdep) -> None:

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -4758,6 +4758,19 @@ def test_manager_ktool_output_itool_marks_stale_without_recomputing(
         output_node = manager._child_node(output_uid)
         assert output_node.source_auto_update is False
 
+        select_child_tool(manager, child_uid)
+        qtbot.wait(child._MANAGER_NOTIFY_DELAY_MS + 50)
+        manager._flush_idle_work(force=True)
+        metadata_updates: list[str] = []
+        original_set_metadata_node = manager._set_metadata_node
+
+        def _record_metadata_rebuild(node) -> None:
+            metadata_updates.append(node.uid)
+            original_set_metadata_node(node)
+
+        monkeypatch.setattr(manager, "_set_metadata_node", _record_metadata_rebuild)
+        manager._mark_workspace_clean()
+
         before = fetch(output_uid).copy(deep=True)
         wait_ms = int(1000 / child._UPDATE_LIMIT_HZ) + 50
         qtbot.wait(wait_ms)
@@ -4771,10 +4784,31 @@ def test_manager_ktool_output_itool_marks_stale_without_recomputing(
             return original_converted_output()
 
         monkeypatch.setattr(child, "_converted_output", _counting_converted_output)
+        notification_count = 0
+        original_notify_data_changed = child._notify_data_changed
+
+        def _counting_notify_data_changed():
+            nonlocal notification_count
+            notification_count += 1
+            original_notify_data_changed()
+
+        monkeypatch.setattr(
+            child, "_notify_data_changed", _counting_notify_data_changed
+        )
 
         delta_spin = child._offset_spins["delta"]
-        delta_spin.setValue(delta_spin.value() + 0.01)
+        with QtCore.QSignalBlocker(delta_spin):
+            delta_spin.setValue(delta_spin.value() + 0.01)
+        child.update()
+        child.update()
+        child.update()
 
+        assert child_uid in manager._workspace_state.dirty_state
+        assert metadata_updates == []
+        assert notification_count == 0
+        qtbot.wait(child._MANAGER_NOTIFY_DELAY_MS + 50)
+        manager._flush_idle_work(force=True)
+        assert notification_count == 1
         qtbot.wait_until(lambda: output_node.source_state == "stale", timeout=5000)
         qtbot.wait(wait_ms)
 

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -523,6 +523,21 @@ def test_childtool_state_changed_marks_dirty_without_details_refresh(
         assert metadata_updates == []
         assert ("tool-info-refresh", uid) not in manager._interaction_gate.pending_keys
 
+        child_node = manager._child_node(uid)
+        manager._mark_workspace_clean()
+        original_node = manager._tool_graph.nodes[uid]
+        try:
+            manager._tool_graph.nodes[uid] = object()
+            child_node._handle_tool_state_changed()
+        finally:
+            manager._tool_graph.nodes[uid] = original_node
+        assert uid not in manager._workspace_state.dirty_state
+
+        with monkeypatch.context() as patch:
+            patch.setattr(erlab.interactive.utils, "qt_is_valid", lambda _obj: False)
+            child_node._handle_tool_state_changed()
+        assert uid not in manager._workspace_state.dirty_state
+
 
 def test_manager_idle_queue_deduplicates_and_waits_for_idle(
     qtbot,

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -485,6 +485,45 @@ def test_childtool_info_changed_debounces_manager_details_refresh(
         assert "updated child info final" in manager.text_box.toPlainText()
 
 
+def test_childtool_state_changed_marks_dirty_without_details_refresh(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        test_data.qshow(manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        tool = _InfoRefreshTool(test_data)
+        uid = manager.add_childtool(tool, 0, show=False)
+        qtbot.wait_until(
+            lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
+            timeout=5000,
+        )
+        select_child_tool(manager, uid)
+        manager._update_info()
+
+        metadata_updates: list[str] = []
+        original_set_metadata_node = manager._set_metadata_node
+
+        def _record_metadata_rebuild(node) -> None:
+            metadata_updates.append(node.uid)
+            original_set_metadata_node(node)
+
+        monkeypatch.setattr(manager, "_set_metadata_node", _record_metadata_rebuild)
+        manager._mark_workspace_clean()
+
+        tool.sigStateChanged.emit()
+
+        assert uid in manager._workspace_state.dirty_state
+        assert metadata_updates == []
+        assert ("tool-info-refresh", uid) not in manager._interaction_gate.pending_keys
+
+
 def test_manager_idle_queue_deduplicates_and_waits_for_idle(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -210,14 +210,16 @@ def test_explorer_close_stops_preview_workers(
             self, timeout_ms: int = _PREVIEW_WORKER_STOP_TIMEOUT_MS
         ) -> bool:
             self.stopped_preview_workers = True
-            return super()._stop_preview_workers(timeout_ms)
+            return True
 
     explorer = _TrackingDataExplorer(root_path=example_data_dir, loader_name="example")
     qtbot.addWidget(explorer)
+    event = QtGui.QCloseEvent()
 
-    explorer.close()
+    explorer.closeEvent(event)
 
     assert explorer.stopped_preview_workers
+    assert event.isAccepted()
 
 
 def test_explorer_close_ignores_busy_preview_workers(

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -199,20 +199,21 @@ def test_tabbed_explorer_close_ignores_busy_preview_workers(qtbot) -> None:
 
 
 def test_explorer_close_stops_preview_workers(
-    qtbot, example_loader, example_data_dir: pathlib.Path
+    qtbot,
 ) -> None:
     class _TrackingDataExplorer(_DataExplorer):
-        def __init__(self, *args, **kwargs) -> None:
+        def __init__(self) -> None:
+            QtWidgets.QMainWindow.__init__(self)
             self.stopped_preview_workers = False
-            super().__init__(*args, **kwargs)
 
         def _stop_preview_workers(
             self, timeout_ms: int = _PREVIEW_WORKER_STOP_TIMEOUT_MS
         ) -> bool:
+            del timeout_ms
             self.stopped_preview_workers = True
             return True
 
-    explorer = _TrackingDataExplorer(root_path=example_data_dir, loader_name="example")
+    explorer = _TrackingDataExplorer()
     qtbot.addWidget(explorer)
     event = QtGui.QCloseEvent()
 

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -810,9 +810,13 @@ def test_ktool_preview_memory_estimate_cached_for_identical_state(
     assert budget_calls == 2
     assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is False
 
-    win.resolution_supergroup.setChecked(True)
+    win._preview_memory_estimate = None
     win.update()
     assert estimate_calls == 2
+
+    win.resolution_supergroup.setChecked(True)
+    win.update()
+    assert estimate_calls == 3
 
 
 def test_ktool_full_output_unsafe_does_not_block_safe_preview(
@@ -854,6 +858,18 @@ def test_ktool_full_output_unsafe_does_not_block_safe_preview(
     assert messages
     assert win.images[1].data_array is not None
     assert getattr(win, "_itool", None) is None
+
+
+def test_ktool_clear_memory_refusal_preview_without_angle_data(qtbot, anglemap) -> None:
+    win = ktool(anglemap, execute=False)
+    _add_hidden_tool(qtbot, win)
+
+    win._clear_kspace_preview_for_memory_refusal()
+
+    assert win.images[0].data_array is not None
+    assert win.images[1].data_array is None
+    assert not win.preview_symmetry_group.isEnabled()
+    assert not win.bz_group.isEnabled()
 
 
 def test_ktool_preview_memory_estimate_recomputed_for_slice_change(
@@ -1687,6 +1703,7 @@ def test_ktool_configuration_state_edges(qtbot, anglemap) -> None:
         update={
             "configuration": int(AxesConfiguration.Type2DA),
             "offsets": {**status.offsets, "unused": 1.0},
+            "angle_scales": {**status.angle_scales, "unused": 1.0},
             "bounds": {**status.bounds, "unused": 1.0},
             "resolution": {**status.resolution, "unused": 1.0},
         }

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -424,14 +424,19 @@ def test_kspace_conversion_estimate_validates_bounds_and_resolution(
     )
     assert estimate_text.startswith("Output: scalar\n")
     assert "Final array:" in estimate_text
-    assert "Available memory:" in estimate_text
+    assert "Available memory:" not in estimate_text
     unsafe_estimate_text = _kspace_conversion.kspace_conversion_estimate_text(
+        _conversion_estimate_stub(safe=False, final_bytes=8, peak_bytes=48),
+    )
+    assert "Open in ImageTool unavailable." in unsafe_estimate_text
+    assert "Final array:" in unsafe_estimate_text
+    assert "Available memory:" not in unsafe_estimate_text
+    preview_estimate_text = _kspace_conversion.kspace_conversion_estimate_text(
         _conversion_estimate_stub(safe=False, final_bytes=8, peak_bytes=48),
         preview=True,
     )
-    assert "Preview unavailable." in unsafe_estimate_text
-    assert "Final array:" in unsafe_estimate_text
-    assert "Available memory:" in unsafe_estimate_text
+    assert "Preview unavailable." in preview_estimate_text
+    assert "Available memory:" not in preview_estimate_text
     with pytest.raises(ValueError, match="finite"):
         _kspace_conversion.estimate_kspace_conversion(
             data,
@@ -447,6 +452,43 @@ def test_kspace_conversion_estimate_validates_bounds_and_resolution(
             data,
             resolution={"kx": 0.0},
         )
+
+
+def test_kspace_conversion_estimate_uses_explicit_grid_directly(
+    monkeypatch,
+    anglemap,
+) -> None:
+    data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
+    data.kspace.work_function = 4.5
+
+    def _unexpected_estimate_bounds(self):
+        del self
+        raise AssertionError("explicit bounds should not estimate transformed bounds")
+
+    def _unexpected_estimate_resolution(self, *args, **kwargs):
+        del self, args, kwargs
+        raise AssertionError("explicit resolution should not estimate resolution")
+
+    monkeypatch.setattr(
+        MomentumAccessor, "estimate_bounds", _unexpected_estimate_bounds
+    )
+    monkeypatch.setattr(
+        MomentumAccessor,
+        "estimate_resolution",
+        _unexpected_estimate_resolution,
+    )
+
+    estimate = _kspace_conversion.estimate_kspace_conversion(
+        data,
+        bounds={"kx": (-1.0, 1.0), "ky": (-2.0, 2.0)},
+        resolution={"kx": 1.0, "ky": 2.0},
+        memory=_memory_budget(),
+    )
+
+    assert estimate.axis_sizes == {"kx": 3, "ky": 3}
+    assert estimate.output_sizes == {"eV": 3, "kx": 3, "ky": 3}
+    assert estimate.total_points == 27
+    assert estimate.final_bytes == 27 * 8
 
 
 def test_kspace_conversion_console_group_stamping_focuses_rows() -> None:
@@ -675,8 +717,12 @@ def test_ktool_unsafe_preview_clears_kspace_image(
     assert win.images[0].data_array is not None
     assert not win.preview_symmetry_group.isEnabled()
     assert not win.bz_group.isEnabled()
-    assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is True
     assert estimate_calls == 1
+    qtbot.wait_until(
+        lambda: win._memory_estimate_label.property("kspaceMemoryUnsafe") is True,
+        timeout=2000,
+    )
+    assert estimate_calls == 2
     assert convert_calls == 0
 
 
@@ -728,10 +774,14 @@ def test_ktool_preview_memory_estimate_uses_preview_data_synchronously(
 
     win.update()
 
-    assert estimated_dims
-    assert estimated_dims[-1] == tuple(preview_data.dims)
-    assert estimated_dims[-1] != tuple(output_data.dims)
-    assert "eV" not in estimated_dims[-1]
+    assert estimated_dims == [tuple(preview_data.dims)]
+    assert estimated_dims[0] != tuple(output_data.dims)
+    assert "eV" not in estimated_dims[0]
+    qtbot.wait_until(
+        lambda: tuple(output_data.dims) in estimated_dims,
+        timeout=2000,
+    )
+    assert estimated_dims[:2] == [tuple(preview_data.dims), tuple(output_data.dims)]
     assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is False
 
 
@@ -776,6 +826,8 @@ def test_ktool_preview_memory_estimate_cached_for_identical_state(
     win = ktool(anglemap, execute=False)
     _add_hidden_tool(qtbot, win)
     win._invalidate_preview_memory_estimate()
+    win._output_memory_estimate_timer.stop()
+    monkeypatch.setattr(win, "_queue_output_memory_estimate", lambda **kwargs: None)
 
     estimate_calls = 0
     budget_calls = 0
@@ -808,11 +860,11 @@ def test_ktool_preview_memory_estimate_cached_for_identical_state(
 
     assert estimate_calls == 1
     assert budget_calls == 2
-    assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is False
 
     win._preview_memory_estimate = None
     win.update()
     assert estimate_calls == 2
+    assert budget_calls == 2
 
     win.resolution_supergroup.setChecked(True)
     win.update()
@@ -851,13 +903,59 @@ def test_ktool_full_output_unsafe_does_not_block_safe_preview(
     win.update()
 
     assert win.images[1].data_array is not None
-    assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is False
+    qtbot.wait_until(
+        lambda: win._memory_estimate_label.property("kspaceMemoryUnsafe") is True,
+        timeout=2000,
+    )
 
     win.show_converted()
 
     assert messages
     assert win.images[1].data_array is not None
     assert getattr(win, "_itool", None) is None
+
+
+def test_ktool_memory_label_uses_full_output_estimate(
+    qtbot,
+    monkeypatch,
+    anglemap,
+) -> None:
+    data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
+    data.kspace.work_function = 4.5
+    win = ktool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+
+    preview_data = win._preview_angle_data()
+    output_data = win._assign_params(win.data.copy(deep=False))
+    large_budget = _memory_budget()
+    preview_estimate = _kspace_conversion.estimate_kspace_conversion(
+        preview_data,
+        bounds=win.bounds,
+        resolution=win.resolution,
+        memory=large_budget,
+    )
+    output_estimate = _kspace_conversion.estimate_kspace_conversion(
+        output_data,
+        bounds=win.bounds,
+        resolution=win.resolution,
+        memory=large_budget,
+    )
+    assert output_estimate.final_bytes > preview_estimate.final_bytes
+
+    monkeypatch.setattr(
+        _kspace_conversion,
+        "system_memory_budget",
+        lambda: large_budget,
+    )
+
+    win.update()
+
+    assert win.images[1].data_array is not None
+    assert win._output_memory_estimate is None
+    qtbot.wait_until(lambda: win._output_memory_estimate is not None, timeout=2000)
+    assert win._output_memory_estimate is not None
+    assert win._output_memory_estimate.final_bytes == output_estimate.final_bytes
+    assert win._output_memory_estimate.final_bytes != preview_estimate.final_bytes
 
 
 def test_ktool_clear_memory_refusal_preview_without_angle_data(qtbot, anglemap) -> None:
@@ -880,6 +978,8 @@ def test_ktool_preview_memory_estimate_recomputed_for_slice_change(
     win = ktool(anglemap, execute=False)
     _add_hidden_tool(qtbot, win)
     win._invalidate_preview_memory_estimate()
+    win._output_memory_estimate_timer.stop()
+    monkeypatch.setattr(win, "_queue_output_memory_estimate", lambda **kwargs: None)
     estimated_dims: list[tuple[str, ...]] = []
 
     def _estimate(data, **kwargs):
@@ -895,13 +995,13 @@ def test_ktool_preview_memory_estimate_recomputed_for_slice_change(
 
     win.update()
     win.update()
-    assert len(estimated_dims) == 1
+    assert estimated_dims == [("alpha", "beta")]
 
     win.width_spin.setValue(win.width_spin.value() + 1)
     win.update()
 
     assert len(estimated_dims) == 2
-    assert estimated_dims[-1] == estimated_dims[0]
+    assert estimated_dims[-1] == ("alpha", "beta")
 
 
 def test_kspace_memory_estimate_labels_wrap(qtbot, anglemap) -> None:
@@ -1238,6 +1338,10 @@ def test_kspace_conversion_dialog_unsafe_accept_shows_error(
         messages[-1][1]["buttons"]
         == imagetool_dialogs.QtWidgets.QDialogButtonBox.StandardButton.Ok
     )
+    assert "Available physical memory" not in messages[-1][1]["informative_text"]
+    assert "Peak estimate" not in messages[-1][1]["detailed_text"]
+    assert "Reserve" not in messages[-1][1]["detailed_text"]
+    assert "Swap" not in messages[-1][1]["detailed_text"]
     assert dialog._memory_estimate_label.property("kspaceMemoryUnsafe") is True
 
 

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -116,11 +116,12 @@ def _conversion_estimate_stub(
     final_bytes: int = 8,
     peak_bytes: int = 8,
 ) -> _kspace_conversion.KspaceConversionEstimate:
+    available_bytes = final_bytes if safe else max(0, final_bytes - 1)
     budget = _kspace_conversion.KspaceMemoryBudget(
-        total_bytes=4,
-        available_bytes=2,
+        total_bytes=max(available_bytes, final_bytes),
+        available_bytes=available_bytes,
         reserve_bytes=1,
-        safe_budget_bytes=peak_bytes if safe else max(0, peak_bytes - 1),
+        safe_budget_bytes=max(0, available_bytes - 1),
     )
     return _kspace_conversion.KspaceConversionEstimate(
         input_dims=(),
@@ -344,7 +345,10 @@ def test_kspace_conversion_memory_budget_uses_available_physical_memory(
     assert budget.safe_budget_bytes == 5 * _GIB
 
 
-def test_kspace_conversion_estimate_blocks_unsafe_peak(monkeypatch, anglemap) -> None:
+def test_kspace_conversion_estimate_blocks_unsafe_final_array(
+    monkeypatch,
+    anglemap,
+) -> None:
     data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
     data.kspace.work_function = 4.5
     monkeypatch.setattr(
@@ -380,19 +384,24 @@ def test_kspace_conversion_estimate_validates_bounds_and_resolution(
         bounds={"kx": (-1.0, 1.0), "ky": (-1.0, 1.0)},
         resolution={"kx": 1.0, "ky": 1.0},
     ).is_safe
+    assert _conversion_estimate_stub(
+        safe=True,
+        final_bytes=8,
+        peak_bytes=48,
+    ).is_safe
     estimate_text = _kspace_conversion.kspace_conversion_estimate_text(
         _conversion_estimate_stub(final_bytes=8, peak_bytes=48)
     )
     assert estimate_text.startswith("Output: scalar\n")
     assert "Final array:" in estimate_text
-    assert "Peak memory:" in estimate_text
+    assert "Available memory:" in estimate_text
     unsafe_estimate_text = _kspace_conversion.kspace_conversion_estimate_text(
         _conversion_estimate_stub(safe=False, final_bytes=8, peak_bytes=48),
         preview=True,
     )
     assert "Preview unavailable." in unsafe_estimate_text
     assert "Final array:" in unsafe_estimate_text
-    assert "Peak memory:" in unsafe_estimate_text
+    assert "Available memory:" in unsafe_estimate_text
     with pytest.raises(ValueError, match="finite"):
         _kspace_conversion.estimate_kspace_conversion(
             data,
@@ -887,7 +896,7 @@ def test_ktool_unsafe_output_shows_blocking_error(
     monkeypatch.setattr(
         _kspace_conversion,
         "system_memory_budget",
-        lambda: _memory_budget(total=4 * _GIB, available=2 * _GIB),
+        lambda: _memory_budget(total=4, available=2),
     )
 
     win.resolution_supergroup.setChecked(True)

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -8,7 +8,7 @@ import scipy.optimize
 import xarray as xr
 
 import erlab
-from erlab.accessors.kspace import IncompleteDataError
+from erlab.accessors.kspace import IncompleteDataError, MomentumAccessor
 from erlab.constants import AxesConfiguration
 from erlab.interactive.imagetool import _kspace_conversion, provenance
 from erlab.interactive.imagetool import dialogs as imagetool_dialogs
@@ -599,33 +599,49 @@ def test_ktool_unsafe_preview_clears_kspace_image(
     _add_hidden_tool(qtbot, win)
     assert win.images[1].data_array is not None
 
+    estimate = _conversion_estimate_stub(safe=False, peak_bytes=16)
+    estimate_calls = 0
+    convert_calls = 0
+
+    def _unsafe_estimate(*args, **kwargs):
+        del args, kwargs
+        nonlocal estimate_calls
+        estimate_calls += 1
+        return estimate
+
+    def _unexpected_convert(*args, **kwargs):
+        del args, kwargs
+        nonlocal convert_calls
+        convert_calls += 1
+        raise AssertionError("unsafe preview conversion should not run")
+
+    monkeypatch.setattr(
+        _kspace_conversion,
+        "estimate_kspace_conversion",
+        _unsafe_estimate,
+    )
     monkeypatch.setattr(
         _kspace_conversion,
         "system_memory_budget",
-        lambda: _memory_budget(total=4, available=2),
+        lambda: estimate.memory,
     )
-
-    def _convert_must_not_run(*args, **kwargs):
-        raise AssertionError("preview conversion should be preflighted first")
-
-    monkeypatch.setattr(
-        "erlab.accessors.kspace.MomentumAccessor.convert",
-        _convert_must_not_run,
-    )
+    monkeypatch.setattr(MomentumAccessor, "convert", _unexpected_convert)
     win.resolution_supergroup.setChecked(True)
     for spin in win._resolution_spins.values():
         spin.setValue(0.0001)
 
     win.update()
 
+    qtbot.wait_until(lambda: win.images[1].data_array is None, timeout=2000)
     assert win.images[0].data_array is not None
-    assert win.images[1].data_array is None
     assert not win.preview_symmetry_group.isEnabled()
     assert not win.bz_group.isEnabled()
     assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is True
+    assert estimate_calls == 1
+    assert convert_calls == 0
 
 
-def test_ktool_preview_guard_estimates_full_output_data(
+def test_ktool_preview_memory_estimate_uses_preview_data_synchronously(
     qtbot,
     monkeypatch,
     anglemap,
@@ -653,39 +669,184 @@ def test_ktool_preview_guard_estimates_full_output_data(
     )
     assert output_estimate.total_points > preview_estimate.total_points
 
-    safe_budget = (preview_estimate.peak_bytes + output_estimate.peak_bytes) // 2
     monkeypatch.setattr(
         _kspace_conversion,
         "system_memory_budget",
-        lambda: _kspace_conversion.KspaceMemoryBudget(
-            total_bytes=large_budget.total_bytes,
-            available_bytes=large_budget.available_bytes,
-            reserve_bytes=large_budget.reserve_bytes,
-            safe_budget_bytes=safe_budget,
-        ),
+        lambda: large_budget,
     )
+    estimated_dims: list[tuple[str, ...]] = []
+    original_estimate = _kspace_conversion.estimate_kspace_conversion
 
-    def _convert_must_not_run(*args, **kwargs):
-        raise AssertionError(
-            "full-output preflight should run before preview conversion"
-        )
+    def _record_estimate(data, **kwargs):
+        estimated_dims.append(tuple(data.dims))
+        return original_estimate(data, **kwargs)
 
     monkeypatch.setattr(
-        "erlab.accessors.kspace.MomentumAccessor.convert",
-        _convert_must_not_run,
+        _kspace_conversion,
+        "estimate_kspace_conversion",
+        _record_estimate,
     )
 
     win.update()
 
-    assert win.images[0].data_array is not None
-    assert win.images[1].data_array is None
-    assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is True
-    assert "Preview unavailable" in win._memory_estimate_label.text()
-    assert "Increase resolution or reduce bounds" in win._memory_estimate_label.text()
-    assert erlab.utils.formatting.format_nbytes(output_estimate.peak_bytes) in (
-        win._memory_estimate_label.text()
+    assert estimated_dims
+    assert estimated_dims[-1] == tuple(preview_data.dims)
+    assert estimated_dims[-1] != tuple(output_data.dims)
+    assert "eV" not in estimated_dims[-1]
+    assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is False
+
+
+def test_ktool_preview_memory_estimate_runs_before_preview_conversion(
+    qtbot,
+    monkeypatch,
+    anglemap,
+) -> None:
+    win = ktool(anglemap, execute=False)
+    _add_hidden_tool(qtbot, win)
+    win._invalidate_preview_memory_estimate()
+    events: list[str] = []
+
+    def _estimate(*args, **kwargs):
+        del args, kwargs
+        events.append("estimate")
+        return _conversion_estimate_stub(safe=True)
+
+    original_convert = MomentumAccessor.convert
+
+    def _record_convert(self, *args, **kwargs):
+        events.append("convert")
+        return original_convert(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        _kspace_conversion,
+        "estimate_kspace_conversion",
+        _estimate,
     )
-    assert "safe budget" not in win._memory_estimate_label.text()
+    monkeypatch.setattr(MomentumAccessor, "convert", _record_convert)
+
+    win.update()
+
+    assert events[:2] == ["estimate", "convert"]
+
+
+def test_ktool_preview_memory_estimate_cached_for_identical_state(
+    qtbot,
+    monkeypatch,
+    anglemap,
+) -> None:
+    win = ktool(anglemap, execute=False)
+    _add_hidden_tool(qtbot, win)
+    win._invalidate_preview_memory_estimate()
+
+    estimate_calls = 0
+    budget_calls = 0
+
+    def _estimate(*args, **kwargs):
+        del args, kwargs
+        nonlocal estimate_calls
+        estimate_calls += 1
+        return _conversion_estimate_stub(safe=True, peak_bytes=32)
+
+    def _budget():
+        nonlocal budget_calls
+        budget_calls += 1
+        return _memory_budget()
+
+    monkeypatch.setattr(
+        _kspace_conversion,
+        "estimate_kspace_conversion",
+        _estimate,
+    )
+    monkeypatch.setattr(
+        _kspace_conversion,
+        "system_memory_budget",
+        _budget,
+    )
+
+    win.update()
+    win.update()
+    win.update()
+
+    assert estimate_calls == 1
+    assert budget_calls == 2
+    assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is False
+
+    win.resolution_supergroup.setChecked(True)
+    win.update()
+    assert estimate_calls == 2
+
+
+def test_ktool_full_output_unsafe_does_not_block_safe_preview(
+    qtbot,
+    monkeypatch,
+    anglemap,
+) -> None:
+    data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
+    data.kspace.work_function = 4.5
+    win = ktool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+    win._invalidate_preview_memory_estimate()
+    messages: list[tuple[tuple, dict]] = []
+
+    def _estimate(data, **kwargs):
+        del kwargs
+        if "eV" in data.dims:
+            return _conversion_estimate_stub(safe=False, peak_bytes=64)
+        return _conversion_estimate_stub(safe=True, peak_bytes=16)
+
+    monkeypatch.setattr(
+        _kspace_conversion,
+        "estimate_kspace_conversion",
+        _estimate,
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        staticmethod(lambda *args, **kwargs: messages.append((args, kwargs)) or 0),
+    )
+
+    win.update()
+
+    assert win.images[1].data_array is not None
+    assert win._memory_estimate_label.property("kspaceMemoryUnsafe") is False
+
+    win.show_converted()
+
+    assert messages
+    assert win.images[1].data_array is not None
+    assert getattr(win, "_itool", None) is None
+
+
+def test_ktool_preview_memory_estimate_recomputed_for_slice_change(
+    qtbot,
+    monkeypatch,
+    anglemap,
+) -> None:
+    win = ktool(anglemap, execute=False)
+    _add_hidden_tool(qtbot, win)
+    win._invalidate_preview_memory_estimate()
+    estimated_dims: list[tuple[str, ...]] = []
+
+    def _estimate(data, **kwargs):
+        del kwargs
+        estimated_dims.append(tuple(data.dims))
+        return _conversion_estimate_stub(safe=True)
+
+    monkeypatch.setattr(
+        _kspace_conversion,
+        "estimate_kspace_conversion",
+        _estimate,
+    )
+
+    win.update()
+    win.update()
+    assert len(estimated_dims) == 1
+
+    win.width_spin.setValue(win.width_spin.value() + 1)
+    win.update()
+
+    assert len(estimated_dims) == 2
+    assert estimated_dims[-1] == estimated_dims[0]
 
 
 def test_kspace_memory_estimate_labels_wrap(qtbot, anglemap) -> None:

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -298,6 +298,36 @@ def test_kspace_conversion_operations_default_source_configuration(anglemap) -> 
     assert operations[1].group.focus == "bounds_resolution"
 
 
+def test_kspace_conversion_operations_include_nondefault_angle_scales(
+    anglemap,
+) -> None:
+    data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
+    data.kspace.work_function = 4.5
+    data.kspace.alpha_scale = 1.2
+    data.kspace.beta_scale = 0.8
+
+    operations = _kspace_conversion.kspace_conversion_operations(
+        data,
+        target_configuration=AxesConfiguration.Type1,
+        source_configuration=None,
+        work_function=4.5,
+        inner_potential=None,
+        normal_emission=(1.0, 2.0),
+        delta=None,
+        bounds=None,
+        resolution=None,
+        force_scalars=False,
+    )
+
+    set_normal = operations[0]
+    assert isinstance(set_normal, provenance.KspaceSetNormalOperation)
+    assert set_normal.alpha_scale == pytest.approx(1.2)
+    assert set_normal.beta_scale == pytest.approx(0.8)
+    code = set_normal.statement_code("data", output_name="data")
+    assert "alpha_scale=1.2" in code
+    assert "beta_scale=0.8" in code
+
+
 @pytest.mark.parametrize("kind", ["cut", "map", "hv"])
 def test_kspace_conversion_estimate_matches_safe_output(
     monkeypatch,
@@ -1233,6 +1263,8 @@ def test_kspace_conversion_dialog_seeds_from_newest_ktool(qtbot, anglemap) -> No
     first._offset_spins["wf"].setValue(3.25)
     second._offset_spins["wf"].setValue(4.75)
     second._offset_spins["delta"].setValue(12.5)
+    second._angle_scale_spins["alpha"].setValue(1.2)
+    second._angle_scale_spins["beta"].setValue(0.8)
     second._sync_normal_emission_spins()
     second.bounds_supergroup.setChecked(True)
     for value, spin in zip(
@@ -1259,6 +1291,8 @@ def test_kspace_conversion_dialog_seeds_from_newest_ktool(qtbot, anglemap) -> No
     assert dialog.normal_emission == pytest.approx(
         second._current_normal_emission_angles()
     )
+    assert dialog._control_data.kspace.alpha_scale == pytest.approx(1.2)
+    assert dialog._control_data.kspace.beta_scale == pytest.approx(0.8)
     assert dialog.res_npts_check.isChecked() is True
     assert list(dialog._resolution_spins) == list(second._resolution_spins)
     assert dialog.bounds_supergroup.isChecked() is True
@@ -1268,6 +1302,45 @@ def test_kspace_conversion_dialog_seeds_from_newest_ktool(qtbot, anglemap) -> No
     assert [
         spin.value() for spin in dialog._resolution_spins.values()
     ] == pytest.approx([spin.value() for spin in second._resolution_spins.values()])
+    set_normal = next(
+        operation
+        for operation in dialog.source_operations()
+        if isinstance(operation, provenance.KspaceSetNormalOperation)
+    )
+    assert set_normal.alpha_scale == pytest.approx(1.2)
+    assert set_normal.beta_scale == pytest.approx(0.8)
+
+
+def test_kspace_conversion_dialog_uses_seeded_scales_for_auto_bounds(
+    qtbot, anglemap
+) -> None:
+    data = anglemap.qsel(eV=-0.1).copy(deep=True)
+    win = erlab.interactive.itool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+
+    child = ktool(data, execute=False)
+    _add_hidden_tool(qtbot, child)
+    child._angle_scale_spins["alpha"].setValue(1.7)
+    child._angle_scale_spins["beta"].setValue(0.6)
+    win.slicer_area.add_tool_window(child)
+
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
+
+    expected_data = dialog._parameterized_data(dialog._control_data.copy(deep=False))
+    expected_bounds = expected_data.kspace.estimate_bounds()
+
+    assert [
+        dialog._bound_spins[f"{axis}{index}"].value()
+        for axis in dialog._control_data.kspace.momentum_axes
+        for index in range(2)
+    ] == pytest.approx(
+        [
+            expected_bounds[axis][index]
+            for axis in dialog._control_data.kspace.momentum_axes
+            for index in range(2)
+        ],
+        abs=5e-5,
+    )
 
 
 def test_kspace_conversion_dialog_seeds_hv_inner_potential_from_ktool(
@@ -1305,15 +1378,64 @@ def test_kspace_conversion_dialog_seeds_hv_inner_potential_from_ktool(
     operations = provenance.stamp_operation_group(
         (
             provenance.KspaceInnerPotentialOperation(inner_potential=13.0),
-            provenance.KspaceSetNormalOperation(alpha=1.0, beta=2.0, delta=3.0),
+            provenance.KspaceSetNormalOperation(
+                alpha=1.0,
+                beta=2.0,
+                delta=3.0,
+                alpha_scale=1.1,
+                beta_scale=0.9,
+            ),
             provenance.KspaceConvertOperation(bounds=None, resolution=None),
         ),
         kind=_kspace_conversion.KSPACE_CONVERSION_GROUP_KIND,
     )
     dialog.restore_transform_operations(operations)
     assert dialog._offset_spins["V0"].value() == pytest.approx(13.0)
+    assert dialog._control_data.kspace.alpha_scale == pytest.approx(1.1)
+    assert dialog._control_data.kspace.beta_scale == pytest.approx(0.9)
     with pytest.raises(ValueError, match="complete kspace conversion"):
         dialog.restore_transform_operation(operations[0])
+
+
+def test_kspace_conversion_dialog_restore_scales_recalculates_auto_bounds(
+    qtbot, anglemap
+) -> None:
+    data = anglemap.qsel(eV=-0.1).copy(deep=True)
+    win = erlab.interactive.itool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
+
+    operations = provenance.stamp_operation_group(
+        (
+            provenance.KspaceSetNormalOperation(
+                alpha=1.0,
+                beta=2.0,
+                delta=3.0,
+                alpha_scale=1.6,
+                beta_scale=0.7,
+            ),
+            provenance.KspaceConvertOperation(bounds=None, resolution=None),
+        ),
+        kind=_kspace_conversion.KSPACE_CONVERSION_GROUP_KIND,
+    )
+
+    dialog.restore_transform_operations(operations)
+
+    expected_data = dialog._parameterized_data(dialog._control_data.copy(deep=False))
+    expected_bounds = expected_data.kspace.estimate_bounds()
+
+    assert [
+        dialog._bound_spins[f"{axis}{index}"].value()
+        for axis in dialog._control_data.kspace.momentum_axes
+        for index in range(2)
+    ] == pytest.approx(
+        [
+            expected_bounds[axis][index]
+            for axis in dialog._control_data.kspace.momentum_axes
+            for index in range(2)
+        ],
+        abs=5e-5,
+    )
 
 
 def test_kspace_conversion_dialog_restores_unordered_setup_group(
@@ -1653,6 +1775,51 @@ def test_ktool_output_provenance_uses_converted_output_name(qtbot) -> None:
     assert code is not None
     assert f"{input_name}_kconv" in code
     assert ".kspace.set_normal(" in code
+    assert "alpha_scale" not in code
+    assert "beta_scale" not in code
+
+
+def test_ktool_angle_scales_are_set_normal_provenance_kwargs(qtbot, anglemap) -> None:
+    data = _make_da_ktool_data(anglemap)
+    win = ktool(data, data_name="scan", execute=False)
+    _add_hidden_tool(qtbot, win)
+
+    win._angle_scale_spins["alpha"].setValue(1.25)
+    win._angle_scale_spins["beta"].setValue(0.75)
+
+    converted = win.output_imagetool_data(KspaceTool.Output.CONVERTED)
+    assert converted is not None
+    spec = win.output_imagetool_provenance(KspaceTool.Output.CONVERTED, converted)
+    assert spec is not None
+
+    set_normal = next(
+        operation
+        for operation in spec.operations
+        if isinstance(operation, provenance.KspaceSetNormalOperation)
+    )
+    assert set_normal.alpha_scale == pytest.approx(1.25)
+    assert set_normal.beta_scale == pytest.approx(0.75)
+
+    code = spec.display_code()
+    assert code is not None
+    assert ".kspace.set_normal(" in code
+    assert "alpha_scale=1.25" in code
+    assert "beta_scale=0.75" in code
+    assert "angle_scales" not in code
+    namespace = {"scan": data.copy(deep=True)}
+    exec(code, {"__builtins__": {}}, namespace)  # noqa: S102
+    xr.testing.assert_allclose(namespace["scan_kconv"], converted)
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        filename = f"{tmp_dir_name}/tool_save.h5"
+        win.to_file(filename)
+        restored = erlab.interactive.utils.ToolWindow.from_file(filename)
+        _add_hidden_tool(qtbot, restored)
+        assert isinstance(restored, KspaceTool)
+        assert restored.data.kspace.alpha_scale == pytest.approx(1.25)
+        assert restored.data.kspace.beta_scale == pytest.approx(0.75)
+        assert restored.tool_status.angle_scales["alpha"] == pytest.approx(1.25)
+        assert restored.tool_status.angle_scales["beta"] == pytest.approx(0.75)
 
 
 def test_ktool_copy_code_aliases_expression_input_names(qtbot) -> None:
@@ -1886,6 +2053,68 @@ def test_ktool_shallow_copy_paths_do_not_mutate_tool_data_attrs(
     win.get_data()
 
     assert win.data.attrs == original_attrs
+
+
+def test_ktool_angle_scale_controls_apply_to_preview_and_output(
+    qtbot, monkeypatch, anglemap
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 4), beta=slice(0, 4), eV=slice(0, 3)).copy(
+        deep=True
+    )
+    win = ktool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+
+    with (
+        imagetool_dialogs.QtCore.QSignalBlocker(win._angle_scale_spins["alpha"]),
+        imagetool_dialogs.QtCore.QSignalBlocker(win._angle_scale_spins["beta"]),
+    ):
+        win._angle_scale_spins["alpha"].setValue(1.25)
+        win._angle_scale_spins["beta"].setValue(0.75)
+    win._sync_angle_scales()
+    win.bounds_supergroup.setChecked(True)
+    win.resolution_supergroup.setChecked(True)
+    for axis in win.data.kspace.momentum_axes:
+        win._bound_spins[f"{axis}0"].setValue(-0.1)
+        win._bound_spins[f"{axis}1"].setValue(0.1)
+        win._resolution_spins[axis].setValue(0.1)
+
+    preview = win._preview_angle_data()
+    np.testing.assert_allclose(preview.alpha.values, data.alpha.values)
+    np.testing.assert_allclose(preview.beta.values, data.beta.values)
+    assert preview.kspace.alpha_scale == pytest.approx(1.25)
+    assert preview.kspace.beta_scale == pytest.approx(0.75)
+
+    manual_preview = preview.assign_coords(
+        alpha=preview.alpha * 1.25,
+        beta=preview.beta * 0.75,
+    )
+    manual_preview.attrs.pop("alpha_scale", None)
+    manual_preview.attrs.pop("beta_scale", None)
+    preview_k = win._preview_kspace_data(preview)
+    expected_preview = manual_preview.kspace.convert(
+        bounds=win.bounds,
+        resolution=win.resolution,
+        silent=True,
+    )
+    xr.testing.assert_allclose(preview_k, expected_preview)
+
+    convert_inputs: list[xr.DataArray] = []
+    original_convert = MomentumAccessor.convert
+
+    def _record_convert(accessor, *args, **kwargs):
+        convert_inputs.append(accessor._obj)
+        return original_convert(accessor, *args, **kwargs)
+
+    monkeypatch.setattr(MomentumAccessor, "convert", _record_convert)
+
+    win._converted_output()
+
+    assert convert_inputs
+    output_input = convert_inputs[-1]
+    np.testing.assert_allclose(output_input.alpha.values, data.alpha.values)
+    np.testing.assert_allclose(output_input.beta.values, data.beta.values)
+    assert output_input.kspace.alpha_scale == pytest.approx(1.25)
+    assert output_input.kspace.beta_scale == pytest.approx(0.75)
 
 
 def test_ktool_nonphysical_kinetic_energy_raises_with_tool_context(
@@ -2150,6 +2379,8 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
     win.preview_symmetry_fold_spin.setValue(4)
     win._offset_spins["delta"].setValue(5.0)
     win._offset_spins["wf"].setValue(4.6)
+    win._angle_scale_spins["alpha"].setValue(1.1)
+    win._angle_scale_spins["beta"].setValue(0.9)
     if "beta" in win._offset_spins:
         win._offset_spins["beta"].setValue(-1.5)
     win.add_circle_btn.click()
@@ -2161,7 +2392,12 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
     win.update_data(new_data)
 
     assert win.tool_status == status
-    xr.testing.assert_identical(win.tool_data, new_data)
+    assert win.data.kspace.alpha_scale == pytest.approx(1.1)
+    assert win.data.kspace.beta_scale == pytest.approx(0.9)
+    expected_tool_data = new_data.copy(deep=True)
+    expected_tool_data.kspace.alpha_scale = 1.1
+    expected_tool_data.kspace.beta_scale = 0.9
+    xr.testing.assert_identical(win.tool_data, expected_tool_data)
     assert win.images[0].data_array is not None
     assert win.images[1].data_array is not None
 


### PR DESCRIPTION
## Summary
- Add a dedicated `sigStateChanged` path so the ImageTool manager can mark workspace state dirty without forcing info refreshes.
- Debounce ktool manager notifications and separate state changes from data-change notifications.
- Cache preview memory estimates for kspace conversions and validate preview safety before running the expensive conversion.
- Tighten manager and kspace tests around dirty-state updates, debouncing, and unsafe-preview handling.

## Testing
- Added and updated unit/integration coverage for manager dirty-state propagation and ktool preview memory estimation.
- Verified unsafe preview paths clear the kspace image without running conversion, and safe preview paths still render correctly.
- Not run (not requested)