### PR TITLE
Improve plot_array selection and color editing

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -13,6 +13,11 @@ from erlab.interactive._figurecomposer._code import (
     _maybe_squeeze_drop_code,
     _selection_code,
 )
+from erlab.interactive._figurecomposer._editor_controls import (
+    MIXED_VALUE,
+    MIXED_VALUES_TEXT,
+    ComboBoxDataControlAdapter,
+)
 from erlab.interactive._figurecomposer._gridspec import _gridspec_valid_axes_ids
 from erlab.interactive._figurecomposer._norms import (
     _MATPLOTLIB_NORM_NAMES,
@@ -40,10 +45,12 @@ from erlab.interactive._figurecomposer._sources import (
     _valid_source_variable,
 )
 from erlab.interactive._figurecomposer._state import (
+    FigureDataSelectionState,
     FigureOperationKind,
     FigureOperationState,
 )
 from erlab.interactive._figurecomposer._text import (
+    FigureComposerInputError,
     _code_kwargs,
     _dict_from_text,
     _format_dict,
@@ -106,6 +113,248 @@ def _selected_plot_array_data(
     return data.squeeze(drop=True) if squeeze else data
 
 
+def _safe_selected_plot_array_data(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    *,
+    squeeze: bool = True,
+) -> xr.DataArray | None:
+    try:
+        return _selected_plot_array_data(tool, operation, squeeze=squeeze)
+    except (IndexError, KeyError, TypeError, ValueError):
+        return None
+
+
+def _primary_selection(operation: FigureOperationState) -> FigureDataSelectionState:
+    if operation.map_selections:
+        return operation.map_selections[0]
+    return FigureDataSelectionState(source=_primary_source(operation) or "")
+
+
+def _plot_array_source_data(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> xr.DataArray | None:
+    source_name = _primary_source(operation)
+    if source_name is None or source_name not in tool._source_data:
+        return None
+    return _public_source_data(tool._source_data[source_name])
+
+
+def _plot_array_selection_error(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> str | None:
+    try:
+        _selected_plot_array_data(tool, operation)
+    except (IndexError, KeyError, TypeError, ValueError) as exc:
+        return str(exc) or exc.__class__.__name__
+    return None
+
+
+def _selection_summary(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> str:
+    source_data = _plot_array_source_data(tool, operation)
+    selection_error = _plot_array_selection_error(tool, operation)
+    selected = (
+        None
+        if selection_error is not None
+        else (_safe_selected_plot_array_data(tool, operation))
+    )
+    input_dims = (
+        "missing"
+        if source_data is None
+        else ", ".join(str(dim) for dim in source_data.dims) or "none"
+    )
+    plotted_dims = (
+        "missing"
+        if selected is None
+        else ", ".join(str(dim) for dim in selected.dims) or "scalar"
+    )
+    text = f"Input dims: {input_dims}\nPlotted dims: {plotted_dims}"
+    if selection_error is not None:
+        text += f"\nSelection error: {selection_error}"
+    return text
+
+
+def _plot_array_operation_with_selection(
+    operation: FigureOperationState,
+    selection: FigureDataSelectionState,
+) -> FigureOperationState:
+    return operation.model_copy(
+        update={
+            "sources": (selection.source,),
+            "map_selections": (selection,),
+        }
+    )
+
+
+def _update_current_selection_source(
+    tool: FigureComposerTool, source: str | None
+) -> None:
+    if source is None:
+        return
+
+    def update_operation(
+        _index: int, target: FigureOperationState
+    ) -> FigureOperationState:
+        selection = _primary_selection(target).model_copy(update={"source": source})
+        return _plot_array_operation_with_selection(target, selection)
+
+    tool._update_operations(update_operation, rebuild_editor=True)
+
+
+_PLOT_ARRAY_SELECTION_MODE_LABELS = {
+    "keep": "Keep",
+    "isel": "isel",
+    "qsel": "qsel",
+    "mean": "Mean",
+}
+_PLOT_ARRAY_SELECTION_VALUE_MODES = {"isel", "qsel"}
+
+
+def _plot_array_selection_dim_mode(
+    selection: FigureDataSelectionState, dim: str
+) -> str:
+    if dim in selection.isel:
+        return "isel"
+    if dim in selection.qsel:
+        return "qsel"
+    if dim in selection.mean_dims:
+        return "mean"
+    return "keep"
+
+
+def _plot_array_selection_dim_value_text(
+    selection: FigureDataSelectionState, dim: str
+) -> str:
+    if dim in selection.isel:
+        return erlab.interactive.utils._parse_single_arg(selection.isel[dim])
+    if dim in selection.qsel:
+        return erlab.interactive.utils._parse_single_arg(selection.qsel[dim])
+    return ""
+
+
+def _plot_array_selection_value_from_text(text: str) -> typing.Any:
+    stripped = text.strip()
+    if not stripped:
+        raise FigureComposerInputError(
+            "Enter a selection value, such as 0 or slice(0, 2)."
+        )
+    try:
+        return _dict_from_text(f"value={stripped}", allow_slice=True)["value"]
+    except FigureComposerInputError as exc:
+        raise FigureComposerInputError(
+            "Enter a selection value, such as 0 or slice(0, 2)."
+        ) from exc
+
+
+def _plot_array_selection_with_dimension(
+    selection: FigureDataSelectionState,
+    dim: str,
+    mode: str,
+    value: typing.Any = None,
+) -> FigureDataSelectionState:
+    isel = dict(selection.isel)
+    qsel = dict(selection.qsel)
+    mean_dims = [target for target in selection.mean_dims if target != dim]
+    isel.pop(dim, None)
+    qsel.pop(dim, None)
+    if mode == "isel":
+        isel[dim] = value
+    elif mode == "qsel":
+        qsel[dim] = value
+    elif mode == "mean":
+        mean_dims.append(dim)
+    return selection.model_copy(
+        update={
+            "isel": isel,
+            "qsel": qsel,
+            "mean_dims": tuple(mean_dims),
+        }
+    )
+
+
+def _update_current_selection_dimension(
+    tool: FigureComposerTool,
+    dim: str,
+    mode: str,
+    value_text: str = "",
+) -> None:
+    if mode not in _PLOT_ARRAY_SELECTION_MODE_LABELS:
+        return
+    value = (
+        _plot_array_selection_value_from_text(value_text)
+        if mode in _PLOT_ARRAY_SELECTION_VALUE_MODES
+        else None
+    )
+
+    def update_operation(
+        _index: int, target: FigureOperationState
+    ) -> FigureOperationState:
+        selection = _plot_array_selection_with_dimension(
+            _primary_selection(target),
+            dim,
+            mode,
+            value,
+        )
+        return _plot_array_operation_with_selection(target, selection)
+
+    tool._update_operations(update_operation, rebuild_editor=True)
+
+
+def _plot_array_selection_mode_combo(
+    tool: FigureComposerTool,
+    *,
+    current: str | None,
+    mixed: bool,
+    parent: QtWidgets.QWidget,
+) -> QtWidgets.QComboBox:
+    combo = QtWidgets.QComboBox(parent)
+    tool._mark_editor_control(combo)
+    if mixed:
+        combo.addItem(MIXED_VALUES_TEXT, MIXED_VALUE)
+    for mode, label in _PLOT_ARRAY_SELECTION_MODE_LABELS.items():
+        combo.addItem(label, mode)
+    if mixed:
+        item = typing.cast("typing.Any", combo.model()).item(0)
+        if item is not None:
+            item.setEnabled(False)
+        combo.setCurrentIndex(0)
+    elif current is not None:
+        for index in range(combo.count()):
+            if combo.itemData(index) == current:
+                combo.setCurrentIndex(index)
+                break
+    return combo
+
+
+def _connect_plot_array_selection_dimension_controls(
+    tool: FigureComposerTool,
+    dim: str,
+    mode_combo: QtWidgets.QComboBox,
+    value_edit: QtWidgets.QLineEdit,
+) -> None:
+    def mode_changed(value: typing.Any) -> None:
+        mode = value if isinstance(value, str) else ""
+        value_edit.setEnabled(mode in _PLOT_ARRAY_SELECTION_VALUE_MODES)
+        if mode in _PLOT_ARRAY_SELECTION_VALUE_MODES:
+            if value_edit.text().strip():
+                _update_current_selection_dimension(tool, dim, mode, value_edit.text())
+            return
+        _update_current_selection_dimension(tool, dim, mode)
+
+    def value_changed(text: str) -> None:
+        mode = mode_combo.currentData()
+        if isinstance(mode, str) and mode in _PLOT_ARRAY_SELECTION_VALUE_MODES:
+            _update_current_selection_dimension(tool, dim, mode, text)
+
+    ComboBoxDataControlAdapter(mode_combo).connect_commit(
+        tool._connect_editor_signal,
+        mode_changed,
+    )
+    tool._connect_line_edit_finished(value_edit, value_changed)
+
+
 def _plot_array_source_code(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> str | None:
@@ -151,13 +400,16 @@ def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> 
         if source_name is not None
         else "missing source"
     )
-    data = _selected_plot_array_data(tool, operation)
-    if data is None:
-        shape = "missing"
-    elif data.ndim == 2:
-        shape = "2D"
+    if _plot_array_selection_error(tool, operation) is not None:
+        shape = "invalid selection"
     else:
-        shape = f"{data.ndim}D"
+        data = _safe_selected_plot_array_data(tool, operation)
+        if data is None:
+            shape = "missing"
+        elif data.ndim == 2:
+            shape = "2D"
+        else:
+            shape = f"{data.ndim}D"
     return f"{prefix}Image plot: {source_text}, {shape}"
 
 
@@ -206,6 +458,139 @@ def _build_source_editor(
     )
 
 
+def _build_plot_array_selection_page(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> QtWidgets.QWidget:
+    page, layout = tool._new_step_form_page("figureComposerPlotArraySelectionPage")
+    selection = _primary_selection(operation)
+
+    summary = QtWidgets.QLabel(_selection_summary(tool, operation), page)
+    summary.setObjectName("figureComposerPlotArraySelectionSummary")
+    summary.setWordWrap(True)
+    tool._add_form_row(
+        layout,
+        "Summary",
+        summary,
+        "Shows the original dimensions and the dimensions plotted by this image step.",
+    )
+
+    source_mixed = tool._batch_is_mixed(operation, _primary_source)
+    source_combo = tool._source_combo(
+        tool._source_names(),
+        None if source_mixed else selection.source or _primary_source(operation),
+        lambda source: _update_current_selection_source(tool, source),
+        parent=page,
+        mixed=source_mixed,
+    )
+    source_combo.setObjectName("figureComposerPlotArraySelectionSourceCombo")
+    tool._add_form_row(
+        layout,
+        "Image data",
+        source_combo,
+        "Data array selected before plot_array draws this image.",
+    )
+
+    source_data = None if source_mixed else _plot_array_source_data(tool, operation)
+    if source_mixed or source_data is None:
+        dimensions_message = QtWidgets.QLabel(
+            "Choose an image data source to edit dimension selections."
+            if source_mixed
+            else "No source dimensions are available.",
+            page,
+        )
+        dimensions_message.setObjectName(
+            "figureComposerPlotArraySelectionDimensionsMessage"
+        )
+        dimensions_message.setWordWrap(True)
+        tool._add_form_row(
+            layout,
+            "Dimensions",
+            dimensions_message,
+            "Dimension controls are available after the source data is known.",
+        )
+        return page
+
+    if not source_data.dims:
+        dimensions_message = QtWidgets.QLabel("No dimensions.", page)
+        dimensions_message.setObjectName(
+            "figureComposerPlotArraySelectionDimensionsMessage"
+        )
+        tool._add_form_row(
+            layout,
+            "Dimensions",
+            dimensions_message,
+            "This source is scalar, so no dimension selections are available.",
+        )
+        return page
+
+    for dim_index, dim in enumerate(source_data.dims):
+        dim_name = str(dim)
+
+        def mode_getter(target: FigureOperationState, dim_name: str = dim_name) -> str:
+            return _plot_array_selection_dim_mode(_primary_selection(target), dim_name)
+
+        def value_getter(target: FigureOperationState, dim_name: str = dim_name) -> str:
+            return _plot_array_selection_dim_value_text(
+                _primary_selection(target), dim_name
+            )
+
+        mode_mixed = tool._batch_is_mixed(operation, mode_getter)
+        value_text, value_mixed = tool._batch_text(
+            operation,
+            value_getter,
+            str,
+        )
+        current_mode = (
+            None if mode_mixed else _plot_array_selection_dim_mode(selection, dim_name)
+        )
+        row = QtWidgets.QWidget(page)
+        row.setObjectName(f"figureComposerPlotArraySelectionDimRow{dim_index}")
+        row.setProperty("figure_composer_plot_array_dim", dim_name)
+        row_layout = QtWidgets.QHBoxLayout(row)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.setSpacing(4)
+
+        mode_combo = _plot_array_selection_mode_combo(
+            tool,
+            current=current_mode,
+            mixed=mode_mixed,
+            parent=row,
+        )
+        mode_combo.setObjectName(
+            f"figureComposerPlotArraySelectionModeCombo{dim_index}"
+        )
+        mode_combo.setProperty("figure_composer_plot_array_dim", dim_name)
+        value_edit = tool._line_edit(value_text, parent=row)
+        value_edit.setObjectName(
+            f"figureComposerPlotArraySelectionValueEdit{dim_index}"
+        )
+        value_edit.setProperty("figure_composer_plot_array_dim", dim_name)
+        value_edit.setPlaceholderText("value")
+        value_edit.setEnabled(
+            current_mode in _PLOT_ARRAY_SELECTION_VALUE_MODES
+            if current_mode is not None
+            else False
+        )
+        tool._apply_mixed_line_edit(value_edit, value_mixed)
+        _connect_plot_array_selection_dimension_controls(
+            tool,
+            dim_name,
+            mode_combo,
+            value_edit,
+        )
+
+        row_layout.addWidget(mode_combo)
+        row_layout.addWidget(value_edit, 1)
+        tool._add_form_row(
+            layout,
+            dim_name,
+            row,
+            "Keep this dimension, select by integer index, select by coordinate, "
+            "or average it before plotting.",
+        )
+    return page
+
+
 def _plot_array_kwargs(operation: FigureOperationState) -> dict[str, typing.Any]:
     kwargs: dict[str, typing.Any] = {}
     if operation.xlim is not None:
@@ -249,11 +634,15 @@ def _render_plot_array(
     axis = _axes_from_selection(tool, operation.axes, axs, for_plot_slices=False)
     if isinstance(axis, (list, tuple)) or hasattr(axis, "flat"):
         raise ValueError("Image Plot requires exactly one target axis")
-    eplt.plot_array(
+    image = eplt.plot_array(
         data,
         ax=typing.cast("matplotlib.axes.Axes", axis),
         **_plot_array_kwargs(operation),
     )
+    if image is not None:
+        tagged_image = typing.cast("typing.Any", image)
+        tagged_image._figure_composer_operation_id = operation.operation_id
+        tagged_image._figure_composer_panel_key = 0, 0
 
 
 def _plot_array_code_kwargs(operation: FigureOperationState) -> dict[str, typing.Any]:
@@ -400,7 +789,7 @@ def _build_plot_array_view_page(
 ) -> QtWidgets.QWidget:
     page, layout = tool._new_step_form_page("figureComposerPlotArrayViewPage")
 
-    data = _selected_plot_array_data(tool, operation)
+    data = _safe_selected_plot_array_data(tool, operation)
     summary = QtWidgets.QLabel(
         "No source data is available."
         if data is None
@@ -496,11 +885,12 @@ def _build_plot_array_colors_page(
     tool._mark_editor_control(cmap_combo)
     cmap_combo.setObjectName("figureComposerPlotArrayCmapCombo")
     cmap_combo.default_cmap = None if cmap_mixed else cmap_base
-    with QtCore.QSignalBlocker(cmap_combo):
-        cmap_combo.ensure_populated()
-        if cmap_mixed:
+    cmap_combo.ensure_populated()
+    if cmap_mixed:
+        with QtCore.QSignalBlocker(cmap_combo):
             tool._set_combo_mixed_placeholder(cmap_combo)
-        else:
+    elif cmap_combo.currentText() != cmap_base:
+        with QtCore.QSignalBlocker(cmap_combo):
             cmap_combo.setCurrentText(cmap_base)
     cmap_reverse_check = tool._check_box(
         cmap_reversed,
@@ -512,11 +902,11 @@ def _build_plot_array_colors_page(
     cmap_reverse_check.setObjectName("figureComposerPlotArrayCmapReverseCheck")
     tool._connect_editor_signal(
         cmap_combo,
-        cmap_combo.activated,
-        lambda _index, combo=cmap_combo: (
+        cmap_combo.currentTextChanged,
+        lambda text, combo=cmap_combo: (
             None
-            if tool._mixed_combo_text(combo.currentText())
-            else _update_current_cmap(tool, base=combo.currentText())
+            if tool._mixed_combo_text(text)
+            else _update_current_cmap(tool, base=text)
         ),
     )
     cmap_layout.addWidget(cmap_combo, 1)
@@ -716,6 +1106,12 @@ def _editor_sections(
 ) -> tuple[StepSection, ...]:
     return (
         StepSection(
+            "selection",
+            "Selection",
+            _build_plot_array_selection_page(tool, operation),
+            "Choose the source data and selection reduced to one 2D image.",
+        ),
+        StepSection(
             "view",
             "View",
             _build_plot_array_view_page(tool, operation),
@@ -745,6 +1141,20 @@ def _section_summary(
             return tool._source_display_name(source_name) if source_name else "none"
         case "axes":
             return tool._axes_target_text(operation.axes)
+        case "selection":
+            if _plot_array_selection_error(tool, operation) is not None:
+                return "invalid"
+            selection = _primary_selection(operation)
+            labels = [
+                label
+                for label, value in (
+                    ("isel", selection.isel),
+                    ("qsel", selection.qsel),
+                    ("mean", selection.mean_dims),
+                )
+                if value
+            ]
+            return ", ".join(labels) if labels else "none"
         case "view":
             labels = [
                 label

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -902,13 +902,14 @@ def _build_plot_array_colors_page(
     cmap_reverse_check.setObjectName("figureComposerPlotArrayCmapReverseCheck")
     tool._connect_editor_signal(
         cmap_combo,
-        cmap_combo.currentTextChanged,
-        lambda text, combo=cmap_combo: (
+        cmap_combo.activated,
+        lambda _index, combo=cmap_combo: (
             None
-            if tool._mixed_combo_text(text)
-            else _update_current_cmap(tool, base=text)
+            if tool._mixed_combo_text(combo.currentText())
+            else _update_current_cmap(tool, base=combo.currentText())
         ),
     )
+    cmap_combo.blockSignals(False)
     cmap_layout.addWidget(cmap_combo, 1)
     cmap_layout.addWidget(cmap_reverse_check)
     tool._add_form_row(

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -756,7 +756,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         changed_operation_ids: set[str] = set()
         changed = False
         for mappable, clim in changes.items():
-            target = self._plot_slices_mappable_target(mappable, operations)
+            target = self._image_mappable_target(mappable, operations)
             if target is None:
                 continue
             index, operation, panel_key = target
@@ -795,7 +795,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.sigInfoChanged.emit()
         self._write_state()
 
-    def _plot_slices_mappable_target(
+    def _image_mappable_target(
         self,
         mappable: object,
         operations: Sequence[FigureOperationState],
@@ -811,9 +811,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         ):
             return None
         for index, operation in enumerate(operations):
-            if (
-                operation.operation_id == operation_id
-                and operation.kind == FigureOperationKind.PLOT_SLICES
+            if operation.operation_id == operation_id and operation.kind in (
+                FigureOperationKind.PLOT_ARRAY,
+                FigureOperationKind.PLOT_SLICES,
             ):
                 return index, operation, typing.cast("tuple[int, int]", panel_key)
         return None
@@ -824,6 +824,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         panel_key: tuple[int, int],
         clim: tuple[float, float],
     ) -> FigureOperationState:
+        if operation.kind == FigureOperationKind.PLOT_ARRAY:
+            if panel_key != (0, 0):
+                return operation
+            vmin, vmax = clim
+            return operation.model_copy(update={"vmin": vmin, "vmax": vmax})
         panel_keys = _plot_slices_panel_keys(self, operation)
         valid_keys = {(key.map_index, key.slice_index) for key in panel_keys}
         if panel_key not in valid_keys:

--- a/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
+++ b/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
@@ -119,6 +119,7 @@ if typing.TYPE_CHECKING:
 _LAYOUT_ENGINE_OPTIONS = ("default", "none", "tight", "constrained", "compressed")
 _STYLE_TARGET_PLOT_SLICES = "plot_slices"
 _STYLE_TARGET_LINE = "line"
+_STYLE_TARGET_IMAGE = "image"
 _STYLE_TARGET_COMBO_MINIMUM_CONTENTS = 28
 
 
@@ -624,7 +625,9 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
         if target is None or operation is None:
             _add_style_placeholder(images_layout, images_page)
             return
-        if _is_single_image_plot_slices_target(tool, operation, target):
+        if operation.kind == FigureOperationKind.PLOT_ARRAY or (
+            _is_single_image_plot_slices_target(tool, operation, target)
+        ):
             editor = _ImageOperationStyleWidget(operation, images_page)
 
             def apply_image_operation(
@@ -1477,7 +1480,7 @@ class _ImageOperationStyleWidget(QtWidgets.QWidget):
         ):
             layout.addRow(label, widget)
 
-        self.cmap_combo.activated.connect(self._cmap_changed)
+        self.cmap_combo.currentTextChanged.connect(self._cmap_changed)
         self.cmap_reverse_check.stateChanged.connect(self._cmap_reverse_changed)
         self.norm_combo.activated.connect(self._norm_changed)
         for attr, edit in (
@@ -1544,7 +1547,7 @@ class _ImageOperationStyleWidget(QtWidgets.QWidget):
             self.norm_kwargs_edit.setText(_format_dict(self._operation.norm_kwargs))
             self.norm_kwargs_edit.setModified(False)
 
-    def _cmap_changed(self, _index: int) -> None:
+    def _cmap_changed(self, _text: str | int) -> None:
         if self._updating:
             return
         self._set_operation(
@@ -1754,6 +1757,19 @@ def _image_style_targets(
         return []
     targets: list[_StyleTarget] = []
     for index, operation in enumerate(tool._recipe.operations):
+        if operation.enabled and operation.kind == FigureOperationKind.PLOT_ARRAY:
+            operation_axes = _axes_for_selection(tool, operation.axes)
+            if len(operation_axes) == 1 and id(operation_axes[0]) in selected_axis_ids:
+                targets.append(
+                    _StyleTarget(
+                        operation.operation_id,
+                        index,
+                        _STYLE_TARGET_IMAGE,
+                        _single_image_style_target_label(index, operation),
+                        tooltip=tool._operation_display_text(operation),
+                    )
+                )
+            continue
         if (
             not operation.enabled
             or operation.kind != FigureOperationKind.PLOT_SLICES
@@ -1777,6 +1793,15 @@ def _image_style_targets(
                 )
             )
     return targets
+
+
+def _single_image_style_target_label(
+    operation_index: int, operation: FigureOperationState
+) -> str:
+    label = operation.label.strip() or "Image plot"
+    if label == "plot_array":
+        label = "Image plot"
+    return f"Step {operation_index + 1}: {label}"
 
 
 def _axis_identity_set(

--- a/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
+++ b/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
@@ -1480,7 +1480,7 @@ class _ImageOperationStyleWidget(QtWidgets.QWidget):
         ):
             layout.addRow(label, widget)
 
-        self.cmap_combo.currentTextChanged.connect(self._cmap_changed)
+        self.cmap_combo.activated.connect(self._cmap_changed)
         self.cmap_reverse_check.stateChanged.connect(self._cmap_reverse_changed)
         self.norm_combo.activated.connect(self._norm_changed)
         for attr, edit in (
@@ -1547,7 +1547,7 @@ class _ImageOperationStyleWidget(QtWidgets.QWidget):
             self.norm_kwargs_edit.setText(_format_dict(self._operation.norm_kwargs))
             self.norm_kwargs_edit.setModified(False)
 
-    def _cmap_changed(self, _text: str | int) -> None:
+    def _cmap_changed(self, _index: int) -> None:
         if self._updating:
             return
         self._set_operation(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1288,6 +1288,191 @@ def test_figure_composer_plot_array_source_selector_updates_selection(qtbot) -> 
     )
 
 
+def test_figure_composer_plot_array_selection_editor_updates_selection(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 2, 2),
+        dims=("hv", "eV", "beta", "alpha"),
+        coords={
+            "hv": [30.0, 40.0],
+            "eV": [-1.0, 0.0, 1.0],
+            "beta": [-0.5, 0.5],
+            "alpha": [0.0, 1.0],
+        },
+        name="map",
+    )
+    operation = FigureOperationState.plot_array(
+        label="plot_array",
+        source="data",
+        map_selections=(
+            FigureDataSelectionState(
+                source="data",
+                qsel={"eV": 0.0},
+                mean_dims=("hv",),
+            ),
+        ),
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("selection")
+
+    def current_dimension_widget(
+        widget_type: type[QtWidgets.QWidget], dim: str
+    ) -> QtWidgets.QWidget:
+        widget = next(
+            (
+                candidate
+                for candidate in tool.findChildren(widget_type)
+                if candidate.property("figure_composer_plot_array_dim") == dim
+                if candidate.property("figure_composer_editor_generation")
+                == tool._operation_editor_generation
+            ),
+            None,
+        )
+        assert widget is not None
+        return widget
+
+    def activate_dimension_mode(dim: str, mode: str) -> None:
+        combo = typing.cast(
+            "QtWidgets.QComboBox",
+            current_dimension_widget(QtWidgets.QComboBox, dim),
+        )
+        index = combo.findData(mode)
+        assert index >= 0
+        combo.setCurrentIndex(index)
+        combo.activated.emit(index)
+
+    def current_dimension_value(dim: str) -> QtWidgets.QLineEdit:
+        return typing.cast(
+            "QtWidgets.QLineEdit",
+            current_dimension_widget(QtWidgets.QLineEdit, dim),
+        )
+
+    summary = tool.findChild(
+        QtWidgets.QLabel, "figureComposerPlotArraySelectionSummary"
+    )
+    assert summary is not None
+    assert "Input dims: hv, eV, beta, alpha" in summary.text()
+    assert "Plotted dims: beta, alpha" in summary.text()
+
+    eV_mode = typing.cast(
+        "QtWidgets.QComboBox",
+        current_dimension_widget(QtWidgets.QComboBox, "eV"),
+    )
+    assert eV_mode.currentData() == "qsel"
+    qsel_edit = current_dimension_value("eV")
+    qsel_edit.setText("1.0")
+    qsel_edit.setModified(True)
+    qsel_edit.editingFinished.emit()
+
+    updated = tool.tool_status.operations[0]
+    assert updated.map_selections == (
+        FigureDataSelectionState(
+            source="data",
+            qsel={"eV": 1.0},
+            mean_dims=("hv",),
+        ),
+    )
+
+    activate_dimension_mode("hv", "keep")
+    activate_dimension_mode("hv", "isel")
+    isel_edit = current_dimension_value("hv")
+    isel_edit.setText("1")
+    isel_edit.setModified(True)
+    isel_edit.editingFinished.emit()
+
+    updated = tool.tool_status.operations[0]
+    assert updated.map_selections == (
+        FigureDataSelectionState(
+            source="data",
+            isel={"hv": 1},
+            qsel={"eV": 1.0},
+        ),
+    )
+
+
+def test_figure_composer_plot_array_selection_error_is_visible(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("y", "x"),
+        coords={"y": [0.0, 1.0], "x": [0.0, 1.0]},
+        name="map",
+    )
+    operation = FigureOperationState.plot_array(
+        label="plot_array",
+        source="data",
+        map_selections=(
+            FigureDataSelectionState(source="data", qsel={"missing": 0.0}),
+        ),
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+
+    assert "invalid selection" in figurecomposer_plot_array._display_text(
+        tool, operation
+    )
+
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("selection")
+
+    summary = tool.findChild(
+        QtWidgets.QLabel, "figureComposerPlotArraySelectionSummary"
+    )
+    assert summary is not None
+    assert "missing" in summary.text()
+
+
+def test_figure_composer_plot_array_colormap_text_change_updates_recipe(
+    qtbot,
+) -> None:
+    data = _figure_composer_image_source("data").isel(eV=0)
+    operation = FigureOperationState.plot_array(label="plot_array", source="data")
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("colors")
+
+    cmap_combo = next(
+        (
+            candidate
+            for candidate in tool.findChildren(
+                erlab.interactive.colors.ColorMapComboBox,
+                "figureComposerPlotArrayCmapCombo",
+            )
+            if candidate.property("figure_composer_editor_generation")
+            == tool._operation_editor_generation
+        ),
+        None,
+    )
+    assert cmap_combo is not None
+    cmap_combo.load_all()
+    current_cmap = cmap_combo.currentText()
+    target_index = next(
+        index
+        for index in range(cmap_combo.count())
+        if cmap_combo.itemText(index) != current_cmap
+    )
+    cmap = cmap_combo.itemText(target_index)
+    cmap_combo.setCurrentText(cmap)
+
+    assert tool.tool_status.operations[0].cmap == cmap
+
+
 def test_figure_composer_plot_array_add_action_and_plain_2d_codegen(
     qtbot, monkeypatch
 ) -> None:
@@ -1413,6 +1598,37 @@ def test_figure_composer_plot_array_render_and_generated_code(
     assert "eplt.plot_array(data.qsel(eV=0.0).T" in code
     namespace = _exec_generated_code(code, {"data": data})
     assert "fig" in namespace
+
+
+def test_figure_composer_plot_array_colorbar_limit_changes_update_recipe(
+    qtbot,
+) -> None:
+    data = _figure_composer_image_source("data").isel(eV=0)
+    operation = FigureOperationState.plot_array(
+        label="plot_array",
+        source="data",
+    ).model_copy(update={"colorbar": "right"})
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+    image = tool.figure.axes[0].images[-1]
+    assert image._figure_composer_operation_id == operation.operation_id
+    assert image._figure_composer_panel_key == (0, 0)
+    assert (
+        tool._operation_with_colorbar_clim(operation, (1, 0), (-1.0, 1.0)) == operation
+    )
+
+    tool._figure_window_colorbar_changed({image: (-1.0, 1.0)})
+
+    updated = tool.tool_status.operations[0]
+    assert updated.vmin == -1.0
+    assert updated.vmax == 1.0
 
 
 def test_figure_composer_plot_array_codegen_handles_spaced_dimension(qtbot) -> None:
@@ -7993,7 +8209,7 @@ def test_figure_composer_colorbar_drag_updates_recipe_limits(qtbot) -> None:
     previous_clim = mappable.get_clim()
 
     operations = tool.tool_status.operations
-    assert tool._plot_slices_mappable_target(object(), operations) is None
+    assert tool._image_mappable_target(object(), operations) is None
     bad_panel_mappable = type("BadPanelMappable", (), {})()
     setattr(
         bad_panel_mappable,
@@ -8005,7 +8221,7 @@ def test_figure_composer_colorbar_drag_updates_recipe_limits(qtbot) -> None:
         figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
         ("bad", 0),
     )
-    assert tool._plot_slices_mappable_target(bad_panel_mappable, operations) is None
+    assert tool._image_mappable_target(bad_panel_mappable, operations) is None
     missing_operation_mappable = type("MissingOperationMappable", (), {})()
     setattr(
         missing_operation_mappable,
@@ -8017,10 +8233,7 @@ def test_figure_composer_colorbar_drag_updates_recipe_limits(qtbot) -> None:
         figurecomposer_plot_slices._PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
         (0, 0),
     )
-    assert (
-        tool._plot_slices_mappable_target(missing_operation_mappable, operations)
-        is None
-    )
+    assert tool._image_mappable_target(missing_operation_mappable, operations) is None
     assert (
         tool._operation_with_colorbar_clim(operation, (99, 99), (1.0, 5.0)) == operation
     )
@@ -14384,6 +14597,68 @@ def test_figure_composer_toolbar_axes_dialog_updates_single_image_style_directly
     assert not gamma_edit.isEnabled()
     assert vmin_edit.isEnabled()
     assert vmax_edit.isEnabled()
+
+
+def test_figure_composer_toolbar_axes_dialog_updates_plot_array_style(
+    qtbot,
+) -> None:
+    data = _figure_composer_image_source("data").isel(eV=0)
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.plot_array(
+                    label="plot_array",
+                    source="data",
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.show_figure_window(activate=False)
+
+    tool._show_axes_customize_dialog()
+    dialog = tool._axes_customize_dialog
+    assert isinstance(dialog, QtWidgets.QDialog)
+    target_combo = dialog.findChild(
+        QtWidgets.QComboBox, "figureComposerToolbarImageTargetCombo"
+    )
+    panel_list = dialog.findChild(
+        QtWidgets.QListWidget, "figureComposerPlotSlicesPanelStyleList"
+    )
+    cmap_combo = dialog.findChild(
+        erlab.interactive.colors.ColorMapComboBox, "figureComposerPanelCmapCombo"
+    )
+    cmap_reverse_check = dialog.findChild(
+        QtWidgets.QCheckBox, "figureComposerPanelCmapReverseCheck"
+    )
+    norm_combo = dialog.findChild(QtWidgets.QComboBox, "figureComposerPanelNormCombo")
+    vmin_edit = dialog.findChild(QtWidgets.QLineEdit, "figureComposerPanelVminEdit")
+    vmax_edit = dialog.findChild(QtWidgets.QLineEdit, "figureComposerPanelVmaxEdit")
+    assert target_combo is not None
+    assert target_combo.count() == 1
+    assert panel_list is None
+    assert cmap_combo is not None
+    assert cmap_reverse_check is not None
+    assert norm_combo is not None
+    assert vmin_edit is not None
+    assert vmax_edit is not None
+
+    cmap_combo.setCurrentText("magma")
+    cmap_reverse_check.setCheckState(QtCore.Qt.CheckState.Checked)
+    _activate_combo_text(norm_combo, "Normalize")
+    vmin_edit.setText("-1")
+    vmin_edit.editingFinished.emit()
+    vmax_edit.setText("1")
+    vmax_edit.editingFinished.emit()
+
+    operation = tool.tool_status.operations[0]
+    assert operation.cmap == "magma_r"
+    assert operation.norm_name == "Normalize"
+    assert operation.vmin == -1.0
+    assert operation.vmax == 1.0
 
 
 def test_figure_composer_toolbar_image_target_combo_elides_long_sources(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1432,7 +1432,7 @@ def test_figure_composer_plot_array_selection_error_is_visible(qtbot) -> None:
     assert "missing" in summary.text()
 
 
-def test_figure_composer_plot_array_colormap_text_change_updates_recipe(
+def test_figure_composer_plot_array_colormap_activation_updates_recipe(
     qtbot,
 ) -> None:
     data = _figure_composer_image_source("data").isel(eV=0)
@@ -1461,6 +1461,7 @@ def test_figure_composer_plot_array_colormap_text_change_updates_recipe(
     )
     assert cmap_combo is not None
     cmap_combo.load_all()
+    assert tool.tool_status.operations[0].cmap is None
     current_cmap = cmap_combo.currentText()
     target_index = next(
         index
@@ -1469,6 +1470,7 @@ def test_figure_composer_plot_array_colormap_text_change_updates_recipe(
     )
     cmap = cmap_combo.itemText(target_index)
     cmap_combo.setCurrentText(cmap)
+    cmap_combo.activated.emit(cmap_combo.currentIndex())
 
     assert tool.tool_status.operations[0].cmap == cmap
 
@@ -14646,7 +14648,10 @@ def test_figure_composer_toolbar_axes_dialog_updates_plot_array_style(
     assert vmin_edit is not None
     assert vmax_edit is not None
 
+    cmap_combo.load_all()
+    assert tool.tool_status.operations[0].cmap is None
     cmap_combo.setCurrentText("magma")
+    cmap_combo.activated.emit(cmap_combo.currentIndex())
     cmap_reverse_check.setCheckState(QtCore.Qt.CheckState.Checked)
     _activate_combo_text(norm_combo, "Normalize")
     vmin_edit.setText("-1")

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1379,6 +1379,25 @@ def test_figure_composer_plot_array_selection_editor_updates_selection(qtbot) ->
         ),
     )
 
+    activate_dimension_mode("eV", "isel")
+    updated = tool.tool_status.operations[0]
+    assert updated.map_selections == (
+        FigureDataSelectionState(
+            source="data",
+            isel={"eV": 1.0},
+            mean_dims=("hv",),
+        ),
+    )
+    activate_dimension_mode("eV", "qsel")
+    updated = tool.tool_status.operations[0]
+    assert updated.map_selections == (
+        FigureDataSelectionState(
+            source="data",
+            qsel={"eV": 1.0},
+            mean_dims=("hv",),
+        ),
+    )
+
     activate_dimension_mode("hv", "keep")
     activate_dimension_mode("hv", "isel")
     isel_edit = current_dimension_value("hv")
@@ -1432,6 +1451,151 @@ def test_figure_composer_plot_array_selection_error_is_visible(qtbot) -> None:
     assert "missing" in summary.text()
 
 
+def test_figure_composer_plot_array_selection_helper_edges(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("y", "x"),
+        coords={"y": [0.0, 1.0], "x": [0.0, 1.0]},
+        name="map",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(
+            FigureOperationState.plot_array(label="plot_array", source="data"),
+        ),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    figurecomposer_plot_array._update_current_selection_source(tool, "data")
+    assert tool.tool_status.operations[0].map_selections == (
+        FigureDataSelectionState(source="data"),
+    )
+
+    missing_operation = FigureOperationState.plot_array(
+        label="missing", source="missing"
+    )
+    assert (
+        figurecomposer_plot_array._plot_array_source_data(tool, missing_operation)
+        is None
+    )
+    assert "missing" in figurecomposer_plot_array._display_text(tool, missing_operation)
+
+    no_update_tool = types.SimpleNamespace(
+        _update_operations=lambda *_args, **_kwargs: pytest.fail(
+            "None source should not update"
+        )
+    )
+    figurecomposer_plot_array._update_current_selection_source(
+        typing.cast("FigureComposerTool", no_update_tool),
+        None,
+    )
+    figurecomposer_plot_array._update_current_selection_dimension(
+        typing.cast("FigureComposerTool", no_update_tool),
+        "x",
+        "bad",
+    )
+
+    with pytest.raises(figurecomposer_text.FigureComposerInputError):
+        figurecomposer_plot_array._plot_array_selection_value_from_text("")
+    with pytest.raises(figurecomposer_text.FigureComposerInputError):
+        figurecomposer_plot_array._plot_array_selection_value_from_text("slice(")
+
+    selection = FigureDataSelectionState(
+        source="data",
+        isel={"x": 0},
+        qsel={"y": 0.0},
+    )
+    assert figurecomposer_plot_array._plot_array_selection_with_dimension(
+        selection,
+        "x",
+        "mean",
+    ) == FigureDataSelectionState(
+        source="data",
+        qsel={"y": 0.0},
+        mean_dims=("x",),
+    )
+
+    combo = figurecomposer_plot_array._plot_array_selection_mode_combo(
+        tool,
+        current=None,
+        mixed=True,
+        parent=tool,
+    )
+    assert combo.currentData() is _editor_controls.MIXED_VALUE
+
+
+def test_figure_composer_plot_array_selection_page_empty_sources(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("y", "x"),
+        coords={"y": [0.0, 1.0], "x": [0.0, 1.0]},
+        name="map",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(
+            FigureOperationState.plot_array(label="missing", source="missing"),
+        ),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("selection")
+    assert (
+        tool.findChild(
+            QtWidgets.QLabel,
+            "figureComposerPlotArraySelectionDimensionsMessage",
+        )
+        is not None
+    )
+
+    scalar = xr.DataArray(1.0, name="scalar")
+    scalar_tool = FigureComposerTool.from_sources(
+        {"scalar": scalar},
+        sources=(FigureSourceState(name="scalar", label="scalar"),),
+        operations=(FigureOperationState.plot_array(label="scalar", source="scalar"),),
+        primary_source="scalar",
+    )
+    qtbot.addWidget(scalar_tool)
+    scalar_tool.operation_list.setCurrentRow(0)
+    scalar_tool._select_step_section("selection")
+    assert (
+        scalar_tool.findChild(
+            QtWidgets.QLabel,
+            "figureComposerPlotArraySelectionDimensionsMessage",
+        )
+        is not None
+    )
+
+    mixed_tool = FigureComposerTool.from_sources(
+        {
+            "first": data,
+            "second": data,
+        },
+        sources=(
+            FigureSourceState(name="first", label="first"),
+            FigureSourceState(name="second", label="second"),
+        ),
+        operations=(
+            FigureOperationState.plot_array(label="first", source="first"),
+            FigureOperationState.plot_array(label="second", source="second"),
+        ),
+        primary_source="first",
+    )
+    qtbot.addWidget(mixed_tool)
+    _select_operation_rows(mixed_tool, (0, 1))
+    mixed_tool._select_step_section("selection")
+    assert (
+        mixed_tool.findChild(
+            QtWidgets.QLabel,
+            "figureComposerPlotArraySelectionDimensionsMessage",
+        )
+        is not None
+    )
+
+
 def test_figure_composer_plot_array_colormap_activation_updates_recipe(
     qtbot,
 ) -> None:
@@ -1473,6 +1637,83 @@ def test_figure_composer_plot_array_colormap_activation_updates_recipe(
     cmap_combo.activated.emit(cmap_combo.currentIndex())
 
     assert tool.tool_status.operations[0].cmap == cmap
+
+
+def test_figure_composer_plot_array_colormap_editor_initialization_edges(
+    qtbot,
+) -> None:
+    data = _figure_composer_image_source("data").isel(eV=0)
+    explicit = FigureOperationState.plot_array(
+        label="explicit",
+        source="data",
+    ).model_copy(update={"cmap": "magma"})
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(explicit,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("colors")
+    cmap_combo = next(
+        (
+            candidate
+            for candidate in tool.findChildren(
+                erlab.interactive.colors.ColorMapComboBox,
+                "figureComposerPlotArrayCmapCombo",
+            )
+            if candidate.property("figure_composer_editor_generation")
+            == tool._operation_editor_generation
+        ),
+        None,
+    )
+    assert cmap_combo is not None
+    assert cmap_combo.currentText() == "magma"
+
+    missing_cmap_tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(explicit.model_copy(update={"cmap": "missing_colormap_name"}),),
+        primary_source="data",
+    )
+    qtbot.addWidget(missing_cmap_tool)
+    missing_cmap_tool.operation_list.setCurrentRow(0)
+    missing_cmap_tool._select_step_section("colors")
+    assert (
+        missing_cmap_tool.findChild(
+            erlab.interactive.colors.ColorMapComboBox,
+            "figureComposerPlotArrayCmapCombo",
+        )
+        is not None
+    )
+
+    mixed_tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(
+            explicit,
+            explicit.model_copy(update={"cmap": "viridis"}),
+        ),
+        primary_source="data",
+    )
+    qtbot.addWidget(mixed_tool)
+    _select_operation_rows(mixed_tool, (0, 1))
+    mixed_tool._select_step_section("colors")
+    mixed_cmap_combo = next(
+        (
+            candidate
+            for candidate in mixed_tool.findChildren(
+                erlab.interactive.colors.ColorMapComboBox,
+                "figureComposerPlotArrayCmapCombo",
+            )
+            if candidate.property("figure_composer_editor_generation")
+            == mixed_tool._operation_editor_generation
+        ),
+        None,
+    )
+    assert mixed_cmap_combo is not None
+    assert mixed_cmap_combo.currentData() is _editor_controls.MIXED_VALUE
 
 
 def test_figure_composer_plot_array_add_action_and_plain_2d_codegen(


### PR DESCRIPTION
## Summary
- Add a dedicated Selection section for `plot_array` steps so source choice and dimension reduction can be edited directly
- Surface invalid selections in the plot_array summary and route image colorbar updates through the image mappable path
- Switch colormap edits to activation-based updates and expose plot_array image styling in the axes customize dialog

## Testing
- Added unit and UI coverage for selection editing, invalid-selection display, colormap activation, colorbar limit updates, and image style dialog behavior