### PR TITLE
Add color options for Figure Composer

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -156,6 +156,8 @@ are a powerful way to control the styling of all figure elements. Figure Compose
 applies the Matplotlib stylesheets configured in the shared {guilabel}`Settings`
 window. These stylesheets affect new figure defaults such as size, dpi, and export
 settings, as well as the styling of all figure elements.
+If {guilabel}`DPI` in Settings has {guilabel}`Override stylesheet` enabled, that value
+is used for new figures instead of the stylesheet default.
 
 To add custom Matplotlib stylesheets:
 

--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -23,8 +23,8 @@ Use the sidebar to switch between setting groups:
   related display defaults.
 - {guilabel}`I/O` controls default loader behavior.
 - {guilabel}`ktool` controls defaults for newly opened momentum-conversion tools.
-- {guilabel}`Figure Composer` controls default Matplotlib stylesheets for newly
-  created figures.
+- {guilabel}`Figure Composer` controls default Matplotlib stylesheets and optional
+  default DPI for newly created figures.
 
 Rows in the {guilabel}`User` scope include a reset action that restores the application
 default for that setting. Broadly resetting all user settings still asks for

--- a/src/erlab/interactive/_figurecomposer/_defaults.py
+++ b/src/erlab/interactive/_figurecomposer/_defaults.py
@@ -90,6 +90,9 @@ def _default_figsize() -> tuple[float, float]:
 
 
 def _default_figure_dpi() -> float:
+    dpi = _current_options().figure.dpi
+    if dpi is not None:
+        return float(dpi)
     return float(_styled_rcparams_value("figure.dpi"))
 
 

--- a/src/erlab/interactive/_figurecomposer/_norms.py
+++ b/src/erlab/interactive/_figurecomposer/_norms.py
@@ -7,6 +7,7 @@ import typing
 import matplotlib.colors as mcolors
 
 import erlab
+import erlab.interactive.colors
 import erlab.interactive.utils
 import erlab.plotting as eplt
 from erlab.interactive._figurecomposer._defaults import _current_options
@@ -133,19 +134,29 @@ def _norm_updates_from_kwargs(
 
 def _cmap_base_and_reverse(cmap: str | None) -> tuple[str, bool]:
     if cmap is None:
-        return _current_options().colors.cmap.name, False
+        return (
+            erlab.interactive.colors.matplotlib_colormap_name(
+                _current_options().colors.cmap.name
+            ),
+            False,
+        )
     if cmap.endswith("_r"):
-        return cmap[:-2], True
-    return cmap, False
+        return erlab.interactive.colors.matplotlib_colormap_name(cmap[:-2]), True
+    return erlab.interactive.colors.matplotlib_colormap_name(cmap), False
 
 
 def _cmap_with_reverse(base: str, reverse: bool) -> str | None:
     if not base:
         return None
-    base = base.removesuffix("_r")
+    base = erlab.interactive.colors.matplotlib_colormap_name(base.removesuffix("_r"))
     if reverse:
         return f"{base}_r"
     return base
+
+
+def _matplotlib_cmap_name(cmap: str) -> str:
+    base, reverse = _cmap_base_and_reverse(cmap)
+    return _cmap_with_reverse(base, reverse) or cmap
 
 
 def _norm_constructor_kwargs(operation: FigureOperationState) -> dict[str, typing.Any]:

--- a/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
@@ -655,7 +655,7 @@ def _add_line_coordinate_color_controls(
         cmap_combo,
         cmap_combo.activated,
         lambda _index: _update_current_line_color_cmap(
-            tool, cmap_combo.currentText(), reverse_check.isChecked()
+            tool, cmap_combo.current_matplotlib_name(), reverse_check.isChecked()
         ),
     )
     tool._connect_editor_signal(
@@ -663,7 +663,7 @@ def _add_line_coordinate_color_controls(
         reverse_check.stateChanged,
         lambda state: _update_current_line_color_cmap(
             tool,
-            cmap_combo.currentText(),
+            cmap_combo.current_matplotlib_name(),
             QtCore.Qt.CheckState(state) == QtCore.Qt.CheckState.Checked,
         ),
     )

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -185,10 +185,13 @@ def _plot_array_operation_with_selection(
     operation: FigureOperationState,
     selection: FigureDataSelectionState,
 ) -> FigureOperationState:
+    map_selections = (
+        (selection,) if selection.isel or selection.qsel or selection.mean_dims else ()
+    )
     return operation.model_copy(
         update={
             "sources": (selection.source,),
-            "map_selections": (selection,),
+            "map_selections": map_selections,
         }
     )
 
@@ -209,7 +212,7 @@ def _update_current_selection_source(
 
 
 _PLOT_ARRAY_SELECTION_MODE_LABELS = {
-    "keep": "Keep",
+    "keep": "None",
     "isel": "isel",
     "qsel": "qsel",
     "mean": "Mean",
@@ -341,11 +344,14 @@ def _connect_plot_array_selection_dimension_controls(
 ) -> None:
     def mode_changed(value: typing.Any) -> None:
         mode = value if isinstance(value, str) else ""
-        value_edit.setEnabled(mode in _PLOT_ARRAY_SELECTION_VALUE_MODES)
-        if mode in _PLOT_ARRAY_SELECTION_VALUE_MODES:
+        value_mode = mode in _PLOT_ARRAY_SELECTION_VALUE_MODES
+        value_edit.setEnabled(value_mode)
+        if value_mode:
             if value_edit.text().strip():
                 _update_current_selection_dimension(tool, dim, mode, value_edit.text())
             return
+        value_edit.clear()
+        value_edit.setModified(False)
         _update_current_selection_dimension(tool, dim, mode)
 
     def value_changed(text: str) -> None:

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -771,19 +771,12 @@ def _plot_array_aspect_combo(
     for label, value in aspect_options:
         combo.addItem(label, value)
     if aspect_mixed:
-        item = typing.cast("typing.Any", combo.model()).item(0)
-        if item is not None:
-            item.setEnabled(False)
+        typing.cast("typing.Any", combo.model()).item(0).setEnabled(False)
         combo.setCurrentIndex(0)
     elif operation.aspect in {None, "auto", "equal"}:
-        for index in range(combo.count()):
-            if combo.itemData(index) == operation.aspect:
-                combo.setCurrentIndex(index)
-                break
+        combo.setCurrentIndex(combo.findData(operation.aspect))
     else:
-        item = typing.cast("typing.Any", combo.model()).item(0)
-        if item is not None:
-            item.setEnabled(False)
+        typing.cast("typing.Any", combo.model()).item(0).setEnabled(False)
 
     ComboBoxDataControlAdapter(combo).connect_commit(
         tool._connect_editor_signal,

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -13,6 +13,7 @@ from erlab.interactive._figurecomposer._code import (
     _maybe_squeeze_drop_code,
     _selection_code,
 )
+from erlab.interactive._figurecomposer._defaults import _styled_rcparams_value
 from erlab.interactive._figurecomposer._editor_controls import (
     MIXED_VALUE,
     MIXED_VALUES_TEXT,
@@ -24,6 +25,7 @@ from erlab.interactive._figurecomposer._norms import (
     _cmap_base_and_reverse,
     _cmap_with_reverse,
     _effective_norm_name,
+    _matplotlib_cmap_name,
     _norm_code,
     _norm_combo_choices,
     _norm_combo_text,
@@ -38,7 +40,10 @@ from erlab.interactive._figurecomposer._operations._base import (
     OperationSpec,
     StepSection,
 )
-from erlab.interactive._figurecomposer._rendering import _axes_from_selection
+from erlab.interactive._figurecomposer._rendering import (
+    _axes_from_selection,
+    _tool_figure_options_context,
+)
 from erlab.interactive._figurecomposer._sources import (
     _public_source_data,
     _selected_data,
@@ -604,7 +609,7 @@ def _plot_array_kwargs(operation: FigureOperationState) -> dict[str, typing.Any]
     if operation.colorbar_kw:
         kwargs["colorbar_kw"] = dict(operation.colorbar_kw)
     if operation.cmap is not None:
-        kwargs["cmap"] = operation.cmap
+        kwargs["cmap"] = _matplotlib_cmap_name(operation.cmap)
     if _use_powernorm_plot_kwargs(operation):
         gamma = operation.norm_gamma
         if gamma is None:
@@ -658,7 +663,7 @@ def _plot_array_code_kwargs(operation: FigureOperationState) -> dict[str, typing
     if operation.colorbar_kw:
         kwargs["colorbar_kw"] = dict(operation.colorbar_kw)
     if operation.cmap is not None:
-        kwargs["cmap"] = operation.cmap
+        kwargs["cmap"] = _matplotlib_cmap_name(operation.cmap)
     if _use_powernorm_plot_kwargs(operation):
         gamma = operation.norm_gamma
         if gamma is None:
@@ -766,6 +771,19 @@ def _update_current_norm_kwargs(tool: FigureComposerTool, text: str) -> None:
     tool._update_current_operation_rebuild(**updates)
 
 
+def _plot_array_default_cmap(tool: FigureComposerTool) -> str:
+    with _tool_figure_options_context(tool):
+        return str(_styled_rcparams_value("image.cmap"))
+
+
+def _plot_array_cmap_base_and_reverse(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> tuple[str, bool]:
+    if operation.cmap is None:
+        return _cmap_base_and_reverse(_plot_array_default_cmap(tool))
+    return _cmap_base_and_reverse(operation.cmap)
+
+
 def _update_current_cmap(
     tool: FigureComposerTool,
     *,
@@ -776,7 +794,7 @@ def _update_current_cmap(
     if current is None:
         return
     _index, operation = current
-    old_base, old_reverse = _cmap_base_and_reverse(operation.cmap)
+    old_base, old_reverse = _plot_array_cmap_base_and_reverse(tool, operation)
     if base is None:
         base = old_base
     if reverse is None:
@@ -874,12 +892,12 @@ def _build_plot_array_colors_page(
     cmap_layout = QtWidgets.QHBoxLayout(cmap_widget)
     cmap_layout.setContentsMargins(0, 0, 0, 0)
     cmap_layout.setSpacing(4)
-    cmap_base, cmap_reversed = _cmap_base_and_reverse(operation.cmap)
+    cmap_base, cmap_reversed = _plot_array_cmap_base_and_reverse(tool, operation)
     cmap_mixed = tool._batch_is_mixed(
-        operation, lambda target: _cmap_base_and_reverse(target.cmap)[0]
+        operation, lambda target: _plot_array_cmap_base_and_reverse(tool, target)[0]
     )
     reverse_mixed = tool._batch_is_mixed(
-        operation, lambda target: _cmap_base_and_reverse(target.cmap)[1]
+        operation, lambda target: _plot_array_cmap_base_and_reverse(tool, target)[1]
     )
     cmap_combo = erlab.interactive.colors.ColorMapComboBox(cmap_widget)
     tool._mark_editor_control(cmap_combo)
@@ -906,7 +924,7 @@ def _build_plot_array_colors_page(
         lambda _index, combo=cmap_combo: (
             None
             if tool._mixed_combo_text(combo.currentText())
-            else _update_current_cmap(tool, base=combo.currentText())
+            else _update_current_cmap(tool, base=combo.current_matplotlib_name())
         ),
     )
     cmap_combo.blockSignals(False)

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -60,6 +60,7 @@ from erlab.interactive._figurecomposer._text import (
     _dict_from_text,
     _format_dict,
     _format_plot_limit,
+    _literal_from_text,
     _plot_limit_from_text,
     _RawCode,
 )
@@ -469,6 +470,11 @@ def _build_plot_array_selection_page(
     page, layout = tool._new_step_form_page("figureComposerPlotArraySelectionPage")
     selection = _primary_selection(operation)
 
+    tool._add_form_section(
+        layout,
+        "Data",
+        object_name="figureComposerPlotArraySelectionDataSection",
+    )
     summary = QtWidgets.QLabel(_selection_summary(tool, operation), page)
     summary.setObjectName("figureComposerPlotArraySelectionSummary")
     summary.setWordWrap(True)
@@ -495,6 +501,11 @@ def _build_plot_array_selection_page(
         "Data array selected before plot_array draws this image.",
     )
 
+    tool._add_form_section(
+        layout,
+        "Dimensions",
+        object_name="figureComposerPlotArraySelectionDimensionsSection",
+    )
     source_data = None if source_mixed else _plot_array_source_data(tool, operation)
     if source_mixed or source_data is None:
         dimensions_message = QtWidgets.QLabel(
@@ -604,6 +615,8 @@ def _plot_array_kwargs(operation: FigureOperationState) -> dict[str, typing.Any]
         kwargs["ylim"] = operation.ylim
     if operation.crop:
         kwargs["crop"] = True
+    if operation.aspect is not None:
+        kwargs["aspect"] = operation.aspect
     if operation.colorbar != "none":
         kwargs["colorbar"] = True
     if operation.colorbar_kw:
@@ -658,6 +671,8 @@ def _plot_array_code_kwargs(operation: FigureOperationState) -> dict[str, typing
         kwargs["ylim"] = operation.ylim
     if operation.crop:
         kwargs["crop"] = True
+    if operation.aspect is not None:
+        kwargs["aspect"] = operation.aspect
     if operation.colorbar != "none":
         kwargs["colorbar"] = True
     if operation.colorbar_kw:
@@ -718,6 +733,33 @@ def _plot_limit_update_callback(
     return lambda text: tool._update_current_operation(
         **{attr: _plot_limit_from_text(text)}
     )
+
+
+def _format_aspect_value(value: typing.Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, int | float):
+        return f"{float(value):g}"
+    return str(value)
+
+
+def _aspect_value_from_text(text: str) -> str | float | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    if stripped in {"auto", "equal"}:
+        return stripped
+    try:
+        value = _literal_from_text(stripped)
+    except FigureComposerInputError:
+        return stripped
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, int | float):
+        return stripped
+    return float(value)
 
 
 def _norm_gamma_value(operation: FigureOperationState) -> float:
@@ -807,6 +849,11 @@ def _build_plot_array_view_page(
 ) -> QtWidgets.QWidget:
     page, layout = tool._new_step_form_page("figureComposerPlotArrayViewPage")
 
+    tool._add_form_section(
+        layout,
+        "Image",
+        object_name="figureComposerPlotArrayViewImageSection",
+    )
     data = _safe_selected_plot_array_data(tool, operation)
     summary = QtWidgets.QLabel(
         "No source data is available."
@@ -839,6 +886,32 @@ def _build_plot_array_view_page(
         "Swap the x/y orientation before calling plot_array.",
     )
 
+    aspect_text, aspect_mixed = tool._batch_text(
+        operation,
+        lambda target: target.aspect,
+        _format_aspect_value,
+    )
+    aspect_edit = tool._line_edit(aspect_text, parent=page)
+    aspect_edit.setObjectName("figureComposerPlotArrayAspectEdit")
+    tool._apply_mixed_line_edit(aspect_edit, aspect_mixed)
+    tool._connect_line_edit_finished(
+        aspect_edit,
+        lambda text: tool._update_current_operation(
+            aspect=_aspect_value_from_text(text)
+        ),
+    )
+    tool._add_form_row(
+        layout,
+        "Aspect",
+        aspect_edit,
+        "Aspect argument passed through to imshow.",
+    )
+
+    tool._add_form_section(
+        layout,
+        "Axes",
+        object_name="figureComposerPlotArrayViewAxesSection",
+    )
     limit_controls: list[tuple[str, QtWidgets.QWidget, str]] = []
     for label, attr in (("x", "xlim"), ("y", "ylim")):
         text, mixed = tool._batch_text(
@@ -888,6 +961,11 @@ def _build_plot_array_colors_page(
 ) -> QtWidgets.QWidget:
     page, layout = tool._new_step_form_page("figureComposerPlotArrayColorsPage")
 
+    tool._add_form_section(
+        layout,
+        "Image color",
+        object_name="figureComposerPlotArrayColorsImageColorSection",
+    )
     cmap_widget = QtWidgets.QWidget(page)
     cmap_layout = QtWidgets.QHBoxLayout(cmap_widget)
     cmap_layout.setContentsMargins(0, 0, 0, 0)
@@ -1062,6 +1140,11 @@ def _build_plot_array_colors_page(
         "Extra dict literal or keyword arguments for the norm constructor.",
     )
 
+    tool._add_form_section(
+        layout,
+        "Colorbar",
+        object_name="figureComposerPlotArrayColorsColorbarSection",
+    )
     colorbar_mixed = tool._batch_is_mixed(operation, lambda target: target.colorbar)
     colorbar_combo = tool._combo(
         ["none", "right"],
@@ -1181,6 +1264,7 @@ def _section_summary(
                     ("x", operation.xlim),
                     ("y", operation.ylim),
                     ("T", operation.transpose),
+                    ("aspect", operation.aspect),
                 )
                 if value
             ]

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -60,7 +60,6 @@ from erlab.interactive._figurecomposer._text import (
     _dict_from_text,
     _format_dict,
     _format_plot_limit,
-    _literal_from_text,
     _plot_limit_from_text,
     _RawCode,
 )
@@ -745,21 +744,46 @@ def _format_aspect_value(value: typing.Any) -> str:
     return str(value)
 
 
-def _aspect_value_from_text(text: str) -> str | float | None:
-    stripped = text.strip()
-    if not stripped:
-        return None
-    if stripped in {"auto", "equal"}:
-        return stripped
-    try:
-        value = _literal_from_text(stripped)
-    except FigureComposerInputError:
-        return stripped
-    if isinstance(value, str):
-        return value
-    if not isinstance(value, int | float):
-        return stripped
-    return float(value)
+def _plot_array_aspect_combo(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    *,
+    parent: QtWidgets.QWidget,
+) -> QtWidgets.QComboBox:
+    aspect_options: tuple[tuple[str, str | None], ...] = (
+        ("default", None),
+        ("auto", "auto"),
+        ("equal", "equal"),
+    )
+    aspect_mixed = tool._batch_is_mixed(operation, lambda target: target.aspect)
+    combo = QtWidgets.QComboBox(parent)
+    tool._mark_editor_control(combo)
+    if aspect_mixed:
+        combo.addItem(MIXED_VALUES_TEXT, MIXED_VALUE)
+    elif operation.aspect not in {None, "auto", "equal"}:
+        combo.addItem(_format_aspect_value(operation.aspect), MIXED_VALUE)
+    for label, value in aspect_options:
+        combo.addItem(label, value)
+    if aspect_mixed:
+        item = typing.cast("typing.Any", combo.model()).item(0)
+        if item is not None:
+            item.setEnabled(False)
+        combo.setCurrentIndex(0)
+    elif operation.aspect in {None, "auto", "equal"}:
+        for index in range(combo.count()):
+            if combo.itemData(index) == operation.aspect:
+                combo.setCurrentIndex(index)
+                break
+    else:
+        item = typing.cast("typing.Any", combo.model()).item(0)
+        if item is not None:
+            item.setEnabled(False)
+
+    ComboBoxDataControlAdapter(combo).connect_commit(
+        tool._connect_editor_signal,
+        lambda value: tool._update_current_operation(aspect=value),
+    )
+    return combo
 
 
 def _norm_gamma_value(operation: FigureOperationState) -> float:
@@ -886,24 +910,12 @@ def _build_plot_array_view_page(
         "Swap the x/y orientation before calling plot_array.",
     )
 
-    aspect_text, aspect_mixed = tool._batch_text(
-        operation,
-        lambda target: target.aspect,
-        _format_aspect_value,
-    )
-    aspect_edit = tool._line_edit(aspect_text, parent=page)
-    aspect_edit.setObjectName("figureComposerPlotArrayAspectEdit")
-    tool._apply_mixed_line_edit(aspect_edit, aspect_mixed)
-    tool._connect_line_edit_finished(
-        aspect_edit,
-        lambda text: tool._update_current_operation(
-            aspect=_aspect_value_from_text(text)
-        ),
-    )
+    aspect_combo = _plot_array_aspect_combo(tool, operation, parent=page)
+    aspect_combo.setObjectName("figureComposerPlotArrayAspectCombo")
     tool._add_form_row(
         layout,
         "Aspect",
-        aspect_edit,
+        aspect_combo,
         "Aspect argument passed through to imshow.",
     )
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -73,6 +73,7 @@ from erlab.interactive._figurecomposer._norms import (
     _cmap_base_and_reverse,
     _cmap_with_reverse,
     _effective_norm_name,
+    _matplotlib_cmap_name,
     _norm_code,
     _norm_combo_choices,
     _norm_combo_text,
@@ -502,8 +503,10 @@ def _effective_panel_cmap(
     operation: FigureOperationState, style: FigurePlotSlicesPanelStyleState
 ) -> str:
     if style.cmap is not None:
-        return style.cmap
-    return operation.cmap or _current_options().colors.cmap.name
+        return _matplotlib_cmap_name(style.cmap)
+    if operation.cmap is not None:
+        return _matplotlib_cmap_name(operation.cmap)
+    return _matplotlib_cmap_name(_current_options().colors.cmap.name)
 
 
 def _operation_with_panel_norm_style(
@@ -566,11 +569,19 @@ def _panel_cmap_argument(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> str | list[list[str]] | None:
     if not operation.panel_styles_enabled or not operation.panel_styles:
-        return operation.cmap
+        return (
+            _matplotlib_cmap_name(operation.cmap)
+            if operation.cmap is not None
+            else None
+        )
     keys = _plot_slices_panel_keys(tool, operation)
     styles = _panel_style_map_for_keys(operation, keys)
     if not any(_panel_style_has_cmap_override(style) for style in styles.values()):
-        return operation.cmap
+        return (
+            _matplotlib_cmap_name(operation.cmap)
+            if operation.cmap is not None
+            else None
+        )
 
     def value_getter(key: _PlotSlicesPanelKey) -> str:
         style = styles.get(
@@ -1637,7 +1648,7 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
             or self.cmap_combo.currentData() is _MISSING
         ):
             return
-        base = self.cmap_combo.currentText()
+        base = self.cmap_combo.current_matplotlib_name()
         reverse = self.cmap_reverse_check.checkState() == QtCore.Qt.CheckState.Checked
         self._update_selected_styles({"cmap": _cmap_with_reverse(base, reverse)})
 
@@ -1649,7 +1660,7 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
             or check_state == QtCore.Qt.CheckState.PartiallyChecked
         ):
             return
-        base = self.cmap_combo.currentText()
+        base = self.cmap_combo.current_matplotlib_name()
         if self.cmap_combo.currentData() is _MISSING:
             base = self._operation.cmap or _current_options().colors.cmap.name
         reverse = check_state == QtCore.Qt.CheckState.Checked
@@ -2456,7 +2467,7 @@ def _add_plot_slices_coordinate_color_controls(
         cmap_combo,
         cmap_combo.activated,
         lambda _index: _update_current_plot_slices_line_color_cmap(
-            tool, cmap_combo.currentText(), reverse_check.isChecked()
+            tool, cmap_combo.current_matplotlib_name(), reverse_check.isChecked()
         ),
     )
     tool._connect_editor_signal(
@@ -2464,7 +2475,7 @@ def _add_plot_slices_coordinate_color_controls(
         reverse_check.stateChanged,
         lambda state: _update_current_plot_slices_line_color_cmap(
             tool,
-            cmap_combo.currentText(),
+            cmap_combo.current_matplotlib_name(),
             QtCore.Qt.CheckState(state) == QtCore.Qt.CheckState.Checked,
         ),
     )
@@ -3310,7 +3321,7 @@ def _build_plot_slices_editor(
             lambda _index, combo=cmap_combo: (
                 None
                 if tool._mixed_combo_text(combo.currentText())
-                else _update_current_cmap(tool, base=combo.currentText())
+                else _update_current_cmap(tool, base=combo.current_matplotlib_name())
             ),
         )
         cmap_combo.blockSignals(False)

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -16,7 +16,10 @@ from erlab.interactive._figurecomposer._code import (
     _maybe_squeeze_drop_code,
     _selection_code,
 )
-from erlab.interactive._figurecomposer._defaults import _current_options
+from erlab.interactive._figurecomposer._defaults import (
+    _current_options,
+    _styled_rcparams_value,
+)
 from erlab.interactive._figurecomposer._label_help import legend_label_input_widget
 from erlab.interactive._figurecomposer._labels import (
     label_context,
@@ -92,6 +95,7 @@ from erlab.interactive._figurecomposer._rendering import (
     _axes_from_selection,
     _iter_axes,
     _live_layout_axes,
+    _tool_figure_options_context,
 )
 from erlab.interactive._figurecomposer._sources import (
     _available_source_dims,
@@ -500,13 +504,31 @@ def _panel_style_has_overrides(style: FigurePlotSlicesPanelStyleState) -> bool:
 
 
 def _effective_panel_cmap(
-    operation: FigureOperationState, style: FigurePlotSlicesPanelStyleState
+    operation: FigureOperationState,
+    style: FigurePlotSlicesPanelStyleState,
+    *,
+    default_cmap: str | None = None,
 ) -> str:
     if style.cmap is not None:
         return _matplotlib_cmap_name(style.cmap)
     if operation.cmap is not None:
         return _matplotlib_cmap_name(operation.cmap)
-    return _matplotlib_cmap_name(_current_options().colors.cmap.name)
+    if default_cmap is None:
+        default_cmap = _current_options().colors.cmap.name
+    return _matplotlib_cmap_name(default_cmap)
+
+
+def _plot_slices_default_cmap(tool: FigureComposerTool) -> str:
+    with _tool_figure_options_context(tool):
+        return str(_styled_rcparams_value("image.cmap"))
+
+
+def _plot_slices_cmap_base_and_reverse(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> tuple[str, bool]:
+    if operation.cmap is None:
+        return _cmap_base_and_reverse(_plot_slices_default_cmap(tool))
+    return _cmap_base_and_reverse(operation.cmap)
 
 
 def _operation_with_panel_norm_style(
@@ -583,6 +605,8 @@ def _panel_cmap_argument(
             else None
         )
 
+    default_cmap = _plot_slices_default_cmap(tool)
+
     def value_getter(key: _PlotSlicesPanelKey) -> str:
         style = styles.get(
             (key.map_index, key.slice_index),
@@ -591,7 +615,7 @@ def _panel_cmap_argument(
                 slice_index=key.slice_index,
             ),
         )
-        return _effective_panel_cmap(operation, style)
+        return _effective_panel_cmap(operation, style, default_cmap=default_cmap)
 
     values = [value_getter(key) for key in keys]
     first = values[0] if values else operation.cmap
@@ -1303,12 +1327,14 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
         connect_signal: Callable[
             [QtWidgets.QWidget, typing.Any, Callable[..., None]], None
         ],
+        default_cmap: str,
         parent: QtWidgets.QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._operation = operation
         self._panel_keys = panel_keys
         self._styles = _panel_style_map(operation)
+        self._default_cmap = default_cmap
         self._updating = False
 
         self.panel_list = QtWidgets.QListWidget(self)
@@ -1452,7 +1478,13 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
         style = _panel_style_from_map(self._styles, key)
         parts = [key.label]
         if _panel_style_has_cmap_override(style):
-            parts.append(_effective_panel_cmap(self._operation, style))
+            parts.append(
+                _effective_panel_cmap(
+                    self._operation,
+                    style,
+                    default_cmap=self._default_cmap,
+                )
+            )
         if _panel_style_has_norm_override(style):
             norm_operation = _operation_with_panel_norm_style(self._operation, style)
             parts.append(_effective_norm_name(norm_operation.norm_name))
@@ -1530,7 +1562,11 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
         values = tuple(
             _cmap_base_and_reverse(style.cmap)[0]
             if style.cmap is not None
-            else _effective_panel_cmap(self._operation, style)
+            else _effective_panel_cmap(
+                self._operation,
+                style,
+                default_cmap=self._default_cmap,
+            )
             for style in styles
         )
         reversed_values = tuple(
@@ -1633,7 +1669,7 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
         if self._updating or check_state == QtCore.Qt.CheckState.PartiallyChecked:
             return
         if check_state == QtCore.Qt.CheckState.Checked:
-            cmap = self._operation.cmap or _current_options().colors.cmap.name
+            cmap = self._operation.cmap or self._default_cmap
             self._update_selected_styles({"cmap": cmap})
         else:
             self._update_selected_styles({"cmap": None})
@@ -1662,7 +1698,7 @@ class _PanelStyleEditorWidget(QtWidgets.QWidget):
             return
         base = self.cmap_combo.current_matplotlib_name()
         if self.cmap_combo.currentData() is _MISSING:
-            base = self._operation.cmap or _current_options().colors.cmap.name
+            base = self._operation.cmap or self._default_cmap
         reverse = check_state == QtCore.Qt.CheckState.Checked
         self._update_selected_styles({"cmap": _cmap_with_reverse(base, reverse)})
 
@@ -3283,7 +3319,7 @@ def _build_plot_slices_editor(
             "Image color",
             object_name="figureComposerPlotSlicesColorsImageColorSection",
         )
-        cmap_base, cmap_reversed = _cmap_base_and_reverse(operation.cmap)
+        cmap_base, cmap_reversed = _plot_slices_cmap_base_and_reverse(tool, operation)
         cmap_widget = QtWidgets.QWidget(colors_page)
         cmap_layout = QtWidgets.QHBoxLayout(cmap_widget)
         cmap_layout.setContentsMargins(0, 0, 0, 0)
@@ -3578,6 +3614,7 @@ def _build_plot_slices_editor(
                 operation,
                 _plot_slices_panel_keys(tool, operation),
                 tool._connect_editor_signal,
+                _plot_slices_default_cmap(tool),
                 colors_page,
             )
             panel_editor.setObjectName("figureComposerPlotSlicesPanelStyleEditor")
@@ -3924,7 +3961,9 @@ def _update_current_cmap(
     def update_operation(
         _operation_index: int, operation: FigureOperationState
     ) -> FigureOperationState:
-        operation_base, operation_reverse = _cmap_base_and_reverse(operation.cmap)
+        operation_base, operation_reverse = _plot_slices_cmap_base_and_reverse(
+            tool, operation
+        )
         next_base = operation_base if base is None else base
         next_reverse = operation_reverse if reverse is None else reverse
         return operation.model_copy(

--- a/src/erlab/interactive/_figurecomposer/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_state.py
@@ -345,6 +345,7 @@ class FigureOperationState(pydantic.BaseModel):
     xlim: FigureLimit | None = None
     ylim: FigureLimit | None = None
     crop: bool = True
+    aspect: str | float | None = None
     same_limits: bool | str = False
     axis: str = "auto"
     show_all_labels: bool = False

--- a/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
+++ b/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
@@ -60,6 +60,7 @@ from erlab.interactive._figurecomposer._operations._plot_slices import (
     _norm_clip_text,
     _PanelLineStyleEditorWidget,
     _PanelStyleEditorWidget,
+    _plot_slices_default_cmap,
     _plot_slices_panel_keys,
     _plot_slices_panel_kind,
     _plot_slices_shape,
@@ -647,6 +648,7 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
             operation,
             target.panel_keys,
             _connect_panel_editor_signal,
+            _plot_slices_default_cmap(tool),
             images_page,
         )
 

--- a/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
+++ b/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
@@ -1358,7 +1358,7 @@ class _LineColorModeWidget(QtWidgets.QWidget):
             self._operation.model_copy(
                 update={
                     "line_color_cmap": _cmap_with_reverse(
-                        self.cmap_combo.currentText(), False
+                        self.cmap_combo.current_matplotlib_name(), False
                     ),
                     "line_color_cmap_reverse": self.reverse_check.isChecked(),
                 }
@@ -1372,7 +1372,7 @@ class _LineColorModeWidget(QtWidgets.QWidget):
             self._operation.model_copy(
                 update={
                     "line_color_cmap": _cmap_with_reverse(
-                        self.cmap_combo.currentText(), False
+                        self.cmap_combo.current_matplotlib_name(), False
                     ),
                     "line_color_cmap_reverse": (
                         QtCore.Qt.CheckState(state) == QtCore.Qt.CheckState.Checked
@@ -1554,7 +1554,7 @@ class _ImageOperationStyleWidget(QtWidgets.QWidget):
             self._operation.model_copy(
                 update={
                     "cmap": _cmap_with_reverse(
-                        self.cmap_combo.currentText(),
+                        self.cmap_combo.current_matplotlib_name(),
                         self.cmap_reverse_check.isChecked(),
                     )
                 }
@@ -1568,7 +1568,7 @@ class _ImageOperationStyleWidget(QtWidgets.QWidget):
             self._operation.model_copy(
                 update={
                     "cmap": _cmap_with_reverse(
-                        self.cmap_combo.currentText(),
+                        self.cmap_combo.current_matplotlib_name(),
                         QtCore.Qt.CheckState(state) == QtCore.Qt.CheckState.Checked,
                     )
                 }

--- a/src/erlab/interactive/_options/__init__.py
+++ b/src/erlab/interactive/_options/__init__.py
@@ -11,6 +11,7 @@ import pyqtgraph.parametertree
 
 from erlab.interactive._options.parameters import (
     ColorListParameter,
+    FigureDpiOverrideParameter,
     StylesheetListParameter,
     _CustomColorMapParameter,
 )
@@ -25,6 +26,10 @@ pyqtgraph.parametertree.registerParameterType(
 
 pyqtgraph.parametertree.registerParameterType(
     "matplotlib_stylesheets", StylesheetListParameter, override=True
+)
+
+pyqtgraph.parametertree.registerParameterType(
+    "figure_dpi_override", FigureDpiOverrideParameter, override=True
 )
 
 __getattr__, __dir__, __all__ = _lazy.attach_stub(__name__, __file__)

--- a/src/erlab/interactive/_options/core.py
+++ b/src/erlab/interactive/_options/core.py
@@ -76,6 +76,8 @@ def _dict_to_qsettings(d: dict, qsettings: QtCore.QSettings, prefix: str = "") -
         key = f"{prefix}/{k}" if prefix else k
         if isinstance(v, dict):
             _dict_to_qsettings(v, qsettings, key)
+        elif v is None:
+            qsettings.remove(key)
         else:
             qsettings.setValue(key, v)
 
@@ -263,7 +265,10 @@ class OptionManager:
         """Set settings by name and value."""
         with self._lock:
             qsettings = self.qsettings
-            qsettings.setValue(name, value)
+            if value is None:
+                qsettings.remove(name)
+            else:
+                qsettings.setValue(name, value)
             qsettings.sync()
 
     def __getitem__(self, name: str) -> typing.Any:

--- a/src/erlab/interactive/_options/parameters.py
+++ b/src/erlab/interactive/_options/parameters.py
@@ -185,6 +185,87 @@ class ColorListParameter(pyqtgraph.parametertree.parameterTypes.SimpleParameter)
         return state
 
 
+class FigureDpiOverrideWidget(QtWidgets.QWidget):
+    """Widget for an optional Figure Composer DPI override."""
+
+    sigDpiChanged = QtCore.Signal(object)
+
+    def __init__(
+        self,
+        dpi: float | None = None,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.override_check = QtWidgets.QCheckBox("Override stylesheet", self)
+        self.override_check.setObjectName("figureDpiOverrideCheck")
+        self.dpi_spin = QtWidgets.QDoubleSpinBox(self)
+        self.dpi_spin.setObjectName("figureDpiSpin")
+        self.dpi_spin.setRange(1.0, 10000.0)
+        self.dpi_spin.setDecimals(1)
+        self.dpi_spin.setSingleStep(10.0)
+        self.dpi_spin.setValue(100.0)
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        layout.addWidget(self.override_check)
+        layout.addWidget(self.dpi_spin)
+        layout.addStretch(1)
+
+        self.override_check.stateChanged.connect(self._override_changed)
+        self.dpi_spin.valueChanged.connect(self._spin_value_changed)
+        self.set_dpi(dpi)
+
+    def get_dpi(self) -> float | None:
+        if not self.override_check.isChecked():
+            return None
+        return float(self.dpi_spin.value())
+
+    def set_dpi(self, dpi: float | None) -> None:
+        value = None if dpi is None else float(dpi)
+        check_was_blocked = self.override_check.blockSignals(True)
+        spin_was_blocked = self.dpi_spin.blockSignals(True)
+        try:
+            if value is not None:
+                self.dpi_spin.setValue(value)
+            self.override_check.setChecked(value is not None)
+            self.dpi_spin.setEnabled(value is not None)
+        finally:
+            self.dpi_spin.blockSignals(spin_was_blocked)
+            self.override_check.blockSignals(check_was_blocked)
+
+    @QtCore.Slot(int)
+    def _override_changed(self, _state: int) -> None:
+        self.dpi_spin.setEnabled(self.override_check.isChecked())
+        self.sigDpiChanged.emit(self.get_dpi())
+
+    @QtCore.Slot(float)
+    def _spin_value_changed(self, _value: float) -> None:
+        self.sigDpiChanged.emit(self.get_dpi())
+
+
+class FigureDpiOverrideParameterItem(
+    pyqtgraph.parametertree.parameterTypes.WidgetParameterItem
+):
+    def makeWidget(self) -> FigureDpiOverrideWidget:
+        w = FigureDpiOverrideWidget()
+        w.sigChanged = w.sigDpiChanged  # type: ignore[attr-defined]
+        w.value = w.get_dpi  # type: ignore[attr-defined]
+        w.setValue = w.set_dpi  # type: ignore[attr-defined]
+        self.hideWidget = False
+        return w
+
+
+class FigureDpiOverrideParameter(
+    pyqtgraph.parametertree.parameterTypes.SimpleParameter
+):
+    itemClass = FigureDpiOverrideParameterItem
+
+    def __init__(self, **opts):
+        opts.setdefault("type", "figure_dpi_override")
+        super().__init__(**opts)
+
+
 class StylesheetListWidget(QtWidgets.QWidget):
     """Widget for editing an ordered list of Matplotlib stylesheets."""
 

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -368,6 +368,20 @@ class FigureOptions(BaseModel):
         ),
         json_schema_extra=_workspace_extra(ui_type="matplotlib_stylesheets"),
     )
+    dpi: float | None = Field(
+        default=None,
+        title="DPI",
+        description=(
+            "Optional default DPI for new Figure Composer figures. "
+            "Leave unset to use the active stylesheet default."
+        ),
+        ge=1.0,
+        le=10000.0,
+        json_schema_extra=_workspace_extra(
+            ui_type="figure_dpi_override",
+            ui_step=10.0,
+        ),
+    )
 
     @field_validator("stylesheets", mode="before")
     @classmethod

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -15,7 +15,11 @@ from erlab.interactive._options.core import (
     option_value,
     workspace_overridable_option_paths,
 )
-from erlab.interactive._options.parameters import ColorListWidget, StylesheetListWidget
+from erlab.interactive._options.parameters import (
+    ColorListWidget,
+    FigureDpiOverrideWidget,
+    StylesheetListWidget,
+)
 from erlab.interactive._options.schema import AppOptions
 
 _Scope = typing.Literal["user", "workspace"]
@@ -402,6 +406,8 @@ class OptionDialog(QtWidgets.QDialog):
             return ColorListWidget(parent=self)
         if ui_type == "matplotlib_stylesheets":
             return StylesheetListWidget(parent=self)
+        if ui_type == "figure_dpi_override":
+            return FigureDpiOverrideWidget(parent=self)
         if ui_type == "list" or "ui_limits" in extra:
             combo = QtWidgets.QComboBox(self)
             for choice in extra.get("ui_limits", ()):
@@ -471,6 +477,10 @@ class OptionDialog(QtWidgets.QDialog):
             control.valueChanged.connect(
                 lambda _value, row=row: self._control_changed(row)
             )
+        elif isinstance(control, FigureDpiOverrideWidget):
+            control.sigDpiChanged.connect(
+                lambda _value, row=row: self._control_changed(row)
+            )
         elif isinstance(control, QtWidgets.QComboBox):
             control.currentIndexChanged.connect(
                 lambda _index, row=row: self._control_changed(row)
@@ -534,6 +544,8 @@ class OptionDialog(QtWidgets.QDialog):
     def _keeps_raw_workspace_value(control: QtWidgets.QWidget) -> bool:
         if isinstance(control, StylesheetListWidget):
             return True
+        if isinstance(control, FigureDpiOverrideWidget):
+            return False
         return isinstance(control, QtWidgets.QComboBox) and not isinstance(
             control, erlab.interactive.colors.ColorMapComboBox
         )
@@ -568,6 +580,8 @@ class OptionDialog(QtWidgets.QDialog):
             return control.get_colors()
         if isinstance(control, StylesheetListWidget):
             return control.get_stylesheets()
+        if isinstance(control, FigureDpiOverrideWidget):
+            return control.get_dpi()
         if isinstance(control, QtWidgets.QLineEdit):
             text = control.text()
             default_value = option_value(AppOptions(), path)
@@ -606,6 +620,9 @@ class OptionDialog(QtWidgets.QDialog):
             return
         if isinstance(control, StylesheetListWidget):
             control.set_stylesheets(_stylesheet_names(value))
+            return
+        if isinstance(control, FigureDpiOverrideWidget):
+            control.set_dpi(value)
             return
         if isinstance(control, QtWidgets.QLineEdit):
             if isinstance(value, list):

--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -145,23 +145,30 @@ class ColorMapComboBox(QtWidgets.QComboBox):
             self._menu.popup(self.mapToGlobal(position))
 
     def load_thumbnail(self, index: int) -> None:
-        if not self.thumbnails_loaded:
+        if not self.thumbnails_loaded and 0 <= index < self.count():
             text = self.itemText(index)
             with contextlib.suppress(RuntimeError):
                 self.setItemIcon(index, QtGui.QIcon(pg_colormap_to_QPixmap(text)))
 
     def load_all(self) -> None:
+        current_data = self.currentData()
+        current_colormap = (
+            current_data if isinstance(current_data, str) else self.currentText()
+        )
+        restored_current = False
         with QtCore.QSignalBlocker(self):
             load_all_colormaps()
             self.loaded_all = True
             self.clear()
             for name in pg_colormap_names("all", exclude_local=True):
-                self._add_colormap_item(
-                    name,
-                    QtGui.QIcon(pg_colormap_to_QPixmap(name)),
-                )
-        self.thumbnails_loaded = False
-        self.resetCmap()
+                self._add_colormap_item(name)
+            self.thumbnails_loaded = False
+            if current_colormap:
+                restored_current = self._set_current_text_if_available(current_colormap)
+            if not restored_current:
+                self.setCurrentIndex(-1)
+        if not restored_current:
+            self.resetCmap()
 
     def _add_colormap_item(self, name: str, icon: QtGui.QIcon | None = None) -> None:
         matplotlib_name = matplotlib_colormap_name(name)
@@ -1308,6 +1315,17 @@ def pg_colormap_powernorm(
     return cmap
 
 
+def _colormap_qpixmap(cmap: pg.ColorMap, w: int, h: int) -> QtGui.QPixmap:
+    cmap_arr = cmap.getLookupTable(0, 1, w, alpha=True)[:, None]
+    img = QtGui.QImage(cmap_arr, w, 1, QtGui.QImage.Format.Format_RGBA8888)
+    return QtGui.QPixmap.fromImage(img).scaled(w, h)
+
+
+@functools.cache
+def _cached_colormap_qpixmap(name: str, w: int, h: int) -> QtGui.QPixmap:
+    return _colormap_qpixmap(pg_colormap_from_name(name, skipCache=True), w, h)
+
+
 def pg_colormap_to_QPixmap(
     cmap: str | pg.ColorMap, w: int = 64, h: int = 16, skipCache: bool = True
 ) -> QtGui.QPixmap:
@@ -1320,8 +1338,9 @@ def pg_colormap_to_QPixmap(
     w, h
         Specifies the dimension of the pixmap.
     skipCache : bool, optional
-        Whether to skip cache, by default `True`. Passed onto
-        :func:`pg_colormap_from_name`.
+        Whether to skip the pyqtgraph colormap cache when resolving a string colormap,
+        by default `True`. Pass `False` to bypass the thumbnail cache and request the
+        pyqtgraph-cached colormap.
 
     Returns
     -------
@@ -1329,16 +1348,12 @@ def pg_colormap_to_QPixmap(
 
     """
     if isinstance(cmap, str):
-        cmap = pg_colormap_from_name(cmap, skipCache=skipCache)
-    # cmap_arr = np.reshape(cmap.getColors()[:, None], (1, -1, 4), order='C')
-    # cmap_arr = np.reshape(
-    # cmap.getLookupTable(0, 1, w, alpha=True)[:, None], (1, -1, 4),
-    # order='C')
-    cmap_arr = cmap.getLookupTable(0, 1, w, alpha=True)[:, None]
-
-    # print(cmap_arr.shape)
-    img = QtGui.QImage(cmap_arr, w, 1, QtGui.QImage.Format.Format_RGBA8888)
-    return QtGui.QPixmap.fromImage(img).scaled(w, h)
+        name = matplotlib_colormap_name(cmap)
+        w, h = int(w), int(h)
+        if not skipCache:
+            return _colormap_qpixmap(pg_colormap_from_name(name, skipCache=False), w, h)
+        return QtGui.QPixmap(_cached_colormap_qpixmap(name, w, h))
+    return _colormap_qpixmap(cmap, int(w), int(h))
 
 
 class ColorCycleDialog(QtWidgets.QDialog):

--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -10,6 +10,7 @@ __all__ = [
     "ColorMapGammaWidget",
     "color_to_QColor",
     "is_dark_mode",
+    "matplotlib_colormap_name",
     "pg_colormap_from_name",
     "pg_colormap_names",
     "pg_colormap_powernorm",
@@ -38,6 +39,36 @@ _ALL_COLORMAPS_LOADED: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "all_colormaps_loaded", default=False
 )
 _POWER_NORM_LUT_CACHE_SIZE = 64
+
+
+def _matplotlib_has_colormap(name: str) -> bool:
+    import matplotlib as mpl
+
+    return name in mpl.colormaps
+
+
+def _colorcet_matplotlib_candidate(name: str) -> str:
+    return name if name.startswith("cet_") else f"cet_{name}"
+
+
+def matplotlib_colormap_name(name: str) -> str:
+    """Return the Matplotlib colormap name matching a pyqtgraph display name."""
+    if not name or _matplotlib_has_colormap(name):
+        return name
+
+    candidate = _colorcet_matplotlib_candidate(name)
+    if _matplotlib_has_colormap(candidate):
+        return candidate
+
+    if not _ALL_COLORMAPS_LOADED.get():
+        with contextlib.suppress(Exception):
+            load_all_colormaps()
+        if _matplotlib_has_colormap(name):
+            return name
+        if _matplotlib_has_colormap(candidate):
+            return candidate
+
+    return name
 
 
 def load_all_colormaps() -> None:
@@ -84,7 +115,7 @@ class ColorMapComboBox(QtWidgets.QComboBox):
         self._populated = True
         with QtCore.QSignalBlocker(self):
             for name in pg_colormap_names("matplotlib", exclude_local=True):
-                self.addItem(name)
+                self._add_colormap_item(name)
             if self.default_cmap is not None:
                 self.setCurrentText(self.default_cmap)
                 self.load_thumbnail(self.currentIndex())
@@ -125,14 +156,33 @@ class ColorMapComboBox(QtWidgets.QComboBox):
             self.loaded_all = True
             self.clear()
             for name in pg_colormap_names("all", exclude_local=True):
-                self.addItem(QtGui.QIcon(pg_colormap_to_QPixmap(name)), name)
+                self._add_colormap_item(
+                    name,
+                    QtGui.QIcon(pg_colormap_to_QPixmap(name)),
+                )
         self.thumbnails_loaded = False
         self.resetCmap()
 
-    def _set_current_text_if_available(self, text: str | None) -> bool:
+    def _add_colormap_item(self, name: str, icon: QtGui.QIcon | None = None) -> None:
+        matplotlib_name = matplotlib_colormap_name(name)
+        if icon is None:
+            self.addItem(name, matplotlib_name)
+        else:
+            self.addItem(icon, name, matplotlib_name)
+
+    def _find_colormap_index(self, text: str | None) -> int:
         if text is None:
-            return False
+            return -1
         index = self.findText(text)
+        if index >= 0:
+            return index
+        index = self.findData(text)
+        if index >= 0:
+            return index
+        return self.findData(matplotlib_colormap_name(text))
+
+    def _set_current_text_if_available(self, text: str | None) -> bool:
+        index = self._find_colormap_index(text)
         if index < 0:
             return False
         self.setCurrentIndex(index)
@@ -207,6 +257,13 @@ class ColorMapComboBox(QtWidgets.QComboBox):
             return
         if self.count():
             self.setCurrentIndex(0)
+
+    def current_matplotlib_name(self) -> str:
+        """Return the selected colormap name as registered by Matplotlib."""
+        data = self.currentData()
+        if isinstance(data, str):
+            return data
+        return matplotlib_colormap_name(self.currentText())
 
     def setCurrentText(self, text: str | None) -> None:
         """Set the current text of the combobox."""

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -1250,7 +1250,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
         right_footer_layout.addWidget(self._loader_combo)
         right_footer_layout.addWidget(
             erlab.interactive.utils.IconActionButton(
-                self._loader_options_act, QtGui.QIcon.fromTheme("preferences-other")
+                self._loader_options_act, QtGui.QIcon.fromTheme("document-properties")
             )
         )
         right_footer_layout.addStretch()

--- a/src/erlab/interactive/imagetool/_highdim.py
+++ b/src/erlab/interactive/imagetool/_highdim.py
@@ -28,8 +28,6 @@ class _ReduceDimensionRow:
         axis: int,
         dim: Hashable,
         row: int,
-        *,
-        require_choice: bool,
     ) -> None:
         self.axis = axis
         self.dim = dim
@@ -45,11 +43,10 @@ class _ReduceDimensionRow:
 
         self.action_combo = QtWidgets.QComboBox()
         self.action_combo.setObjectName(f"reduce_dimension_action_{axis}")
-        self.action_combo.addItem("Choose...", None)
         self.action_combo.addItem("Keep", "keep")
         self.action_combo.addItem("Select", "select")
         self.action_combo.addItem("Aggregate", "aggregate")
-        self.action_combo.setCurrentIndex(0 if require_choice else 1)
+        self.action_combo.setCurrentIndex(0)
 
         self.scalar_controls = _ScalarSelectionControls(
             data,
@@ -151,8 +148,6 @@ class _HighDimensionalReductionDialog(QtWidgets.QDialog):
             self.grid_layout.addWidget(header, 0, column)
         layout.addLayout(self.grid_layout)
 
-        non_singleton_dims = [dim for dim in data.dims if data.sizes[dim] != 1]
-        keep_without_choice = set(non_singleton_dims[:4])
         self.rows: list[_ReduceDimensionRow] = []
         for axis, dim in enumerate(data.dims):
             self.rows.append(
@@ -161,9 +156,6 @@ class _HighDimensionalReductionDialog(QtWidgets.QDialog):
                     axis,
                     dim,
                     axis + 1,
-                    require_choice=(
-                        data.sizes[dim] != 1 and dim not in keep_without_choice
-                    ),
                 )
             )
 
@@ -247,9 +239,6 @@ class _HighDimensionalReductionDialog(QtWidgets.QDialog):
         except Exception:
             return ""
 
-    def _choices_complete(self) -> bool:
-        return all(row.action is not None for row in self.rows)
-
     @staticmethod
     def _processed_ndim_from_shape(shape: tuple[int, ...]) -> int:
         if len(shape) == 1:
@@ -295,12 +284,6 @@ class _HighDimensionalReductionDialog(QtWidgets.QDialog):
             QtWidgets.QDialogButtonBox.StandardButton.Open
         )
         self._result_data = None
-
-        if not self._choices_complete():
-            self.preview_label.setText("Choose an action for each required dimension.")
-            if ok_button is not None:
-                ok_button.setEnabled(False)
-            return
 
         valid = self._set_preview_from_metadata(*self._preview_dims_shape())
         if ok_button is not None:

--- a/src/erlab/interactive/imagetool/_highdim.py
+++ b/src/erlab/interactive/imagetool/_highdim.py
@@ -54,7 +54,6 @@ class _ReduceDimensionRow:
             axis,
             object_name_prefix="reduce_dimension",
             current_index=data.sizes[dim] // 2,
-            include_width=False,
             default_method="isel",
         )
         self.reducer_combo = QtWidgets.QComboBox()
@@ -68,6 +67,7 @@ class _ReduceDimensionRow:
                 self.action_combo,
                 self.scalar_controls.method_combo,
                 self.scalar_controls.stack,
+                self.scalar_controls.width_widget,
                 self.reducer_combo,
             )
         ):
@@ -75,6 +75,8 @@ class _ReduceDimensionRow:
 
         self.action_combo.currentIndexChanged.connect(self.sync_widgets)
         self.action_combo.currentIndexChanged.connect(dialog.update_preview)
+        self.scalar_controls.method_combo.currentIndexChanged.connect(self.sync_widgets)
+        self.scalar_controls.width_check.toggled.connect(self.sync_widgets)
         self.scalar_controls.connect_changed(dialog.update_preview)
         self.reducer_combo.currentIndexChanged.connect(dialog.update_preview)
         self.sync_widgets()
@@ -90,14 +92,25 @@ class _ReduceDimensionRow:
 
     def sync_widgets(self) -> None:
         action = self.action
-        self.scalar_controls.method_combo.setEnabled(action == "select")
-        self.scalar_controls.stack.setEnabled(action == "select")
+        is_selecting = action == "select"
+        width_enabled = is_selecting and self.scalar_controls.method == "qsel"
+        self.scalar_controls.method_combo.setEnabled(is_selecting)
+        self.scalar_controls.stack.setEnabled(is_selecting)
+        self.scalar_controls.width_widget.setEnabled(width_enabled)
+        self.scalar_controls.width_spin.setEnabled(
+            width_enabled and self.scalar_controls.width_check.isChecked()
+        )
         self.reducer_combo.setEnabled(action == "aggregate")
 
     def selection_indexer(self) -> tuple[Hashable, typing.Any] | None:
         if self.action != "select":
             return None
         return self.scalar_controls.indexer()
+
+    def qsel_width_indexer(self) -> tuple[str, float] | None:
+        if self.action != "select":
+            return None
+        return self.scalar_controls.qsel_width_indexer()
 
     def aggregate_operation(self) -> provenance.QSelAggregationOperation | None:
         if self.action != "aggregate":
@@ -141,7 +154,7 @@ class _HighDimensionalReductionDialog(QtWidgets.QDialog):
         self.grid_layout.setHorizontalSpacing(8)
         self.grid_layout.setVerticalSpacing(4)
         for column, label in enumerate(
-            ("Dimension", "Size", "Action", "Method", "Selection", "Reducer")
+            ("Dimension", "Size", "Action", "Method", "Selection", "Width", "Reducer")
         ):
             header = QtWidgets.QLabel(label)
             header.setObjectName(f"reduce_dimension_header_{column}")
@@ -210,6 +223,10 @@ class _HighDimensionalReductionDialog(QtWidgets.QDialog):
             if indexer is not None:
                 dim, value = indexer
                 selection_target[row.scalar_controls.method][dim] = value
+                width_indexer = row.qsel_width_indexer()
+                if width_indexer is not None:
+                    width_dim, width = width_indexer
+                    qsel_kwargs[width_dim] = width
                 continue
             aggregate_operation = row.aggregate_operation()
             if aggregate_operation is not None:

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -164,7 +164,7 @@ import math
 import pathlib
 import typing
 import uuid
-from collections.abc import Callable, Hashable, Mapping, Sequence
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
 
 import numpy as np
@@ -281,6 +281,146 @@ class _ProvenanceDisplayRow:
     scope: typing.Literal["display", "source"] = "display"
     children: tuple[_ProvenanceDisplayRow, ...] = ()
     script_input_path: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class _ProvenanceDisplayContext:
+    """Cheap metadata known while streamlining provenance display rows."""
+
+    dims: tuple[Hashable, ...] | None = None
+    sizes: dict[Hashable, int] | None = None
+
+    @classmethod
+    def from_source(
+        cls,
+        source_kind: _SourceKind,
+        parent_data: xr.DataArray | None,
+    ) -> _ProvenanceDisplayContext:
+        if parent_data is None:
+            return cls()
+        if source_kind != "full_data" and cls.dims_may_restore_nonuniform(
+            parent_data.dims
+        ):
+            return cls()
+        return cls(tuple(parent_data.dims), dict(parent_data.sizes))
+
+    @staticmethod
+    def dims_may_restore_nonuniform(dims: Sequence[Hashable]) -> bool:
+        return any(isinstance(dim, str) and dim.endswith("_idx") for dim in dims)
+
+    @staticmethod
+    def _isel_indexer_size(indexer: typing.Any, size: int) -> tuple[bool, int | None]:
+        if isinstance(indexer, slice):
+            return True, len(range(*indexer.indices(size)))
+        if isinstance(indexer, (bool, np.bool_)):
+            return False, None
+        if isinstance(indexer, (int, np.integer)):
+            return True, None
+        if isinstance(indexer, xr.DataArray):
+            return False, None
+        if isinstance(indexer, np.ndarray):
+            if indexer.ndim == 0:
+                return True, None
+            if indexer.ndim != 1 or indexer.dtype == np.dtype(bool):
+                return False, None
+            return True, int(indexer.shape[0])
+        if isinstance(indexer, range):
+            return True, len(indexer)
+        if isinstance(indexer, Sequence) and not isinstance(indexer, (bytes, str)):
+            if len(indexer) and all(
+                isinstance(item, (bool, np.bool_)) for item in indexer
+            ):
+                return False, None
+            return True, len(indexer)
+        return False, None
+
+    def _with_dims(self, dims: Iterable[Hashable]) -> _ProvenanceDisplayContext:
+        dims = tuple(dims)
+        return type(self)(
+            dims,
+            None
+            if self.sizes is None
+            else {dim: self.sizes[dim] for dim in dims if dim in self.sizes},
+        )
+
+    def advance(self, operation: ToolProvenanceOperation) -> _ProvenanceDisplayContext:
+        operation_name = getattr(operation, "op", None)
+        if operation_name in {"sort_coord_order", "rename"}:
+            return self
+        if operation_name == "source_view":
+            if self.dims is not None and (
+                getattr(operation, "source_kind", None) == "full_data"
+                or not self.dims_may_restore_nonuniform(self.dims)
+            ):
+                return self
+            return type(self)()
+        if operation_name in {"qsel", "sel"}:
+            return (
+                self if not getattr(operation, "decoded_kwargs", {}) else type(self)()
+            )
+        if operation_name == "isel":
+            kwargs = getattr(operation, "decoded_kwargs", {})
+            if not kwargs:
+                return self
+            if self.dims is None or self.sizes is None:
+                return type(self)()
+            dims = list(self.dims)
+            sizes = dict(self.sizes)
+            for dim, indexer in kwargs.items():
+                if dim not in dims or dim not in sizes:
+                    return type(self)()
+                known, indexer_size = self._isel_indexer_size(indexer, sizes[dim])
+                if not known:
+                    return type(self)()
+                if indexer_size is None:
+                    dims.remove(dim)
+                    sizes.pop(dim, None)
+                else:
+                    sizes[dim] = indexer_size
+            return type(self)(
+                tuple(dims),
+                {dim: sizes[dim] for dim in dims if dim in sizes},
+            )
+        if operation_name == "transpose":
+            if self.dims is None:
+                return type(self)()
+            operation_dims = getattr(operation, "dims", None)
+            target_dims = (
+                tuple(operation_dims)
+                if operation_dims is not None
+                else tuple(reversed(self.dims))
+            )
+            if set(target_dims) != set(self.dims) or len(target_dims) != len(self.dims):
+                return type(self)()
+            return self._with_dims(target_dims)
+        if operation_name == "squeeze":
+            if self.dims is None or self.sizes is None:
+                return type(self)()
+            operation_dims = getattr(operation, "dims", None)
+            if operation_dims is None:
+                return self._with_dims(
+                    [dim for dim in self.dims if self.sizes.get(dim) != 1]
+                )
+            target_dims = tuple(operation_dims)
+            if any(
+                dim not in self.dims or dim not in self.sizes for dim in target_dims
+            ):
+                return type(self)()
+            singleton_dims = [dim for dim in target_dims if self.sizes.get(dim) == 1]
+            if not singleton_dims:
+                return self
+            if len(singleton_dims) != len(target_dims):
+                return type(self)()
+            return self._with_dims(
+                dim for dim in self.dims if dim not in singleton_dims
+            )
+        if operation_name == "restore_nonuniform_dims":
+            if self.dims is not None and not self.dims_may_restore_nonuniform(
+                self.dims
+            ):
+                return self
+            return type(self)()
+        return type(self)()
 
 
 @dataclass(frozen=True)
@@ -2898,12 +3038,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         parent_data: xr.DataArray | None = None,
         include_hidden_script_code: bool = False,
     ) -> tuple[tuple[int, ToolProvenanceOperation], ...]:
-        current_data: xr.DataArray | None = None
-        if parent_data is not None:
-            current_data = ToolProvenanceSpec._starting_data_for_kind(
-                source_kind,
-                parent_data,
-            )
+        context = _ProvenanceDisplayContext.from_source(source_kind, parent_data)
 
         streamlined: list[tuple[int, ToolProvenanceOperation]] = []
         for index, operation in enumerate(operations):
@@ -2942,49 +3077,38 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                     )
                 )
             # Rule 3: drop transpose calls that do not change dimension order.
-            elif _operation_is(operation, "transpose") and current_data is not None:
+            elif _operation_is(operation, "transpose") and context.dims is not None:
                 operation_dims = getattr(operation, "dims", None)
                 target_dims = (
                     tuple(operation_dims)
                     if operation_dims is not None
-                    else tuple(reversed(current_data.dims))
+                    else tuple(reversed(context.dims))
                 )
-                hide_operation = target_dims == tuple(current_data.dims)
+                hide_operation = target_dims == context.dims
             # Rule 4: drop squeeze calls that would not remove singleton dimensions.
-            elif _operation_is(operation, "squeeze") and current_data is not None:
+            elif _operation_is(operation, "squeeze") and context.sizes is not None:
                 operation_dims = getattr(operation, "dims", None)
                 if operation_dims is None:
-                    hide_operation = not any(size == 1 for size in current_data.shape)
+                    hide_operation = not any(
+                        size == 1 for size in context.sizes.values()
+                    )
                 else:
                     hide_operation = not any(
-                        current_data.sizes.get(dim) == 1 for dim in operation_dims
+                        context.sizes.get(dim) == 1 for dim in operation_dims
                     )
             # Rule 5: drop nonuniform restoration when it would not change dimensions.
             elif (
                 _operation_is(operation, "restore_nonuniform_dims")
-                and current_data is not None
+                and context.dims is not None
             ):
-                hide_operation = (
-                    erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
-                        current_data
-                    ).dims
-                    == current_data.dims
-                )
+                hide_operation = not context.dims_may_restore_nonuniform(context.dims)
             if not hide_operation:
                 streamlined.append((index, operation))
 
-            # Rule 6: keep anything ambiguous. If replaying an operation fails while
-            # building the heuristic context, stop making data-dependent decisions for
-            # later steps and preserve them verbatim.
-            if current_data is None or parent_data is None:
-                current_data = None
-            else:
-                try:
-                    current_data = operation.apply(
-                        current_data, parent_data=parent_data
-                    )
-                except Exception:
-                    current_data = None
+            # Rule 6: keep anything ambiguous. Metadata-only display never executes
+            # operations; if a step has unknown effects, later no-op checks become
+            # conservative and preserve rows/code.
+            context = context.advance(operation)
 
         return tuple(streamlined)
 
@@ -3110,21 +3234,17 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             for script_input in self.script_inputs
         )
 
-        current_data = parent_data
+        stage_parent_data = parent_data
         for stage in self.replay_stages:
             entries.extend(
                 operation.derivation_entry()
                 for _, operation in self._streamlined_operation_refs(
                     stage.source_kind,
                     stage.operations,
-                    parent_data=current_data,
+                    parent_data=stage_parent_data,
                 )
             )
-            if current_data is not None:
-                try:
-                    current_data = _apply_replay_stage(stage, current_data)
-                except Exception:
-                    current_data = None
+            stage_parent_data = None
 
         entries.extend(
             operation.derivation_entry()
@@ -3234,12 +3354,12 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                         ),
                     )
                 )
-            current_data = parent_data
+            stage_parent_data = parent_data
             for stage_index, stage in enumerate(self.replay_stages):
                 for operation_index, operation in self._streamlined_operation_refs(
                     stage.source_kind,
                     stage.operations,
-                    parent_data=current_data,
+                    parent_data=stage_parent_data,
                 ):
                     step_ref = _ProvenanceStepRef(
                         "operation",
@@ -3253,11 +3373,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                             replay_ref=step_ref,
                         )
                     )
-                if current_data is not None:
-                    try:
-                        current_data = _apply_replay_stage(stage, current_data)
-                    except Exception:
-                        current_data = None
+                stage_parent_data = None
             rows.extend(
                 _ProvenanceDisplayRow(
                     operation.derivation_entry(),
@@ -3285,12 +3401,12 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             )
             return scoped_rows(rows)
         if self.kind == "file":
-            current_data = parent_data
+            stage_parent_data = parent_data
             for stage_index, stage in enumerate(self.replay_stages):
                 for operation_index, operation in self._streamlined_operation_refs(
                     stage.source_kind,
                     stage.operations,
-                    parent_data=current_data,
+                    parent_data=stage_parent_data,
                 ):
                     step_ref = _ProvenanceStepRef(
                         "operation",
@@ -3304,11 +3420,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                             replay_ref=step_ref,
                         )
                     )
-                if current_data is not None:
-                    try:
-                        current_data = _apply_replay_stage(stage, current_data)
-                    except Exception:
-                        current_data = None
+                stage_parent_data = None
             return scoped_rows(rows)
 
         rows.extend(

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -310,6 +310,7 @@ class _DataManipulationDialog(QtWidgets.QDialog):
         if self.title is not None:
             self.setWindowTitle(self.title)
 
+        self._slicer_area: Callable[[], ImageSlicerArea | None]
         self.slicer_area = slicer_area
         self._provenance_edit_mode = provenance_edit_mode
         self._batch_manager = (

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -300,12 +300,13 @@ class _DataManipulationDialog(QtWidgets.QDialog):
 
     def __init__(
         self,
-        slicer_area: ImageSlicerArea,
+        slicer_area: ImageSlicerArea | None,
         *,
         batch_manager: ImageToolManager | None = None,
         provenance_edit_mode: bool = False,
+        dialog_parent: QtWidgets.QWidget | None = None,
     ) -> None:
-        super().__init__(slicer_area)
+        super().__init__(slicer_area if dialog_parent is None else dialog_parent)
         if self.title is not None:
             self.setWindowTitle(self.title)
 
@@ -353,7 +354,10 @@ class _DataManipulationDialog(QtWidgets.QDialog):
         raise LookupError("Parent was destroyed")
 
     @slicer_area.setter
-    def slicer_area(self, value: ImageSlicerArea) -> None:
+    def slicer_area(self, value: ImageSlicerArea | None) -> None:
+        if value is None:
+            self._slicer_area = lambda: None
+            return
         self._slicer_area = weakref.ref(value)
 
     @property
@@ -452,7 +456,10 @@ class _DataManipulationDialog(QtWidgets.QDialog):
         return ""
 
     def _copy_data_name(self) -> str:
-        return self.slicer_area.watched_data_name or "data"
+        slicer_area = self._slicer_area()
+        if slicer_area is None:
+            return "data"
+        return slicer_area.watched_data_name or "data"
 
 
 class DataTransformDialog(_DataManipulationDialog):
@@ -535,15 +542,17 @@ class DataTransformDialog(_DataManipulationDialog):
 
     def __init__(
         self,
-        slicer_area: ImageSlicerArea,
+        slicer_area: ImageSlicerArea | None,
         *,
         batch_manager: ImageToolManager | None = None,
         provenance_edit_mode: bool = False,
+        dialog_parent: QtWidgets.QWidget | None = None,
     ) -> None:
         super().__init__(
             slicer_area,
             batch_manager=batch_manager,
             provenance_edit_mode=provenance_edit_mode,
+            dialog_parent=dialog_parent,
         )
         if self.is_provenance_edit_mode:
             return
@@ -1025,11 +1034,13 @@ class DataFilterDialog(_DataManipulationDialog):
         *,
         batch_manager: ImageToolManager | None = None,
         provenance_edit_mode: bool = False,
+        dialog_parent: QtWidgets.QWidget | None = None,
     ) -> None:
         super().__init__(
             slicer_area,
             batch_manager=batch_manager,
             provenance_edit_mode=provenance_edit_mode,
+            dialog_parent=dialog_parent,
         )
         self._previewed: bool = False
         self._starting_applied_func = self.slicer_area._applied_func
@@ -1998,21 +2009,17 @@ class _SelectionRow:
         self.dim = dim
 
         data = dialog.public_data
-        current_index = dialog.array_slicer.get_index(
-            dialog.slicer_area.current_cursor, axis
-        )
+        current_index = dialog._current_selection_index(axis)
+        bin_values = dialog._selection_bin_values()
+        binned = dialog._selection_binned()
         scalar_controls = _ScalarSelectionControls(
             data,
             dim,
             axis,
             object_name_prefix="selection",
             current_index=current_index,
-            bin_value=dialog.array_slicer.get_bin_values(
-                dialog.slicer_area.current_cursor
-            )[axis],
-            is_binned=dialog.array_slicer.get_binned(dialog.slicer_area.current_cursor)[
-                axis
-            ],
+            bin_value=bin_values[axis],
+            is_binned=binned[axis],
         )
         self._scalar_controls = scalar_controls
         self._coord_ascending = scalar_controls.coord_ascending
@@ -2318,9 +2325,38 @@ class SelectionDialog(DataTransformDialog):
         provenance.QSelOperation,
     )
 
+    def __init__(
+        self,
+        slicer_area: ImageSlicerArea | None = None,
+        *,
+        batch_manager: ImageToolManager | None = None,
+        provenance_edit_mode: bool = False,
+        dialog_parent: QtWidgets.QWidget | None = None,
+        source_data: xr.DataArray | None = None,
+    ) -> None:
+        if slicer_area is None:
+            if source_data is None:
+                raise ValueError(
+                    "SelectionDialog requires a slicer area or source data"
+                )
+            if not provenance_edit_mode:
+                raise ValueError(
+                    "Source-data-only SelectionDialog requires provenance edit mode"
+                )
+        self._source_data = source_data
+        super().__init__(
+            slicer_area,
+            batch_manager=batch_manager,
+            provenance_edit_mode=provenance_edit_mode,
+            dialog_parent=dialog_parent,
+        )
+
     def setup_widgets(self) -> None:
+        source_data = self._source_data
+        if source_data is None:
+            source_data = self.slicer_area.data
         self.public_data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
-            self.slicer_area.data
+            source_data
         )
 
         self.grid_layout = QtWidgets.QGridLayout()
@@ -2369,6 +2405,23 @@ class SelectionDialog(DataTransformDialog):
         self.layout_.addRow("Result", self.preview_label)
         self.layout_.addRow("Code", self.code_preview)
         self.update_preview()
+
+    def _current_selection_index(self, axis: int) -> int:
+        if self._source_data is None:
+            return self.array_slicer.get_index(self.slicer_area.current_cursor, axis)
+        dim = self.public_data.dims[axis]
+        size = self.public_data.sizes[dim]
+        return max(0, min(size // 2, size - 1))
+
+    def _selection_bin_values(self) -> tuple[float, ...]:
+        if self._source_data is None:
+            return self.array_slicer.get_bin_values(self.slicer_area.current_cursor)
+        return (0.0,) * self.public_data.ndim
+
+    def _selection_binned(self) -> tuple[bool, ...]:
+        if self._source_data is None:
+            return self.array_slicer.get_binned(self.slicer_area.current_cursor)
+        return (False,) * self.public_data.ndim
 
     def _selection_kwargs(
         self,

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -7,6 +7,7 @@ import traceback
 import typing
 import warnings
 
+import numpy as np
 from qtpy import QtCore, QtWidgets
 
 import erlab
@@ -68,6 +69,21 @@ class _OperationDialogMatch:
     start: int
     stop: int
     focus: str | None = None
+
+
+_NATIVE_TERMINAL_CURRENT_DATA_EDITORS: tuple[
+    tuple[
+        type[dialogs._DataManipulationDialog],
+        type[provenance.ToolProvenanceOperation],
+    ],
+    ...,
+] = (
+    (dialogs.NormalizeDialog, provenance.NormalizeOperation),
+    (dialogs.GaussianFilterDialog, provenance.GaussianFilterOperation),
+    (dialogs.DivideByCoordDialog, provenance.DivideByCoordOperation),
+    (dialogs.SortByDialog, provenance.SortByOperation),
+    (dialogs.LeadingEdgeDialog, provenance.LeadingEdgeOperation),
+)
 
 
 class _ProvenanceReplayFailure(RuntimeError):
@@ -1910,19 +1926,27 @@ class _ProvenanceEditController:
             operation_index=dialog_match.start,
             stage_index=ref.stage_index,
         )
-        try:
-            prefix_data, _prefix = self._replay_candidate_result(
-                node,
-                row.scope,
-                spec._prefix_before_ref(start_ref),
-            )
-        except _TrustedScriptReplayCancelled:
-            raise
-        except Exception as exc:
-            raise _ProvenanceReplayFailure(
-                "opening the provenance editor: replaying the input to this step",
-                exc,
-            ) from exc
+        prefix_data = self._native_edit_seed_data_without_replay(
+            node,
+            spec,
+            ref,
+            dialog_match,
+            operations,
+        )
+        if prefix_data is None:
+            try:
+                prefix_data, _prefix = self._replay_candidate_result(
+                    node,
+                    row.scope,
+                    spec._prefix_before_ref(start_ref),
+                )
+            except _TrustedScriptReplayCancelled:
+                raise
+            except Exception as exc:
+                raise _ProvenanceReplayFailure(
+                    "opening the provenance editor: replaying the input to this step",
+                    exc,
+                ) from exc
 
         dialog_parent = (
             self._manager if isinstance(self._manager, QtWidgets.QWidget) else None
@@ -1955,6 +1979,131 @@ class _ProvenanceEditController:
             if temp_tool is not None:
                 temp_tool.close()
                 temp_tool.deleteLater()
+
+    def _native_edit_seed_data_without_replay(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        spec: provenance.ToolProvenanceSpec,
+        ref: provenance._ProvenanceStepRef,
+        dialog_match: _OperationDialogMatch,
+        operations: Sequence[provenance.ToolProvenanceOperation],
+    ) -> xr.DataArray | None:
+        for seed_builder in (
+            self._terminal_current_data_edit_seed,
+            self._terminal_affine_coord_edit_seed,
+        ):
+            seed_data = seed_builder(node, spec, ref, dialog_match, operations)
+            if seed_data is not None:
+                return seed_data
+        return None
+
+    def _terminal_current_data_edit_seed(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        spec: provenance.ToolProvenanceSpec,
+        ref: provenance._ProvenanceStepRef,
+        dialog_match: _OperationDialogMatch,
+        operations: Sequence[provenance.ToolProvenanceOperation],
+    ) -> xr.DataArray | None:
+        if len(operations) != 1:
+            return None
+        if dialog_match.stop != len(_operations_for_ref(spec, ref)):
+            return None
+        operation = operations[0]
+        if not any(
+            issubclass(dialog_match.dialog_cls, dialog_cls)
+            and isinstance(operation, operation_cls)
+            for dialog_cls, operation_cls in _NATIVE_TERMINAL_CURRENT_DATA_EDITORS
+        ):
+            return None
+        try:
+            data = node.current_source_data().copy(deep=False)
+        except Exception:
+            return None
+        if isinstance(operation, provenance.NormalizeOperation) and not set(
+            operation.dims
+        ).issubset(data.dims):
+            return None
+        if isinstance(operation, provenance.GaussianFilterOperation):
+            if not set(operation.sigma).issubset(data.dims):
+                return None
+            try:
+                for dim in operation.sigma:
+                    coord = np.asarray(data[dim].values, dtype=np.float64)
+                    if (
+                        coord.size < 2
+                        or np.allclose(np.diff(coord), 0.0)
+                        or not erlab.utils.array.is_uniform_spaced(coord)
+                    ):
+                        return None
+            except Exception:
+                return None
+        if isinstance(operation, provenance.DivideByCoordOperation):
+            if operation.coord_name not in data.coords:
+                return None
+            coord = data.coords[operation.coord_name]
+            if (
+                not set(coord.dims).issubset(data.dims)
+                or not np.issubdtype(coord.dtype, np.number)
+                or np.issubdtype(coord.dtype, np.complexfloating)
+            ):
+                return None
+        if isinstance(operation, provenance.SortByOperation):
+            sort_keys = set(data.dims)
+            for name, coord in data.coords.items():
+                if (
+                    coord.ndim == 1
+                    and len(coord.dims) == 1
+                    and coord.dims[0] in data.dims
+                ):
+                    sort_keys.add(name)
+            if not all(key in sort_keys for key in operation.variables):
+                return None
+        if (
+            isinstance(operation, provenance.LeadingEdgeOperation)
+            and operation.dim not in data.dims
+        ):
+            return None
+        return data
+
+    def _terminal_affine_coord_edit_seed(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        spec: provenance.ToolProvenanceSpec,
+        ref: provenance._ProvenanceStepRef,
+        dialog_match: _OperationDialogMatch,
+        operations: Sequence[provenance.ToolProvenanceOperation],
+    ) -> xr.DataArray | None:
+        if not issubclass(dialog_match.dialog_cls, dialogs.AssignCoordsDialog):
+            return None
+        if len(operations) != 1:
+            return None
+        operation = operations[0]
+        if not isinstance(operation, provenance.AffineCoordOperation):
+            return None
+        if operation.scale == 0.0:
+            return None
+
+        if dialog_match.stop != len(_operations_for_ref(spec, ref)):
+            return None
+
+        try:
+            data = node.current_source_data().copy(deep=False)
+            coord = data.coords[operation.coord_name]
+            coord_values = np.asarray(coord.values)
+            if not np.issubdtype(coord_values.dtype, np.number) or np.issubdtype(
+                coord_values.dtype,
+                np.complexfloating,
+            ):
+                return None
+            old_coord_values = (coord_values - operation.offset) / operation.scale
+            if not np.all(np.isfinite(old_coord_values)):
+                return None
+            return data.assign_coords(
+                {operation.coord_name: coord.copy(data=old_coord_values)}
+            )
+        except Exception:
+            return None
 
     @staticmethod
     def _restore_native_edit_dialog(

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -1924,19 +1924,37 @@ class _ProvenanceEditController:
                 exc,
             ) from exc
 
-        temp_tool = erlab.interactive.imagetool.ImageTool(prefix_data)
+        dialog_parent = (
+            self._manager if isinstance(self._manager, QtWidgets.QWidget) else None
+        )
+        temp_tool = None
         try:
-            dialog = dialog_match.dialog_cls(
-                temp_tool.slicer_area,
-                provenance_edit_mode=True,
-            )
+            if issubclass(dialog_match.dialog_cls, dialogs.SelectionDialog):
+                selection_dialog_cls = typing.cast(
+                    "type[dialogs.SelectionDialog]",
+                    dialog_match.dialog_cls,
+                )
+                dialog = selection_dialog_cls(
+                    provenance_edit_mode=True,
+                    dialog_parent=dialog_parent,
+                    source_data=prefix_data,
+                )
+            else:
+                temp_tool = erlab.interactive.imagetool.ImageTool(prefix_data)
+                temp_tool.hide()
+                dialog = dialog_match.dialog_cls(
+                    temp_tool.slicer_area,
+                    provenance_edit_mode=True,
+                    dialog_parent=dialog_parent,
+                )
             self._restore_native_edit_dialog(dialog, operations, dialog_match.focus)
             if dialog.exec() != int(QtWidgets.QDialog.DialogCode.Accepted):
                 return None
             return dialog.provenance_edit_operations()
         finally:
-            temp_tool.close()
-            temp_tool.deleteLater()
+            if temp_tool is not None:
+                temp_tool.close()
+                temp_tool.deleteLater()
 
     @staticmethod
     def _restore_native_edit_dialog(

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -1948,16 +1948,12 @@ class _ProvenanceEditController:
                     exc,
                 ) from exc
 
-        dialog_parent = (
-            self._manager if isinstance(self._manager, QtWidgets.QWidget) else None
-        )
+        manager: object = self._manager
+        dialog_parent = manager if isinstance(manager, QtWidgets.QWidget) else None
         temp_tool = None
         try:
             if issubclass(dialog_match.dialog_cls, dialogs.SelectionDialog):
-                selection_dialog_cls = typing.cast(
-                    "type[dialogs.SelectionDialog]",
-                    dialog_match.dialog_cls,
-                )
+                selection_dialog_cls = dialog_match.dialog_cls
                 dialog = selection_dialog_cls(
                     provenance_edit_mode=True,
                     dialog_parent=dialog_parent,

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -82,7 +82,6 @@ _NATIVE_TERMINAL_CURRENT_DATA_EDITORS: tuple[
     (dialogs.GaussianFilterDialog, provenance.GaussianFilterOperation),
     (dialogs.DivideByCoordDialog, provenance.DivideByCoordOperation),
     (dialogs.SortByDialog, provenance.SortByOperation),
-    (dialogs.LeadingEdgeDialog, provenance.LeadingEdgeOperation),
 )
 
 
@@ -2055,11 +2054,6 @@ class _ProvenanceEditController:
                     sort_keys.add(name)
             if not all(key in sort_keys for key in operation.variables):
                 return None
-        if (
-            isinstance(operation, provenance.LeadingEdgeOperation)
-            and operation.dim not in data.dims
-        ):
-            return None
         return data
 
     def _terminal_affine_coord_edit_seed(

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -963,7 +963,6 @@ class _ManagedWindowNode(QtCore.QObject):
             if source_spec is not None:
                 rows.extend(
                     source_spec.display_rows(
-                        parent_data=parent.current_source_data(),
                         scope="source",
                     )
                 )

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1930,7 +1930,7 @@ def test_figure_composer_plot_array_render_and_generated_code(
             "norm_gamma": 0.5,
             "vmin": 0.0,
             "vmax": 2.0,
-            "extra_kwargs": {"aspect": "equal"},
+            "aspect": "equal",
         }
     )
     tool = FigureComposerTool.from_sources(
@@ -1965,6 +1965,65 @@ def test_figure_composer_plot_array_render_and_generated_code(
     assert "eplt.plot_array(data.qsel(eV=0.0).T" in code
     namespace = _exec_generated_code(code, {"data": data})
     assert "fig" in namespace
+
+
+def test_figure_composer_plot_array_aspect_control_updates_recipe(qtbot) -> None:
+    data = _figure_composer_image_source("data").isel(eV=0)
+    operation = FigureOperationState.plot_array(
+        label="plot_array",
+        source="data",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("view")
+
+    aspect_edit = next(
+        (
+            candidate
+            for candidate in tool.findChildren(
+                QtWidgets.QLineEdit,
+                "figureComposerPlotArrayAspectEdit",
+            )
+            if candidate.property("figure_composer_editor_generation")
+            == tool._operation_editor_generation
+        ),
+        None,
+    )
+    assert aspect_edit is not None
+    assert aspect_edit.text() == ""
+
+    aspect_edit.setText("equal")
+    aspect_edit.editingFinished.emit()
+    assert tool.tool_status.operations[0].aspect == "equal"
+    assert (
+        figurecomposer_plot_array._plot_array_kwargs(tool.tool_status.operations[0])[
+            "aspect"
+        ]
+        == "equal"
+    )
+
+    aspect_edit.setText("2.5")
+    aspect_edit.editingFinished.emit()
+    assert tool.tool_status.operations[0].aspect == 2.5
+    assert (
+        figurecomposer_plot_array._plot_array_code_kwargs(
+            tool.tool_status.operations[0]
+        )["aspect"]
+        == 2.5
+    )
+
+    aspect_edit.setText("")
+    aspect_edit.editingFinished.emit()
+    assert tool.tool_status.operations[0].aspect is None
+    assert "aspect" not in figurecomposer_plot_array._plot_array_kwargs(
+        tool.tool_status.operations[0]
+    )
 
 
 def test_figure_composer_plot_array_colorbar_limit_changes_update_recipe(
@@ -2227,7 +2286,7 @@ def test_figure_composer_plot_array_norm_and_callback_helpers() -> None:
             "gamma": 0.75,
             "vmin": 0.0,
             "vmax": 1.0,
-            "extra_kwargs": {"aspect": "equal"},
+            "aspect": "equal",
         }
     )
 
@@ -2245,7 +2304,25 @@ def test_figure_composer_plot_array_norm_and_callback_helpers() -> None:
 
     code_kwargs = figurecomposer_plot_array._plot_array_code_kwargs(power_operation)
     assert code_kwargs == runtime_kwargs
+    override_operation = power_operation.model_copy(
+        update={"extra_kwargs": {"aspect": "auto"}}
+    )
+    assert (
+        figurecomposer_plot_array._plot_array_kwargs(override_operation)["aspect"]
+        == "auto"
+    )
     assert figurecomposer_plot_array._norm_gamma_value(power_operation) == 0.75
+
+    assert figurecomposer_plot_array._format_aspect_value(None) == ""
+    assert figurecomposer_plot_array._format_aspect_value("equal") == "equal"
+    assert figurecomposer_plot_array._format_aspect_value(2) == "2"
+    assert figurecomposer_plot_array._aspect_value_from_text("") is None
+    assert figurecomposer_plot_array._aspect_value_from_text("auto") == "auto"
+    assert figurecomposer_plot_array._aspect_value_from_text("equal") == "equal"
+    assert figurecomposer_plot_array._aspect_value_from_text("2") == 2.0
+    assert figurecomposer_plot_array._aspect_value_from_text("custom") == "custom"
+    assert figurecomposer_plot_array._aspect_value_from_text("'manual'") == "manual"
+    assert figurecomposer_plot_array._aspect_value_from_text("[1, 2]") == "[1, 2]"
 
     norm_operation = power_operation.model_copy(
         update={
@@ -3979,6 +4056,10 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
                 name="plot",
                 axes=FigureAxesSelectionState(axes=((0, 0),)),
             ),
+            FigureOperationState.plot_array(
+                label="image plot",
+                source="image",
+            ).model_copy(update={"colorbar": "right"}),
         ),
         primary_source="image",
     )
@@ -4108,6 +4189,40 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
     _assert_step_editor_section(method_page, "figureComposerMethodCallSection")
     _assert_step_editor_section(method_page, "figureComposerMethodValuesSection")
     _assert_step_editor_section(method_page, "figureComposerMethodAdvancedSection")
+
+    tool.operation_list.setCurrentRow(4)
+    tool._update_operation_editor()
+    tool._select_step_section("selection")
+    plot_array_selection_page = tool.step_editor_stack.currentWidget()
+    assert plot_array_selection_page is not None
+    _assert_step_editor_section(
+        plot_array_selection_page,
+        "figureComposerPlotArraySelectionDataSection",
+    )
+    _assert_step_editor_section(
+        plot_array_selection_page,
+        "figureComposerPlotArraySelectionDimensionsSection",
+    )
+    tool._select_step_section("view")
+    plot_array_view_page = tool.step_editor_stack.currentWidget()
+    assert plot_array_view_page is not None
+    _assert_step_editor_section(
+        plot_array_view_page, "figureComposerPlotArrayViewImageSection"
+    )
+    _assert_step_editor_section(
+        plot_array_view_page, "figureComposerPlotArrayViewAxesSection"
+    )
+    tool._select_step_section("colors")
+    plot_array_colors_page = tool.step_editor_stack.currentWidget()
+    assert plot_array_colors_page is not None
+    _assert_step_editor_section(
+        plot_array_colors_page,
+        "figureComposerPlotArrayColorsImageColorSection",
+    )
+    _assert_step_editor_section(
+        plot_array_colors_page,
+        "figureComposerPlotArrayColorsColorbarSection",
+    )
 
 
 def test_figure_composer_norm_helpers_cover_structured_and_custom_norms(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -9027,6 +9027,46 @@ def test_figure_composer_defaults_follow_stylesheet_rcparams(
     assert export.bbox_inches == expected_bbox
 
 
+def test_figure_composer_default_dpi_option_overrides_stylesheet(
+    monkeypatch,
+    restore_interactive_options,
+) -> None:
+    options.model = options.model.model_copy(
+        update={"figure": FigureOptions(stylesheets=["classic"], dpi=180.0)}
+    )
+    monkeypatch.setattr(
+        figurecomposer_defaults,
+        "_configured_stylesheets",
+        lambda: ("classic",),
+    )
+
+    assert figurecomposer_defaults._default_figure_dpi() == 180.0
+    assert FigureSubplotsState().dpi == 180.0
+
+
+def test_figure_composer_dpi_option_affects_only_new_recipes(
+    qtbot,
+    restore_interactive_options,
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4.0)})
+    options.model = options.model.model_copy(
+        update={"figure": FigureOptions(dpi=120.0)}
+    )
+    tool = FigureComposerTool(data)
+    qtbot.addWidget(tool)
+
+    assert tool.tool_status.setup.dpi == 120.0
+
+    options.model = options.model.model_copy(
+        update={"figure": FigureOptions(dpi=220.0)}
+    )
+    new_tool = FigureComposerTool(data)
+    qtbot.addWidget(new_tool)
+
+    assert tool.tool_status.setup.dpi == 120.0
+    assert new_tool.tool_status.setup.dpi == 220.0
+
+
 def test_figure_composer_defaults_skip_unavailable_stylesheets(
     monkeypatch,
     restore_interactive_options,

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1639,6 +1639,130 @@ def test_figure_composer_plot_array_colormap_activation_updates_recipe(
     assert tool.tool_status.operations[0].cmap == cmap
 
 
+def test_figure_composer_plot_array_colorcet_selection_uses_matplotlib_name(
+    qtbot,
+) -> None:
+    pytest.importorskip("colorcet")
+
+    data = _figure_composer_image_source("data").isel(eV=0)
+    operation = FigureOperationState.plot_array(label="plot_array", source="data")
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("colors")
+
+    cmap_combo = next(
+        (
+            candidate
+            for candidate in tool.findChildren(
+                erlab.interactive.colors.ColorMapComboBox,
+                "figureComposerPlotArrayCmapCombo",
+            )
+            if candidate.property("figure_composer_editor_generation")
+            == tool._operation_editor_generation
+        ),
+        None,
+    )
+    assert cmap_combo is not None
+    cmap_combo.load_all()
+    cmap_combo.setCurrentText("CET_C1")
+    cmap_combo.activated.emit(cmap_combo.currentIndex())
+
+    operation = tool.tool_status.operations[0]
+    assert operation.cmap == "cet_CET_C1"
+    assert (
+        figurecomposer_plot_array._plot_array_kwargs(operation)["cmap"] == "cet_CET_C1"
+    )
+    assert (
+        figurecomposer_plot_array._plot_array_code_kwargs(operation)["cmap"]
+        == "cet_CET_C1"
+    )
+
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+
+    assert tool.figure.axes[0].images[-1].get_cmap().name == "cet_CET_C1"
+
+
+def test_figure_composer_plot_array_default_colormap_editor_uses_stylesheet(
+    qtbot,
+    tmp_path: Path,
+) -> None:
+    style_name = "erlab-test-image-cmap"
+    style_dir = tmp_path / "stylelib"
+    style_dir.mkdir()
+    (style_dir / f"{style_name}.mplstyle").write_text(
+        "image.cmap: plasma\n", encoding="utf-8"
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=mpl.MatplotlibDeprecationWarning)
+        import matplotlib.style.core as mpl_style_core
+
+    mpl_style_core.USER_LIBRARY_PATHS.append(str(style_dir))
+    try:
+        mpl_style.reload_library()
+        _set_figure_stylesheets([style_name])
+        data = _figure_composer_image_source("data").isel(eV=0)
+        operation = FigureOperationState.plot_array(label="plot_array", source="data")
+        tool = FigureComposerTool.from_sources(
+            {"data": data},
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        )
+        qtbot.addWidget(tool)
+        tool.operation_list.setCurrentRow(0)
+        tool._select_step_section("colors")
+
+        cmap_combo = next(
+            (
+                candidate
+                for candidate in tool.findChildren(
+                    erlab.interactive.colors.ColorMapComboBox,
+                    "figureComposerPlotArrayCmapCombo",
+                )
+                if candidate.property("figure_composer_editor_generation")
+                == tool._operation_editor_generation
+            ),
+            None,
+        )
+        cmap_reverse_check = next(
+            (
+                candidate
+                for candidate in tool.findChildren(
+                    QtWidgets.QCheckBox, "figureComposerPlotArrayCmapReverseCheck"
+                )
+                if candidate.property("figure_composer_editor_generation")
+                == tool._operation_editor_generation
+            ),
+            None,
+        )
+        assert cmap_combo is not None
+        assert cmap_reverse_check is not None
+        assert cmap_combo.currentText() == "plasma"
+        assert cmap_reverse_check.checkState() == QtCore.Qt.CheckState.Unchecked
+        assert tool.tool_status.operations[0].cmap is None
+
+        figurecomposer_rendering._render_into_figure(
+            tool, tool.figure, sync_visible=False
+        )
+        assert tool.figure.axes[0].images[-1].get_cmap().name == "plasma"
+        assert "cmap" not in figurecomposer_plot_array._plot_array_kwargs(
+            tool.tool_status.operations[0]
+        )
+
+        cmap_reverse_check.setChecked(True)
+
+        assert tool.tool_status.operations[0].cmap == "plasma_r"
+    finally:
+        mpl_style_core.USER_LIBRARY_PATHS.remove(str(style_dir))
+        mpl_style.reload_library()
+
+
 def test_figure_composer_plot_array_colormap_editor_initialization_edges(
     qtbot,
 ) -> None:
@@ -4047,6 +4171,62 @@ def test_figure_composer_norm_helpers_cover_structured_and_custom_norms(
     assert custom_calls[-1] == ((), {"alpha": 3})
     assert figurecomposer_norms._norm_code(custom_no_gamma) == (
         "eplt.CustomNorm(alpha=3)"
+    )
+
+
+def test_figure_composer_cmap_helpers_normalize_colorcet_names() -> None:
+    pytest.importorskip("colorcet")
+
+    erlab.interactive.colors.load_all_colormaps()
+
+    assert figurecomposer_norms._cmap_base_and_reverse("CET_C1_r") == (
+        "cet_CET_C1",
+        True,
+    )
+    assert figurecomposer_norms._cmap_with_reverse("fire", True) == "cet_fire_r"
+
+
+def test_figure_composer_plot_slices_kwargs_normalize_colorcet_colormaps(
+    qtbot,
+) -> None:
+    pytest.importorskip("colorcet")
+
+    erlab.interactive.colors.load_all_colormaps()
+    data = _figure_composer_image_source("data")
+    operation = FigureOperationState.plot_slices(
+        label="plot_slices",
+        sources=("data",),
+        slice_dim="eV",
+        slice_values=(0.0,),
+    ).model_copy(update={"cmap": "CET_C1"})
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+
+    assert figurecomposer_plot_slices._plot_slices_kwargs(tool, operation)["cmap"] == (
+        "cet_CET_C1"
+    )
+
+    panel_operation = operation.model_copy(
+        update={
+            "panel_styles_enabled": True,
+            "panel_styles": (
+                FigurePlotSlicesPanelStyleState(
+                    map_index=0,
+                    slice_index=0,
+                    cmap="fire",
+                ),
+            ),
+        }
+    )
+
+    assert (
+        figurecomposer_plot_slices._plot_slices_kwargs(tool, panel_operation)["cmap"]
+        == "cet_fire"
     )
 
 
@@ -21858,6 +22038,22 @@ def test_figure_composer_line_colormap_equal_values_use_midpoint() -> None:
     )
     expected = plt.get_cmap("viridis")([0.45, 0.45])
     np.testing.assert_allclose(colors, expected)
+
+
+def test_figure_composer_line_colormap_normalizes_colorcet_name() -> None:
+    pytest.importorskip("colorcet")
+
+    erlab.interactive.colors.load_all_colormaps()
+    operation = FigureOperationState.line(label="profiles", source="data").model_copy(
+        update={
+            "line_color_cmap": "fire",
+            "line_color_cmap_reverse": True,
+        }
+    )
+
+    assert figurecomposer_line_colormap.effective_line_color_cmap(operation) == (
+        "cet_fire_r"
+    )
 
 
 def test_figure_composer_line_colormap_rejects_invalid_trim() -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -2229,6 +2229,50 @@ def test_figure_composer_plot_array_aspect_control_preserves_saved_custom_value(
     assert tool.tool_status.operations[0].aspect == "auto"
 
 
+def test_figure_composer_plot_array_aspect_control_shows_mixed_batch_value(
+    qtbot,
+) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    operation = FigureOperationState.plot_array(
+        label="plot_array",
+        source="data",
+    )
+
+    class _BatchTool:
+        def _batch_is_mixed(
+            self,
+            _operation: FigureOperationState,
+            _value: Callable[[FigureOperationState], object],
+        ) -> bool:
+            return True
+
+        def _mark_editor_control(self, _widget: QtWidgets.QWidget) -> None:
+            return
+
+        def _connect_editor_signal(
+            self,
+            _owner: QtWidgets.QWidget,
+            signal: object,
+            slot: Callable[..., None],
+        ) -> None:
+            signal.connect(slot)
+
+        def _update_current_operation(self, **_updates: object) -> None:
+            return
+
+    combo = figurecomposer_plot_array._plot_array_aspect_combo(
+        typing.cast("FigureComposerTool", _BatchTool()),
+        operation,
+        parent=parent,
+    )
+
+    item = typing.cast("typing.Any", combo.model()).item(0)
+    assert combo.currentData() is _editor_controls.MIXED_VALUE
+    assert item is not None
+    assert not item.isEnabled()
+
+
 def test_figure_composer_plot_array_colorbar_limit_changes_update_recipe(
     qtbot,
 ) -> None:
@@ -2519,6 +2563,7 @@ def test_figure_composer_plot_array_norm_and_callback_helpers() -> None:
     assert figurecomposer_plot_array._format_aspect_value(None) == ""
     assert figurecomposer_plot_array._format_aspect_value("equal") == "equal"
     assert figurecomposer_plot_array._format_aspect_value(2) == "2"
+    assert figurecomposer_plot_array._format_aspect_value((1, 2)) == "(1, 2)"
 
     norm_operation = power_operation.model_copy(
         update={
@@ -5467,6 +5512,12 @@ def test_figure_composer_plot_slices_panel_helpers_cover_style_contract(
     assert figurecomposer_plot_slices._panel_cmap_argument(tool, operation) == [
         ["magma", "plasma"]
     ]
+    assert figurecomposer_plot_slices._effective_panel_cmap(
+        FigureOperationState.plot_slices(label="default", sources=("data",)),
+        FigurePlotSlicesPanelStyleState(map_index=0, slice_index=0),
+    ) == figurecomposer_plot_slices._matplotlib_cmap_name(
+        options.model.colors.cmap.name
+    )
     assert figurecomposer_plot_slices._panel_line_kw_argument(tool, operation) == [
         [{"linewidth": 1.5, "color": "red"}, {"linewidth": 1.5, "color": "blue"}]
     ]
@@ -6426,6 +6477,59 @@ def test_figure_composer_plot_slices_panel_override_controls_stay_live(
             norm_name="PowerNorm",
         ),
     )
+
+
+def test_figure_composer_plot_slices_panel_style_editor_reverses_mixed_cmap(
+    qtbot,
+) -> None:
+    operation = FigureOperationState.plot_slices(
+        label="image",
+        sources=("data",),
+    ).model_copy(
+        update={
+            "cmap": "viridis",
+            "panel_styles_enabled": True,
+            "panel_styles": (
+                FigurePlotSlicesPanelStyleState(
+                    map_index=0,
+                    slice_index=0,
+                    cmap="magma",
+                ),
+                FigurePlotSlicesPanelStyleState(
+                    map_index=0,
+                    slice_index=1,
+                    cmap="plasma",
+                ),
+            ),
+        }
+    )
+    keys = (
+        figurecomposer_plot_slices._PlotSlicesPanelKey(0, 0, "panel 1"),
+        figurecomposer_plot_slices._PlotSlicesPanelKey(0, 1, "panel 2"),
+    )
+    editor = figurecomposer_plot_slices._PanelStyleEditorWidget(
+        operation,
+        keys,
+        lambda _owner, signal, slot: signal.connect(slot),
+        "viridis",
+    )
+    qtbot.addWidget(editor)
+    emitted: list[tuple[FigurePlotSlicesPanelStyleState, ...]] = []
+    editor.sigPanelStylesChanged.connect(emitted.append)
+
+    for row in range(editor.panel_list.count()):
+        item = editor.panel_list.item(row)
+        assert item is not None
+        item.setSelected(True)
+    editor._sync_controls()
+    assert editor.cmap_combo.currentData() is figurecomposer_plot_slices._MISSING
+    with QtCore.QSignalBlocker(editor.cmap_override_check):
+        editor.cmap_override_check.setCheckState(QtCore.Qt.CheckState.Checked)
+
+    editor._cmap_reverse_changed(QtCore.Qt.CheckState.Checked.value)
+
+    assert emitted
+    assert tuple(style.cmap for style in emitted[-1]) == ("viridis_r", "viridis_r")
 
 
 def test_figure_composer_plot_slices_line_panel_style_editor_updates_styles(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1415,6 +1415,82 @@ def test_figure_composer_plot_array_selection_editor_updates_selection(qtbot) ->
     )
 
 
+def test_figure_composer_plot_array_qsel_to_keep_clears_selection(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 2, 2),
+        dims=("eV", "beta", "alpha"),
+        coords={
+            "eV": [-1.0, 0.0, 1.0],
+            "beta": [-0.5, 0.5],
+            "alpha": [0.0, 1.0],
+        },
+        name="map",
+    )
+    operation = FigureOperationState.plot_array(label="plot_array", source="data")
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("selection")
+
+    def current_dimension_widget(
+        widget_type: type[QtWidgets.QWidget], dim: str
+    ) -> QtWidgets.QWidget:
+        widget = next(
+            (
+                candidate
+                for candidate in tool.findChildren(widget_type)
+                if candidate.property("figure_composer_plot_array_dim") == dim
+                if candidate.property("figure_composer_editor_generation")
+                == tool._operation_editor_generation
+            ),
+            None,
+        )
+        assert widget is not None
+        return widget
+
+    def activate_dimension_mode(dim: str, mode: str) -> None:
+        combo = typing.cast(
+            "QtWidgets.QComboBox",
+            current_dimension_widget(QtWidgets.QComboBox, dim),
+        )
+        index = combo.findData(mode)
+        assert index >= 0
+        combo.setCurrentIndex(index)
+        combo.activated.emit(index)
+
+    activate_dimension_mode("eV", "qsel")
+    qsel_edit = typing.cast(
+        "QtWidgets.QLineEdit",
+        current_dimension_widget(QtWidgets.QLineEdit, "eV"),
+    )
+    assert qsel_edit.isEnabled()
+    qsel_edit.setText("0.0")
+    qsel_edit.setModified(True)
+    qsel_edit.editingFinished.emit()
+
+    updated = tool.tool_status.operations[0]
+    assert updated.map_selections == (
+        FigureDataSelectionState(source="data", qsel={"eV": 0.0}),
+    )
+
+    activate_dimension_mode("eV", "keep")
+
+    updated = tool.tool_status.operations[0]
+    assert updated.sources == ("data",)
+    assert updated.map_selections == ()
+    value_edit = typing.cast(
+        "QtWidgets.QLineEdit",
+        current_dimension_widget(QtWidgets.QLineEdit, "eV"),
+    )
+    assert not value_edit.isEnabled()
+    assert value_edit.text() == ""
+
+
 def test_figure_composer_plot_array_selection_error_is_visible(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
@@ -1468,9 +1544,8 @@ def test_figure_composer_plot_array_selection_helper_edges(qtbot) -> None:
     )
     qtbot.addWidget(tool)
     figurecomposer_plot_array._update_current_selection_source(tool, "data")
-    assert tool.tool_status.operations[0].map_selections == (
-        FigureDataSelectionState(source="data"),
-    )
+    assert tool.tool_status.operations[0].sources == ("data",)
+    assert tool.tool_status.operations[0].map_selections == ()
 
     missing_operation = FigureOperationState.plot_array(
         label="missing", source="missing"
@@ -1515,6 +1590,13 @@ def test_figure_composer_plot_array_selection_helper_edges(qtbot) -> None:
         qsel={"y": 0.0},
         mean_dims=("x",),
     )
+
+    empty_selection = FigureDataSelectionState(source="data", qsel={"x": 0.0})
+    assert figurecomposer_plot_array._plot_array_selection_with_dimension(
+        empty_selection,
+        "x",
+        "keep",
+    ) == FigureDataSelectionState(source="data")
 
     combo = figurecomposer_plot_array._plot_array_selection_mode_combo(
         tool,

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1845,6 +1845,85 @@ def test_figure_composer_plot_array_default_colormap_editor_uses_stylesheet(
         mpl_style.reload_library()
 
 
+def test_figure_composer_plot_slices_default_colormap_editor_uses_stylesheet(
+    qtbot,
+    tmp_path: Path,
+) -> None:
+    style_name = "erlab-test-slices-image-cmap"
+    style_dir = tmp_path / "stylelib"
+    style_dir.mkdir()
+    (style_dir / f"{style_name}.mplstyle").write_text(
+        "image.cmap: plasma\n", encoding="utf-8"
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=mpl.MatplotlibDeprecationWarning)
+        import matplotlib.style.core as mpl_style_core
+
+    mpl_style_core.USER_LIBRARY_PATHS.append(str(style_dir))
+    try:
+        mpl_style.reload_library()
+        _set_figure_stylesheets([style_name])
+        data = _figure_composer_image_source("data").isel(eV=0)
+        operation = FigureOperationState.plot_slices(
+            label="plot_slices",
+            sources=("data",),
+        )
+        tool = FigureComposerTool.from_sources(
+            {"data": data},
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        )
+        qtbot.addWidget(tool)
+        tool.operation_list.setCurrentRow(0)
+        tool._select_step_section("colors")
+
+        cmap_combo = next(
+            (
+                candidate
+                for candidate in tool.findChildren(
+                    erlab.interactive.colors.ColorMapComboBox,
+                    "figureComposerCmapCombo",
+                )
+                if candidate.property("figure_composer_editor_generation")
+                == tool._operation_editor_generation
+            ),
+            None,
+        )
+        cmap_reverse_check = next(
+            (
+                candidate
+                for candidate in tool.findChildren(
+                    QtWidgets.QCheckBox, "figureComposerCmapReverseCheck"
+                )
+                if candidate.property("figure_composer_editor_generation")
+                == tool._operation_editor_generation
+            ),
+            None,
+        )
+        assert cmap_combo is not None
+        assert cmap_reverse_check is not None
+        assert cmap_combo.currentText() == "plasma"
+        assert cmap_reverse_check.checkState() == QtCore.Qt.CheckState.Unchecked
+        assert tool.tool_status.operations[0].cmap is None
+
+        kwargs = figurecomposer_plot_slices._plot_slices_kwargs(
+            tool, tool.tool_status.operations[0]
+        )
+        assert "cmap" not in kwargs
+        figurecomposer_rendering._render_into_figure(
+            tool, tool.figure, sync_visible=False
+        )
+        assert tool.figure.axes[0].images[-1].get_cmap().name == "plasma"
+
+        cmap_reverse_check.setChecked(True)
+
+        assert tool.tool_status.operations[0].cmap == "plasma_r"
+    finally:
+        mpl_style_core.USER_LIBRARY_PATHS.remove(str(style_dir))
+        mpl_style.reload_library()
+
+
 def test_figure_composer_plot_array_colormap_editor_initialization_edges(
     qtbot,
 ) -> None:
@@ -6255,6 +6334,7 @@ def test_figure_composer_plot_slices_image_panel_style_editor_updates_styles(
         operation,
         keys,
         lambda _owner, signal, slot: signal.connect(slot),
+        "viridis",
     )
     qtbot.addWidget(editor)
     emitted: list[tuple[FigurePlotSlicesPanelStyleState, ...]] = []
@@ -6305,6 +6385,7 @@ def test_figure_composer_plot_slices_panel_override_controls_stay_live(
         operation,
         keys,
         lambda _owner, signal, slot: signal.connect(slot),
+        "viridis",
     )
     qtbot.addWidget(editor)
     emitted: list[tuple[FigurePlotSlicesPanelStyleState, ...]] = []
@@ -14043,6 +14124,66 @@ def test_figure_composer_toolbar_line_style_widget_updates_all_controls(qtbot) -
     assert updated.line_kw["dash_capstyle"] == "round"
     assert "mfc" not in updated.line_kw
     assert "custom" not in updated.line_kw
+
+
+def test_figure_composer_toolbar_plot_slices_panel_cmap_uses_stylesheet(
+    qtbot,
+    tmp_path: Path,
+) -> None:
+    style_name = "erlab-test-toolbar-panel-cmap"
+    style_dir = tmp_path / "stylelib"
+    style_dir.mkdir()
+    (style_dir / f"{style_name}.mplstyle").write_text(
+        "image.cmap: plasma\n", encoding="utf-8"
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=mpl.MatplotlibDeprecationWarning)
+        import matplotlib.style.core as mpl_style_core
+
+    mpl_style_core.USER_LIBRARY_PATHS.append(str(style_dir))
+    try:
+        mpl_style.reload_library()
+        _set_figure_stylesheets([style_name])
+        data = _figure_composer_image_source("data")
+        operation = FigureOperationState.plot_slices(
+            label="plot_slices",
+            sources=("data",),
+            axes=FigureAxesSelectionState(axes=((0, 0), (0, 1))),
+            slice_dim="eV",
+            slice_values=(-0.5, 0.5),
+        )
+        tool = FigureComposerTool(
+            data,
+            recipe=FigureRecipeState(
+                setup=FigureSubplotsState(ncols=2),
+                sources=(FigureSourceState(name="data", label="data"),),
+                operations=(operation,),
+                primary_source="data",
+            ),
+        )
+        qtbot.addWidget(tool)
+        tool.show_figure_window(activate=False)
+
+        figurecomposer_toolbar_dialogs.show_axes_customize_dialog(tool)
+        dialog = typing.cast("QtWidgets.QDialog", tool._axes_customize_dialog)
+        qtbot.addWidget(dialog)
+        editor = dialog.findChild(figurecomposer_plot_slices._PanelStyleEditorWidget)
+        assert editor is not None
+        assert editor.cmap_combo.currentText() == "plasma"
+        assert editor.cmap_override_check.checkState() == QtCore.Qt.CheckState.Unchecked
+
+        editor.cmap_override_check.click()
+
+        assert tool.tool_status.operations[0].panel_styles == (
+            FigurePlotSlicesPanelStyleState(
+                map_index=0,
+                slice_index=0,
+                cmap="plasma",
+            ),
+        )
+    finally:
+        mpl_style_core.USER_LIBRARY_PATHS.remove(str(style_dir))
+        mpl_style.reload_library()
 
 
 def test_figure_composer_toolbar_operation_helpers_update_recipe(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -1983,23 +1983,27 @@ def test_figure_composer_plot_array_aspect_control_updates_recipe(qtbot) -> None
     tool.operation_list.setCurrentRow(0)
     tool._select_step_section("view")
 
-    aspect_edit = next(
+    aspect_combo = next(
         (
             candidate
             for candidate in tool.findChildren(
-                QtWidgets.QLineEdit,
-                "figureComposerPlotArrayAspectEdit",
+                QtWidgets.QComboBox,
+                "figureComposerPlotArrayAspectCombo",
             )
             if candidate.property("figure_composer_editor_generation")
             == tool._operation_editor_generation
         ),
         None,
     )
-    assert aspect_edit is not None
-    assert aspect_edit.text() == ""
+    assert aspect_combo is not None
+    assert [aspect_combo.itemData(index) for index in range(aspect_combo.count())] == [
+        None,
+        "auto",
+        "equal",
+    ]
+    assert aspect_combo.currentData() is None
 
-    aspect_edit.setText("equal")
-    aspect_edit.editingFinished.emit()
+    _activate_combo_index(aspect_combo, aspect_combo.findData("equal"))
     assert tool.tool_status.operations[0].aspect == "equal"
     assert (
         figurecomposer_plot_array._plot_array_kwargs(tool.tool_status.operations[0])[
@@ -2008,22 +2012,60 @@ def test_figure_composer_plot_array_aspect_control_updates_recipe(qtbot) -> None
         == "equal"
     )
 
-    aspect_edit.setText("2.5")
-    aspect_edit.editingFinished.emit()
-    assert tool.tool_status.operations[0].aspect == 2.5
+    _activate_combo_index(aspect_combo, aspect_combo.findData("auto"))
+    assert tool.tool_status.operations[0].aspect == "auto"
     assert (
         figurecomposer_plot_array._plot_array_code_kwargs(
             tool.tool_status.operations[0]
         )["aspect"]
-        == 2.5
+        == "auto"
     )
 
-    aspect_edit.setText("")
-    aspect_edit.editingFinished.emit()
+    _activate_combo_index(aspect_combo, aspect_combo.findData(None))
     assert tool.tool_status.operations[0].aspect is None
     assert "aspect" not in figurecomposer_plot_array._plot_array_kwargs(
         tool.tool_status.operations[0]
     )
+
+
+def test_figure_composer_plot_array_aspect_control_preserves_saved_custom_value(
+    qtbot,
+) -> None:
+    data = _figure_composer_image_source("data").isel(eV=0)
+    operation = FigureOperationState.plot_array(
+        label="plot_array",
+        source="data",
+    ).model_copy(update={"aspect": 2.5})
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(operation,),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("view")
+
+    aspect_combo = next(
+        (
+            candidate
+            for candidate in tool.findChildren(
+                QtWidgets.QComboBox,
+                "figureComposerPlotArrayAspectCombo",
+            )
+            if candidate.property("figure_composer_editor_generation")
+            == tool._operation_editor_generation
+        ),
+        None,
+    )
+
+    assert aspect_combo is not None
+    assert aspect_combo.currentData() is _editor_controls.MIXED_VALUE
+    assert tool.tool_status.operations[0].aspect == 2.5
+
+    _activate_combo_index(aspect_combo, aspect_combo.findData("auto"))
+
+    assert tool.tool_status.operations[0].aspect == "auto"
 
 
 def test_figure_composer_plot_array_colorbar_limit_changes_update_recipe(
@@ -2316,13 +2358,6 @@ def test_figure_composer_plot_array_norm_and_callback_helpers() -> None:
     assert figurecomposer_plot_array._format_aspect_value(None) == ""
     assert figurecomposer_plot_array._format_aspect_value("equal") == "equal"
     assert figurecomposer_plot_array._format_aspect_value(2) == "2"
-    assert figurecomposer_plot_array._aspect_value_from_text("") is None
-    assert figurecomposer_plot_array._aspect_value_from_text("auto") == "auto"
-    assert figurecomposer_plot_array._aspect_value_from_text("equal") == "equal"
-    assert figurecomposer_plot_array._aspect_value_from_text("2") == 2.0
-    assert figurecomposer_plot_array._aspect_value_from_text("custom") == "custom"
-    assert figurecomposer_plot_array._aspect_value_from_text("'manual'") == "manual"
-    assert figurecomposer_plot_array._aspect_value_from_text("[1, 2]") == "[1, 2]"
 
     norm_operation = power_operation.model_copy(
         update={

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1107,6 +1107,82 @@ def _trust_required_script_spec() -> provenance.ToolProvenanceSpec:
     )
 
 
+def test_manager_selection_provenance_edit_restores_from_high_dimensional_source(
+    qtbot: typing.Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_data = xr.DataArray(
+        np.zeros((2, 3, 4, 5, 6)),
+        dims=("scan", "eV", "kx", "ky", "temperature"),
+    )
+    spec = provenance.full_data(provenance.IselOperation(kwargs={"scan": 1}))
+    node = _fake_edit_node(spec)
+    node.detached_live_parent_data = parent_data
+
+    manager = QtWidgets.QWidget()
+    qtbot.addWidget(manager)
+    manager._metadata_node_uid = "node"
+    manager._tool_graph = types.SimpleNamespace(nodes={"node": node})
+    manager._selected_imagetool_targets = lambda: ()
+    manager._node_for_target = lambda target: manager._tool_graph.nodes[target]
+    manager._parent_node = lambda _node: pytest.fail("parent data should be detached")
+    manager._script_input_can_reload = lambda *_args, **_kwargs: True
+    manager._rebuild_script_provenance = lambda *_args, **_kwargs: pytest.fail(
+        "selection edit should not rebuild script provenance"
+    )
+    manager._ensure_script_provenance_trusted = lambda *_args, **_kwargs: None
+    manager._update_info = lambda **_kwargs: None
+    controller = manager_provenance_edit._ProvenanceEditController(
+        typing.cast("typing.Any", manager)
+    )
+
+    monkeypatch.setattr(
+        erlab.interactive.imagetool,
+        "ImageTool",
+        lambda *_args, **_kwargs: pytest.fail(
+            "selection provenance edits should not create a temporary ImageTool"
+        ),
+    )
+
+    captured: dict[str, typing.Any] = {}
+
+    def exec_dialog(dialog: SelectionDialog) -> int:
+        scan_row = next(row for row in dialog.rows if row.dim == "scan")
+        captured["parent"] = dialog.parent()
+        captured["dims"] = dialog.public_data.dims
+        captured["scan_checked"] = scan_row.use_check.isChecked()
+        captured["scan_method"] = scan_row.method
+        captured["scan_index"] = int(scan_row.index_start_spin.value())
+        return int(QtWidgets.QDialog.DialogCode.Accepted)
+
+    monkeypatch.setattr(SelectionDialog, "exec", exec_dialog)
+
+    row = spec.display_rows(parent_data=parent_data)[1]
+    assert row.edit_ref is not None
+    dialog_match = manager_provenance_edit._dialog_match_for_operation_ref(
+        spec,
+        row.edit_ref,
+    )
+    assert dialog_match is not None
+
+    replacements = controller._edited_native_operations(
+        node,
+        row,
+        spec,
+        row.edit_ref,
+        dialog_match,
+    )
+
+    assert captured == {
+        "parent": manager,
+        "dims": parent_data.dims,
+        "scan_checked": True,
+        "scan_method": "isel",
+        "scan_index": 1,
+    }
+    assert replacements == [provenance.IselOperation(kwargs={"scan": 1})]
+
+
 def test_manager_source_bound_derivation_rows_are_metadata_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1107,6 +1107,55 @@ def _trust_required_script_spec() -> provenance.ToolProvenanceSpec:
     )
 
 
+def test_manager_source_bound_derivation_rows_are_metadata_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def record_apply(
+        self: provenance.ToolProvenanceOperation,
+        data: xr.DataArray,
+        *,
+        parent_data: xr.DataArray,
+    ) -> xr.DataArray:
+        calls.append(self.op)
+        return data
+
+    monkeypatch.setattr(
+        provenance.SymmetrizeNfoldOperation,
+        "apply",
+        record_apply,
+    )
+    monkeypatch.setattr(
+        provenance.KspaceConvertOperation,
+        "apply",
+        record_apply,
+    )
+    source_spec = provenance.full_data(
+        provenance.SymmetrizeNfoldOperation(fold=4, axes=("x", "y")),
+        provenance.KspaceConvertOperation(),
+    )
+    parent = _fake_edit_node(provenance.full_data(), uid="parent")
+    parent.current_source_data = lambda: pytest.fail(
+        "metadata rendering must not compute parent source data"
+    )
+    child = _fake_edit_node(
+        None,
+        uid="child",
+        parent_uid="parent",
+        source_spec=source_spec,
+        source_display_spec=source_spec,
+    )
+    child.manager = types.SimpleNamespace(_parent_node=lambda _node: parent)
+
+    rows = manager_wrapper._ManagedWindowNode.derivation_display_rows.fget(child)
+
+    assert calls == []
+    assert rows is not None
+    assert any(row.entry.label.startswith("Rotational Symmetrize") for row in rows)
+    assert any(row.entry.label.startswith("Convert to momentum") for row in rows)
+
+
 def test_manager_trusted_script_replay_prompt_is_session_scoped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -6301,6 +6350,21 @@ def test_manager_metadata_uses_streamlined_child_derivation(
         )
 
         child_uid = manager._tool_graph.root_wrappers[0]._childtool_indices[0]
+        parent_node = manager._tool_graph.root_wrappers[0]
+        original_current_source_data = type(parent_node).current_source_data
+
+        def fail_parent_current_source_data(self):
+            if self is parent_node:
+                raise AssertionError(
+                    "metadata rendering must not compute parent source data"
+                )
+            return original_current_source_data(self)
+
+        monkeypatch.setattr(
+            type(parent_node),
+            "current_source_data",
+            fail_parent_current_source_data,
+        )
         manager.tree_view.clearSelection()
         select_child_tool(manager, child_uid)
         manager._update_info(uid=child_uid)
@@ -6311,6 +6375,11 @@ def test_manager_metadata_uses_streamlined_child_derivation(
         assert not any("Sort coordinates" in line for line in derivation)
         assert any(line.startswith("transpose(") for line in derivation)
 
+        monkeypatch.setattr(
+            type(parent_node),
+            "current_source_data",
+            original_current_source_data,
+        )
         copied = copy_full_code_for_uid(monkeypatch, manager, child_uid)
         namespace = _exec_generated_code(
             copied,

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -5062,6 +5062,486 @@ def test_manager_provenance_native_selection_edit_restores_slice_operations(
     ]
 
 
+def _native_current_seed_data() -> xr.DataArray:
+    return xr.DataArray(
+        np.arange(12, dtype=float).reshape((3, 4)) + 1.0,
+        dims=("x", "eV"),
+        coords={
+            "x": [0.0, 1.0, 2.0],
+            "eV": [-1.0, 0.0, 1.0, 2.0],
+            "scale": ("x", [1.0, 2.0, 4.0]),
+            "order": ("x", [2.0, 1.0, 3.0]),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("operation", "dialog_cls"),
+    [
+        pytest.param(
+            provenance.NormalizeOperation(
+                dims=("x",),
+                mode="minmax",
+                denominator_rtol=1e-7,
+            ),
+            manager_provenance_edit.dialogs.NormalizeDialog,
+            id="normalize",
+        ),
+        pytest.param(
+            provenance.GaussianFilterOperation(sigma={"x": 0.25}),
+            manager_provenance_edit.dialogs.GaussianFilterDialog,
+            id="gaussian",
+        ),
+        pytest.param(
+            provenance.DivideByCoordOperation(coord_name="scale"),
+            manager_provenance_edit.dialogs.DivideByCoordDialog,
+            id="divide_by_coord",
+        ),
+        pytest.param(
+            provenance.SortByOperation(variables=("order",), ascending=False),
+            manager_provenance_edit.dialogs.SortByDialog,
+            id="sortby",
+        ),
+        pytest.param(
+            provenance.LeadingEdgeOperation(
+                dim="eV",
+                fraction=0.25,
+                direction="negative",
+            ),
+            manager_provenance_edit.dialogs.LeadingEdgeDialog,
+            id="leading_edge",
+        ),
+    ],
+)
+def test_manager_terminal_current_data_edit_opens_without_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    operation: provenance.ToolProvenanceOperation,
+    dialog_cls: type[manager_provenance_edit.dialogs._DataManipulationDialog],
+) -> None:
+    base = _native_current_seed_data()
+    current = (
+        base.copy(deep=False)
+        if isinstance(operation, provenance.LeadingEdgeOperation)
+        else operation.apply(base, parent_data=base)
+    )
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", operation)
+    node = _fake_edit_node(spec)
+    node.current_source_data = lambda: current
+    controller = _fake_edit_controller(node)
+    monkeypatch.setattr(
+        controller,
+        "_replay_candidate_result",
+        lambda *_args, **_kwargs: pytest.fail("opening the editor should not replay"),
+    )
+
+    captured: dict[str, typing.Any] = {}
+
+    def exec_dialog(
+        dialog: manager_provenance_edit.dialogs._DataManipulationDialog,
+    ) -> int:
+        captured["dialog_cls"] = type(dialog)
+        if isinstance(dialog, manager_provenance_edit.dialogs.NormalizeDialog):
+            captured["dims"] = tuple(
+                dim for dim, check in dialog.dim_checks.items() if check.isChecked()
+            )
+            captured["mode"] = dialog._mode
+            captured["denominator_rtol"] = dialog.denominator_rtol
+        elif isinstance(dialog, manager_provenance_edit.dialogs.GaussianFilterDialog):
+            captured["dims"] = tuple(
+                dim for dim, check in dialog.dim_checks.items() if check.isChecked()
+            )
+            captured["sigma"] = {
+                dim: dialog._spin_value(dialog.sigma_spins[dim])
+                for dim in dialog.sigma_spins
+            }
+        elif isinstance(dialog, manager_provenance_edit.dialogs.DivideByCoordDialog):
+            captured["coord_name"] = dialog._selected_coord_name
+        elif isinstance(dialog, manager_provenance_edit.dialogs.SortByDialog):
+            captured["sort_keys"] = dialog._sort_keys
+            captured["ascending"] = dialog.ascending_combo.currentData(
+                QtCore.Qt.ItemDataRole.UserRole
+            )
+        elif isinstance(dialog, manager_provenance_edit.dialogs.LeadingEdgeDialog):
+            captured["dim"] = dialog._selected_dim
+            captured["fraction"] = float(dialog.fraction_spin.value())
+            captured["direction"] = dialog._direction
+        return int(QtWidgets.QDialog.DialogCode.Rejected)
+
+    monkeypatch.setattr(dialog_cls, "exec", exec_dialog)
+
+    row = spec.display_rows()[1]
+    assert row.edit_ref is not None
+    dialog_match = manager_provenance_edit._dialog_match_for_operation_ref(
+        spec,
+        row.edit_ref,
+    )
+    assert dialog_match is not None
+
+    assert (
+        controller._edited_native_operations(
+            node,
+            row,
+            spec,
+            row.edit_ref,
+            dialog_match,
+        )
+        is None
+    )
+
+    assert captured["dialog_cls"] is dialog_cls
+    if isinstance(operation, provenance.NormalizeOperation):
+        assert captured["dims"] == ("x",)
+        assert captured["mode"] == "minmax"
+        assert captured["denominator_rtol"] == pytest.approx(1e-7)
+    elif isinstance(operation, provenance.GaussianFilterOperation):
+        assert captured["dims"] == ("x",)
+        assert captured["sigma"]["x"] == pytest.approx(0.25)
+    elif isinstance(operation, provenance.DivideByCoordOperation):
+        assert captured["coord_name"] == "scale"
+    elif isinstance(operation, provenance.SortByOperation):
+        assert captured["sort_keys"] == ("order",)
+        assert captured["ascending"] is False
+    elif isinstance(operation, provenance.LeadingEdgeOperation):
+        assert captured["dim"] == "eV"
+        assert captured["fraction"] == pytest.approx(0.25)
+        assert captured["direction"] == "negative"
+
+
+def test_manager_terminal_current_data_edit_accept_still_replays_for_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    base = _native_current_seed_data()
+    operation = provenance.NormalizeOperation(
+        dims=("x",),
+        mode="minmax",
+        denominator_rtol=1e-7,
+    )
+    current = operation.apply(base, parent_data=base)
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", operation)
+    node = _fake_edit_node(spec)
+    node.current_source_data = lambda: current
+    controller = _fake_edit_controller(node)
+    replayed: list[provenance.ToolProvenanceSpec] = []
+    replaced: list[provenance.ToolProvenanceSpec] = []
+
+    def replay_candidate_result(
+        _node: typing.Any,
+        _scope: typing.Literal["display", "source"],
+        candidate: provenance.ToolProvenanceSpec,
+    ) -> tuple[xr.DataArray, provenance.ToolProvenanceSpec]:
+        replayed.append(candidate)
+        return current, candidate
+
+    monkeypatch.setattr(controller, "_replay_candidate_result", replay_candidate_result)
+    monkeypatch.setattr(
+        controller,
+        "_replace_node_data",
+        lambda _node, _scope, _data, candidate, _filter: replaced.append(candidate),
+    )
+    monkeypatch.setattr(
+        manager_provenance_edit.dialogs.NormalizeDialog,
+        "exec",
+        lambda _dialog: int(QtWidgets.QDialog.DialogCode.Accepted),
+    )
+
+    row = spec.display_rows()[1]
+    controller.edit_row(row)
+
+    assert replayed == [spec]
+    assert replaced == [spec]
+
+
+def test_manager_affine_coord_edit_opens_without_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    base = xr.DataArray(
+        np.arange(6, dtype=float).reshape((2, 3)),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [10.0, 20.0, 30.0]},
+    )
+    operation = provenance.AffineCoordOperation(
+        coord_name="y",
+        scale=2.0,
+        offset=0.5,
+    )
+    current = operation.apply(base, parent_data=base)
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", operation)
+    node = _fake_edit_node(spec)
+    node.current_source_data = lambda: current
+    controller = _fake_edit_controller(node)
+    monkeypatch.setattr(
+        controller,
+        "_replay_candidate_result",
+        lambda *_args, **_kwargs: pytest.fail("opening the editor should not replay"),
+    )
+
+    captured: dict[str, typing.Any] = {}
+
+    def exec_dialog(dialog: manager_provenance_edit.dialogs.AssignCoordsDialog) -> int:
+        captured["coord_name"] = dialog.current_coord_name
+        captured["scale"] = float(dialog.coord_widget.scale_spin.value())
+        captured["offset"] = float(dialog.coord_widget.offset_spin.value())
+        captured["reference_coord"] = dialog.coord_widget._old_coord.copy()
+        captured["dialog_coord"] = dialog.slicer_area.data["y"].values.copy()
+        return int(QtWidgets.QDialog.DialogCode.Rejected)
+
+    monkeypatch.setattr(
+        manager_provenance_edit.dialogs.AssignCoordsDialog,
+        "exec",
+        exec_dialog,
+    )
+
+    row = spec.display_rows()[1]
+    assert row.edit_ref is not None
+    dialog_match = manager_provenance_edit._dialog_match_for_operation_ref(
+        spec,
+        row.edit_ref,
+    )
+    assert dialog_match is not None
+
+    assert (
+        controller._edited_native_operations(
+            node,
+            row,
+            spec,
+            row.edit_ref,
+            dialog_match,
+        )
+        is None
+    )
+
+    assert captured["coord_name"] == "y"
+    assert captured["scale"] == 2.0
+    assert captured["offset"] == 0.5
+    np.testing.assert_allclose(captured["reference_coord"], base.y.values)
+    np.testing.assert_allclose(captured["dialog_coord"], base.y.values)
+
+
+def test_manager_affine_coord_edit_accept_still_replays_for_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    base = xr.DataArray(
+        np.arange(6, dtype=float).reshape((2, 3)),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [10.0, 20.0, 30.0]},
+    )
+    operation = provenance.AffineCoordOperation(
+        coord_name="y",
+        scale=2.0,
+        offset=0.5,
+    )
+    current = operation.apply(base, parent_data=base)
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", operation)
+    node = _fake_edit_node(spec)
+    node.current_source_data = lambda: current
+    controller = _fake_edit_controller(node)
+    replayed: list[provenance.ToolProvenanceSpec] = []
+    replaced: list[provenance.ToolProvenanceSpec] = []
+
+    def replay_candidate_result(
+        _node: typing.Any,
+        _scope: typing.Literal["display", "source"],
+        candidate: provenance.ToolProvenanceSpec,
+    ) -> tuple[xr.DataArray, provenance.ToolProvenanceSpec]:
+        replayed.append(candidate)
+        return current, candidate
+
+    monkeypatch.setattr(controller, "_replay_candidate_result", replay_candidate_result)
+    monkeypatch.setattr(
+        controller,
+        "_replace_node_data",
+        lambda _node, _scope, _data, candidate, _filter: replaced.append(candidate),
+    )
+    monkeypatch.setattr(
+        manager_provenance_edit.dialogs.AssignCoordsDialog,
+        "exec",
+        lambda _dialog: int(QtWidgets.QDialog.DialogCode.Accepted),
+    )
+
+    row = spec.display_rows()[1]
+    controller.edit_row(row)
+
+    assert replayed == [spec]
+    assert replaced == [spec]
+
+
+@pytest.mark.parametrize(
+    ("operations", "current_data"),
+    [
+        pytest.param(
+            (
+                provenance.AffineCoordOperation(
+                    coord_name="y",
+                    scale=2.0,
+                    offset=0.5,
+                ),
+                provenance.TransposeOperation(dims=("y", "x")),
+            ),
+            xr.DataArray(
+                np.arange(6, dtype=float).reshape((2, 3)),
+                dims=("x", "y"),
+                coords={"x": [0.0, 1.0], "y": [20.5, 40.5, 60.5]},
+            ).transpose("y", "x"),
+            id="nonterminal",
+        ),
+        pytest.param(
+            (
+                provenance.AffineCoordOperation(
+                    coord_name="y",
+                    scale=0.0,
+                    offset=0.5,
+                ),
+            ),
+            xr.DataArray(
+                np.arange(6, dtype=float).reshape((2, 3)),
+                dims=("x", "y"),
+                coords={"x": [0.0, 1.0], "y": [0.5, 0.5, 0.5]},
+            ),
+            id="zero-scale",
+        ),
+    ],
+)
+def test_manager_affine_coord_edit_falls_back_to_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    operations: tuple[provenance.ToolProvenanceOperation, ...],
+    current_data: xr.DataArray,
+) -> None:
+    replay_data = xr.DataArray(
+        np.arange(6, dtype=float).reshape((2, 3)),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [10.0, 20.0, 30.0]},
+    )
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", *operations)
+    node = _fake_edit_node(spec)
+    node.current_source_data = lambda: current_data
+    controller = _fake_edit_controller(node)
+    replayed: list[provenance.ToolProvenanceSpec] = []
+
+    def replay_candidate_result(
+        _node: typing.Any,
+        _scope: typing.Literal["display", "source"],
+        candidate: provenance.ToolProvenanceSpec,
+    ) -> tuple[xr.DataArray, provenance.ToolProvenanceSpec]:
+        replayed.append(candidate)
+        return replay_data, candidate
+
+    monkeypatch.setattr(controller, "_replay_candidate_result", replay_candidate_result)
+    monkeypatch.setattr(
+        manager_provenance_edit.dialogs.AssignCoordsDialog,
+        "exec",
+        lambda _dialog: int(QtWidgets.QDialog.DialogCode.Rejected),
+    )
+
+    row = spec.display_rows()[1]
+    assert row.edit_ref is not None
+    dialog_match = manager_provenance_edit._dialog_match_for_operation_ref(
+        spec,
+        row.edit_ref,
+    )
+    assert dialog_match is not None
+
+    assert (
+        controller._edited_native_operations(
+            node,
+            row,
+            spec,
+            row.edit_ref,
+            dialog_match,
+        )
+        is None
+    )
+    assert len(replayed) == 1
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["nonterminal", "current-source-unavailable", "leading-edge-missing-dim"],
+)
+def test_manager_terminal_current_data_edit_falls_back_to_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    case: str,
+) -> None:
+    replay_data = _native_current_seed_data()
+    operation: provenance.ToolProvenanceOperation
+    if case == "nonterminal":
+        operation = provenance.NormalizeOperation(dims=("x",), mode="minmax")
+        operations: tuple[provenance.ToolProvenanceOperation, ...] = (
+            operation,
+            provenance.TransposeOperation(dims=("eV", "x")),
+        )
+        current_data = operation.apply(replay_data, parent_data=replay_data).transpose(
+            "eV",
+            "x",
+        )
+        dialog_cls = manager_provenance_edit.dialogs.NormalizeDialog
+    elif case == "current-source-unavailable":
+        operation = provenance.NormalizeOperation(dims=("x",), mode="minmax")
+        operations = (operation,)
+        current_data = None
+        dialog_cls = manager_provenance_edit.dialogs.NormalizeDialog
+    else:
+        operation = provenance.LeadingEdgeOperation(
+            dim="eV",
+            fraction=0.25,
+            direction="negative",
+        )
+        operations = (operation,)
+        current_data = operation.apply(replay_data, parent_data=replay_data)
+        dialog_cls = manager_provenance_edit.dialogs.LeadingEdgeDialog
+
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", *operations)
+    node = _fake_edit_node(spec)
+    if current_data is None:
+        node.current_source_data = lambda: (_ for _ in ()).throw(
+            RuntimeError("missing current data")
+        )
+    else:
+        node.current_source_data = lambda: current_data
+    controller = _fake_edit_controller(node)
+    replayed: list[provenance.ToolProvenanceSpec] = []
+
+    def replay_candidate_result(
+        _node: typing.Any,
+        _scope: typing.Literal["display", "source"],
+        candidate: provenance.ToolProvenanceSpec,
+    ) -> tuple[xr.DataArray, provenance.ToolProvenanceSpec]:
+        replayed.append(candidate)
+        return replay_data, candidate
+
+    monkeypatch.setattr(controller, "_replay_candidate_result", replay_candidate_result)
+    monkeypatch.setattr(
+        dialog_cls,
+        "exec",
+        lambda _dialog: int(QtWidgets.QDialog.DialogCode.Rejected),
+    )
+
+    row = spec.display_rows()[1]
+    assert row.edit_ref is not None
+    dialog_match = manager_provenance_edit._dialog_match_for_operation_ref(
+        spec,
+        row.edit_ref,
+    )
+    assert dialog_match is not None
+
+    assert (
+        controller._edited_native_operations(
+            node,
+            row,
+            spec,
+            row.edit_ref,
+            dialog_match,
+        )
+        is None
+    )
+    assert len(replayed) == 1
+
+
 def test_manager_provenance_edit_controller_native_dialog_error_branches() -> None:
     controller = _fake_edit_controller()
     operation = provenance.NormalizeOperation(dims=("x",), mode="area")

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -5102,15 +5102,6 @@ def _native_current_seed_data() -> xr.DataArray:
             manager_provenance_edit.dialogs.SortByDialog,
             id="sortby",
         ),
-        pytest.param(
-            provenance.LeadingEdgeOperation(
-                dim="eV",
-                fraction=0.25,
-                direction="negative",
-            ),
-            manager_provenance_edit.dialogs.LeadingEdgeDialog,
-            id="leading_edge",
-        ),
     ],
 )
 def test_manager_terminal_current_data_edit_opens_without_replay(
@@ -5120,11 +5111,7 @@ def test_manager_terminal_current_data_edit_opens_without_replay(
     dialog_cls: type[manager_provenance_edit.dialogs._DataManipulationDialog],
 ) -> None:
     base = _native_current_seed_data()
-    current = (
-        base.copy(deep=False)
-        if isinstance(operation, provenance.LeadingEdgeOperation)
-        else operation.apply(base, parent_data=base)
-    )
+    current = operation.apply(base, parent_data=base)
     spec = _manager_replay_file_spec(tmp_path / "source.h5", operation)
     node = _fake_edit_node(spec)
     node.current_source_data = lambda: current
@@ -5162,10 +5149,6 @@ def test_manager_terminal_current_data_edit_opens_without_replay(
             captured["ascending"] = dialog.ascending_combo.currentData(
                 QtCore.Qt.ItemDataRole.UserRole
             )
-        elif isinstance(dialog, manager_provenance_edit.dialogs.LeadingEdgeDialog):
-            captured["dim"] = dialog._selected_dim
-            captured["fraction"] = float(dialog.fraction_spin.value())
-            captured["direction"] = dialog._direction
         return int(QtWidgets.QDialog.DialogCode.Rejected)
 
     monkeypatch.setattr(dialog_cls, "exec", exec_dialog)
@@ -5202,10 +5185,6 @@ def test_manager_terminal_current_data_edit_opens_without_replay(
     elif isinstance(operation, provenance.SortByOperation):
         assert captured["sort_keys"] == ("order",)
         assert captured["ascending"] is False
-    elif isinstance(operation, provenance.LeadingEdgeOperation):
-        assert captured["dim"] == "eV"
-        assert captured["fraction"] == pytest.approx(0.25)
-        assert captured["direction"] == "negative"
 
 
 def test_manager_terminal_current_data_edit_accept_still_replays_for_validation(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -5071,6 +5071,7 @@ def _native_current_seed_data() -> xr.DataArray:
             "eV": [-1.0, 0.0, 1.0, 2.0],
             "scale": ("x", [1.0, 2.0, 4.0]),
             "order": ("x", [2.0, 1.0, 3.0]),
+            "meta": "scan",
         },
     )
 
@@ -5232,6 +5233,108 @@ def test_manager_terminal_current_data_edit_accept_still_replays_for_validation(
     assert replaced == [spec]
 
 
+def test_manager_terminal_current_data_edit_seed_rejects_grouped_operations(
+    tmp_path: pathlib.Path,
+) -> None:
+    data = _native_current_seed_data()
+    operation = provenance.NormalizeOperation(dims=("x",), mode="minmax")
+    operations: tuple[provenance.ToolProvenanceOperation, ...] = (
+        operation,
+        provenance.SortByOperation(variables=("x",)),
+    )
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", *operations)
+    node = _fake_edit_node(spec)
+    node.current_source_data = lambda: data
+    controller = _fake_edit_controller(node)
+    row = spec.display_rows()[1]
+    assert row.edit_ref is not None
+
+    seed = controller._terminal_current_data_edit_seed(
+        node,
+        spec,
+        row.edit_ref,
+        manager_provenance_edit._OperationDialogMatch(
+            manager_provenance_edit.dialogs.NormalizeDialog,
+            0,
+            len(operations),
+        ),
+        operations,
+    )
+
+    assert seed is None
+
+
+@pytest.mark.parametrize(
+    ("operation", "dialog_cls", "current_data"),
+    [
+        pytest.param(
+            provenance.NormalizeOperation(dims=("missing",), mode="minmax"),
+            manager_provenance_edit.dialogs.NormalizeDialog,
+            _native_current_seed_data(),
+            id="normalize-missing-dim",
+        ),
+        pytest.param(
+            provenance.GaussianFilterOperation(sigma={"missing": 0.25}),
+            manager_provenance_edit.dialogs.GaussianFilterDialog,
+            _native_current_seed_data(),
+            id="gaussian-missing-dim",
+        ),
+        pytest.param(
+            provenance.GaussianFilterOperation(sigma={"x": 0.25}),
+            manager_provenance_edit.dialogs.GaussianFilterDialog,
+            _native_current_seed_data().isel(x=slice(0, 1)),
+            id="gaussian-degenerate-coord",
+        ),
+        pytest.param(
+            provenance.GaussianFilterOperation(sigma={"x": 0.25}),
+            manager_provenance_edit.dialogs.GaussianFilterDialog,
+            _native_current_seed_data().assign_coords(x=["a", "b", "c"]),
+            id="gaussian-nonnumeric-coord",
+        ),
+        pytest.param(
+            provenance.DivideByCoordOperation(coord_name="missing"),
+            manager_provenance_edit.dialogs.DivideByCoordDialog,
+            _native_current_seed_data(),
+            id="divide-by-missing-coord",
+        ),
+        pytest.param(
+            provenance.DivideByCoordOperation(coord_name="label"),
+            manager_provenance_edit.dialogs.DivideByCoordDialog,
+            _native_current_seed_data().assign_coords(label=("x", ["a", "b", "c"])),
+            id="divide-by-nonnumeric-coord",
+        ),
+        pytest.param(
+            provenance.SortByOperation(variables=("missing",)),
+            manager_provenance_edit.dialogs.SortByDialog,
+            _native_current_seed_data(),
+            id="sortby-missing-key",
+        ),
+    ],
+)
+def test_manager_terminal_current_data_edit_seed_rejects_invalid_metadata(
+    tmp_path: pathlib.Path,
+    operation: provenance.ToolProvenanceOperation,
+    dialog_cls: type[manager_provenance_edit.dialogs._DataManipulationDialog],
+    current_data: xr.DataArray,
+) -> None:
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", operation)
+    node = _fake_edit_node(spec)
+    node.current_source_data = lambda: current_data
+    controller = _fake_edit_controller(node)
+    row = spec.display_rows()[1]
+    assert row.edit_ref is not None
+
+    seed = controller._terminal_current_data_edit_seed(
+        node,
+        spec,
+        row.edit_ref,
+        manager_provenance_edit._OperationDialogMatch(dialog_cls, 0, 1),
+        (operation,),
+    )
+
+    assert seed is None
+
+
 def test_manager_affine_coord_edit_opens_without_replay(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pathlib.Path,
@@ -5346,6 +5449,108 @@ def test_manager_affine_coord_edit_accept_still_replays_for_validation(
 
     assert replayed == [spec]
     assert replaced == [spec]
+
+
+@pytest.mark.parametrize(
+    ("operations", "current_data"),
+    [
+        pytest.param(
+            (
+                provenance.AffineCoordOperation(
+                    coord_name="y",
+                    scale=2.0,
+                    offset=0.5,
+                ),
+                provenance.SortByOperation(variables=("y",)),
+            ),
+            xr.DataArray(
+                np.arange(6, dtype=float).reshape((2, 3)),
+                dims=("x", "y"),
+                coords={"x": [0.0, 1.0], "y": [20.5, 40.5, 60.5]},
+            ),
+            id="grouped-operations",
+        ),
+        pytest.param(
+            (provenance.NormalizeOperation(dims=("x",), mode="minmax"),),
+            xr.DataArray(
+                np.arange(6, dtype=float).reshape((2, 3)),
+                dims=("x", "y"),
+                coords={"x": [0.0, 1.0], "y": [10.0, 20.0, 30.0]},
+            ),
+            id="wrong-operation",
+        ),
+        pytest.param(
+            (
+                provenance.AffineCoordOperation(
+                    coord_name="y",
+                    scale=2.0,
+                    offset=0.5,
+                ),
+            ),
+            xr.DataArray(
+                np.arange(6, dtype=float).reshape((2, 3)),
+                dims=("x", "y"),
+                coords={"x": [0.0, 1.0], "y": [10.0 + 0.0j, 20.0 + 0.0j, 30.0 + 0.0j]},
+            ),
+            id="complex-coordinate",
+        ),
+        pytest.param(
+            (
+                provenance.AffineCoordOperation(
+                    coord_name="y",
+                    scale=2.0,
+                    offset=0.5,
+                ),
+            ),
+            xr.DataArray(
+                np.arange(6, dtype=float).reshape((2, 3)),
+                dims=("x", "y"),
+                coords={"x": [0.0, 1.0], "y": [10.0, np.inf, 30.0]},
+            ),
+            id="nonfinite-coordinate",
+        ),
+        pytest.param(
+            (
+                provenance.AffineCoordOperation(
+                    coord_name="missing",
+                    scale=2.0,
+                    offset=0.5,
+                ),
+            ),
+            xr.DataArray(
+                np.arange(6, dtype=float).reshape((2, 3)),
+                dims=("x", "y"),
+                coords={"x": [0.0, 1.0], "y": [10.0, 20.0, 30.0]},
+            ),
+            id="missing-coordinate",
+        ),
+    ],
+)
+def test_manager_affine_coord_edit_seed_rejects_unsafe_current_data(
+    tmp_path: pathlib.Path,
+    operations: tuple[provenance.ToolProvenanceOperation, ...],
+    current_data: xr.DataArray,
+) -> None:
+    spec = _manager_replay_file_spec(tmp_path / "source.h5", *operations)
+    node = _fake_edit_node(spec)
+    node.current_source_data = lambda: current_data
+    controller = _fake_edit_controller(node)
+    row = spec.display_rows()[1]
+    assert row.edit_ref is not None
+
+    seed = controller._terminal_affine_coord_edit_seed(
+        node,
+        spec,
+        row.edit_ref,
+        manager_provenance_edit._OperationDialogMatch(
+            manager_provenance_edit.dialogs.AssignCoordsDialog,
+            0,
+            len(operations),
+        ),
+        operations,
+    )
+
+    assert seed is None
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -7456,8 +7456,12 @@ def test_high_dimensional_reduction_dialog_selects_scalar(qtbot) -> None:
     )
 
     assert not open_button.isEnabled()
-
+    assert all(row.action == "keep" for row in dialog.rows)
     row = dialog.rows[-1]
+    assert row.action_combo.findData(None) == -1
+    assert [
+        row.action_combo.itemText(index) for index in range(row.action_combo.count())
+    ] == ["Keep", "Select", "Aggregate"]
     _set_combo_data(row.action_combo, "select")
     row.scalar_controls.index_spin.setValue(2)
 
@@ -7668,6 +7672,7 @@ def test_high_dimensional_reduction_dialog_metadata_and_warning_paths(
     assert dialog._set_preview_from_metadata(("profile",), (5,))
 
     row = dialog.rows[-1]
+    _set_combo_data(row.action_combo, "keep")
     dialog.accept()
     assert len(warnings) == 1
     assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -7458,6 +7458,7 @@ def test_high_dimensional_reduction_dialog_selects_scalar(qtbot) -> None:
     assert not open_button.isEnabled()
     assert all(row.action == "keep" for row in dialog.rows)
     row = dialog.rows[-1]
+    assert not row.scalar_controls.width_widget.isEnabled()
     assert row.action_combo.findData(None) == -1
     assert [
         row.action_combo.itemText(index) for index in range(row.action_combo.count())
@@ -7479,6 +7480,80 @@ def test_high_dimensional_reduction_dialog_selects_scalar(qtbot) -> None:
     dialog.accept()
     assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
     xarray.testing.assert_identical(dialog.result_data, expected)
+
+
+def test_high_dimensional_reduction_dialog_qsel_width(qtbot) -> None:
+    data = _high_dimensional_data()
+    dialog = imagetool_highdim._HighDimensionalReductionDialog(None, data)
+    qtbot.addWidget(dialog)
+    open_button = dialog.button_box.button(
+        QtWidgets.QDialogButtonBox.StandardButton.Open
+    )
+    row = dialog.rows[-1]
+
+    _set_combo_data(row.action_combo, "select")
+    assert row.scalar_controls.method == "isel"
+    assert not row.scalar_controls.width_widget.isEnabled()
+
+    _set_combo_data(row.scalar_controls.method_combo, "sel")
+    assert not row.scalar_controls.width_widget.isEnabled()
+
+    _set_combo_data(row.scalar_controls.method_combo, "qsel")
+    assert row.scalar_controls.width_widget.isEnabled()
+    assert not row.scalar_controls.width_spin.isEnabled()
+    row.scalar_controls.value_spin.setValue(2.0)
+    row.scalar_controls.width_check.setChecked(True)
+    assert row.scalar_controls.width_spin.isEnabled()
+    row.scalar_controls.width_spin.setValue(2.0)
+
+    operation = provenance.QSelOperation(kwargs={"x": 2.0, "x_width": 2.0})
+    expected = data.qsel(x=2.0, x_width=2.0)
+    assert open_button.isEnabled()
+    assert dialog.source_operations() == [operation]
+    xarray.testing.assert_identical(
+        _exec_data_fragment(data, dialog.make_code()), expected
+    )
+    dialog.accept()
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+    xarray.testing.assert_identical(dialog.result_data, expected)
+
+
+def test_high_dimensional_reduction_dialog_qsel_width_omission(qtbot) -> None:
+    data = _high_dimensional_data()
+    dialog = imagetool_highdim._HighDimensionalReductionDialog(None, data)
+    qtbot.addWidget(dialog)
+    row = dialog.rows[-1]
+
+    _set_combo_data(row.action_combo, "select")
+    _set_combo_data(row.scalar_controls.method_combo, "qsel")
+    row.scalar_controls.value_spin.setValue(2.0)
+
+    assert row.scalar_controls.width_widget.isEnabled()
+    assert not row.scalar_controls.width_spin.isEnabled()
+    assert dialog.source_operations() == [provenance.QSelOperation(kwargs={"x": 2.0})]
+
+    row.scalar_controls.width_check.setChecked(True)
+    row.scalar_controls.width_spin.setValue(0.0)
+    assert dialog.source_operations() == [provenance.QSelOperation(kwargs={"x": 2.0})]
+
+    row.scalar_controls.width_spin.setValue(1.0)
+    _set_combo_data(row.scalar_controls.method_combo, "sel")
+    assert not row.scalar_controls.width_widget.isEnabled()
+    assert not row.scalar_controls.width_spin.isEnabled()
+    assert dialog.source_operations() == [provenance.SelOperation(kwargs={"x": 2.0})]
+
+    _set_combo_data(row.scalar_controls.method_combo, "qsel")
+    _set_combo_data(row.action_combo, "keep")
+    assert not row.scalar_controls.width_widget.isEnabled()
+    assert not row.scalar_controls.width_spin.isEnabled()
+    assert dialog.source_operations() == []
+
+    _set_combo_data(row.action_combo, "aggregate")
+    assert not row.scalar_controls.width_widget.isEnabled()
+    assert not row.scalar_controls.width_spin.isEnabled()
+    assert dialog.source_operations() == [
+        provenance.QSelAggregationOperation(dims=("x",), func="mean")
+    ]
 
 
 def test_high_dimensional_reduction_dialog_aggregates_dimension(qtbot) -> None:

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -7546,6 +7546,7 @@ def test_high_dimensional_reduction_dialog_qsel_width_omission(qtbot) -> None:
     _set_combo_data(row.action_combo, "keep")
     assert not row.scalar_controls.width_widget.isEnabled()
     assert not row.scalar_controls.width_spin.isEnabled()
+    assert row.qsel_width_indexer() is None
     assert dialog.source_operations() == []
 
     _set_combo_data(row.action_combo, "aggregate")
@@ -7836,6 +7837,16 @@ def test_scalar_selection_controls_non_numeric_and_width_branches(qtbot) -> None
     numeric_controls.width_check.setChecked(True)
     numeric_controls.width_spin.setValue(0.0)
     assert numeric_controls.qsel_width_indexer() is None
+
+
+def test_selection_dialog_source_data_only_requires_edit_mode() -> None:
+    data = _selection_4d_data()
+
+    with pytest.raises(ValueError, match="requires a slicer area or source data"):
+        SelectionDialog(None)
+
+    with pytest.raises(ValueError, match="requires provenance edit mode"):
+        SelectionDialog(None, source_data=data)
 
 
 def test_selection_dialog_seeds_4d_cursor_slice(qtbot) -> None:

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1829,6 +1829,117 @@ def test_tool_provenance_display_entries_streamline_live_source() -> None:
         data.isel(z=slice(0, 1)).squeeze(dim=("z",), drop=True),
     )
 
+    chained_squeeze_data = xr.DataArray(
+        np.ones((1, 1)),
+        dims=("x", "z"),
+        name="scan",
+    )
+    chained_squeeze_spec = provenance.full_data(
+        provenance.SqueezeOperation(dims=("z",)),
+        provenance.SqueezeOperation(),
+    )
+    chained_squeeze_entries = chained_squeeze_spec.display_entries(
+        parent_data=chained_squeeze_data
+    )
+    assert [entry.label for entry in chained_squeeze_entries] == [
+        "Start from current parent ImageTool data",
+        'squeeze(dim=("z",))',
+        "squeeze()",
+    ]
+    chained_squeeze_code = typing.cast(
+        "str",
+        chained_squeeze_spec.display_code(parent_data=chained_squeeze_data),
+    )
+    chained_namespace = _exec_generated_code(
+        chained_squeeze_code,
+        {"data": chained_squeeze_data.copy(deep=True)},
+    )
+    chained_squeezed = chained_namespace["derived"]
+    assert isinstance(chained_squeezed, xr.DataArray)
+    xr.testing.assert_identical(
+        chained_squeezed,
+        chained_squeeze_data.squeeze(dim=("z",)).squeeze(),
+    )
+
+
+def test_tool_provenance_display_streamlining_is_metadata_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _base_data()
+    calls: list[str] = []
+
+    def record_apply(
+        self: provenance.ToolProvenanceOperation,
+        data: xr.DataArray,
+        *,
+        parent_data: xr.DataArray,
+    ) -> xr.DataArray:
+        calls.append(self.op)
+        return data
+
+    monkeypatch.setattr(
+        provenance.SymmetrizeNfoldOperation,
+        "apply",
+        record_apply,
+    )
+    monkeypatch.setattr(
+        provenance.KspaceConvertOperation,
+        "apply",
+        record_apply,
+    )
+    spec = provenance.full_data(
+        provenance.SymmetrizeNfoldOperation(fold=4, axes=("x", "y")),
+        provenance.KspaceConvertOperation(),
+    )
+
+    rows = spec.display_rows(parent_data=data)
+    entries = spec.display_entries(parent_data=data)
+    code = spec.display_code(parent_data=data)
+
+    assert calls == []
+    assert any(row.entry.label.startswith("Rotational Symmetrize") for row in rows)
+    assert any(entry.label.startswith("Convert to momentum") for entry in entries)
+    assert code is not None
+    assert "symmetrize_nfold" in code
+    assert ".kspace.convert(" in code
+
+    staged_spec = provenance.script(
+        start_label="Run script",
+        seed_code="derived = data",
+        active_name="derived",
+        replay_stages=(provenance.ReplayStage.from_source_spec(spec),),
+    )
+    assert staged_spec.display_rows(parent_data=data)
+    assert staged_spec.display_code(parent_data=data) is not None
+    assert calls == []
+
+    spec.apply(data)
+    assert calls == ["symmetrize_nfold", "kspace_convert"]
+
+
+def test_tool_provenance_unknown_display_context_keeps_noop_candidates() -> None:
+    spec = provenance.full_data(
+        provenance.TransposeOperation(dims=("x", "y", "z")),
+        provenance.SqueezeOperation(),
+        provenance.RestoreNonuniformDimsOperation(),
+    )
+    assert [entry.label for entry in spec.display_entries()] == [
+        "Start from current parent ImageTool data",
+        "transpose(('x', 'y', 'z'))",
+        "squeeze()",
+        "Restore nonuniform dimensions",
+    ]
+    unknown_code = typing.cast("str", spec.display_code())
+    assert ".transpose(" in unknown_code
+    assert ".squeeze()" in unknown_code
+    assert "restore_nonuniform_dims" in unknown_code
+
+    data = _base_data()
+    assert [entry.label for entry in spec.display_entries(parent_data=data)] == [
+        "Start from current parent ImageTool data",
+    ]
+    assert spec.display_code(parent_data=data) is None
+
 
 def test_tool_provenance_display_entries_keep_ambiguous_script_steps() -> None:
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -1941,6 +1941,128 @@ def test_tool_provenance_unknown_display_context_keeps_noop_candidates() -> None
     assert spec.display_code(parent_data=data) is None
 
 
+def test_tool_provenance_display_metadata_context_branches() -> None:
+    data = _base_data()
+    context_cls = _provenance_framework._ProvenanceDisplayContext
+
+    context = context_cls.from_source("full_data", data)
+    assert context.dims == data.dims
+    assert context.sizes == dict(data.sizes)
+    nonuniform_data = xr.DataArray(np.ones(2), dims=("x_idx",), name="scan")
+    assert context_cls.from_source("public_data", nonuniform_data).dims is None
+    assert context_cls.dims_may_restore_nonuniform(("x_idx",))
+    assert not context_cls.dims_may_restore_nonuniform(("x",))
+
+    indexer_size = context_cls._isel_indexer_size
+    assert indexer_size(slice(None, None, 2), 5) == (True, 3)
+    assert indexer_size(True, 5) == (False, None)
+    assert indexer_size(np.bool_(False), 5) == (False, None)
+    assert indexer_size(1, 5) == (True, None)
+    assert indexer_size(np.int64(1), 5) == (True, None)
+    assert indexer_size(xr.DataArray([0], dims=("index",)), 5) == (False, None)
+    assert indexer_size(np.array(1), 5) == (True, None)
+    assert indexer_size(np.array([0, 2]), 5) == (True, 2)
+    assert indexer_size(np.array([[0, 1]]), 5) == (False, None)
+    assert indexer_size(np.array([True, False]), 5) == (False, None)
+    assert indexer_size(range(0, 5, 2), 5) == (True, 3)
+    assert indexer_size([True, False], 5) == (False, None)
+    assert indexer_size([0, 2], 5) == (True, 2)
+    assert indexer_size(object(), 5) == (False, None)
+
+    assert context.advance(provenance.SortCoordOrderOperation()) == context
+    assert context.advance(provenance.RenameOperation(name="renamed")) == context
+    assert (
+        context.advance(
+            _provenance_framework._SourceViewOperation(source_kind="full_data")
+        )
+        == context
+    )
+    assert (
+        context.advance(
+            _provenance_framework._SourceViewOperation(source_kind="public_data")
+        )
+        == context
+    )
+    nonuniform_context = context_cls(("x_idx", "y"), {"x_idx": 3, "y": 4})
+    assert (
+        nonuniform_context.advance(
+            _provenance_framework._SourceViewOperation(source_kind="public_data")
+        ).dims
+        is None
+    )
+    assert context.advance(provenance.QSelOperation()) == context
+    assert context.advance(provenance.QSelOperation(kwargs={"x": 1.0})).dims is None
+    assert context.advance(provenance.SelOperation()) == context
+    assert context.advance(provenance.SelOperation(kwargs={"x": 1.0})).dims is None
+    assert context.advance(provenance.IselOperation()) == context
+    assert context.advance(provenance.IselOperation(kwargs={"missing": 0})).dims is None
+    assert (
+        context.advance(
+            provenance.IselOperation(kwargs={"x": xr.DataArray([0], dims=("index",))})
+        ).dims
+        is None
+    )
+    assert context.advance(provenance.IselOperation(kwargs={"z": 0})).dims == (
+        "x",
+        "y",
+    )
+    vector_index_context = context.advance(
+        provenance.IselOperation(kwargs={"x": [0, 2]})
+    )
+    assert vector_index_context.dims == data.dims
+    assert vector_index_context.sizes == {"x": 2, "y": 4, "z": 2}
+    assert (
+        context.advance(provenance.TransposeOperation(dims=("x", "missing", "z"))).dims
+        is None
+    )
+    assert context.advance(provenance.TransposeOperation()).dims == ("z", "y", "x")
+
+    unknown_context = context_cls()
+    assert unknown_context.advance(provenance.TransposeOperation()).dims is None
+    assert unknown_context.advance(provenance.SqueezeOperation()).dims is None
+
+    assert context.advance(provenance.SqueezeOperation(dims=("missing",))).dims is None
+    mixed_squeeze_context = context_cls.from_source(
+        "full_data", xr.DataArray(np.ones((1, 2)), dims=("x", "z"), name="scan")
+    )
+    assert (
+        mixed_squeeze_context.advance(provenance.SqueezeOperation(dims=("x", "z"))).dims
+        is None
+    )
+    assert (
+        mixed_squeeze_context.advance(provenance.SqueezeOperation(dims=("z",)))
+        == mixed_squeeze_context
+    )
+    assert mixed_squeeze_context.advance(
+        provenance.SqueezeOperation(dims=("x",))
+    ).dims == ("z",)
+    assert mixed_squeeze_context.advance(provenance.SqueezeOperation()).dims == ("z",)
+    assert context.advance(provenance.RestoreNonuniformDimsOperation()) == context
+    assert (
+        nonuniform_context.advance(provenance.RestoreNonuniformDimsOperation()).dims
+        is None
+    )
+    assert context.advance(provenance.AverageOperation(dims=("x",))).dims is None
+
+    staged_spec = provenance.script(
+        start_label="Run script",
+        seed_code="derived = data",
+        active_name="derived",
+        replay_stages=(
+            provenance.ReplayStage(
+                source_kind="full_data",
+                operations=(
+                    provenance.RestoreNonuniformDimsOperation(),
+                    provenance.SqueezeOperation(),
+                ),
+            ),
+        ),
+    )
+    assert [
+        entry.label for entry in staged_spec._code_fallback_entries(parent_data=data)
+    ] == ["Run script"]
+
+
 def test_tool_provenance_display_entries_keep_ambiguous_script_steps() -> None:
 
     spec = provenance.script(

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -472,6 +472,24 @@ def test_colormap_combobox_ignores_unavailable_text(qtbot):
     assert combo.currentText() == valid
 
 
+def test_colormap_combobox_exposes_matplotlib_name_for_colorcet(qtbot):
+    pytest.importorskip("colorcet")
+
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+    combo.load_all()
+
+    combo.setCurrentText("CET_C1")
+
+    assert combo.currentText() == "CET_C1"
+    assert combo.current_matplotlib_name() == "cet_CET_C1"
+
+    combo.setCurrentText("cet_CET_C1")
+
+    assert combo.currentText() == "CET_C1"
+    assert combo.current_matplotlib_name() == "cet_CET_C1"
+
+
 def test_colormap_combobox_missing_default_load_all_falls_back(qtbot):
     missing = "__erlab_missing_colormap__"
 

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -10,8 +10,10 @@ from erlab.interactive.colors import (
     BetterImageItem,
     ColorCycleDialog,
     ColorMapComboBox,
+    pg_colormap_from_name,
     pg_colormap_names,
     pg_colormap_powernorm,
+    pg_colormap_to_QPixmap,
 )
 
 
@@ -488,6 +490,128 @@ def test_colormap_combobox_exposes_matplotlib_name_for_colorcet(qtbot):
 
     assert combo.currentText() == "CET_C1"
     assert combo.current_matplotlib_name() == "cet_CET_C1"
+
+
+def test_colormap_thumbnail_pixmap_uses_string_cache(qtbot) -> None:
+    erlab.interactive.colors._cached_colormap_qpixmap.cache_clear()
+
+    first = pg_colormap_to_QPixmap("viridis")
+    second = pg_colormap_to_QPixmap("viridis")
+
+    assert not first.isNull()
+    assert not second.isNull()
+    cache_info = erlab.interactive.colors._cached_colormap_qpixmap.cache_info()
+    assert cache_info.hits == 1
+    assert cache_info.misses == 1
+
+
+def test_colormap_thumbnail_pixmap_normalizes_colorcet_cache_key(qtbot) -> None:
+    pytest.importorskip("colorcet")
+
+    erlab.interactive.colors._cached_colormap_qpixmap.cache_clear()
+
+    display_pixmap = pg_colormap_to_QPixmap("CET_C1")
+    matplotlib_pixmap = pg_colormap_to_QPixmap("cet_CET_C1")
+
+    assert not display_pixmap.isNull()
+    assert not matplotlib_pixmap.isNull()
+    cache_info = erlab.interactive.colors._cached_colormap_qpixmap.cache_info()
+    assert cache_info.hits == 1
+    assert cache_info.misses == 1
+
+
+def test_colormap_combobox_load_all_defers_thumbnail_rendering(
+    qtbot, monkeypatch
+) -> None:
+    rendered: list[str] = []
+
+    def record_thumbnail(name, *args, **kwargs):
+        rendered.append(name)
+        return QtGui.QPixmap(64, 16)
+
+    monkeypatch.setattr(
+        erlab.interactive.colors, "pg_colormap_to_QPixmap", record_thumbnail
+    )
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+
+    combo.load_all()
+
+    assert combo.count() == len(pg_colormap_names("all", exclude_local=True))
+    assert rendered == []
+
+    combo.load_thumbnail(0)
+
+    assert rendered == [combo.itemText(0)]
+
+
+def test_colormap_combobox_load_all_keeps_current_selection(qtbot) -> None:
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+    combo.ensure_populated()
+    if combo.count() < 2:
+        pytest.skip("Need multiple colormaps to test selection preservation")
+    combo.setCurrentIndex(1)
+    current_name = combo.current_matplotlib_name()
+
+    combo.load_all()
+
+    assert combo.current_matplotlib_name() == current_name
+
+
+def test_colormap_comboboxes_share_thumbnail_cache(qtbot) -> None:
+    erlab.interactive.colors._cached_colormap_qpixmap.cache_clear()
+    first = ColorMapComboBox()
+    second = ColorMapComboBox()
+    qtbot.addWidget(first)
+    qtbot.addWidget(second)
+    first.ensure_populated()
+    second.ensure_populated()
+
+    first.load_thumbnail(0)
+    second.load_thumbnail(0)
+
+    cache_info = erlab.interactive.colors._cached_colormap_qpixmap.cache_info()
+    assert cache_info.hits == 1
+    assert cache_info.misses == 1
+
+
+def test_colormap_thumbnail_pixmap_does_not_cache_colormap_objects(qtbot) -> None:
+    erlab.interactive.colors._cached_colormap_qpixmap.cache_clear()
+    cmap = pg_colormap_from_name("viridis")
+
+    first = pg_colormap_to_QPixmap(cmap)
+    second = pg_colormap_to_QPixmap(cmap)
+
+    assert not first.isNull()
+    assert not second.isNull()
+    cache_info = erlab.interactive.colors._cached_colormap_qpixmap.cache_info()
+    assert cache_info.hits == 0
+    assert cache_info.misses == 0
+
+
+def test_colormap_thumbnail_pixmap_respects_skip_cache_false(
+    qtbot, monkeypatch
+) -> None:
+    original = erlab.interactive.colors.pg_colormap_from_name
+    calls: list[tuple[str, bool]] = []
+
+    def record_colormap_lookup(name: str, skipCache: bool = True):
+        calls.append((name, skipCache))
+        return original(name, skipCache=skipCache)
+
+    monkeypatch.setattr(
+        erlab.interactive.colors, "pg_colormap_from_name", record_colormap_lookup
+    )
+    erlab.interactive.colors._cached_colormap_qpixmap.cache_clear()
+
+    pixmap = pg_colormap_to_QPixmap("viridis", skipCache=False)
+
+    assert not pixmap.isNull()
+    assert calls == [("viridis", False)]
+    cache_info = erlab.interactive.colors._cached_colormap_qpixmap.cache_info()
+    assert cache_info.hits == 0
+    assert cache_info.misses == 0
 
 
 def test_colormap_combobox_missing_default_load_all_falls_back(qtbot):

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -10,6 +10,7 @@ from erlab.interactive.colors import (
     BetterImageItem,
     ColorCycleDialog,
     ColorMapComboBox,
+    matplotlib_colormap_name,
     pg_colormap_from_name,
     pg_colormap_names,
     pg_colormap_powernorm,
@@ -490,6 +491,60 @@ def test_colormap_combobox_exposes_matplotlib_name_for_colorcet(qtbot):
 
     assert combo.currentText() == "CET_C1"
     assert combo.current_matplotlib_name() == "cet_CET_C1"
+
+
+def test_matplotlib_colormap_name_checks_again_after_loading(monkeypatch) -> None:
+    available: set[str] = set()
+
+    def has_colormap(name: str) -> bool:
+        return name in available
+
+    def load_colormaps() -> None:
+        available.update({"late_cmap", "cet_late_colorcet"})
+
+    token = erlab.interactive.colors._ALL_COLORMAPS_LOADED.set(False)
+    try:
+        monkeypatch.setattr(
+            erlab.interactive.colors, "_matplotlib_has_colormap", has_colormap
+        )
+        monkeypatch.setattr(
+            erlab.interactive.colors, "load_all_colormaps", load_colormaps
+        )
+
+        assert matplotlib_colormap_name("late_cmap") == "late_cmap"
+        available.clear()
+        assert matplotlib_colormap_name("late_colorcet") == "cet_late_colorcet"
+    finally:
+        erlab.interactive.colors._ALL_COLORMAPS_LOADED.reset(token)
+
+
+def test_colormap_combobox_explicit_icon_and_fallback_helpers(qtbot) -> None:
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+
+    assert combo._find_colormap_index(None) == -1
+
+    pixmap = QtGui.QPixmap(16, 16)
+    pixmap.fill(QtGui.QColor("red"))
+    with QtCore.QSignalBlocker(combo):
+        combo._add_colormap_item("viridis", QtGui.QIcon(pixmap))
+
+    assert combo.itemData(0) == "viridis"
+    assert not combo.itemIcon(0).isNull()
+
+    combo.clear()
+    combo.addItem("viridis")
+    combo.setCurrentIndex(0)
+    assert combo.current_matplotlib_name() == "viridis"
+
+
+def test_colormap_combobox_load_thumbnail_ignores_invalid_index(qtbot) -> None:
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+
+    combo.load_thumbnail(-1)
+
+    assert combo.count() == 0
 
 
 def test_colormap_thumbnail_pixmap_uses_string_cache(qtbot) -> None:

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -749,6 +749,9 @@ def test_options_get_set():
     assert options.model.figure.stylesheets == ["classic", "missing-style"]
     assert options.model.figure.dpi == pytest.approx(150.0)
 
+    options["figure/dpi"] = None
+    assert options["figure/dpi"] is None
+
     options.restore()
     assert options["figure/dpi"] is None
 

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 
+import pydantic
 import pytest
 from qtpy import QtWidgets
 
@@ -14,7 +15,11 @@ from erlab.interactive._options.core import (
     option_paths,
     workspace_overridable_option_paths,
 )
-from erlab.interactive._options.parameters import ColorListWidget, StylesheetListWidget
+from erlab.interactive._options.parameters import (
+    ColorListWidget,
+    FigureDpiOverrideWidget,
+    StylesheetListWidget,
+)
 from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.colors import ColorMapComboBox
 
@@ -202,6 +207,12 @@ def test_stylesheet_editor_fits_settings_page(dialog: OptionDialog, qtbot):
         "figure/stylesheets",
         StylesheetListWidget,
     )
+    _control(
+        dialog,
+        "user",
+        "figure/dpi",
+        FigureDpiOverrideWidget,
+    )
 
     qtbot.waitUntil(lambda: page.horizontalScrollBar().maximum() == 0)
 
@@ -324,6 +335,13 @@ def test_dialog_control_value_helpers(dialog: OptionDialog, qtbot):
         "ggplot",
     ]
 
+    figure_dpi = FigureDpiOverrideWidget()
+    qtbot.addWidget(figure_dpi)
+    assert dialog._control_value(figure_dpi, "figure/dpi") is None
+    figure_dpi.override_check.setChecked(True)
+    figure_dpi.dpi_spin.setValue(180.0)
+    assert dialog._control_value(figure_dpi, "figure/dpi") == pytest.approx(180.0)
+
     list_line = QtWidgets.QLineEdit("one, two,, ")
     qtbot.addWidget(list_line)
     assert dialog._control_value(list_line, "colors/cmap/exclude") == ["one", "two"]
@@ -355,6 +373,17 @@ def test_dialog_set_control_value_helpers(dialog: OptionDialog, qtbot):
     qtbot.addWidget(text_line)
     dialog._set_control_value(text_line, "io/default_loader", "example")
     assert text_line.text() == "example"
+
+    figure_dpi = FigureDpiOverrideWidget()
+    qtbot.addWidget(figure_dpi)
+    dialog._set_control_value(figure_dpi, "figure/dpi", 150.0)
+    assert figure_dpi.override_check.isChecked()
+    assert figure_dpi.dpi_spin.isEnabled()
+    assert figure_dpi.get_dpi() == pytest.approx(150.0)
+    dialog._set_control_value(figure_dpi, "figure/dpi", None)
+    assert not figure_dpi.override_check.isChecked()
+    assert not figure_dpi.dpi_spin.isEnabled()
+    assert figure_dpi.get_dpi() is None
 
 
 def test_dialog_spinbox_constraint_variants(
@@ -434,6 +463,33 @@ def test_workspace_override_switch_saves_sparse_override(qtbot):
 
     assert manager.overrides[path] == "bwr"
     assert combo.isEnabled()
+
+
+def test_workspace_figure_dpi_override_supports_unset_and_numeric(qtbot):
+    path = "figure/dpi"
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+    dlg.scope_tabs.setCurrentIndex(1)
+
+    control = typing.cast(
+        "FigureDpiOverrideWidget",
+        _control(dlg, "workspace", path, FigureDpiOverrideWidget),
+    )
+    override = _override(dlg, path)
+
+    assert not control.isEnabled()
+    override.setChecked(True)
+    assert manager.overrides[path] is None
+    assert control.isEnabled()
+
+    control.override_check.setChecked(True)
+    control.dpi_spin.setValue(180.0)
+    assert manager.overrides[path] == pytest.approx(180.0)
+
+    control.override_check.setChecked(False)
+    assert manager.overrides[path] is None
 
 
 def test_workspace_control_change_without_override_is_ignored(qtbot):
@@ -655,12 +711,14 @@ def test_workspace_override_helpers_filter_to_curated_subset() -> None:
     assert "colors/cmap/name" in paths
     assert "colors/cmap/packages" not in paths
     assert "io/workspace/compress" not in paths
+    assert "figure/dpi" in paths
     assert normalize_workspace_option_overrides(
         {
             "colors/cmap/name": "bwr",
             "io/workspace/compress": False,
+            "figure/dpi": 180.0,
         }
-    ) == {"colors/cmap/name": "bwr"}
+    ) == {"colors/cmap/name": "bwr", "figure/dpi": 180.0}
 
 
 def test_options_get_set():
@@ -670,24 +728,35 @@ def test_options_get_set():
     assert options["io/workspace/compress"] is True
     assert options["io/workspace/use_incremental"] is True
     assert options["io/workspace/incremental_save_on_remote"] is False
+    assert options["figure/dpi"] is None
 
     options["colors/cmap/name"] = "viridis"
     options["io/workspace/compress"] = False
     options["io/workspace/use_incremental"] = False
     options["io/workspace/incremental_save_on_remote"] = True
     options["figure/stylesheets"] = ["classic", "missing-style"]
+    options["figure/dpi"] = 150.0
 
     assert options["colors/cmap/name"] == "viridis"
     assert options["io/workspace/compress"] is False
     assert options["io/workspace/use_incremental"] is False
     assert options["io/workspace/incremental_save_on_remote"] is True
     assert options["figure/stylesheets"] == ["classic", "missing-style"]
+    assert options["figure/dpi"] == pytest.approx(150.0)
     assert not options.model.io.workspace.compress
     assert not options.model.io.workspace.use_incremental
     assert options.model.io.workspace.incremental_save_on_remote
     assert options.model.figure.stylesheets == ["classic", "missing-style"]
+    assert options.model.figure.dpi == pytest.approx(150.0)
 
     options.restore()
+    assert options["figure/dpi"] is None
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, "not-a-number"])
+def test_figure_dpi_option_validates(value: object) -> None:
+    with pytest.raises(pydantic.ValidationError):
+        AppOptions.model_validate({"figure": {"dpi": value}})
 
 
 def test_option_manager_uses_configured_settings_path(monkeypatch, tmp_path):

--- a/tests/interactive/test_options_parameters.py
+++ b/tests/interactive/test_options_parameters.py
@@ -9,6 +9,8 @@ from erlab.interactive._options.parameters import (
     _STYLESHEET_NAME_ROLE,
     ColorListParameter,
     ColorListWidget,
+    FigureDpiOverrideParameter,
+    FigureDpiOverrideWidget,
     StylesheetListParameter,
     StylesheetListWidget,
     _stylesheet_names,
@@ -71,6 +73,20 @@ def test_colorlistparameter_save_state() -> None:
     param = ColorListParameter(name="colors", value=[QtGui.QColor("#010203")])
     state = param.saveState()
     assert state["value"][0][:3] == (1, 2, 3)
+
+
+def test_figure_dpi_override_parameter_item_widget(qtbot) -> None:
+    param = FigureDpiOverrideParameter(name="dpi", value=150.0)
+    item = param.makeTreeItem(0)
+    widget = item.widget
+    qtbot.addWidget(widget)
+
+    assert isinstance(widget, FigureDpiOverrideWidget)
+    assert not item.hideWidget
+    assert widget.value() == pytest.approx(150.0)
+
+    widget.override_check.setChecked(False)
+    assert param.value() is None
 
 
 def test_style_library_paths_falls_back_to_matplotlib_core(monkeypatch) -> None:

--- a/tests/interactive/test_options_tree.py
+++ b/tests/interactive/test_options_tree.py
@@ -49,15 +49,19 @@ def test_make_parameter_defaults_and_missing_child_continue() -> None:
     assert opts.colors == AppOptions().colors
 
 
-def test_make_parameter_round_trips_figure_stylesheets() -> None:
+def test_make_parameter_round_trips_figure_options() -> None:
     options = AppOptions.model_validate(
-        {"figure": {"stylesheets": ["classic", "missing-style"]}}
+        {"figure": {"stylesheets": ["classic", "missing-style"], "dpi": 150.0}}
     )
     param = make_parameter(options)
 
     stylesheet_param = param.child("figure").child("stylesheets")
     assert stylesheet_param.opts["type"] == "matplotlib_stylesheets"
     assert stylesheet_param.value() == ["classic", "missing-style"]
+    dpi_param = param.child("figure").child("dpi")
+    assert dpi_param.opts["type"] == "figure_dpi_override"
+    assert dpi_param.value() == 150.0
 
     opts = parameter_to_options(param)
     assert opts.figure.stylesheets == ["classic", "missing-style"]
+    assert opts.figure.dpi == 150.0


### PR DESCRIPTION
## Summary
- Add configurable color support across Figure Composer defaults, state, norms, and plot operations
- Extend the options UI and schema to expose the new color settings
- Update Figure Composer docs and add coverage for color-related behavior

## Testing
- Added and updated unit tests for color utilities, options handling, and Figure Composer behavior
- Not run (not requested)