### PR TITLE
fix(imagetool): reduce redundant drag refreshes

### DIFF
--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -3002,27 +3002,75 @@ class ItoolPlotItem(pg.PlotItem):
             data_pos_coords = (data_pos.x(), data_pos.y())
 
         with self.slicer_area._defer_dask_point_value_updates(defer_point_value):
+            value_changed_axes: set[int] = set()
+            selection_changed_axes: set[int] = set()
             if QtCore.Qt.KeyboardModifier.AltModifier in modifiers:
                 cursors = tuple(range(self.slicer_area.n_cursors))
                 for c in range(self.slicer_area.n_cursors):
                     for i, ax in enumerate(self.display_axis):
-                        self.slicer_area.set_value(
-                            ax,
-                            data_pos_coords[i],
-                            update=False,
-                            uniform=True,
-                            cursor=c,
+                        value_changed, selection_changed = self._set_drag_value(
+                            c, ax, data_pos_coords[i]
                         )
-                self.slicer_area.refresh(cursors, self.display_axis)
+                        if value_changed:
+                            value_changed_axes.add(ax)
+                        if selection_changed:
+                            selection_changed_axes.add(ax)
+                self._refresh_dragged_cursors(
+                    cursors,
+                    self._drag_refresh_axes(
+                        value_changed_axes
+                        if self.slicer_area.is_linked
+                        else selection_changed_axes
+                    ),
+                )
             else:
                 for i, ax in enumerate(self.display_axis):
-                    self.slicer_area.set_value(
-                        ax, data_pos_coords[i], update=False, uniform=True
+                    value_changed, selection_changed = self._set_drag_value(
+                        self.slicer_area.current_cursor, ax, data_pos_coords[i]
                     )
-                self.slicer_area.refresh_current(self.display_axis)
+                    if value_changed:
+                        value_changed_axes.add(ax)
+                    if selection_changed:
+                        selection_changed_axes.add(ax)
+                self._refresh_dragged_current(
+                    self._drag_refresh_axes(
+                        value_changed_axes
+                        if self.slicer_area.is_linked
+                        else selection_changed_axes
+                    )
+                )
 
         if self.slicer_area.bench:
             self._time_end = time.perf_counter()
+
+    def _set_drag_value(
+        self, cursor: int, axis: int, value: float
+    ) -> tuple[bool, bool]:
+        before = self.array_slicer._axis_selection_key(cursor, axis)
+        changed_axes = self.slicer_area.set_value(
+            axis, value, update=False, uniform=True, cursor=cursor
+        )
+        after = self.array_slicer._axis_selection_key(cursor, axis)
+        return bool(changed_axes), before != after
+
+    def _drag_refresh_axes(self, changed_axes: set[int]) -> tuple[int, ...]:
+        return tuple(axis for axis in self.display_axis if axis in changed_axes)
+
+    def _refresh_dragged_current(self, axes: tuple[int, ...]) -> None:
+        refresh_current = typing.cast("typing.Any", self.slicer_area.refresh_current)
+        if self.slicer_area.is_linked and not axes:
+            refresh_current(axes, __slicer_skip_sync=True)
+            return
+        refresh_current(axes)
+
+    def _refresh_dragged_cursors(
+        self, cursors: tuple[int, ...], axes: tuple[int, ...]
+    ) -> None:
+        refresh = typing.cast("typing.Any", self.slicer_area.refresh)
+        if self.slicer_area.is_linked and not axes:
+            refresh(cursors, axes, __slicer_skip_sync=True)
+            return
+        refresh(cursors, axes)
 
     def set_cursor_colors(self, colors: Iterable[QtGui.QColor]) -> None:
         """Set the colors of the cursors and spans."""
@@ -3159,11 +3207,16 @@ class ItoolPlotItem(pg.PlotItem):
             )
         else:
             cursors = tuple(c for c in range(self.slicer_area.n_cursors))
+            changed_axes: set[int] = set()
             for c in cursors:
-                self.slicer_area.set_value(
+                if self.slicer_area.set_value(
                     axis, value, update=False, uniform=True, cursor=c
-                )
-            self.slicer_area.refresh(cursors, (axis,))
+                ):
+                    changed_axes.add(axis)
+            self._refresh_dragged_cursors(
+                cursors,
+                self._drag_refresh_axes(changed_axes),
+            )
 
     def remove_cursor(self, index: int) -> None:
         item = self.slicer_data_items.pop(index)

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -2989,26 +2989,37 @@ class ItoolPlotItem(pg.PlotItem):
 
         ev, modifiers = sig
         data_pos = self.getViewBox().mapSceneToView(ev.scenePos())
+        is_finish = getattr(ev, "isFinish", None)
+        defer_point_value = (
+            callable(is_finish)
+            and not is_finish()
+            and self.slicer_area.array_slicer._obj.chunks is not None
+        )
 
         if (not self.is_image) and self.slicer_data_items[-1].is_vertical:
             data_pos_coords = (data_pos.y(), data_pos.x())
         else:
             data_pos_coords = (data_pos.x(), data_pos.y())
 
-        if QtCore.Qt.KeyboardModifier.AltModifier in modifiers:
-            cursors = tuple(range(self.slicer_area.n_cursors))
-            for c in range(self.slicer_area.n_cursors):
+        with self.slicer_area._defer_dask_point_value_updates(defer_point_value):
+            if QtCore.Qt.KeyboardModifier.AltModifier in modifiers:
+                cursors = tuple(range(self.slicer_area.n_cursors))
+                for c in range(self.slicer_area.n_cursors):
+                    for i, ax in enumerate(self.display_axis):
+                        self.slicer_area.set_value(
+                            ax,
+                            data_pos_coords[i],
+                            update=False,
+                            uniform=True,
+                            cursor=c,
+                        )
+                self.slicer_area.refresh(cursors, self.display_axis)
+            else:
                 for i, ax in enumerate(self.display_axis):
                     self.slicer_area.set_value(
-                        ax, data_pos_coords[i], update=False, uniform=True, cursor=c
+                        ax, data_pos_coords[i], update=False, uniform=True
                     )
-            self.slicer_area.refresh(cursors, self.display_axis)
-        else:
-            for i, ax in enumerate(self.display_axis):
-                self.slicer_area.set_value(
-                    ax, data_pos_coords[i], update=False, uniform=True
-                )
-            self.slicer_area.refresh_current(self.display_axis)
+                self.slicer_area.refresh_current(self.display_axis)
 
         if self.slicer_area.bench:
             self._time_end = time.perf_counter()

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -1442,6 +1442,17 @@ class ArraySlicer(QtCore.QObject):
             return center
         return slice(center, center + 1)
 
+    def _axis_selection_key(
+        self, cursor: int, axis: int
+    ) -> int | tuple[int | None, int | None, int | None]:
+        """Return the source selection identity for a cursor and axis."""
+        if self._binned[cursor][axis]:
+            selection = self._bin_slice(cursor, axis)
+            if isinstance(selection, slice):
+                return (selection.start, selection.stop, selection.step)
+            return selection
+        return self._indices[cursor][axis]
+
     def _bin_along_axis(
         self, cursor: int, axis: int
     ) -> npt.NDArray[np.floating] | np.floating | dask.array.Array:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -51,6 +51,7 @@ else:
     qtawesome = _lazy.load("qtawesome")
 
 from erlab.interactive.imagetool.viewer_linking import (
+    LinkSyncResult,
     SlicerLinkProxy,
     _sync_splitters,
     link_slicer,
@@ -3009,10 +3010,20 @@ class ImageSlicerArea(QtWidgets.QWidget):
         update: bool = True,
         uniform: bool = False,
         cursor: int | None = None,
-    ) -> None:
+    ) -> list[int | None]:
         if cursor is None:  # pragma: no branch
             cursor = self.current_cursor
-        self.array_slicer.set_value(cursor, axis, value, update, uniform)
+        axes = self.array_slicer.set_value(
+            cursor, axis, value, update=False, uniform=uniform
+        )
+        if axes and update:
+            self.sigIndexChanged.emit(cursor, tuple(axes))
+        sync_arguments = None
+        if axes:
+            sync_arguments = {
+                "value": self.array_slicer.get_value(cursor, axis, uniform=uniform)
+            }
+        return LinkSyncResult(axes, sync=bool(axes), arguments=sync_arguments)
 
     @QtCore.Slot(int, int, bool)
     @link_slicer(indices=True, steps=True)

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -270,6 +270,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         self._in_manager: bool = _in_manager  #: Internal flag for tools inside manager
         self._update_delayed: bool = _in_manager  #: Internal flag for delayed updates
+        self._defer_dask_point_value_readout: bool = False
         self._defer_state_refresh = _defer_state_refresh
         self._defer_secondary_plots = _defer_secondary_plots
         self._secondary_plots_materialized = False
@@ -1781,6 +1782,15 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         logger.debug("Connected signals")
 
+    @contextlib.contextmanager
+    def _defer_dask_point_value_updates(self, defer: bool) -> Iterator[None]:
+        previous = self._defer_dask_point_value_readout
+        self._defer_dask_point_value_readout = previous or defer
+        try:
+            yield
+        finally:
+            self._defer_dask_point_value_readout = previous
+
     @QtCore.Slot(int, object)
     @QtCore.Slot(object, object)
     def _refresh_cursor_colors(
@@ -1874,10 +1884,12 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 coord_or_rect_list.append(coord_or_rects)
                 arrays_list_flat.extend(arrays)
 
-        # Also get the point value at the current cursor
-        arrays_list_flat.append(
-            self.array_slicer.point_value(self.current_cursor, binned=True)
-        )
+        compute_point_value = not self._defer_dask_point_value_readout
+        if compute_point_value:
+            # Also get the point value at the current cursor.
+            arrays_list_flat.append(
+                self.array_slicer.point_value(self.current_cursor, binned=True)
+            )
 
         if arrays_list_flat:
             arrays_list_flat = dask.compute(*arrays_list_flat)
@@ -1898,9 +1910,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 obj.update_data(coord_or_rect, next(arrays_it))
             ax.vb.blockSignals(False)
 
-        self.sigPointValueChanged.emit(
-            self.array_slicer.display_safe_float(next(arrays_it))
-        )
+        if compute_point_value:
+            self.sigPointValueChanged.emit(
+                self.array_slicer.display_safe_float(next(arrays_it))
+            )
 
     def link(self, proxy: SlicerLinkProxy) -> None:
         proxy.add(self)

--- a/src/erlab/interactive/imagetool/viewer_linking.py
+++ b/src/erlab/interactive/imagetool/viewer_linking.py
@@ -16,6 +16,21 @@ if typing.TYPE_CHECKING:
     from erlab.interactive.imagetool.viewer import ImageSlicerArea
 
 
+class LinkSyncResult(list):
+    """List return value with private link-sync metadata."""
+
+    def __init__(
+        self,
+        values: typing.Iterable[typing.Any] = (),
+        *,
+        sync: bool = True,
+        arguments: dict[str, typing.Any] | None = None,
+    ) -> None:
+        super().__init__(values)
+        self.sync = sync
+        self.arguments = arguments
+
+
 def _link_splitters(
     s0: QtWidgets.QSplitter, s1: QtWidgets.QSplitter, reverse: bool = False
 ) -> None:
@@ -147,15 +162,21 @@ def link_slicer(
                 call_kwargs["__slicer_transaction_id"] = transaction_id
                 call_kwargs["__slicer_keep_pending"] = keep_pending
             out = func(*args, **call_kwargs)
+            if sync_enabled and isinstance(out, LinkSyncResult) and not out.sync:
+                sync_enabled = False
             if sync_enabled:
                 all_args = inspect.Signature.from_callable(func).bind(*args, **kwargs)
                 all_args.apply_defaults()
                 obj = all_args.arguments.pop("self")
+                sync_arguments = all_args.arguments
+                if isinstance(out, LinkSyncResult) and out.arguments is not None:
+                    sync_arguments = dict(sync_arguments)
+                    sync_arguments.update(out.arguments)
                 if obj._linking_proxy is not None:  # pragma: no branch
                     obj._linking_proxy.sync(
                         obj,
                         func.__name__,
-                        all_args.arguments,
+                        sync_arguments,
                         source_dims,
                         indices,
                         steps,

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5058,11 +5058,15 @@ def test_manual_limits_ignore_dimensions_missing_from_data(qtbot) -> None:
 
 
 class _SceneDragEvent:
-    def __init__(self, scene_pos: QtCore.QPointF) -> None:
+    def __init__(self, scene_pos: QtCore.QPointF, *, finish: bool = False) -> None:
         self._scene_pos = scene_pos
+        self._finish = finish
 
     def scenePos(self) -> QtCore.QPointF:
         return self._scene_pos
+
+    def isFinish(self) -> bool:
+        return self._finish
 
 
 def _cursor_line_values(image, cursor: int) -> tuple[float, ...]:
@@ -5242,6 +5246,66 @@ def test_linked_command_option_image_drag_refreshes_linked_cursors(qtbot) -> Non
     win0.slicer_area.unlink()
     win0.close()
     win1.close()
+
+
+def test_dask_command_drag_defers_point_readout_until_finish(
+    qtbot, monkeypatch
+) -> None:
+    da = pytest.importorskip("dask.array")
+
+    values = np.arange(4 * 5 * 6, dtype=np.float32).reshape((4, 5, 6))
+    data = xr.DataArray(
+        da.from_array(values, chunks=(2, 5, 3)),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(4), "y": np.arange(5), "z": np.arange(6)},
+    )
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    profile = area.get_axes(3)
+    image_item = area.main_image.slicer_data_items[0]
+    image_updates = []
+    original_update_data = image_item.update_data
+
+    def _record_image_update(*args) -> None:
+        image_updates.append(args)
+        original_update_data(*args)
+
+    monkeypatch.setattr(image_item, "update_data", _record_image_update)
+    emissions: list[float] = []
+    area.sigPointValueChanged.connect(emissions.append)
+
+    scene_pos = profile.getViewBox().mapViewToScene(QtCore.QPointF(3.0, 0.0))
+    profile.process_drag(
+        (_SceneDragEvent(scene_pos), QtCore.Qt.KeyboardModifier.ControlModifier)
+    )
+
+    assert emissions == []
+    assert image_updates
+    assert area.get_current_index(2) == 3
+
+    finish_pos = profile.getViewBox().mapViewToScene(QtCore.QPointF(4.0, 0.0))
+    profile.process_drag(
+        (
+            _SceneDragEvent(finish_pos, finish=True),
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+        )
+    )
+
+    assert emissions == [
+        pytest.approx(
+            values[
+                area.get_current_index(0),
+                area.get_current_index(1),
+                area.get_current_index(2),
+            ]
+        )
+    ]
+    win.close()
 
 
 def test_linked_option_cursor_line_drag_refreshes_linked_cursors(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -4958,6 +4958,25 @@ def _linked_pair(qtbot):
     return typing.cast("list[ImageTool]", wins)
 
 
+def _linked_pair_with_different_x_grids(qtbot):
+    source = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.arange(5, dtype=float), "y": np.arange(5, dtype=float)},
+    )
+    target = xr.DataArray(
+        np.arange(45).reshape((9, 5)).astype(float),
+        dims=["x", "y"],
+        coords={"x": np.linspace(0.0, 4.0, 9), "y": np.arange(5, dtype=float)},
+    )
+    wins = itool([source, target], execute=False, link=True)
+    assert isinstance(wins, list)
+    assert len(wins) == 2
+    for win in wins:
+        qtbot.addWidget(win)
+    return typing.cast("list[ImageTool]", wins)
+
+
 def test_linked_swap_axes_skips_targets_without_swapped_dimensions(qtbot) -> None:
     data2d = xr.DataArray(
         np.arange(25).reshape((5, 5)).astype(float),
@@ -5248,6 +5267,48 @@ def test_linked_command_option_image_drag_refreshes_linked_cursors(qtbot) -> Non
     win1.close()
 
 
+def test_linked_snap_command_drag_syncs_only_source_updates(qtbot) -> None:
+    win0, win1 = _linked_pair_with_different_x_grids(qtbot)
+    win0.array_slicer.snap_to_data = True
+
+    with qtbot.waitExposed(win0):
+        win0.show()
+    with qtbot.waitExposed(win1):
+        win1.show()
+
+    source_image = win0.slicer_area.main_image
+    target_image = win1.slicer_area.main_image
+    target_emissions = []
+    win1.slicer_area.sigIndexChanged.connect(
+        lambda cursor, axes: target_emissions.append((cursor, axes))
+    )
+
+    scene_pos = source_image.getViewBox().mapViewToScene(QtCore.QPointF(2.2, 2.0))
+    source_image.process_drag(
+        (_SceneDragEvent(scene_pos), QtCore.Qt.KeyboardModifier.ControlModifier)
+    )
+
+    assert win0.array_slicer.get_value(0, 0) == pytest.approx(2.0)
+    assert win1.array_slicer.get_value(0, 0) == pytest.approx(2.0)
+    assert _cursor_line_values(target_image, 0) == (2.0, 2.0)
+    assert target_emissions == []
+
+    scene_pos = source_image.getViewBox().mapViewToScene(QtCore.QPointF(2.6, 2.0))
+    source_image.process_drag(
+        (_SceneDragEvent(scene_pos), QtCore.Qt.KeyboardModifier.ControlModifier)
+    )
+
+    qtbot.waitUntil(
+        lambda: np.allclose(_cursor_line_values(target_image, 0), (3.0, 2.0))
+    )
+    assert win0.array_slicer.get_value(0, 0) == pytest.approx(3.0)
+    assert win1.array_slicer.get_value(0, 0) == pytest.approx(3.0)
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
 def test_dask_command_drag_defers_point_readout_until_finish(
     qtbot, monkeypatch
 ) -> None:
@@ -5308,6 +5369,106 @@ def test_dask_command_drag_defers_point_readout_until_finish(
     win.close()
 
 
+def test_dask_command_drag_same_index_skips_data_refresh(qtbot, monkeypatch) -> None:
+    da = pytest.importorskip("dask.array")
+    from dask.callbacks import Callback
+
+    values = np.arange(4 * 5 * 6, dtype=np.float32).reshape((4, 5, 6))
+    data = xr.DataArray(
+        da.from_array(values, chunks=(2, 5, 3)),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(4), "y": np.arange(5), "z": np.arange(6)},
+    )
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    profile = area.get_axes(3)
+    image_item = area.main_image.slicer_data_items[0]
+    area.array_slicer.set_index(0, 2, 3, update=False)
+
+    image_updates = []
+    monkeypatch.setattr(
+        image_item,
+        "update_data",
+        lambda *args: image_updates.append(args),
+    )
+    computed_keys: list[object] = []
+
+    scene_pos = profile.getViewBox().mapViewToScene(QtCore.QPointF(3.1, 0.0))
+    with Callback(pretask=lambda key, _dsk, _state: computed_keys.append(key)):
+        profile.process_drag(
+            (_SceneDragEvent(scene_pos), QtCore.Qt.KeyboardModifier.ControlModifier)
+        )
+
+    assert computed_keys == []
+    assert image_updates == []
+    assert area.get_current_index(2) == 3
+    assert area.array_slicer.get_value(0, 2, uniform=True) == pytest.approx(3.1)
+    assert _cursor_line_values(profile, 0) == (pytest.approx(3.1),)
+    win.close()
+
+
+def test_dask_command_drag_same_binned_window_skips_data_refresh(
+    qtbot, monkeypatch
+) -> None:
+    da = pytest.importorskip("dask.array")
+    from dask.callbacks import Callback
+
+    values = np.arange(4 * 5 * 6, dtype=np.float32).reshape((4, 5, 6))
+    data = xr.DataArray(
+        da.from_array(values, chunks=(2, 5, 3)),
+        dims=["x", "y", "z"],
+        coords={"x": np.arange(4), "y": np.arange(5), "z": np.arange(6)},
+    )
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    profile = area.get_axes(3)
+    image_item = area.main_image.slicer_data_items[0]
+    area.array_slicer.set_bin(0, 2, 5, update=False)
+    area.array_slicer.set_index(0, 2, 0, update=False)
+
+    image_updates = []
+    original_update_data = image_item.update_data
+
+    def _record_image_update(*args) -> None:
+        image_updates.append(args)
+        original_update_data(*args)
+
+    monkeypatch.setattr(image_item, "update_data", _record_image_update)
+
+    scene_pos = profile.getViewBox().mapViewToScene(QtCore.QPointF(1.0, 0.0))
+    computed_keys: list[object] = []
+    with Callback(pretask=lambda key, _dsk, _state: computed_keys.append(key)):
+        profile.process_drag(
+            (_SceneDragEvent(scene_pos), QtCore.Qt.KeyboardModifier.ControlModifier)
+        )
+
+    assert computed_keys == []
+    assert image_updates == []
+    assert area.get_current_index(2) == 1
+
+    scene_pos = profile.getViewBox().mapViewToScene(QtCore.QPointF(3.0, 0.0))
+    computed_keys.clear()
+    with Callback(pretask=lambda key, _dsk, _state: computed_keys.append(key)):
+        profile.process_drag(
+            (_SceneDragEvent(scene_pos), QtCore.Qt.KeyboardModifier.ControlModifier)
+        )
+
+    assert computed_keys
+    assert image_updates
+    assert area.get_current_index(2) == 3
+    win.close()
+
+
 def test_linked_option_cursor_line_drag_refreshes_linked_cursors(
     qtbot, monkeypatch
 ) -> None:
@@ -5340,6 +5501,52 @@ def test_linked_option_cursor_line_drag_refreshes_linked_cursors(
         )
         assert win0.array_slicer.get_indices(cursor) == [4, 2]
         assert win1.array_slicer.get_indices(cursor) == [4, 2]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_snap_cursor_line_drag_syncs_only_source_updates(
+    qtbot, monkeypatch
+) -> None:
+    win0, win1 = _linked_pair_with_different_x_grids(qtbot)
+    win0.array_slicer.snap_to_data = True
+
+    with qtbot.waitExposed(win0):
+        win0.show()
+    with qtbot.waitExposed(win1):
+        win1.show()
+
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "keyboardModifiers",
+        staticmethod(lambda: QtCore.Qt.KeyboardModifier.NoModifier),
+    )
+
+    source_image = win0.slicer_area.main_image
+    target_image = win1.slicer_area.main_image
+    axis = source_image.display_axis[0]
+    line = source_image.cursor_lines[0][axis]
+    target_emissions = []
+    win1.slicer_area.sigIndexChanged.connect(
+        lambda cursor, axes: target_emissions.append((cursor, axes))
+    )
+
+    source_image.line_drag(line, 2.2, axis)
+
+    assert win0.array_slicer.get_value(0, axis) == pytest.approx(2.0)
+    assert win1.array_slicer.get_value(0, axis) == pytest.approx(2.0)
+    assert _cursor_line_values(target_image, 0) == (2.0, 2.0)
+    assert target_emissions == []
+
+    source_image.line_drag(line, 2.6, axis)
+
+    qtbot.waitUntil(
+        lambda: np.allclose(_cursor_line_values(target_image, 0), (3.0, 2.0))
+    )
+    assert win0.array_slicer.get_value(0, axis) == pytest.approx(3.0)
+    assert win1.array_slicer.get_value(0, axis) == pytest.approx(3.0)
 
     win0.slicer_area.unlink()
     win0.close()

--- a/tests/interactive/imagetool/test_manager_warnings.py
+++ b/tests/interactive/imagetool/test_manager_warnings.py
@@ -1,4 +1,9 @@
+import contextlib
 import logging
+from collections.abc import Iterator
+
+import pytest
+from qtpy import QtCore, QtWidgets
 
 from erlab.interactive.imagetool.manager._mainwindow import (
     _WarningEmitter,
@@ -6,8 +11,24 @@ from erlab.interactive.imagetool.manager._mainwindow import (
 )
 
 
-def test_warning_handler_formats_message(qtbot) -> None:
+@pytest.fixture
+def warning_emitter(qapp: QtWidgets.QApplication) -> Iterator[_WarningEmitter]:
     emitter = _WarningEmitter()
+    try:
+        yield emitter
+    finally:
+        with contextlib.suppress(RuntimeError, TypeError):
+            emitter.warning_received.disconnect()
+        with contextlib.suppress(RuntimeError):
+            emitter.deleteLater()
+        QtWidgets.QApplication.sendPostedEvents(
+            emitter, QtCore.QEvent.Type.DeferredDelete
+        )
+        qapp.processEvents()
+
+
+def test_warning_handler_formats_message(warning_emitter: _WarningEmitter) -> None:
+    emitter = warning_emitter
     handler = _WarningNotificationHandler(emitter)
 
     received: list[tuple[str, int, str, str]] = []
@@ -33,8 +54,8 @@ def test_warning_handler_formats_message(qtbot) -> None:
     assert received[0][2] == "hello world"
 
 
-def test_warning_handler_formats_exc_info(qtbot) -> None:
-    emitter = _WarningEmitter()
+def test_warning_handler_formats_exc_info(warning_emitter: _WarningEmitter) -> None:
+    emitter = warning_emitter
     handler = _WarningNotificationHandler(emitter)
 
     received: list[tuple[str, int, str, str]] = []

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -692,8 +692,10 @@ def test_ptable_launcher_and_search_highlight(
     assert root_layout.contentsMargins().left() <= 8
     assert root_layout.contentsMargins().top() <= 8
     assert root_layout.spacing() <= 8
+    reference_list = QtWidgets.QListWidget()
+    qtbot.addWidget(reference_list)
     assert _effective_point_size(win.search_popup.font()) == pytest.approx(
-        _effective_point_size(QtWidgets.QListWidget().font())
+        _effective_point_size(reference_list.font())
     )
     empty_summary_height = win.inspector.summary_frame.height()
     table_container_layout = win.inspector.table_container.layout()
@@ -1725,7 +1727,9 @@ def test_ptable_category_legend_click_opens_and_retargets_reference_dialog(
     assert dialog._background_color.alpha() == 255
     assert dialog._background_color != QtCore.Qt.GlobalColor.transparent
     base_point_size = dialog.font().pointSizeF()
-    standard_dialog_font = QtWidgets.QDialog().font().pointSizeF()
+    standard_dialog = QtWidgets.QDialog()
+    qtbot.addWidget(standard_dialog)
+    standard_dialog_font = standard_dialog.font().pointSizeF()
     assert base_point_size > 0.0
     assert base_point_size == pytest.approx(standard_dialog_font)
     assert dialog.title_label.font().pointSizeF() == pytest.approx(base_point_size)
@@ -3503,8 +3507,10 @@ def test_ptable_search_popup_completion_helpers_respect_focus_state(
 def test_ptable_search_popup_widget_helpers_emit_indexes(qtbot) -> None:
     popup = erlab.interactive.ptable._window._SearchPopup()
     qtbot.addWidget(popup)
+    reference_list = QtWidgets.QListWidget()
+    qtbot.addWidget(reference_list)
     assert _effective_point_size(popup.font()) == pytest.approx(
-        _effective_point_size(QtWidgets.QListWidget().font())
+        _effective_point_size(reference_list.font())
     )
     popup.addItem(QtWidgets.QListWidgetItem("Au - Gold"))
     popup.addItem(QtWidgets.QListWidgetItem("Cu - Copper"))


### PR DESCRIPTION
## Summary

- Defer dask-backed point-value readout during intermediate Ctrl-drag slicing updates, while still computing the final readout when the drag finishes.
- Skip dask plot-slice recomputation when Ctrl-drag changes cursor coordinates but not the effective data selection.
- Make linked snapped drags source-authoritative: linked tools update only when the dragged source cursor actually changes, and they receive the source's snapped coordinate rather than the raw mouse coordinate.
- Clean up Qt smoke-test helper object lifetimes so PyQt6 smoke jobs do not segfault during post-test teardown.

## Why

The dask refresh path was doing avoidable work during realtime slicing: scalar readout was computed on every intermediate drag tick, and same-selection mouse motion could still trigger full dask slice refreshes. Linked tools also followed raw drag coordinates even when snap-to-grid kept the source cursor on the same data point, which was especially visible when linked tools used different grids.

The failing smoke job reached a clean pytest summary and then exited with code 139, which pointed to Qt cleanup rather than a test assertion. The cleanup patch gives pytest-qt ownership of temporary ptable helper widgets and explicitly disposes the manager warning emitter QObjects.

## Validation

- `PYTEST_QT_API=pyqt6 QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run --python 3.11 --all-extras --dev --group pyqt6 pytest -m compat -o faulthandler_timeout=300 tests/accessors/test_fit.py tests/accessors/test_general.py tests/analysis/test_transform.py tests/analysis/test_xps.py tests/io/test_igor.py tests/io/test_io_utils.py tests/plotting/test_atoms.py tests/plotting/test_general.py tests/interactive/test_colors.py tests/interactive/test_options.py tests/interactive/test_ptable.py tests/interactive/imagetool/test_module_split.py tests/interactive/imagetool/test_server_multipart.py tests/interactive/imagetool/test_manager_warnings.py tests/io/test_dataloader.py::test_loader tests/utils/test_array.py`
- `PYTEST_QT_API=pyqt6 QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run --python 3.11 --all-extras --dev --group pyqt6 pytest -m compat -o faulthandler_timeout=300 tests/interactive/test_ptable.py::test_ptable_launcher_and_search_highlight tests/interactive/test_ptable.py::test_ptable_category_legend_click_opens_and_retargets_reference_dialog tests/interactive/test_ptable.py::test_ptable_search_popup_widget_helpers_emit_indexes tests/interactive/imagetool/test_manager_warnings.py -q`
- `PYTEST_QT_API=pyqt6 QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run --python 3.11 --all-extras --dev --group pyqt6 pytest tests/interactive/imagetool/test_imagetool.py::test_linked_snap_command_drag_syncs_only_source_updates tests/interactive/imagetool/test_imagetool.py::test_dask_command_drag_defers_point_readout_until_finish tests/interactive/imagetool/test_imagetool.py::test_dask_command_drag_same_index_skips_data_refresh tests/interactive/imagetool/test_imagetool.py::test_dask_command_drag_same_binned_window_skips_data_refresh tests/interactive/imagetool/test_imagetool.py::test_linked_option_cursor_line_drag_refreshes_linked_cursors tests/interactive/imagetool/test_imagetool.py::test_linked_snap_cursor_line_drag_syncs_only_source_updates -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src/erlab/interactive/imagetool/viewer_linking.py src/erlab/interactive/imagetool/viewer.py src/erlab/interactive/imagetool/slicer.py src/erlab/interactive/imagetool/plot_items.py`
- `git diff --check`
