### PR TITLE
Add configurable ImageTool Manager default folder

### DIFF
--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -21,10 +21,16 @@ Use the sidebar to switch between setting groups:
 
 - {guilabel}`Visualization` controls default colormap, gamma, cursor colors, and
   related display defaults.
-- {guilabel}`I/O` controls default loader behavior.
+- {guilabel}`I/O` controls the default loader and the default folder used by
+  manager file dialogs and new Data Explorer windows.
 - {guilabel}`ktool` controls defaults for newly opened momentum-conversion tools.
 - {guilabel}`Figure Composer` controls default Matplotlib stylesheets and optional
   default DPI for newly created figures.
+
+```{versionadded} 3.25.0
+The I/O settings include a default folder for ImageTool Manager file dialogs and
+new Data Explorer windows.
+```
 
 Rows in the {guilabel}`User` scope include a reset action that restores the application
 default for that setting. Broadly resetting all user settings still asks for

--- a/src/erlab/interactive/_options/__init__.py
+++ b/src/erlab/interactive/_options/__init__.py
@@ -11,6 +11,7 @@ import pyqtgraph.parametertree
 
 from erlab.interactive._options.parameters import (
     ColorListParameter,
+    DirectoryPathParameter,
     FigureDpiOverrideParameter,
     StylesheetListParameter,
     _CustomColorMapParameter,
@@ -30,6 +31,10 @@ pyqtgraph.parametertree.registerParameterType(
 
 pyqtgraph.parametertree.registerParameterType(
     "figure_dpi_override", FigureDpiOverrideParameter, override=True
+)
+
+pyqtgraph.parametertree.registerParameterType(
+    "directory_path", DirectoryPathParameter, override=True
 )
 
 __getattr__, __dir__, __all__ = _lazy.attach_stub(__name__, __file__)

--- a/src/erlab/interactive/_options/parameters.py
+++ b/src/erlab/interactive/_options/parameters.py
@@ -266,6 +266,108 @@ class FigureDpiOverrideParameter(
         super().__init__(**opts)
 
 
+class DirectoryPathWidget(QtWidgets.QWidget):
+    """Widget for editing an optional directory path."""
+
+    sigPathChanged = QtCore.Signal(str)
+
+    def __init__(
+        self,
+        path: str | None = "",
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+
+        self.line_edit = QtWidgets.QLineEdit(self)
+        self.line_edit.setObjectName("directoryPathLineEdit")
+        self.line_edit.editingFinished.connect(self._editing_finished)
+
+        self.browse_button = QtWidgets.QToolButton(self)
+        self.browse_button.setObjectName("directoryPathBrowseButton")
+        self.browse_button.setText("Browse")
+        self.browse_button.setIcon(QtGui.QIcon.fromTheme("folder-open"))
+        self.browse_button.setToolTip("Choose a folder.")
+        self.browse_button.clicked.connect(self.browse_directory)
+
+        self.clear_button = QtWidgets.QToolButton(self)
+        self.clear_button.setObjectName("directoryPathClearButton")
+        self.clear_button.setText("Clear")
+        self.clear_button.setIcon(QtGui.QIcon.fromTheme("edit-clear"))
+        self.clear_button.setToolTip("Clear the selected folder.")
+        self.clear_button.clicked.connect(self.clear_path)
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+        layout.addWidget(self.line_edit, 1)
+        layout.addWidget(self.browse_button)
+        layout.addWidget(self.clear_button)
+
+        self.set_path(path)
+
+    def get_path(self) -> str:
+        return self.line_edit.text().strip()
+
+    def set_path(self, path: str | None) -> None:
+        text = "" if path is None else str(path).strip()
+        was_blocked = self.line_edit.blockSignals(True)
+        try:
+            self.line_edit.setText(text)
+        finally:
+            self.line_edit.blockSignals(was_blocked)
+        self._update_clear_button()
+
+    @QtCore.Slot()
+    def browse_directory(self) -> None:
+        current_path = self.get_path()
+        directory = QtWidgets.QFileDialog.getExistingDirectory(
+            self,
+            "Select Default Folder",
+            QtCore.QDir.toNativeSeparators(current_path) if current_path else "",
+        )
+        if not directory:
+            return
+        self.set_path(directory)
+        self.sigPathChanged.emit(self.get_path())
+
+    @QtCore.Slot()
+    def clear_path(self) -> None:
+        if not self.get_path():
+            return
+        self.set_path("")
+        self.sigPathChanged.emit("")
+
+    @QtCore.Slot()
+    def _editing_finished(self) -> None:
+        path = self.get_path()
+        if self.line_edit.text() != path:
+            self.set_path(path)
+        self.sigPathChanged.emit(path)
+
+    def _update_clear_button(self) -> None:
+        self.clear_button.setEnabled(bool(self.get_path()))
+
+
+class DirectoryPathParameterItem(
+    pyqtgraph.parametertree.parameterTypes.WidgetParameterItem
+):
+    def makeWidget(self) -> DirectoryPathWidget:
+        w = DirectoryPathWidget()
+        w.sigChanged = w.sigPathChanged  # type: ignore[attr-defined]
+        w.value = w.get_path  # type: ignore[attr-defined]
+        w.setValue = w.set_path  # type: ignore[attr-defined]
+        self.hideWidget = False
+        return w
+
+
+class DirectoryPathParameter(pyqtgraph.parametertree.parameterTypes.SimpleParameter):
+    itemClass = DirectoryPathParameterItem
+
+    def __init__(self, **opts):
+        opts.setdefault("type", "directory_path")
+        super().__init__(**opts)
+
+
 class StylesheetListWidget(QtWidgets.QWidget):
     """Widget for editing an ordered list of Matplotlib stylesheets."""
 

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -269,6 +269,15 @@ class IOOptions(BaseModel):
             )
         },
     )
+    default_directory: str = Field(
+        default="",
+        title="Default folder",
+        description=(
+            "Folder ImageTool Manager uses for file dialogs and new Data Explorer "
+            "windows before another folder has been used."
+        ),
+        json_schema_extra={"ui_type": "directory_path"},
+    )
 
     dask: DaskOptions = Field(default_factory=DaskOptions, title="Dask")
     workspace: WorkspaceOptions = Field(
@@ -287,6 +296,13 @@ class IOOptions(BaseModel):
                 "Loader '" + v + "' not registered; available: " + str(available)
             )
         return v
+
+    @field_validator("default_directory", mode="before")
+    @classmethod
+    def normalize_default_directory(cls, v: typing.Any) -> str:
+        if v is None:
+            return ""
+        return str(v).strip()
 
 
 class ColorMapOptions(BaseModel):

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -17,6 +17,7 @@ from erlab.interactive._options.core import (
 )
 from erlab.interactive._options.parameters import (
     ColorListWidget,
+    DirectoryPathWidget,
     FigureDpiOverrideWidget,
     StylesheetListWidget,
 )
@@ -603,6 +604,8 @@ class OptionDialog(QtWidgets.QDialog):
             return StylesheetListWidget(parent=self)
         if ui_type == "figure_dpi_override":
             return FigureDpiOverrideWidget(parent=self)
+        if ui_type == "directory_path":
+            return DirectoryPathWidget(parent=self)
         if ui_type == "choice_slider":
             return _ChoiceSlider(extra.get("ui_choices", ()), self)
         if ui_type == "list" or "ui_limits" in extra:
@@ -693,6 +696,10 @@ class OptionDialog(QtWidgets.QDialog):
         elif isinstance(control, StylesheetListWidget):
             control.sigStylesheetsChanged.connect(
                 lambda _stylesheets, row=row: self._control_changed(row)
+            )
+        elif isinstance(control, DirectoryPathWidget):
+            control.sigPathChanged.connect(
+                lambda _path, row=row: self._control_changed(row)
             )
         elif isinstance(control, QtWidgets.QLineEdit):
             control.editingFinished.connect(lambda row=row: self._control_changed(row))
@@ -787,6 +794,8 @@ class OptionDialog(QtWidgets.QDialog):
             return control.get_stylesheets()
         if isinstance(control, FigureDpiOverrideWidget):
             return control.get_dpi()
+        if isinstance(control, DirectoryPathWidget):
+            return control.get_path()
         if isinstance(control, QtWidgets.QLineEdit):
             text = control.text()
             default_value = option_value(AppOptions(), path)
@@ -831,6 +840,9 @@ class OptionDialog(QtWidgets.QDialog):
             return
         if isinstance(control, FigureDpiOverrideWidget):
             control.set_dpi(value)
+            return
+        if isinstance(control, DirectoryPathWidget):
+            control.set_path(None if value is None else str(value))
             return
         if isinstance(control, QtWidgets.QLineEdit):
             if isinstance(value, list):

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -434,8 +434,9 @@ class ImageTool(BaseImageTool):
 
     @property
     def _recent_directory(self) -> str | None:
-        if self.slicer_area._manager_instance is not None:
-            return self.slicer_area._manager_instance._recent_directory
+        manager = self.slicer_area._manager_instance
+        if manager is not None:
+            return manager._recent_or_default_directory()
         return self.__recent_directory
 
     @_recent_directory.setter

--- a/src/erlab/interactive/imagetool/manager/__init__.py
+++ b/src/erlab/interactive/imagetool/manager/__init__.py
@@ -465,16 +465,16 @@ def main(execute: bool = True) -> None:
 
 
 def _get_recent_directory() -> str:
-    """Return the most recent directory used by the ImageToolManager.
+    """Return the active directory used by the ImageToolManager.
 
     Used internally to set the default directory for various file dialogs in tools
-    launched inside the manager. Returns an empty string if no directory has been set
-    yet, or if the manager is running in a different process.
+    launched inside the manager. Returns the most recent directory when available, then
+    the configured default directory. Returns an empty string if neither is available,
+    or if the manager is running in a different process.
 
     """
-    if (
-        _manager_instance is not None
-        and _manager_instance._recent_directory is not None
-    ):
-        return str(_manager_instance._recent_directory)
+    if _manager_instance is not None:
+        directory = _manager_instance._recent_or_default_directory()
+        if directory is not None:
+            return str(directory)
     return ""

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 __all__ = ["_ImageToolManagerBase"]
 
+import os
 import threading
 import typing
 import weakref
@@ -278,6 +279,14 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
             self._workspace_state.option_overrides,
         )
 
+    def _recent_or_default_directory(self) -> str | None:
+        if self._recent_directory is not None:
+            return self._recent_directory
+        default_directory = self.effective_interactive_options.io.default_directory
+        if default_directory:
+            return os.path.expanduser(default_directory)
+        return None
+
     def _node_for_target(
         self, target: int | str
     ) -> _ImageToolWrapper | _ManagedWindowNode:
@@ -413,7 +422,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         if loader_name is None:
             loader_name = self.effective_interactive_options.io.default_loader
         explorer = _TabbedExplorer(
-            root_path=self._recent_directory,
+            root_path=self._recent_or_default_directory(),
             loader_name=loader_name,
         )
         loader_kwargs, loader_extensions = (

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -2653,8 +2653,8 @@ class _WorkspaceIOController:
             dialog.selectFile(str(selected_file))
         elif self._manager._workspace_state.path is not None:
             dialog.selectFile(str(self._manager._workspace_state.path))
-        elif self._manager._recent_directory is not None:
-            dialog.setDirectory(self._manager._recent_directory)
+        elif (directory := self._manager._recent_or_default_directory()) is not None:
+            dialog.setDirectory(directory)
         if not native:  # pragma: no branch
             dialog.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog)
 
@@ -3811,8 +3811,8 @@ class _WorkspaceIOController:
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptMode.AcceptOpen)
         dialog.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFile)
         dialog.setNameFilter("ImageTool Workspace Files (*.itws)")
-        if self._manager._recent_directory is not None:
-            dialog.setDirectory(self._manager._recent_directory)
+        if (directory := self._manager._recent_or_default_directory()) is not None:
+            dialog.setDirectory(directory)
         if not native:  # pragma: no branch
             dialog.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog)
 
@@ -3860,8 +3860,8 @@ class _WorkspaceIOController:
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptMode.AcceptOpen)
         dialog.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFile)
         dialog.setNameFilter("ImageTool Workspace Files (*.itws)")
-        if self._manager._recent_directory is not None:
-            dialog.setDirectory(self._manager._recent_directory)
+        if (directory := self._manager._recent_or_default_directory()) is not None:
+            dialog.setDirectory(directory)
         if not native:  # pragma: no branch
             dialog.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog)
 
@@ -3923,8 +3923,8 @@ class _WorkspaceIOController:
         preferred_name_filter = self._manager._preferred_name_filter(valid_loaders)
         if preferred_name_filter is not None:
             dialog.selectNameFilter(preferred_name_filter)
-        if self._manager._recent_directory is not None:
-            dialog.setDirectory(self._manager._recent_directory)
+        if (directory := self._manager._recent_or_default_directory()) is not None:
+            dialog.setDirectory(directory)
 
         if dialog.exec():
             file_names = dialog.selectedFiles()

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -27,6 +27,7 @@ import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._updater_gui as manager_updater_gui
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
+from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
 from erlab.interactive.imagetool.manager import load_in_manager
 from erlab.interactive.imagetool.manager._server import (
@@ -1220,6 +1221,68 @@ def test_manager_explorer_launcher_reuses_instance_and_opens_directory_tabs(
         qtbot.wait_until(lambda: explorer.tab_widget.count() == 2)
         assert explorer.current_explorer is not None
         assert explorer.current_explorer.current_directory == pathlib.Path(dropped_dir)
+
+
+def test_manager_explorer_uses_default_directory_before_recent(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    tmp_path: pathlib.Path,
+) -> None:
+    default_dir = tmp_path / "default"
+    recent_dir = tmp_path / "recent"
+    default_dir.mkdir()
+    recent_dir.mkdir()
+    erlab.interactive.options.model = AppOptions().model_copy(
+        update={
+            "io": AppOptions().io.model_copy(
+                update={"default_directory": str(default_dir)}
+            )
+        }
+    )
+
+    with manager_context() as manager:
+        manager.ensure_explorer_initialized()
+        explorer = manager.explorer.current_explorer
+        if explorer is None:
+            raise AssertionError("Data Explorer tab was not initialized")
+        assert explorer.current_directory == default_dir
+
+    with manager_context() as manager:
+        manager._recent_directory = str(recent_dir)
+        manager.ensure_explorer_initialized()
+        explorer = manager.explorer.current_explorer
+        if explorer is None:
+            raise AssertionError("Data Explorer tab was not initialized")
+        assert explorer.current_directory == recent_dir
+
+
+def test_get_recent_directory_uses_default_directory_before_recent(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    tmp_path: pathlib.Path,
+) -> None:
+    default_dir = tmp_path / "default"
+    recent_dir = tmp_path / "recent"
+    default_dir.mkdir()
+    recent_dir.mkdir()
+    erlab.interactive.options.model = AppOptions().model_copy(
+        update={
+            "io": AppOptions().io.model_copy(
+                update={"default_directory": str(default_dir)}
+            )
+        }
+    )
+
+    with manager_context() as manager:
+        qtbot.wait_until(manager_package.is_running)
+        assert manager_package._get_recent_directory() == str(default_dir)
+
+        manager._recent_directory = str(recent_dir)
+
+        assert manager_package._get_recent_directory() == str(recent_dir)
 
 
 def test_manager_ptable_launcher_reuses_instance_without_affecting_tree(

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -1211,6 +1211,8 @@ def test_manager_open_preselects_default_loader_filter(
 ) -> None:
     _set_default_loader_option(monkeypatch, "example")
     example_filter = "Example Raw Data (*.h5)"
+    default_directory = "/example/default"
+    directories: list[str] = []
     selected_filters: list[str] = []
     real_file_dialog = QtWidgets.QFileDialog
 
@@ -1238,7 +1240,7 @@ def test_manager_open_preselects_default_loader_filter(
             selected_filters.append(selected_filter)
 
         def setDirectory(self, directory: str) -> None:
-            pass
+            directories.append(directory)
 
         def exec(self) -> bool:
             return False
@@ -1249,6 +1251,9 @@ def test_manager_open_preselects_default_loader_filter(
             self._recent_name_filter = None
             self._recent_directory = None
             self.effective_interactive_options = erlab.interactive.options.model
+
+        def _recent_or_default_directory(self) -> str | None:
+            return self._recent_directory or default_directory
 
     manager = _FakeManager()
     manager._preferred_name_filter = types.MethodType(
@@ -1272,6 +1277,7 @@ def test_manager_open_preselects_default_loader_filter(
     _WorkspaceIOController(manager).open(native=False)
 
     assert selected_filters == [example_filter]
+    assert directories == [default_directory]
 
 
 @pytest.mark.parametrize("mode", ["dragdrop", "ask"])
@@ -1588,6 +1594,9 @@ def test_manager_open_loader_selection_branches(
             self._add_from_multiple_files = lambda *args, **kwargs: add_calls.append(
                 (args, kwargs)
             )
+
+        def _recent_or_default_directory(self) -> str | None:
+            return self._recent_directory
 
     manager = _FakeManager()
     manager._preferred_name_filter = types.MethodType(

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -1280,6 +1280,76 @@ def test_manager_open_preselects_default_loader_filter(
     assert directories == [default_directory]
 
 
+def test_managed_imagetool_open_uses_default_directory_before_recent(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    default_dir = tmp_path / "default"
+    default_dir.mkdir()
+    options = erlab.interactive.options.model
+    monkeypatch.setattr(
+        erlab.interactive.options,
+        "model",
+        options.model_copy(
+            update={
+                "io": options.io.model_copy(
+                    update={"default_directory": str(default_dir)}
+                )
+            }
+        ),
+    )
+    directories: list[str] = []
+    real_file_dialog = QtWidgets.QFileDialog
+
+    class _FakeFileDialog:
+        AcceptMode = real_file_dialog.AcceptMode
+        FileMode = real_file_dialog.FileMode
+        Option = real_file_dialog.Option
+
+        def __init__(self, parent) -> None:
+            pass
+
+        def setAcceptMode(self, mode) -> None:
+            pass
+
+        def setFileMode(self, mode) -> None:
+            pass
+
+        def setNameFilters(self, filters) -> None:
+            pass
+
+        def setOption(self, option) -> None:
+            pass
+
+        def selectNameFilter(self, selected_filter: str) -> None:
+            pass
+
+        def setDirectory(self, directory: str) -> None:
+            directories.append(directory)
+
+        def exec(self) -> bool:
+            return False
+
+    monkeypatch.setattr(QtWidgets, "QFileDialog", _FakeFileDialog)
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "file_loaders",
+        lambda *_args: {"xarray HDF5 Files (*.h5)": (xr.load_dataarray, {})},
+    )
+
+    with manager_context() as manager:
+        itool(xr.DataArray(np.arange(4).reshape((2, 2)), dims=["x", "y"]), manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        manager.get_imagetool(0)._open_file(native=False)
+
+    assert directories == [str(default_dir)]
+
+
 @pytest.mark.parametrize("mode", ["dragdrop", "ask"])
 def test_manager_open_files(
     qtbot,

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -37,6 +37,7 @@ import erlab.interactive.imagetool.plot_items as imagetool_plot_items
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
+from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import itool, provenance
@@ -7779,6 +7780,21 @@ def test_manager_workspace_save_dialog_paths(
         assert ("select", str(tmp_path / "bound.itws")) in calls
 
         manager._workspace_state.path = None
+        manager._recent_directory = None
+        default_dir = tmp_path / "default"
+        default_dir.mkdir()
+        erlab.interactive.options.model = AppOptions().model_copy(
+            update={
+                "io": AppOptions().io.model_copy(
+                    update={"default_directory": str(default_dir)}
+                )
+            }
+        )
+        assert manager._workspace_save_dialog(native=True) == str(
+            tmp_path / "selected.itws"
+        )
+        assert ("directory", str(default_dir)) in calls
+
         manager._recent_directory = str(tmp_path)
         assert manager._workspace_save_dialog(native=True) == str(
             tmp_path / "selected.itws"

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -17,6 +17,7 @@ from erlab.interactive._options.core import (
 )
 from erlab.interactive._options.parameters import (
     ColorListWidget,
+    DirectoryPathWidget,
     FigureDpiOverrideWidget,
     StylesheetListWidget,
 )
@@ -170,6 +171,18 @@ def test_dialog_multiline_setting_keeps_child_tooltips(dialog: OptionDialog):
     assert control.toolTip() == ""
     assert control.accessibleDescription() == description
     assert add_button.toolTip()
+
+
+def test_dialog_default_directory_control_has_accessible_description(
+    dialog: OptionDialog,
+):
+    path = "io/default_directory"
+    control = _control(dialog, "user", path, DirectoryPathWidget)
+    description = _description(dialog, "user", path).text()
+
+    assert description
+    assert control.toolTip() == ""
+    assert control.accessibleDescription() == description
 
 
 def test_dialog_rebuild_pages_replaces_existing_pages(dialog: OptionDialog):
@@ -401,6 +414,10 @@ def test_dialog_control_value_helpers(dialog: OptionDialog, qtbot):
     figure_dpi.dpi_spin.setValue(180.0)
     assert dialog._control_value(figure_dpi, "figure/dpi") == pytest.approx(180.0)
 
+    directory_path = DirectoryPathWidget("~/data")
+    qtbot.addWidget(directory_path)
+    assert dialog._control_value(directory_path, "io/default_directory") == "~/data"
+
     list_line = QtWidgets.QLineEdit("one, two,, ")
     qtbot.addWidget(list_line)
     assert dialog._control_value(list_line, "colors/cmap/exclude") == ["one", "two"]
@@ -456,6 +473,13 @@ def test_dialog_set_control_value_helpers(dialog: OptionDialog, qtbot):
     assert not figure_dpi.override_check.isChecked()
     assert not figure_dpi.dpi_spin.isEnabled()
     assert figure_dpi.get_dpi() is None
+
+    directory_path = DirectoryPathWidget()
+    qtbot.addWidget(directory_path)
+    dialog._set_control_value(directory_path, "io/default_directory", "~/data")
+    assert directory_path.get_path() == "~/data"
+    dialog._set_control_value(directory_path, "io/default_directory", None)
+    assert directory_path.get_path() == ""
 
 
 def test_choice_slider_labels_align_with_ticks(qtbot):
@@ -933,6 +957,7 @@ def test_workspace_override_helpers_filter_to_curated_subset() -> None:
 
     assert "colors/cmap/name" in paths
     assert "colors/cmap/packages" not in paths
+    assert "io/default_directory" not in paths
     assert "io/workspace/compression" in paths
     assert "io/workspace/compress" not in paths
     assert "figure/dpi" in paths
@@ -992,12 +1017,14 @@ def test_options_get_set():
     assert options["io/workspace/compress"] is True
     assert options["io/workspace/use_incremental"] is True
     assert options["io/workspace/incremental_save_on_remote"] is False
+    assert options["io/default_directory"] == ""
     assert options["figure/dpi"] is None
 
     options["colors/cmap/name"] = "viridis"
     options["io/workspace/compression"] = "blosclz3"
     options["io/workspace/use_incremental"] = False
     options["io/workspace/incremental_save_on_remote"] = True
+    options["io/default_directory"] = "~/data"
     options["figure/stylesheets"] = ["classic", "missing-style"]
     options["figure/dpi"] = 150.0
 
@@ -1006,6 +1033,7 @@ def test_options_get_set():
     assert options["io/workspace/compress"] is True
     assert options["io/workspace/use_incremental"] is False
     assert options["io/workspace/incremental_save_on_remote"] is True
+    assert options["io/default_directory"] == "~/data"
     assert options["figure/stylesheets"] == ["classic", "missing-style"]
     assert options["figure/dpi"] == pytest.approx(150.0)
     assert options.model.io.workspace.compression == "blosclz3"

--- a/tests/interactive/test_options_parameters.py
+++ b/tests/interactive/test_options_parameters.py
@@ -9,6 +9,8 @@ from erlab.interactive._options.parameters import (
     _STYLESHEET_NAME_ROLE,
     ColorListParameter,
     ColorListWidget,
+    DirectoryPathParameter,
+    DirectoryPathWidget,
     FigureDpiOverrideParameter,
     FigureDpiOverrideWidget,
     StylesheetListParameter,
@@ -87,6 +89,84 @@ def test_figure_dpi_override_parameter_item_widget(qtbot) -> None:
 
     widget.override_check.setChecked(False)
     assert param.value() is None
+
+
+def test_directory_path_widget_initialization(qtbot) -> None:
+    widget = DirectoryPathWidget("  ~/data  ")
+    qtbot.addWidget(widget)
+
+    assert widget.get_path() == "~/data"
+    assert widget.clear_button.isEnabled()
+
+
+def test_directory_path_widget_editing_trims_and_emits(qtbot) -> None:
+    widget = DirectoryPathWidget()
+    qtbot.addWidget(widget)
+    widget.line_edit.setText("  ~/data  ")
+
+    with qtbot.waitSignal(widget.sigPathChanged, timeout=1000) as blocker:
+        widget.line_edit.editingFinished.emit()
+
+    assert blocker.args == ["~/data"]
+    assert widget.get_path() == "~/data"
+
+
+def test_directory_path_widget_browse_accepts(qtbot, monkeypatch, tmp_path) -> None:
+    widget = DirectoryPathWidget()
+    qtbot.addWidget(widget)
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getExistingDirectory",
+        lambda *_args: str(tmp_path),
+    )
+
+    with qtbot.waitSignal(widget.sigPathChanged, timeout=1000) as blocker:
+        widget.browse_directory()
+
+    assert blocker.args == [str(tmp_path)]
+    assert widget.get_path() == str(tmp_path)
+
+
+def test_directory_path_widget_browse_cancel_keeps_value(
+    qtbot, monkeypatch, tmp_path
+) -> None:
+    widget = DirectoryPathWidget(str(tmp_path))
+    qtbot.addWidget(widget)
+    changed: list[str] = []
+    widget.sigPathChanged.connect(changed.append)
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getExistingDirectory",
+        lambda *_args: "",
+    )
+
+    widget.browse_directory()
+
+    assert widget.get_path() == str(tmp_path)
+    assert changed == []
+
+
+def test_directory_path_widget_clear_emits(qtbot, tmp_path) -> None:
+    widget = DirectoryPathWidget(str(tmp_path))
+    qtbot.addWidget(widget)
+
+    with qtbot.waitSignal(widget.sigPathChanged, timeout=1000) as blocker:
+        widget.clear_path()
+
+    assert blocker.args == [""]
+    assert widget.get_path() == ""
+    assert not widget.clear_button.isEnabled()
+
+
+def test_directory_path_parameter_item_widget(qtbot) -> None:
+    param = DirectoryPathParameter(name="folder", value="~/data")
+    item = param.makeTreeItem(0)
+    widget = item.widget
+    qtbot.addWidget(widget)
+
+    assert isinstance(widget, DirectoryPathWidget)
+    assert not item.hideWidget
+    assert widget.value() == "~/data"
 
 
 def test_style_library_paths_falls_back_to_matplotlib_core(monkeypatch) -> None:

--- a/tests/interactive/test_options_tree.py
+++ b/tests/interactive/test_options_tree.py
@@ -67,6 +67,19 @@ def test_make_parameter_round_trips_figure_options() -> None:
     assert opts.figure.dpi == 150.0
 
 
+def test_make_parameter_round_trips_default_directory() -> None:
+    options = AppOptions.model_validate({"io": {"default_directory": "~/data"}})
+    param = make_parameter(options)
+
+    directory_param = param.child("io").child("default_directory")
+    assert directory_param.opts["type"] == "directory_path"
+    assert directory_param.value() == "~/data"
+
+    directory_param.setValue("~/other-data")
+
+    assert parameter_to_options(param).io.default_directory == "~/other-data"
+
+
 def test_make_parameter_workspace_compression_uses_display_labels() -> None:
     param = make_parameter()
     compression_param = param.child("io").child("workspace").child("compression")


### PR DESCRIPTION
## Summary

- Add a user-level I/O setting for the default folder used by ImageTool Manager before a recent or restored folder exists.
- Add a directory-picker control to the settings UI and pyqtgraph parameter tree.
- Use the configured folder for manager file dialogs, new Data Explorer windows, and manager-launched child tool dialogs while preserving recent/restored-folder precedence.

## Validation

- `uv sync --all-extras --dev --group pyqt6`
- `uv run pytest tests/interactive/test_options.py tests/interactive/test_options_parameters.py tests/interactive/test_options_tree.py tests/interactive/test_explorer.py tests/interactive/imagetool/manager/test_app.py tests/interactive/imagetool/manager/test_modelview.py tests/interactive/imagetool/manager/test_workspace.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `git diff --check`