### PR TITLE
Compress ImageTool workspace option state for faster saves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,17 @@ jobs:
           - group: "cov-qt-imagetool"
             timeout-minutes: 30
             use-xdist: true
+          - group: "cov-qt-manager-figurecomposer"
+            timeout-minutes: 25
+            use-xdist: true
           - group: "cov-qt-manager-mainwindow"
             timeout-minutes: 25
             use-xdist: true
-          - group: "cov-qt-manager-workspace"
-            timeout-minutes: 25
+          - group: "cov-qt-manager-workspace-a"
+            timeout-minutes: 20
+            use-xdist: true
+          - group: "cov-qt-manager-workspace-b"
+            timeout-minutes: 20
             use-xdist: true
           - group: "cov-qt-manager-provenance-console"
             timeout-minutes: 30

--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -467,6 +467,11 @@ Some implementation details matter:
   and is stored separately in workspace files. If you need to persist expensive
   calculated arrays, use the explicit persistence hooks instead of `tool_status` so
   ordinary history snapshots stay cheap.
+- Keep workspace restore cheap. If a saved tool has optional cached results, preview
+  images, deserialized fit objects, or rendered figures, validate the saved state
+  eagerly but defer that derived work through `ToolWindow` restore hooks. Hidden tools
+  in a manager workspace should not deserialize, recompute, or render data until the
+  user shows the tool or asks for its output.
 - Record undo/redo checkpoints after user-visible state changes by calling
   `_write_state()`. Call `_reset_history_stack()` after construction, file restore,
   duplication, or source-data replacement so a restored or refreshed tool starts from
@@ -514,6 +519,73 @@ Some implementation details matter:
 `DerivativeTool` in `erlab.interactive.derivative` is a good synchronous example:
 `tool_status` captures the preprocessing controls, and `update_data()` swaps in the new
 array while preserving the current settings.
+
+## Defer expensive restored work
+
+Direct `ToolWindow.from_dataset()` calls restore tools eagerly, which keeps scripts and
+standalone file restores simple. The ImageTool manager uses the same restore path with
+an internal deferred mode so loading a workspace can finish before hidden tools rebuild
+optional cached state.
+
+For new tools, split restore work into two categories:
+
+- Required work: validation, source-reference resolution, UI state restoration, and
+  anything needed for the tool to be structurally valid. Run this eagerly.
+- Optional work: derived objects, rendered views, preview data, or result arrays that
+  are expensive to materialize and can be recreated from saved state. Use the restore
+  framework for this work. Existing examples include deserializing saved fit results,
+  building a figure window, and preparing reduced preview data.
+
+The normal pattern is:
+
+```python
+def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
+    self._serialized_result = np.array(ds["result_blob"].values, copy=True)
+    self._run_or_defer_restore_work(
+        self._restore_result_cache,
+        run_on_show=True,
+    )
+
+
+def _restore_result_cache(self) -> None:
+    self._result = deserialize_result(self._serialized_result)
+    self._serialized_result = None
+    self._notify_data_changed()
+```
+
+Use `run_on_show=True` when hidden tools can wait until the user shows them. ToolWindow
+will also flush deferred work before saving, copying generated code, returning declared
+ImageTool outputs, closing, and other correctness boundaries it owns.
+
+Call `_flush_restore_work(...)` from a subclass only when that subclass has a narrower
+data boundary. For example, `DerivativeTool.result` flushes the pending recomputation
+before returning the result array. Do not flush from passive metadata paths merely to
+build manager labels or dependency status.
+
+Call `_discard_restore_work(...)` only when explicit work has superseded a queued
+restore callback. For example, if a user-triggered preview update already rebuilt the
+same preview that was queued during restore, discard the queued restore preview so it
+cannot run later and overwrite newer state.
+
+Use an explicit `key=` only when another path must address the deferred work by a
+stable handle. The main use case is saving raw persisted payloads unchanged. For
+example, a tool can keep a serialized result payload pending and have its save hook
+flush other deferred work while skipping that payload, so a save immediately after
+workspace load writes the original payload unchanged.
+
+The restore hook should stay focused on derived work. Required validation and
+source-reference resolution should run before any deferral, and passive manager
+metadata paths should not flush restore work just to build labels or dependency status.
+
+Tests for deferred restore should assert user-visible behavior instead of inspecting the
+internal restore queue:
+
+- direct `from_dataset()` remains eager;
+- manager-style deferred restore does not run the expensive callback during hidden load;
+- showing the tool or requesting its output flushes the callback exactly once;
+- saving before flush preserves any raw serialized payload that is meant to stay raw;
+  and
+- generated code, declared outputs, and provenance remain identical after flush.
 
 ## Add manager-facing metadata
 
@@ -753,6 +825,8 @@ At minimum, add tests in `tests/interactive/test_<tool>.py` that cover:
   tool uses them;
 - `validate_update_data()` and `update_data()` branches, including {guilabel}`Stale` or
   {guilabel}`Unavailable` cases after the ImageTool that opened the tool changes;
+- deferred restore behavior for any expensive restored cache, preview, render, or
+  result recomputation;
 - dialog accept and cancel paths for any new dialogs, including {guilabel}`Save` and
   {guilabel}`Update Now` paths if the tool participates in automatic updates; and
 - manager launch paths, preferably by patching manager functions unless a live manager

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import pathlib
 from collections import Counter, defaultdict
 from typing import TYPE_CHECKING
@@ -9,6 +10,30 @@ if TYPE_CHECKING:
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 TESTS_ROOT = REPO_ROOT / "tests"
+
+
+def _test_function_names(file_target: str) -> tuple[str, ...]:
+    file_path = REPO_ROOT / file_target
+    tree = ast.parse(file_path.read_text())
+    return tuple(
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+    )
+
+
+def _split_test_file_targets(
+    file_target: str, *, index: int, total: int
+) -> tuple[str, ...]:
+    if not 0 <= index < total:
+        raise ValueError("split index must be in range(total)")
+    nodeids = tuple(
+        f"{file_target}::{name}" for name in _test_function_names(file_target)
+    )
+    if not nodeids:
+        raise ValueError(f"No top-level test functions found in {file_target}")
+    return nodeids[index::total]
+
 
 COMPAT_TARGETS: tuple[str, ...] = (
     "tests/accessors/test_fit.py",
@@ -64,14 +89,23 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
         "tests/interactive/imagetool/test_slicer.py",
         "tests/interactive/imagetool/test_watcher.py",
     ),
-    "cov-qt-manager-mainwindow": (
+    "cov-qt-manager-figurecomposer": (
         "tests/interactive/imagetool/manager/test_figurecomposer.py",
+    ),
+    "cov-qt-manager-mainwindow": (
         "tests/interactive/imagetool/manager/test_mainwindow.py",
         "tests/interactive/imagetool/manager/test_modelview.py",
         "tests/interactive/imagetool/manager/test_wrapper.py",
     ),
-    "cov-qt-manager-workspace": (
+    "cov-qt-manager-workspace-a": _split_test_file_targets(
         "tests/interactive/imagetool/manager/test_workspace.py",
+        index=0,
+        total=2,
+    ),
+    "cov-qt-manager-workspace-b": _split_test_file_targets(
+        "tests/interactive/imagetool/manager/test_workspace.py",
+        index=1,
+        total=2,
     ),
     "cov-qt-manager-provenance-console": (
         "tests/interactive/imagetool/manager/test_provenance.py",
@@ -199,20 +233,33 @@ def coverage_membership() -> dict[str, list[str]]:
     return dict(membership)
 
 
+def coverage_nodeid_membership() -> dict[str, dict[str, list[str]]]:
+    membership: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+    for group_name, targets in COVERAGE_GROUPS.items():
+        for target in expand_targets(targets):
+            if "::" not in target:
+                continue
+            file_target, nodeid = target.split("::", maxsplit=1)
+            membership[file_target][nodeid].append(group_name)
+    return {file_target: dict(nodeids) for file_target, nodeids in membership.items()}
+
+
 def check_coverage_partition() -> list[str]:
     all_files = set(iter_all_test_files())
     membership = coverage_membership()
+    nodeid_membership = coverage_nodeid_membership()
     counts = Counter(
         {file_target: len(groups) for file_target, groups in membership.items()}
     )
 
-    missing = sorted(all_files - counts.keys())
+    missing = sorted(all_files - counts.keys() - nodeid_membership.keys())
     duplicate_members = {
         file_target: groups
         for file_target, groups in sorted(membership.items())
         if len(groups) > 1
     }
-    extras = sorted(counts.keys() - all_files)
+    split_and_file_members = sorted(counts.keys() & nodeid_membership.keys())
+    extras = sorted((counts.keys() | nodeid_membership.keys()) - all_files)
 
     errors: list[str] = []
     if missing:
@@ -224,6 +271,32 @@ def check_coverage_partition() -> list[str]:
             f"  - {file_target}: {', '.join(groups)}"
             for file_target, groups in duplicate_members.items()
         )
+    if split_and_file_members:
+        errors.append("Covered both as a full file and split nodeids:")
+        errors.extend(f"  - {file_target}" for file_target in split_and_file_members)
+    for file_target, nodeids in sorted(nodeid_membership.items()):
+        expected_nodeids = set(_test_function_names(file_target))
+        missing_nodeids = sorted(expected_nodeids - nodeids.keys())
+        extra_nodeids = sorted(nodeids.keys() - expected_nodeids)
+        duplicate_nodeids = {
+            nodeid: groups
+            for nodeid, groups in sorted(nodeids.items())
+            if len(groups) > 1
+        }
+        if missing_nodeids:
+            errors.append(
+                f"Missing split nodeids from coverage partition: {file_target}"
+            )
+            errors.extend(f"  - {nodeid}" for nodeid in missing_nodeids)
+        if duplicate_nodeids:
+            errors.append(f"Split nodeids covered by multiple groups: {file_target}")
+            errors.extend(
+                f"  - {nodeid}: {', '.join(groups)}"
+                for nodeid, groups in duplicate_nodeids.items()
+            )
+        if extra_nodeids:
+            errors.append(f"Unknown split nodeids in coverage partition: {file_target}")
+            errors.extend(f"  - {nodeid}" for nodeid in extra_nodeids)
     if extras:
         errors.append("Unknown files referenced by coverage groups:")
         errors.extend(f"  - {file_target}" for file_target in extras)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -5454,12 +5454,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return row_widget
 
     def generated_code(self) -> str:
+        self._flush_restore_work()
         self._flush_pending_editor_commits()
         with self._figure_options_context():
             return erlab.interactive._figurecomposer._codegen.generated_code(self)
 
     @QtCore.Slot()
     def copy_code(self) -> None:
+        self._flush_restore_work()
         if self._warn_invalid_operation_targets():
             return
         try:
@@ -5480,6 +5482,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     @QtCore.Slot()
     def export_figure(self) -> None:
+        self._flush_restore_work()
         if self._warn_invalid_operation_targets():
             return
         self._flush_pending_editor_commits()
@@ -5523,7 +5526,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._ensure_primary_source_data()
         self._apply_recipe_to_controls()
         self._sync_figure_window_to_recipe_setup()
-        if getattr(self, "_restoring_from_dataset", False):
+        if self._dataset_restore_in_progress:
             self._mark_preview_pixmap_stale()
             return
         _render_preview(self)
@@ -5689,11 +5692,19 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _queue_post_restore_redraw_if_needed(self, ds: xr.Dataset) -> None:
         if not self._saved_tool_window_visible(ds) or not self._auto_redraw_enabled():
             return
+        if self._defer_restore_work(
+            self._redraw_restored_plot,
+            run_on_show=True,
+        ):
+            return
         erlab.interactive.utils.single_shot(
             self,
             0,
             functools.partial(self._redraw_plot, show_window=True),
         )
+
+    def _redraw_restored_plot(self) -> None:
+        self._redraw_plot(show_window=True)
 
     def _persisted_preview_cache_pixmap(self) -> QtGui.QPixmap | None:
         preview = self._preview_pixmap_cache
@@ -5929,7 +5940,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def source_data(self) -> dict[str, xr.DataArray]:
         return dict(self._source_data)
 
-    def current_provenance_spec(self) -> provenance.ToolProvenanceSpec | None:
+    def current_provenance_spec(
+        self, *, flush_deferred_restore: bool = True
+    ) -> provenance.ToolProvenanceSpec | None:
+        del flush_deferred_restore
         script_inputs = tuple(
             script_input
             for source in self._recipe.sources

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -995,6 +995,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._last_fit_y: np.ndarray | None = None
         self._last_residual: np.ndarray | None = None
         self._last_result_ds: xr.Dataset | None = None
+        self._pending_persisted_fit_result_blob: np.ndarray | None = None
+        self._pending_persisted_fit_is_current = False
         self._slider_drag_range: tuple[float, float] | None = None
         self._fit_is_current: bool = False
         self._table_widths_initialized: bool = False
@@ -2877,6 +2879,16 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._set_fit_stats(restore.result)
 
     def _append_persistence_payload(self, ds: xr.Dataset) -> xr.Dataset:
+        if self._pending_persisted_fit_result_blob is not None:
+            ds = ds.copy()
+            ds[self._PERSISTED_FIT_RESULT_VAR] = xr.DataArray(
+                np.array(self._pending_persisted_fit_result_blob, copy=True),
+                dims=(self._PERSISTED_FIT_RESULT_DIM,),
+            )
+            ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(
+                self._pending_persisted_fit_is_current
+            )
+            return ds
         if self._last_result_ds is None:
             return ds
         ds = ds.copy()
@@ -2887,21 +2899,46 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(self._fit_is_current)
         return ds
 
-    def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
-        if self._PERSISTED_FIT_RESULT_VAR not in ds:
-            return
+    def _restore_persisted_fit_result_blob(
+        self, blob: np.ndarray, *, fit_is_current: bool
+    ) -> None:
         self._last_result_ds = _load_lmfit_for_ftool_restore(
-            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(
-                ds[self._PERSISTED_FIT_RESULT_VAR].values
-            )
+            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(blob)
         )
         result = self._last_result_ds.modelfit_results.compute().item()
         self._set_fit_stats(result)
         self._update_fit_curve()
-        if bool(ds.attrs.get(self._PERSISTED_FIT_CURRENT_ATTR, False)):
+        if fit_is_current:
             self._mark_fit_fresh()
         else:
             self._mark_fit_stale()
+        self._pending_persisted_fit_result_blob = None
+        self._pending_persisted_fit_is_current = False
+
+    def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
+        if self._PERSISTED_FIT_RESULT_VAR not in ds:
+            return
+        blob = np.array(
+            ds[self._PERSISTED_FIT_RESULT_VAR].values,
+            copy=True,
+        )
+        fit_is_current = bool(ds.attrs.get(self._PERSISTED_FIT_CURRENT_ATTR, False))
+        self._pending_persisted_fit_result_blob = blob
+        self._pending_persisted_fit_is_current = fit_is_current
+        self._run_or_defer_restore_work(
+            lambda: self._restore_persisted_fit_result_blob(
+                blob,
+                fit_is_current=fit_is_current,
+            ),
+            key=self._PERSISTED_FIT_RESULT_VAR,
+            run_on_show=True,
+        )
+
+    def _flush_restore_work_for_save(self) -> None:
+        if self._pending_persisted_fit_result_blob is None:
+            super()._flush_restore_work_for_save()
+            return
+        self._flush_restore_work(skip=(self._PERSISTED_FIT_RESULT_VAR,))
 
     def _fit_running(self) -> bool:
         # Consider any live thread object as running to avoid startup/teardown races.
@@ -3356,6 +3393,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     @QtCore.Slot()
     def _save_fit(self) -> None:
+        self._flush_restore_work()
         if self._last_result_ds is None:
             self._show_warning("No fit result", "There is no fit result to save.")
             return

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -1679,6 +1679,16 @@ class Fit2DTool(Fit1DTool):
         self._update_param_plot()
 
     def _append_persistence_payload(self, ds: xr.Dataset) -> xr.Dataset:
+        if self._pending_persisted_fit_result_blob is not None:
+            ds = ds.copy()
+            ds[self._PERSISTED_FIT_RESULT_VAR] = xr.DataArray(
+                np.array(self._pending_persisted_fit_result_blob, copy=True),
+                dims=(self._PERSISTED_FIT_RESULT_DIM,),
+            )
+            ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(
+                self._pending_persisted_fit_is_current
+            )
+            return ds
         saved_results = [
             result_ds.expand_dims({self._PERSISTED_FIT_INDEX_DIM: [idx]})
             for idx, result_ds in enumerate(self._result_ds_full)
@@ -1703,13 +1713,11 @@ class Fit2DTool(Fit1DTool):
         ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(self._fit_is_current)
         return ds
 
-    def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
-        if self._PERSISTED_FIT_RESULT_VAR not in ds:
-            return
+    def _restore_persisted_fit_result_blob(
+        self, blob: np.ndarray, *, fit_is_current: bool
+    ) -> None:
         sparse = _load_lmfit_for_ftool_restore(
-            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(
-                ds[self._PERSISTED_FIT_RESULT_VAR].values
-            )
+            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(blob)
         )
         y_size = int(self._data_full.sizes[self._y_dim_name])
         self._result_ds_full = [None] * y_size
@@ -1728,13 +1736,30 @@ class Fit2DTool(Fit1DTool):
                         }
                     )
                 self._result_ds_full[idx] = result_ds
-        self._refresh_contents_from_index(
-            mark_fit_stale=not bool(
-                ds.attrs.get(self._PERSISTED_FIT_CURRENT_ATTR, False)
-            )
-        )
+        self._refresh_contents_from_index(mark_fit_stale=not fit_is_current)
         self._update_param_plot_options()
         self._update_param_plot()
+        self._pending_persisted_fit_result_blob = None
+        self._pending_persisted_fit_is_current = False
+
+    def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
+        if self._PERSISTED_FIT_RESULT_VAR not in ds:
+            return
+        blob = np.array(
+            ds[self._PERSISTED_FIT_RESULT_VAR].values,
+            copy=True,
+        )
+        fit_is_current = bool(ds.attrs.get(self._PERSISTED_FIT_CURRENT_ATTR, False))
+        self._pending_persisted_fit_result_blob = blob
+        self._pending_persisted_fit_is_current = fit_is_current
+        self._run_or_defer_restore_work(
+            lambda: self._restore_persisted_fit_result_blob(
+                blob,
+                fit_is_current=fit_is_current,
+            ),
+            key=self._PERSISTED_FIT_RESULT_VAR,
+            run_on_show=True,
+        )
 
     @QtCore.Slot()
     def _y_minmax_changed(self) -> None:
@@ -2141,6 +2166,7 @@ class Fit2DTool(Fit1DTool):
 
     @QtCore.Slot()
     def _save_fit_full(self) -> None:
+        self._flush_restore_work()
         results = []
         for i, ds in enumerate(self._result_ds_full[self._y_range_slice()]):
             if ds is None:
@@ -2407,11 +2433,14 @@ class Fit2DTool(Fit1DTool):
         return prelude or None
 
     def current_provenance_spec(
-        self,
+        self, *, flush_deferred_restore: bool = True
     ) -> provenance.ToolProvenanceSpec | None:
         # Manager metadata and other passive provenance consumers should not trigger
         # interactive warnings for incomplete fit ranges.
-        return self._resolve_script_provenance(self._DETACHED_COPY_PROVENANCE)
+        return self._resolve_script_provenance(
+            self._DETACHED_COPY_PROVENANCE,
+            flush_deferred_restore=flush_deferred_restore,
+        )
 
     @QtCore.Slot()
     def copy_code(self) -> str:
@@ -2463,6 +2492,7 @@ class Fit2DTool(Fit1DTool):
         return param_name, stderr
 
     def output_imagetool_data(self, output_id: str | enum.Enum) -> xr.DataArray | None:
+        self._flush_restore_work()
         parts = self._parameter_output_parts(output_id)
         if parts is None:
             return super().output_imagetool_data(output_id)
@@ -2479,6 +2509,7 @@ class Fit2DTool(Fit1DTool):
     def output_imagetool_provenance(
         self, output_id: str | enum.Enum, data: xr.DataArray
     ) -> provenance.ToolProvenanceSpec | None:
+        self._flush_restore_work()
         parts = self._parameter_output_parts(output_id)
         if parts is None:
             return super().output_imagetool_provenance(output_id, data)

--- a/src/erlab/interactive/_mesh.py
+++ b/src/erlab/interactive/_mesh.py
@@ -227,7 +227,10 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
 
         self.higher_order_targets: list[pg.TargetItem] = []
 
-        self.set_data_beforecalc(initial=True)
+        self._run_or_defer_restore_work(
+            self._restore_initial_preview,
+            run_on_show=True,
+        )
 
         opts = erlab.interactive.options.model
         for img in (self.main_image, self.corr_image):
@@ -350,6 +353,7 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
 
     @QtCore.Slot()
     def set_data_beforecalc(self, initial: bool = False) -> None:
+        self._discard_restore_work(self._restore_initial_preview)
         reduced, log_magnitude = self.get_reduced()
         n_pad: int = self.tool_status.n_pad
 
@@ -365,6 +369,9 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
             self.mesh_image.setDataArray(placeholder)
             self.corr_fft_image.setImage(log_magnitude_unpadded)
             self.mask_fft_image.setImage(placeholder.values.T)
+
+    def _restore_initial_preview(self) -> None:
+        self.set_data_beforecalc(initial=True)
 
     @QtCore.Slot()
     def _update_target_pos(self) -> None:
@@ -462,6 +469,7 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
 
     @QtCore.Slot()
     def update(self) -> None:
+        self._discard_restore_work(self._restore_initial_preview)
         with erlab.interactive.utils.wait_dialog(self, "Removing mesh..."):
             (
                 self._corrected,

--- a/src/erlab/interactive/_options/core.py
+++ b/src/erlab/interactive/_options/core.py
@@ -13,9 +13,14 @@ import typing
 import pydantic
 from qtpy import QtCore
 
-from erlab.interactive._options.schema import AppOptions
+from erlab.interactive._options.schema import (
+    AppOptions,
+    normalize_workspace_compression_mode,
+)
 
 _SETTINGS_PATH_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH"
+_WORKSPACE_COMPRESSION_PATH = "io/workspace/compression"
+_LEGACY_WORKSPACE_COMPRESS_PATH = "io/workspace/compress"
 
 
 def _qsettings_to_dict(
@@ -96,9 +101,14 @@ def read_settings(qsettings: QtCore.QSettings) -> AppOptions:
         An instance of AppOptions populated with values from QSettings.
 
     """
-    return AppOptions.model_validate(
-        _qsettings_to_dict(qsettings, AppOptions().model_dump())
-    )
+    values = _qsettings_to_dict(qsettings, AppOptions().model_dump())
+    if not qsettings.contains(_WORKSPACE_COMPRESSION_PATH) and qsettings.contains(
+        _LEGACY_WORKSPACE_COMPRESS_PATH
+    ):
+        values["io"]["workspace"]["compression"] = normalize_workspace_compression_mode(
+            qsettings.value(_LEGACY_WORKSPACE_COMPRESS_PATH)
+        )
+    return AppOptions.model_validate(values)
 
 
 def write_settings(opts: AppOptions, qsettings: QtCore.QSettings) -> None:
@@ -111,11 +121,14 @@ def write_settings(opts: AppOptions, qsettings: QtCore.QSettings) -> None:
     qsettings : QtCore.QSettings
         The QSettings object to write to.
     """
+    qsettings.remove(_LEGACY_WORKSPACE_COMPRESS_PATH)
     _dict_to_qsettings(opts.model_dump(), qsettings)
 
 
 def option_value(model: AppOptions, name: str) -> typing.Any:
     """Return an option value by slash-separated path."""
+    if name == _LEGACY_WORKSPACE_COMPRESS_PATH:
+        return option_value(model, _WORKSPACE_COMPRESSION_PATH) != "none"
     value: typing.Any = model
     for key in name.split("/"):
         value = getattr(value, key)
@@ -126,6 +139,9 @@ def option_model_with_value(
     model: AppOptions, name: str, value: typing.Any
 ) -> AppOptions:
     """Return a copy of *model* with one slash-separated option path changed."""
+    if name == _LEGACY_WORKSPACE_COMPRESS_PATH:
+        name = _WORKSPACE_COMPRESSION_PATH
+        value = normalize_workspace_compression_mode(value)
     data = model.model_dump()
     target = data
     keys = name.split("/")
@@ -251,6 +267,8 @@ class OptionManager:
 
     def get(self, name: str) -> typing.Any:
         """Get settings by name."""
+        if name == _LEGACY_WORKSPACE_COMPRESS_PATH:
+            return self.get(_WORKSPACE_COMPRESSION_PATH) != "none"
         keys = name.split("/")
         option: typing.Any = self.model.model_dump()
         for key in keys:
@@ -265,10 +283,23 @@ class OptionManager:
         """Set settings by name and value."""
         with self._lock:
             qsettings = self.qsettings
+            if name == _LEGACY_WORKSPACE_COMPRESS_PATH:
+                qsettings.remove(_LEGACY_WORKSPACE_COMPRESS_PATH)
+                if value is None:
+                    qsettings.remove(_WORKSPACE_COMPRESSION_PATH)
+                else:
+                    qsettings.setValue(
+                        _WORKSPACE_COMPRESSION_PATH,
+                        normalize_workspace_compression_mode(value),
+                    )
+                qsettings.sync()
+                return
             if value is None:
                 qsettings.remove(name)
             else:
                 qsettings.setValue(name, value)
+            if name == _WORKSPACE_COMPRESSION_PATH:
+                qsettings.remove(_LEGACY_WORKSPACE_COMPRESS_PATH)
             qsettings.sync()
 
     def __getitem__(self, name: str) -> typing.Any:

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import typing
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 import erlab
 
@@ -58,8 +58,26 @@ __all__ = [
     "ColorOptions",
     "FigureOptions",
     "IOOptions",
+    "WorkspaceCompressionMode",
     "WorkspaceOptions",
+    "normalize_workspace_compression_mode",
 ]
+
+WorkspaceCompressionMode = typing.Literal["none", "blosclz3", "zstd1"]
+
+
+def normalize_workspace_compression_mode(value: typing.Any) -> typing.Any:
+    """Return the canonical workspace compression mode for legacy values."""
+    if isinstance(value, bool):
+        return "zstd1" if value else "none"
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"false", "0", "no", "off"}:
+            return "none"
+        if normalized in {"true", "1", "yes", "on"}:
+            return "zstd1"
+        return normalized
+    return value
 
 
 def _unique_seq(seq: list[str]) -> list[str]:
@@ -188,12 +206,20 @@ class DaskOptions(BaseModel):
 class WorkspaceOptions(BaseModel):
     """ImageTool Manager workspace file options."""
 
-    compress: bool = Field(
-        default=True,
-        title="Compress workspace files",
+    compression: WorkspaceCompressionMode = Field(
+        default="zstd1",
+        title="Workspace compression",
         description=(
-            "Compress large numeric data arrays when saving ImageTool Manager "
-            "workspace files."
+            "Choose how much workspace saves compress large numeric data. Off uses "
+            "more disk space; Compact writes smaller files and may read more slowly."
+        ),
+        json_schema_extra=_workspace_extra(
+            ui_type="choice_slider",
+            ui_choices=[
+                {"label": "Off", "value": "none"},
+                {"label": "Standard", "value": "blosclz3"},
+                {"label": "Compact", "value": "zstd1"},
+            ],
         ),
     )
     use_incremental: bool = Field(
@@ -213,6 +239,20 @@ class WorkspaceOptions(BaseModel):
             "for these paths."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_compress(cls, value: typing.Any) -> typing.Any:
+        if not isinstance(value, dict):
+            return value
+        if "compression" not in value and "compress" in value:
+            value = {**value, "compression": value["compress"]}
+        return value
+
+    @field_validator("compression", mode="before")
+    @classmethod
+    def normalize_compression(cls, value: typing.Any) -> typing.Any:
+        return normalize_workspace_compression_mode(value)
 
 
 class IOOptions(BaseModel):

--- a/src/erlab/interactive/_options/tree.py
+++ b/src/erlab/interactive/_options/tree.py
@@ -45,10 +45,18 @@ def _build_leaf_param(
     param_type: str
     limits = None
     opts: dict[str, typing.Any] = {}
+    extras = getattr(field_info, "json_schema_extra", None) or {}
 
     if "enum" in schema:
         param_type = "list"
-        opts["limits"] = schema["enum"]
+        choices = extras.get("ui_choices") if isinstance(extras, dict) else None
+        if isinstance(choices, list):
+            opts["limits"] = {
+                str(choice.get("label", choice.get("value"))): choice.get("value")
+                for choice in choices
+            }
+        else:
+            opts["limits"] = schema["enum"]
     else:
         stype = schema.get("type")
         if ui_type:
@@ -72,10 +80,9 @@ def _build_leaf_param(
                 case _:
                     param_type = "str"
 
-    extras = getattr(field_info, "json_schema_extra", None) or {}
     if isinstance(extras, dict):
         for k, v in extras.items():
-            if k.startswith("ui_") and k != "ui_type":
+            if k.startswith("ui_") and k not in {"ui_type", "ui_choices"}:
                 opts[k.removeprefix("ui_")] = v
 
     param: dict[str, typing.Any] = {

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -312,7 +312,7 @@ class _ChoiceSlider(QtWidgets.QWidget):
         if margins.left() != left_margin or margins.right() != right_margin:
             self._slider_layout.setContentsMargins(left_margin, 0, right_margin, 0)
             layout = self.layout()
-            if layout is not None:
+            if layout is not None:  # pragma: no branch
                 layout.activate()
         self._label_row.update_label_positions()
 

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -201,7 +201,10 @@ class _ChoiceSliderLabelRow(QtWidgets.QWidget):
         self._slider.initStyleOption(option)
         option.sliderPosition = index
         option.sliderValue = index
-        handle_rect = self._slider.style().subControlRect(
+        style = self._slider.style()
+        if style is None:
+            raise RuntimeError("Workspace compression slider has no Qt style")
+        handle_rect = style.subControlRect(
             QtWidgets.QStyle.ComplexControl.CC_Slider,
             option,
             QtWidgets.QStyle.SubControl.SC_SliderHandle,

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -125,6 +125,96 @@ def _stylesheet_names(value: typing.Any) -> list[str]:
     return out
 
 
+class _ChoiceSliderLabelRow(QtWidgets.QWidget):
+    def __init__(
+        self,
+        slider: QtWidgets.QSlider,
+        labels: typing.Sequence[str],
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._slider = slider
+        self._labels: tuple[QtWidgets.QLabel, ...] = tuple(
+            self._make_label(index, label) for index, label in enumerate(labels)
+        )
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+
+    def _make_label(self, index: int, text: str) -> QtWidgets.QLabel:
+        label = QtWidgets.QLabel(text, self)
+        label.setObjectName(f"choiceSliderLabel_{index}")
+        label.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        label.setAttribute(QtCore.Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        return label
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(
+            sum(label.sizeHint().width() for label in self._labels),
+            self._label_height(),
+        )
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        return self.sizeHint()
+
+    def edge_margins(self) -> tuple[int, int]:
+        if not self._labels:
+            return 0, 0
+        left_inset = self._slider_handle_center(0).x()
+        right_inset = (
+            self._slider.width()
+            - 1
+            - self._slider_handle_center(len(self._labels) - 1).x()
+        )
+        return (
+            max(0, self._half_label_width(self._labels[0]) - left_inset),
+            max(0, self._half_label_width(self._labels[-1]) - right_inset),
+        )
+
+    def update_label_positions(self) -> None:
+        row_height = self.height()
+        for index, label in enumerate(self._labels):
+            label_size = label.sizeHint()
+            tick_x = self._tick_x(index)
+            label.setGeometry(
+                tick_x - label_size.width() // 2,
+                0,
+                label_size.width(),
+                row_height,
+            )
+
+    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
+        super().resizeEvent(event)
+        self.update_label_positions()
+
+    @staticmethod
+    def _half_label_width(label: QtWidgets.QLabel) -> int:
+        return (label.sizeHint().width() + 1) // 2
+
+    def _label_height(self) -> int:
+        return max((label.sizeHint().height() for label in self._labels), default=0)
+
+    def _slider_handle_center(self, index: int) -> QtCore.QPoint:
+        option = QtWidgets.QStyleOptionSlider()
+        self._slider.initStyleOption(option)
+        option.sliderPosition = index
+        option.sliderValue = index
+        handle_rect = self._slider.style().subControlRect(
+            QtWidgets.QStyle.ComplexControl.CC_Slider,
+            option,
+            QtWidgets.QStyle.SubControl.SC_SliderHandle,
+            self._slider,
+        )
+        return handle_rect.center()
+
+    def _tick_x(self, index: int) -> int:
+        return self.mapFromGlobal(
+            self._slider.mapToGlobal(self._slider_handle_center(index))
+        ).x()
+
+
 class _ChoiceSlider(QtWidgets.QWidget):
     sigValueChanged = QtCore.Signal(object)
 
@@ -150,21 +240,22 @@ class _ChoiceSlider(QtWidgets.QWidget):
         self.slider.valueChanged.connect(self._slider_value_changed)
         self.setFocusProxy(self.slider)
 
-        label_row = QtWidgets.QWidget(self)
-        label_layout = QtWidgets.QHBoxLayout(label_row)
-        label_layout.setContentsMargins(0, 0, 0, 0)
-        label_layout.setSpacing(0)
-        for label, _value in self._choices:
-            label_widget = QtWidgets.QLabel(label, label_row)
-            label_widget.setTextFormat(QtCore.Qt.TextFormat.PlainText)
-            label_widget.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-            label_layout.addWidget(label_widget, 1)
+        slider_row = QtWidgets.QWidget(self)
+        self._slider_layout = QtWidgets.QHBoxLayout(slider_row)
+        self._slider_layout.setContentsMargins(0, 0, 0, 0)
+        self._slider_layout.setSpacing(0)
+        self._slider_layout.addWidget(self.slider)
+
+        self._label_row = _ChoiceSliderLabelRow(
+            self.slider, [label for label, _value in self._choices], self
+        )
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
-        layout.addWidget(self.slider)
-        layout.addWidget(label_row)
+        layout.addWidget(slider_row)
+        layout.addWidget(self._label_row)
+        self._sync_label_geometry()
 
     def count(self) -> int:
         return len(self._choices)
@@ -189,6 +280,38 @@ class _ChoiceSlider(QtWidgets.QWidget):
         if index < 0:
             raise ValueError(f"Unknown choice slider value: {value!r}")
         self.slider.setValue(index)
+
+    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
+        super().resizeEvent(event)
+        self._sync_label_geometry()
+
+    def showEvent(self, event: QtGui.QShowEvent | None) -> None:
+        super().showEvent(event)
+        self._sync_label_geometry()
+
+    def event(self, event: QtCore.QEvent | None) -> bool:
+        handled = super().event(event)
+        if (
+            event is not None
+            and hasattr(self, "_label_row")
+            and event.type()
+            in {
+                QtCore.QEvent.Type.FontChange,
+                QtCore.QEvent.Type.StyleChange,
+            }
+        ):
+            self._sync_label_geometry()
+        return handled
+
+    def _sync_label_geometry(self) -> None:
+        left_margin, right_margin = self._label_row.edge_margins()
+        margins = self._slider_layout.contentsMargins()
+        if margins.left() != left_margin or margins.right() != right_margin:
+            self._slider_layout.setContentsMargins(left_margin, 0, right_margin, 0)
+            layout = self.layout()
+            if layout is not None:
+                layout.activate()
+        self._label_row.update_label_positions()
 
     def _slider_value_changed(self, _value: int) -> None:
         self.sigValueChanged.emit(self.currentData())

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -125,6 +125,75 @@ def _stylesheet_names(value: typing.Any) -> list[str]:
     return out
 
 
+class _ChoiceSlider(QtWidgets.QWidget):
+    sigValueChanged = QtCore.Signal(object)
+
+    def __init__(
+        self,
+        choices: typing.Sequence[typing.Mapping[str, typing.Any]],
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        if not choices:
+            raise ValueError("Choice slider requires at least one choice")
+        self._choices = tuple(
+            (str(choice.get("label", choice.get("value"))), choice.get("value"))
+            for choice in choices
+        )
+
+        self.slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal, self)
+        self.slider.setRange(0, len(self._choices) - 1)
+        self.slider.setSingleStep(1)
+        self.slider.setPageStep(1)
+        self.slider.setTickInterval(1)
+        self.slider.setTickPosition(QtWidgets.QSlider.TickPosition.TicksBelow)
+        self.slider.valueChanged.connect(self._slider_value_changed)
+        self.setFocusProxy(self.slider)
+
+        label_row = QtWidgets.QWidget(self)
+        label_layout = QtWidgets.QHBoxLayout(label_row)
+        label_layout.setContentsMargins(0, 0, 0, 0)
+        label_layout.setSpacing(0)
+        for label, _value in self._choices:
+            label_widget = QtWidgets.QLabel(label, label_row)
+            label_widget.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+            label_widget.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+            label_layout.addWidget(label_widget, 1)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+        layout.addWidget(self.slider)
+        layout.addWidget(label_row)
+
+    def count(self) -> int:
+        return len(self._choices)
+
+    def itemText(self, index: int) -> str:
+        return self._choices[index][0]
+
+    def itemData(self, index: int) -> typing.Any:
+        return self._choices[index][1]
+
+    def findData(self, value: typing.Any) -> int:
+        for index, (_label, choice_value) in enumerate(self._choices):
+            if choice_value == value:
+                return index
+        return -1
+
+    def currentData(self) -> typing.Any:
+        return self.itemData(self.slider.value())
+
+    def setCurrentData(self, value: typing.Any) -> None:
+        index = self.findData(value)
+        if index < 0:
+            raise ValueError(f"Unknown choice slider value: {value!r}")
+        self.slider.setValue(index)
+
+    def _slider_value_changed(self, _value: int) -> None:
+        self.sigValueChanged.emit(self.currentData())
+
+
 class _SettingsRow(QtWidgets.QFrame):
     def __init__(
         self,
@@ -408,6 +477,8 @@ class OptionDialog(QtWidgets.QDialog):
             return StylesheetListWidget(parent=self)
         if ui_type == "figure_dpi_override":
             return FigureDpiOverrideWidget(parent=self)
+        if ui_type == "choice_slider":
+            return _ChoiceSlider(extra.get("ui_choices", ()), self)
         if ui_type == "list" or "ui_limits" in extra:
             combo = QtWidgets.QComboBox(self)
             for choice in extra.get("ui_limits", ()):
@@ -481,6 +552,10 @@ class OptionDialog(QtWidgets.QDialog):
             control.sigDpiChanged.connect(
                 lambda _value, row=row: self._control_changed(row)
             )
+        elif isinstance(control, _ChoiceSlider):
+            control.sigValueChanged.connect(
+                lambda _value, row=row: self._control_changed(row)
+            )
         elif isinstance(control, QtWidgets.QComboBox):
             control.currentIndexChanged.connect(
                 lambda _index, row=row: self._control_changed(row)
@@ -546,6 +621,8 @@ class OptionDialog(QtWidgets.QDialog):
             return True
         if isinstance(control, FigureDpiOverrideWidget):
             return False
+        if isinstance(control, _ChoiceSlider):
+            return False
         return isinstance(control, QtWidgets.QComboBox) and not isinstance(
             control, erlab.interactive.colors.ColorMapComboBox
         )
@@ -573,6 +650,8 @@ class OptionDialog(QtWidgets.QDialog):
             return control.value()
         if isinstance(control, erlab.interactive.colors.ColorMapComboBox):
             return control.currentText()
+        if isinstance(control, _ChoiceSlider):
+            return control.currentData()
         if isinstance(control, QtWidgets.QComboBox):
             value = control.currentData()
             return control.currentText() if value is None else value
@@ -605,6 +684,9 @@ class OptionDialog(QtWidgets.QDialog):
         if isinstance(control, erlab.interactive.colors.ColorMapComboBox):
             control.ensure_populated()
             control.setCurrentText(str(value))
+            return
+        if isinstance(control, _ChoiceSlider):
+            control.setCurrentData(value)
             return
         if isinstance(control, QtWidgets.QComboBox):
             index = control.findData(value)

--- a/src/erlab/interactive/derivative.py
+++ b/src/erlab/interactive/derivative.py
@@ -351,6 +351,7 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
 
     @property
     def result(self) -> xr.DataArray:
+        self._flush_restore_work(self._update_result_now)
         return self._result
 
     @result.setter
@@ -393,7 +394,8 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
     def update_image(self) -> None:
         if not self._pause_update:
             self.images[1].setDataArray(
-                self.result, levels=self.get_levels(self.result.values)
+                self._result,
+                levels=self.get_levels(self._result.values),
             )
             self._write_state()
 
@@ -460,9 +462,15 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
     @QtCore.Slot()
     def update_result(self) -> None:
         if not self._pause_update:
-            self.result = self.process_func(self.processed_data, **self.process_kwargs)
-            self._notify_data_changed()
-            self._write_state()
+            self._run_or_defer_restore_work(
+                self._update_result_now,
+                run_on_show=True,
+            )
+
+    def _update_result_now(self) -> None:
+        self.result = self.process_func(self.processed_data, **self.process_kwargs)
+        self._notify_data_changed()
+        self._write_state()
 
     @QtCore.Slot()
     def open_itool(self) -> None:

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -2264,7 +2264,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self.x1_spin.setMinimum(self.x0_spin.value())
 
         self._clear_fit_preview()
-        if self.live_check.isChecked():
+        if self.live_check.isChecked() and not self._dataset_restore_in_progress:
             self._sigTriggerFit.emit()
 
     @QtCore.Slot()
@@ -2288,7 +2288,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self.y1_spin.setMinimum(self.y0_spin.value())
 
         self._update_edc()
-        if self.live_check.isChecked():
+        if self.live_check.isChecked() and not self._dataset_restore_in_progress:
             self._sigTriggerFit.emit()
 
 

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -33,6 +33,8 @@ from erlab.interactive.imagetool.manager._wrapper import (
     _ManagedWindowNode,
 )
 
+_workspace_repack_estimate = _manager_workspace._workspace_manifest_repack_estimate
+
 if typing.TYPE_CHECKING:
     import datetime
     from collections.abc import Callable, Iterable, Mapping
@@ -1220,7 +1222,7 @@ class _ActionsController:
                                     (
                                         schema_version,
                                         delta_save_count,
-                                        _manifest,
+                                        manifest,
                                     ) = metadata_from_attrs(workspace_dt.attrs)
                                     if not self._manager._confirm_save_dirty_workspace(
                                         "Opening a workspace replaces the windows "
@@ -1241,10 +1243,25 @@ class _ActionsController:
                                         )
                                     )
                                     if loaded_workspace:
+                                        (
+                                            estimated_obsolete_bytes,
+                                            replacement_delta_count,
+                                            repack_estimate_known,
+                                        ) = _workspace_repack_estimate(
+                                            manifest,
+                                            delta_save_count=delta_save_count,
+                                        )
                                         self._manager._associate_loaded_workspace_file(
                                             access.path,
                                             schema_version,
                                             delta_save_count=delta_save_count,
+                                            estimated_obsolete_bytes=(
+                                                estimated_obsolete_bytes
+                                            ),
+                                            replacement_delta_count=(
+                                                replacement_delta_count
+                                            ),
+                                            repack_estimate_known=repack_estimate_known,
                                             workspace_access=access,
                                             rebind_data=False,
                                         )

--- a/src/erlab/interactive/imagetool/manager/_dependency.py
+++ b/src/erlab/interactive/imagetool/manager/_dependency.py
@@ -33,14 +33,23 @@ class _ManagerDependencyTracker:
 
     def refs_for_uid(self, uid: str) -> tuple[provenance.ScriptInputDependencyRef, ...]:
         node = self._graph.nodes.get(uid)
-        if node is None or node.provenance_spec is None:
+        if node is None:
             self._ref_cache.pop(uid, None)
             return ()
-        spec_id = id(node.provenance_spec)
+        tool_window = node.tool_window
+        spec = (
+            tool_window.current_provenance_spec(flush_deferred_restore=False)
+            if tool_window is not None
+            else node.provenance_spec
+        )
+        if spec is None:
+            self._ref_cache.pop(uid, None)
+            return ()
+        spec_id = id(spec)
         cached = self._ref_cache.get(uid)
         if cached is not None and cached[0] == spec_id:
             return cached[1]
-        refs = provenance.script_input_dependency_refs(node.provenance_spec)
+        refs = provenance.script_input_dependency_refs(spec)
         self._ref_cache[uid] = (spec_id, refs)
         return refs
 

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -66,6 +66,7 @@ if typing.TYPE_CHECKING:
     import numpy as np
     import xarray as xr
 
+    from erlab.interactive._options.schema import WorkspaceCompressionMode
     from erlab.interactive.imagetool import provenance
     from erlab.interactive.imagetool._load_source import _LoadSourceDetails
     from erlab.interactive.imagetool._mainwindow import ImageTool
@@ -3888,6 +3889,9 @@ class ImageToolManager(_ImageToolManagerBase):
             delta_save_count=delta_save_count
         )
 
+    def _workspace_compression_mode(self) -> WorkspaceCompressionMode:
+        return self._workspace_controller._workspace_compression_mode()
+
     def _workspace_layout_snapshot(self) -> dict[str, typing.Any]:
         return self._workspace_controller._workspace_layout_snapshot()
 
@@ -3896,8 +3900,16 @@ class ImageToolManager(_ImageToolManagerBase):
     ) -> None:
         self._workspace_controller._restore_workspace_layout(manifest)
 
-    def _write_full_workspace_file(self, fname: str | os.PathLike[str]) -> None:
-        self._workspace_controller._write_full_workspace_file(fname)
+    def _write_full_workspace_file(
+        self,
+        fname: str | os.PathLike[str],
+        *,
+        reuse_unchanged_groups: bool = True,
+    ) -> None:
+        self._workspace_controller._write_full_workspace_file(
+            fname,
+            reuse_unchanged_groups=reuse_unchanged_groups,
+        )
 
     def _workspace_highest_dirty_data_roots(self) -> list[str]:
         return self._workspace_controller._workspace_highest_dirty_data_roots()
@@ -3911,9 +3923,13 @@ class ImageToolManager(_ImageToolManagerBase):
         *,
         force_full: bool = False,
         document_access: _WorkspaceDocumentAccess | None = None,
+        reuse_unchanged_groups: bool = True,
     ) -> None:
         self._workspace_controller._save_workspace_document(
-            fname, force_full=force_full, document_access=document_access
+            fname,
+            force_full=force_full,
+            document_access=document_access,
+            reuse_unchanged_groups=reuse_unchanged_groups,
         )
 
     def _workspace_save_dialog(

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1488,6 +1488,8 @@ class ImageToolManager(_ImageToolManagerBase):
                         event.ignore()
                     return
 
+            self._compact_workspace_before_shutdown()
+
             logger.debug("Stopping servers...")
             self._registry_heartbeat_timer.stop()
             self._registry_heartbeat.stop()
@@ -3905,10 +3907,12 @@ class ImageToolManager(_ImageToolManagerBase):
         fname: str | os.PathLike[str],
         *,
         reuse_unchanged_groups: bool = True,
+        require_matching_compression: bool = False,
     ) -> None:
         self._workspace_controller._write_full_workspace_file(
             fname,
             reuse_unchanged_groups=reuse_unchanged_groups,
+            require_matching_compression=require_matching_compression,
         )
 
     def _workspace_highest_dirty_data_roots(self) -> list[str]:
@@ -3924,12 +3928,14 @@ class ImageToolManager(_ImageToolManagerBase):
         force_full: bool = False,
         document_access: _WorkspaceDocumentAccess | None = None,
         reuse_unchanged_groups: bool = True,
+        require_matching_compression: bool = False,
     ) -> None:
         self._workspace_controller._save_workspace_document(
             fname,
             force_full=force_full,
             document_access=document_access,
             reuse_unchanged_groups=reuse_unchanged_groups,
+            require_matching_compression=require_matching_compression,
         )
 
     def _workspace_save_dialog(
@@ -4049,9 +4055,17 @@ class ImageToolManager(_ImageToolManagerBase):
         return self._workspace_controller._workspace_full_save_snapshot(generation)
 
     def _workspace_full_save_copy_groups(
-        self, tree: xr.DataTree
+        self,
+        tree: xr.DataTree,
+        *,
+        compression_mode: WorkspaceCompressionMode | None = None,
+        require_matching_compression: bool = False,
     ) -> tuple[str | None, tuple[tuple[str, str, dict[str, typing.Any] | None], ...]]:
-        return self._workspace_controller._workspace_full_save_copy_groups(tree)
+        return self._workspace_controller._workspace_full_save_copy_groups(
+            tree,
+            compression_mode=compression_mode,
+            require_matching_compression=require_matching_compression,
+        )
 
     def _open_workspace_save_wait_dialog(
         self,

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3885,10 +3885,18 @@ class ImageToolManager(_ImageToolManagerBase):
         return _WorkspaceIOController._tree_item_child_by_key(item, key)
 
     def _workspace_root_attrs_payload(
-        self, *, delta_save_count: int | None = None
+        self,
+        *,
+        delta_save_count: int | None = None,
+        estimated_obsolete_bytes: int | None = None,
+        replacement_delta_count: int | None = None,
+        repack_estimate_known: bool | None = None,
     ) -> dict[str, typing.Any]:
         return self._workspace_controller._workspace_root_attrs_payload(
-            delta_save_count=delta_save_count
+            delta_save_count=delta_save_count,
+            estimated_obsolete_bytes=estimated_obsolete_bytes,
+            replacement_delta_count=replacement_delta_count,
+            repack_estimate_known=repack_estimate_known,
         )
 
     def _workspace_compression_mode(self) -> WorkspaceCompressionMode:
@@ -3975,6 +3983,9 @@ class ImageToolManager(_ImageToolManagerBase):
         *,
         native: bool = True,
         delta_save_count: int = 0,
+        estimated_obsolete_bytes: int = 0,
+        replacement_delta_count: int = 0,
+        repack_estimate_known: bool = True,
         workspace_access: _WorkspaceDocumentAccess | None = None,
         rebind_data: bool = True,
     ) -> None:
@@ -3983,6 +3994,9 @@ class ImageToolManager(_ImageToolManagerBase):
             schema_version,
             native=native,
             delta_save_count=delta_save_count,
+            estimated_obsolete_bytes=estimated_obsolete_bytes,
+            replacement_delta_count=replacement_delta_count,
+            repack_estimate_known=repack_estimate_known,
             workspace_access=workspace_access,
             rebind_data=rebind_data,
         )

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -134,7 +134,11 @@ class _WorkspaceSaveSnapshot:
     generation: int
     root_attrs: dict[str, typing.Any]
     delta_save_count: int
+    estimated_obsolete_bytes: int = 0
+    replacement_delta_count: int = 0
+    repack_estimate_known: bool = True
     compression_mode: WorkspaceCompressionMode = "zstd1"
+    file_repack: bool = False
     full_tree: xr.DataTree | None = None
     copy_source: str | None = None
     copy_groups: tuple[tuple[str, str, dict[str, typing.Any] | None], ...] = ()
@@ -207,7 +211,16 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
         error_text = ""
         ok = False
         try:
-            if self._snapshot.full_tree is None:
+            if self._snapshot.file_repack:
+                _write_full_workspace_tree_file(
+                    self._fname,
+                    None,
+                    self._snapshot.root_attrs,
+                    copy_source=self._snapshot.copy_source,
+                    copy_groups=self._snapshot.copy_groups,
+                    compression_mode=self._snapshot.compression_mode,
+                )
+            elif self._snapshot.full_tree is None:
                 _write_workspace_transaction_file(
                     self._fname,
                     self._snapshot.rewrite_groups,
@@ -372,6 +385,34 @@ def _workspace_delta_save_count_from_attrs(
     return 0
 
 
+def _workspace_manifest_nonnegative_int(
+    manifest: Mapping[str, typing.Any], key: str
+) -> int:
+    value = manifest.get(key, 0)
+    with contextlib.suppress(TypeError, ValueError):
+        return max(0, int(value))
+    return 0
+
+
+def _workspace_manifest_repack_estimate(
+    manifest: Mapping[str, typing.Any] | None,
+    *,
+    delta_save_count: int,
+) -> tuple[int, int, bool]:
+    if delta_save_count <= 0:
+        return 0, 0, True
+    if manifest is None:
+        return 0, 0, False
+    has_estimate = (
+        "estimated_obsolete_bytes" in manifest and "replacement_delta_count" in manifest
+    )
+    return (
+        _workspace_manifest_nonnegative_int(manifest, "estimated_obsolete_bytes"),
+        _workspace_manifest_nonnegative_int(manifest, "replacement_delta_count"),
+        has_estimate,
+    )
+
+
 def _workspace_file_metadata_from_attrs(
     attrs: Mapping[typing.Hashable, typing.Any],
 ) -> tuple[int, int, dict[str, typing.Any] | None]:
@@ -380,6 +421,60 @@ def _workspace_file_metadata_from_attrs(
     if schema_version >= _WORKSPACE_SCHEMA_VERSION:
         manifest = _workspace_manifest_from_attrs(attrs) or None
     return schema_version, _workspace_delta_save_count_from_attrs(attrs), manifest
+
+
+def _compacted_workspace_root_attrs(
+    attrs: Mapping[typing.Hashable, typing.Any],
+) -> dict[str, typing.Any]:
+    schema_version, _delta_save_count, manifest = _workspace_file_metadata_from_attrs(
+        attrs
+    )
+    if schema_version != _WORKSPACE_SCHEMA_VERSION or manifest is None:
+        raise ValueError(
+            "File-level workspace repack requires current workspace schema"
+        )
+    compacted_manifest = dict(manifest)
+    compacted_manifest["schema_version"] = _WORKSPACE_SCHEMA_VERSION
+    compacted_manifest["erlab_version"] = erlab.__version__
+    compacted_manifest.pop("delta_save_count", None)
+    compacted_manifest.pop("transaction_protocol", None)
+    compacted_manifest.pop("estimated_obsolete_bytes", None)
+    compacted_manifest.pop("replacement_delta_count", None)
+
+    root_attrs = dict(attrs)
+    root_attrs["imagetool_workspace_schema_version"] = _WORKSPACE_SCHEMA_VERSION
+    root_attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(compacted_manifest)
+    root_attrs["erlab_version"] = erlab.__version__
+    return root_attrs
+
+
+def _workspace_root_attrs_with_repack_estimate(
+    attrs: Mapping[typing.Hashable, typing.Any],
+    *,
+    estimated_obsolete_bytes: int,
+    replacement_delta_count: int,
+    repack_estimate_known: bool = True,
+) -> dict[str, typing.Any]:
+    schema_version, delta_save_count, manifest = _workspace_file_metadata_from_attrs(
+        attrs
+    )
+    if schema_version != _WORKSPACE_SCHEMA_VERSION or manifest is None:
+        return dict(attrs)
+    updated_manifest = dict(manifest)
+    if delta_save_count > 0 and repack_estimate_known:
+        updated_manifest["estimated_obsolete_bytes"] = max(
+            0, int(estimated_obsolete_bytes)
+        )
+        updated_manifest["replacement_delta_count"] = max(
+            0, int(replacement_delta_count)
+        )
+    else:
+        updated_manifest.pop("estimated_obsolete_bytes", None)
+        updated_manifest.pop("replacement_delta_count", None)
+
+    root_attrs = dict(attrs)
+    root_attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(updated_manifest)
+    return root_attrs
 
 
 def _current_workspace_schema_version() -> int:
@@ -419,6 +514,9 @@ def _workspace_root_attrs_payload(
     loader_state: Mapping[str, typing.Any] | None = None,
     standalone_apps: Mapping[str, typing.Any] | None = None,
     option_overrides: Mapping[str, typing.Any] | None = None,
+    estimated_obsolete_bytes: int = 0,
+    replacement_delta_count: int = 0,
+    repack_estimate_known: bool = True,
 ) -> dict[str, typing.Any]:
     manifest: dict[str, typing.Any] = {
         "schema_version": _WORKSPACE_SCHEMA_VERSION,
@@ -447,6 +545,9 @@ def _workspace_root_attrs_payload(
         # Marks files written through the recoverable in-place delta-save protocol.
         manifest["transaction_protocol"] = _WORKSPACE_TRANSACTION_PROTOCOL
         manifest["delta_save_count"] = int(delta_save_count)
+        if repack_estimate_known:
+            manifest["estimated_obsolete_bytes"] = max(0, int(estimated_obsolete_bytes))
+            manifest["replacement_delta_count"] = max(0, int(replacement_delta_count))
     return {
         "imagetool_workspace_schema_version": _WORKSPACE_SCHEMA_VERSION,
         _WORKSPACE_MANIFEST_ATTR: json.dumps(manifest),
@@ -1144,6 +1245,94 @@ def _read_workspace_root_attrs_h5py(
         if not _workspace_file_is_workspace(h5_file):
             raise ValueError("Not a valid workspace file")
         return _h5py_attrs_to_dict(h5_file.attrs)
+
+
+def _workspace_live_root_group_copy_groups(
+    fname: str | os.PathLike[str],
+) -> tuple[tuple[str, str, dict[str, typing.Any] | None], ...]:
+    import h5py
+
+    _xarray.ensure_workspace_hdf5_filters_registered()
+    with _xarray._workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
+        if not _workspace_file_is_workspace(h5_file):
+            raise ValueError("Not a valid workspace file")
+        return tuple(
+            (name, name, None)
+            for name, item in h5_file.items()
+            if isinstance(item, h5py.Group)
+            and not _is_workspace_internal_group_name(name)
+        )
+
+
+def _workspace_h5_object_storage_size(obj: typing.Any) -> int:
+    import h5py
+
+    if isinstance(obj, h5py.Dataset):
+        return max(0, int(obj.id.get_storage_size()))
+    if isinstance(obj, h5py.Group):
+        return sum(_workspace_h5_object_storage_size(child) for child in obj.values())
+    return 0
+
+
+def _workspace_h5_paths_storage_size(
+    fname: str | os.PathLike[str],
+    paths: Iterable[str],
+) -> tuple[int, int]:
+    import h5py
+
+    total = 0
+    existing_count = 0
+    _xarray.ensure_workspace_hdf5_filters_registered()
+    with _xarray._workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
+        if not _workspace_file_is_workspace(h5_file):
+            raise ValueError("Not a valid workspace file")
+        for path in paths:
+            path = path.strip("/")
+            if path not in h5_file:
+                continue
+            existing_count += 1
+            total += _workspace_h5_object_storage_size(h5_file[path])
+    return total, existing_count
+
+
+def _workspace_live_h5_storage_size(fname: str | os.PathLike[str]) -> int:
+    import h5py
+
+    total = 0
+    _xarray.ensure_workspace_hdf5_filters_registered()
+    with _xarray._workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
+        if not _workspace_file_is_workspace(h5_file):
+            raise ValueError("Not a valid workspace file")
+        for name, item in h5_file.items():
+            if isinstance(item, h5py.Group) and not _is_workspace_internal_group_name(
+                name
+            ):
+                total += _workspace_h5_object_storage_size(item)
+    return total
+
+
+def _workspace_obsolete_estimate(
+    fname: str | os.PathLike[str],
+) -> int:
+    try:
+        file_size = pathlib.Path(fname).stat().st_size
+    except OSError:
+        return 0
+    live_storage_size = _workspace_live_h5_storage_size(fname)
+    return max(0, int(file_size) - live_storage_size)
+
+
+def _workspace_file_repack_payload(
+    fname: str | os.PathLike[str],
+) -> tuple[
+    dict[str, typing.Any], tuple[tuple[str, str, dict[str, typing.Any] | None], ...]
+]:
+    _recover_workspace_transactions(fname)
+    root_attrs = _read_workspace_root_attrs_h5py(fname)
+    return (
+        _compacted_workspace_root_attrs(root_attrs),
+        _workspace_live_root_group_copy_groups(fname),
+    )
 
 
 def _workspace_h5py_dataset_storage_supported(dataset: typing.Any) -> bool:
@@ -2275,7 +2464,7 @@ def _write_workspace_transaction_file(
 
 def _write_full_workspace_tree_file(
     fname: str | os.PathLike[str],
-    tree: xr.DataTree,
+    tree: xr.DataTree | None,
     root_attrs: Mapping[str, typing.Any],
     *,
     copy_source: str | os.PathLike[str] | None = None,
@@ -2300,6 +2489,11 @@ def _write_full_workspace_tree_file(
         _xarray.ensure_workspace_hdf5_filters_registered()
         copy_groups_tuple = tuple(copy_groups)
         if use_scratch and _workspace_path_is_likely_network_path(fname):
+            if tree is None and copy_source is not None and copy_groups_tuple:
+                raise ValueError(
+                    "File-level workspace repack cannot run when HDF5 group "
+                    "copy reuse is disabled"
+                )
             copy_source = None
             copy_groups_tuple = ()
         if copy_source is not None and copy_groups_tuple:
@@ -2327,18 +2521,19 @@ def _write_full_workspace_tree_file(
                     tmp_file, root_attrs, replace=True
                 )
 
-        for node in sorted(tree.subtree, key=lambda value: value.path.count("/")):
-            group_path = node.path.strip("/")
-            if not group_path or group_path in copied_paths:
-                continue
-            ds = node.to_dataset(inherit=False)
-            if ds.variables or ds.attrs:
-                _write_workspace_dataset_group_to_file(
-                    tmp_fname,
-                    group_path,
-                    ds,
-                    compression_mode=compression_mode,
-                )
+        if tree is not None:
+            for node in sorted(tree.subtree, key=lambda value: value.path.count("/")):
+                group_path = node.path.strip("/")
+                if not group_path or group_path in copied_paths:
+                    continue
+                ds = node.to_dataset(inherit=False)
+                if ds.variables or ds.attrs:
+                    _write_workspace_dataset_group_to_file(
+                        tmp_fname,
+                        group_path,
+                        ds,
+                        compression_mode=compression_mode,
+                    )
 
         _validate_workspace_h5_file(tmp_fname)
         _fsync_file(tmp_fname)

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -86,6 +86,9 @@ _WORKSPACE_ENCODED_ATTRS_VERSION = 1
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
 _SAVED_TOOL_DATA_BLOB_DIM_PREFIX = _serialization.SAVED_TOOL_DATA_BLOB_DIM_PREFIX
+_WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS = frozenset(
+    {"CLASS", "NAME", "DIMENSION_LIST", "REFERENCE_LIST"}
+)
 
 
 class WorkspaceLoaderState(pydantic.BaseModel):
@@ -1263,6 +1266,200 @@ def _workspace_h5py_create_kwargs(
     return kwargs
 
 
+def _workspace_h5py_filter_options(dataset: typing.Any) -> dict[int, tuple[int, ...]]:
+    create_plist = dataset.id.get_create_plist()
+    return {
+        create_plist.get_filter(index)[0]: tuple(create_plist.get_filter(index)[2])
+        for index in range(create_plist.get_nfilters())
+    }
+
+
+def _workspace_h5py_dataset_matches_encoding(
+    dataset: typing.Any,
+    encoding: Mapping[typing.Hashable, typing.Any],
+) -> bool:
+    filters = _workspace_h5py_filter_options(dataset)
+    expected_filter = encoding.get("compression")
+    if expected_filter is None:
+        return not filters
+    actual_options = filters.get(int(expected_filter))
+    if actual_options is None:
+        return False
+    expected_options = encoding.get("compression_opts")
+    return expected_options is None or actual_options == tuple(expected_options)
+
+
+def _workspace_h5_group_matches_compression_mode(
+    h5_file: typing.Any,
+    group_path: str,
+    ds: xr.Dataset,
+    compression_mode: WorkspaceCompressionMode,
+) -> bool:
+    group_path = group_path.strip("/")
+    if group_path not in h5_file:
+        return False
+    group = h5_file[group_path]
+    encoding = _xarray.workspace_dataset_encoding(ds, compression_mode=compression_mode)
+    for name in ds.data_vars:
+        dataset_name = str(name)
+        if dataset_name not in group:
+            return False
+        dataset = group[dataset_name]
+        if not _workspace_h5py_dataset_matches_encoding(
+            dataset, encoding.get(name, {})
+        ):
+            return False
+    return True
+
+
+def _workspace_h5py_attr_text(value: typing.Any) -> str | None:
+    if isinstance(value, bytes):
+        return value.decode()
+    if hasattr(value, "decode"):
+        decoded = value.decode()
+        return str(decoded)
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _workspace_h5py_dataset_is_dimension_scale(dataset: typing.Any) -> bool:
+    return _workspace_h5py_attr_text(dataset.attrs.get("CLASS")) == "DIMENSION_SCALE"
+
+
+def _workspace_h5py_type_contains_reference(type_id: typing.Any) -> bool:
+    import h5py
+
+    type_class = type_id.get_class()
+    if type_class == h5py.h5t.REFERENCE:
+        return True
+    if type_class in {h5py.h5t.ARRAY, h5py.h5t.VLEN}:
+        super_type = type_id.get_super()
+        try:
+            return _workspace_h5py_type_contains_reference(super_type)
+        finally:
+            super_type.close()
+    if type_class == h5py.h5t.COMPOUND:
+        for index in range(type_id.get_nmembers()):
+            member_type = type_id.get_member_type(index)
+            try:
+                if _workspace_h5py_type_contains_reference(member_type):
+                    return True
+            finally:
+                member_type.close()
+    return False
+
+
+def _workspace_h5py_attr_contains_reference(
+    source_attrs: typing.Any, key: typing.Hashable
+) -> bool:
+    attr_id = source_attrs.get_id(key)
+    type_id = attr_id.get_type()
+    try:
+        return _workspace_h5py_type_contains_reference(type_id)
+    finally:
+        type_id.close()
+        attr_id.close()
+
+
+def _workspace_h5py_copy_regular_attrs(
+    source_attrs: typing.Any,
+    target_attrs: typing.Any,
+    *,
+    skip_dimension_scale_attrs: bool,
+) -> None:
+    for key, value in source_attrs.items():
+        if skip_dimension_scale_attrs and key in _WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS:
+            continue
+        if _workspace_h5py_attr_contains_reference(source_attrs, key):
+            continue
+        target_attrs[key] = value
+
+
+def _workspace_h5py_rebuild_dimension_scales(
+    source_group: typing.Any,
+    target_group: typing.Any,
+) -> None:
+    import h5py
+    import numpy as np
+
+    _workspace_h5py_copy_regular_attrs(
+        source_group.attrs,
+        target_group.attrs,
+        skip_dimension_scale_attrs=False,
+    )
+    scales_by_id: dict[int, typing.Any] = {}
+    for name, source_obj in source_group.items():
+        target_obj = target_group[name]
+        if isinstance(source_obj, h5py.Group):
+            _workspace_h5py_rebuild_dimension_scales(source_obj, target_obj)
+            continue
+        if not isinstance(source_obj, h5py.Dataset):
+            continue
+        _workspace_h5py_copy_regular_attrs(
+            source_obj.attrs,
+            target_obj.attrs,
+            skip_dimension_scale_attrs=True,
+        )
+        if not _workspace_h5py_dataset_is_dimension_scale(source_obj):
+            continue
+        dim_id = source_obj.attrs.get("_Netcdf4Dimid")
+        if dim_id is None:
+            continue
+        scale_name = _workspace_h5py_attr_text(source_obj.attrs.get("NAME")) or name
+        target_obj.make_scale(scale_name)
+        target_obj.attrs["_Netcdf4Dimid"] = np.int32(dim_id)
+        if "_Netcdf4Coordinates" in source_obj.attrs:
+            target_obj.attrs["_Netcdf4Coordinates"] = source_obj.attrs[
+                "_Netcdf4Coordinates"
+            ]
+        scales_by_id[int(dim_id)] = target_obj
+
+    for name, source_obj in source_group.items():
+        if not isinstance(source_obj, h5py.Dataset):
+            continue
+        if _workspace_h5py_dataset_is_dimension_scale(source_obj):
+            continue
+        if "_Netcdf4Coordinates" not in source_obj.attrs:
+            continue
+        target_obj = target_group[name]
+        coordinate_ids = np.asarray(source_obj.attrs["_Netcdf4Coordinates"]).reshape(-1)
+        if len(coordinate_ids) != target_obj.ndim:
+            continue
+        for axis, dim_id in enumerate(coordinate_ids):
+            scale = scales_by_id.get(int(dim_id))
+            if scale is not None:
+                target_obj.dims[axis].attach_scale(scale)
+
+
+def _copy_workspace_h5_group_to_open_file(
+    source_file: typing.Any,
+    target_file: typing.Any,
+    source_path: str,
+    target_path: str,
+    attrs: Mapping[str, typing.Any] | None,
+) -> bool:
+    import h5py
+
+    source_path = source_path.strip("/")
+    target_path = target_path.strip("/")
+    if source_path not in source_file:
+        return False
+    source_group = source_file[source_path]
+    if not isinstance(source_group, h5py.Group):
+        return False
+    parent = _ensure_h5_parent_group(target_file, target_path)
+    target_name = target_path.rsplit("/", maxsplit=1)[-1]
+    if target_name in parent:
+        del parent[target_name]
+    source_file.copy(source_path, parent, name=target_name, without_attrs=True)
+    target_group = parent[target_name]
+    _workspace_h5py_rebuild_dimension_scales(source_group, target_group)
+    if attrs is not None:
+        _replace_h5_attrs(target_group.attrs, attrs)
+    return True
+
+
 def _workspace_h5py_create_dataset(
     group: typing.Any,
     name: str,
@@ -2106,44 +2303,24 @@ def _write_full_workspace_tree_file(
             copy_source = None
             copy_groups_tuple = ()
         if copy_source is not None and copy_groups_tuple:
-            with _xarray._workspace_file_lock(copy_source):
-                shutil.copyfile(copy_source, tmp_fname)
-            staging_root = f"__itws_copy_{uuid.uuid4().hex}"
-            staged_groups: list[
-                tuple[str, tuple[str, str, dict[str, typing.Any] | None]]
-            ] = []
-            with h5py.File(tmp_fname, "a") as tmp_file:
-                tmp_file.create_group(staging_root)
-                for index, (source_path, destination_path, attrs) in enumerate(
-                    copy_groups_tuple
-                ):
-                    source_path = source_path.strip("/")
-                    if source_path not in tmp_file:
-                        continue
-                    stage_path = f"{staging_root}/{index}"
-                    _move_h5_path(tmp_file, source_path, stage_path)
-                    staged_groups.append(
-                        (stage_path, (source_path, destination_path, attrs))
-                    )
-
-                for name in list(tmp_file):
-                    if name != staging_root:
-                        del tmp_file[name]
+            with (
+                _xarray._workspace_file_lock(copy_source),
+                h5py.File(copy_source, "r") as source_file,
+                h5py.File(tmp_fname, "w") as tmp_file,
+            ):
                 _write_root_attrs_to_open_workspace_file(
                     tmp_file, root_attrs, replace=True
                 )
-
-                for stage_path, (
-                    _source_path,
-                    destination_path,
-                    attrs,
-                ) in staged_groups:
+                for source_path, destination_path, attrs in copy_groups_tuple:
                     destination_path = destination_path.strip("/")
-                    _move_h5_path(tmp_file, stage_path, destination_path)
-                    if attrs is not None:
-                        _replace_h5_attrs(tmp_file[destination_path].attrs, attrs)
-                    copied_paths.add(destination_path)
-                del tmp_file[staging_root]
+                    if _copy_workspace_h5_group_to_open_file(
+                        source_file,
+                        tmp_file,
+                        source_path,
+                        destination_path,
+                        attrs,
+                    ):
+                        copied_paths.add(destination_path)
         else:
             with h5py.File(tmp_fname, "w") as tmp_file:
                 _write_root_attrs_to_open_workspace_file(

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -363,7 +363,7 @@ def _acquire_workspace_document_lock(
 
 
 def _workspace_manifest_from_attrs(
-    attrs: Mapping[typing.Hashable, typing.Any],
+    attrs: Mapping[typing.Any, typing.Any],
 ) -> dict[str, typing.Any]:
     raw_manifest = attrs.get(_WORKSPACE_MANIFEST_ATTR)
     if isinstance(raw_manifest, bytes):
@@ -377,7 +377,7 @@ def _workspace_manifest_from_attrs(
 
 
 def _workspace_delta_save_count_from_attrs(
-    attrs: Mapping[typing.Hashable, typing.Any],
+    attrs: Mapping[typing.Any, typing.Any],
 ) -> int:
     value = _workspace_manifest_from_attrs(attrs).get("delta_save_count", 0)
     with contextlib.suppress(TypeError, ValueError):
@@ -414,7 +414,7 @@ def _workspace_manifest_repack_estimate(
 
 
 def _workspace_file_metadata_from_attrs(
-    attrs: Mapping[typing.Hashable, typing.Any],
+    attrs: Mapping[typing.Any, typing.Any],
 ) -> tuple[int, int, dict[str, typing.Any] | None]:
     schema_version = int(attrs.get("imagetool_workspace_schema_version", 1))
     manifest = None
@@ -424,7 +424,7 @@ def _workspace_file_metadata_from_attrs(
 
 
 def _compacted_workspace_root_attrs(
-    attrs: Mapping[typing.Hashable, typing.Any],
+    attrs: Mapping[typing.Any, typing.Any],
 ) -> dict[str, typing.Any]:
     schema_version, _delta_save_count, manifest = _workspace_file_metadata_from_attrs(
         attrs
@@ -441,7 +441,7 @@ def _compacted_workspace_root_attrs(
     compacted_manifest.pop("estimated_obsolete_bytes", None)
     compacted_manifest.pop("replacement_delta_count", None)
 
-    root_attrs = dict(attrs)
+    root_attrs = {str(key): value for key, value in attrs.items()}
     root_attrs["imagetool_workspace_schema_version"] = _WORKSPACE_SCHEMA_VERSION
     root_attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(compacted_manifest)
     root_attrs["erlab_version"] = erlab.__version__
@@ -449,7 +449,7 @@ def _compacted_workspace_root_attrs(
 
 
 def _workspace_root_attrs_with_repack_estimate(
-    attrs: Mapping[typing.Hashable, typing.Any],
+    attrs: Mapping[typing.Any, typing.Any],
     *,
     estimated_obsolete_bytes: int,
     replacement_delta_count: int,
@@ -459,7 +459,7 @@ def _workspace_root_attrs_with_repack_estimate(
         attrs
     )
     if schema_version != _WORKSPACE_SCHEMA_VERSION or manifest is None:
-        return dict(attrs)
+        return {str(key): value for key, value in attrs.items()}
     updated_manifest = dict(manifest)
     if delta_save_count > 0 and repack_estimate_known:
         updated_manifest["estimated_obsolete_bytes"] = max(
@@ -472,7 +472,7 @@ def _workspace_root_attrs_with_repack_estimate(
         updated_manifest.pop("estimated_obsolete_bytes", None)
         updated_manifest.pop("replacement_delta_count", None)
 
-    root_attrs = dict(attrs)
+    root_attrs = {str(key): value for key, value in attrs.items()}
     root_attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(updated_manifest)
     return root_attrs
 
@@ -1465,7 +1465,7 @@ def _workspace_h5py_filter_options(dataset: typing.Any) -> dict[int, tuple[int, 
 
 def _workspace_h5py_dataset_matches_encoding(
     dataset: typing.Any,
-    encoding: Mapping[typing.Hashable, typing.Any],
+    encoding: Mapping[typing.Any, typing.Any],
 ) -> bool:
     filters = _workspace_h5py_filter_options(dataset)
     expected_filter = encoding.get("compression")

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -1244,14 +1244,32 @@ def _workspace_h5py_dataset_variable(
     return _workspace_h5py_decode_coord_variable(variable, name)
 
 
+def _workspace_h5py_create_kwargs(
+    encoding: Mapping[str, typing.Any] | None,
+) -> dict[str, typing.Any]:
+    if encoding is None:
+        return {}
+    kwargs: dict[str, typing.Any] = {}
+    if "chunksizes" in encoding:
+        kwargs["chunks"] = encoding["chunksizes"]
+    for key in ("compression", "compression_opts", "shuffle", "fletcher32"):
+        if key in encoding:
+            kwargs[key] = encoding[key]
+    return kwargs
+
+
 def _workspace_h5py_create_dataset(
-    group: typing.Any, name: str, variable: xr.Variable
+    group: typing.Any,
+    name: str,
+    variable: xr.Variable,
+    *,
+    encoding: Mapping[str, typing.Any] | None = None,
 ) -> typing.Any | None:
     payload = _workspace_h5py_variable_payload(variable, name)
     if payload is None:
         return None
     data, attrs, dtype = payload
-    kwargs: dict[str, typing.Any] = {}
+    kwargs = _workspace_h5py_create_kwargs(encoding)
     if dtype is not None:
         kwargs["dtype"] = dtype
     dataset = group.create_dataset(name, data=data, **kwargs)
@@ -1620,10 +1638,15 @@ def _workspace_dataset_can_write_h5py(ds: xr.Dataset) -> bool:
 def _write_workspace_independent_tool_items_h5py(
     group: typing.Any,
     ds: xr.Dataset,
+    *,
+    encoding: Mapping[typing.Hashable, Mapping[str, typing.Any]] | None = None,
 ) -> bool:
     for variable_name, data_array in ds.data_vars.items():
         dataset = _workspace_h5py_create_dataset(
-            group, str(variable_name), data_array.variable
+            group,
+            str(variable_name),
+            data_array.variable,
+            encoding=None if encoding is None else encoding.get(variable_name),
         )
         if dataset is None:
             return False
@@ -1659,8 +1682,12 @@ def _write_workspace_dataset_group_h5py(
         try:
             for key, value in ds.attrs.items():
                 group.attrs[key] = value
+            if encoding is None:
+                encoding = _xarray.workspace_dataset_encoding(ds)
             if _workspace_h5py_dataset_has_only_independent_tool_items(ds, data_name):
-                if not _write_workspace_independent_tool_items_h5py(group, ds):
+                if not _write_workspace_independent_tool_items_h5py(
+                    group, ds, encoding=encoding
+                ):
                     del parent[group_name]
                     return False
                 return True
@@ -1683,19 +1710,11 @@ def _write_workspace_dataset_group_h5py(
                 dim_scales.append(coord_dataset)
                 dim_scales_by_name[dim] = coord_dataset
 
-            if encoding is None:
-                encoding = _xarray.workspace_dataset_encoding(ds)
             data_encoding = encoding.get(data_name, {})
-            create_kwargs: dict[str, typing.Any] = {}
-            if "chunksizes" in data_encoding:
-                create_kwargs["chunks"] = data_encoding["chunksizes"]
-            for key in ("compression", "compression_opts", "shuffle", "fletcher32"):
-                if key in data_encoding:
-                    create_kwargs[key] = data_encoding[key]
             data_dataset = group.create_dataset(
                 str(data_name),
                 data=np.asarray(data_array.data),
-                **create_kwargs,
+                **_workspace_h5py_create_kwargs(data_encoding),
             )
             for dim_index, scale in enumerate(dim_scales):
                 data_dataset.dims[dim_index].attach_scale(scale)
@@ -1758,7 +1777,10 @@ def _write_workspace_dataset_group_h5py(
             for extra_name in _workspace_h5py_extra_tool_data_names(ds, data_name):
                 extra_data = ds[extra_name]
                 extra_dataset = _workspace_h5py_create_dataset(
-                    group, str(extra_name), extra_data.variable
+                    group,
+                    str(extra_name),
+                    extra_data.variable,
+                    encoding=encoding.get(extra_name),
                 )
                 if extra_dataset is None:
                     del parent[group_name]

--- a/src/erlab/interactive/imagetool/manager/_workspace.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace.py
@@ -72,6 +72,8 @@ if typing.TYPE_CHECKING:
 
     import xarray as xr
 
+    from erlab.interactive._options.schema import WorkspaceCompressionMode
+
 _WORKSPACE_SCHEMA_VERSION = 4
 _WORKSPACE_LEGACY_SCHEMA_VERSION = 3
 _WORKSPACE_MANIFEST_ATTR = "imagetool_workspace_manifest"
@@ -129,6 +131,7 @@ class _WorkspaceSaveSnapshot:
     generation: int
     root_attrs: dict[str, typing.Any]
     delta_save_count: int
+    compression_mode: WorkspaceCompressionMode = "zstd1"
     full_tree: xr.DataTree | None = None
     copy_source: str | None = None
     copy_groups: tuple[tuple[str, str, dict[str, typing.Any] | None], ...] = ()
@@ -207,6 +210,7 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
                     self._snapshot.rewrite_groups,
                     self._snapshot.attr_updates,
                     self._snapshot.root_attrs,
+                    compression_mode=self._snapshot.compression_mode,
                 )
             else:
                 _write_full_workspace_tree_file(
@@ -215,6 +219,7 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
                     self._snapshot.root_attrs,
                     copy_source=self._snapshot.copy_source,
                     copy_groups=self._snapshot.copy_groups,
+                    compression_mode=self._snapshot.compression_mode,
                 )
             ok = True
         except Exception:
@@ -1797,8 +1802,9 @@ def _write_workspace_dataset_group_to_file(
     ds: xr.Dataset,
     *,
     lock_path: str | os.PathLike[str] | None = None,
+    compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
-    encoding = _xarray.workspace_dataset_encoding(ds)
+    encoding = _xarray.workspace_dataset_encoding(ds, compression_mode=compression_mode)
     if lock_path is not None:
         normalized_lock_path = _xarray._normalized_file_path(lock_path)
         if normalized_lock_path is not None and any(
@@ -1851,6 +1857,8 @@ def _write_workspace_constructor_groups_to_pending(
     constructor: Mapping[str, xr.Dataset],
     group_path: str,
     pending_path: str,
+    *,
+    compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
     target_group_path = group_path.strip("/")
     pending_path = pending_path.strip("/")
@@ -1867,7 +1875,11 @@ def _write_workspace_constructor_groups_to_pending(
             pending_path if not relative_path else f"{pending_path}/{relative_path}"
         )
         _write_workspace_dataset_group_to_file(
-            fname, pending_group_path, ds, lock_path=fname
+            fname,
+            pending_group_path,
+            ds,
+            lock_path=fname,
+            compression_mode=compression_mode,
         )
 
 
@@ -1961,6 +1973,8 @@ def _write_workspace_transaction_pending_groups(
     fname: str | os.PathLike[str],
     rewrite_map: Mapping[str, tuple[str, dict[str, xr.Dataset]]],
     pending_root: str,
+    *,
+    compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
     try:
         for group_path, (rewrite_group_path, constructor) in sorted(
@@ -1972,6 +1986,7 @@ def _write_workspace_transaction_pending_groups(
                 constructor,
                 rewrite_group_path,
                 pending_group_path,
+                compression_mode=compression_mode,
             )
     except Exception:
         with _open_workspace_h5_file_for_update(fname) as h5_file:
@@ -2019,6 +2034,8 @@ def _write_workspace_transaction_file(
         tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
     ],
     root_attrs: Mapping[str, typing.Any],
+    *,
+    compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
     _recover_workspace_transactions(fname)
     rewrite_map = {
@@ -2040,7 +2057,12 @@ def _write_workspace_transaction_file(
         root_attrs,
     )
     try:
-        _write_workspace_transaction_pending_groups(fname, rewrite_map, pending_root)
+        _write_workspace_transaction_pending_groups(
+            fname,
+            rewrite_map,
+            pending_root,
+            compression_mode=compression_mode,
+        )
         _commit_workspace_transaction(
             fname,
             txn_path,
@@ -2061,6 +2083,7 @@ def _write_full_workspace_tree_file(
     *,
     copy_source: str | os.PathLike[str] | None = None,
     copy_groups: Iterable[tuple[str, str, dict[str, typing.Any] | None]] = (),
+    compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
     import shutil
 
@@ -2133,7 +2156,12 @@ def _write_full_workspace_tree_file(
                 continue
             ds = node.to_dataset(inherit=False)
             if ds.variables or ds.attrs:
-                _write_workspace_dataset_group_to_file(tmp_fname, group_path, ds)
+                _write_workspace_dataset_group_to_file(
+                    tmp_fname,
+                    group_path,
+                    ds,
+                    compression_mode=compression_mode,
+                )
 
         _validate_workspace_h5_file(tmp_fname)
         _fsync_file(tmp_fname)

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -3423,7 +3423,11 @@ class _WorkspaceIOController:
             with erlab.interactive.utils.wait_dialog(
                 origin or self._manager, "Compacting workspace..."
             ):
-                self._manager._save_workspace_document(workspace_path, force_full=True)
+                self._manager._save_workspace_document(
+                    workspace_path,
+                    force_full=True,
+                    reuse_unchanged_groups=False,
+                )
                 self._manager._rebind_workspace_backed_imagetools(
                     workspace_path,
                     backing_snapshot=backing_snapshot,

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -1329,6 +1329,7 @@ class _WorkspaceIOController:
                     ds,
                     _source_parent_data=source_parent_data,
                     _tool_data_reference_resolver=_tool_data_reference_resolver,
+                    _defer_restore_work=True,
                 )
             )
         with _workspace_load_stage(profiler, "tool manager registration"):

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -70,6 +70,10 @@ _WORKSPACE_LOAD_TIMING_ENV = "ERLAB_WORKSPACE_LOAD_TIMING"
 _WORKSPACE_SAVE_SUFFIX_ERROR = "ImageTool workspace documents must be saved as .itws"
 _WORKSPACE_LOAD_SUFFIX_ERROR = "ImageTool workspace files must use the .itws extension"
 _WORKSPACE_SAVE_SUFFIX_WARNING = "ImageTool Manager saves workspaces as .itws files."
+_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES = 128 * 1024 * 1024
+_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO = 0.10
+_workspace_obsolete_estimate = _manager_workspace._workspace_obsolete_estimate
+_workspace_repack_estimate = _manager_workspace._workspace_manifest_repack_estimate
 
 
 def _require_itws_workspace_path(fname: str | os.PathLike[str], message: str) -> None:
@@ -642,6 +646,8 @@ class _WorkspaceIOController:
         self._manager._release_workspace_lock()
         self._manager._workspace_state.lock = workspace_lock
         self._manager._workspace_state.path = workspace_path
+        self._manager._workspace_state.delta_save_count = 0
+        self._manager._workspace_state.reset_repack_estimate()
         if self._manager._workspace_state.path is not None:
             self._manager._recent_directory = str(
                 self._manager._workspace_state.path.parent
@@ -2193,10 +2199,22 @@ class _WorkspaceIOController:
         return None
 
     def _workspace_root_attrs_payload(
-        self, *, delta_save_count: int | None = None
+        self,
+        *,
+        delta_save_count: int | None = None,
+        estimated_obsolete_bytes: int | None = None,
+        replacement_delta_count: int | None = None,
+        repack_estimate_known: bool | None = None,
     ) -> dict[str, typing.Any]:
+        state = self._manager._workspace_state
         if delta_save_count is None:
-            delta_save_count = self._manager._workspace_state.delta_save_count
+            delta_save_count = state.delta_save_count
+        if estimated_obsolete_bytes is None:
+            estimated_obsolete_bytes = state.estimated_obsolete_bytes
+        if replacement_delta_count is None:
+            replacement_delta_count = state.replacement_delta_count
+        if repack_estimate_known is None:
+            repack_estimate_known = state.repack_estimate_known
         return _manager_workspace._workspace_root_attrs_payload(
             root_order=self._manager._workspace_root_indices(),
             nodes=self._manager._workspace_node_manifest_entries(),
@@ -2207,6 +2225,9 @@ class _WorkspaceIOController:
             loader_state=self._workspace_loader_state_snapshot(),
             standalone_apps=self._workspace_standalone_apps_snapshot(),
             option_overrides=self._workspace_option_overrides_snapshot(),
+            estimated_obsolete_bytes=estimated_obsolete_bytes,
+            replacement_delta_count=replacement_delta_count,
+            repack_estimate_known=repack_estimate_known,
         )
 
     def _workspace_compression_mode(self) -> WorkspaceCompressionMode:
@@ -2559,6 +2580,12 @@ class _WorkspaceIOController:
                 snapshot.root_attrs,
                 compression_mode=snapshot.compression_mode,
             )
+            self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
+            self._manager._workspace_state.set_repack_estimate(
+                estimated_obsolete_bytes=snapshot.estimated_obsolete_bytes,
+                replacement_delta_count=snapshot.replacement_delta_count,
+                known=snapshot.repack_estimate_known,
+            )
         finally:
             snapshot.close()
 
@@ -2598,12 +2625,12 @@ class _WorkspaceIOController:
                     require_matching_compression=require_matching_compression,
                 )
                 self._manager._workspace_state.delta_save_count = 0
+                self._manager._workspace_state.reset_repack_estimate()
                 self._manager._workspace_state.schema_version = (
                     _manager_workspace._current_workspace_schema_version()
                 )
             else:
                 self._manager._save_workspace_delta(fname)
-                self._manager._workspace_state.delta_save_count += 1
         finally:
             self._manager._workspace_state.saving_depth -= 1
         self._manager._workspace_state.needs_full_save = False
@@ -2721,6 +2748,9 @@ class _WorkspaceIOController:
         *,
         native: bool = True,
         delta_save_count: int = 0,
+        estimated_obsolete_bytes: int = 0,
+        replacement_delta_count: int = 0,
+        repack_estimate_known: bool = True,
         workspace_access: _WorkspaceDocumentAccess | None = None,
         rebind_data: bool = True,
     ) -> None:
@@ -2739,6 +2769,9 @@ class _WorkspaceIOController:
                 return
             associated_fname, associated_lock = converted
             delta_save_count = 0
+            estimated_obsolete_bytes = 0
+            replacement_delta_count = 0
+            repack_estimate_known = True
             schema_version = _manager_workspace._current_workspace_schema_version()
         elif workspace_access is not None:
             associated_lock = workspace_access.take_lock()
@@ -2747,6 +2780,11 @@ class _WorkspaceIOController:
             associated_fname, workspace_lock=associated_lock
         )
         self._manager._workspace_state.delta_save_count = delta_save_count
+        self._manager._workspace_state.set_repack_estimate(
+            estimated_obsolete_bytes=estimated_obsolete_bytes,
+            replacement_delta_count=replacement_delta_count,
+            known=repack_estimate_known,
+        )
         self._manager._workspace_state.schema_version = schema_version
         self._manager._workspace_state.needs_full_save = (
             _manager_workspace._workspace_schema_requires_full_save(schema_version)
@@ -2986,6 +3024,7 @@ class _WorkspaceIOController:
         root_attrs: dict[str, typing.Any],
         delta_save_count: int,
     ) -> _manager_workspace._WorkspaceSaveSnapshot:
+        state = self._manager._workspace_state
         rewrite_groups: list[tuple[str, dict[str, xr.Dataset]]] = []
         rewritten_uids: set[str] = set()
         for uid in self._manager._workspace_highest_dirty_data_roots():
@@ -3011,10 +3050,33 @@ class _WorkspaceIOController:
             if update is not None:
                 attr_updates.append(update)
 
+        estimated_obsolete_bytes = state.estimated_obsolete_bytes
+        replacement_delta_count = state.replacement_delta_count
+        repack_estimate_known = state.repack_estimate_known
+        if repack_estimate_known and rewrite_groups and state.path is not None:
+            old_bytes, replaced_group_count = (
+                _manager_workspace._workspace_h5_paths_storage_size(
+                    state.path,
+                    (group_path for group_path, _constructor in rewrite_groups),
+                )
+            )
+            estimated_obsolete_bytes += old_bytes
+            if replaced_group_count > 0:
+                replacement_delta_count += 1
+        root_attrs = _manager_workspace._workspace_root_attrs_with_repack_estimate(
+            root_attrs,
+            estimated_obsolete_bytes=estimated_obsolete_bytes,
+            replacement_delta_count=replacement_delta_count,
+            repack_estimate_known=repack_estimate_known,
+        )
+
         return _manager_workspace._WorkspaceSaveSnapshot(
             generation=generation,
             root_attrs=root_attrs,
             delta_save_count=delta_save_count,
+            estimated_obsolete_bytes=estimated_obsolete_bytes,
+            replacement_delta_count=replacement_delta_count,
+            repack_estimate_known=repack_estimate_known,
             compression_mode=self._workspace_compression_mode(),
             rewrite_groups=tuple(rewrite_groups),
             attr_updates=tuple(attr_updates),
@@ -3063,6 +3125,64 @@ class _WorkspaceIOController:
             full_tree=tree,
             copy_source=copy_source,
             copy_groups=copy_groups,
+        )
+
+    def _workspace_file_repack_snapshot(
+        self, generation: int
+    ) -> _manager_workspace._WorkspaceSaveSnapshot | None:
+        workspace_path = self._manager._workspace_state.path
+        if workspace_path is None:
+            return None
+        if _manager_workspace._workspace_path_is_likely_network_path(workspace_path):
+            return None
+        try:
+            root_attrs, copy_groups = _manager_workspace._workspace_file_repack_payload(
+                workspace_path
+            )
+        except Exception:
+            logger.debug(
+                "Skipping shutdown compaction; file-level repack snapshot failed",
+                exc_info=True,
+            )
+            return None
+        return _manager_workspace._WorkspaceSaveSnapshot(
+            generation=generation,
+            root_attrs=root_attrs,
+            delta_save_count=0,
+            compression_mode=self._workspace_compression_mode(),
+            file_repack=True,
+            copy_source=str(workspace_path),
+            copy_groups=copy_groups,
+        )
+
+    def _workspace_should_repack_before_shutdown(self) -> bool:
+        workspace_path = self._manager._workspace_state.path
+        if workspace_path is None:
+            return False
+        state = self._manager._workspace_state
+        if state.repack_estimate_known:
+            if state.replacement_delta_count <= 0:
+                return False
+            estimated_obsolete_bytes = state.estimated_obsolete_bytes
+        else:
+            try:
+                estimated_obsolete_bytes = _workspace_obsolete_estimate(workspace_path)
+            except Exception:
+                logger.debug(
+                    "Failed to estimate workspace repack benefit before shutdown",
+                    exc_info=True,
+                )
+                return False
+        try:
+            file_size = pathlib.Path(workspace_path).stat().st_size
+        except OSError:
+            return False
+        if file_size <= 0:
+            return False
+        return (
+            estimated_obsolete_bytes >= _WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES
+            and estimated_obsolete_bytes / file_size
+            >= _WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO
         )
 
     def _workspace_full_save_copy_groups(
@@ -3309,6 +3429,11 @@ class _WorkspaceIOController:
 
         self._manager._workspace_state.needs_full_save = False
         self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
+        self._manager._workspace_state.set_repack_estimate(
+            estimated_obsolete_bytes=snapshot.estimated_obsolete_bytes,
+            replacement_delta_count=snapshot.replacement_delta_count,
+            known=snapshot.repack_estimate_known,
+        )
         if snapshot.full_tree is not None:
             self._manager._workspace_state.schema_version = (
                 _manager_workspace._current_workspace_schema_version()
@@ -3393,13 +3518,17 @@ class _WorkspaceIOController:
             or self._manager._workspace_state.loading_depth > 0
         ):
             return
+        if not self._workspace_should_repack_before_shutdown():
+            return
         try:
             logger.debug("Compacting workspace before shutdown...")
             self._manager._drain_workspace_deferred_events()
             generation = self._manager._workspace_state.dirty_generation
             self._manager._workspace_state.saving_depth += 1
             try:
-                snapshot = self._manager._workspace_full_save_snapshot(generation)
+                snapshot = self._workspace_file_repack_snapshot(generation)
+                if snapshot is None:
+                    return
             finally:
                 self._manager._workspace_state.saving_depth -= 1
             try:
@@ -3422,6 +3551,7 @@ class _WorkspaceIOController:
                 return
             self._manager._workspace_state.needs_full_save = False
             self._manager._workspace_state.delta_save_count = 0
+            self._manager._workspace_state.reset_repack_estimate()
             self._manager._workspace_state.schema_version = (
                 _manager_workspace._current_workspace_schema_version()
             )
@@ -3480,6 +3610,7 @@ class _WorkspaceIOController:
             return False
 
         self._manager._restore_focus_after_workspace_save(origin)
+        self._manager._workspace_state.reset_repack_estimate()
         return True
 
     def _save_to_file(self, fname: str):
@@ -3596,11 +3727,22 @@ class _WorkspaceIOController:
                             profiler=profiler,
                         )
                         if loaded and associate:
+                            (
+                                estimated_obsolete_bytes,
+                                replacement_delta_count,
+                                repack_estimate_known,
+                            ) = _workspace_repack_estimate(
+                                manifest,
+                                delta_save_count=delta_save_count,
+                            )
                             self._manager._associate_loaded_workspace_file(
                                 access.path,
                                 schema_version,
                                 native=native,
                                 delta_save_count=delta_save_count,
+                                estimated_obsolete_bytes=estimated_obsolete_bytes,
+                                replacement_delta_count=replacement_delta_count,
+                                repack_estimate_known=repack_estimate_known,
                                 workspace_access=access,
                                 rebind_data=False,
                             )
@@ -3633,11 +3775,22 @@ class _WorkspaceIOController:
                     profiler=profiler,
                 )
                 if loaded and associate:
+                    (
+                        estimated_obsolete_bytes,
+                        replacement_delta_count,
+                        repack_estimate_known,
+                    ) = _workspace_repack_estimate(
+                        manifest,
+                        delta_save_count=delta_save_count,
+                    )
                     self._manager._associate_loaded_workspace_file(
                         access.path,
                         schema_version,
                         native=native,
                         delta_save_count=delta_save_count,
+                        estimated_obsolete_bytes=estimated_obsolete_bytes,
+                        replacement_delta_count=replacement_delta_count,
+                        repack_estimate_known=repack_estimate_known,
                         workspace_access=access,
                         rebind_data=False,
                     )

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -2463,11 +2463,14 @@ class _WorkspaceIOController:
         fname: str | os.PathLike[str],
         *,
         reuse_unchanged_groups: bool = True,
+        require_matching_compression: bool = False,
     ) -> None:
         tree: xr.DataTree = self._manager._to_datatree()
         if reuse_unchanged_groups:
             copy_source, copy_groups = self._manager._workspace_full_save_copy_groups(
-                tree
+                tree,
+                compression_mode=self._workspace_compression_mode(),
+                require_matching_compression=require_matching_compression,
             )
         else:
             copy_source, copy_groups = None, ()
@@ -2566,6 +2569,7 @@ class _WorkspaceIOController:
         force_full: bool = False,
         document_access: _WorkspaceDocumentAccess | None = None,
         reuse_unchanged_groups: bool = True,
+        require_matching_compression: bool = False,
     ) -> None:
         if document_access is None:
             _require_itws_workspace_path(fname, _WORKSPACE_SAVE_SUFFIX_ERROR)
@@ -2575,6 +2579,7 @@ class _WorkspaceIOController:
                     force_full=force_full,
                     document_access=access,
                     reuse_unchanged_groups=reuse_unchanged_groups,
+                    require_matching_compression=require_matching_compression,
                 )
             return
 
@@ -2590,6 +2595,7 @@ class _WorkspaceIOController:
                 self._manager._write_full_workspace_file(
                     fname,
                     reuse_unchanged_groups=reuse_unchanged_groups,
+                    require_matching_compression=require_matching_compression,
                 )
                 self._manager._workspace_state.delta_save_count = 0
                 self._manager._workspace_state.schema_version = (
@@ -3045,7 +3051,10 @@ class _WorkspaceIOController:
         self, generation: int
     ) -> _manager_workspace._WorkspaceSaveSnapshot:
         tree = self._manager._to_datatree()
-        copy_source, copy_groups = self._manager._workspace_full_save_copy_groups(tree)
+        copy_source, copy_groups = self._manager._workspace_full_save_copy_groups(
+            tree,
+            compression_mode=self._workspace_compression_mode(),
+        )
         return _manager_workspace._WorkspaceSaveSnapshot(
             generation=generation,
             root_attrs=self._manager._workspace_root_attrs_payload(delta_save_count=0),
@@ -3057,7 +3066,11 @@ class _WorkspaceIOController:
         )
 
     def _workspace_full_save_copy_groups(
-        self, tree: xr.DataTree
+        self,
+        tree: xr.DataTree,
+        *,
+        compression_mode: WorkspaceCompressionMode | None = None,
+        require_matching_compression: bool = False,
     ) -> tuple[str | None, tuple[tuple[str, str, dict[str, typing.Any] | None], ...]]:
         if self._manager._workspace_state.path is None:
             return None, ()
@@ -3101,32 +3114,55 @@ class _WorkspaceIOController:
                 ):
                     identities[(uid, kind)] = f"{path}/{kind}"
         copy_groups: list[tuple[str, str, dict[str, typing.Any] | None]] = []
-        for uid, node in self._manager._tool_graph.nodes.items():
-            if (
-                uid in self._manager._workspace_state.dirty_data
-                or uid in self._manager._workspace_state.dirty_added
-            ):
-                continue
-            if not node.is_imagetool:
-                tool = node.tool_window
-                if tool is None or not tool.can_save_and_load():
+        context = contextlib.nullcontext(None)
+        if require_matching_compression and compression_mode is not None:
+            import h5py
+
+            context = h5py.File(workspace_path, "r")
+        with context as h5_file:
+            for uid, node in self._manager._tool_graph.nodes.items():
+                if (
+                    uid in self._manager._workspace_state.dirty_data
+                    or uid in self._manager._workspace_state.dirty_added
+                ):
                     continue
-            kind = "imagetool" if node.is_imagetool else "tool"
-            source_path = identities.get((uid, kind))
-            if source_path is None:
-                continue
-            payload_path = self._manager._workspace_payload_path(uid)
-            try:
-                payload_tree = typing.cast("xr.DataTree", tree[payload_path])
-            except KeyError:
-                continue
-            attrs = None
-            if (
-                uid in self._manager._workspace_state.dirty_state
-                or source_path != payload_path
-            ):
-                attrs = dict(payload_tree.to_dataset(inherit=False).attrs)
-            copy_groups.append((source_path, payload_path, attrs))
+                if not node.is_imagetool:
+                    tool = node.tool_window
+                    if tool is None or not tool.can_save_and_load():
+                        continue
+                kind = "imagetool" if node.is_imagetool else "tool"
+                source_path = identities.get((uid, kind))
+                if source_path is None:
+                    continue
+                payload_path = self._manager._workspace_payload_path(uid)
+                try:
+                    payload_tree = typing.cast("xr.DataTree", tree[payload_path])
+                except KeyError:
+                    continue
+                payload_ds = payload_tree.to_dataset(inherit=False)
+                compression_matches = (
+                    h5_file is None
+                    or compression_mode is None
+                    or _manager_workspace._workspace_h5_group_matches_compression_mode(
+                        h5_file,
+                        source_path,
+                        payload_ds,
+                        compression_mode,
+                    )
+                )
+                if (
+                    require_matching_compression
+                    and compression_mode is not None
+                    and not compression_matches
+                ):
+                    continue
+                attrs = None
+                if (
+                    uid in self._manager._workspace_state.dirty_state
+                    or source_path != payload_path
+                ):
+                    attrs = dict(payload_ds.attrs)
+                copy_groups.append((source_path, payload_path, attrs))
         return str(workspace_path), tuple(copy_groups)
 
     def _open_workspace_save_wait_dialog(
@@ -3426,7 +3462,7 @@ class _WorkspaceIOController:
                 self._manager._save_workspace_document(
                     workspace_path,
                     force_full=True,
-                    reuse_unchanged_groups=False,
+                    require_matching_compression=True,
                 )
                 self._manager._rebind_workspace_backed_imagetools(
                     workspace_path,

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -59,6 +59,7 @@ if typing.TYPE_CHECKING:
         Sequence,
     )
 
+    from erlab.interactive._options.schema import WorkspaceCompressionMode
     from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
     from erlab.interactive.imagetool.manager._workspace_state import (
         _WorkspaceStateSnapshot,
@@ -2208,6 +2209,9 @@ class _WorkspaceIOController:
             option_overrides=self._workspace_option_overrides_snapshot(),
         )
 
+    def _workspace_compression_mode(self) -> WorkspaceCompressionMode:
+        return self._manager.effective_interactive_options.io.workspace.compression
+
     def _workspace_layout_snapshot(self) -> dict[str, typing.Any]:
         return {
             "window_state": _qt_state.qt_window_state_payload(self._manager),
@@ -2454,9 +2458,19 @@ class _WorkspaceIOController:
                 else:
                     self._manager._standalone_app_pending_states[key] = app_state
 
-    def _write_full_workspace_file(self, fname: str | os.PathLike[str]) -> None:
+    def _write_full_workspace_file(
+        self,
+        fname: str | os.PathLike[str],
+        *,
+        reuse_unchanged_groups: bool = True,
+    ) -> None:
         tree: xr.DataTree = self._manager._to_datatree()
-        copy_source, copy_groups = self._manager._workspace_full_save_copy_groups(tree)
+        if reuse_unchanged_groups:
+            copy_source, copy_groups = self._manager._workspace_full_save_copy_groups(
+                tree
+            )
+        else:
+            copy_source, copy_groups = None, ()
         try:
             _manager_workspace._write_full_workspace_tree_file(
                 fname,
@@ -2464,6 +2478,7 @@ class _WorkspaceIOController:
                 self._manager._workspace_root_attrs_payload(delta_save_count=0),
                 copy_source=copy_source,
                 copy_groups=copy_groups,
+                compression_mode=self._workspace_compression_mode(),
             )
         finally:
             tree.close()
@@ -2539,6 +2554,7 @@ class _WorkspaceIOController:
                 snapshot.rewrite_groups,
                 snapshot.attr_updates,
                 snapshot.root_attrs,
+                compression_mode=snapshot.compression_mode,
             )
         finally:
             snapshot.close()
@@ -2549,6 +2565,7 @@ class _WorkspaceIOController:
         *,
         force_full: bool = False,
         document_access: _WorkspaceDocumentAccess | None = None,
+        reuse_unchanged_groups: bool = True,
     ) -> None:
         if document_access is None:
             _require_itws_workspace_path(fname, _WORKSPACE_SAVE_SUFFIX_ERROR)
@@ -2557,6 +2574,7 @@ class _WorkspaceIOController:
                     access.path,
                     force_full=force_full,
                     document_access=access,
+                    reuse_unchanged_groups=reuse_unchanged_groups,
                 )
             return
 
@@ -2569,7 +2587,10 @@ class _WorkspaceIOController:
                 force_full or self._manager._workspace_requires_full_save(fname)
             )
             if requires_full_save:
-                self._manager._write_full_workspace_file(fname)
+                self._manager._write_full_workspace_file(
+                    fname,
+                    reuse_unchanged_groups=reuse_unchanged_groups,
+                )
                 self._manager._workspace_state.delta_save_count = 0
                 self._manager._workspace_state.schema_version = (
                     _manager_workspace._current_workspace_schema_version()
@@ -2988,6 +3009,7 @@ class _WorkspaceIOController:
             generation=generation,
             root_attrs=root_attrs,
             delta_save_count=delta_save_count,
+            compression_mode=self._workspace_compression_mode(),
             rewrite_groups=tuple(rewrite_groups),
             attr_updates=tuple(attr_updates),
         )
@@ -3028,6 +3050,7 @@ class _WorkspaceIOController:
             generation=generation,
             root_attrs=self._manager._workspace_root_attrs_payload(delta_save_count=0),
             delta_save_count=0,
+            compression_mode=self._workspace_compression_mode(),
             full_tree=tree,
             copy_source=copy_source,
             copy_groups=copy_groups,
@@ -3472,7 +3495,10 @@ class _WorkspaceIOController:
                     fname,
                     engine="h5netcdf",
                     invalid_netcdf=True,
-                    encoding=_manager_xarray.workspace_datatree_encoding(tree),
+                    encoding=_manager_xarray.workspace_datatree_encoding(
+                        tree,
+                        compression_mode=self._workspace_compression_mode(),
+                    ),
                 )
         finally:
             tree.close()

--- a/src/erlab/interactive/imagetool/manager/_workspace_state.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_state.py
@@ -34,6 +34,9 @@ class _WorkspaceStateSnapshot(typing.TypedDict):
     dirty_generation: int
     dirty_events: tuple[_manager_workspace._WorkspaceDirtyEvent, ...]
     delta_save_count: int
+    estimated_obsolete_bytes: int
+    replacement_delta_count: int
+    repack_estimate_known: bool
     schema_version: int
 
 
@@ -59,6 +62,9 @@ class _ManagerWorkspaceState:
         self.dirty_events: list[_manager_workspace._WorkspaceDirtyEvent] = []
         self.save_in_progress: bool = False
         self.delta_save_count: int = 0
+        self.estimated_obsolete_bytes: int = 0
+        self.replacement_delta_count: int = 0
+        self.repack_estimate_known: bool = True
         self.schema_version: int = (
             _manager_workspace._current_workspace_schema_version()
         )
@@ -143,6 +149,22 @@ class _ManagerWorkspaceState:
             self.apply_dirty_event(event)
         self.dirty_events = events
 
+    def reset_repack_estimate(self) -> None:
+        self.estimated_obsolete_bytes = 0
+        self.replacement_delta_count = 0
+        self.repack_estimate_known = True
+
+    def set_repack_estimate(
+        self,
+        *,
+        estimated_obsolete_bytes: int,
+        replacement_delta_count: int,
+        known: bool = True,
+    ) -> None:
+        self.estimated_obsolete_bytes = max(0, int(estimated_obsolete_bytes))
+        self.replacement_delta_count = max(0, int(replacement_delta_count))
+        self.repack_estimate_known = known
+
     @contextlib.contextmanager
     def load_context(self) -> Iterator[None]:
         self.loading_depth += 1
@@ -169,6 +191,9 @@ class _ManagerWorkspaceState:
             "dirty_generation": self.dirty_generation,
             "dirty_events": tuple(self.dirty_events),
             "delta_save_count": self.delta_save_count,
+            "estimated_obsolete_bytes": self.estimated_obsolete_bytes,
+            "replacement_delta_count": self.replacement_delta_count,
+            "repack_estimate_known": self.repack_estimate_known,
             "schema_version": self.schema_version,
         }
 
@@ -188,5 +213,8 @@ class _ManagerWorkspaceState:
         self.dirty_generation = snapshot["dirty_generation"]
         self.dirty_events = list(snapshot["dirty_events"])
         self.delta_save_count = snapshot["delta_save_count"]
+        self.estimated_obsolete_bytes = snapshot["estimated_obsolete_bytes"]
+        self.replacement_delta_count = snapshot["replacement_delta_count"]
+        self.repack_estimate_known = snapshot["repack_estimate_known"]
         self.schema_version = snapshot["schema_version"]
         return self.dirty_added | self.dirty_data | self.dirty_state

--- a/src/erlab/interactive/imagetool/manager/_xarray.py
+++ b/src/erlab/interactive/imagetool/manager/_xarray.py
@@ -16,6 +16,8 @@ from xarray.backends import CachingFileManager, H5NetCDFStore
 if typing.TYPE_CHECKING:
     from collections.abc import Hashable, Iterator
 
+    from erlab.interactive._options.schema import WorkspaceCompressionMode
+
 _WORKSPACE_FILE_LOCKS: dict[str, threading.RLock] = {}
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 
@@ -99,21 +101,53 @@ def ensure_workspace_hdf5_filters_registered() -> None:
 
 
 def workspace_compression_enabled() -> bool:
+    return workspace_compression_mode() != "none"
+
+
+def workspace_compression_mode() -> WorkspaceCompressionMode:
     import erlab
 
-    return bool(erlab.interactive.options.model.io.workspace.compress)
+    return erlab.interactive.options.model.io.workspace.compression
 
 
-def _workspace_blosc2_encoding() -> dict[str, typing.Any]:
+def _workspace_blosc2_encoding(
+    compression_mode: WorkspaceCompressionMode,
+) -> dict[str, typing.Any]:
+    if compression_mode == "none":
+        return {}
+
     ensure_workspace_hdf5_filters_registered()
+    match compression_mode:
+        case "blosclz3":
+            cname = "blosclz"
+            clevel = 3
+        case "zstd1":
+            cname = "zstd"
+            clevel = 1
+        case _:
+            raise ValueError(f"Unknown workspace compression mode: {compression_mode}")
 
     return dict(
         hdf5plugin.Blosc2(
-            cname="blosclz",
-            clevel=3,
+            cname=cname,
+            clevel=clevel,
             filters=hdf5plugin.Blosc2.SHUFFLE,
         )
     )
+
+
+def _resolve_workspace_compression_mode(
+    *,
+    compression_mode: WorkspaceCompressionMode | None,
+    compress: bool | None,
+) -> WorkspaceCompressionMode:
+    if compression_mode is not None:
+        return compression_mode
+    if compress is False:
+        return "none"
+    if compress is True:
+        return "zstd1"
+    return workspace_compression_mode()
 
 
 def _should_compress_workspace_variable(
@@ -148,10 +182,13 @@ def workspace_dataset_encoding(
     *,
     min_bytes: int = _WORKSPACE_COMPRESSION_MIN_BYTES,
     compress: bool | None = None,
+    compression_mode: WorkspaceCompressionMode | None = None,
 ) -> dict[Hashable, dict[str, typing.Any]]:
     """Return h5netcdf encodings for workspace data variables."""
-    if compress is None:
-        compress = workspace_compression_enabled()
+    compression_mode = _resolve_workspace_compression_mode(
+        compression_mode=compression_mode, compress=compress
+    )
+    compression_encoding = _workspace_blosc2_encoding(compression_mode)
 
     encoding: dict[Hashable, dict[str, typing.Any]] = {}
     for name, data_array in ds.data_vars.items():
@@ -159,10 +196,10 @@ def workspace_dataset_encoding(
         chunksizes = _workspace_chunksizes_for_dataarray(data_array)
         if chunksizes is not None:
             var_encoding["chunksizes"] = chunksizes
-        if compress and _should_compress_workspace_variable(
+        if compression_encoding and _should_compress_workspace_variable(
             data_array.variable, min_bytes=min_bytes
         ):
-            var_encoding.update(_workspace_blosc2_encoding())
+            var_encoding.update(compression_encoding)
         if var_encoding:
             encoding[name] = var_encoding
     return encoding
@@ -173,15 +210,19 @@ def workspace_datatree_encoding(
     *,
     min_bytes: int = _WORKSPACE_COMPRESSION_MIN_BYTES,
     compress: bool | None = None,
+    compression_mode: WorkspaceCompressionMode | None = None,
 ) -> dict[str, dict[Hashable, dict[str, typing.Any]]]:
     """Return nested h5netcdf encodings for workspace payloads."""
-    if compress is None:
-        compress = workspace_compression_enabled()
+    compression_mode = _resolve_workspace_compression_mode(
+        compression_mode=compression_mode, compress=compress
+    )
 
     encoding: dict[str, dict[Hashable, dict[str, typing.Any]]] = {}
     for node in tree.subtree:
         node_encoding = workspace_dataset_encoding(
-            node.to_dataset(inherit=False), min_bytes=min_bytes, compress=compress
+            node.to_dataset(inherit=False),
+            min_bytes=min_bytes,
+            compression_mode=compression_mode,
         )
         if node_encoding:
             encoding[node.path] = node_encoding

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -1701,6 +1701,12 @@ class KspaceTool(KspaceToolGUI):
 
     @QtCore.Slot()
     def update(self) -> None:
+        self._run_or_defer_restore_work(
+            self._update_now,
+            run_on_show=True,
+        )
+
+    def _update_now(self) -> None:
         try:
             ang, k = self.get_data()
         except _kspace_conversion.KspaceConversionMemoryError:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -10,6 +10,7 @@ import ast
 import bisect
 import collections
 import contextlib
+import contextvars
 import enum
 import fnmatch
 import importlib
@@ -100,6 +101,11 @@ __all__ = [
 _LOAD_UI_LOCK = threading.RLock()
 logger = logging.getLogger(__name__)
 _TOOL_HISTORY_WRITE_QUIET_INTERVAL_MS = 150
+
+
+_TOOL_WINDOW_RESTORE_DEFER: contextvars.ContextVar[bool | None] = (
+    contextvars.ContextVar("_TOOL_WINDOW_RESTORE_DEFER", default=None)
+)
 
 
 def _manager_perf_timing_enabled() -> bool:
@@ -3167,6 +3173,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
       :class:`xarray.DataArray` being analyzed, which will be passed to the constructor
       of the subclass when restoring from a file.
 
+    - Optional restored caches, preview data, and calculated results should use
+      `_run_or_defer_restore_work` or `_defer_restore_work` instead of running
+      expensive work unconditionally during restore. Direct calls to
+      `from_dataset` remain eager; the ImageTool manager uses this protected framework
+      internally so hidden restored tools do not slow down workspace loading.
+
     For tools that support refreshing their data from an ImageTool source, subclasses
     should also override the following hooks:
 
@@ -3230,6 +3242,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        restore_defer = _TOOL_WINDOW_RESTORE_DEFER.get()
 
         self._tool_root_widget = QtWidgets.QWidget(self)
         self._tool_root_layout = QtWidgets.QVBoxLayout(self._tool_root_widget)
@@ -3294,7 +3307,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._history_write_timer.setSingleShot(True)
         self._history_write_timer.setInterval(_TOOL_HISTORY_WRITE_QUIET_INTERVAL_MS)
         self._history_write_timer.timeout.connect(self._flush_pending_history_write)
-        self._restoring_from_dataset = False
+        self._restoring_from_dataset = restore_defer is not None
+        self._defer_restored_tool_work = bool(restore_defer)
+        self._deferred_restore_work: dict[
+            Hashable, tuple[Callable[[], None], bool]
+        ] = {}
+        self._flushing_restore_work = False
 
         menu_bar = typing.cast("QtWidgets.QMenuBar", self.menuBar())
         self._tool_file_menu = typing.cast("QtWidgets.QMenu", menu_bar.addMenu("&File"))
@@ -3444,6 +3462,145 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             self.undo_action.setEnabled(self.undoable)
         if hasattr(self, "redo_action") and qt_is_valid(self.redo_action):
             self.redo_action.setEnabled(self.redoable)
+
+    @property
+    def _dataset_restore_in_progress(self) -> bool:
+        """Return whether saved dataset state is currently being applied."""
+        return self._restoring_from_dataset
+
+    @property
+    def _should_defer_restore_work(self) -> bool:
+        """Return whether optional restore work should be queued instead of run."""
+        return (
+            self._dataset_restore_in_progress
+            and self._defer_restored_tool_work
+            and not self._flushing_restore_work
+        )
+
+    @staticmethod
+    def _restore_work_key(
+        callback: Callable[[], None] | None = None,
+        *,
+        key: Hashable | None = None,
+    ) -> Hashable | None:
+        if key is not None:
+            return key
+        if callback is None:
+            return None
+        return typing.cast("Hashable", callback)
+
+    def _defer_restore_work(
+        self,
+        callback: Callable[[], None],
+        *,
+        key: Hashable | None = None,
+        run_on_show: bool = False,
+    ) -> bool:
+        """Queue optional work only when dataset restore is currently deferred.
+
+        Subclasses can call this from restore hooks when the eager fallback needs a
+        different execution path. It returns ``True`` only when the callback was queued;
+        otherwise the caller remains responsible for running the work.
+
+        Use this only for derived UI/cache/result work. Required validation and state
+        needed to make the restored tool structurally valid must still run eagerly.
+        """
+        if not self._should_defer_restore_work:
+            return False
+        task_key = self._restore_work_key(callback, key=key)
+        if task_key is None:
+            raise TypeError("restore work requires a callback or key")
+        self._deferred_restore_work[task_key] = (callback, run_on_show)
+        return True
+
+    def _run_or_defer_restore_work(
+        self,
+        callback: Callable[[], None],
+        *,
+        key: Hashable | None = None,
+        run_on_show: bool = False,
+    ) -> bool:
+        """Run optional restore work now, or queue it while restore is deferred.
+
+        This is the default hook for subclass authors. Call it where restore-time work
+        would otherwise deserialize, render, or recompute optional data. The callback is
+        run immediately for normal standalone restores and queued during manager
+        workspace restore. Set ``run_on_show=True`` when hidden tools can wait until the
+        user shows the window.
+
+        The callback itself is normally the queue key, so repeated calls coalesce. Pass
+        ``key`` only when another method must address the work by a stable handle, for
+        example to preserve a raw persisted payload while saving.
+        """
+        if self._defer_restore_work(
+            callback,
+            key=key,
+            run_on_show=run_on_show,
+        ):
+            return True
+        if key is None:
+            self._discard_restore_work(callback)
+        else:
+            self._discard_restore_work(key=key)
+        callback()
+        return False
+
+    def _discard_restore_work(
+        self,
+        callback: Callable[[], None] | None = None,
+        *,
+        key: Hashable | None = None,
+    ) -> None:
+        """Drop queued restore work that has been superseded by fresher work.
+
+        Subclasses should call this sparingly, only when explicit recomputation has
+        already produced the data that a queued restore callback would produce. This
+        prevents stale restore-time previews or caches from running later.
+        """
+        if not self._flushing_restore_work:
+            task_key = self._restore_work_key(callback, key=key)
+            if task_key is not None:
+                self._deferred_restore_work.pop(task_key, None)
+
+    def _flush_restore_work(
+        self,
+        callback: Callable[[], None] | None = None,
+        *,
+        key: Hashable | None = None,
+        run_on_show_only: bool = False,
+        skip: Iterable[Hashable] = (),
+    ) -> bool:
+        """Materialize queued work before returning data or serialized state.
+
+        `ToolWindow` already calls this before save, copy/provenance generation, output
+        access, show, and close. Subclasses should call it only at narrower correctness
+        boundaries they own, such as a property that returns a derived result. Use
+        ``skip`` only when saving can preserve a still-deferred raw payload unchanged.
+        """
+        if self._flushing_restore_work:
+            return False
+        skip_keys = frozenset(skip)
+        flushed = False
+        task_key = self._restore_work_key(callback, key=key)
+        if task_key is None:
+            tasks = list(self._deferred_restore_work.items())
+        elif task_key in self._deferred_restore_work:
+            tasks = [(task_key, self._deferred_restore_work[task_key])]
+        else:
+            return False
+        for pending_key, (pending_callback, run_on_show) in tasks:
+            if pending_key in skip_keys:
+                continue
+            if run_on_show_only and not run_on_show:
+                continue
+            self._flushing_restore_work = True
+            try:
+                pending_callback()
+            finally:
+                self._flushing_restore_work = False
+            self._deferred_restore_work.pop(pending_key, None)
+            flushed = True
+        return flushed
 
     @QtCore.Slot()
     def undo(self) -> None:
@@ -3648,7 +3805,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         return target
 
     def current_provenance_spec(
-        self,
+        self, *, flush_deferred_restore: bool = True
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
         """Return replay provenance for the main copy-code action.
 
@@ -3656,8 +3813,18 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         this method only when the tool needs custom behavior beyond
         ``ToolScriptProvenanceDefinition``. This describes the main tool action, not
         any manager-tracked child ImageTool outputs declared in ``IMAGE_TOOL_OUTPUTS``.
+
+        Parameters
+        ----------
+        flush_deferred_restore
+            Whether to materialize optional restored work before building provenance.
+            Keep the default for user-facing copy/export paths. Manager metadata scans
+            may pass ``False`` so dependency checks do not slow down workspace loading.
         """
-        return self._resolve_script_provenance(self.COPY_PROVENANCE)
+        return self._resolve_script_provenance(
+            self.COPY_PROVENANCE,
+            flush_deferred_restore=flush_deferred_restore,
+        )
 
     @property
     def input_provenance_spec(
@@ -3956,7 +4123,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         *,
         data: xr.DataArray | None = None,
         include_parent_provenance: bool = True,
+        flush_deferred_restore: bool = True,
     ) -> erlab.interactive.imagetool.provenance.ToolProvenanceSpec | None:
+        if flush_deferred_restore and not self._flushing_restore_work:
+            self._flush_restore_work()
         if definition is None:
             return None
         input_provenance = (
@@ -4000,8 +4170,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
         Subclasses should declare outputs in ``IMAGE_TOOL_OUTPUTS`` instead of
         overriding this method directly. The base implementation resolves
-        ``output_id`` against that mapping and calls the declared data method.
+        ``output_id`` against that mapping, flushes any deferred restored work, and
+        calls the declared data method.
         """
+        self._flush_restore_work()
         _, definition = self._image_output_definition(output_id)
         return typing.cast(
             "Callable[[], xr.DataArray | None]",
@@ -4015,9 +4187,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
         Subclasses should declare outputs in ``IMAGE_TOOL_OUTPUTS`` instead of
         overriding this method directly. The base implementation resolves
-        ``output_id`` against that mapping and resolves the declared provenance
-        definition.
+        ``output_id`` against that mapping, flushes any deferred restored work, and
+        resolves the declared provenance definition.
         """
+        self._flush_restore_work()
         _, definition = self._image_output_definition(output_id)
         return self._resolve_script_provenance(definition.provenance, data=data)
 
@@ -4098,6 +4271,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         output_id: str | enum.Enum,
     ) -> erlab.interactive.imagetool.ImageTool | None:
         """Open or refresh a manager-tracked child ImageTool for a declared output."""
+        self._flush_restore_work()
         normalized_output_id, _ = self._image_output_definition(output_id)
         return self._open_output_imagetool(
             data,
@@ -4122,6 +4296,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         detached replay provenance when the caller provides it. Standalone tools create
         a fresh standalone ImageTool window.
         """
+        self._flush_restore_work()
         return self._open_output_imagetool(
             data,
             output_id=None,
@@ -4803,6 +4978,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Restore named data artifacts saved by `_persistence_data_items()`."""
         del data_items, ds
 
+    def _flush_restore_work_for_save(self) -> None:
+        """Materialize deferred restore work required before serialization."""
+        self._flush_restore_work()
+
     @contextlib.contextmanager
     def _save_tool_data_reference_context(
         self, available_node_uids: Iterable[str] | None = None
@@ -4897,12 +5076,16 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def to_dataset(self) -> xr.Dataset:
         """Get the :class:`xarray.Dataset` representation of the tool window.
 
+        Deferred restore work is flushed before serialization unless a subclass
+        save hook explicitly preserves a raw persisted payload unchanged.
+
         Returns
         -------
         Dataset
             A dataset containing the data and attributes needed to restore the tool.
 
         """
+        self._flush_restore_work_for_save()
         self._flush_pending_history_write()
         ds = self._saved_tool_data_dataset()
         return self._append_persistence_payload(ds)
@@ -5035,6 +5218,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def from_dataset(cls, ds: xr.Dataset, **kwargs) -> typing.Self:
         """Restore a tool window from a :class:`xarray.Dataset`.
 
+        Normal standalone restores are eager: optional restored work runs before this
+        method returns. The ImageTool manager passes private internal keywords to defer
+        optional work for hidden workspace tools; those keywords are not part of the
+        public user-facing API.
+
         Parameters
         ----------
         ds
@@ -5052,6 +5240,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             "Callable[[Mapping[str, typing.Any]], xr.DataArray | None] | None",
             kwargs.pop("_tool_data_reference_resolver", None),
         )
+        defer_restore_work = bool(kwargs.pop("_defer_restore_work", False))
         ds = _serialization.restore_private_coords(ds, _SAVED_TOOL_DATA_NAME)
 
         saved_version = ds.attrs.get("erlab_version", "0.0.0")
@@ -5079,88 +5268,99 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         tool_data_name: str | None = ds.attrs.get("tool_data_name", "<none-value>")
         if tool_data_name == "<none-value>":
             tool_data_name = None
-        tool = cls_obj(
-            data_items[_SAVED_TOOL_DATA_NAME].rename(tool_data_name), **kwargs
-        )
-        previous_restoring = bool(getattr(tool, "_restoring_from_dataset", False))
+        token = _TOOL_WINDOW_RESTORE_DEFER.set(defer_restore_work)
+        try:
+            tool = cls_obj(
+                data_items[_SAVED_TOOL_DATA_NAME].rename(tool_data_name), **kwargs
+            )
+        finally:
+            _TOOL_WINDOW_RESTORE_DEFER.reset(token)
+        previous_restoring = False
+        previous_defer_restore = False
         tool._restoring_from_dataset = True
+        tool._defer_restored_tool_work = defer_restore_work
         try:
             with tool._history_suppressed():
                 tool.tool_status = cls_obj.StateModel.model_validate_json(
                     ds.attrs["tool_state"]
                 )
+            tool._tool_display_name = ds.attrs.get("tool_display_name", "")
+            source_spec = None
+            if _TOOL_SOURCE_SPEC_ATTR in ds.attrs:
+                try:
+                    provenance = erlab.interactive.imagetool.provenance
+                    source_spec = provenance.parse_tool_provenance_spec(
+                        typing.cast(
+                            "Mapping[str, typing.Any]",
+                            json.loads(ds.attrs[_TOOL_SOURCE_SPEC_ATTR]),
+                        )
+                    )
+                    source_spec = provenance.require_live_source_spec(source_spec)
+                except Exception:
+                    logger.warning(
+                        "Ignoring invalid saved tool source provenance for %s",
+                        cls_obj.__qualname__,
+                        exc_info=True,
+                    )
+            source_binding = None
+            if source_spec is None and _TOOL_SOURCE_BINDING_ATTR in ds.attrs:
+                try:
+                    provenance = erlab.interactive.imagetool.provenance
+                    binding_type = provenance.ImageToolSelectionSourceBinding
+                    source_binding = binding_type.model_validate(
+                        typing.cast(
+                            "Mapping[str, typing.Any]",
+                            json.loads(ds.attrs[_TOOL_SOURCE_BINDING_ATTR]),
+                        )
+                    )
+                except Exception:
+                    logger.warning(
+                        "Ignoring invalid saved tool source binding for %s",
+                        cls_obj.__qualname__,
+                        exc_info=True,
+                    )
+            if source_spec is not None or source_binding is not None:
+                tool.set_source_binding(
+                    source_spec,
+                    source_binding=source_binding,
+                    auto_update=bool(
+                        ds.attrs.get(_TOOL_SOURCE_AUTO_UPDATE_ATTR, False)
+                    ),
+                    state=typing.cast(
+                        "typing.Literal['fresh', 'stale', 'unavailable']",
+                        ds.attrs.get(_TOOL_SOURCE_STATE_ATTR, "fresh"),
+                    ),
+                )
+            if _TOOL_INPUT_PROVENANCE_SPEC_ATTR in ds.attrs:
+                try:
+                    tool.set_input_provenance_spec(
+                        typing.cast(
+                            "Mapping[str, typing.Any]",
+                            json.loads(ds.attrs[_TOOL_INPUT_PROVENANCE_SPEC_ATTR]),
+                        )
+                    )
+                except Exception:
+                    logger.warning(
+                        "Ignoring invalid saved tool input provenance for %s",
+                        cls_obj.__qualname__,
+                        exc_info=True,
+                    )
+            tool._restore_persistence_payload(ds)
+            tool._restore_persistence_data_items(data_items, ds)
+            tool.setWindowTitle(ds.attrs["tool_title"])
+            if (
+                not _qt_state.restore_qt_window_state(
+                    tool, ds.attrs.get("tool_window_state")
+                )
+                and "tool_rect" in ds.attrs
+            ):
+                tool.setGeometry(*ds.attrs["tool_rect"])
+            tool._reset_history_stack()
         finally:
             tool._restoring_from_dataset = previous_restoring
-        tool._tool_display_name = ds.attrs.get("tool_display_name", "")
-        source_spec = None
-        if _TOOL_SOURCE_SPEC_ATTR in ds.attrs:
-            try:
-                provenance = erlab.interactive.imagetool.provenance
-                source_spec = provenance.parse_tool_provenance_spec(
-                    typing.cast(
-                        "Mapping[str, typing.Any]",
-                        json.loads(ds.attrs[_TOOL_SOURCE_SPEC_ATTR]),
-                    )
-                )
-                source_spec = provenance.require_live_source_spec(source_spec)
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid saved tool source provenance for %s",
-                    cls_obj.__qualname__,
-                    exc_info=True,
-                )
-        source_binding = None
-        if source_spec is None and _TOOL_SOURCE_BINDING_ATTR in ds.attrs:
-            try:
-                provenance = erlab.interactive.imagetool.provenance
-                binding_type = provenance.ImageToolSelectionSourceBinding
-                source_binding = binding_type.model_validate(
-                    typing.cast(
-                        "Mapping[str, typing.Any]",
-                        json.loads(ds.attrs[_TOOL_SOURCE_BINDING_ATTR]),
-                    )
-                )
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid saved tool source binding for %s",
-                    cls_obj.__qualname__,
-                    exc_info=True,
-                )
-        if source_spec is not None or source_binding is not None:
-            tool.set_source_binding(
-                source_spec,
-                source_binding=source_binding,
-                auto_update=bool(ds.attrs.get(_TOOL_SOURCE_AUTO_UPDATE_ATTR, False)),
-                state=typing.cast(
-                    "typing.Literal['fresh', 'stale', 'unavailable']",
-                    ds.attrs.get(_TOOL_SOURCE_STATE_ATTR, "fresh"),
-                ),
-            )
-        if _TOOL_INPUT_PROVENANCE_SPEC_ATTR in ds.attrs:
-            try:
-                tool.set_input_provenance_spec(
-                    typing.cast(
-                        "Mapping[str, typing.Any]",
-                        json.loads(ds.attrs[_TOOL_INPUT_PROVENANCE_SPEC_ATTR]),
-                    )
-                )
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid saved tool input provenance for %s",
-                    cls_obj.__qualname__,
-                    exc_info=True,
-                )
-        tool._restore_persistence_payload(ds)
-        tool._restore_persistence_data_items(data_items, ds)
-        tool.setWindowTitle(ds.attrs["tool_title"])
-        if (
-            not _qt_state.restore_qt_window_state(
-                tool, ds.attrs.get("tool_window_state")
-            )
-            and "tool_rect" in ds.attrs
-        ):
-            tool.setGeometry(*ds.attrs["tool_rect"])
-        tool._reset_history_stack()
+            tool._defer_restored_tool_work = previous_defer_restore
+        if not defer_restore_work:
+            tool._flush_restore_work()
         return tool
 
     def to_file(self, filename: str | os.PathLike) -> None:
@@ -5213,7 +5413,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """
         return self.from_dataset(self.to_dataset(), **kwargs)
 
+    def showEvent(self, event: QtGui.QShowEvent | None) -> None:
+        self._flush_restore_work(run_on_show_only=True)
+        return super().showEvent(event)
+
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        self._flush_restore_work()
         self._flush_pending_history_write()
         return super().closeEvent(event)
 

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -16100,7 +16100,9 @@ def test_figure_composer_method_docs_button_opens_current_url(
     ]
 
 
-def test_figure_composer_method_helper_edge_contracts(qtbot) -> None:
+def test_figure_composer_method_helper_edge_contracts(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
     data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
         dims=("kx", "ky"),
@@ -16129,6 +16131,15 @@ def test_figure_composer_method_helper_edge_contracts(qtbot) -> None:
         ),
     )
     qtbot.addWidget(tool)
+
+    render_calls: list[FigureComposerTool] = []
+    monkeypatch.setattr(
+        figurecomposer_tool_module,
+        "_render_preview",
+        lambda tool: render_calls.append(tool),
+    )
+    tool.tool_status = tool.tool_status
+    assert render_calls == [tool]
 
     with pytest.raises(ValueError, match="Unsupported axes method"):
         figurecomposer_method._method_spec(
@@ -16223,10 +16234,16 @@ def test_figure_composer_method_helper_edge_contracts(qtbot) -> None:
         ),
     )
     qtbot.addWidget(grid_tool)
-    grid_tool.show_figure_window(activate=False)
-    grid_axes = figurecomposer_method._live_layout_axes(grid_tool)
+    live_layout_axes = figurecomposer_method._live_layout_axes
+    assert live_layout_axes(grid_tool) is None
+    grid_axes = live_layout_axes(grid_tool, render_if_missing=True)
     assert isinstance(grid_axes, dict)
     assert set(grid_axes) == {"axis-a"}
+    monkeypatch.setattr(
+        figurecomposer_method,
+        "_live_layout_axes",
+        lambda _tool, *, render_if_missing=False: grid_axes,
+    )
     assert (
         figurecomposer_method._first_live_axis(
             grid_tool,
@@ -16234,8 +16251,7 @@ def test_figure_composer_method_helper_edge_contracts(qtbot) -> None:
         )
         is grid_axes["axis-a"]
     )
-    grid_tool.figure.clear()
-    assert figurecomposer_method._live_layout_axes(grid_tool) is None
+    assert live_layout_axes(grid_tool) is None
     assert (
         figurecomposer_method._limit_method_default_args(
             grid_tool,
@@ -16244,6 +16260,20 @@ def test_figure_composer_method_helper_edge_contracts(qtbot) -> None:
         )
         == ()
     )
+
+    scheduled_calls: list[tuple[QtCore.QObject, int, Callable[[], None]]] = []
+    monkeypatch.setattr(grid_tool, "_saved_tool_window_visible", lambda _ds: True)
+    monkeypatch.setattr(grid_tool, "_auto_redraw_enabled", lambda: True)
+    monkeypatch.setattr(
+        grid_tool, "_defer_restore_work", lambda *_args, **_kwargs: False
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "single_shot",
+        lambda *args: scheduled_calls.append(args),
+    )
+    grid_tool._queue_post_restore_redraw_if_needed(xr.Dataset())
+    assert len(scheduled_calls) == 1
 
     int_control = figurecomposer_method.MethodControlSpec(
         kind=figurecomposer_method.MethodControlKind.INT_ARG,
@@ -27640,6 +27670,57 @@ def test_figure_composer_deferred_restore_delays_visible_redraw(
 
     qtbot.wait_until(lambda: bool(render_calls), timeout=5000)
     assert render_calls == [((restored,), {"show_window": True})]
+
+
+def test_figure_composer_flushes_restore_work_before_user_outputs(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="line",
+    )
+    tool = FigureComposerTool(data)
+    qtbot.addWidget(tool)
+    calls: list[str] = []
+
+    monkeypatch.setattr(tool, "_flush_restore_work", lambda: calls.append("flush"))
+    monkeypatch.setattr(
+        tool, "_flush_pending_editor_commits", lambda: calls.append("commit")
+    )
+    monkeypatch.setattr(tool, "_warn_invalid_operation_targets", lambda: False)
+    monkeypatch.setattr(
+        erlab.interactive._figurecomposer._codegen,
+        "generated_code",
+        lambda _tool: "figure_code",
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "copy_to_clipboard",
+        lambda code: calls.append(f"copy:{code}"),
+    )
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *_args, **_kwargs: ("", ""),
+    )
+
+    assert tool.generated_code() == "figure_code"
+    tool.copy_code()
+    tool.export_figure()
+    tool.current_provenance_spec(flush_deferred_restore=False)
+
+    assert calls == [
+        "flush",
+        "commit",
+        "flush",
+        "flush",
+        "commit",
+        "copy:figure_code",
+        "flush",
+        "commit",
+    ]
 
 
 def test_figure_composer_skips_preview_cache_when_unrendered(

--- a/tests/interactive/imagetool/manager/test_figurecomposer.py
+++ b/tests/interactive/imagetool/manager/test_figurecomposer.py
@@ -27599,6 +27599,49 @@ def test_figure_composer_visible_restore_queues_auto_redraw(
     assert render_calls == [((restored,), {"show_window": True})]
 
 
+def test_figure_composer_deferred_restore_delays_visible_redraw(
+    qtbot,
+    monkeypatch,
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="line",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"line": data},
+        sources=(FigureSourceState(name="line", label="line"),),
+        operations=(FigureOperationState.line(label="line", source="line"),),
+        primary_source="line",
+    )
+    qtbot.addWidget(tool)
+    ds = tool.to_dataset()
+    window_state = json.loads(ds.attrs["tool_window_state"])
+    window_state["visible"] = True
+    ds.attrs["tool_window_state"] = json.dumps(window_state)
+
+    render_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def record_render(*args, **kwargs) -> None:
+        render_calls.append((args, kwargs))
+
+    monkeypatch.setattr(figurecomposer_tool_module, "_render_preview", record_render)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        ds,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, FigureComposerTool)
+    assert render_calls == []
+
+    restored.show()
+
+    qtbot.wait_until(lambda: bool(render_calls), timeout=5000)
+    assert render_calls == [((restored,), {"show_window": True})]
+
+
 def test_figure_composer_skips_preview_cache_when_unrendered(
     qtbot, monkeypatch
 ) -> None:

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -19,9 +19,10 @@ import erlab.interactive._options.core
 import erlab.interactive.imagetool.manager._base as manager_base
 import erlab.interactive.imagetool.manager._io as manager_io
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state
-from erlab.interactive.imagetool import itool
+from erlab.interactive.imagetool import itool, provenance
 from erlab.interactive.imagetool.manager import ImageToolManager, load_in_manager
 from erlab.interactive.imagetool.manager._actions import _ActionsController
+from erlab.interactive.imagetool.manager._dependency import _ManagerDependencyTracker
 from erlab.interactive.imagetool.manager._dialogs import _NameFilterDialog
 from erlab.interactive.imagetool.manager._modelview import (
     _MIME,
@@ -45,6 +46,51 @@ if typing.TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+
+def test_dependency_tracker_uses_passive_tool_provenance() -> None:
+    source = provenance.script(
+        start_label="Source",
+        seed_code="source = data",
+        active_name="source",
+    )
+    dependent = provenance.script(
+        start_label="Dependent",
+        seed_code="derived = source",
+        active_name="derived",
+        script_inputs=(
+            provenance.ScriptInput(
+                name="source",
+                label="Source",
+                node_uid="source-uid",
+                provenance_spec=source,
+            ),
+        ),
+    )
+
+    class _PassiveTool:
+        def current_provenance_spec(
+            self, *, flush_deferred_restore: bool = True
+        ) -> provenance.ToolProvenanceSpec:
+            assert flush_deferred_restore is False
+            return dependent
+
+    class _PassiveNode:
+        @property
+        def tool_window(self):
+            return _PassiveTool()
+
+        @property
+        def provenance_spec(self):
+            pytest.fail("dependency tracking must not request flushing provenance")
+
+    graph = types.SimpleNamespace(nodes={"dependent-uid": _PassiveNode()})
+    tracker = _ManagerDependencyTracker(typing.cast("_ManagerToolGraph", graph))
+
+    refs = tracker.refs_for_uid("dependent-uid")
+
+    assert len(refs) == 1
+    assert refs[0].node_uid == "source-uid"
 
 
 class _InfoRefreshToolState(pydantic.BaseModel):

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -6881,8 +6881,9 @@ def test_manager_non_imagetool_node_displayed_provenance_uses_tool_provenance(
             return True
 
         def current_provenance_spec(
-            self,
+            self, *, flush_deferred_restore: bool = True
         ) -> provenance.ToolProvenanceSpec | None:
+            del flush_deferred_restore
             return self._provenance_spec
 
     data = xr.DataArray(np.arange(4.0), dims=("x",))

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -3412,6 +3412,9 @@ def test_workspace_writer_encodes_saved_tool_spaced_associated_coord(
 def test_workspace_h5py_fast_path_roundtrips_saved_tool_extra_blob(
     tmp_path,
 ) -> None:
+    import h5py
+    import hdf5plugin
+
     data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
     primary = xr.DataArray(
         np.arange(6.0).reshape(2, 3),
@@ -3425,9 +3428,9 @@ def test_workspace_h5py_fast_path_roundtrips_saved_tool_extra_blob(
         name="primary",
     )
     secondary = xr.DataArray(
-        np.arange(4.0),
+        np.arange(200_000.0),
         dims=("z",),
-        coords={"z": np.linspace(0.0, 1.0, 4)},
+        coords={"z": np.linspace(0.0, 1.0, 200_000)},
         name=None,
     )
     ds = primary.to_dataset(name=data_name)
@@ -3445,12 +3448,28 @@ def test_workspace_h5py_fast_path_roundtrips_saved_tool_extra_blob(
     assert manager_workspace._workspace_dataset_can_write_h5py(
         imagetool_serialization.encode_private_coords(ds, data_name)
     )
+    with h5py.File(fname, "r") as h5_file:
+        assert hdf5plugin.Blosc2.filter_id in _hdf5_filter_ids(h5_file["0/tool/data_1"])
     xr.testing.assert_identical(loaded[data_name], primary.rename(data_name))
     xr.testing.assert_equal(
         loaded[data_name].coords["Fake Motor"], primary.coords["Fake Motor"]
     )
     restored_secondary = erlab.interactive.utils._tool_data_from_blob(loaded["data_1"])
     xr.testing.assert_equal(restored_secondary, secondary)
+
+    old_value = erlab.interactive.options["io/workspace/compress"]
+    try:
+        erlab.interactive.options["io/workspace/compress"] = False
+        uncompressed_fname = tmp_path / "uncompressed-saved-tool-extra-blob.itws"
+        manager_workspace._write_workspace_dataset_group_to_file(
+            uncompressed_fname, "0/tool", ds
+        )
+    finally:
+        erlab.interactive.options["io/workspace/compress"] = old_value
+    with h5py.File(uncompressed_fname, "r") as h5_file:
+        assert hdf5plugin.Blosc2.filter_id not in _hdf5_filter_ids(
+            h5_file["0/tool/data_1"]
+        )
 
 
 def test_workspace_h5py_fast_path_roundtrips_saved_tool_references(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -4937,6 +4937,14 @@ def test_write_full_workspace_tree_file_copies_unchanged_payload_groups(
             group[manager_workspace_io._ITOOL_DATA_NAME][...],
             np.arange(12, dtype=np.float64).reshape(3, 4),
         )
+    opened = manager_xarray.open_workspace_datatree(fname, chunks=None)
+    try:
+        xr.testing.assert_identical(
+            opened["0/imagetool"].to_dataset()[manager_workspace_io._ITOOL_DATA_NAME],
+            rewritten[manager_workspace_io._ITOOL_DATA_NAME],
+        )
+    finally:
+        opened.close()
 
 
 def test_write_full_workspace_tree_file_network_scratch_skips_copy_reuse(
@@ -5808,7 +5816,7 @@ def test_manager_close_save_path_updates_file_path(
         assert not manager._workspace_state.closing_document
 
 
-def test_manager_close_does_not_compact_workspace(
+def test_manager_close_compacts_clean_delta_workspace(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
@@ -5828,7 +5836,7 @@ def test_manager_close_does_not_compact_workspace(
 
         assert manager.close()
 
-    assert compact_calls == []
+    assert compact_calls == ["compact"]
 
 
 def test_workspace_lock_error_message_without_owner(monkeypatch, tmp_path) -> None:
@@ -7023,7 +7031,7 @@ def test_manager_compact_workspace_edge_paths(
         assert focus_restores == [None]
 
 
-def test_manager_compact_workspace_rewrites_without_copy_groups(
+def test_manager_compact_workspace_copies_matching_groups(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -7084,7 +7092,9 @@ def test_manager_compact_workspace_rewrites_without_copy_groups(
 
         assert manager.compact_workspace()
 
-        assert full_write_calls[-1] == (None, ())
+        copy_source, copy_groups = full_write_calls[-1]
+        assert copy_source == str(fname)
+        assert copy_groups
 
 
 def test_manager_compact_workspace_reduces_internal_holes(
@@ -7180,14 +7190,36 @@ def test_manager_compact_workspace_reapplies_compression_mode(
                     is None
                 )
 
+            original_write = manager_workspace._write_full_workspace_tree_file
+            full_write_calls: list[
+                tuple[str | os.PathLike[str] | None, tuple[object, ...]]
+            ] = []
+
+            def _record_full_write(
+                write_fname: str | os.PathLike[str],
+                write_tree: xr.DataTree,
+                root_attrs: Mapping[str, typing.Any],
+                **kwargs: typing.Any,
+            ) -> None:
+                full_write_calls.append(
+                    (kwargs.get("copy_source"), tuple(kwargs.get("copy_groups", ())))
+                )
+                original_write(write_fname, write_tree, root_attrs, **kwargs)
+
             erlab.interactive.options["io/workspace/compression"] = "zstd1"
             monkeypatch.setattr(
                 erlab.interactive.utils,
                 "wait_dialog",
                 lambda *args, **kwargs: contextlib.nullcontext(),
             )
+            monkeypatch.setattr(
+                manager_workspace,
+                "_write_full_workspace_tree_file",
+                _record_full_write,
+            )
             assert manager.compact_workspace()
 
+            assert full_write_calls[-1] == (str(fname), ())
             with h5py.File(fname, "r") as h5_file:
                 assert _hdf5_blosc2_level_codec(
                     h5_file["0/imagetool"][manager_workspace_io._ITOOL_DATA_NAME]

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -2707,6 +2707,61 @@ def _assert_no_workspace_internal_groups(fname: pathlib.Path) -> None:
         )
 
 
+def test_workspace_file_repack_payload_strips_delta_and_skips_internal_groups(
+    tmp_path,
+) -> None:
+    import h5py
+
+    fname = tmp_path / "file-repack.itws"
+    _write_transaction_test_workspace(fname)
+    manager_workspace._write_workspace_root_attrs_to_file(
+        fname,
+        _transaction_test_root_attrs(delta_save_count=3),
+        replace=True,
+    )
+    with h5py.File(fname, "a") as h5_file:
+        h5_file.create_group("__itws_pending_orphan")
+        h5_file.create_dataset("root_dataset", data=np.arange(3))
+
+    assert manager_workspace._workspace_live_root_group_copy_groups(fname) == (
+        ("0", "0", None),
+    )
+    storage_size, existing_count = manager_workspace._workspace_h5_paths_storage_size(
+        fname, ("0", "missing")
+    )
+    assert storage_size >= np.dtype(np.float64).itemsize
+    assert existing_count == 1
+    assert manager_workspace._workspace_live_h5_storage_size(fname) == storage_size
+    assert manager_workspace._workspace_obsolete_estimate(fname) >= 0
+    root_attrs, copy_groups = manager_workspace._workspace_file_repack_payload(fname)
+
+    manifest = manager_workspace._workspace_manifest_from_attrs(root_attrs)
+    assert "delta_save_count" not in manifest
+    assert "transaction_protocol" not in manifest
+    assert (
+        manifest["schema_version"]
+        == manager_workspace._current_workspace_schema_version()
+    )
+    assert manifest["erlab_version"] == erlab.__version__
+    assert copy_groups == (("0", "0", None),)
+
+    manager_workspace._write_full_workspace_tree_file(
+        fname,
+        None,
+        root_attrs,
+        copy_source=fname,
+        copy_groups=copy_groups,
+    )
+
+    assert _read_transaction_test_value(fname) == 1.0
+    _assert_no_workspace_internal_groups(fname)
+    with h5py.File(fname, "r") as h5_file:
+        assert set(h5_file) == {"0"}
+        manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert "delta_save_count" not in manifest
+        assert "transaction_protocol" not in manifest
+
+
 def test_workspace_dataset_encoding_compresses_only_large_numeric_payloads() -> None:
     import hdf5plugin
 
@@ -7228,6 +7283,71 @@ def test_manager_compact_workspace_reapplies_compression_mode(
         erlab.interactive.options["io/workspace/compression"] = old_compression
 
 
+def test_manager_shutdown_compact_preserves_existing_dataset_filters(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    old_compression = erlab.interactive.options["io/workspace/compression"]
+    try:
+        erlab.interactive.options["io/workspace/compression"] = "none"
+        with manager_context() as manager:
+            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+            data = xr.DataArray(
+                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
+                dims=("x", "y"),
+            )
+
+            root = itool(data, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+            uid = manager._tool_graph.root_wrappers[0].uid
+
+            fname = tmp_path / "shutdown-preserve-filters.itws"
+            manager._save_workspace_document(fname, force_full=True)
+            manager._adopt_workspace_path(fname)
+            manager._mark_workspace_clean()
+            manager._mark_node_data_dirty(uid)
+            assert manager.save()
+
+            with h5py.File(fname, "r") as h5_file:
+                assert (
+                    _hdf5_blosc2_level_codec(
+                        h5_file["0/imagetool"][manager_workspace_io._ITOOL_DATA_NAME]
+                    )
+                    is None
+                )
+
+            erlab.interactive.options["io/workspace/compression"] = "zstd1"
+            monkeypatch.setattr(
+                manager_workspace_io,
+                "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
+                1,
+            )
+            monkeypatch.setattr(
+                manager_workspace_io,
+                "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
+                0.0,
+            )
+
+            manager._compact_workspace_before_shutdown()
+
+            with h5py.File(fname, "r") as h5_file:
+                assert (
+                    _hdf5_blosc2_level_codec(
+                        h5_file["0/imagetool"][manager_workspace_io._ITOOL_DATA_NAME]
+                    )
+                    is None
+                )
+    finally:
+        erlab.interactive.options["io/workspace/compression"] = old_compression
+
+
 def test_manager_shutdown_compaction_logs_failure(
     caplog,
     monkeypatch,
@@ -7239,6 +7359,26 @@ def test_manager_shutdown_compaction_logs_failure(
     with manager_context() as manager:
         manager._workspace_state.path = tmp_path / "workspace.itws"
         manager._workspace_state.delta_save_count = 1
+        manager._workspace_state.set_repack_estimate(
+            estimated_obsolete_bytes=100,
+            replacement_delta_count=1,
+        )
+
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_should_repack_before_shutdown",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_file_repack_snapshot",
+            lambda generation: manager_workspace._WorkspaceSaveSnapshot(
+                generation=generation,
+                root_attrs=_transaction_test_root_attrs(delta_save_count=1),
+                delta_save_count=0,
+                file_repack=True,
+            ),
+        )
 
         def _fail_worker(
             _fname: str | os.PathLike[str],
@@ -7605,6 +7745,15 @@ def test_workspace_metadata_helpers_cover_invalid_payloads() -> None:
         )["delta_save_count"]
         == 2
     )
+    manifest = manager_workspace._workspace_manifest_from_attrs(
+        {manager_workspace._WORKSPACE_MANIFEST_ATTR: raw_manifest}
+    )
+    assert manager_workspace._workspace_manifest_repack_estimate(
+        manifest, delta_save_count=2
+    ) == (0, 0, True)
+    assert manager_workspace._workspace_manifest_repack_estimate(
+        {"delta_save_count": 2}, delta_save_count=2
+    ) == (0, 0, False)
     assert (
         manager_workspace._workspace_manifest_from_attrs(
             {manager_workspace._WORKSPACE_MANIFEST_ATTR: "{not-json"}
@@ -9406,6 +9555,12 @@ def test_manager_workspace_compact_resets_delta_count_and_cleans_internal_groups
         manager._mark_node_state_dirty(uid)
         assert manager.save()
         assert manager._workspace_state.delta_save_count == 1
+        assert manager._workspace_state.estimated_obsolete_bytes == 0
+        assert manager._workspace_state.replacement_delta_count == 0
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert manifest["estimated_obsolete_bytes"] == 0
+        assert manifest["replacement_delta_count"] == 0
 
         monkeypatch.setattr(
             erlab.interactive.utils,
@@ -9415,6 +9570,8 @@ def test_manager_workspace_compact_resets_delta_count_and_cleans_internal_groups
 
         assert manager.compact_workspace()
         assert manager._workspace_state.delta_save_count == 0
+        assert manager._workspace_state.estimated_obsolete_bytes == 0
+        assert manager._workspace_state.replacement_delta_count == 0
         _assert_no_workspace_internal_groups(fname)
         with h5py.File(fname, "r") as h5_file:
             assert (
@@ -9426,8 +9583,57 @@ def test_manager_workspace_compact_resets_delta_count_and_cleans_internal_groups
             assert "transaction_protocol" not in manifest
 
 
+def test_manager_workspace_delta_save_tracks_repack_benefit(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+
+        fname = tmp_path / "delta-benefit.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+        manager._mark_node_data_dirty(uid)
+        assert manager.save()
+
+        assert manager._workspace_state.delta_save_count == 1
+        assert manager._workspace_state.estimated_obsolete_bytes > 0
+        assert manager._workspace_state.replacement_delta_count == 1
+        assert manager._workspace_state.repack_estimate_known
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert (
+            manifest["estimated_obsolete_bytes"]
+            == manager._workspace_state.estimated_obsolete_bytes
+        )
+        assert manifest["replacement_delta_count"] == 1
+
+        manager._save_workspace_document(fname, force_full=True)
+
+        assert manager._workspace_state.delta_save_count == 0
+        assert manager._workspace_state.estimated_obsolete_bytes == 0
+        assert manager._workspace_state.replacement_delta_count == 0
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+        assert "estimated_obsolete_bytes" not in manifest
+        assert "replacement_delta_count" not in manifest
+
+
 def test_manager_workspace_shutdown_compacts_clean_delta_workspace(
     qtbot,
+    monkeypatch,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -9448,13 +9654,29 @@ def test_manager_workspace_shutdown_compacts_clean_delta_workspace(
         manager._save_workspace_document(fname, force_full=True)
         manager._adopt_workspace_path(fname)
         manager._mark_workspace_clean()
-        manager._mark_node_state_dirty(uid)
+        manager._mark_node_data_dirty(uid)
         assert manager.save()
         assert manager._workspace_state.delta_save_count == 1
+        assert manager._workspace_state.estimated_obsolete_bytes > 0
+        assert manager._workspace_state.replacement_delta_count == 1
+
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
+            1,
+        )
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
+            0.0,
+        )
 
         manager._compact_workspace_before_shutdown()
 
         assert manager._workspace_state.delta_save_count == 0
+        assert manager._workspace_state.estimated_obsolete_bytes == 0
+        assert manager._workspace_state.replacement_delta_count == 0
+        _assert_no_workspace_internal_groups(fname)
         with h5py.File(fname, "r") as h5_file:
             assert (
                 manager_workspace._workspace_delta_save_count_from_attrs(h5_file.attrs)
@@ -9463,6 +9685,261 @@ def test_manager_workspace_shutdown_compacts_clean_delta_workspace(
             manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
             assert "delta_save_count" not in manifest
             assert "transaction_protocol" not in manifest
+
+
+def test_manager_workspace_shutdown_compact_uses_file_level_repack(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+
+        fname = tmp_path / "shutdown-file-repack.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+        manager._mark_node_data_dirty(uid)
+        assert manager.save()
+        assert manager._workspace_state.delta_save_count == 1
+        assert manager._workspace_state.replacement_delta_count == 1
+
+        def _fail_to_datatree() -> xr.DataTree:
+            pytest.fail("Shutdown file-level repack should not serialize tools")
+
+        monkeypatch.setattr(manager, "_to_datatree", _fail_to_datatree)
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
+            1,
+        )
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
+            0.0,
+        )
+
+        manager._compact_workspace_before_shutdown()
+
+        assert manager._workspace_state.delta_save_count == 0
+        _assert_no_workspace_internal_groups(fname)
+        with h5py.File(fname, "r") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+            assert "delta_save_count" not in manifest
+            assert "transaction_protocol" not in manifest
+
+
+def test_manager_workspace_shutdown_compact_skips_state_only_delta(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+
+        fname = tmp_path / "shutdown-state-skip.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+        manager._mark_node_state_dirty(uid)
+        assert manager.save()
+        assert manager._workspace_state.delta_save_count == 1
+        assert manager._workspace_state.replacement_delta_count == 0
+
+        monkeypatch.setattr(
+            manager,
+            "_run_workspace_save_worker",
+            lambda *args, **kwargs: pytest.fail(
+                "State-only shutdown compaction should skip"
+            ),
+        )
+
+        manager._compact_workspace_before_shutdown()
+
+        assert manager._workspace_state.delta_save_count == 1
+
+
+def test_manager_workspace_shutdown_compact_skips_below_threshold_data_delta(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+
+        fname = tmp_path / "shutdown-threshold-skip.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+        manager._mark_node_data_dirty(uid)
+        assert manager.save()
+        assert manager._workspace_state.delta_save_count == 1
+        assert manager._workspace_state.estimated_obsolete_bytes > 0
+        assert manager._workspace_state.replacement_delta_count == 1
+
+        monkeypatch.setattr(
+            manager,
+            "_run_workspace_save_worker",
+            lambda *args, **kwargs: pytest.fail(
+                "Below-threshold shutdown compaction should skip"
+            ),
+        )
+
+        manager._compact_workspace_before_shutdown()
+
+        assert manager._workspace_state.delta_save_count == 1
+
+
+def test_manager_workspace_shutdown_compact_scans_when_estimate_missing(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+
+        fname = tmp_path / "shutdown-missing-estimate.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+        manager._mark_node_data_dirty(uid)
+        assert manager.save()
+        with h5py.File(fname, "a") as h5_file:
+            manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
+            manifest.pop("estimated_obsolete_bytes", None)
+            manifest.pop("replacement_delta_count", None)
+            h5_file.attrs[manager_workspace._WORKSPACE_MANIFEST_ATTR] = json.dumps(
+                manifest
+            )
+        manager._workspace_state.set_repack_estimate(
+            estimated_obsolete_bytes=0,
+            replacement_delta_count=0,
+            known=False,
+        )
+
+        scan_calls: list[pathlib.Path] = []
+
+        def _fake_estimate(path: str | os.PathLike[str]) -> int:
+            scan_calls.append(pathlib.Path(path))
+            return 100
+
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_workspace_obsolete_estimate",
+            _fake_estimate,
+        )
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
+            1,
+        )
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
+            0.0,
+        )
+
+        manager._compact_workspace_before_shutdown()
+
+        assert scan_calls == [fname.resolve()]
+        assert manager._workspace_state.delta_save_count == 0
+
+
+def test_manager_workspace_shutdown_compact_skips_if_file_repack_unavailable(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+
+        fname = tmp_path / "shutdown-fallback-repack.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+        manager._mark_node_data_dirty(uid)
+        assert manager.save()
+        assert manager._workspace_state.delta_save_count == 1
+
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
+            1,
+        )
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
+            0.0,
+        )
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_file_repack_snapshot",
+            lambda _generation: None,
+        )
+
+        def _fail_full_save_snapshot(
+            _generation: int,
+        ) -> manager_workspace._WorkspaceSaveSnapshot:
+            pytest.fail("Shutdown compaction should not serialize as a fallback")
+
+        monkeypatch.setattr(
+            manager,
+            "_workspace_full_save_snapshot",
+            _fail_full_save_snapshot,
+        )
+
+        manager._compact_workspace_before_shutdown()
+
+        assert manager._workspace_state.delta_save_count == 1
 
 
 def test_manager_workspace_shutdown_compact_shows_optimization_wait_dialog(
@@ -9486,7 +9963,7 @@ def test_manager_workspace_shutdown_compact_shows_optimization_wait_dialog(
         manager._save_workspace_document(fname, force_full=True)
         manager._adopt_workspace_path(fname)
         manager._mark_workspace_clean()
-        manager._mark_node_state_dirty(uid)
+        manager._mark_node_data_dirty(uid)
         assert manager.save()
         assert manager._workspace_state.delta_save_count == 1
 
@@ -9511,6 +9988,16 @@ def test_manager_workspace_shutdown_compact_shows_optimization_wait_dialog(
             erlab.interactive.imagetool.manager._workspace_io,
             "_WORKSPACE_SAVE_WAIT_DIALOG_THRESHOLD_SECONDS",
             0.01,
+        )
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
+            1,
+        )
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
+            0.0,
         )
         monkeypatch.setattr(
             manager_workspace,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -14,6 +14,7 @@ import warnings
 import weakref
 from collections.abc import Callable, Iterable, Mapping
 
+import hdf5plugin
 import numpy as np
 import pydantic
 import pytest
@@ -699,6 +700,7 @@ def test_manager_workspace_option_overrides_roundtrip_and_mark_dirty(
     overrides = {
         "colors/cmap/name": "viridis",
         "colors/max_rendered_abs_value": 12.0,
+        "io/workspace/compression": "none",
         "figure/stylesheets": ["classic", "missing-style"],
     }
 
@@ -2640,6 +2642,15 @@ def _hdf5_filter_ids(dataset) -> list[int]:
     return [create_plist.get_filter(i)[0] for i in range(create_plist.get_nfilters())]
 
 
+def _hdf5_blosc2_level_codec(dataset) -> tuple[int, int] | None:
+    create_plist = dataset.id.get_create_plist()
+    for index in range(create_plist.get_nfilters()):
+        filter_id, _flags, cd_values, _name = create_plist.get_filter(index)
+        if filter_id == hdf5plugin.Blosc2.filter_id:
+            return cd_values[4], cd_values[6]
+    return None
+
+
 def _transaction_test_root_attrs(delta_save_count: int = 0) -> dict[str, object]:
     manifest: dict[str, object] = {
         "schema_version": 4,
@@ -2720,11 +2731,44 @@ def test_workspace_dataset_encoding_compresses_only_large_numeric_payloads() -> 
     assert set(encoding) == {"large"}
     assert encoding["large"] == dict(
         hdf5plugin.Blosc2(
-            cname="blosclz",
-            clevel=3,
+            cname="zstd",
+            clevel=1,
             filters=hdf5plugin.Blosc2.SHUFFLE,
         )
     )
+
+
+def test_workspace_dataset_encoding_supports_compression_modes() -> None:
+    ds = xr.Dataset(
+        {
+            "large": (
+                ("x", "y"),
+                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
+            )
+        }
+    )
+
+    assert manager_xarray.workspace_dataset_encoding(ds, compression_mode="none") == {}
+    assert manager_xarray.workspace_dataset_encoding(
+        ds, compression_mode="blosclz3"
+    ) == {
+        "large": dict(
+            hdf5plugin.Blosc2(
+                cname="blosclz",
+                clevel=3,
+                filters=hdf5plugin.Blosc2.SHUFFLE,
+            )
+        )
+    }
+    assert manager_xarray.workspace_dataset_encoding(ds, compression_mode="zstd1") == {
+        "large": dict(
+            hdf5plugin.Blosc2(
+                cname="zstd",
+                clevel=1,
+                filters=hdf5plugin.Blosc2.SHUFFLE,
+            )
+        )
+    }
 
 
 def test_workspace_dataset_encoding_respects_compression_preference() -> None:
@@ -2736,15 +2780,30 @@ def test_workspace_dataset_encoding_respects_compression_preference() -> None:
             )
         }
     )
-    old_value = erlab.interactive.options["io/workspace/compress"]
+    old_value = erlab.interactive.options["io/workspace/compression"]
     try:
-        erlab.interactive.options["io/workspace/compress"] = False
+        erlab.interactive.options["io/workspace/compression"] = "none"
         assert manager_xarray.workspace_dataset_encoding(ds) == {}
 
-        erlab.interactive.options["io/workspace/compress"] = True
-        assert set(manager_xarray.workspace_dataset_encoding(ds)) == {"large"}
+        erlab.interactive.options["io/workspace/compression"] = "blosclz3"
+        assert manager_xarray.workspace_dataset_encoding(ds)["large"] == dict(
+            hdf5plugin.Blosc2(
+                cname="blosclz",
+                clevel=3,
+                filters=hdf5plugin.Blosc2.SHUFFLE,
+            )
+        )
+
+        erlab.interactive.options["io/workspace/compression"] = "zstd1"
+        assert manager_xarray.workspace_dataset_encoding(ds)["large"] == dict(
+            hdf5plugin.Blosc2(
+                cname="zstd",
+                clevel=1,
+                filters=hdf5plugin.Blosc2.SHUFFLE,
+            )
+        )
     finally:
-        erlab.interactive.options["io/workspace/compress"] = old_value
+        erlab.interactive.options["io/workspace/compression"] = old_value
 
 
 def test_workspace_dataset_encoding_persists_dask_chunksizes() -> None:
@@ -3450,6 +3509,7 @@ def test_workspace_h5py_fast_path_roundtrips_saved_tool_extra_blob(
     )
     with h5py.File(fname, "r") as h5_file:
         assert hdf5plugin.Blosc2.filter_id in _hdf5_filter_ids(h5_file["0/tool/data_1"])
+        assert _hdf5_blosc2_level_codec(h5_file["0/tool/data_1"]) == (1, 5)
     xr.testing.assert_identical(loaded[data_name], primary.rename(data_name))
     xr.testing.assert_equal(
         loaded[data_name].coords["Fake Motor"], primary.coords["Fake Motor"]
@@ -3457,15 +3517,23 @@ def test_workspace_h5py_fast_path_roundtrips_saved_tool_extra_blob(
     restored_secondary = erlab.interactive.utils._tool_data_from_blob(loaded["data_1"])
     xr.testing.assert_equal(restored_secondary, secondary)
 
-    old_value = erlab.interactive.options["io/workspace/compress"]
+    old_value = erlab.interactive.options["io/workspace/compression"]
     try:
-        erlab.interactive.options["io/workspace/compress"] = False
+        erlab.interactive.options["io/workspace/compression"] = "blosclz3"
+        blosclz_fname = tmp_path / "blosclz-saved-tool-extra-blob.itws"
+        manager_workspace._write_workspace_dataset_group_to_file(
+            blosclz_fname, "0/tool", ds
+        )
+
+        erlab.interactive.options["io/workspace/compression"] = "none"
         uncompressed_fname = tmp_path / "uncompressed-saved-tool-extra-blob.itws"
         manager_workspace._write_workspace_dataset_group_to_file(
             uncompressed_fname, "0/tool", ds
         )
     finally:
-        erlab.interactive.options["io/workspace/compress"] = old_value
+        erlab.interactive.options["io/workspace/compression"] = old_value
+    with h5py.File(blosclz_fname, "r") as h5_file:
+        assert _hdf5_blosc2_level_codec(h5_file["0/tool/data_1"]) == (3, 0)
     with h5py.File(uncompressed_fname, "r") as h5_file:
         assert hdf5plugin.Blosc2.filter_id not in _hdf5_filter_ids(
             h5_file["0/tool/data_1"]
@@ -8871,12 +8939,15 @@ def test_manager_workspace_state_save_updates_attrs_without_full_rewrite(
                 ]
             ],
             root_attrs: Mapping[str, typing.Any],
+            **kwargs: typing.Any,
         ) -> None:
             rewrite_groups = tuple(rewrite_groups)
             updates = tuple(attr_updates)
             assert rewrite_groups == ()
             attr_write_calls.extend(update[0] for update in updates)
-            original_transaction_write(_fname, rewrite_groups, updates, root_attrs)
+            original_transaction_write(
+                _fname, rewrite_groups, updates, root_attrs, **kwargs
+            )
 
         monkeypatch.setattr(
             manager_workspace,
@@ -9320,6 +9391,32 @@ def test_manager_workspace_high_risk_path_forces_full_save_snapshot(
         try:
             assert snapshot.full_tree is not None
             assert snapshot.delta_save_count == 0
+        finally:
+            snapshot.close()
+
+
+def test_manager_workspace_save_snapshot_uses_compression_override(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        manager._set_workspace_option_overrides(
+            {"io/workspace/compression": "blosclz3"}
+        )
+        assert manager._workspace_compression_mode() == "blosclz3"
+
+        snapshot = manager._workspace_save_snapshot(tmp_path / "snapshot.itws")
+        try:
+            assert snapshot.compression_mode == "blosclz3"
         finally:
             snapshot.close()
 

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -2759,7 +2759,224 @@ def test_workspace_file_repack_payload_strips_delta_and_skips_internal_groups(
         assert set(h5_file) == {"0"}
         manifest = manager_workspace._workspace_manifest_from_attrs(h5_file.attrs)
         assert "delta_save_count" not in manifest
-        assert "transaction_protocol" not in manifest
+
+
+def test_workspace_h5py_helpers_reject_non_workspace_files(tmp_path) -> None:
+    import h5py
+
+    fname = tmp_path / "not-workspace.itws"
+    with h5py.File(fname, "w") as h5_file:
+        h5_file.create_group("0")
+
+    with pytest.raises(ValueError, match="Not a valid workspace file"):
+        manager_workspace._workspace_live_root_group_copy_groups(fname)
+    with pytest.raises(ValueError, match="Not a valid workspace file"):
+        manager_workspace._workspace_h5_paths_storage_size(fname, ("0",))
+    with pytest.raises(ValueError, match="Not a valid workspace file"):
+        manager_workspace._workspace_live_h5_storage_size(fname)
+
+    assert (
+        manager_workspace._workspace_obsolete_estimate(tmp_path / "missing.itws") == 0
+    )
+    assert manager_workspace._workspace_h5_object_storage_size(object()) == 0
+
+
+def test_workspace_h5py_filter_matching_edge_cases(tmp_path) -> None:
+    import h5py
+
+    fname = tmp_path / "filters.h5"
+    with h5py.File(fname, "w") as h5_file:
+        plain = h5_file.create_dataset("plain", data=np.arange(3))
+        compressed = h5_file.create_dataset(
+            "compressed",
+            data=np.arange(3),
+            **hdf5plugin.Blosc2(
+                cname="zstd",
+                clevel=1,
+                filters=hdf5plugin.Blosc2.SHUFFLE,
+            ),
+        )
+        group = h5_file.create_group("payload")
+        group.create_dataset("data", data=np.arange(3), compression="gzip")
+
+        assert manager_workspace._workspace_h5py_dataset_matches_encoding(plain, {})
+        assert not manager_workspace._workspace_h5py_dataset_matches_encoding(
+            plain, {"compression": hdf5plugin.Blosc2.filter_id}
+        )
+        assert manager_workspace._workspace_h5py_dataset_matches_encoding(
+            compressed, {"compression": hdf5plugin.Blosc2.filter_id}
+        )
+        assert not manager_workspace._workspace_h5_group_matches_compression_mode(
+            h5_file,
+            "missing",
+            xr.Dataset({"data": ("x", np.arange(3))}),
+            "none",
+        )
+        assert not manager_workspace._workspace_h5_group_matches_compression_mode(
+            h5_file,
+            "payload",
+            xr.Dataset({"missing": ("x", np.arange(3))}),
+            "none",
+        )
+        assert not manager_workspace._workspace_h5_group_matches_compression_mode(
+            h5_file,
+            "payload",
+            xr.Dataset({"data": ("x", np.arange(3))}),
+            "none",
+        )
+
+
+def test_workspace_h5py_copy_rebuilds_attrs_and_dimension_scales(tmp_path) -> None:
+    import h5py
+
+    class _FakeH5Type:
+        def __init__(
+            self,
+            type_class: object,
+            *,
+            super_type: "_FakeH5Type | None" = None,
+            member_types: tuple["_FakeH5Type", ...] = (),
+        ) -> None:
+            self._type_class = type_class
+            self._super_type = super_type
+            self._member_types = member_types
+            self.closed = False
+
+        def get_class(self) -> object:
+            return self._type_class
+
+        def get_super(self) -> "_FakeH5Type":
+            if self._super_type is None:
+                raise RuntimeError("missing super type")
+            return self._super_type
+
+        def get_nmembers(self) -> int:
+            return len(self._member_types)
+
+        def get_member_type(self, index: int) -> "_FakeH5Type":
+            return self._member_types[index]
+
+        def close(self) -> None:
+            self.closed = True
+
+    array_member = _FakeH5Type(h5py.h5t.REFERENCE)
+    array_type = _FakeH5Type(h5py.h5t.ARRAY, super_type=array_member)
+    assert manager_workspace._workspace_h5py_type_contains_reference(array_type)
+    assert array_member.closed
+
+    plain_member = _FakeH5Type(h5py.h5t.INTEGER)
+    compound_type = _FakeH5Type(h5py.h5t.COMPOUND, member_types=(plain_member,))
+    assert not manager_workspace._workspace_h5py_type_contains_reference(compound_type)
+    assert plain_member.closed
+
+    fname = tmp_path / "dimension-scales.h5"
+    with h5py.File(fname, "w") as h5_file:
+        source = h5_file.create_group("source")
+        source.create_group("nested")
+        source.create_dataset("plain", data=np.arange(2))
+        source["plain"].attrs["_Netcdf4Coordinates"] = np.array([0, 1])
+        source.create_dataset("scale_without_dimid", data=np.arange(2))
+        source["scale_without_dimid"].attrs["CLASS"] = b"DIMENSION_SCALE"
+        source["named_type"] = np.dtype("int32")
+
+        scale = source.create_dataset("x", data=np.arange(2))
+        scale.attrs["CLASS"] = b"DIMENSION_SCALE"
+        scale.attrs["NAME"] = b"x"
+        scale.attrs["_Netcdf4Dimid"] = np.int32(0)
+
+        values = source.create_dataset("values", data=np.arange(2))
+        values.attrs["_Netcdf4Coordinates"] = np.array([0])
+        values_missing_scale = source.create_dataset(
+            "values_missing_scale", data=np.arange(2)
+        )
+        values_missing_scale.attrs["_Netcdf4Coordinates"] = np.array([99])
+        source.attrs["reference"] = values.ref
+        source.attrs["reference_array"] = np.array([values.ref], dtype=h5py.ref_dtype)
+        source.attrs["reference_compound"] = np.array(
+            [(values.ref, 1)],
+            dtype=np.dtype([("reference", h5py.ref_dtype), ("value", np.int32)]),
+        )[0]
+
+        target = h5_file.create_group("target")
+        target.create_group("nested")
+        target.create_dataset("plain", data=np.arange(2))
+        target.create_dataset("scale_without_dimid", data=np.arange(2))
+        target["named_type"] = np.dtype("int32")
+        target.create_dataset("x", data=np.arange(2))
+        target.create_dataset("values", data=np.arange(2))
+        target.create_dataset("values_missing_scale", data=np.arange(2))
+
+        assert manager_workspace._workspace_h5py_attr_text(np.bytes_(b"x")) == "x"
+        assert (
+            manager_workspace._workspace_h5py_attr_text(
+                types.SimpleNamespace(decode=lambda: "decoded")
+            )
+            == "decoded"
+        )
+        assert manager_workspace._workspace_h5py_attr_text("x") == "x"
+        assert manager_workspace._workspace_h5py_attr_text(object()) is None
+
+        manager_workspace._workspace_h5py_rebuild_dimension_scales(source, target)
+
+        assert "reference" not in target.attrs
+        assert "reference_array" not in target.attrs
+        assert "reference_compound" not in target.attrs
+        assert target["x"].attrs["_Netcdf4Dimid"] == 0
+        assert len(target["values"].dims[0]) == 1
+
+
+def test_copy_workspace_h5_group_to_open_file_edge_cases(tmp_path) -> None:
+    import h5py
+
+    fname = tmp_path / "copy.h5"
+    with h5py.File(fname, "w") as h5_file:
+        h5_file.create_dataset("dataset", data=np.arange(2))
+        h5_file.create_group("source").create_dataset("data", data=np.arange(2))
+        h5_file.create_group("target").create_group("source")
+
+        assert not manager_workspace._copy_workspace_h5_group_to_open_file(
+            h5_file, h5_file, "missing", "target/missing", None
+        )
+        assert not manager_workspace._copy_workspace_h5_group_to_open_file(
+            h5_file, h5_file, "dataset", "target/dataset", None
+        )
+        assert manager_workspace._copy_workspace_h5_group_to_open_file(
+            h5_file,
+            h5_file,
+            "source",
+            "target/source",
+            {"title": "copied"},
+        )
+        assert h5_file["target/source"].attrs["title"] == "copied"
+
+
+def test_write_workspace_dataset_group_h5py_cleans_failed_independent_items(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "independent-items.itws"
+    saved_tool_data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
+    ds = xr.Dataset(
+        {
+            saved_tool_data_name: (
+                (manager_workspace._SAVED_TOOL_DATA_REFERENCE_DIM,),
+                np.empty(0, dtype=np.float64),
+            )
+        }
+    )
+    monkeypatch.setattr(
+        manager_workspace,
+        "_workspace_h5py_create_dataset",
+        lambda *_args, **_kwargs: None,
+    )
+
+    assert not manager_workspace._write_workspace_dataset_group_h5py(
+        fname, "0/tool", ds
+    )
+
+    import h5py
+
+    with h5py.File(fname, "r") as h5_file:
+        assert "0/tool" not in h5_file
 
 
 def test_workspace_dataset_encoding_compresses_only_large_numeric_payloads() -> None:
@@ -2824,6 +3041,22 @@ def test_workspace_dataset_encoding_supports_compression_modes() -> None:
             )
         )
     }
+    assert manager_xarray.workspace_dataset_encoding(ds, compress=True) == {
+        "large": dict(
+            hdf5plugin.Blosc2(
+                cname="zstd",
+                clevel=1,
+                filters=hdf5plugin.Blosc2.SHUFFLE,
+            )
+        )
+    }
+    with pytest.raises(ValueError, match="Unknown workspace compression mode"):
+        manager_xarray.workspace_dataset_encoding(
+            ds,
+            compression_mode=typing.cast(
+                "manager_xarray.WorkspaceCompressionMode", "missing"
+            ),
+        )
 
 
 def test_workspace_dataset_encoding_respects_compression_preference() -> None:
@@ -2838,6 +3071,7 @@ def test_workspace_dataset_encoding_respects_compression_preference() -> None:
     old_value = erlab.interactive.options["io/workspace/compression"]
     try:
         erlab.interactive.options["io/workspace/compression"] = "none"
+        assert not manager_xarray.workspace_compression_enabled()
         assert manager_xarray.workspace_dataset_encoding(ds) == {}
 
         erlab.interactive.options["io/workspace/compression"] = "blosclz3"
@@ -4603,6 +4837,41 @@ def test_manager_from_h5py_workspace_falls_back_after_fast_read_error(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
 
+def test_manager_load_workspace_file_falls_back_after_fast_path_error(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25.0).reshape(5, 5), dims=("x", "y"))
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        fname = tmp_path / "load-fallback.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+        def _raise_fast_load(*_args, **_kwargs) -> bool:
+            raise RuntimeError("fast load failed")
+
+        monkeypatch.setattr(manager, "_from_h5py_workspace_file", _raise_fast_load)
+
+        assert manager._load_workspace_file(
+            fname,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        assert manager._workspace_state.path == fname.resolve()
+
+
 def test_manager_from_h5py_workspace_logs_restore_failure(
     qtbot,
     caplog,
@@ -4721,8 +4990,14 @@ def test_manager_workspace_full_save_copy_group_edge_cases(
         tool = DerivativeTool(data)
         monkeypatch.setattr(tool, "can_save_and_load", lambda: False)
         manager.add_childtool(tool, 0, show=False)
+        manager.add_childtool(_AddedTimeChildTool(data), 0, show=False)
         manager._mark_workspace_clean()
         tree = manager._to_datatree()
+        monkeypatch.setitem(
+            manager._tool_graph.nodes,
+            "missing-tool",
+            types.SimpleNamespace(is_imagetool=False, tool_window=None),
+        )
         try:
             manifest_without_identities = {
                 "schema_version": manager_workspace._current_workspace_schema_version(),
@@ -4772,6 +5047,7 @@ def test_manager_workspace_full_save_copy_group_edge_cases(
             )
         finally:
             tree.close()
+            manager._tool_graph.nodes.pop("missing-tool", None)
 
 
 def test_prepare_workspace_transaction_promotes_missing_attr_fallback(
@@ -5088,6 +5364,43 @@ def test_write_full_workspace_tree_file_scratch_exdev_fallback(
     assert replace_calls[1][0].parent == fname.parent
     assert replace_calls[1][1] == fname
     assert not list(fname.parent.glob(f"{fname.name}.tmp-*"))
+
+
+def test_write_full_workspace_tree_file_rejects_file_repack_on_network_path(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "network.itws"
+    _write_transaction_test_workspace(fname)
+
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_high_risk", lambda *_: True
+    )
+    monkeypatch.setattr(
+        manager_workspace, "_workspace_path_is_likely_network_path", lambda *_: True
+    )
+
+    with pytest.raises(ValueError, match="File-level workspace repack cannot run"):
+        manager_workspace._write_full_workspace_tree_file(
+            fname,
+            None,
+            _transaction_test_root_attrs(),
+            copy_source=fname,
+            copy_groups=(("0", "0", None),),
+        )
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(5.0, title="network")}
+    )
+    try:
+        manager_workspace._write_full_workspace_tree_file(
+            fname,
+            tree,
+            _transaction_test_root_attrs(),
+            copy_source=fname,
+            copy_groups=(("0", "0", None),),
+        )
+    finally:
+        tree.close()
+    assert _read_transaction_test_value(fname) == 5.0
 
 
 def test_write_full_workspace_tree_file_scratch_replace_failure_preserves_old(
@@ -7754,6 +8067,16 @@ def test_workspace_metadata_helpers_cover_invalid_payloads() -> None:
     assert manager_workspace._workspace_manifest_repack_estimate(
         {"delta_save_count": 2}, delta_save_count=2
     ) == (0, 0, False)
+    assert manager_workspace._workspace_manifest_repack_estimate(
+        None, delta_save_count=2
+    ) == (0, 0, False)
+    assert (
+        manager_workspace._workspace_manifest_nonnegative_int(
+            {"estimated_obsolete_bytes": "not-an-int"},
+            "estimated_obsolete_bytes",
+        )
+        == 0
+    )
     assert (
         manager_workspace._workspace_manifest_from_attrs(
             {manager_workspace._WORKSPACE_MANIFEST_ATTR: "{not-json"}
@@ -7770,6 +8093,15 @@ def test_workspace_metadata_helpers_cover_invalid_payloads() -> None:
         )
         == 0
     )
+    with pytest.raises(ValueError, match="current workspace schema"):
+        manager_workspace._compacted_workspace_root_attrs(
+            {"imagetool_workspace_schema_version": 1}
+        )
+    assert manager_workspace._workspace_root_attrs_with_repack_estimate(
+        {"imagetool_workspace_schema_version": 1},
+        estimated_obsolete_bytes=1,
+        replacement_delta_count=1,
+    ) == {"imagetool_workspace_schema_version": 1}
 
 
 def test_workspace_path_risk_detection_fallbacks(monkeypatch, tmp_path) -> None:
@@ -10105,12 +10437,284 @@ def test_manager_workspace_save_snapshot_uses_compression_override(
             {"io/workspace/compression": "blosclz3"}
         )
         assert manager._workspace_compression_mode() == "blosclz3"
+        manager._workspace_state.delta_save_count = 2
+        manager._workspace_state.set_repack_estimate(
+            estimated_obsolete_bytes=128,
+            replacement_delta_count=3,
+            known=False,
+        )
+        root_attrs = manager._workspace_root_attrs_payload()
+        manifest = manager_workspace._workspace_manifest_from_attrs(root_attrs)
+        assert manifest["delta_save_count"] == 2
+        assert "estimated_obsolete_bytes" not in manifest
+        root_attrs = manager._workspace_root_attrs_payload(
+            delta_save_count=1,
+            estimated_obsolete_bytes=1024,
+            replacement_delta_count=5,
+            repack_estimate_known=True,
+        )
+        manifest = manager_workspace._workspace_manifest_from_attrs(root_attrs)
+        assert manifest["estimated_obsolete_bytes"] == 1024
+        assert manifest["replacement_delta_count"] == 5
 
         snapshot = manager._workspace_save_snapshot(tmp_path / "snapshot.itws")
         try:
             assert snapshot.compression_mode == "blosclz3"
         finally:
             snapshot.close()
+
+
+def test_manager_workspace_delta_save_updates_repack_state(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        writes: list[tuple[object, ...]] = []
+
+        def _snapshot(
+            generation: int,
+            root_attrs: dict[str, typing.Any],
+            delta_save_count: int,
+        ) -> manager_workspace._WorkspaceSaveSnapshot:
+            return manager_workspace._WorkspaceSaveSnapshot(
+                generation=generation,
+                root_attrs=root_attrs,
+                delta_save_count=delta_save_count,
+                estimated_obsolete_bytes=256,
+                replacement_delta_count=4,
+                rewrite_groups=(),
+                attr_updates=(),
+            )
+
+        def _record_write(*args, **kwargs) -> None:
+            writes.append((*args, kwargs))
+
+        monkeypatch.setattr(manager, "_workspace_delta_save_snapshot", _snapshot)
+        monkeypatch.setattr(
+            manager_workspace,
+            "_write_workspace_transaction_file",
+            _record_write,
+        )
+
+        manager._workspace_state.dirty_generation = 5
+        manager._workspace_state.delta_save_count = 6
+        manager._workspace_controller._save_workspace_delta(tmp_path / "delta.itws")
+
+        assert writes
+        assert manager._workspace_state.delta_save_count == 7
+        assert manager._workspace_state.estimated_obsolete_bytes == 256
+        assert manager._workspace_state.replacement_delta_count == 4
+
+
+def test_manager_workspace_delta_snapshot_keeps_replacement_count_for_missing_groups(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        controller = manager._workspace_controller
+
+        manager._workspace_state.path = tmp_path / "workspace.itws"
+        manager._workspace_state.set_repack_estimate(
+            estimated_obsolete_bytes=100,
+            replacement_delta_count=2,
+        )
+
+        monkeypatch.setattr(
+            manager,
+            "_workspace_highest_dirty_data_roots",
+            lambda: ("uid",),
+        )
+        monkeypatch.setattr(
+            manager,
+            "_workspace_rewrite_group_snapshot",
+            lambda _uid: ("0", {}),
+        )
+        monkeypatch.setattr(manager, "_iter_descendant_uids", lambda _uid: ())
+        monkeypatch.setattr(
+            controller,
+            "_workspace_manifest_node_uids",
+            lambda _root_attrs: frozenset(),
+        )
+        monkeypatch.setattr(
+            controller,
+            "_workspace_stale_reference_rewrite_uids",
+            lambda _manifest_uids: (),
+        )
+        monkeypatch.setattr(
+            manager_workspace,
+            "_workspace_h5_paths_storage_size",
+            lambda *_args, **_kwargs: (256, 0),
+        )
+
+        snapshot = controller._workspace_delta_save_snapshot(1, {}, 3)
+
+        assert snapshot.estimated_obsolete_bytes == 356
+        assert snapshot.replacement_delta_count == 2
+
+
+def test_manager_write_full_workspace_file_can_disable_group_reuse(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        controller = manager._workspace_controller
+        tree = xr.DataTree()
+        writes: list[dict[str, typing.Any]] = []
+
+        monkeypatch.setattr(manager, "_to_datatree", lambda: tree)
+        monkeypatch.setattr(
+            manager,
+            "_workspace_full_save_copy_groups",
+            lambda *_args, **_kwargs: pytest.fail("copy groups should not be reused"),
+        )
+
+        def _record_write(*_args, **kwargs) -> None:
+            writes.append(kwargs)
+
+        monkeypatch.setattr(
+            manager_workspace,
+            "_write_full_workspace_tree_file",
+            _record_write,
+        )
+
+        controller._write_full_workspace_file(
+            tmp_path / "full.itws", reuse_unchanged_groups=False
+        )
+
+        assert writes
+        assert writes[0]["copy_source"] is None
+        assert writes[0]["copy_groups"] == ()
+
+
+def test_manager_associate_loaded_legacy_workspace_resets_repack_state(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        converted = tmp_path / "converted.itws"
+        manager._workspace_state.path = converted.resolve()
+
+        monkeypatch.setattr(
+            manager_workspace,
+            "_workspace_schema_requires_conversion",
+            lambda _schema_version: True,
+        )
+        monkeypatch.setattr(
+            manager,
+            "_save_legacy_workspace_as_v4",
+            lambda *_, **__: (str(converted), None),
+        )
+
+        manager._associate_loaded_workspace_file(
+            tmp_path / "legacy.itws",
+            1,
+            delta_save_count=5,
+            estimated_obsolete_bytes=100,
+            replacement_delta_count=2,
+            repack_estimate_known=False,
+            rebind_data=False,
+        )
+
+        assert manager._workspace_state.path == converted
+        assert manager._workspace_state.delta_save_count == 0
+        assert manager._workspace_state.estimated_obsolete_bytes == 0
+        assert manager._workspace_state.replacement_delta_count == 0
+        assert manager._workspace_state.repack_estimate_known
+
+
+def test_manager_workspace_file_repack_snapshot_guards(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        controller = manager._workspace_controller
+
+        manager._workspace_state.path = None
+        assert controller._workspace_file_repack_snapshot(1) is None
+
+        manager._workspace_state.path = tmp_path / "network.itws"
+        monkeypatch.setattr(
+            manager_workspace,
+            "_workspace_path_is_likely_network_path",
+            lambda _path: True,
+        )
+        assert controller._workspace_file_repack_snapshot(1) is None
+
+        monkeypatch.setattr(
+            manager_workspace,
+            "_workspace_path_is_likely_network_path",
+            lambda _path: False,
+        )
+        monkeypatch.setattr(
+            manager_workspace,
+            "_workspace_file_repack_payload",
+            lambda _path: (_ for _ in ()).throw(RuntimeError("repack failed")),
+        )
+        assert controller._workspace_file_repack_snapshot(1) is None
+
+
+def test_manager_workspace_shutdown_repack_gate_edges(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        controller = manager._workspace_controller
+
+        manager._workspace_state.path = None
+        assert not controller._workspace_should_repack_before_shutdown()
+
+        workspace_path = tmp_path / "workspace.itws"
+        manager._workspace_state.path = workspace_path
+        manager._workspace_state.set_repack_estimate(
+            estimated_obsolete_bytes=0,
+            replacement_delta_count=0,
+            known=False,
+        )
+        monkeypatch.setattr(
+            manager_workspace_io,
+            "_workspace_obsolete_estimate",
+            lambda _path: (_ for _ in ()).throw(RuntimeError("estimate failed")),
+        )
+        assert not controller._workspace_should_repack_before_shutdown()
+
+        manager._workspace_state.set_repack_estimate(
+            estimated_obsolete_bytes=100,
+            replacement_delta_count=1,
+        )
+        assert not controller._workspace_should_repack_before_shutdown()
+
+        workspace_path.touch()
+        assert not controller._workspace_should_repack_before_shutdown()
 
 
 def test_workspace_remote_incremental_option_allows_delta_save(

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -7023,6 +7023,179 @@ def test_manager_compact_workspace_edge_paths(
         assert focus_restores == [None]
 
 
+def test_manager_compact_workspace_rewrites_without_copy_groups(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25.0).reshape(5, 5), dims=("x", "y"))
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "manual-repack.itws"
+        manager._save_workspace_document(fname, force_full=True)
+        manager._adopt_workspace_path(fname)
+        manager._mark_workspace_clean()
+
+        tree = manager._to_datatree()
+        try:
+            copy_source, copy_groups = manager._workspace_full_save_copy_groups(tree)
+        finally:
+            tree.close()
+        assert copy_source == str(fname)
+        assert copy_groups
+
+        original_write = manager_workspace._write_full_workspace_tree_file
+        full_write_calls: list[
+            tuple[
+                str | os.PathLike[str] | None,
+                tuple[tuple[str, str, dict[str, typing.Any] | None], ...],
+            ]
+        ] = []
+
+        def _record_full_write(
+            write_fname: str | os.PathLike[str],
+            write_tree: xr.DataTree,
+            root_attrs: Mapping[str, typing.Any],
+            **kwargs: typing.Any,
+        ) -> None:
+            full_write_calls.append(
+                (kwargs.get("copy_source"), tuple(kwargs.get("copy_groups", ())))
+            )
+            original_write(write_fname, write_tree, root_attrs, **kwargs)
+
+        monkeypatch.setattr(
+            erlab.interactive.utils,
+            "wait_dialog",
+            lambda *args, **kwargs: contextlib.nullcontext(),
+        )
+        monkeypatch.setattr(
+            manager_workspace,
+            "_write_full_workspace_tree_file",
+            _record_full_write,
+        )
+
+        assert manager.compact_workspace()
+
+        assert full_write_calls[-1] == (None, ())
+
+
+def test_manager_compact_workspace_reduces_internal_holes(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    old_compression = erlab.interactive.options["io/workspace/compression"]
+    erlab.interactive.options["io/workspace/compression"] = "none"
+    try:
+        with manager_context() as manager:
+            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+            rng = np.random.default_rng(1234)
+            data = xr.DataArray(
+                rng.integers(0, 256, size=(2048, 2048), dtype=np.uint8),
+                dims=("x", "y"),
+            )
+            updated = xr.DataArray(
+                rng.integers(0, 256, size=(2048, 2048), dtype=np.uint8),
+                dims=("x", "y"),
+            )
+
+            root = itool(data, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+            uid = manager._tool_graph.root_wrappers[0].uid
+
+            fname = tmp_path / "hole-repack.itws"
+            manager._save_workspace_document(fname, force_full=True)
+            manager._adopt_workspace_path(fname)
+            manager._mark_workspace_clean()
+            size_full = fname.stat().st_size
+
+            manager.get_imagetool(0).slicer_area.replace_source_data(
+                updated,
+                auto_compute=False,
+            )
+            manager._mark_node_data_dirty(uid)
+            assert manager.save()
+            size_incremental = fname.stat().st_size
+
+            monkeypatch.setattr(
+                erlab.interactive.utils,
+                "wait_dialog",
+                lambda *args, **kwargs: contextlib.nullcontext(),
+            )
+            assert manager.compact_workspace()
+            size_compact = fname.stat().st_size
+
+            assert size_incremental > size_full + data.nbytes // 2
+            assert size_compact < size_incremental - data.nbytes // 2
+            _assert_no_workspace_internal_groups(fname)
+    finally:
+        erlab.interactive.options["io/workspace/compression"] = old_compression
+
+
+def test_manager_compact_workspace_reapplies_compression_mode(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    import h5py
+
+    old_compression = erlab.interactive.options["io/workspace/compression"]
+    try:
+        erlab.interactive.options["io/workspace/compression"] = "none"
+        with manager_context() as manager:
+            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+            data = xr.DataArray(
+                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
+                dims=("x", "y"),
+            )
+
+            root = itool(data, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+            fname = tmp_path / "compression-repack.itws"
+            manager._save_workspace_document(fname, force_full=True)
+            manager._adopt_workspace_path(fname)
+            manager._mark_workspace_clean()
+            with h5py.File(fname, "r") as h5_file:
+                assert (
+                    _hdf5_blosc2_level_codec(
+                        h5_file["0/imagetool"][manager_workspace_io._ITOOL_DATA_NAME]
+                    )
+                    is None
+                )
+
+            erlab.interactive.options["io/workspace/compression"] = "zstd1"
+            monkeypatch.setattr(
+                erlab.interactive.utils,
+                "wait_dialog",
+                lambda *args, **kwargs: contextlib.nullcontext(),
+            )
+            assert manager.compact_workspace()
+
+            with h5py.File(fname, "r") as h5_file:
+                assert _hdf5_blosc2_level_codec(
+                    h5_file["0/imagetool"][manager_workspace_io._ITOOL_DATA_NAME]
+                ) == (1, 5)
+    finally:
+        erlab.interactive.options["io/workspace/compression"] = old_compression
+
+
 def test_manager_shutdown_compaction_logs_failure(
     caplog,
     monkeypatch,

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -136,6 +136,39 @@ def test_dtool_smoothing_copy_code_uses_readable_steps(qtbot) -> None:
     xr.testing.assert_identical(win.result, result)
 
 
+def test_dtool_deferred_restore_delays_result_recompute(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
+    ).astype(np.float64)
+    win: DerivativeTool = dtool(data, execute=False)
+    qtbot.addWidget(win)
+    win.tab_widget.setCurrentIndex(1)
+    expected = win.result.copy(deep=True)
+    saved = win.to_dataset()
+    calls: list[DerivativeTool] = []
+    original = DerivativeTool._update_result_now
+
+    def _tracked_update_result_now(self: DerivativeTool) -> None:
+        calls.append(self)
+        original(self)
+
+    monkeypatch.setattr(
+        DerivativeTool, "_update_result_now", _tracked_update_result_now
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, DerivativeTool)
+    assert calls == []
+
+    xr.testing.assert_identical(restored.result, expected)
+
+    assert calls == [restored]
+
+
 def test_dtool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> None:
     data = xr.DataArray(
         np.arange(49).reshape((7, 7)), dims=["x", "y"], name="data"

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -973,6 +973,40 @@ def test_restool(qtbot) -> None:
     tmp_dir.cleanup()
 
 
+def test_restool_deferred_restore_live_fit_does_not_trigger_fit(qtbot, monkeypatch):
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+    win.live_check.setChecked(True)
+    saved = win.to_dataset()
+    calls: list[ResolutionTool] = []
+
+    def _tracked_start_fit_worker(self: ResolutionTool) -> bool:
+        calls.append(self)
+        return True
+
+    monkeypatch.setattr(
+        ResolutionTool,
+        "_start_fit_worker",
+        _tracked_start_fit_worker,
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, ResolutionTool)
+    assert restored.live_check.isChecked()
+    assert calls == []
+
+    restored.do_fit()
+
+    assert calls == [restored]
+
+
 def test_restool_undo_redo_state_change(qtbot) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -11,6 +11,8 @@ import xarray_lmfit as xlm
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive._fit1d as fit1d_module
+from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive.fermiedge import (
     EdgeFitSignals,
     EdgeFitTask,
@@ -168,6 +170,67 @@ def test_goldtool_roundtrip_unfitted(qtbot, gold) -> None:
         assert win_restored.result is None
         assert not hasattr(win_restored, "edge_center")
         assert not hasattr(win_restored, "edge_stderr")
+
+
+def test_fit1d_persistence_helper_edges(qtbot, monkeypatch, gold) -> None:
+    win = Fit1DTool(gold.mean("alpha"), data_name="gold_input")
+    qtbot.addWidget(win)
+
+    empty = xr.Dataset()
+    win._restore_persistence_payload(empty)
+    assert win._append_persistence_payload(empty) is empty
+
+    blob = np.array([1, 2, 3], dtype=np.uint8)
+    win._pending_persisted_fit_result_blob = blob
+    win._pending_persisted_fit_is_current = True
+    appended = win._append_persistence_payload(empty)
+    np.testing.assert_array_equal(
+        appended[win._PERSISTED_FIT_RESULT_VAR].values,
+        blob,
+    )
+    assert appended.attrs[win._PERSISTED_FIT_CURRENT_ATTR] is True
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        win, "_flush_restore_work", lambda *_, **__: calls.append("flush")
+    )
+    monkeypatch.setattr(
+        win,
+        "_show_warning",
+        lambda title, message: calls.append(f"{title}: {message}"),
+    )
+
+    win._last_result_ds = None
+    win._save_fit()
+
+    assert calls == ["flush", "No fit result: There is no fit result to save."]
+
+    class _FakeFitResults:
+        def compute(self):
+            return self
+
+        def item(self):
+            return object()
+
+    fake_result_ds = typing.cast(
+        "xr.Dataset",
+        typing.cast("object", type("FakeResultDataset", (), {})()),
+    )
+    fake_result_ds.modelfit_results = _FakeFitResults()
+    monkeypatch.setattr(
+        fit1d_module,
+        "_load_lmfit_for_ftool_restore",
+        lambda load, **_kwargs: fake_result_ds,
+    )
+    monkeypatch.setattr(win, "_set_fit_stats", lambda _result: calls.append("stats"))
+    monkeypatch.setattr(win, "_update_fit_curve", lambda: calls.append("curve"))
+    monkeypatch.setattr(win, "_mark_fit_fresh", lambda: calls.append("fresh"))
+    monkeypatch.setattr(win, "_mark_fit_stale", lambda: calls.append("stale"))
+
+    win._restore_persisted_fit_result_blob(blob, fit_is_current=True)
+    win._restore_persisted_fit_result_blob(blob, fit_is_current=False)
+
+    assert calls[-6:] == ["stats", "curve", "fresh", "stats", "curve", "stale"]
 
 
 def test_goldtool_roundtrip_fitted(qtbot, gold) -> None:

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1551,6 +1551,74 @@ def test_fit2d_persistence_roundtrip_preserves_sparse_results(
     assert win_restored.current_provenance_spec() is None
 
 
+def test_fit2d_deferred_restore_preserves_raw_fit_blob_until_needed(
+    qtbot, exp_decay_model, monkeypatch
+) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    y = np.arange(3)
+    data = np.stack([((1.0 + 0.5 * idx) * np.exp(-t / 2.0)) for idx in y], axis=0)
+    data = xr.DataArray(data, dims=("y", "t"), coords={"y": y, "t": t}, name="decay2d")
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        data, model=exp_decay_model, params=params, execute=False
+    )
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    _seed_fit2d_full_results(win, exp_decay_model, params)
+    expected_results = [
+        None if ds is None else ds.copy(deep=True) for ds in win._result_ds_full
+    ]
+    saved = win.to_dataset()
+    calls = []
+    fail_next_deserialize = {"value": False}
+    original = erlab.interactive.utils._deserialize_fit_dataset_blob
+
+    def _tracked_deserialize(blob):
+        calls.append(np.asarray(blob).size)
+        if fail_next_deserialize["value"]:
+            fail_next_deserialize["value"] = False
+            raise RuntimeError("fit deserialize failed")
+        return original(blob)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_deserialize_fit_dataset_blob",
+        _tracked_deserialize,
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit2DTool)
+    assert calls == []
+
+    resaved = restored.to_dataset()
+    assert calls == []
+    np.testing.assert_array_equal(
+        resaved[Fit2DTool._PERSISTED_FIT_RESULT_VAR].values,
+        saved[Fit2DTool._PERSISTED_FIT_RESULT_VAR].values,
+    )
+
+    fail_next_deserialize["value"] = True
+    with pytest.raises(RuntimeError, match="fit deserialize failed"):
+        restored._flush_restore_work()
+    assert len(calls) == 1
+
+    resaved_after_failure = restored.to_dataset()
+    assert len(calls) == 1
+    np.testing.assert_array_equal(
+        resaved_after_failure[Fit2DTool._PERSISTED_FIT_RESULT_VAR].values,
+        saved[Fit2DTool._PERSISTED_FIT_RESULT_VAR].values,
+    )
+
+    restored._flush_restore_work()
+
+    assert len(calls) == 2
+    _assert_fit_result_list_equivalent(restored._result_ds_full, expected_results)
+
+
 def test_fit2d_full_save_and_param_plot(qtbot, exp_decay_model, monkeypatch) -> None:
     t = np.linspace(0.0, 4.0, 25)
     y = np.arange(3)

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -2025,6 +2025,35 @@ def test_ktool_update_rate_limited(qtbot, anglemap, monkeypatch) -> None:
     assert call_count == 2
 
 
+def test_ktool_deferred_restore_queues_preview_update(
+    qtbot, anglemap, monkeypatch
+) -> None:
+    data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
+    win = ktool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+    saved = win.to_dataset()
+    calls: list[KspaceTool] = []
+    original = KspaceTool._update_now
+
+    def _tracked_update_now(self: KspaceTool) -> None:
+        calls.append(self)
+        original(self)
+
+    monkeypatch.setattr(KspaceTool, "_update_now", _tracked_update_now)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    _add_hidden_tool(qtbot, restored)
+    assert isinstance(restored, KspaceTool)
+    assert calls == []
+
+    restored.show()
+
+    qtbot.wait_until(lambda: calls == [restored], timeout=5000)
+
+
 def test_ktool_kinetic_energy_axis_preview(qtbot, anglemap) -> None:
     data = anglemap.copy().assign_coords(hv=6.2)
     data = data.assign_coords(eV=data.hv - data.kspace.work_function + data.eV)

--- a/tests/interactive/test_mesh.py
+++ b/tests/interactive/test_mesh.py
@@ -182,6 +182,38 @@ def test_meshtool_autofind_and_persistence(
     xr.testing.assert_identical(restored.tool_data, win.tool_data)
 
 
+def test_meshtool_deferred_restore_queues_initial_preview(
+    qtbot, meshy_data, monkeypatch
+) -> None:
+    win: MeshTool = meshtool(meshy_data, execute=False)
+    qtbot.addWidget(win)
+    saved = win.to_dataset()
+    calls: list[tuple[MeshTool, bool]] = []
+    original = MeshTool.set_data_beforecalc
+
+    def _tracked_set_data_beforecalc(self: MeshTool, initial: bool = False) -> None:
+        calls.append((self, initial))
+        original(self, initial=initial)
+
+    monkeypatch.setattr(
+        MeshTool,
+        "set_data_beforecalc",
+        _tracked_set_data_beforecalc,
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, MeshTool)
+    assert calls == []
+
+    restored.show()
+
+    qtbot.wait_until(lambda: calls == [(restored, True)], timeout=5000)
+
+
 def test_meshtool_autofind_invalid_peaks_warns_and_keeps_values(
     qtbot, meshy_data, monkeypatch
 ) -> None:

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -319,6 +319,20 @@ def test_dialog_control_value_helpers(dialog: OptionDialog, qtbot):
     combo_with_data.addItem("Visible text", "stored-value")
     assert dialog._control_value(combo_with_data, "io/default_loader") == "stored-value"
 
+    compression_slider = options_ui._ChoiceSlider(
+        [
+            {"label": "Off", "value": "none"},
+            {"label": "Standard", "value": "blosclz3"},
+            {"label": "Compact", "value": "zstd1"},
+        ]
+    )
+    qtbot.addWidget(compression_slider)
+    compression_slider.setCurrentData("blosclz3")
+    assert (
+        dialog._control_value(compression_slider, "io/workspace/compression")
+        == "blosclz3"
+    )
+
     colors = ColorListWidget()
     qtbot.addWidget(colors)
     colors.set_colors(["#ff0000", "#00ff00"])
@@ -363,6 +377,19 @@ def test_dialog_set_control_value_helpers(dialog: OptionDialog, qtbot):
 
     assert combo.currentData() == "missing"
     assert combo.currentText() == "missing (unavailable)"
+
+    compression_slider = options_ui._ChoiceSlider(
+        [
+            {"label": "Off", "value": "none"},
+            {"label": "Standard", "value": "blosclz3"},
+            {"label": "Compact", "value": "zstd1"},
+        ]
+    )
+    qtbot.addWidget(compression_slider)
+    dialog._set_control_value(
+        compression_slider, "io/workspace/compression", "blosclz3"
+    )
+    assert compression_slider.currentData() == "blosclz3"
 
     list_line = QtWidgets.QLineEdit()
     qtbot.addWidget(list_line)
@@ -463,6 +490,46 @@ def test_workspace_override_switch_saves_sparse_override(qtbot):
 
     assert manager.overrides[path] == "bwr"
     assert combo.isEnabled()
+
+
+def test_workspace_compression_slider_uses_stored_mode_values(qtbot):
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dlg = OptionDialog(manager)
+    qtbot.addWidget(dlg)
+
+    user_control = typing.cast(
+        "options_ui._ChoiceSlider",
+        _control(dlg, "user", "io/workspace/compression", options_ui._ChoiceSlider),
+    )
+
+    assert [user_control.itemData(index) for index in range(user_control.count())] == [
+        "none",
+        "blosclz3",
+        "zstd1",
+    ]
+
+    user_control.setCurrentData("blosclz3")
+    assert options.model.io.workspace.compression == "blosclz3"
+
+    dlg.scope_tabs.setCurrentIndex(1)
+    workspace_control = typing.cast(
+        "options_ui._ChoiceSlider",
+        _control(
+            dlg,
+            "workspace",
+            "io/workspace/compression",
+            options_ui._ChoiceSlider,
+        ),
+    )
+    override = _override(dlg, "io/workspace/compression")
+
+    assert not workspace_control.isEnabled()
+    override.setChecked(True)
+    workspace_control.setCurrentData("none")
+
+    assert manager.overrides["io/workspace/compression"] == "none"
+    assert workspace_control.isEnabled()
 
 
 def test_workspace_figure_dpi_override_supports_unset_and_numeric(qtbot):
@@ -710,50 +777,85 @@ def test_workspace_override_helpers_filter_to_curated_subset() -> None:
 
     assert "colors/cmap/name" in paths
     assert "colors/cmap/packages" not in paths
+    assert "io/workspace/compression" in paths
     assert "io/workspace/compress" not in paths
     assert "figure/dpi" in paths
     assert normalize_workspace_option_overrides(
         {
             "colors/cmap/name": "bwr",
+            "io/workspace/compression": "none",
             "io/workspace/compress": False,
             "figure/dpi": 180.0,
         }
-    ) == {"colors/cmap/name": "bwr", "figure/dpi": 180.0}
+    ) == {
+        "colors/cmap/name": "bwr",
+        "io/workspace/compression": "none",
+        "figure/dpi": 180.0,
+    }
 
 
 def test_options_get_set():
     options.restore()
 
     assert options["colors/cmap/name"] == AppOptions().colors.cmap.name
+    assert options["io/workspace/compression"] == "zstd1"
     assert options["io/workspace/compress"] is True
     assert options["io/workspace/use_incremental"] is True
     assert options["io/workspace/incremental_save_on_remote"] is False
     assert options["figure/dpi"] is None
 
     options["colors/cmap/name"] = "viridis"
-    options["io/workspace/compress"] = False
+    options["io/workspace/compression"] = "blosclz3"
     options["io/workspace/use_incremental"] = False
     options["io/workspace/incremental_save_on_remote"] = True
     options["figure/stylesheets"] = ["classic", "missing-style"]
     options["figure/dpi"] = 150.0
 
     assert options["colors/cmap/name"] == "viridis"
-    assert options["io/workspace/compress"] is False
+    assert options["io/workspace/compression"] == "blosclz3"
+    assert options["io/workspace/compress"] is True
     assert options["io/workspace/use_incremental"] is False
     assert options["io/workspace/incremental_save_on_remote"] is True
     assert options["figure/stylesheets"] == ["classic", "missing-style"]
     assert options["figure/dpi"] == pytest.approx(150.0)
-    assert not options.model.io.workspace.compress
+    assert options.model.io.workspace.compression == "blosclz3"
     assert not options.model.io.workspace.use_incremental
     assert options.model.io.workspace.incremental_save_on_remote
     assert options.model.figure.stylesheets == ["classic", "missing-style"]
     assert options.model.figure.dpi == pytest.approx(150.0)
+
+    options["io/workspace/compress"] = False
+    assert options["io/workspace/compression"] == "none"
+    assert options["io/workspace/compress"] is False
+
+    options["io/workspace/compress"] = True
+    assert options["io/workspace/compression"] == "zstd1"
+    assert options["io/workspace/compress"] is True
 
     options["figure/dpi"] = None
     assert options["figure/dpi"] is None
 
     options.restore()
     assert options["figure/dpi"] is None
+
+
+@pytest.mark.parametrize(
+    ("legacy_value", "expected"),
+    [(False, "none"), (True, "zstd1")],
+)
+def test_legacy_workspace_compress_setting_migrates(
+    legacy_value: bool, expected: str
+) -> None:
+    qsettings = options.qsettings
+    qsettings.clear()
+    qsettings.setValue("io/workspace/compress", legacy_value)
+    qsettings.sync()
+
+    assert options.model.io.workspace.compression == expected
+
+    options.model = options.model
+    assert not qsettings.contains("io/workspace/compress")
+    assert qsettings.value("io/workspace/compression") == expected
 
 
 @pytest.mark.parametrize("value", [0.0, -1.0, "not-a-number"])

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -4,7 +4,7 @@ import typing
 
 import pydantic
 import pytest
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 import erlab.interactive._options.ui as options_ui
 from erlab.interactive._options import OptionDialog, options
@@ -20,7 +20,11 @@ from erlab.interactive._options.parameters import (
     FigureDpiOverrideWidget,
     StylesheetListWidget,
 )
-from erlab.interactive._options.schema import AppOptions
+from erlab.interactive._options.schema import (
+    AppOptions,
+    WorkspaceOptions,
+    normalize_workspace_compression_mode,
+)
 from erlab.interactive.colors import ColorMapComboBox
 
 
@@ -451,6 +455,62 @@ def test_choice_slider_labels_align_with_ticks(qtbot):
         assert label.geometry().right() < label_row.width()
 
 
+def test_choice_slider_edge_cases(qtbot):
+    slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
+    qtbot.addWidget(slider)
+
+    empty_row = options_ui._ChoiceSliderLabelRow(slider, ())
+    qtbot.addWidget(empty_row)
+    assert empty_row.edge_margins() == (0, 0)
+
+    with pytest.raises(ValueError, match="at least one choice"):
+        options_ui._ChoiceSlider(())
+
+    choice_slider = options_ui._ChoiceSlider(
+        [
+            {"label": "Off", "value": "none"},
+            {"label": "Standard", "value": "blosclz3"},
+            {"label": "Compact", "value": "zstd1"},
+        ]
+    )
+    qtbot.addWidget(choice_slider)
+
+    assert choice_slider.itemText(1) == "Standard"
+    assert choice_slider.findData("missing") == -1
+    with pytest.raises(ValueError, match="Unknown choice slider value"):
+        choice_slider.setCurrentData("missing")
+
+    events: list[None] = []
+    original_sync = choice_slider._sync_label_geometry
+
+    def _record_sync() -> None:
+        events.append(None)
+        original_sync()
+
+    choice_slider._sync_label_geometry = _record_sync
+    QtWidgets.QApplication.sendEvent(
+        choice_slider, QtCore.QEvent(QtCore.QEvent.Type.FontChange)
+    )
+    assert events
+
+
+def test_choice_slider_label_row_raises_without_style(qtbot):
+    class _StylelessSlider:
+        def initStyleOption(self, _option) -> None:
+            return None
+
+        def style(self) -> None:
+            return None
+
+    row = options_ui._ChoiceSliderLabelRow(
+        typing.cast("QtWidgets.QSlider", _StylelessSlider()), ("Off",)
+    )
+    qtbot.addWidget(row)
+
+    with pytest.raises(RuntimeError, match="has no Qt style"):
+        row.edge_margins()
+
+
 def test_dialog_spinbox_constraint_variants(
     monkeypatch: pytest.MonkeyPatch, dialog: OptionDialog, qtbot
 ):
@@ -832,6 +892,40 @@ def test_workspace_override_helpers_filter_to_curated_subset() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (" false ", "none"),
+        ("OFF", "none"),
+        ("1", "zstd1"),
+        ("yes", "zstd1"),
+        (" BloscLz3 ", "blosclz3"),
+        (None, None),
+    ],
+)
+def test_workspace_compression_mode_normalizes_legacy_values(
+    value: object, expected: object
+) -> None:
+    assert normalize_workspace_compression_mode(value) == expected
+
+    migrated = WorkspaceOptions.model_validate({"compress": False})
+    assert migrated.compression == "none"
+
+    with pytest.raises(pydantic.ValidationError):
+        WorkspaceOptions.model_validate("not-a-workspace-options")
+
+
+def test_option_path_helpers_support_legacy_workspace_compress() -> None:
+    from erlab.interactive._options.core import option_model_with_value, option_value
+
+    model = AppOptions()
+
+    assert option_value(model, "io/workspace/compress") is True
+
+    disabled = option_model_with_value(model, "io/workspace/compress", False)
+    assert disabled.io.workspace.compression == "none"
+
+
 def test_options_get_set():
     options.restore()
 
@@ -869,6 +963,9 @@ def test_options_get_set():
     options["io/workspace/compress"] = True
     assert options["io/workspace/compression"] == "zstd1"
     assert options["io/workspace/compress"] is True
+
+    options["io/workspace/compress"] = None
+    assert options["io/workspace/compression"] == "zstd1"
 
     options["figure/dpi"] = None
     assert options["figure/dpi"] is None

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -413,6 +413,44 @@ def test_dialog_set_control_value_helpers(dialog: OptionDialog, qtbot):
     assert figure_dpi.get_dpi() is None
 
 
+def test_choice_slider_labels_align_with_ticks(qtbot):
+    compression_slider = options_ui._ChoiceSlider(
+        [
+            {"label": "Off", "value": "none"},
+            {"label": "Standard", "value": "blosclz3"},
+            {"label": "Compact", "value": "zstd1"},
+        ]
+    )
+    qtbot.addWidget(compression_slider)
+    compression_slider.resize(360, compression_slider.sizeHint().height())
+    compression_slider.show()
+    QtWidgets.QApplication.processEvents()
+
+    label_row = compression_slider._label_row
+    for index in range(compression_slider.count()):
+        option = QtWidgets.QStyleOptionSlider()
+        compression_slider.slider.initStyleOption(option)
+        option.sliderPosition = index
+        option.sliderValue = index
+        handle_rect = compression_slider.slider.style().subControlRect(
+            QtWidgets.QStyle.ComplexControl.CC_Slider,
+            option,
+            QtWidgets.QStyle.SubControl.SC_SliderHandle,
+            compression_slider.slider,
+        )
+        tick_x = label_row.mapFromGlobal(
+            compression_slider.slider.mapToGlobal(handle_rect.center())
+        ).x()
+        label = compression_slider.findChild(
+            QtWidgets.QLabel, f"choiceSliderLabel_{index}"
+        )
+
+        assert label is not None
+        assert abs(label.geometry().center().x() - tick_x) <= 1
+        assert label.geometry().left() >= 0
+        assert label.geometry().right() < label_row.width()
+
+
 def test_dialog_spinbox_constraint_variants(
     monkeypatch: pytest.MonkeyPatch, dialog: OptionDialog, qtbot
 ):

--- a/tests/interactive/test_options_tree.py
+++ b/tests/interactive/test_options_tree.py
@@ -65,3 +65,19 @@ def test_make_parameter_round_trips_figure_options() -> None:
     opts = parameter_to_options(param)
     assert opts.figure.stylesheets == ["classic", "missing-style"]
     assert opts.figure.dpi == 150.0
+
+
+def test_make_parameter_workspace_compression_uses_display_labels() -> None:
+    param = make_parameter()
+    compression_param = param.child("io").child("workspace").child("compression")
+
+    assert compression_param.opts["type"] == "list"
+    assert set(compression_param.opts["limits"].values()) == {
+        "none",
+        "blosclz3",
+        "zstd1",
+    }
+
+    compression_param.setValue("blosclz3")
+
+    assert parameter_to_options(param).io.workspace.compression == "blosclz3"

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -444,6 +444,32 @@ def test_tool_window_failed_deferred_restore_can_retry(qtbot) -> None:
     assert restored.deferred_runs == 1
 
 
+def test_tool_window_deferred_restore_helper_edges(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    win = _DeferredRestoreTool(data)
+    qtbot.addWidget(win)
+    win._restoring_from_dataset = True
+    win._defer_restored_tool_work = True
+
+    with pytest.raises(TypeError, match="requires a callback or key"):
+        win._defer_restore_work(typing.cast("typing.Callable[[], None]", None))
+
+    calls: list[None] = []
+    win._defer_restore_work(lambda: calls.append(None), key="manual")
+    assert not win._flush_restore_work(run_on_show_only=True)
+    assert calls == []
+    assert win._flush_restore_work(key="manual")
+    assert calls == [None]
+
+    win._discard_restore_work()
+
+    win._flushing_restore_work = True
+    try:
+        assert not win._flush_restore_work()
+    finally:
+        win._flushing_restore_work = False
+
+
 @pytest.fixture
 def action():
     action = QtGui.QAction("Test Action")

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -85,6 +85,88 @@ class _PersistentTool(erlab.interactive.utils.ToolWindow[_PersistentToolState]):
         self._data = new_data
 
 
+class _DeferredRestoreToolState(pydantic.BaseModel):
+    value: int = 0
+
+
+class _DeferredRestoreTool(
+    erlab.interactive.utils.ToolWindow[_DeferredRestoreToolState]
+):
+    StateModel = _DeferredRestoreToolState
+    tool_name = "deferred-dummy"
+    COPY_PROVENANCE: typing.ClassVar = (
+        erlab.interactive.utils.ToolScriptProvenanceDefinition(
+            start_label="Start from current deferred dummy input data",
+            label="Compute deferred dummy output",
+            expression_method="_copy_expression",
+            assign="result",
+        )
+    )
+
+    class Output(enum.StrEnum):
+        RESULT = "deferred-dummy.result"
+
+    IMAGE_TOOL_OUTPUTS: typing.ClassVar = {
+        Output.RESULT: erlab.interactive.utils.ToolImageOutputDefinition(
+            data_method="_result_output_data",
+            provenance=erlab.interactive.utils.ToolScriptProvenanceDefinition(
+                start_label="Start from current deferred dummy input data",
+                label="Compute deferred dummy output",
+                expression_method="_copy_expression",
+                assign="result",
+            ),
+        )
+    }
+
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__()
+        self._data = data
+        self._status = _DeferredRestoreToolState()
+        self.construct_restoring = self._dataset_restore_in_progress
+        self.construct_deferred = self._should_defer_restore_work
+        self.deferred_runs = 0
+        self.fail_next_deferred_restore = False
+        if self._dataset_restore_in_progress:
+            self._run_or_defer_restore_work(
+                self._run_deferred_restore_task,
+                key="dummy-restore-task",
+                run_on_show=True,
+            )
+
+    @property
+    def tool_status(self) -> _DeferredRestoreToolState:
+        return self._status
+
+    @tool_status.setter
+    def tool_status(self, status: _DeferredRestoreToolState) -> None:
+        self._status = status
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    def update_data(self, new_data: xr.DataArray) -> None:
+        self._data = new_data
+
+    def _run_deferred_restore_task(self) -> None:
+        if self.fail_next_deferred_restore:
+            self.fail_next_deferred_restore = False
+            raise RuntimeError("deferred restore failed")
+        self.deferred_runs += 1
+
+    def _copy_expression(
+        self,
+        *,
+        input_name: str | None = None,
+        data: xr.DataArray | None = None,
+    ) -> str:
+        del input_name, data
+        return f"data + {self.deferred_runs}"
+
+    def _result_output_data(self) -> xr.DataArray:
+        return self._data + self.deferred_runs
+
+
 def test_tool_window_history_actions_undo_redo(qtbot) -> None:
     data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
     win = _PersistentTool(data)
@@ -247,6 +329,119 @@ def test_tool_window_from_dataset_starts_with_clean_history(qtbot) -> None:
     assert duplicated.tool_status == _PersistentToolState(value=1)
     assert not duplicated.undoable
     assert not duplicated.redoable
+
+
+def test_tool_window_direct_restore_runs_deferred_task_eagerly(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    saved = _DeferredRestoreTool(data).to_dataset()
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, _DeferredRestoreTool)
+    assert restored.construct_restoring is True
+    assert restored.construct_deferred is False
+    assert restored.deferred_runs == 1
+
+
+def test_tool_window_private_deferred_restore_queues_constructor_task(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    saved = _DeferredRestoreTool(data).to_dataset()
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, _DeferredRestoreTool)
+    assert restored.construct_restoring is True
+    assert restored.construct_deferred is True
+    assert restored.deferred_runs == 0
+
+    assert restored._flush_restore_work(key="dummy-restore-task")
+    assert restored.deferred_runs == 1
+
+
+def test_tool_window_deferred_restore_flushes_before_save(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    saved = _DeferredRestoreTool(data).to_dataset()
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _DeferredRestoreTool)
+
+    restored.to_dataset()
+
+    assert restored.deferred_runs == 1
+
+
+def test_tool_window_deferred_restore_flushes_on_show(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    saved = _DeferredRestoreTool(data).to_dataset()
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _DeferredRestoreTool)
+
+    restored.show()
+    qtbot.waitUntil(lambda: restored.deferred_runs == 1, timeout=1000)
+
+
+def test_tool_window_deferred_restore_flushes_before_output(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    saved = _DeferredRestoreTool(data).to_dataset()
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _DeferredRestoreTool)
+
+    xr.testing.assert_identical(
+        restored.output_imagetool_data(_DeferredRestoreTool.Output.RESULT),
+        data + 1,
+    )
+    assert restored.deferred_runs == 1
+
+
+def test_tool_window_deferred_restore_flushes_before_copy(qtbot, monkeypatch) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    saved = _DeferredRestoreTool(data).to_dataset()
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _DeferredRestoreTool)
+    monkeypatch.setattr(erlab.interactive.utils, "copy_to_clipboard", lambda code: code)
+
+    restored.copy_code()
+
+    assert restored.deferred_runs == 1
+
+
+def test_tool_window_failed_deferred_restore_can_retry(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    saved = _DeferredRestoreTool(data).to_dataset()
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _DeferredRestoreTool)
+    restored.fail_next_deferred_restore = True
+
+    with pytest.raises(RuntimeError, match="deferred restore failed"):
+        restored._flush_restore_work(key="dummy-restore-task")
+
+    assert restored.deferred_runs == 0
+    assert restored._flush_restore_work(key="dummy-restore-task")
+    assert restored.deferred_runs == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Store ImageTool workspace option data in a more compact form to reduce save size and serialization overhead
- Update workspace load/save and xarray conversion paths to preserve the same option state while using the new representation
- Adjust the options UI, tree handling, and main window integration to work with the compressed schema
- Add coverage for workspace persistence and options tree behavior

## Testing
- Added and updated unit tests for workspace round-trips and options tree serialization
- Not run (not requested)