### PR TITLE
Refine provenance edit dialogs and generated code output

### DIFF
--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -632,6 +632,13 @@ which ImageTool data and selection opened it:
   should not remain group-editable. When full groups are pasted, refresh their group
   identities before appending them to the destination provenance so adjacent copies
   remain separate editable groups.
+- To make a transform or filter dialog reusable for manager step edits, keep the widget
+  state restoration separate from the normal apply path. Transform dialogs should
+  implement `restore_transform_operation(...)` or `restore_transform_operations(...)`
+  and return current edits from `source_operations(...)`; filter dialogs should
+  implement `restore_filter_operation(...)` and `filter_operation(...)`. The manager
+  opens the dialog on data replayed up to the edited step and reads the corresponding
+  operation methods after the user accepts.
 - When implementing a custom ``ToolProvenanceOperation.derivation_entry()``, return a
   ``DerivationEntry`` for steps that should appear in the manager derivation list or
   copied code. Return ``None`` only for operations that must still run during an update

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -337,10 +337,7 @@ class _DataManipulationDialog(QtWidgets.QDialog):
 
         self.setup_widgets()
 
-        if self.is_provenance_edit_mode:
-            self.buttonBox.accepted.connect(self._accept_provenance_edit)
-        else:
-            self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
         self.layout_.addRow(self.buttonBox)
 
@@ -396,6 +393,13 @@ class _DataManipulationDialog(QtWidgets.QDialog):
             erlab.interactive.utils.MessageDialog.critical(
                 self, "Error", "An error occurred while editing provenance."
             )
+            return
+        super().accept()
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        if self.is_provenance_edit_mode:
+            self._accept_provenance_edit()
             return
         super().accept()
 
@@ -873,7 +877,7 @@ class DataTransformDialog(_DataManipulationDialog):
     @QtCore.Slot()
     def accept(self) -> None:
         if self.is_provenance_edit_mode:
-            self._accept_provenance_edit()
+            super().accept()
             return
 
         manager = self.batch_manager
@@ -1114,7 +1118,7 @@ class DataFilterDialog(_DataManipulationDialog):
     @QtCore.Slot()
     def accept(self) -> None:
         if self.is_provenance_edit_mode:
-            self._accept_provenance_edit()
+            super().accept()
             return
 
         manager = self.batch_manager

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -303,12 +303,14 @@ class _DataManipulationDialog(QtWidgets.QDialog):
         slicer_area: ImageSlicerArea,
         *,
         batch_manager: ImageToolManager | None = None,
+        provenance_edit_mode: bool = False,
     ) -> None:
         super().__init__(slicer_area)
         if self.title is not None:
             self.setWindowTitle(self.title)
 
         self.slicer_area = slicer_area
+        self._provenance_edit_mode = provenance_edit_mode
         self._batch_manager = (
             None if batch_manager is None else weakref.ref(batch_manager)
         )
@@ -335,7 +337,10 @@ class _DataManipulationDialog(QtWidgets.QDialog):
 
         self.setup_widgets()
 
-        self.buttonBox.accepted.connect(self.accept)
+        if self.is_provenance_edit_mode:
+            self.buttonBox.accepted.connect(self._accept_provenance_edit)
+        else:
+            self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
         self.layout_.addRow(self.buttonBox)
 
@@ -367,6 +372,32 @@ class _DataManipulationDialog(QtWidgets.QDialog):
     @property
     def is_batch_mode(self) -> bool:
         return self.batch_manager is not None
+
+    @property
+    def is_provenance_edit_mode(self) -> bool:
+        return self._provenance_edit_mode
+
+    def provenance_edit_operations(
+        self,
+    ) -> list[provenance.ToolProvenanceOperation]:
+        raise NotImplementedError
+
+    @QtCore.Slot()
+    def _accept_provenance_edit(self) -> None:
+        try:
+            if not self.provenance_edit_operations():
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "No Operation",
+                    "Select at least one operation before applying.",
+                )
+                return
+        except Exception:
+            erlab.interactive.utils.MessageDialog.critical(
+                self, "Error", "An error occurred while editing provenance."
+            )
+            return
+        super().accept()
 
     @QtCore.Slot()
     def _copy(self) -> None:
@@ -503,8 +534,15 @@ class DataTransformDialog(_DataManipulationDialog):
         slicer_area: ImageSlicerArea,
         *,
         batch_manager: ImageToolManager | None = None,
+        provenance_edit_mode: bool = False,
     ) -> None:
-        super().__init__(slicer_area, batch_manager=batch_manager)
+        super().__init__(
+            slicer_area,
+            batch_manager=batch_manager,
+            provenance_edit_mode=provenance_edit_mode,
+        )
+        if self.is_provenance_edit_mode:
+            return
         self.launch_mode_combo = QtWidgets.QComboBox()
         for value, label, tooltip in self._available_launch_modes():
             self.launch_mode_combo.addItem(label, userData=value)
@@ -563,6 +601,11 @@ class DataTransformDialog(_DataManipulationDialog):
     ) -> list[provenance.ToolProvenanceOperation]:
         operation = self.source_transform_operation()
         return [] if operation is None else [operation]
+
+    def provenance_edit_operations(
+        self,
+    ) -> list[provenance.ToolProvenanceOperation]:
+        return self.source_operations()
 
     def source_transform_operation(
         self,
@@ -829,6 +872,10 @@ class DataTransformDialog(_DataManipulationDialog):
 
     @QtCore.Slot()
     def accept(self) -> None:
+        if self.is_provenance_edit_mode:
+            self._accept_provenance_edit()
+            return
+
         manager = self.batch_manager
         if manager is not None:
             try:
@@ -973,15 +1020,24 @@ class DataFilterDialog(_DataManipulationDialog):
         slicer_area: ImageSlicerArea,
         *,
         batch_manager: ImageToolManager | None = None,
+        provenance_edit_mode: bool = False,
     ) -> None:
-        super().__init__(slicer_area, batch_manager=batch_manager)
+        super().__init__(
+            slicer_area,
+            batch_manager=batch_manager,
+            provenance_edit_mode=provenance_edit_mode,
+        )
         self._previewed: bool = False
         self._starting_applied_func = self.slicer_area._applied_func
         self._starting_filter_operation = (
             self.slicer_area._accepted_filter_provenance_operation
         )
 
-        if self.enable_preview and not self.is_batch_mode:
+        if (
+            self.enable_preview
+            and not self.is_batch_mode
+            and not self.is_provenance_edit_mode
+        ):
             self.preview_button = QtWidgets.QPushButton("Preview")
             self.preview_button.clicked.connect(self._preview)
             self.buttonBox.addButton(
@@ -1057,6 +1113,10 @@ class DataFilterDialog(_DataManipulationDialog):
 
     @QtCore.Slot()
     def accept(self) -> None:
+        if self.is_provenance_edit_mode:
+            self._accept_provenance_edit()
+            return
+
         manager = self.batch_manager
         if manager is not None:
             try:
@@ -1099,6 +1159,11 @@ class DataFilterDialog(_DataManipulationDialog):
     ) -> list[provenance.ToolProvenanceOperation]:
         operation = self.filter_operation()
         return [] if operation is None else [operation]
+
+    def provenance_edit_operations(
+        self,
+    ) -> list[provenance.ToolProvenanceOperation]:
+        return self.filter_operations()
 
     def make_code(self) -> str:
         try:

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -548,121 +548,6 @@ class _FileLoadEditDialog(QtWidgets.QDialog):
         super().accept()
 
 
-def _operation_field_names(
-    operation: provenance.ToolProvenanceOperation,
-) -> tuple[str, ...]:
-    return tuple(
-        name for name in type(operation).model_fields if name not in {"op", "group"}
-    )
-
-
-def _operation_value_text(value: typing.Any) -> str:
-    return repr(value)
-
-
-def _parse_operation_value(text: str) -> typing.Any:
-    text = text.strip()
-    if not text:
-        raise ValueError("Operation values must be Python literals.")
-    return ast.literal_eval(text)
-
-
-def _operation_from_field_text(
-    operation: provenance.ToolProvenanceOperation,
-    field_text: dict[str, str],
-) -> provenance.ToolProvenanceOperation:
-    payload = operation.model_dump(mode="python")
-    for field_name, text in field_text.items():
-        payload[field_name] = _parse_operation_value(text)
-    return type(operation).model_validate(payload)
-
-
-class _RecordedOperationEditDialog(QtWidgets.QDialog):
-    def __init__(
-        self,
-        operations: Sequence[provenance.ToolProvenanceOperation],
-        parent: QtWidgets.QWidget,
-        *,
-        focus: str | None = None,
-    ) -> None:
-        super().__init__(parent)
-        self.setObjectName("managerProvenanceRecordedOperationEditDialog")
-        self.setWindowTitle("Edit Provenance Operation")
-        self.setModal(True)
-        self._operations = tuple(operations)
-        self._field_edits: dict[tuple[int, str], QtWidgets.QLineEdit] = {}
-
-        layout = QtWidgets.QVBoxLayout(self)
-        for index, operation in enumerate(self._operations):
-            group = QtWidgets.QGroupBox(_operation_title(operation), self)
-            group.setObjectName(f"managerProvenanceOperationGroup{index}")
-            form = QtWidgets.QFormLayout(group)
-            form.setFieldGrowthPolicy(
-                QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
-            )
-            field_names = _operation_field_names(operation)
-            if not field_names:
-                form.addRow(QtWidgets.QLabel("This operation has no editable values."))
-            for field_name in field_names:
-                edit = QtWidgets.QLineEdit(
-                    _operation_value_text(getattr(operation, field_name)),
-                    group,
-                )
-                edit.setObjectName(
-                    f"managerProvenanceOperationField_{index}_{field_name}"
-                )
-                edit.setToolTip("Enter a Python literal value.")
-                self._field_edits[(index, field_name)] = edit
-                form.addRow(field_name, edit)
-            layout.addWidget(group)
-
-        self.button_box = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.StandardButton.Ok
-            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
-            self,
-        )
-        self.button_box.setObjectName("managerProvenanceOperationEditButtonBox")
-        self.button_box.accepted.connect(self.accept)
-        self.button_box.rejected.connect(self.reject)
-        layout.addWidget(self.button_box)
-        if focus is not None:
-            self._focus_field(focus)
-
-    def _focus_field(self, focus: str) -> None:
-        for (_index, field_name), edit in self._field_edits.items():
-            if field_name == focus:
-                edit.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
-                edit.selectAll()
-                return
-
-    def edited_operations(self) -> list[provenance.ToolProvenanceOperation]:
-        edited: list[provenance.ToolProvenanceOperation] = []
-        for index, operation in enumerate(self._operations):
-            edited.append(
-                _operation_from_field_text(
-                    operation,
-                    {
-                        field_name: self._field_edits[(index, field_name)].text()
-                        for field_name in _operation_field_names(operation)
-                    },
-                )
-            )
-        return edited
-
-    @QtCore.Slot()
-    def accept(self) -> None:
-        try:
-            self.edited_operations()
-        except Exception as exc:
-            QtWidgets.QMessageBox.warning(
-                self,
-                "Invalid Operation Value",
-                str(exc),
-            )
-            return
-        super().accept()
-
-
 class _ScriptCodeEditDialog(QtWidgets.QDialog):
     def __init__(
         self,
@@ -720,35 +605,6 @@ class _ScriptCodeEditDialog(QtWidgets.QDialog):
         super().accept()
 
 
-def _operation_title(operation: provenance.ToolProvenanceOperation) -> str:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        try:
-            return operation.derivation_label()
-        except Exception:
-            return type(operation).__name__
-
-
-def _recorded_operation_edit_unavailable_reason(
-    operations: Sequence[provenance.ToolProvenanceOperation],
-) -> str | None:
-    for operation in operations:
-        try:
-            _operation_from_field_text(
-                operation,
-                {
-                    field_name: _operation_value_text(getattr(operation, field_name))
-                    for field_name in _operation_field_names(operation)
-                },
-            )
-        except Exception as exc:
-            return (
-                f"{_operation_title(operation)} cannot be edited safely from "
-                f"recorded metadata: {exc}"
-            )
-    return None
-
-
 def _iter_dialog_classes(
     cls: type[dialogs._DataManipulationDialog],
 ) -> Iterator[type[dialogs._DataManipulationDialog]]:
@@ -757,37 +613,191 @@ def _iter_dialog_classes(
         yield from _iter_dialog_classes(subclass)
 
 
+def _iter_imagetool_dialog_classes(
+    cls: type[dialogs._DataManipulationDialog],
+) -> Iterator[type[dialogs._DataManipulationDialog]]:
+    for dialog_cls in _iter_dialog_classes(cls):
+        if dialog_cls.__module__ == dialogs.__name__:
+            yield dialog_cls
+
+
+def _dialog_declares_operation_type(
+    dialog_cls: type[dialogs._DataManipulationDialog],
+    operation_type: type[provenance.ToolProvenanceOperation],
+) -> bool:
+    return any(
+        issubclass(operation_type, declared_type)
+        for declared_type in dialog_cls.operation_types
+    )
+
+
+def _operation_matches_dialog(
+    operation: provenance.ToolProvenanceOperation,
+    dialog_cls: type[dialogs._DataManipulationDialog],
+) -> bool:
+    return any(
+        isinstance(operation, operation_type)
+        for operation_type in dialog_cls.operation_types
+    )
+
+
+def _dialog_supports_transform_restore(
+    dialog_cls: type[dialogs.DataTransformDialog],
+) -> bool:
+    return (
+        dialog_cls.restore_transform_operation
+        is not dialogs.DataTransformDialog.restore_transform_operation
+        or dialog_cls.restore_transform_operations
+        is not dialogs.DataTransformDialog.restore_transform_operations
+    )
+
+
+def _dialog_supports_filter_restore(
+    dialog_cls: type[dialogs.DataFilterDialog],
+) -> bool:
+    return (
+        dialog_cls.restore_filter_operation
+        is not dialogs.DataFilterDialog.restore_filter_operation
+    )
+
+
+def _dialog_is_group_editor(dialog_cls: type[dialogs.DataTransformDialog]) -> bool:
+    return bool(dialog_cls.grouped_operation_only or dialog_cls.operation_group_kind)
+
+
+def _dialog_overrides_operation_group_for_edit(
+    dialog_cls: type[dialogs.DataTransformDialog],
+) -> bool:
+    return (
+        typing.cast("typing.Any", dialog_cls.operation_group_for_edit).__func__
+        is not typing.cast(
+            "typing.Any", dialogs.DataTransformDialog.operation_group_for_edit
+        ).__func__
+    )
+
+
+def _standalone_editor_dialog_classes_for_operation_type(
+    operation_type: type[provenance.ToolProvenanceOperation],
+) -> tuple[type[dialogs._DataManipulationDialog], ...]:
+    matches: list[type[dialogs._DataManipulationDialog]] = []
+    for dialog_base_cls in _iter_imagetool_dialog_classes(dialogs.DataTransformDialog):
+        dialog_cls = typing.cast("type[dialogs.DataTransformDialog]", dialog_base_cls)
+        if not _dialog_declares_operation_type(dialog_cls, operation_type):
+            continue
+        if not _dialog_supports_transform_restore(dialog_cls):
+            continue
+        if _dialog_is_group_editor(dialog_cls):
+            continue
+        matches.append(dialog_cls)
+    for dialog_base_cls in _iter_imagetool_dialog_classes(dialogs.DataFilterDialog):
+        dialog_cls = typing.cast("type[dialogs.DataFilterDialog]", dialog_base_cls)
+        if not _dialog_declares_operation_type(dialog_cls, operation_type):
+            continue
+        if not _dialog_supports_filter_restore(dialog_cls):
+            continue
+        matches.append(dialog_cls)
+    return tuple(matches)
+
+
+def _grouped_editor_dialog_classes_for_operation_type(
+    operation_type: type[provenance.ToolProvenanceOperation],
+) -> tuple[type[dialogs.DataTransformDialog], ...]:
+    matches: list[type[dialogs.DataTransformDialog]] = []
+    for dialog_base_cls in _iter_imagetool_dialog_classes(dialogs.DataTransformDialog):
+        dialog_cls = typing.cast("type[dialogs.DataTransformDialog]", dialog_base_cls)
+        if not _dialog_declares_operation_type(dialog_cls, operation_type):
+            continue
+        if not _dialog_supports_transform_restore(dialog_cls):
+            continue
+        if _dialog_is_group_editor(
+            dialog_cls
+        ) and _dialog_overrides_operation_group_for_edit(dialog_cls):
+            matches.append(dialog_cls)
+    return tuple(matches)
+
+
+def _standalone_editor_dialog_class_for_operation_type(
+    operation_type: type[provenance.ToolProvenanceOperation],
+) -> type[dialogs._DataManipulationDialog] | None:
+    matches = _standalone_editor_dialog_classes_for_operation_type(operation_type)
+    if len(matches) > 1:
+        names = ", ".join(dialog_cls.__name__ for dialog_cls in matches)
+        raise RuntimeError(
+            f"Multiple standalone provenance editors handle "
+            f"{operation_type.__name__}: {names}"
+        )
+    return matches[0] if matches else None
+
+
+def _operation_editor_contract_errors() -> list[str]:
+    operation_types: set[type[provenance.ToolProvenanceOperation]] = set()
+    for base_cls in (dialogs.DataTransformDialog, dialogs.DataFilterDialog):
+        for dialog_cls in _iter_imagetool_dialog_classes(base_cls):
+            operation_types.update(dialog_cls.operation_types)
+
+    errors: list[str] = []
+    for operation_type in sorted(operation_types, key=lambda cls: cls.__name__):
+        standalone = _standalone_editor_dialog_classes_for_operation_type(
+            operation_type
+        )
+        grouped = _grouped_editor_dialog_classes_for_operation_type(operation_type)
+        broken_grouped: list[type[dialogs.DataTransformDialog]] = []
+        for dialog_base_cls in _iter_imagetool_dialog_classes(
+            dialogs.DataTransformDialog
+        ):
+            dialog_cls = typing.cast(
+                "type[dialogs.DataTransformDialog]", dialog_base_cls
+            )
+            if not _dialog_declares_operation_type(dialog_cls, operation_type):
+                continue
+            if not _dialog_supports_transform_restore(dialog_cls):
+                continue
+            if _dialog_is_group_editor(
+                dialog_cls
+            ) and not _dialog_overrides_operation_group_for_edit(dialog_cls):
+                broken_grouped.append(dialog_cls)
+        if len(standalone) > 1:
+            names = ", ".join(dialog_cls.__name__ for dialog_cls in standalone)
+            errors.append(
+                f"{operation_type.__name__} has multiple standalone editors: {names}"
+            )
+        if len(grouped) > 1:
+            names = ", ".join(dialog_cls.__name__ for dialog_cls in grouped)
+            errors.append(
+                f"{operation_type.__name__} has multiple grouped editors: {names}"
+            )
+        if standalone and grouped:
+            standalone_names = ", ".join(
+                dialog_cls.__name__ for dialog_cls in standalone
+            )
+            grouped_names = ", ".join(dialog_cls.__name__ for dialog_cls in grouped)
+            errors.append(
+                f"{operation_type.__name__} has both standalone and grouped editors: "
+                f"{standalone_names}; {grouped_names}"
+            )
+        errors.extend(
+            f"{dialog_cls.__name__} declares {operation_type.__name__} as a "
+            "grouped editor but does not override operation_group_for_edit"
+            for dialog_cls in broken_grouped
+        )
+        if not standalone and not grouped and not broken_grouped:
+            errors.append(f"{operation_type.__name__} has no provenance editor")
+    return errors
+
+
+def _validate_operation_editor_contract() -> None:
+    errors = _operation_editor_contract_errors()
+    if errors:
+        raise RuntimeError(
+            "Invalid ImageTool provenance editor contract:\n- " + "\n- ".join(errors)
+        )
+
+
 def _dialog_class_for_operation(
     operation: provenance.ToolProvenanceOperation,
 ) -> type[dialogs._DataManipulationDialog] | None:
-    for dialog_cls in (
-        *_iter_dialog_classes(dialogs.DataTransformDialog),
-        *_iter_dialog_classes(dialogs.DataFilterDialog),
-    ):
-        if not any(
-            isinstance(operation, operation_type)
-            for operation_type in dialog_cls.operation_types
-        ):
-            continue
-        if (
-            issubclass(dialog_cls, dialogs.DataTransformDialog)
-            and dialog_cls.restore_transform_operation
-            is dialogs.DataTransformDialog.restore_transform_operation
-        ):
-            continue
-        if (
-            issubclass(dialog_cls, dialogs.DataTransformDialog)
-            and dialog_cls.grouped_operation_only
-        ):
-            continue
-        if (
-            issubclass(dialog_cls, dialogs.DataFilterDialog)
-            and dialog_cls.restore_filter_operation
-            is dialogs.DataFilterDialog.restore_filter_operation
-        ):
-            continue
-        return dialog_cls
-    return None
+    _validate_operation_editor_contract()
+    return _standalone_editor_dialog_class_for_operation_type(type(operation))
 
 
 def _operations_for_ref(
@@ -808,6 +818,7 @@ def _dialog_match_for_operation_ref(
     spec: provenance.ToolProvenanceSpec,
     ref: provenance._ProvenanceStepRef,
 ) -> _OperationDialogMatch | None:
+    _validate_operation_editor_contract()
     operation = spec._operation_for_ref(ref)
     if operation is None or ref.operation_index is None:
         return None
@@ -815,19 +826,11 @@ def _dialog_match_for_operation_ref(
     if not operations:
         return None
 
-    for dialog_base_cls in _iter_dialog_classes(dialogs.DataTransformDialog):
+    for dialog_base_cls in _iter_imagetool_dialog_classes(dialogs.DataTransformDialog):
         dialog_cls = typing.cast("type[dialogs.DataTransformDialog]", dialog_base_cls)
-        if not any(
-            isinstance(operation, operation_type)
-            for operation_type in dialog_cls.operation_types
-        ):
+        if not _operation_matches_dialog(operation, dialog_cls):
             continue
-        if (
-            dialog_cls.restore_transform_operation
-            is dialogs.DataTransformDialog.restore_transform_operation
-            and dialog_cls.restore_transform_operations
-            is dialogs.DataTransformDialog.restore_transform_operations
-        ):
+        if not _dialog_supports_transform_restore(dialog_cls):
             continue
         group_kind = dialog_cls.operation_group_kind
         if group_kind is not None:
@@ -854,17 +857,11 @@ def _dialog_match_for_operation_ref(
             ref.operation_index + 1,
         )
 
-    for dialog_base_cls in _iter_dialog_classes(dialogs.DataFilterDialog):
+    for dialog_base_cls in _iter_imagetool_dialog_classes(dialogs.DataFilterDialog):
         dialog_cls = typing.cast("type[dialogs.DataFilterDialog]", dialog_base_cls)
-        if not any(
-            isinstance(operation, operation_type)
-            for operation_type in dialog_cls.operation_types
-        ):
+        if not _operation_matches_dialog(operation, dialog_cls):
             continue
-        if (
-            dialog_cls.restore_filter_operation
-            is dialogs.DataFilterDialog.restore_filter_operation
-        ):
+        if not _dialog_supports_filter_restore(dialog_cls):
             continue
         return _OperationDialogMatch(
             dialog_cls,
@@ -1167,13 +1164,6 @@ class _ProvenanceEditController:
             return False, reason or "No editing dialog is available for this step."
         if not row.script_input_path and active_filter_ref == row.edit_ref:
             return True, ""
-        reason = _recorded_operation_edit_unavailable_reason(
-            _operations_for_ref(spec, row.edit_ref)[
-                dialog_match.start : dialog_match.stop
-            ]
-        )
-        if reason is not None:
-            return False, reason
         return True, ""
 
     def can_revert_row(
@@ -1858,12 +1848,12 @@ class _ProvenanceEditController:
             self._edit_active_filter(node, operation, dialog_match.dialog_cls)
             return
 
-        operations = _operations_for_ref(spec, ref)[
-            dialog_match.start : dialog_match.stop
-        ]
-        replacements = self._edited_recorded_operations(
-            operations,
-            focus=dialog_match.focus,
+        replacements = self._edited_native_operations(
+            node,
+            row,
+            spec,
+            ref,
+            dialog_match,
         )
         if replacements is None:
             return
@@ -1902,21 +1892,68 @@ class _ProvenanceEditController:
             where="validating the edited Python code",
         )
 
-    def _edited_recorded_operations(
+    def _edited_native_operations(
         self,
-        operations: Sequence[provenance.ToolProvenanceOperation],
-        *,
-        focus: str | None = None,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        row: provenance._ProvenanceDisplayRow,
+        spec: provenance.ToolProvenanceSpec,
+        ref: provenance._ProvenanceStepRef,
+        dialog_match: _OperationDialogMatch,
     ) -> list[provenance.ToolProvenanceOperation] | None:
-        operations = tuple(operations)
+        operations = tuple(
+            _operations_for_ref(spec, ref)[dialog_match.start : dialog_match.stop]
+        )
         if not operations:
             raise ValueError("No provenance operations were provided for editing")
-        if reason := _recorded_operation_edit_unavailable_reason(operations):
-            raise RuntimeError(reason)
-        dialog = _RecordedOperationEditDialog(operations, self._manager, focus=focus)
-        if dialog.exec() != int(QtWidgets.QDialog.DialogCode.Accepted):
-            return None
-        return dialog.edited_operations()
+        start_ref = provenance._ProvenanceStepRef(
+            "operation",
+            operation_index=dialog_match.start,
+            stage_index=ref.stage_index,
+        )
+        try:
+            prefix_data, _prefix = self._replay_candidate_result(
+                node,
+                row.scope,
+                spec._prefix_before_ref(start_ref),
+            )
+        except _TrustedScriptReplayCancelled:
+            raise
+        except Exception as exc:
+            raise _ProvenanceReplayFailure(
+                "opening the provenance editor: replaying the input to this step",
+                exc,
+            ) from exc
+
+        temp_tool = erlab.interactive.imagetool.ImageTool(prefix_data)
+        try:
+            dialog = dialog_match.dialog_cls(
+                temp_tool.slicer_area,
+                provenance_edit_mode=True,
+            )
+            self._restore_native_edit_dialog(dialog, operations, dialog_match.focus)
+            if dialog.exec() != int(QtWidgets.QDialog.DialogCode.Accepted):
+                return None
+            return dialog.provenance_edit_operations()
+        finally:
+            temp_tool.close()
+            temp_tool.deleteLater()
+
+    @staticmethod
+    def _restore_native_edit_dialog(
+        dialog: dialogs._DataManipulationDialog,
+        operations: Sequence[provenance.ToolProvenanceOperation],
+        focus: str | None,
+    ) -> None:
+        if isinstance(dialog, dialogs.DataTransformDialog):
+            dialog.restore_transform_operations(operations)
+            dialog.focus_operation_group_control(focus)
+            return
+        if isinstance(dialog, dialogs.DataFilterDialog):
+            if len(operations) != 1:
+                raise ValueError("Filter edit dialogs can only restore one operation")
+            dialog.restore_filter_operation(operations[0])
+            return
+        raise TypeError("Provenance edits require a transform or filter dialog")
 
     def _edit_active_filter(
         self,

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -4,7 +4,7 @@ import pathlib
 import types
 import typing
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 import lmfit
 import numpy as np
@@ -122,17 +122,57 @@ def _add_file_replay_tool(
     return tool
 
 
-def _recorded_operation_field_edit(
+def _set_combo_data(combo: QtWidgets.QComboBox, data: object) -> None:
+    index = combo.findData(data, QtCore.Qt.ItemDataRole.UserRole)
+    assert index >= 0
+    combo.setCurrentIndex(index)
+
+
+def _selection_dialog_row(dialog: QtWidgets.QDialog, dim: str) -> typing.Any:
+    assert isinstance(dialog, SelectionDialog)
+    row = next(row for row in dialog.rows if row.dim == dim)
+    row.use_check.setChecked(True)
+    return row
+
+
+def _set_selection_point(
     dialog: QtWidgets.QDialog,
-    operation_index: int,
-    field_name: str,
-) -> QtWidgets.QLineEdit:
-    edit = dialog.findChild(
-        QtWidgets.QLineEdit,
-        f"managerProvenanceOperationField_{operation_index}_{field_name}",
-    )
-    assert edit is not None
-    return edit
+    *,
+    dim: str,
+    method: str,
+    value: float,
+) -> None:
+    row = _selection_dialog_row(dialog, dim)
+    _set_combo_data(row.method_combo, method)
+    _set_combo_data(row.kind_combo, "point")
+    row.value_start_spin.setValue(value)
+
+
+def _set_selection_range(
+    dialog: QtWidgets.QDialog,
+    *,
+    dim: str,
+    method: str,
+    start: float,
+    stop: float,
+) -> None:
+    row = _selection_dialog_row(dialog, dim)
+    _set_combo_data(row.method_combo, method)
+    _set_combo_data(row.kind_combo, "range")
+    row.value_start_spin.setValue(start)
+    row.value_stop_spin.setValue(stop)
+
+
+def _set_aggregate(
+    dialog: QtWidgets.QDialog,
+    *,
+    dims: tuple[str, ...],
+    func: str,
+) -> None:
+    assert isinstance(dialog, manager_provenance_edit.dialogs.AggregateDialog)
+    for dim, check in dialog.dim_checks.items():
+        check.setChecked(dim in dims)
+    _set_combo_data(dialog.reducer_combo, func)
 
 
 def _provenance_paste_test_data(name: str = "data") -> xr.DataArray:
@@ -708,6 +748,95 @@ def test_manager_provenance_structured_operations_have_edit_dialogs(
     operation: provenance.ToolProvenanceOperation,
 ) -> None:
     assert manager_provenance_edit._dialog_class_for_operation(operation) is not None
+
+
+def test_manager_provenance_operation_editor_contract_is_valid() -> None:
+    manager_provenance_edit._validate_operation_editor_contract()
+
+
+def test_manager_provenance_editor_contract_rejects_group_without_matcher() -> None:
+    class _MissingGroupMatcherDialog(
+        manager_provenance_edit.dialogs.DataTransformDialog
+    ):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+        grouped_operation_only = True
+
+        def restore_transform_operations(
+            self,
+            operations: Sequence[provenance.ToolProvenanceOperation],
+        ) -> None:
+            del operations
+
+    try:
+        errors = manager_provenance_edit._operation_editor_contract_errors()
+    finally:
+        _MissingGroupMatcherDialog.operation_types = ()
+
+    assert (
+        "_MissingGroupMatcherDialog declares ScriptCodeOperation as a grouped editor "
+        "but does not override operation_group_for_edit"
+    ) in errors
+
+
+def test_manager_provenance_editor_contract_rejects_mixed_editors() -> None:
+    class _StandaloneScriptDialog(manager_provenance_edit.dialogs.DataTransformDialog):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+
+        def restore_transform_operation(
+            self,
+            operation: provenance.ToolProvenanceOperation,
+        ) -> None:
+            del operation
+
+    class _GroupedScriptDialog(manager_provenance_edit.dialogs.DataTransformDialog):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+        grouped_operation_only = True
+
+        @classmethod
+        def operation_group_for_edit(
+            cls,
+            operations: Sequence[provenance.ToolProvenanceOperation],
+            operation_index: int,
+        ) -> tuple[int, int] | None:
+            del cls, operations, operation_index
+            return (0, 1)
+
+        def restore_transform_operations(
+            self,
+            operations: Sequence[provenance.ToolProvenanceOperation],
+        ) -> None:
+            del operations
+
+    try:
+        errors = manager_provenance_edit._operation_editor_contract_errors()
+    finally:
+        _StandaloneScriptDialog.operation_types = ()
+        _GroupedScriptDialog.operation_types = ()
+
+    assert (
+        "ScriptCodeOperation has both standalone and grouped editors: "
+        "_StandaloneScriptDialog; _GroupedScriptDialog"
+    ) in errors
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        provenance.SelOperation(kwargs={"x": slice(0.0, 1.0)}),
+        provenance.IselOperation(kwargs={"x": slice(0, 1)}),
+        provenance.QSelOperation(kwargs={"x": 1.0}),
+    ],
+)
+def test_manager_provenance_selection_operations_use_selection_dialog(
+    operation: provenance.ToolProvenanceOperation,
+) -> None:
+    assert (
+        manager_provenance_edit._dialog_class_for_operation(operation)
+        is SelectionDialog
+    )
 
 
 def test_manager_provenance_loader_kwargs_parser_and_file_dialog_branches(
@@ -2567,7 +2696,7 @@ def test_manager_provenance_edit_nested_script_input_operation(
     )
     monkeypatch.setattr(
         controller,
-        "_edited_recorded_operations",
+        "_edited_native_operations",
         lambda *_args, **_kwargs: [replacement],
     )
     monkeypatch.setattr(
@@ -3515,8 +3644,8 @@ def test_manager_provenance_missing_source_after_edit_ok_opens_file_load_editor(
     )
     monkeypatch.setattr(
         controller,
-        "_edited_recorded_operations",
-        lambda _operations, **_kwargs: [provenance.IselOperation(kwargs={"x": 0})],
+        "_edited_native_operations",
+        lambda *_args, **_kwargs: [provenance.IselOperation(kwargs={"x": 0})],
     )
     missing = manager_provenance_edit._MissingProvenanceSourceFileError(missing_path)
     failure = manager_provenance_edit._ProvenanceReplayFailure(
@@ -4528,55 +4657,68 @@ def test_manager_provenance_edit_controller_private_error_branches() -> None:
         )
 
 
-def test_manager_provenance_edit_controller_recorded_dialog_branches(
-    monkeypatch: pytest.MonkeyPatch,
+def test_manager_provenance_native_transform_edit_mode_uses_dialog_operations(
+    qtbot,
 ) -> None:
-    controller = _fake_edit_controller()
-    operation = provenance.NormalizeOperation(dims=("x",), mode="area")
-
-    class _RejectingDialog:
-        def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-            del args, kwargs
-
-        def exec(self) -> int:
-            return int(QtWidgets.QDialog.DialogCode.Rejected)
-
-        def edited_operations(self) -> list[provenance.ToolProvenanceOperation]:
-            raise AssertionError("cancel must not read edited operations")
-
-    monkeypatch.setattr(
-        manager_provenance_edit,
-        "_RecordedOperationEditDialog",
-        _RejectingDialog,
+    data = xr.DataArray(
+        np.arange(3 * 4 * 2, dtype=float).reshape((3, 4, 2)),
+        dims=("x", "y", "z"),
+        coords={"x": [0.0, 1.0, 2.0], "y": np.arange(4), "z": [0.0, 1.0]},
     )
-    assert controller._edited_recorded_operations((operation,), focus="dims") is None
-
-    replacement = provenance.NormalizeOperation(dims=("y",), mode="min")
-
-    class _AcceptingDialog:
-        def __init__(
-            self, operations: typing.Any, _parent: typing.Any, **kwargs: typing.Any
-        ) -> None:
-            assert tuple(operations) == (operation,)
-            assert kwargs == {"focus": "dims"}
-
-        def exec(self) -> int:
-            return int(QtWidgets.QDialog.DialogCode.Accepted)
-
-        def edited_operations(self) -> list[provenance.ToolProvenanceOperation]:
-            return [replacement]
-
-    monkeypatch.setattr(
-        manager_provenance_edit,
-        "_RecordedOperationEditDialog",
-        _AcceptingDialog,
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+    dialog = manager_provenance_edit.dialogs.AggregateDialog(
+        tool.slicer_area,
+        provenance_edit_mode=True,
     )
-    assert controller._edited_recorded_operations((operation,), focus="dims") == [
-        replacement
+
+    assert not hasattr(dialog, "launch_mode_combo")
+    manager_provenance_edit._ProvenanceEditController._restore_native_edit_dialog(
+        dialog,
+        (provenance.QSelAggregationOperation(dims=("y",), func="mean"),),
+        "dims",
+    )
+    _set_aggregate(dialog, dims=("x",), func="sum")
+
+    assert dialog.provenance_edit_operations() == [
+        provenance.QSelAggregationOperation(dims=("x",), func="sum")
     ]
 
-    with pytest.raises(ValueError, match="No provenance operations"):
-        controller._edited_recorded_operations(())
+
+def test_manager_provenance_native_selection_edit_restores_slice_operations(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(3 * 4, dtype=float).reshape((3, 4)),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0, 2.0], "y": np.arange(4.0)},
+    )
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+    dialog = SelectionDialog(tool.slicer_area, provenance_edit_mode=True)
+
+    assert not hasattr(dialog, "launch_mode_combo")
+    manager_provenance_edit._ProvenanceEditController._restore_native_edit_dialog(
+        dialog,
+        (provenance.SelOperation(kwargs={"y": slice(1.0, 3.0)}),),
+        None,
+    )
+
+    assert dialog.provenance_edit_operations() == [
+        provenance.SelOperation(kwargs={"y": slice(1.0, 3.0)})
+    ]
+
+
+def test_manager_provenance_edit_controller_native_dialog_error_branches() -> None:
+    controller = _fake_edit_controller()
+    operation = provenance.NormalizeOperation(dims=("x",), mode="area")
+    spec = provenance.full_data(
+        provenance.QSelAggregationOperation(dims=("x",), func="mean")
+    )
+    row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("Aggregate", None),
+    )
+    ref = provenance._ProvenanceStepRef("operation", operation_index=0)
 
     with pytest.raises(RuntimeError, match="Active display filter"):
         controller._edit_active_filter(
@@ -4584,159 +4726,43 @@ def test_manager_provenance_edit_controller_recorded_dialog_branches(
             operation,
             manager_provenance_edit.dialogs.AggregateDialog,
         )
+    with pytest.raises(ValueError, match="No provenance operations"):
+        controller._edited_native_operations(
+            typing.cast("typing.Any", _fake_edit_node(spec)),
+            row,
+            spec,
+            ref,
+            manager_provenance_edit._OperationDialogMatch(
+                manager_provenance_edit.dialogs.AggregateDialog,
+                0,
+                0,
+            ),
+        )
 
 
-def test_manager_provenance_recorded_operation_dialog_handles_empty_operations(
-    qtbot,
+@pytest.mark.parametrize(
+    "operation",
+    [
+        provenance.QSelOperation(kwargs={"x": slice(0.0, 2.0)}),
+        provenance.SelOperation(kwargs={"y": slice(1.0, 3.0)}),
+        provenance.IselOperation(kwargs={"y": slice(1, 3)}),
+    ],
+)
+def test_manager_provenance_slice_selection_rows_remain_editable(
+    operation: provenance.ToolProvenanceOperation,
 ) -> None:
-    parent = QtWidgets.QWidget()
-    qtbot.addWidget(parent)
-    operation = provenance.SqueezeOperation()
-    dialog = manager_provenance_edit._RecordedOperationEditDialog(
-        (operation,),
-        parent,
-        focus="missing",
+    spec = provenance.selection(operation)
+    controller = _fake_edit_controller(
+        _fake_edit_node(
+            provenance.full_data(),
+            source_spec=spec,
+            source_display_spec=spec,
+            parent_uid="parent",
+        )
     )
-    qtbot.addWidget(dialog)
+    row = spec.display_rows(scope="source")[1]
 
-    assert dialog.edited_operations() == [operation]
-    assert dialog.findChild(QtWidgets.QLabel) is not None
-
-
-def test_manager_provenance_operation_title_falls_back_on_label_failure() -> None:
-    class _BrokenTitleOperation(provenance.ToolProvenanceOperation):
-        def derivation_label(self) -> str:
-            raise RuntimeError("label failed")
-
-    assert (
-        manager_provenance_edit._operation_title(_BrokenTitleOperation())
-        == "_BrokenTitleOperation"
-    )
-
-
-def test_manager_provenance_recorded_operation_dialog_round_trips_values(
-    qtbot,
-) -> None:
-    operations = provenance.stamp_operation_group(
-        (
-            provenance.AverageOperation(dims=("x",)),
-            provenance.IselOperation(kwargs={"x": 0}),
-            provenance.KspaceSetNormalOperation(alpha=1.0, beta=2.0, delta=None),
-            provenance.KspaceConvertOperation(bounds=None, resolution=None),
-        ),
-        kind="test_group",
-        focuses=("dims", "kwargs", "delta", "resolution"),
-        group_id="stable-group",
-    )
-    parent = QtWidgets.QWidget()
-    qtbot.addWidget(parent)
-    dialog = manager_provenance_edit._RecordedOperationEditDialog(
-        operations,
-        parent,
-        focus="kwargs",
-    )
-    qtbot.addWidget(dialog)
-
-    dims_edit = _recorded_operation_field_edit(dialog, 0, "dims")
-    kwargs_edit = _recorded_operation_field_edit(dialog, 1, "kwargs")
-    delta_edit = _recorded_operation_field_edit(dialog, 2, "delta")
-    resolution_edit = _recorded_operation_field_edit(dialog, 3, "resolution")
-
-    dims_edit.setText("('y',)")
-    kwargs_edit.setText("{'y': 1}")
-    delta_edit.setText("3.0")
-    resolution_edit.setText("{'kx': 0.05}")
-
-    edited = dialog.edited_operations()
-
-    assert isinstance(edited[0], provenance.AverageOperation)
-    assert edited[0].dims == ("y",)
-    assert isinstance(edited[1], provenance.IselOperation)
-    assert edited[1].kwargs == {"y": 1}
-    assert isinstance(edited[2], provenance.KspaceSetNormalOperation)
-    assert edited[2].delta == 3.0
-    assert isinstance(edited[3], provenance.KspaceConvertOperation)
-    assert edited[3].resolution == {"kx": 0.05}
-    assert [operation.group for operation in edited] == [
-        operation.group for operation in operations
-    ]
-
-
-def test_manager_provenance_recorded_operation_dialog_invalid_literal_stays_open(
-    qtbot,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    operation = provenance.NormalizeOperation(dims=("x",), mode="area")
-    parent = QtWidgets.QWidget()
-    qtbot.addWidget(parent)
-    dialog = manager_provenance_edit._RecordedOperationEditDialog(
-        (operation,),
-        parent,
-    )
-    qtbot.addWidget(dialog)
-    dims_edit = _recorded_operation_field_edit(dialog, 0, "dims")
-    dims_edit.setText("not a literal")
-    warnings_shown: list[tuple[str, str]] = []
-
-    def _record_warning(
-        _parent: typing.Any,
-        title: str,
-        text: str,
-    ) -> QtWidgets.QMessageBox.StandardButton:
-        warnings_shown.append((title, text))
-        return QtWidgets.QMessageBox.StandardButton.Ok
-
-    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
-
-    dialog.accept()
-
-    assert warnings_shown
-    assert dialog.result() != int(QtWidgets.QDialog.DialogCode.Accepted)
-    with pytest.raises(ValueError, match="Python literals"):
-        manager_provenance_edit._parse_operation_value("")
-
-
-def test_manager_provenance_recorded_operation_unavailable_reason_for_nonliteral(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    operation = provenance.NormalizeOperation(dims=("x",), mode="area")
-    monkeypatch.setattr(
-        manager_provenance_edit,
-        "_operation_value_text",
-        lambda _value: "<not a Python literal>",
-    )
-
-    reason = manager_provenance_edit._recorded_operation_edit_unavailable_reason(
-        (operation,)
-    )
-
-    assert reason is not None
-    assert "recorded metadata" in reason
-
-
-def test_manager_provenance_recorded_operation_unavailable_blocks_edit(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    operation = provenance.NormalizeOperation(dims=("x",), mode="area")
-    spec = _manager_replay_file_spec(pathlib.Path("scan.h5"), operation)
-    controller = _fake_edit_controller(_fake_edit_node(spec))
-    row = provenance._ProvenanceDisplayRow(
-        provenance.DerivationEntry("Normalize", None),
-        edit_ref=provenance._ProvenanceStepRef(
-            "operation",
-            operation_index=0,
-            stage_index=0,
-        ),
-    )
-    monkeypatch.setattr(
-        manager_provenance_edit,
-        "_recorded_operation_edit_unavailable_reason",
-        lambda _operations: "unsafe operation metadata",
-    )
-
-    assert controller.can_edit_row(row) == (False, "unsafe operation metadata")
-    with pytest.raises(RuntimeError, match="unsafe operation metadata"):
-        controller._edited_recorded_operations((operation,))
+    assert controller.can_edit_row(row) == (True, "")
 
 
 def test_manager_provenance_validation_preserves_active_filter_with_one_replay(
@@ -6574,8 +6600,7 @@ def test_manager_batch_selection_replace_qsel_remains_editable(
         )
 
         def _edit_qsel(dialog: QtWidgets.QDialog) -> None:
-            kwargs_edit = _recorded_operation_field_edit(dialog, 0, "kwargs")
-            kwargs_edit.setText("{'x': 2.0}")
+            _set_selection_point(dialog, dim="x", method="qsel", value=2.0)
 
         accept_dialog(manager._edit_selected_derivation_step, pre_call=_edit_qsel)
 
@@ -6583,6 +6608,34 @@ def test_manager_batch_selection_replace_qsel_remains_editable(
         xarray.testing.assert_identical(
             first.slicer_area._data.rename(None),
             data.qsel(x=2.0).qsel(y=slice(1.0, 3.0)).rename(None),
+        )
+
+        manager._update_info()
+        select_metadata_rows(manager, [2])
+        selected_row = manager._selected_derivation_row()
+        assert selected_row is not None
+        assert manager._provenance_edit_controller.can_edit_row(selected_row) == (
+            True,
+            "",
+        )
+
+        def _edit_qsel_range(dialog: QtWidgets.QDialog) -> None:
+            _set_selection_range(
+                dialog,
+                dim="y",
+                method="qsel",
+                start=0.0,
+                stop=2.0,
+            )
+
+        accept_dialog(
+            manager._edit_selected_derivation_step,
+            pre_call=_edit_qsel_range,
+        )
+
+        xarray.testing.assert_identical(
+            first.slicer_area._data.rename(None),
+            data.qsel(x=2.0).qsel(y=slice(0.0, 2.0)).rename(None),
         )
 
 
@@ -8466,10 +8519,7 @@ def test_manager_provenance_structured_operation_edit_accept_and_cancel(
         xr.testing.assert_identical(tool.slicer_area._data, before_data)
 
         def _edit_aggregate(dialog: QtWidgets.QDialog) -> None:
-            dims_edit = _recorded_operation_field_edit(dialog, 0, "dims")
-            func_edit = _recorded_operation_field_edit(dialog, 0, "func")
-            dims_edit.setText("('x',)")
-            func_edit.setText("'sum'")
+            _set_aggregate(dialog, dims=("x",), func="sum")
 
         accept_dialog(manager._edit_selected_derivation_step, pre_call=_edit_aggregate)
 
@@ -8545,10 +8595,7 @@ def test_manager_provenance_script_derived_structured_step_is_editable(
         select_metadata_rows(manager, [3])
 
         def _edit_aggregate(dialog: QtWidgets.QDialog) -> None:
-            dims_edit = _recorded_operation_field_edit(dialog, 0, "dims")
-            func_edit = _recorded_operation_field_edit(dialog, 0, "func")
-            dims_edit.setText("('x',)")
-            func_edit.setText("'sum'")
+            _set_aggregate(dialog, dims=("x",), func="sum")
 
         accept_dialog(manager._edit_selected_derivation_step, pre_call=_edit_aggregate)
 
@@ -8672,8 +8719,8 @@ def test_manager_provenance_edit_rejects_incompatible_downstream_and_reverts(
         )
         monkeypatch.setattr(
             manager._provenance_edit_controller,
-            "_edited_recorded_operations",
-            lambda _operations, **_kwargs: [
+            "_edited_native_operations",
+            lambda *_args, **_kwargs: [
                 provenance.QSelAggregationOperation(dims=("y",), func="mean")
             ],
         )

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -4685,6 +4685,45 @@ def test_manager_provenance_native_transform_edit_mode_uses_dialog_operations(
     ]
 
 
+def test_manager_provenance_native_edit_mode_uses_dialog_accept_validation(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = xr.DataArray(
+        np.arange(3 * 4, dtype=float).reshape((3, 4)),
+        dims=("x", "y"),
+        coords={"x": np.arange(3), "y": np.arange(4)},
+    )
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+    dialog = manager_provenance_edit.dialogs.AggregateDialog(
+        tool.slicer_area,
+        provenance_edit_mode=True,
+    )
+    _set_aggregate(dialog, dims=("x", "y"), func="mean")
+
+    warnings_shown: list[tuple[object, ...]] = []
+
+    def _record_warning(*args: object) -> QtWidgets.QMessageBox.StandardButton:
+        warnings_shown.append(args)
+        return QtWidgets.QMessageBox.StandardButton.Ok
+
+    def _unexpected_provenance_accept() -> None:
+        raise AssertionError("dialog validation must run before edit acceptance")
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _record_warning)
+    monkeypatch.setattr(
+        dialog,
+        "_accept_provenance_edit",
+        _unexpected_provenance_accept,
+    )
+
+    dialog.buttonBox.accepted.emit()
+
+    assert warnings_shown
+    assert dialog.result() != int(QtWidgets.QDialog.DialogCode.Accepted)
+
+
 def test_manager_provenance_native_selection_edit_restores_slice_operations(
     qtbot,
 ) -> None:

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -822,6 +822,118 @@ def test_manager_provenance_editor_contract_rejects_mixed_editors() -> None:
     ) in errors
 
 
+def test_manager_provenance_editor_contract_rejects_ambiguous_editors() -> None:
+    class _StandaloneScriptDialogA(manager_provenance_edit.dialogs.DataTransformDialog):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+
+        def restore_transform_operation(
+            self,
+            operation: provenance.ToolProvenanceOperation,
+        ) -> None:
+            del operation
+
+    class _StandaloneScriptDialogB(manager_provenance_edit.dialogs.DataTransformDialog):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+
+        def restore_transform_operation(
+            self,
+            operation: provenance.ToolProvenanceOperation,
+        ) -> None:
+            del operation
+
+    try:
+        errors = manager_provenance_edit._operation_editor_contract_errors()
+        with pytest.raises(RuntimeError, match="Multiple standalone"):
+            manager_provenance_edit._standalone_editor_dialog_class_for_operation_type(
+                provenance.ScriptCodeOperation
+            )
+    finally:
+        _StandaloneScriptDialogA.operation_types = ()
+        _StandaloneScriptDialogB.operation_types = ()
+
+    assert (
+        "ScriptCodeOperation has multiple standalone editors: "
+        "_StandaloneScriptDialogA, _StandaloneScriptDialogB"
+    ) in errors
+
+
+def test_manager_provenance_editor_contract_rejects_multiple_grouped_editors() -> None:
+    class _GroupedScriptDialogA(manager_provenance_edit.dialogs.DataTransformDialog):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+        grouped_operation_only = True
+
+        @classmethod
+        def operation_group_for_edit(
+            cls,
+            operations: Sequence[provenance.ToolProvenanceOperation],
+            operation_index: int,
+        ) -> tuple[int, int] | None:
+            del cls, operations, operation_index
+            return (0, 1)
+
+        def restore_transform_operations(
+            self,
+            operations: Sequence[provenance.ToolProvenanceOperation],
+        ) -> None:
+            del operations
+
+    class _GroupedScriptDialogB(manager_provenance_edit.dialogs.DataTransformDialog):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+        grouped_operation_only = True
+
+        @classmethod
+        def operation_group_for_edit(
+            cls,
+            operations: Sequence[provenance.ToolProvenanceOperation],
+            operation_index: int,
+        ) -> tuple[int, int] | None:
+            del cls, operations, operation_index
+            return (0, 1)
+
+        def restore_transform_operations(
+            self,
+            operations: Sequence[provenance.ToolProvenanceOperation],
+        ) -> None:
+            del operations
+
+    try:
+        errors = manager_provenance_edit._operation_editor_contract_errors()
+    finally:
+        _GroupedScriptDialogA.operation_types = ()
+        _GroupedScriptDialogB.operation_types = ()
+
+    assert (
+        "ScriptCodeOperation has multiple grouped editors: "
+        "_GroupedScriptDialogA, _GroupedScriptDialogB"
+    ) in errors
+
+
+def test_manager_provenance_editor_contract_rejects_missing_editor() -> None:
+    class _ScriptDialogWithoutRestore(
+        manager_provenance_edit.dialogs.DataTransformDialog
+    ):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+
+    class _ScriptFilterWithoutRestore(manager_provenance_edit.dialogs.DataFilterDialog):
+        __module__ = manager_provenance_edit.dialogs.__name__
+        operation_types = (provenance.ScriptCodeOperation,)
+
+    try:
+        errors = manager_provenance_edit._operation_editor_contract_errors()
+        with pytest.raises(RuntimeError, match="Invalid ImageTool"):
+            manager_provenance_edit._validate_operation_editor_contract()
+    finally:
+        _ScriptDialogWithoutRestore.operation_types = ()
+        _ScriptFilterWithoutRestore.operation_types = ()
+
+    assert "ScriptCodeOperation has no provenance editor" in errors
+
+
 @pytest.mark.parametrize(
     "operation",
     [
@@ -4724,6 +4836,83 @@ def test_manager_provenance_native_edit_mode_uses_dialog_accept_validation(
     assert dialog.result() != int(QtWidgets.QDialog.DialogCode.Accepted)
 
 
+@pytest.mark.parametrize("mode", ["empty", "error", "valid"])
+def test_manager_provenance_base_edit_mode_accept_paths(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims=("x",))
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+
+    class _EditModeDialog(manager_provenance_edit.dialogs._DataManipulationDialog):
+        def provenance_edit_operations(
+            self,
+        ) -> list[provenance.ToolProvenanceOperation]:
+            if mode == "empty":
+                return []
+            if mode == "error":
+                raise RuntimeError("operation failure")
+            return [provenance.IselOperation(kwargs={"x": 0})]
+
+    dialog = _EditModeDialog(tool.slicer_area, provenance_edit_mode=True)
+    warnings_shown: list[tuple[object, ...]] = []
+    critical_shown: list[tuple[object, ...]] = []
+
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda *args: (
+            warnings_shown.append(args) or QtWidgets.QMessageBox.StandardButton.Ok
+        ),
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        lambda *args, **_kwargs: critical_shown.append(args),
+    )
+
+    dialog.accept()
+
+    if mode == "valid":
+        assert dialog.result() == int(QtWidgets.QDialog.DialogCode.Accepted)
+        assert warnings_shown == []
+        assert critical_shown == []
+    else:
+        assert dialog.result() != int(QtWidgets.QDialog.DialogCode.Accepted)
+        assert bool(warnings_shown) is (mode == "empty")
+        assert bool(critical_shown) is (mode == "error")
+
+
+def test_manager_provenance_base_edit_operations_must_be_implemented(qtbot) -> None:
+    data = xr.DataArray([1.0, 2.0], dims=("x",))
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+    dialog = manager_provenance_edit.dialogs._DataManipulationDialog(tool.slicer_area)
+
+    with pytest.raises(NotImplementedError):
+        dialog.provenance_edit_operations()
+
+
+def test_manager_provenance_filter_edit_mode_accept_skips_preview_apply(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",))
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+    dialog = manager_provenance_edit.dialogs.NormalizeDialog(
+        tool.slicer_area,
+        provenance_edit_mode=True,
+    )
+    dialog.dim_checks["x"].setChecked(True)
+
+    assert not hasattr(dialog, "preview_button")
+
+    dialog.accept()
+
+    assert dialog.result() == int(QtWidgets.QDialog.DialogCode.Accepted)
+    assert tool.slicer_area._accepted_filter_provenance_operation is None
+
+
 def test_manager_provenance_native_selection_edit_restores_slice_operations(
     qtbot,
 ) -> None:
@@ -4776,6 +4965,129 @@ def test_manager_provenance_edit_controller_native_dialog_error_branches() -> No
                 0,
                 0,
             ),
+        )
+
+
+def test_manager_provenance_native_operation_editor_cancel_and_replay_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _fake_edit_controller()
+    data = xr.DataArray(np.arange(4.0), dims=("x",))
+    operation = provenance.IselOperation(kwargs={"x": 0})
+    spec = provenance.full_data(operation)
+    row = provenance._ProvenanceDisplayRow(
+        provenance.DerivationEntry("isel", None),
+        edit_ref=provenance._ProvenanceStepRef("operation", operation_index=0),
+    )
+    ref = typing.cast("provenance._ProvenanceStepRef", row.edit_ref)
+    dialog_match = manager_provenance_edit._OperationDialogMatch(
+        SelectionDialog,
+        0,
+        1,
+    )
+    replayed_specs: list[provenance.ToolProvenanceSpec] = []
+
+    def _replay_candidate_result(
+        _node: typing.Any,
+        _scope: typing.Literal["display", "source"],
+        candidate: provenance.ToolProvenanceSpec,
+    ) -> tuple[xr.DataArray, provenance.ToolProvenanceSpec]:
+        replayed_specs.append(candidate)
+        return data, candidate
+
+    monkeypatch.setattr(
+        controller,
+        "_replay_candidate_result",
+        _replay_candidate_result,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QDialog,
+        "exec",
+        lambda _dialog: int(QtWidgets.QDialog.DialogCode.Rejected),
+    )
+
+    assert (
+        controller._edited_native_operations(
+            typing.cast("typing.Any", _fake_edit_node(spec)),
+            row,
+            spec,
+            ref,
+            dialog_match,
+        )
+        is None
+    )
+    assert replayed_specs == [provenance.full_data()]
+
+    def _raise_replay_cancelled(
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[xr.DataArray, provenance.ToolProvenanceSpec]:
+        raise manager_provenance_edit._TrustedScriptReplayCancelled
+
+    monkeypatch.setattr(
+        controller,
+        "_replay_candidate_result",
+        _raise_replay_cancelled,
+    )
+    with pytest.raises(manager_provenance_edit._TrustedScriptReplayCancelled):
+        controller._edited_native_operations(
+            typing.cast("typing.Any", _fake_edit_node(spec)),
+            row,
+            spec,
+            ref,
+            dialog_match,
+        )
+
+    monkeypatch.setattr(
+        controller,
+        "_replay_candidate_result",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("replay failed")),
+    )
+    with pytest.raises(manager_provenance_edit._ProvenanceReplayFailure) as exc:
+        controller._edited_native_operations(
+            typing.cast("typing.Any", _fake_edit_node(spec)),
+            row,
+            spec,
+            ref,
+            dialog_match,
+        )
+    assert "opening the provenance editor" in str(exc.value)
+
+
+def test_manager_provenance_restore_native_edit_dialog_rejects_bad_dialogs(
+    qtbot,
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",))
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+    filter_dialog = manager_provenance_edit.dialogs.NormalizeDialog(tool.slicer_area)
+    base_dialog = manager_provenance_edit.dialogs._DataManipulationDialog(
+        tool.slicer_area
+    )
+    filter_operation = provenance.NormalizeOperation(dims=("x",), mode="area")
+
+    manager_provenance_edit._ProvenanceEditController._restore_native_edit_dialog(
+        filter_dialog,
+        (filter_operation,),
+        None,
+    )
+
+    assert filter_dialog.provenance_edit_operations() == [filter_operation]
+
+    with pytest.raises(ValueError, match="one operation"):
+        manager_provenance_edit._ProvenanceEditController._restore_native_edit_dialog(
+            filter_dialog,
+            (
+                provenance.NormalizeOperation(dims=("x",), mode="area"),
+                provenance.NormalizeOperation(dims=("x",), mode="min"),
+            ),
+            None,
+        )
+    with pytest.raises(TypeError, match="transform or filter"):
+        manager_provenance_edit._ProvenanceEditController._restore_native_edit_dialog(
+            base_dialog,
+            (provenance.IselOperation(kwargs={"x": 0}),),
+            None,
         )
 
 


### PR DESCRIPTION
## Summary
- Simplify provenance edit dialogs for ImageTool manager flows
- Tighten provenance-edit handling in the manager implementation
- Update tool-authoring docs to match the current provenance editing behavior
- Add regression coverage for provenance editing paths

## Testing
- Not run (not requested)