### PR TITLE
Harden GoldTool persistence restore

### DIFF
--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -11,7 +11,7 @@ import time
 import traceback
 import typing
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 
 import numpy as np
 import pydantic
@@ -60,6 +60,8 @@ LMFIT_METHODS = [
 ]
 
 logger = logging.getLogger(__name__)
+
+_GOLDTOOL_STATE_SCHEMA_VERSION = 2
 
 
 def _disconnect_signal(signal: typing.Any) -> None:
@@ -181,9 +183,9 @@ class _GoldUpdateRequest:
     had_fit: bool
     roi_limits: tuple[float, float, float, float]
     tab_index: int
-    edge_values: dict[str, typing.Any]
-    poly_values: dict[str, typing.Any]
-    spline_values: dict[str, typing.Any]
+    edge_values: "_GoldEdgeState"
+    poly_values: "_GoldPolyState"
+    spline_values: "_GoldSplineState"
     refit: bool
 
 
@@ -191,6 +193,90 @@ class _GoldFitSnapshot(pydantic.BaseModel):
     along_coords: list[float]
     edge_center: list[float]
     edge_stderr: list[float]
+
+
+class _GoldStateBase(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )
+
+
+class _GoldEdgeState(_GoldStateBase):
+    temperature: float = pydantic.Field(default=30.0, alias="T (K)")
+    fix_temperature: bool = pydantic.Field(default=True, alias="Fix T")
+    bin_x: int = pydantic.Field(default=1, alias="Bin x")
+    bin_y: int = pydantic.Field(default=1, alias="Bin y")
+    resolution: float = pydantic.Field(default=0.02, alias="Resolution")
+    fast: bool = pydantic.Field(default=False, alias="Fast")
+    linear: bool = pydantic.Field(default=True, alias="Linear")
+    method: str = pydantic.Field(default="least_squares", alias="Method")
+    scale_cov: bool = pydantic.Field(default=True, alias="Scale cov")
+    num_cpu: int = pydantic.Field(default=1, alias="# CPU")
+
+    @pydantic.field_validator("bin_x", "bin_y", "num_cpu", mode="before")
+    @classmethod
+    def _positive_int(cls, value: typing.Any) -> int:
+        with contextlib.suppress(TypeError, ValueError):
+            return max(1, int(value))
+        return 1
+
+    @pydantic.field_validator("method", mode="before")
+    @classmethod
+    def _supported_method(cls, value: typing.Any) -> str:
+        method = str(value)
+        if method in LMFIT_METHODS:
+            return method
+        logger.warning(
+            "Unknown saved lmfit method %r for goldtool; using least_squares",
+            value,
+        )
+        return "least_squares"
+
+
+class _GoldPolyState(_GoldStateBase):
+    degree: int = pydantic.Field(default=4, alias="Degree")
+    scale_cov: bool = pydantic.Field(default=True, alias="Scale cov")
+    residuals: bool = pydantic.Field(default=False, alias="Residuals")
+    corrected: bool = pydantic.Field(default=False, alias="Corrected")
+    shift_coords: bool = pydantic.Field(default=True, alias="Shift coords")
+
+
+class _GoldSplineState(_GoldStateBase):
+    auto: bool = pydantic.Field(default=True, alias="Auto")
+    lambda_value: float = pydantic.Field(default=0.0, alias="lambda")
+    residuals: bool = pydantic.Field(default=False, alias="Residuals")
+    corrected: bool = pydantic.Field(default=False, alias="Corrected")
+    shift_coords: bool = pydantic.Field(default=True, alias="Shift coords")
+
+
+class _GoldToolState(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    schema_version: int = _GOLDTOOL_STATE_SCHEMA_VERSION
+    data_name: str
+    roi_limits: tuple[float, float, float, float]
+    edge_values: _GoldEdgeState
+    poly_values: _GoldPolyState
+    spline_values: _GoldSplineState
+    tab_index: typing.Literal[0, 1]
+    refit_on_source_update: bool = False
+    fit_snapshot: _GoldFitSnapshot | None = None
+
+    @pydantic.field_validator("schema_version", mode="before")
+    @classmethod
+    def _coerce_schema_version(cls, value: typing.Any) -> int:
+        with contextlib.suppress(TypeError, ValueError):
+            return int(value)
+        return _GOLDTOOL_STATE_SCHEMA_VERSION
+
+    @pydantic.field_validator("tab_index", mode="before")
+    @classmethod
+    def _coerce_tab_index(cls, value: typing.Any) -> typing.Literal[0, 1]:
+        with contextlib.suppress(TypeError, ValueError):
+            return 1 if int(value) == 1 else 0
+        return 0
 
 
 class GoldTool(erlab.interactive.utils.AnalysisWindow):
@@ -221,6 +307,11 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     """
 
     tool_name = "goldtool"
+    _PERSISTED_FIT_SNAPSHOT_KEY: typing.ClassVar[str] = "__goldtool_fit_snapshot__"
+    _PERSISTED_FIT_POINT_DIM: typing.ClassVar[str] = "__goldtool_fit_point__"
+    _PERSISTED_FIT_ALONG_VAR: typing.ClassVar[str] = "__goldtool_fit_along__"
+    _PERSISTED_EDGE_CENTER_VAR: typing.ClassVar[str] = "__goldtool_edge_center__"
+    _PERSISTED_EDGE_STDERR_VAR: typing.ClassVar[str] = "__goldtool_edge_stderr__"
     COPY_PROVENANCE: typing.ClassVar = (
         erlab.interactive.utils.ToolScriptProvenanceDefinition(
             start_label="Start from current goldtool input data",
@@ -247,15 +338,8 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         )
     }
 
-    class StateModel(pydantic.BaseModel):
-        data_name: str
-        roi_limits: tuple[float, float, float, float]
-        edge_values: dict[str, typing.Any]
-        poly_values: dict[str, typing.Any]
-        spline_values: dict[str, typing.Any]
-        tab_index: typing.Literal[0, 1]
-        refit_on_source_update: bool = False
-        fit_snapshot: _GoldFitSnapshot | None = None
+    class StateModel(_GoldToolState):
+        pass
 
     sigProgressUpdated = QtCore.Signal(int)  #: :meta private:
     sigAbortFitting = QtCore.Signal()  #: :meta private:
@@ -333,6 +417,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             x_decimals=x_decimals,
             y_decimals=y_decimals,
         )
+        cpu_count = os.cpu_count() or 1
         self.params_edge = erlab.interactive.utils.ParameterGroup(
             {
                 "T (K)": {"qwtype": "dblspin", "value": temp, "range": (0.0, 400.0)},
@@ -362,9 +447,9 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
                 "Scale cov": {"qwtype": "chkbox", "checked": True},
                 "# CPU": {
                     "qwtype": "spin",
-                    "value": os.cpu_count(),
+                    "value": cpu_count,
                     "minimum": 1,
-                    "maximum": os.cpu_count(),
+                    "maximum": cpu_count,
                 },
                 "go": {
                     "qwtype": "pushbtn",
@@ -544,6 +629,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
         # Initialize fit result
         self.result: scipy.interpolate.BSpline | xr.Dataset | None = None
+        self._pending_persisted_fit_snapshot: _GoldFitSnapshot | None = None
         self._reset_history_stack()
 
     @property
@@ -554,28 +640,40 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     def data_name(self, value: str) -> None:
         self._argnames["data"] = value
 
+    def _fit_snapshot(self) -> _GoldFitSnapshot | None:
+        if not (hasattr(self, "edge_center") and hasattr(self, "edge_stderr")):
+            return getattr(self, "_pending_persisted_fit_snapshot", None)
+        return _GoldFitSnapshot(
+            along_coords=np.asarray(
+                self.edge_center[self._along_dim].values, dtype=float
+            ).tolist(),
+            edge_center=np.asarray(self.edge_center.values, dtype=float).tolist(),
+            edge_stderr=np.asarray(self.edge_stderr.values, dtype=float).tolist(),
+        )
+
+    def _edge_state_from_widgets(self) -> _GoldEdgeState:
+        return _GoldEdgeState.model_validate(dict(self.params_edge.values))
+
+    def _poly_state_from_widgets(self) -> _GoldPolyState:
+        return _GoldPolyState.model_validate(dict(self.params_poly.values))
+
+    def _spline_state_from_widgets(self) -> _GoldSplineState:
+        return _GoldSplineState.model_validate(dict(self.params_spl.values))
+
     @property
     def tool_status(self) -> StateModel:
-        fit_snapshot: _GoldFitSnapshot | None = None
-        if hasattr(self, "edge_center") and hasattr(self, "edge_stderr"):
-            fit_snapshot = _GoldFitSnapshot(
-                along_coords=np.asarray(
-                    self.edge_center[self._along_dim].values, dtype=float
-                ).tolist(),
-                edge_center=np.asarray(self.edge_center.values, dtype=float).tolist(),
-                edge_stderr=np.asarray(self.edge_stderr.values, dtype=float).tolist(),
-            )
         return self.StateModel(
+            schema_version=_GOLDTOOL_STATE_SCHEMA_VERSION,
             data_name=self.data_name,
             roi_limits=self.params_roi.roi_limits,
-            edge_values=dict(self.params_edge.values),
-            poly_values=dict(self.params_poly.values),
-            spline_values=dict(self.params_spl.values),
+            edge_values=self._edge_state_from_widgets(),
+            poly_values=self._poly_state_from_widgets(),
+            spline_values=self._spline_state_from_widgets(),
             tab_index=typing.cast(
                 "typing.Literal[0, 1]", self.params_tab.currentIndex()
             ),
             refit_on_source_update=self.refit_on_source_update_check.isChecked(),
-            fit_snapshot=fit_snapshot,
+            fit_snapshot=self._fit_snapshot(),
         )
 
     @tool_status.setter
@@ -590,9 +688,15 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             QtCore.QSignalBlocker(self.params_tab),
             QtCore.QSignalBlocker(self.refit_on_source_update_check),
         ):
-            self._restore_parameter_group_values(self.params_edge, status.edge_values)
-            self._restore_parameter_group_values(self.params_poly, status.poly_values)
-            self._restore_parameter_group_values(self.params_spl, status.spline_values)
+            self._restore_parameter_group_values(
+                self.params_edge, status.edge_values.model_dump(by_alias=True)
+            )
+            self._restore_parameter_group_values(
+                self.params_poly, status.poly_values.model_dump(by_alias=True)
+            )
+            self._restore_parameter_group_values(
+                self.params_spl, status.spline_values.model_dump(by_alias=True)
+            )
             self.params_tab.setCurrentIndex(status.tab_index)
             self.refit_on_source_update_check.setChecked(status.refit_on_source_update)
 
@@ -602,7 +706,9 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         self._sync_spline_lambda_enabled()
 
         if status.fit_snapshot is not None:
-            self._restore_fit_snapshot(status.fit_snapshot)
+            self._restore_or_defer_fit_snapshot(
+                status.fit_snapshot, key=self._PERSISTED_FIT_SNAPSHOT_KEY
+            )
 
     @property
     def tool_data(self) -> xr.DataArray:
@@ -645,11 +751,11 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         from erlab.utils.formatting import format_darr_shape_html
 
         status = self.tool_status
-        edge = status.edge_values
+        edge = status.edge_values.model_dump(by_alias=True)
         mode = "Polynomial" if status.tab_index == 0 else "Spline"
         mode_params = (
             status.poly_values if status.tab_index == 0 else status.spline_values
-        )
+        ).model_dump(by_alias=True)
 
         roi_rows = [
             ("Along range", f"{status.roi_limits[0]} to {status.roi_limits[2]}"),
@@ -725,6 +831,8 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         return info
 
     def _clear_edge_fit_results(self) -> None:
+        self._pending_persisted_fit_snapshot = None
+        self._discard_restore_work(key=self._PERSISTED_FIT_SNAPSHOT_KEY)
         self.result = None
         self._fit_task = None
         self.progress.reset()
@@ -758,9 +866,12 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     @staticmethod
     def _restore_parameter_group_values(
         group: erlab.interactive.utils.ParameterGroup,
-        values: dict[str, typing.Any],
+        values: Mapping[str, typing.Any],
     ) -> None:
         for name, value in values.items():
+            if name not in group.widgets:
+                logger.debug("Ignoring unknown saved goldtool parameter %r", name)
+                continue
             widget = group.widgets[name]
             widget.blockSignals(True)
             try:
@@ -772,14 +883,18 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
                 elif isinstance(widget, QtWidgets.QComboBox):
                     index = widget.findText(str(value))
                     if index < 0:
-                        raise ValueError(
-                            f"Unknown saved value {value!r} for {name!r} in goldtool"
+                        logger.warning(
+                            "Ignoring unknown saved goldtool value %r for %r",
+                            value,
+                            name,
                         )
+                        continue
                     widget.setCurrentIndex(index)
             finally:
                 widget.blockSignals(False)
 
-    def _restore_fit_snapshot(self, snapshot: _GoldFitSnapshot) -> None:
+    @staticmethod
+    def _validate_fit_snapshot(snapshot: _GoldFitSnapshot) -> None:
         if not (
             len(snapshot.along_coords)
             == len(snapshot.edge_center)
@@ -787,6 +902,20 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         ):
             raise ValueError("Saved goldtool fit snapshot has mismatched array lengths")
 
+    def _restore_or_defer_fit_snapshot(
+        self, snapshot: _GoldFitSnapshot, *, key: str
+    ) -> None:
+        self._validate_fit_snapshot(snapshot)
+        self._pending_persisted_fit_snapshot = snapshot
+        self._run_or_defer_restore_work(
+            lambda snapshot=snapshot: self._restore_fit_snapshot(snapshot),
+            key=key,
+            run_on_show=True,
+        )
+
+    def _restore_fit_snapshot(self, snapshot: _GoldFitSnapshot) -> None:
+        self._validate_fit_snapshot(snapshot)
+        self._pending_persisted_fit_snapshot = None
         coords = {self._along_dim: np.asarray(snapshot.along_coords, dtype=float)}
         self.post_fit(
             xr.DataArray(
@@ -800,6 +929,65 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
                 dims=(self._along_dim,),
             ),
         )
+
+    @property
+    def _saved_tool_attrs(self) -> dict:
+        attrs = super()._saved_tool_attrs
+        attrs["tool_state"] = self.tool_status.model_dump_json(exclude={"fit_snapshot"})
+        return attrs
+
+    def _append_persistence_payload(self, ds: xr.Dataset) -> xr.Dataset:
+        snapshot = self._fit_snapshot()
+        if snapshot is None:
+            snapshot = self._pending_persisted_fit_snapshot
+        if snapshot is None:
+            return ds
+
+        ds = ds.copy()
+        dim = self._PERSISTED_FIT_POINT_DIM
+        ds[self._PERSISTED_FIT_ALONG_VAR] = xr.DataArray(
+            np.asarray(snapshot.along_coords, dtype=float),
+            dims=(dim,),
+        )
+        ds[self._PERSISTED_EDGE_CENTER_VAR] = xr.DataArray(
+            np.asarray(snapshot.edge_center, dtype=float),
+            dims=(dim,),
+        )
+        ds[self._PERSISTED_EDGE_STDERR_VAR] = xr.DataArray(
+            np.asarray(snapshot.edge_stderr, dtype=float),
+            dims=(dim,),
+        )
+        return ds
+
+    def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
+        required_vars = (
+            self._PERSISTED_FIT_ALONG_VAR,
+            self._PERSISTED_EDGE_CENTER_VAR,
+            self._PERSISTED_EDGE_STDERR_VAR,
+        )
+        if not all(name in ds for name in required_vars):
+            return
+
+        self._restore_or_defer_fit_snapshot(
+            _GoldFitSnapshot(
+                along_coords=np.asarray(
+                    ds[self._PERSISTED_FIT_ALONG_VAR].values, dtype=float
+                ).tolist(),
+                edge_center=np.asarray(
+                    ds[self._PERSISTED_EDGE_CENTER_VAR].values, dtype=float
+                ).tolist(),
+                edge_stderr=np.asarray(
+                    ds[self._PERSISTED_EDGE_STDERR_VAR].values, dtype=float
+                ).tolist(),
+            ),
+            key=self._PERSISTED_FIT_SNAPSHOT_KEY,
+        )
+
+    def _flush_restore_work_for_save(self) -> None:
+        if self._pending_persisted_fit_snapshot is None:
+            super()._flush_restore_work_for_save()
+            return
+        self._flush_restore_work(skip=(self._PERSISTED_FIT_SNAPSHOT_KEY,))
 
     def _ensure_serializable_state(self) -> None:
         if self.data_corr is not None:
@@ -839,12 +1027,12 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     def _make_update_request(self, data: xr.DataArray) -> _GoldUpdateRequest:
         return _GoldUpdateRequest(
             data=data,
-            had_fit=hasattr(self, "edge_center"),
+            had_fit=self._fit_snapshot() is not None,
             roi_limits=self.params_roi.roi_limits,
             tab_index=self.params_tab.currentIndex(),
-            edge_values=dict(self.params_edge.values),
-            poly_values=dict(self.params_poly.values),
-            spline_values=dict(self.params_spl.values),
+            edge_values=self._edge_state_from_widgets(),
+            poly_values=self._poly_state_from_widgets(),
+            spline_values=self._spline_state_from_widgets(),
             refit=self.refit_on_source_update_check.isChecked(),
         )
 
@@ -889,13 +1077,13 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
                 QtCore.QSignalBlocker(self.params_tab),
             ):
                 self._restore_parameter_group_values(
-                    self.params_edge, request.edge_values
+                    self.params_edge, request.edge_values.model_dump(by_alias=True)
                 )
                 self._restore_parameter_group_values(
-                    self.params_poly, request.poly_values
+                    self.params_poly, request.poly_values.model_dump(by_alias=True)
                 )
                 self._restore_parameter_group_values(
-                    self.params_spl, request.spline_values
+                    self.params_spl, request.spline_values.model_dump(by_alias=True)
                 )
                 self.params_tab.setCurrentIndex(request.tab_index)
             self._toggle_fast()
@@ -986,12 +1174,23 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         self.params_roi.draw_button.setChecked(False)
         x0, y0, x1, y1 = self.roi_limits_ordered
         params = self.params_edge.values
-        n_total: int = len(
+        selected_along = (
             self.data[self._along_dim]
             .coarsen({self._along_dim: int(params["Bin x"])}, boundary="trim")
             .mean()
             .sel({self._along_dim: slice(x0, x1)})
         )
+        selected_eV = (
+            self.data.eV.coarsen(eV=int(params["Bin y"]), boundary="trim")
+            .mean()
+            .sel(eV=slice(y0, y1))
+        )
+        n_total = len(selected_along)
+        if n_total == 0 or selected_eV.size == 0:
+            self.progress.reset()
+            self._show_empty_fit_selection_warning()
+            self._emit_info_changed()
+            return
         self.progress.setMaximum(n_total)
         self._abort_fit_task()
         task = EdgeFitTask(self.data, self._along_dim, x0, y0, x1, y1, params)
@@ -1009,6 +1208,13 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         )
         self._threadpool.start(task)
         self._emit_info_changed()
+
+    def _show_empty_fit_selection_warning(self) -> None:
+        QtWidgets.QMessageBox.warning(
+            self,
+            "Empty fit selection",
+            "The selected goldtool ROI does not contain enough points to fit.",
+        )
 
     @QtCore.Slot()
     def abort_fit(self) -> None:
@@ -1040,6 +1246,8 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             self._fit_closing or not erlab.interactive.utils.qt_is_valid(self)
         ):
             return
+        self._pending_persisted_fit_snapshot = None
+        self._discard_restore_work(key=self._PERSISTED_FIT_SNAPSHOT_KEY)
         self.progress.reset()
         if task is not None:
             self._disconnect_fit_task_signals(task)
@@ -1163,6 +1371,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     @property
     def corrected(self) -> xr.DataArray:
+        self._flush_restore_work(key=self._PERSISTED_FIT_SNAPSHOT_KEY)
         target = self.data if self.data_corr is None else self.data_corr
         return erlab.analysis.gold.correct_with_edge(
             target,

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -907,8 +907,12 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     ) -> None:
         self._validate_fit_snapshot(snapshot)
         self._pending_persisted_fit_snapshot = snapshot
+
+        def restore_snapshot() -> None:
+            self._restore_fit_snapshot(snapshot)
+
         self._run_or_defer_restore_work(
-            lambda snapshot=snapshot: self._restore_fit_snapshot(snapshot),
+            restore_snapshot,
             key=key,
             run_on_show=True,
         )

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -82,6 +82,34 @@ def _configure_goldtool_state(
         win.post_fit(edge_center, edge_stderr)
 
 
+def _spy_goldtool_post_fit(monkeypatch: pytest.MonkeyPatch) -> list[GoldTool]:
+    calls: list[GoldTool] = []
+    original_post_fit = GoldTool.post_fit
+
+    def tracked_post_fit(
+        self: GoldTool,
+        edge_center: xr.DataArray,
+        edge_stderr: xr.DataArray,
+        *,
+        task: EdgeFitTask | None = None,
+    ) -> None:
+        calls.append(self)
+        original_post_fit(self, edge_center, edge_stderr, task=task)
+
+    monkeypatch.setattr(GoldTool, "post_fit", tracked_post_fit)
+    return calls
+
+
+def _drop_goldtool_fit_payload(ds: xr.Dataset) -> xr.Dataset:
+    return ds.drop_vars(
+        [
+            GoldTool._PERSISTED_FIT_ALONG_VAR,
+            GoldTool._PERSISTED_EDGE_CENTER_VAR,
+            GoldTool._PERSISTED_EDGE_STDERR_VAR,
+        ]
+    )
+
+
 def test_goldtool_can_save_and_load() -> None:
     assert GoldTool.can_save_and_load() is True
 
@@ -242,6 +270,18 @@ def test_goldtool_roundtrip_fitted(qtbot, gold) -> None:
         filename = f"{tmp_dir_name}/goldtool_fitted.h5"
         win.to_file(filename)
 
+        with xr.load_dataset(filename, engine="h5netcdf") as saved:
+            saved_state = json.loads(saved.attrs["tool_state"])
+            assert saved_state["schema_version"] == 2
+            assert "fit_snapshot" not in saved_state
+            assert "go" not in saved_state["edge_values"]
+            assert "copy" not in saved_state["poly_values"]
+            assert "itool" not in saved_state["poly_values"]
+            assert "save" not in saved_state["poly_values"]
+            assert GoldTool._PERSISTED_FIT_ALONG_VAR in saved
+            assert GoldTool._PERSISTED_EDGE_CENTER_VAR in saved
+            assert GoldTool._PERSISTED_EDGE_STDERR_VAR in saved
+
         win_restored = erlab.interactive.utils.ToolWindow.from_file(filename)
         qtbot.addWidget(win_restored)
         assert isinstance(win_restored, GoldTool)
@@ -251,6 +291,211 @@ def test_goldtool_roundtrip_fitted(qtbot, gold) -> None:
         assert isinstance(win_restored.result, scipy.interpolate.BSpline)
         xr.testing.assert_identical(win.corrected, win_restored.corrected)
         assert str(win_restored.info_text) == str(win.info_text)
+
+
+def test_goldtool_loads_legacy_state_with_raw_dicts_and_fit_snapshot(
+    qtbot, gold
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
+    qtbot.addWidget(win)
+    _configure_goldtool_state(win, fitted=True, spline=True)
+    snapshot = win.tool_status.fit_snapshot
+    assert snapshot is not None
+
+    saved = _drop_goldtool_fit_payload(win.to_dataset())
+    legacy_state = json.loads(saved.attrs["tool_state"])
+    legacy_state.pop("schema_version", None)
+    legacy_state["edge_values"] = {
+        **dict(win.params_edge.values),
+        "go": True,
+        "unknown": "ignored",
+        "Method": "unsupported-method",
+        "# CPU": 0,
+    }
+    legacy_state["poly_values"] = {
+        **dict(win.params_poly.values),
+        "itool": True,
+        "copy": True,
+        "save": True,
+        "unknown": "ignored",
+    }
+    legacy_state["spline_values"] = {
+        **dict(win.params_spl.values),
+        "itool": True,
+        "copy": True,
+        "unknown": "ignored",
+    }
+    legacy_state["tab_index"] = "invalid"
+    legacy_state["fit_snapshot"] = snapshot.model_dump()
+    saved.attrs["tool_state"] = json.dumps(legacy_state)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, GoldTool)
+
+    assert restored.params_tab.currentIndex() == 0
+    assert restored.params_edge.values["Method"] == "least_squares"
+    assert restored.params_edge.values["# CPU"] == 1
+    assert "go" not in restored.tool_status.edge_values.model_dump(by_alias=True)
+    assert "copy" not in restored.tool_status.poly_values.model_dump(by_alias=True)
+    xr.testing.assert_equal(restored.edge_center, win.edge_center)
+    xr.testing.assert_equal(restored.edge_stderr, win.edge_stderr)
+
+
+def test_goldtool_deferred_restore_fit_payload(qtbot, gold, monkeypatch) -> None:
+    win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
+    qtbot.addWidget(win)
+    _configure_goldtool_state(win, fitted=True, spline=True)
+    expected_corrected = win.corrected
+    saved = win.to_dataset()
+
+    post_fit_calls = _spy_goldtool_post_fit(monkeypatch)
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved, _defer_restore_work=True
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, GoldTool)
+
+    assert post_fit_calls == []
+    assert not hasattr(restored, "edge_center")
+    assert restored.result is None
+    assert restored._pending_persisted_fit_snapshot is not None
+
+    restored._flush_restore_work()
+
+    assert post_fit_calls == [restored]
+    assert restored._pending_persisted_fit_snapshot is None
+    assert isinstance(restored.result, scipy.interpolate.BSpline)
+    xr.testing.assert_identical(restored.corrected, expected_corrected)
+
+
+def test_goldtool_deferred_restore_legacy_fit_snapshot(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
+    qtbot.addWidget(win)
+    _configure_goldtool_state(win, fitted=True, spline=True)
+    snapshot = win.tool_status.fit_snapshot
+    assert snapshot is not None
+
+    saved = _drop_goldtool_fit_payload(win.to_dataset())
+    legacy_state = json.loads(saved.attrs["tool_state"])
+    legacy_state["fit_snapshot"] = snapshot.model_dump()
+    saved.attrs["tool_state"] = json.dumps(legacy_state)
+
+    post_fit_calls = _spy_goldtool_post_fit(monkeypatch)
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved, _defer_restore_work=True
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, GoldTool)
+
+    assert post_fit_calls == []
+    assert not hasattr(restored, "edge_center")
+    assert restored._pending_persisted_fit_snapshot is not None
+
+    restored._flush_restore_work()
+
+    assert post_fit_calls == [restored]
+    assert restored._pending_persisted_fit_snapshot is None
+    xr.testing.assert_equal(restored.edge_center, win.edge_center)
+    xr.testing.assert_equal(restored.edge_stderr, win.edge_stderr)
+
+
+def test_goldtool_deferred_restore_resaves_fit_payload_before_show(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
+    qtbot.addWidget(win)
+    _configure_goldtool_state(win, fitted=True, spline=True)
+    expected_corrected = win.corrected
+    saved = win.to_dataset()
+
+    post_fit_calls = _spy_goldtool_post_fit(monkeypatch)
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved, _defer_restore_work=True
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, GoldTool)
+
+    resaved = restored.to_dataset()
+
+    assert post_fit_calls == []
+    assert restored.result is None
+    assert restored._pending_persisted_fit_snapshot is not None
+    assert GoldTool._PERSISTED_FIT_ALONG_VAR in resaved
+    assert GoldTool._PERSISTED_EDGE_CENTER_VAR in resaved
+    assert GoldTool._PERSISTED_EDGE_STDERR_VAR in resaved
+
+    eager_restored = erlab.interactive.utils.ToolWindow.from_dataset(resaved)
+    qtbot.addWidget(eager_restored)
+    assert isinstance(eager_restored, GoldTool)
+
+    assert post_fit_calls == [eager_restored]
+    assert isinstance(eager_restored.result, scipy.interpolate.BSpline)
+    xr.testing.assert_identical(eager_restored.corrected, expected_corrected)
+
+
+def test_goldtool_deferred_restore_update_data_refits_pending_fit(
+    qtbot, gold, monkeypatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
+    qtbot.addWidget(win)
+    _configure_goldtool_state(win, fitted=True, spline=True)
+    saved = win.to_dataset()
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved, _defer_restore_work=True
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, GoldTool)
+    assert not hasattr(restored, "edge_center")
+    assert restored._pending_persisted_fit_snapshot is not None
+
+    called: list[bool] = []
+    monkeypatch.setattr(restored, "perform_edge_fit", lambda: called.append(True))
+    new_gold = gold.copy(deep=True)
+    new_gold.data = np.asarray(new_gold.data) * 1.02
+
+    assert restored.update_data(new_gold) is False
+
+    assert called == [True]
+    assert restored._pending_persisted_fit_snapshot is None
+    assert not hasattr(restored, "edge_center")
+    xr.testing.assert_identical(restored.data, new_gold)
+
+
+@pytest.mark.parametrize("defer_restore_work", [False, True])
+def test_goldtool_legacy_bad_fit_snapshot_lengths_raise(
+    qtbot, gold, defer_restore_work
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
+    qtbot.addWidget(win)
+
+    saved = win.to_dataset()
+    legacy_state = json.loads(saved.attrs["tool_state"])
+    legacy_state["fit_snapshot"] = {
+        "along_coords": [0.0, 1.0],
+        "edge_center": [0.0],
+        "edge_stderr": [0.0, 0.0],
+    }
+    saved.attrs["tool_state"] = json.dumps(legacy_state)
+
+    with pytest.raises(ValueError, match="mismatched array lengths"):
+        erlab.interactive.utils.ToolWindow.from_dataset(
+            saved, _defer_restore_work=defer_restore_work
+        )
+
+
+def test_goldtool_handles_missing_cpu_count(qtbot, gold, monkeypatch) -> None:
+    monkeypatch.setattr("erlab.interactive.fermiedge.os.cpu_count", lambda: None)
+
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    cpu_widget = typing.cast("QtWidgets.QSpinBox", win.params_edge.widgets["# CPU"])
+    assert cpu_widget.value() == 1
+    assert cpu_widget.maximum() == 1
 
 
 def test_goldtool_duplicate_roundtrip(qtbot, gold) -> None:
@@ -664,6 +909,52 @@ def test_goldtool_perform_edge_fit_ignores_pending_or_closing_updates(
     win.perform_edge_fit()
 
     assert win._fit_task is None
+
+
+@pytest.mark.parametrize(
+    "empty_case", ["empty_roi", "overlarge_bin_x", "overlarge_bin_y"]
+)
+def test_goldtool_perform_edge_fit_skips_empty_selection(
+    qtbot, gold, monkeypatch, empty_case
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    if empty_case == "empty_roi":
+        between = float((gold.alpha.values[0] + gold.alpha.values[1]) / 2)
+        win.params_roi._x_decimals = 12
+        win.params_roi.modify_roi(x0=between, x1=between, y0=-0.2, y1=0.1)
+    elif empty_case == "overlarge_bin_x":
+        typing.cast("QtWidgets.QSpinBox", win.params_edge.widgets["Bin x"]).setValue(
+            gold.sizes["alpha"] + 1
+        )
+    else:
+        typing.cast("QtWidgets.QSpinBox", win.params_edge.widgets["Bin y"]).setValue(
+            gold.sizes["eV"] + 1
+        )
+
+    class _ThreadPoolDouble:
+        def __init__(self) -> None:
+            self.started_tasks: list[EdgeFitTask] = []
+
+        def activeThreadCount(self) -> int:
+            return 0
+
+        def start(self, task: EdgeFitTask) -> None:
+            self.started_tasks.append(task)
+
+    warnings: list[bool] = []
+    threadpool = _ThreadPoolDouble()
+    monkeypatch.setattr(
+        win, "_show_empty_fit_selection_warning", lambda: warnings.append(True)
+    )
+    win._threadpool = threadpool  # type: ignore[assignment]
+
+    win.perform_edge_fit()
+
+    assert warnings == [True]
+    assert win._fit_task is None
+    assert threadpool.started_tasks == []
 
 
 def test_goldtool_post_fit_accepts_current_task_and_disconnects(


### PR DESCRIPTION
## Summary
- Replace GoldTool raw widget-state dict persistence with schema-versioned pydantic state while preserving legacy aliases.
- Move fitted edge arrays out of saved `tool_state` into explicit payload variables and defer fitted-result restore during hidden workspace loading.
- Preserve pending fit payloads across save-before-show, keep legacy `fit_snapshot` loading, and guard empty ROI/binning fit starts.

## Validation
- `uv run pytest tests/interactive/test_fermiedge.py -q`
- `uv run pytest tests/interactive/imagetool/manager/test_workspace.py::test_manager_workspace_roundtrip_goldtool_child tests/interactive/imagetool/manager/test_mainwindow.py::test_manager_goldtool_output_itool_nests_under_tool -q`
- `uv run ruff format --check src/erlab/interactive/fermiedge.py tests/interactive/test_fermiedge.py`
- `uv run ruff check src/erlab/interactive/fermiedge.py tests/interactive/test_fermiedge.py`
- `git diff --check`
