### PR TITLE
Drop legacy .h5 workspace support

### DIFF
--- a/src/erlab/interactive/imagetool/manager/__init__.py
+++ b/src/erlab/interactive/imagetool/manager/__init__.py
@@ -240,21 +240,7 @@ def _parse_startup_args(args: Iterable[str]) -> _StartupArgs:
 
 
 def _startup_path_is_workspace(path: pathlib.Path) -> bool:
-    suffix = path.suffix.lower()
-    if suffix == ".itws":
-        return True
-    if suffix != ".h5":
-        return False
-    try:
-        import h5py
-
-        with h5py.File(path, "r") as h5_file:
-            return (
-                "imagetool_workspace_schema_version" in h5_file.attrs
-                or h5_file.attrs.get("is_itool_workspace", 0) == 1
-            )
-    except Exception:
-        return False
+    return path.suffix.lower() == ".itws"
 
 
 def _startup_pending_files(

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -1095,7 +1095,7 @@ class _ActionsController:
                 return
             self._manager.open_multiple_files(
                 file_paths,
-                try_workspace=(extensions == {".itws"} or extensions == {".h5"}),
+                try_workspace=extensions == {".itws"},
             )
 
     def _show_loaded_info(

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -745,7 +745,7 @@ def _workspace_file_type_text(path: pathlib.Path | None) -> str:
         case ".itws":
             return "ImageTool Workspace (.itws)"
         case ".h5":
-            return "xarray HDF5 Workspace (.h5)"
+            return "HDF5 file (.h5)"
         case suffix if suffix:
             return f"{suffix.removeprefix('.').upper()} file"
         case _:

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -378,6 +378,12 @@ def _current_workspace_schema_version() -> int:
     return _WORKSPACE_SCHEMA_VERSION
 
 
+def _workspace_path_is_itws(
+    fname: str | os.PathLike[str],
+) -> bool:
+    return pathlib.Path(fname).suffix.lower() == ".itws"
+
+
 def _set_legacy_workspace_schema(
     attrs: MutableMapping[typing.Hashable, typing.Any],
 ) -> None:
@@ -1070,6 +1076,8 @@ def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
     import h5py
 
     if not pathlib.Path(fname).exists():
+        return
+    if not _workspace_path_is_itws(fname):
         return
     with _xarray._workspace_file_lock(fname), h5py.File(fname, "a") as h5_file:
         if not _workspace_file_is_workspace(h5_file):

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -66,6 +66,22 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _WORKSPACE_LOAD_TIMING_ENV = "ERLAB_WORKSPACE_LOAD_TIMING"
+_WORKSPACE_SAVE_SUFFIX_ERROR = "ImageTool workspace documents must be saved as .itws"
+_WORKSPACE_LOAD_SUFFIX_ERROR = "ImageTool workspace files must use the .itws extension"
+_WORKSPACE_SAVE_SUFFIX_WARNING = "ImageTool Manager saves workspaces as .itws files."
+
+
+def _require_itws_workspace_path(fname: str | os.PathLike[str], message: str) -> None:
+    if not _manager_workspace._workspace_path_is_itws(fname):
+        raise ValueError(message)
+
+
+def _show_itws_workspace_warning(parent: QtWidgets.QWidget) -> None:
+    QtWidgets.QMessageBox.warning(
+        parent,
+        "Workspace Not Saved",
+        _WORKSPACE_SAVE_SUFFIX_WARNING,
+    )
 
 
 class _WorkspaceLoadProfiler:
@@ -437,8 +453,8 @@ class _WorkspaceIOController:
     def open_recent_workspace(self, fname: str | os.PathLike[str]) -> bool:
         """Open a recently used workspace file."""
         path = pathlib.Path(fname).expanduser().resolve()
+        path_key = os.path.normcase(str(path))
         if not path.exists():
-            path_key = os.path.normcase(str(path))
             self._manager._set_recent_workspace_paths(
                 existing
                 for existing in self._manager._recent_workspace_paths()
@@ -449,6 +465,19 @@ class _WorkspaceIOController:
                 self._manager,
                 "Workspace Not Found",
                 f"The recent workspace file no longer exists:\n{path}",
+            )
+            return False
+        if not _manager_workspace._workspace_path_is_itws(path):
+            self._manager._set_recent_workspace_paths(
+                existing
+                for existing in self._manager._recent_workspace_paths()
+                if os.path.normcase(str(existing)) != path_key
+            )
+            self._manager._refresh_open_recent_menu_action()
+            QtWidgets.QMessageBox.warning(
+                self._manager,
+                "Unsupported Workspace File",
+                "ImageTool Manager opens workspace files with the .itws extension.",
             )
             return False
         if not self._manager._confirm_save_dirty_workspace(
@@ -563,6 +592,12 @@ class _WorkspaceIOController:
             return
         self._manager._workspace_state.lock.unlock()
         self._manager._workspace_state.lock = None
+
+    def _current_workspace_document_path(self) -> pathlib.Path | None:
+        path = self._manager._workspace_state.path
+        if path is None or not _manager_workspace._workspace_path_is_itws(path):
+            return None
+        return path
 
     def _workspace_document_access(
         self, fname: str | os.PathLike[str]
@@ -2516,6 +2551,7 @@ class _WorkspaceIOController:
         document_access: _WorkspaceDocumentAccess | None = None,
     ) -> None:
         if document_access is None:
+            _require_itws_workspace_path(fname, _WORKSPACE_SAVE_SUFFIX_ERROR)
             with self._manager._workspace_document_access_context(fname) as access:
                 self._manager._save_workspace_document(
                     access.path,
@@ -2525,6 +2561,7 @@ class _WorkspaceIOController:
             return
 
         fname = document_access.path
+        _require_itws_workspace_path(fname, _WORKSPACE_SAVE_SUFFIX_ERROR)
         self._manager._workspace_state.saving_depth += 1
         try:
             _manager_workspace._recover_workspace_transactions(fname)
@@ -2598,9 +2635,9 @@ class _WorkspaceIOController:
         msg_box = QtWidgets.QMessageBox(self._manager)
         msg_box.setIcon(QtWidgets.QMessageBox.Icon.Information)
         msg_box.setWindowTitle("Save Legacy Workspace")
-        msg_box.setText("This workspace uses an older file format.")
+        msg_box.setText("This workspace uses a legacy file format.")
         msg_box.setInformativeText(
-            "Save it again so ImageTool Manager can read it properly."
+            "Save it as an .itws file so ImageTool Manager can update it safely."
         )
         msg_box.setDetailedText(str(pathlib.Path(fname)))
         msg_box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
@@ -2623,6 +2660,9 @@ class _WorkspaceIOController:
         if converted_fname is None:
             return None
         converted_path = pathlib.Path(converted_fname).resolve()
+        if not _manager_workspace._workspace_path_is_itws(converted_path):
+            _show_itws_workspace_warning(self._manager)
+            return None
         if existing_access is not None and converted_path == existing_access.path:
             with erlab.interactive.utils.wait_dialog(
                 self._manager, "Saving workspace..."
@@ -3173,7 +3213,8 @@ class _WorkspaceIOController:
             Whether to use the native file dialog, by default `True`. This option is
             used when testing the application to ensure reproducibility.
         """
-        if self._manager._workspace_state.path is None:
+        workspace_path = self._current_workspace_document_path()
+        if workspace_path is None:
             return self._manager.save_as(native=native)
         if self._manager._workspace_state.save_in_progress:
             self._manager._status_bar.showMessage(
@@ -3181,16 +3222,14 @@ class _WorkspaceIOController:
             )
             return False
         origin = self._manager._active_managed_window()
-        old_workspace_path = self._manager._workspace_state.path
+        old_workspace_path = workspace_path
         backing_snapshot = self._manager._workspace_data_backing_snapshot()
         self._manager._status_bar.showMessage("Saving workspace...")
         try:
-            snapshot = self._manager._workspace_save_snapshot(
-                self._manager._workspace_state.path
-            )
+            snapshot = self._manager._workspace_save_snapshot(workspace_path)
             try:
                 ok, elapsed, error_text = self._manager._run_workspace_save_worker(
-                    self._manager._workspace_state.path, snapshot, origin
+                    workspace_path, snapshot, origin
                 )
             except Exception:
                 snapshot.close()
@@ -3216,7 +3255,7 @@ class _WorkspaceIOController:
                 _manager_workspace._current_workspace_schema_version()
             )
             self._manager._rebind_workspace_backed_imagetools(
-                self._manager._workspace_state.path,
+                workspace_path,
                 backing_snapshot=backing_snapshot,
                 old_workspace_path=old_workspace_path,
             )
@@ -3238,7 +3277,7 @@ class _WorkspaceIOController:
             )
         self._manager._status_bar.showMessage(message, 5000)
         self._manager._restore_focus_after_workspace_save(origin)
-        self._manager._record_recent_workspace(self._manager._workspace_state.path)
+        self._manager._record_recent_workspace(workspace_path)
         return True
 
     def save_as(self, *, native: bool = True) -> bool:
@@ -3248,6 +3287,9 @@ class _WorkspaceIOController:
             native=native, caption="Save Workspace As"
         )
         if fname is None:
+            return False
+        if not _manager_workspace._workspace_path_is_itws(fname):
+            _show_itws_workspace_warning(self._manager)
             return False
         old_workspace_path = self._manager._workspace_state.path
         backing_snapshot = self._manager._workspace_data_backing_snapshot()
@@ -3342,7 +3384,8 @@ class _WorkspaceIOController:
 
     def compact_workspace(self) -> bool:
         """Rewrite the current workspace file to remove unused space."""
-        if self._manager._workspace_state.path is None:
+        workspace_path = self._current_workspace_document_path()
+        if workspace_path is None:
             return self._manager.save_as()
         if self._manager._workspace_state.save_in_progress:
             self._manager._status_bar.showMessage(
@@ -3351,17 +3394,15 @@ class _WorkspaceIOController:
             return False
 
         origin = self._manager._active_managed_window()
-        old_workspace_path = self._manager._workspace_state.path
+        old_workspace_path = workspace_path
         backing_snapshot = self._manager._workspace_data_backing_snapshot()
         try:
             with erlab.interactive.utils.wait_dialog(
                 origin or self._manager, "Compacting workspace..."
             ):
-                self._manager._save_workspace_document(
-                    self._manager._workspace_state.path, force_full=True
-                )
+                self._manager._save_workspace_document(workspace_path, force_full=True)
                 self._manager._rebind_workspace_backed_imagetools(
-                    self._manager._workspace_state.path,
+                    workspace_path,
                     backing_snapshot=backing_snapshot,
                     old_workspace_path=old_workspace_path,
                 )
@@ -3385,6 +3426,7 @@ class _WorkspaceIOController:
         private callers. Document-style Save and Save As use
         :meth:`_save_workspace_document` instead.
         """
+        _require_itws_workspace_path(fname, _WORKSPACE_SAVE_SUFFIX_ERROR)
         tree: xr.DataTree = self._manager._to_datatree()
         try:
             dialog = _ChooseFromDataTreeDialog(self._manager, tree, mode="save")
@@ -3445,6 +3487,7 @@ class _WorkspaceIOController:
         select: bool,
         native: bool = True,
     ) -> bool:
+        _require_itws_workspace_path(fname, _WORKSPACE_LOAD_SUFFIX_ERROR)
         previous_missing_colormaps = self._missing_workspace_colormaps
         previous_skipped_nodes = self._skipped_workspace_nodes
         self._missing_workspace_colormaps = []
@@ -3547,9 +3590,7 @@ class _WorkspaceIOController:
         dialog = QtWidgets.QFileDialog(self._manager)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptMode.AcceptOpen)
         dialog.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFile)
-        dialog.setNameFilters(
-            ["ImageTool Workspace Files (*.itws)", "xarray HDF5 Files (*.h5)"]
-        )
+        dialog.setNameFilter("ImageTool Workspace Files (*.itws)")
         if self._manager._recent_directory is not None:
             dialog.setDirectory(self._manager._recent_directory)
         if not native:  # pragma: no branch
@@ -3598,9 +3639,7 @@ class _WorkspaceIOController:
         dialog = QtWidgets.QFileDialog(self._manager)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptMode.AcceptOpen)
         dialog.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFile)
-        dialog.setNameFilters(
-            ["ImageTool Workspace Files (*.itws)", "xarray HDF5 Files (*.h5)"]
-        )
+        dialog.setNameFilter("ImageTool Workspace Files (*.itws)")
         if self._manager._recent_directory is not None:
             dialog.setDirectory(self._manager._recent_directory)
         if not native:  # pragma: no branch

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -2167,7 +2167,7 @@ def test_workspace_properties_dialog_file_detail_branches(
         "ImageTool Workspace (.itws)"
     )
     assert manager_widgets._workspace_file_type_text(tmp_path / "workspace.h5") == (
-        "xarray HDF5 Workspace (.h5)"
+        "HDF5 file (.h5)"
     )
     assert manager_widgets._workspace_file_type_text(tmp_path / "notes.txt") == (
         "TXT file"

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -2871,6 +2871,7 @@ def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:
 
     assert file_manager.workspace_path == "fallback.itws"
     assert captured["args"][0] == "fallback.itws"
+    assert captured["kwargs"]["mode"] == "r+"
 
 
 def test_open_workspace_dataset_uses_fsdecode_fallback(monkeypatch) -> None:
@@ -5999,6 +6000,34 @@ def test_manager_workspace_save_as_reports_document_write_error(
     ]
 
 
+def test_manager_workspace_save_as_rejects_h5_target(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    fname = tmp_path / "workspace.h5"
+    warnings: list[tuple[typing.Any, ...]] = []
+
+    with manager_context() as manager:
+        monkeypatch.setattr(
+            manager, "_workspace_save_dialog", lambda *args, **kwargs: str(fname)
+        )
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox, "warning", lambda *args: warnings.append(args)
+        )
+
+        assert not manager.save_as(native=False)
+
+    assert len(warnings) == 1
+    assert warnings[0][1:] == (
+        "Workspace Not Saved",
+        "ImageTool Manager saves workspaces as .itws files.",
+    )
+    assert not fname.exists()
+
+
 def test_manager_workspace_load_locks_before_recovery(
     monkeypatch,
     tmp_path,
@@ -6229,6 +6258,31 @@ def test_manager_open_recent_workspace_flow(
 
         assert not manager.open_recent_workspace(missing)
         assert len(missing_warnings) == 1
+        assert manager._recent_workspace_paths() == [older.resolve()]
+
+        h5_workspace = tmp_path / "old-workspace.h5"
+        h5_workspace.touch()
+        confirm_calls: list[str] = []
+        unsupported_warnings: list[tuple[typing.Any, ...]] = []
+        manager._set_recent_workspace_paths([h5_workspace.resolve(), older.resolve()])
+        monkeypatch.setattr(
+            manager,
+            "_confirm_save_dirty_workspace",
+            lambda message: confirm_calls.append(message) or True,
+        )
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "warning",
+            lambda *args: unsupported_warnings.append(args),
+        )
+
+        assert not manager.open_recent_workspace(h5_workspace)
+        assert len(unsupported_warnings) == 1
+        assert unsupported_warnings[0][1:] == (
+            "Unsupported Workspace File",
+            "ImageTool Manager opens workspace files with the .itws extension.",
+        )
+        assert confirm_calls == []
         assert manager._recent_workspace_paths() == [older.resolve()]
 
 
@@ -6621,23 +6675,31 @@ def test_manager_startup_forward_empty_and_uninspectable_state(
     assert "Could not inspect live managers" in caplog.text
 
 
-def test_manager_startup_forward_h5_workspace_files_stay_local(
+def test_manager_startup_h5_workspace_files_are_not_workspace_documents(
     monkeypatch, tmp_path
 ) -> None:
     import h5py
 
-    workspace = tmp_path / "workspace.h5"
-    with h5py.File(workspace, "w") as h5_file:
+    h5_workspace = tmp_path / "workspace.h5"
+    with h5py.File(h5_workspace, "w") as h5_file:
         h5_file.attrs["imagetool_workspace_schema_version"] = 5
+    inspected: list[bool] = []
     monkeypatch.setattr(
         manager_module,
         "manager_selection_info",
-        lambda **_kwargs: (_ for _ in ()).throw(
-            AssertionError("should not inspect managers")
+        lambda **_kwargs: (
+            inspected.append(True)
+            or {
+                "resolved_index": None,
+                "needs_selection": False,
+                "managers": [],
+            }
         ),
     )
 
-    assert not manager_module._try_forward_startup_files([workspace])
+    assert not manager_module._startup_path_is_workspace(h5_workspace)
+    assert not manager_module._try_forward_startup_files([h5_workspace])
+    assert inspected == [True]
 
 
 @pytest.mark.parametrize(
@@ -6997,7 +7059,7 @@ def test_manager_confirm_save_dirty_workspace_save_branch(
         assert manager._confirm_save_dirty_workspace("Save before continuing.")
 
 
-def test_manager_legacy_workspace_save_helpers(
+def test_manager_legacy_itws_schema_save_helpers(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -7010,10 +7072,13 @@ def test_manager_legacy_workspace_save_helpers(
             "exec",
             lambda _msg_box: QtWidgets.QMessageBox.StandardButton.Ok,
         )
-        manager._show_legacy_workspace_upgrade_message(tmp_path / "legacy.itws")
+        manager._show_legacy_workspace_upgrade_message(tmp_path / "legacy-schema.itws")
 
         monkeypatch.setattr(manager, "_workspace_save_dialog", lambda **_kwargs: None)
-        assert manager._save_legacy_workspace_as_v4(tmp_path / "legacy.itws") is None
+        assert (
+            manager._save_legacy_workspace_as_v4(tmp_path / "legacy-schema.itws")
+            is None
+        )
 
         dirty_reasons: list[str] = []
         monkeypatch.setattr(
@@ -7025,7 +7090,7 @@ def test_manager_legacy_workspace_save_helpers(
             manager, "_mark_workspace_structure_dirty", dirty_reasons.append
         )
         manager._associate_loaded_workspace_file(
-            tmp_path / "legacy.itws",
+            tmp_path / "legacy-schema.itws",
             manager_workspace._WORKSPACE_LEGACY_SCHEMA_VERSION - 1,
         )
 
@@ -7146,6 +7211,30 @@ def test_open_multiple_files_loads_workspace_and_reads_metadata(
 
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         assert manager.workspace_path == str(fname.resolve())
+
+
+def test_manager_drop_h5_file_does_not_try_workspace(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    fname = tmp_path / "data.h5"
+    calls: list[tuple[list[pathlib.Path], bool]] = []
+
+    with manager_context() as manager:
+        monkeypatch.setattr(
+            manager,
+            "open_multiple_files",
+            lambda paths, *, try_workspace=False: calls.append(
+                (list(paths), try_workspace)
+            ),
+        )
+
+        manager._handle_dropped_files([fname])
+
+    assert calls == [([fname], False)]
 
 
 def test_workspace_high_risk_path_detection() -> None:
@@ -11027,87 +11116,29 @@ def test_manager_workspace_roundtrip_recursive_nested_imagetools(
         )
 
 
-def test_manager_workspace_load_legacy(
+def test_manager_workspace_rejects_h5_workspace_file(
     qtbot,
-    accept_dialog,
     datadir,
-    monkeypatch,
     tmp_path,
-    test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
     legacy_workspace = tmp_path / "manager_workspace_legacy.h5"
     legacy_workspace.write_bytes((datadir / "manager_workspace_legacy.h5").read_bytes())
+    original_legacy_bytes = legacy_workspace.read_bytes()
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        manager.show()
 
-        def _go_to_file(dialog: QtWidgets.QFileDialog):
-            dialog.setDirectory(str(tmp_path))
-            dialog.selectFile(str(legacy_workspace))
-            focused = dialog.focusWidget()
-            if isinstance(focused, QtWidgets.QLineEdit):
-                focused.setText("manager_workspace_legacy.h5")
-
-        legacy_notices: list[pathlib.Path] = []
-        save_dialog_calls: list[tuple[bool, str, pathlib.Path | None]] = []
-
-        def _record_legacy_notice(fname: str | os.PathLike[str]) -> None:
-            legacy_notices.append(pathlib.Path(fname))
-
-        def _record_save_dialog(
-            *,
-            native: bool = True,
-            caption: str = "Save Workspace",
-            selected_file: str | os.PathLike[str] | None = None,
-        ) -> str:
-            selected_path = (
-                None if selected_file is None else pathlib.Path(selected_file)
+        with pytest.raises(ValueError, match=r"\.itws"):
+            manager._load_workspace_file(
+                legacy_workspace,
+                replace=True,
+                associate=True,
+                mark_dirty=False,
+                select=False,
             )
-            save_dialog_calls.append((native, caption, selected_path))
-            return str(legacy_workspace)
 
-        monkeypatch.setattr(
-            manager, "_show_legacy_workspace_upgrade_message", _record_legacy_notice
-        )
-        monkeypatch.setattr(manager, "_workspace_save_dialog", _record_save_dialog)
-
-        # Load workspace
-        accept_dialog(lambda: manager.load(native=False), pre_call=_go_to_file)
-
-        assert legacy_notices == [legacy_workspace]
-        assert save_dialog_calls == [
-            (False, "Save Converted Workspace", legacy_workspace)
-        ]
-
-        # Check if the data is loaded
-        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
-
-        # Check data
-        xr.testing.assert_identical(
-            manager.get_imagetool(0).slicer_area._data,
-            test_data,
-        )
-
-        assert not manager.is_workspace_modified
-        assert manager.save()
-        import h5py
-
-        with h5py.File(legacy_workspace, "r") as h5_file:
-            assert h5_file.attrs["imagetool_workspace_schema_version"] == 4
-
-        select_tools(manager, list(manager._tool_graph.root_wrappers.keys()))
-        accept_dialog(manager.remove_action.trigger)
-        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
-
-        assert manager._load_workspace_file(
-            legacy_workspace,
-            replace=True,
-            associate=True,
-            mark_dirty=False,
-            select=False,
-        )
-        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        assert manager.ntools == 0
+        assert legacy_workspace.read_bytes() == original_legacy_bytes


### PR DESCRIPTION
## Summary

Stop treating `.h5` files as ImageTool workspace documents. Workspace load/import/startup/drop/recent handling now recognizes only `.itws` as a workspace file.

## Details

- Remove `.h5` workspace detection from startup and drag/drop routing so `.h5` files fall through to normal data loaders instead of workspace probing.
- Remove `.h5` from workspace load/import file dialogs and reject direct workspace load/save/export paths for non-`.itws` paths.
- Keep transaction recovery limited to `.itws` paths.
- Prune unsupported `.h5` entries from the recent-workspace menu before prompting to replace the current workspace.
- Keep old-schema `.itws` conversion support intact.
- Update labels and tests so `.h5` is presented as a normal HDF5 file, not a workspace format.

## User impact

Legacy `.h5` workspace documents are no longer supported by ImageTool Manager. Users should use `.itws` workspace files; ordinary `.h5` data files are no longer inspected as potential workspaces during manager open/drop/startup handling.

## Validation

- `uv sync --all-extras --dev --group pyqt6`
- `uv run mypy src`
- `uv run --group pyqt6 pytest tests/interactive/imagetool/manager/test_workspace.py -k "workspace_file_manager_uses_fsdecode_fallback or open_workspace_dataset_uses_fsdecode_fallback or open_workspace_datatree_closes_partial_groups_on_error or manager_workspace_save_as_rejects_h5_target or manager_legacy_itws_schema_save_helpers or manager_workspace_rejects_h5_workspace_file or manager_startup_h5_workspace_files_are_not_workspace_documents or manager_drop_h5_file_does_not_try_workspace or open_multiple_files_loads_workspace_and_reads_metadata or manager_open_recent_workspace_flow"`
- `uv run --group pyqt6 pytest tests/interactive/imagetool/manager/test_mainwindow.py -k "workspace_properties_dialog_file_detail_branches"`
- `uv run ruff format --check src/erlab/interactive/imagetool/manager/_workspace_io.py tests/interactive/imagetool/manager/test_workspace.py`
- `uv run ruff check src/erlab/interactive/imagetool/manager/_workspace_io.py tests/interactive/imagetool/manager/test_workspace.py`
- `git diff --check`
