### PR TITLE
Fix ImageToolManager early layout event crash

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -653,6 +653,7 @@ class ImageToolManager(_ImageToolManagerBase):
     # Signal emitted to notify ipython watchers of data changes.
 
     def __init__(self) -> None:
+        self._manager_layout_tracking_enabled = False
         super().__init__()
 
         # Initialize warning notifications
@@ -778,7 +779,6 @@ class ImageToolManager(_ImageToolManagerBase):
         self._progress_bars: dict[int, QtWidgets.QProgressDialog] = {}
 
         self._bulk_remove_depth: int = 0
-        self._manager_layout_tracking_enabled = False
 
         # Initialize actions
         self.settings_action = QtWidgets.QAction("Settings", self)
@@ -1450,10 +1450,15 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def event(self, event: QtCore.QEvent | None) -> bool:
         handled = super().event(event)
-        if event is not None and event.type() in (
-            QtCore.QEvent.Type.Move,
-            QtCore.QEvent.Type.Resize,
-            QtCore.QEvent.Type.WindowStateChange,
+        if (
+            self._manager_layout_tracking_enabled
+            and event is not None
+            and event.type()
+            in (
+                QtCore.QEvent.Type.Move,
+                QtCore.QEvent.Type.Resize,
+                QtCore.QEvent.Type.WindowStateChange,
+            )
         ):
             self._mark_workspace_layout_dirty()
         return handled

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -166,6 +166,45 @@ def test_manager_open_settings_reuses_live_dialog(
         qtbot.wait_until(lambda: "settings" not in manager._additional_windows)
 
 
+def test_manager_layout_events_wait_for_tracking_enabled(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        workspace_controller = manager._workspace_controller
+        manager._manager_layout_tracking_enabled = False
+        del manager._workspace_controller
+        try:
+            manager.event(QtCore.QEvent(QtCore.QEvent.Type.WindowStateChange))
+        finally:
+            manager._workspace_controller = workspace_controller
+            manager._manager_layout_tracking_enabled = True
+
+        dirty_calls = 0
+
+        def _record_workspace_layout_dirty() -> None:
+            nonlocal dirty_calls
+            dirty_calls += 1
+
+        monkeypatch.setattr(
+            manager,
+            "_mark_workspace_layout_dirty",
+            _record_workspace_layout_dirty,
+        )
+        manager._manager_layout_tracking_enabled = False
+        manager.event(QtCore.QEvent(QtCore.QEvent.Type.WindowStateChange))
+        assert dirty_calls == 0
+
+        manager._manager_layout_tracking_enabled = True
+        manager.event(QtCore.QEvent(QtCore.QEvent.Type.WindowStateChange))
+        assert dirty_calls == 1
+
+
 @pytest.mark.parametrize(
     ("platform", "rename_shortcut", "show_shortcut", "expected_shortcuts"),
     [


### PR DESCRIPTION
## Summary

- Initialize `ImageToolManager` layout tracking before Qt can deliver early window events.
- Gate move, resize, and window-state dirty tracking until manager initialization enables it.
- Add a regression test that verifies early layout events do not require `_workspace_controller`, while normal post-init events still mark layout dirty.

## Root Cause

Qt can deliver `Move`, `Resize`, or `WindowStateChange` events while `ImageToolManager.__init__` is still running. The `event()` override marked workspace layout dirty immediately, which delegated to `_workspace_controller` before that attribute was assigned.

## Validation

- `uv run pytest tests/interactive/imagetool/manager/test_mainwindow.py`
- `uv run ruff check src/erlab/interactive/imagetool/manager/_mainwindow.py tests/interactive/imagetool/manager/test_mainwindow.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/manager/_mainwindow.py tests/interactive/imagetool/manager/test_mainwindow.py`