### PR TITLE
Improve Figure Composer source workflows

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -36,10 +36,11 @@ figure is created.
 The {guilabel}`Sources` tab lists the named data variables stored with the figure. Data
 must be added to this list before it can be plotted.
 
-Use {guilabel}`Add…` to choose ImageTool rows from the manager. You can also drag
+Use {guilabel}`Add…` to select ImageTool rows from the manager. You can also drag
 ImageTool rows from the manager into the composer controls or figure window.
 
-Use {guilabel}`Refresh Sources` to fetch latest data from the linked ImageTool.
+Select one or more sources and use {guilabel}`Refresh` to update them from their
+ImageTools.
 
 When you choose {guilabel}`Add to Figure…` from ImageTool Manager, the corresponding
 ImageTool rows are added to the figure sources. In that dialog, different choices for
@@ -82,6 +83,11 @@ the figure state created by earlier steps.
 Every step has a type, a target (axes or figure), and a set of controls for the
 arguments of the plotting or styling calls it generates.
 
+The step table shows each operation, its target, and its current status. For steps that
+act on axes, the {guilabel}`Target` column highlights the affected axes in a miniature
+of the current subplot or GridSpec layout. The {guilabel}`Status` reports missing sources, invalid targets or inputs, and rendering errors
+when they occur. Hover over a reported problem for details.
+
 There are several step types:
 
 - {guilabel}`Set Palette` to set the line color cycle with {func}`seaborn.set_palette`.
@@ -117,9 +123,9 @@ method.
 
 :::
 
-Steps can be enabled, disabled, cut, copied, pasted, or removed from the toolbar.
-Reorder steps by dragging them in the list. Use the right-click context menu to
-duplicate steps or move them.
+Use the checkbox beside a step to enable or disable it. Steps can be cut, copied,
+pasted, or removed from the toolbar. Reorder steps by dragging their rows. Use the
+right-click context menu to duplicate steps or move them.
 
 By selecting multiple steps, you can edit them simultaneously to apply the same change
 to all selected steps. Copied or cut steps can be pasted into another Figure Composer.

--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -23,19 +23,43 @@ Open data in ImageTool Manager, then use one of these entry points:
   existing figure.
 - From ImageTool Manager, select one or more ImageTool rows and click
   {guilabel}`Add to Figure…` in the right-click context menu of the selection.
+- Drag ImageTool rows from the manager into an open Figure Composer window to add them
+  as sources.
 
 Figures are listed in the manager's {guilabel}`Figures` tab, which appears after a
 figure is created.
+
+(figure-composer-sources)=
+
+## Sources
+
+The {guilabel}`Sources` tab lists the named data variables stored with the figure. Data
+must be added to this list before it can be plotted.
+
+Use {guilabel}`Add…` to choose ImageTool rows from the manager. You can also drag
+ImageTool rows from the manager into the composer controls or figure window.
+
+Use {guilabel}`Refresh Sources` to fetch latest data from the linked ImageTool.
+
+When you choose {guilabel}`Add to Figure…` from ImageTool Manager, the corresponding
+ImageTool rows are added to the figure sources. In that dialog, different choices for
+{guilabel}`Action` determine how the selected data is added to the figure:
+
+- {guilabel}`New Figure` creates another Figure Composer window.
+- {guilabel}`Add New Step` adds the selected ImageTool data and appends a plotting step.
+- {guilabel}`Add Source Only` adds the selected ImageTool data to the figure without
+  creating or changing recipe steps.
+- {guilabel}`Replace Source` keeps the existing figure recipe intact but swaps one
+  source to use data from the selected ImageTool. This is useful when you have formatted
+  a figure and want to reuse the same recipe, axes, styles, and generated variable names
+  with updated or comparable data.
 
 (figure-composer-layout)=
 
 ## Layout
 
-In the controls window of the Figure Composer, the layout shows tabs for the global
-figure structure and the recipe steps.
-
-The {guilabel}`Layout` tab controls the global figure structure, where you can define
-the size and DPI of the figure, and the number of axes and their arrangement.
+The {guilabel}`Layout` tab controls the global figure structure. You can define the size
+and DPI of the figure, and the number of axes and their arrangement.
 
 - Use {guilabel}`Subplots` mode for regular grids created with
   {func}`matplotlib.pyplot.subplots`.
@@ -58,8 +82,7 @@ the figure state created by earlier steps.
 Every step has a type, a target (axes or figure), and a set of controls for the
 arguments of the plotting or styling calls it generates.
 
-There are several step types, each with a different set of controls for the generated
-code:
+There are several step types:
 
 - {guilabel}`Set Palette` to set the line color cycle with {func}`seaborn.set_palette`.
 - {guilabel}`Image Plot` for one two-dimensional image on one axes. Uses
@@ -94,34 +117,15 @@ method.
 
 :::
 
-Steps can be enabled, disabled, duplicated, reordered, cut, copied, pasted, or removed.
+Steps can be enabled, disabled, cut, copied, pasted, or removed from the toolbar.
+Reorder steps by dragging them in the list. Use the right-click context menu to
+duplicate steps or move them.
 
 By selecting multiple steps, you can edit them simultaneously to apply the same change
 to all selected steps. Copied or cut steps can be pasted into another Figure Composer.
 
 When the source and destination composers are open in the same app process, pasted steps
 also bring the data sources they use.
-
-(figure-composer-sources)=
-
-### Step sources
-
-Because data sources are selected and updated per recipe step, the step controls include
-a {guilabel}`Sources` view. It lists the data stored with the figure, indicates which
-sources are used by the selected step, and lets you update the data available to recipe
-steps without rebuilding the rest of the figure.
-
-When you choose {guilabel}`Add to Figure…` from ImageTool Manager, the
-{guilabel}`Action` menu updates this same source set:
-
-- {guilabel}`New Figure` creates another Figure Composer window.
-- {guilabel}`Add New Step` adds the selected ImageTool data and appends a plotting step.
-- {guilabel}`Add Source Only` adds the selected ImageTool data to the figure without
-  creating or changing recipe steps.
-- {guilabel}`Replace Source` keeps the existing figure recipe intact but swaps one
-  source to use data from the selected ImageTool. This is useful when you have formatted
-  a figure and want to reuse the same recipe, axes, styles, and generated variable names
-  with updated or comparable data.
 
 (figure-composer-toolbar)=
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -249,7 +249,7 @@ and right-click context menus:
 - {guilabel}`Add to Figure…`
 
   Create a new {ref}`Figure Composer <figure-composer>` figure from the selected rows.
-  When figures already exist, this action can also add a new plotting step, add data
+  When figures already exist, this action can also append a plotting step, add data
   sources without changing the recipe, or replace a source in the selected figure.
 
 - {guilabel}`Reload Data`
@@ -293,6 +293,9 @@ ImageTool rows to send their data to {ref}`Figure Composer <figure-composer>`. W
 figures exist, the manager creates a new figure immediately. When figures already exist,
 choose whether to create another figure, append a new recipe step, add the selected data
 as sources only, or replace one source in the selected figure.
+
+You can also drag ImageTool rows from the manager tree into an open Figure Composer
+window to add them as sources.
 
 New figures appear in a {guilabel}`Figures` tab in the manager.
 

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -78,7 +78,7 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `assign`, `IMAGE_TOOL_OUTPUTS`, `set_source_binding`, or `update_data` for
   contributor questions about adding new interactive tools.
 - Search `Figure Composer`, `Add to Figure`, `Append to Figure`, `New Figure`,
-  `Recipe steps`, `Step sources`, `Sources`, `Add New Step`, `Add Source Only`,
+  `Recipe steps`, `Sources`, `Add New Step`, `Add Source Only`,
   `Replace Source`, `Set Palette`, `Image Plot`, `Slice Plot`, `Line/Profile`,
   `Python`, `plot_array`, `plot_slices`, `qplot`, `fermiline`, `nice_colorbar`,
   `plot_bz`, `BZ Overlay`, `Photon Energy Overlay`, `plot_in_plane_bz`,

--- a/skills/arpes-analysis/references/docs-links.md
+++ b/skills/arpes-analysis/references/docs-links.md
@@ -58,7 +58,7 @@ Last updated: 2026-06-18.
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/figure-composer.html#figure-composer-open
 - Figure Composer recipe steps:
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/figure-composer.html#figure-composer-recipe
-- Figure Composer step sources:
+- Figure Composer sources:
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/figure-composer.html#figure-composer-sources
 - Manager Figure Composer workflow:
   https://erlabpy.readthedocs.io/en/stable/user-guide/interactive/manager.html#imagetool-manager-figure-composer
@@ -136,7 +136,7 @@ Last updated: 2026-06-18.
   `site:erlabpy.readthedocs.io/en/stable "<symbol or topic>"`
 - Figure Composer search hints:
   `site:erlabpy.readthedocs.io/en/stable "Figure Composer" "BZ Overlay"`,
-  `site:erlabpy.readthedocs.io/en/stable "Figure Composer" "Step sources"`,
+  `site:erlabpy.readthedocs.io/en/stable "Figure Composer" "Sources"`,
   `site:erlabpy.readthedocs.io/en/stable "Add to Figure" "Replace Source"`,
   `site:erlabpy.readthedocs.io/en/stable "plot_in_plane_bz"`, and
   `site:erlabpy.readthedocs.io/en/stable "hv_to_kz" "Photon Energy Overlay"`

--- a/src/erlab/interactive/_figurecomposer/_codegen.py
+++ b/src/erlab/interactive/_figurecomposer/_codegen.py
@@ -15,7 +15,10 @@ from erlab.interactive._figurecomposer._sources import (
     _source_has_selection,
     _valid_source_variable,
 )
-from erlab.interactive._figurecomposer._state import FigureDataSelectionState
+from erlab.interactive._figurecomposer._state import (
+    FigureDataSelectionState,
+    FigureOperationKind,
+)
 
 if typing.TYPE_CHECKING:
     from collections.abc import Mapping
@@ -64,23 +67,42 @@ def generated_code(
     style_lines = _style_code_lines()
     if style_lines:
         lines.extend(["", *style_lines])
+    source_name_replacements = (
+        _normalized_source_load_replacements(source_name_map) if source_name_map else {}
+    )
+    operation_line_groups: list[list[str]] = []
+    has_custom_code_lines = False
+    for operation in tool._recipe.operations:
+        if not operation.enabled:
+            continue
+        operation_lines = _registry.spec_for(operation.kind).code_lines(tool, operation)
+        if source_name_replacements and operation.kind != FigureOperationKind.CUSTOM:
+            operation_lines = _replace_source_load_names_in_lines(
+                operation_lines, source_name_replacements
+            )
+        elif operation.kind == FigureOperationKind.CUSTOM and operation_lines:
+            has_custom_code_lines = True
+        operation_line_groups.append(operation_lines)
+
+    if source_name_replacements and has_custom_code_lines:
+        lines.extend(["", *_source_alias_assignment_lines(source_name_replacements)])
+
     source_lines = _source_selection_code_lines(
         tool,
         skip_source_names=skip_source_selection_names,
     )
+    if source_name_replacements:
+        source_lines = _replace_source_load_names_in_lines(
+            source_lines, source_name_replacements
+        )
     if source_lines:
         lines.extend(["", *source_lines])
     lines.extend(["", _setup_code(tool)])
 
-    for operation in tool._recipe.operations:
-        if not operation.enabled:
-            continue
-        lines.extend(_registry.spec_for(operation.kind).code_lines(tool, operation))
+    for operation_lines in operation_line_groups:
+        lines.extend(operation_lines)
 
-    code = "\n".join(lines)
-    if source_name_map:
-        return _replace_source_load_names(code, source_name_map)
-    return code
+    return "\n".join(lines)
 
 
 def _source_selection_code_lines(
@@ -104,17 +126,35 @@ def _source_selection_code_lines(
     return lines
 
 
+def _normalized_source_load_replacements(
+    replacements: Mapping[str, str],
+) -> dict[str, str]:
+    return {
+        source: target
+        for source, target in replacements.items()
+        if source != target and source.isidentifier() and target.isidentifier()
+    }
+
+
+def _replace_source_load_names_in_lines(
+    lines: list[str], replacements: Mapping[str, str]
+) -> list[str]:
+    if not lines or not replacements:
+        return lines
+    return _replace_source_load_names("\n".join(lines), replacements).splitlines()
+
+
+def _source_alias_assignment_lines(replacements: Mapping[str, str]) -> list[str]:
+    return [f"{source} = {target}" for source, target in replacements.items()]
+
+
 def _replace_source_load_names(code: str, replacements: Mapping[str, str]) -> str:
     try:
         module = ast.parse(code, mode="exec")
     except SyntaxError:
         return code
 
-    normalized = {
-        source: target
-        for source, target in replacements.items()
-        if source != target and source.isidentifier() and target.isidentifier()
-    }
+    normalized = _normalized_source_load_replacements(replacements)
     if not normalized:
         return code
 

--- a/src/erlab/interactive/_figurecomposer/_codegen.py
+++ b/src/erlab/interactive/_figurecomposer/_codegen.py
@@ -145,7 +145,16 @@ def _replace_source_load_names_in_lines(
 
 
 def _source_alias_assignment_lines(replacements: Mapping[str, str]) -> list[str]:
-    return [f"{source} = {target}" for source, target in replacements.items()]
+    if not replacements:
+        return []
+    sources = tuple(replacements)
+    if len(sources) == 1:
+        source = sources[0]
+        return [f"{source} = {replacements[source]}"]
+    return [
+        f"{', '.join(sources)} = "
+        f"{', '.join(replacements[source] for source in sources)}"
+    ]
 
 
 def _replace_source_load_names(code: str, replacements: Mapping[str, str]) -> str:

--- a/src/erlab/interactive/_figurecomposer/_codegen.py
+++ b/src/erlab/interactive/_figurecomposer/_codegen.py
@@ -12,6 +12,7 @@ from erlab.interactive._figurecomposer._defaults import (
 )
 from erlab.interactive._figurecomposer._operations import _registry
 from erlab.interactive._figurecomposer._sources import (
+    _FIGURE_CODE_RESERVED_NAMES,
     _source_has_selection,
     _valid_source_variable,
 )
@@ -110,14 +111,46 @@ def _source_selection_code_lines(
     *,
     skip_source_names: frozenset[str] = frozenset(),
 ) -> list[str]:
+    used_source_names = tool._direct_sources_used_by_recipe(
+        enabled_only=True, executable_only=True
+    )
+    selected_sources = tuple(
+        source
+        for source in tool._recipe.sources
+        if source.name in used_source_names
+        and source.name not in skip_source_names
+        and _source_has_selection(source)
+    )
+    assigned_names = {source.name for source in selected_sources}
+    captured_names = {
+        source.selection_source
+        for source in selected_sources
+        if source.selection_source is not None
+        and source.selection_source != source.name
+        and source.selection_source in assigned_names
+    }
+
     lines: list[str] = []
+    reserved_names = set(tool._source_names()) | set(_FIGURE_CODE_RESERVED_NAMES)
+    input_names: dict[str, str] = {}
     for source in tool._recipe.sources:
-        if not _source_has_selection(source) or source.name in skip_source_names:
+        if source.name not in captured_names:
             continue
+        stem = f"_{source.name}_input"
+        input_name = stem
+        suffix = 2
+        while input_name in reserved_names:
+            input_name = f"{stem}_{suffix}"
+            suffix += 1
+        reserved_names.add(input_name)
+        input_names[source.name] = input_name
+        lines.append(f"{input_name} = {_valid_source_variable(source.name)}")
+
+    for source in selected_sources:
         target = _valid_source_variable(source.name)
         selection_source = source.selection_source or source.name
         selection = FigureDataSelectionState(
-            source=selection_source,
+            source=input_names.get(selection_source, selection_source),
             isel=dict(source.isel),
             qsel=dict(source.qsel),
             mean_dims=tuple(source.mean_dims),

--- a/src/erlab/interactive/_figurecomposer/_codegen.py
+++ b/src/erlab/interactive/_figurecomposer/_codegen.py
@@ -2,20 +2,33 @@
 
 from __future__ import annotations
 
+import ast
 import typing
 
-from erlab.interactive._figurecomposer._code import _setup_code
+from erlab.interactive._figurecomposer._code import _selection_code, _setup_code
 from erlab.interactive._figurecomposer._defaults import (
     _style_code_lines,
     _style_required_imports,
 )
 from erlab.interactive._figurecomposer._operations import _registry
+from erlab.interactive._figurecomposer._sources import (
+    _source_has_selection,
+    _valid_source_variable,
+)
+from erlab.interactive._figurecomposer._state import FigureDataSelectionState
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from erlab.interactive._figurecomposer._tool import FigureComposerTool
 
 
-def generated_code(tool: FigureComposerTool) -> str:
+def generated_code(
+    tool: FigureComposerTool,
+    *,
+    skip_source_selection_names: frozenset[str] = frozenset(),
+    source_name_map: Mapping[str, str] | None = None,
+) -> str:
     invalid_indices = tool._invalid_operation_indices()
     if invalid_indices:
         if any(
@@ -51,6 +64,12 @@ def generated_code(tool: FigureComposerTool) -> str:
     style_lines = _style_code_lines()
     if style_lines:
         lines.extend(["", *style_lines])
+    source_lines = _source_selection_code_lines(
+        tool,
+        skip_source_names=skip_source_selection_names,
+    )
+    if source_lines:
+        lines.extend(["", *source_lines])
     lines.extend(["", _setup_code(tool)])
 
     for operation in tool._recipe.operations:
@@ -58,4 +77,55 @@ def generated_code(tool: FigureComposerTool) -> str:
             continue
         lines.extend(_registry.spec_for(operation.kind).code_lines(tool, operation))
 
-    return "\n".join(lines)
+    code = "\n".join(lines)
+    if source_name_map:
+        return _replace_source_load_names(code, source_name_map)
+    return code
+
+
+def _source_selection_code_lines(
+    tool: FigureComposerTool,
+    *,
+    skip_source_names: frozenset[str] = frozenset(),
+) -> list[str]:
+    lines: list[str] = []
+    for source in tool._recipe.sources:
+        if not _source_has_selection(source) or source.name in skip_source_names:
+            continue
+        target = _valid_source_variable(source.name)
+        selection_source = source.selection_source or source.name
+        selection = FigureDataSelectionState(
+            source=selection_source,
+            isel=dict(source.isel),
+            qsel=dict(source.qsel),
+            mean_dims=tuple(source.mean_dims),
+        )
+        lines.append(f"{target} = {_selection_code(selection)}")
+    return lines
+
+
+def _replace_source_load_names(code: str, replacements: Mapping[str, str]) -> str:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return code
+
+    normalized = {
+        source: target
+        for source, target in replacements.items()
+        if source != target and source.isidentifier() and target.isidentifier()
+    }
+    if not normalized:
+        return code
+
+    class SourceLoadNameReplacer(ast.NodeTransformer):
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            if not isinstance(node.ctx, ast.Load):
+                return node
+            replacement = normalized.get(node.id)
+            if replacement is None:
+                return node
+            return ast.copy_location(ast.Name(replacement, ctx=node.ctx), node)
+
+    updated = typing.cast("ast.Module", SourceLoadNameReplacer().visit(module))
+    return ast.unparse(ast.fix_missing_locations(updated))

--- a/src/erlab/interactive/_figurecomposer/_codegen.py
+++ b/src/erlab/interactive/_figurecomposer/_codegen.py
@@ -12,7 +12,6 @@ from erlab.interactive._figurecomposer._defaults import (
 )
 from erlab.interactive._figurecomposer._operations import _registry
 from erlab.interactive._figurecomposer._sources import (
-    _FIGURE_CODE_RESERVED_NAMES,
     _source_has_selection,
     _valid_source_variable,
 )
@@ -111,46 +110,26 @@ def _source_selection_code_lines(
     *,
     skip_source_names: frozenset[str] = frozenset(),
 ) -> list[str]:
-    used_source_names = tool._direct_sources_used_by_recipe(
-        enabled_only=True, executable_only=True
+    dependency_names = tool._source_dependency_names(
+        tool._direct_sources_used_by_recipe(enabled_only=True, executable_only=True),
+        stop_at=skip_source_names,
+        reject_cycles=True,
     )
+    source_by_name = tool._source_by_name()
     selected_sources = tuple(
-        source
-        for source in tool._recipe.sources
-        if source.name in used_source_names
-        and source.name not in skip_source_names
-        and _source_has_selection(source)
+        source_by_name[name]
+        for name in dependency_names
+        if name in source_by_name
+        and name not in skip_source_names
+        and _source_has_selection(source_by_name[name])
     )
-    assigned_names = {source.name for source in selected_sources}
-    captured_names = {
-        source.selection_source
-        for source in selected_sources
-        if source.selection_source is not None
-        and source.selection_source != source.name
-        and source.selection_source in assigned_names
-    }
 
     lines: list[str] = []
-    reserved_names = set(tool._source_names()) | set(_FIGURE_CODE_RESERVED_NAMES)
-    input_names: dict[str, str] = {}
-    for source in tool._recipe.sources:
-        if source.name not in captured_names:
-            continue
-        stem = f"_{source.name}_input"
-        input_name = stem
-        suffix = 2
-        while input_name in reserved_names:
-            input_name = f"{stem}_{suffix}"
-            suffix += 1
-        reserved_names.add(input_name)
-        input_names[source.name] = input_name
-        lines.append(f"{input_name} = {_valid_source_variable(source.name)}")
-
     for source in selected_sources:
         target = _valid_source_variable(source.name)
         selection_source = source.selection_source or source.name
         selection = FigureDataSelectionState(
-            source=input_names.get(selection_source, selection_source),
+            source=selection_source,
             isel=dict(source.isel),
             qsel=dict(source.qsel),
             mean_dims=tuple(source.mean_dims),

--- a/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
@@ -768,8 +768,7 @@ def _create_operation(tool: FigureComposerTool) -> FigureOperationState:
 
 
 def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
-    prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
-    return f"{prefix}BZ Overlay: {_mode_text(operation.bz_mode)}"
+    return f"BZ Overlay: {_mode_text(operation.bz_mode)}"
 
 
 def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:

--- a/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
@@ -238,14 +238,23 @@ def _required_imports(
 
 def _custom_code_names(code: str) -> frozenset[str]:
     try:
-        tree = ast.parse(code)
+        root = symtable.symtable(code, "<figure-composer-python-step>", "exec")
     except SyntaxError:
         return frozenset()
-    return frozenset(
-        node.id
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
-    )
+    external: set[str] = set()
+    tables = [root]
+    while tables:
+        table = tables.pop()
+        tables.extend(table.get_children())
+        for symbol in table.get_symbols():
+            if not symbol.is_referenced() or symbol.is_imported():
+                continue
+            if table is root:
+                if not symbol.is_assigned():
+                    external.add(symbol.get_name())
+            elif symbol.is_global():
+                external.add(symbol.get_name())
+    return frozenset(external)
 
 
 def _renamed_source_loads(code: str, replacements: dict[str, str]) -> str:

--- a/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import collections
 import symtable
 import typing
 
@@ -238,23 +239,529 @@ def _required_imports(
 
 def _custom_code_names(code: str) -> frozenset[str]:
     try:
+        tree = ast.parse(code, mode="exec")
         root = symtable.symtable(code, "<figure-composer-python-step>", "exec")
     except SyntaxError:
         return frozenset()
+
+    analyzer = _TopLevelExternalNameAnalyzer()
+    analyzer.visit(tree)
+    scope_module_bindings = _scope_module_bindings(tree, analyzer.scope_bindings)
+    external = set(analyzer.external)
+    external.update(_class_local_external_names(tree, root, scope_module_bindings))
+    external.update(_child_global_reference_names(tree, root, scope_module_bindings))
+    external.update(_child_global_mutation_names(tree, scope_module_bindings))
+    return frozenset(external)
+
+
+def _scope_module_bindings(
+    tree: ast.Module,
+    direct_bindings: dict[int, frozenset[str]],
+) -> dict[int, frozenset[str]]:
+    """Propagate module bindings at top-level scope creation into nested scopes."""
+    output: dict[int, frozenset[str]] = {}
+    scope_types = (
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.ClassDef,
+        ast.Lambda,
+        ast.ListComp,
+        ast.SetComp,
+        ast.DictComp,
+        ast.GeneratorExp,
+    )
+
+    def collect(node: ast.AST, inherited: frozenset[str]) -> None:
+        current = direct_bindings.get(id(node), inherited)
+        if isinstance(node, scope_types):
+            output[id(node)] = current
+        for child in ast.iter_child_nodes(node):
+            collect(child, current)
+
+    collect(tree, frozenset())
+    return output
+
+
+def _scope_symbol_key(node: ast.AST) -> tuple[str, str, int] | None:
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        return ("function", node.name, node.lineno)
+    if isinstance(node, ast.ClassDef):
+        return ("class", node.name, node.lineno)
+    if isinstance(node, ast.Lambda):
+        return ("function", "lambda", node.lineno)
+    if isinstance(node, ast.ListComp):
+        return ("function", "listcomp", node.lineno)
+    if isinstance(node, ast.SetComp):
+        return ("function", "setcomp", node.lineno)
+    if isinstance(node, ast.DictComp):
+        return ("function", "dictcomp", node.lineno)
+    if isinstance(node, ast.GeneratorExp):
+        return ("function", "genexpr", node.lineno)
+    return None
+
+
+def _scope_symbol_tables(
+    tree: ast.Module,
+    root: symtable.SymbolTable,
+) -> dict[int, symtable.SymbolTable]:
+    tables_by_key: collections.defaultdict[
+        tuple[str, str, int],
+        collections.deque[symtable.SymbolTable],
+    ] = collections.defaultdict(collections.deque)
+
+    def collect_tables(table: symtable.SymbolTable) -> None:
+        for child in table.get_children():
+            lineno = child.get_lineno()
+            if lineno is not None:
+                tables_by_key[(child.get_type(), child.get_name(), lineno)].append(
+                    child
+                )
+            collect_tables(child)
+
+    collect_tables(root)
+
+    output: dict[int, symtable.SymbolTable] = {}
+
+    def pair_scopes(node: ast.AST) -> None:
+        key = _scope_symbol_key(node)
+        if key is not None and tables_by_key[key]:
+            output[id(node)] = tables_by_key[key].popleft()
+        for child in ast.iter_child_nodes(node):
+            pair_scopes(child)
+
+    pair_scopes(tree)
+    return output
+
+
+def _class_local_external_names(
+    tree: ast.Module,
+    root: symtable.SymbolTable,
+    scope_module_bindings: dict[int, frozenset[str]],
+) -> set[str]:
+    """Return class-local names whose value is read before its class binding."""
+    scope_tables = _scope_symbol_tables(tree, root)
+
     external: set[str] = set()
-    tables = [root]
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        table = scope_tables.get(id(node))
+        if table is None:
+            continue
+        analyzer = _TopLevelExternalNameAnalyzer()
+        analyzer._analyze_block(node.body, set())
+        class_local_names = {
+            symbol.get_name() for symbol in table.get_symbols() if symbol.is_local()
+        }
+        external.update(
+            (analyzer.external & class_local_names)
+            - scope_module_bindings.get(id(node), frozenset())
+        )
+    return external
+
+
+def _child_global_reference_names(
+    tree: ast.Module,
+    root: symtable.SymbolTable,
+    scope_module_bindings: dict[int, frozenset[str]],
+) -> set[str]:
+    """Return child-scope global reads without a definite module binding."""
+    scope_tables = _scope_symbol_tables(tree, root)
+    external: set[str] = set()
+    for node in ast.walk(tree):
+        table = scope_tables.get(id(node))
+        if table is None:
+            continue
+        referenced_globals = {
+            symbol.get_name()
+            for symbol in table.get_symbols()
+            if symbol.is_global()
+            and not symbol.is_imported()
+            and symbol.is_referenced()
+        }
+        external.update(
+            referenced_globals - scope_module_bindings.get(id(node), frozenset())
+        )
+    return external
+
+
+def _child_global_mutation_names(
+    tree: ast.Module,
+    scope_module_bindings: dict[int, frozenset[str]],
+) -> set[str]:
+    """Return child-scope globals read implicitly by mutation or deletion."""
+    external: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        analyzer = _CurrentScopeGlobalMutationAnalyzer()
+        for statement in node.body:
+            analyzer.visit(statement)
+        external.update(
+            (analyzer.global_names & analyzer.mutated_names)
+            - scope_module_bindings.get(id(node), frozenset())
+        )
+    return external
+
+
+class _CurrentScopeGlobalMutationAnalyzer(ast.NodeVisitor):
+    """Collect explicit globals mutated in one function or class scope."""
+
+    def __init__(self) -> None:
+        self.global_names: set[str] = set()
+        self.mutated_names: set[str] = set()
+
+    def visit_Global(self, node: ast.Global) -> None:
+        self.global_names.update(node.names)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        if isinstance(node.target, ast.Name):
+            self.mutated_names.add(node.target.id)
+        self.generic_visit(node)
+
+    def visit_Delete(self, node: ast.Delete) -> None:
+        self.mutated_names.update(
+            target.id for target in node.targets if isinstance(target, ast.Name)
+        )
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, _node: ast.FunctionDef) -> None:
+        return
+
+    def visit_AsyncFunctionDef(self, _node: ast.AsyncFunctionDef) -> None:
+        return
+
+    def visit_ClassDef(self, _node: ast.ClassDef) -> None:
+        return
+
+    def visit_Lambda(self, _node: ast.Lambda) -> None:
+        return
+
+
+def _match_pattern_bound_names(pattern: ast.pattern) -> set[str]:
+    bound: set[str] = set()
+    for node in ast.walk(pattern):
+        if isinstance(node, ast.MatchAs | ast.MatchStar) and node.name is not None:
+            bound.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest is not None:
+            bound.add(node.rest)
+    return bound
+
+
+def _custom_code_bound_names(code: str) -> frozenset[str]:
+    """Return names that custom code can bind in the generated module."""
+    try:
+        root = symtable.symtable(code, "<figure-composer-python-step>", "exec")
+    except SyntaxError:
+        return frozenset()
+    return _custom_code_bound_names_from_table(root)
+
+
+def _custom_code_bound_names_from_table(
+    root: symtable.SymbolTable,
+) -> frozenset[str]:
+    bound = {
+        symbol.get_name()
+        for symbol in root.get_symbols()
+        if symbol.is_assigned() or symbol.is_imported()
+    }
+    tables = list(root.get_children())
     while tables:
         table = tables.pop()
         tables.extend(table.get_children())
-        for symbol in table.get_symbols():
-            if not symbol.is_referenced() or symbol.is_imported():
-                continue
-            if table is root:
-                if not symbol.is_assigned():
-                    external.add(symbol.get_name())
-            elif symbol.is_global():
-                external.add(symbol.get_name())
-    return frozenset(external)
+        bound.update(
+            symbol.get_name()
+            for symbol in table.get_symbols()
+            if symbol.is_global() and (symbol.is_assigned() or symbol.is_imported())
+        )
+    return frozenset(bound)
+
+
+class _TopLevelExternalNameAnalyzer(ast.NodeVisitor):
+    """Collect module-level names read before a definite local binding."""
+
+    def __init__(self) -> None:
+        self.bound: set[str] = set()
+        self.external: set[str] = set()
+        self.scope_bindings: dict[int, frozenset[str]] = {}
+
+    def _analyze_block(self, statements: list[ast.stmt], initial: set[str]) -> set[str]:
+        previous = self.bound
+        self.bound = set(initial)
+        for statement in statements:
+            self.visit(statement)
+        result = set(self.bound)
+        self.bound = previous
+        return result
+
+    def _analyze_node(self, node: ast.AST, initial: set[str]) -> set[str]:
+        previous = self.bound
+        self.bound = set(initial)
+        self.visit(node)
+        result = set(self.bound)
+        self.bound = previous
+        return result
+
+    def _read_target(self, target: ast.expr) -> None:
+        if isinstance(target, ast.Name):
+            if target.id not in self.bound:
+                self.external.add(target.id)
+            return
+        self.visit(target)
+
+    def _bind_target(self, target: ast.expr) -> None:
+        if isinstance(target, ast.Name):
+            self.bound.add(target.id)
+            return
+        if isinstance(target, ast.Starred):
+            self._bind_target(target.value)
+            return
+        if isinstance(target, ast.Tuple | ast.List):
+            for item in target.elts:
+                self._bind_target(item)
+            return
+        self.visit(target)
+
+    def _visit_function_signature(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in node.args.defaults:
+            self.visit(default)
+        for default in node.args.kw_defaults:
+            if default is not None:
+                self.visit(default)
+        for argument in (
+            *node.args.posonlyargs,
+            *node.args.args,
+            *node.args.kwonlyargs,
+        ):
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        if node.args.vararg is not None and node.args.vararg.annotation is not None:
+            self.visit(node.args.vararg.annotation)
+        if node.args.kwarg is not None and node.args.kwarg.annotation is not None:
+            self.visit(node.args.kwarg.annotation)
+        if node.returns is not None:
+            self.visit(node.returns)
+        for type_param in getattr(node, "type_params", ()):
+            self.visit(type_param)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Load) and node.id not in self.bound:
+            self.external.add(node.id)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        for target in node.targets:
+            self._bind_target(target)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self.visit(node.annotation)
+        if node.value is None:
+            if not isinstance(node.target, ast.Name):
+                self.visit(node.target)
+            return
+        self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self._read_target(node.target)
+        self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_Delete(self, node: ast.Delete) -> None:
+        for target in node.targets:
+            self._read_target(target)
+            if isinstance(target, ast.Name):
+                self.bound.discard(target.id)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.bound.add(alias.asname or alias.name.partition(".")[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name != "*":
+                self.bound.add(alias.asname or alias.name)
+
+    def visit_If(self, node: ast.If) -> None:
+        self.visit(node.test)
+        initial = set(self.bound)
+        body_bound = self._analyze_block(node.body, initial)
+        else_bound = (
+            self._analyze_block(node.orelse, initial) if node.orelse else initial
+        )
+        self.bound = body_bound & else_bound
+
+    def visit_IfExp(self, node: ast.IfExp) -> None:
+        self.visit(node.test)
+        initial = set(self.bound)
+        body_bound = self._analyze_node(node.body, initial)
+        else_bound = self._analyze_node(node.orelse, initial)
+        self.bound = body_bound & else_bound
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> None:
+        if not node.values:
+            return
+        self.visit(node.values[0])
+        definite_bound = set(self.bound)
+        conditional_bound = set(definite_bound)
+        for value in node.values[1:]:
+            conditional_bound = self._analyze_node(value, conditional_bound)
+        self.bound = definite_bound
+
+    def visit_Match(self, node: ast.Match) -> None:
+        self.visit(node.subject)
+        initial = set(self.bound)
+        for case in node.cases:
+            previous = self.bound
+            self.bound = set(initial)
+            self.visit(case.pattern)
+            self.bound.update(_match_pattern_bound_names(case.pattern))
+            if case.guard is not None:
+                self.visit(case.guard)
+            for statement in case.body:
+                self.visit(statement)
+            self.bound = previous
+        self.bound = initial
+
+    def visit_For(self, node: ast.For | ast.AsyncFor) -> None:
+        self.visit(node.iter)
+        initial = set(self.bound)
+        previous = self.bound
+        self.bound = set(initial)
+        self._bind_target(node.target)
+        for statement in node.body:
+            self.visit(statement)
+        self.bound = previous
+        self._analyze_block(node.orelse, initial)
+        self.bound = initial
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self.visit_For(node)
+
+    def visit_While(self, node: ast.While) -> None:
+        self.visit(node.test)
+        initial = set(self.bound)
+        self._analyze_block(node.body, initial)
+        self._analyze_block(node.orelse, initial)
+        self.bound = initial
+
+    def visit_With(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self._bind_target(item.optional_vars)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self.visit_With(node)
+
+    def visit_Try(self, node: ast.Try | ast.TryStar) -> None:
+        initial = set(self.bound)
+        body_bound = self._analyze_block(node.body, initial)
+        success_bound = self._analyze_block(node.orelse, body_bound)
+        path_bounds = [success_bound]
+        for handler in node.handlers:
+            if handler.type is not None:
+                previous = self.bound
+                self.bound = set(initial)
+                self.visit(handler.type)
+                self.bound = previous
+            handler_initial = set(initial)
+            if handler.name is not None:
+                handler_initial.add(handler.name)
+            handler_bound = self._analyze_block(handler.body, handler_initial)
+            if handler.name is not None:
+                handler_bound.discard(handler.name)
+            path_bounds.append(handler_bound)
+        merged = set.intersection(*path_bounds)
+        self.bound = self._analyze_block(node.finalbody, merged)
+
+    def visit_TryStar(self, node: ast.TryStar) -> None:
+        self.visit_Try(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function_signature(node)
+        self.scope_bindings[id(node)] = frozenset((*self.bound, node.name))
+        self.bound.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function_signature(node)
+        self.scope_bindings[id(node)] = frozenset((*self.bound, node.name))
+        self.bound.add(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in node.args.defaults:
+            self.visit(default)
+        for default in node.args.kw_defaults:
+            if default is not None:
+                self.visit(default)
+        self.scope_bindings[id(node)] = frozenset(self.bound)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        for type_param in getattr(node, "type_params", ()):
+            self.visit(type_param)
+        self.scope_bindings[id(node)] = frozenset(self.bound)
+        class_analyzer = _TopLevelExternalNameAnalyzer()
+        class_analyzer._analyze_block(node.body, set())
+        self.external.update(class_analyzer.external - self.bound)
+        self.bound.add(node.name)
+
+    def _visit_comprehension(
+        self,
+        node: ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp,
+        generators: list[ast.comprehension],
+        *value_nodes: ast.expr,
+    ) -> None:
+        if not generators:
+            for value_node in value_nodes:
+                self.visit(value_node)
+            self.scope_bindings[id(node)] = frozenset(self.bound)
+            return
+
+        first, *remaining = generators
+        self.visit(first.iter)
+        module_bound = set(self.bound)
+        self.scope_bindings[id(node)] = frozenset(self.bound)
+
+        self.bound = set(module_bound)
+        self._bind_target(first.target)
+        for condition in first.ifs:
+            self.visit(condition)
+        for generator in remaining:
+            self.visit(generator.iter)
+            self._bind_target(generator.target)
+            for condition in generator.ifs:
+                self.visit(condition)
+        for value_node in value_nodes:
+            self.visit(value_node)
+        self.bound = module_bound
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node, node.generators, node.elt)
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node, node.generators, node.elt)
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node, node.generators, node.elt)
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node, node.generators, node.key, node.value)
 
 
 def _renamed_source_loads(code: str, replacements: dict[str, str]) -> str:

--- a/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import ast
 import collections
+import io
 import symtable
+import tokenize
 import typing
 
 from qtpy import QtCore, QtWidgets
@@ -771,8 +773,18 @@ def _renamed_source_loads(code: str, replacements: dict[str, str]) -> str:
         for old, new in replacements.items()
         if old != new and old.isidentifier()
     }
-    if not replacements:
+    if not replacements or not any(old in code for old in replacements):
         return code
+    try:
+        has_source_identifier = any(
+            token.type == tokenize.NAME and token.string in replacements
+            for token in tokenize.generate_tokens(io.StringIO(code).readline)
+        )
+    except (IndentationError, tokenize.TokenError):
+        pass
+    else:
+        if not has_source_identifier:
+            return code
     try:
         tree = ast.parse(code, mode="exec")
     except SyntaxError as exc:

--- a/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import symtable
 import typing
 
 from qtpy import QtCore, QtWidgets
@@ -245,6 +246,90 @@ def _custom_code_names(code: str) -> frozenset[str]:
         for node in ast.walk(tree)
         if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
     )
+
+
+def _renamed_source_loads(code: str, replacements: dict[str, str]) -> str:
+    """Rename unambiguous source-variable reads without reformatting user code."""
+    replacements = {
+        old: new
+        for old, new in replacements.items()
+        if old != new and old.isidentifier()
+    }
+    if not replacements:
+        return code
+    try:
+        tree = ast.parse(code, mode="exec")
+    except SyntaxError as exc:
+        raise ValueError(
+            "the Python step does not currently contain valid code"
+        ) from exc
+
+    load_nodes = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name)
+        and isinstance(node.ctx, ast.Load)
+        and node.id in replacements
+    ]
+    destructive_uses = [
+        node
+        for node in ast.walk(tree)
+        if (
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Del)
+            and node.id in replacements
+        )
+        or (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id in replacements
+        )
+    ]
+    if not load_nodes and not destructive_uses:
+        return code
+
+    tables = [symtable.symtable(code, "<figure-composer-python-step>", "exec")]
+    ambiguous_names: set[str] = set()
+    while tables:
+        table = tables.pop()
+        tables.extend(table.get_children())
+        for name in replacements:
+            try:
+                symbol = table.lookup(name)
+            except KeyError:
+                continue
+            if (
+                symbol.is_assigned()
+                or symbol.is_imported()
+                or symbol.is_parameter()
+                or symbol.is_nonlocal()
+                or symbol.is_declared_global()
+            ):
+                ambiguous_names.add(name)
+    ambiguous = sorted(ambiguous_names)
+    if ambiguous:
+        names = ", ".join(repr(name) for name in ambiguous)
+        raise ValueError(
+            f"the Python step also binds {names}; rename that local binding first"
+        )
+
+    encoded = code.encode("utf-8")
+    line_offsets: list[int] = []
+    offset = 0
+    for line in code.splitlines(keepends=True):
+        line_offsets.append(offset)
+        offset += len(line.encode("utf-8"))
+
+    edits: list[tuple[int, int, bytes]] = []
+    for node in load_nodes:
+        if node.end_lineno is None or node.end_col_offset is None:  # pragma: no cover
+            raise RuntimeError("parsed source name is missing location information")
+        start = line_offsets[node.lineno - 1] + node.col_offset
+        end = line_offsets[node.end_lineno - 1] + node.end_col_offset
+        edits.append((start, end, replacements[node.id].encode("utf-8")))
+    for start, end, replacement in sorted(edits, reverse=True):
+        encoded = encoded[:start] + replacement + encoded[end:]
+    return encoded.decode("utf-8")
 
 
 def _custom_axes_alias_lines(tool: FigureComposerTool) -> list[str]:

--- a/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
@@ -13,6 +13,7 @@ from erlab.interactive._figurecomposer._code import (
     _axes_sequence_code,
     _maybe_squeeze_drop_code,
     _needs_squeeze_drop,
+    _selection_code,
 )
 from erlab.interactive._figurecomposer._gridspec import _gridspec_valid_axes_ids
 from erlab.interactive._figurecomposer._label_help import legend_label_input_widget
@@ -79,6 +80,7 @@ from erlab.interactive._figurecomposer._rendering import (
 from erlab.interactive._figurecomposer._sources import (
     _available_source_dims,
     _public_source_data,
+    _selected_data,
     _valid_source_variable,
 )
 from erlab.interactive._figurecomposer._state import (
@@ -1250,28 +1252,38 @@ def _line_data_items(
 def _line_data_items_with_sources(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> list[tuple[xr.DataArray, str | None]]:
-    if operation.line_source is None:
-        return []
-    data = tool._source_data.get(operation.line_source)
-    if data is None:
-        return []
-    data = _public_source_data(data)
-    if operation.line_selection:
-        data = data.qsel(operation.line_selection)
-    line_data = data.squeeze(drop=True)
-    if operation.line_y:
-        line_data = line_data[operation.line_y]
-    line_data = _reduced_line_iter_data(line_data, operation)
-    if operation.line_iter_dim and operation.line_iter_dim in line_data.dims:
+    if len(operation.map_selections) > 1:
         line_items = [
             (
-                item.squeeze(drop=True),
-                tool._source_display_name(operation.line_source),
+                selected.squeeze(drop=True),
+                tool._source_display_name(selection.source),
             )
-            for item in line_data.transpose(operation.line_iter_dim, ...)
+            for selection in operation.map_selections
+            if (selected := _selected_data(tool._source_data, selection)) is not None
         ]
+    elif operation.line_source is not None:
+        data = tool._source_data.get(operation.line_source)
+        if data is None:
+            return []
+        data = _public_source_data(data)
+        if operation.line_selection:
+            data = data.qsel(operation.line_selection)
+        line_data = data.squeeze(drop=True)
+        if operation.line_y:
+            line_data = line_data[operation.line_y]
+        line_data = _reduced_line_iter_data(line_data, operation)
+        if operation.line_iter_dim and operation.line_iter_dim in line_data.dims:
+            line_items = [
+                (
+                    item.squeeze(drop=True),
+                    tool._source_display_name(operation.line_source),
+                )
+                for item in line_data.transpose(operation.line_iter_dim, ...)
+            ]
+        else:
+            line_items = [(line_data, tool._source_display_name(operation.line_source))]
     else:
-        line_items = [(line_data, tool._source_display_name(operation.line_source))]
+        return []
 
     profiles: list[tuple[xr.DataArray, str | None]] = []
     for line_data, source in line_items:
@@ -1465,6 +1477,8 @@ def _line_text_values(
 
 
 def _line_code(tool: FigureComposerTool, operation: FigureOperationState) -> list[str]:
+    if len(operation.map_selections) > 1:
+        return _line_selection_code(tool, operation)
     source_expression = _line_source_expression_and_data(tool, operation)
     if source_expression is None:
         return []
@@ -1535,6 +1549,27 @@ def _line_stack_transform_code(
     return profile_stack_transform_code(
         operation, data_name="profile_data", line_data=line_data
     )
+
+
+def _line_selection_code(
+    tool: FigureComposerTool, operation: FigureOperationState
+) -> list[str]:
+    selected_items = tuple(
+        (selection, selected)
+        for selection in operation.map_selections
+        if (selected := _selected_data(tool._source_data, selection)) is not None
+    )
+    lines = ["profiles = ["]
+    lines.extend(
+        f"    {_maybe_squeeze_drop_code(_selection_code(selection), selected)},"
+        for selection, selected in selected_items
+    )
+    lines.append("]")
+    if operation.line_placement == "one_per_axis":
+        lines.extend(_one_profile_per_axis_code(tool, operation))
+        return lines
+    lines.extend(_regular_line_code(tool, operation))
+    return lines
 
 
 def _regular_line_code(
@@ -2080,6 +2115,10 @@ def _has_invalid_target(
 
 
 def _source_names(operation: FigureOperationState) -> tuple[str, ...]:
+    if len(operation.map_selections) > 1:
+        return tuple(
+            dict.fromkeys(selection.source for selection in operation.map_selections)
+        )
     return _line_selection_sources(operation)
 
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
@@ -2060,10 +2060,9 @@ def _default_profile_x_dim(
 
 
 def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
-    prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
     source_names = _line_selection_sources(operation)
     source = ", ".join(tool._source_display_names(source_names)) or "missing source"
-    return f"{prefix}Line/profile: {source}"
+    return f"Line/profile: {source}"
 
 
 def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:

--- a/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
@@ -13,7 +13,6 @@ from erlab.interactive._figurecomposer._code import (
     _axes_sequence_code,
     _maybe_squeeze_drop_code,
     _needs_squeeze_drop,
-    _selection_code,
 )
 from erlab.interactive._figurecomposer._gridspec import _gridspec_valid_axes_ids
 from erlab.interactive._figurecomposer._label_help import legend_label_input_widget
@@ -80,7 +79,6 @@ from erlab.interactive._figurecomposer._rendering import (
 from erlab.interactive._figurecomposer._sources import (
     _available_source_dims,
     _public_source_data,
-    _selected_data,
     _valid_source_variable,
 )
 from erlab.interactive._figurecomposer._state import (
@@ -181,6 +179,12 @@ def _line_color_mode_from_text(
     return "manual"
 
 
+def _line_selection_sources(operation: FigureOperationState) -> tuple[str, ...]:
+    if operation.line_source is None:
+        return ()
+    return (operation.line_source,)
+
+
 def _line_reduce_active(operation: FigureOperationState) -> bool:
     return operation.line_iter_dim is not None and operation.line_reduce != "disabled"
 
@@ -246,6 +250,14 @@ def _available_line_offset_coords(
     line_data = data.squeeze(drop=True)
     if operation.line_y:
         line_data = line_data[operation.line_y]
+    return _line_offset_coord_names(line_data, operation)
+
+
+def _line_offset_coord_names(
+    line_data: xr.DataArray, operation: FigureOperationState
+) -> list[str]:
+    if operation.line_iter_dim is None:
+        return []
     coords: list[str] = []
     for name, coord in line_data.coords.items():
         if name == operation.line_iter_dim:
@@ -1238,38 +1250,28 @@ def _line_data_items(
 def _line_data_items_with_sources(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> list[tuple[xr.DataArray, str | None]]:
-    if operation.map_selections:
+    if operation.line_source is None:
+        return []
+    data = tool._source_data.get(operation.line_source)
+    if data is None:
+        return []
+    data = _public_source_data(data)
+    if operation.line_selection:
+        data = data.qsel(operation.line_selection)
+    line_data = data.squeeze(drop=True)
+    if operation.line_y:
+        line_data = line_data[operation.line_y]
+    line_data = _reduced_line_iter_data(line_data, operation)
+    if operation.line_iter_dim and operation.line_iter_dim in line_data.dims:
         line_items = [
             (
-                selected.squeeze(drop=True),
-                tool._source_display_name(selection.source),
+                item.squeeze(drop=True),
+                tool._source_display_name(operation.line_source),
             )
-            for selection in operation.map_selections
-            if (selected := _selected_data(tool._source_data, selection)) is not None
+            for item in line_data.transpose(operation.line_iter_dim, ...)
         ]
-    elif operation.line_source is not None:
-        data = tool._source_data.get(operation.line_source)
-        if data is None:
-            return []
-        data = _public_source_data(data)
-        if operation.line_selection:
-            data = data.qsel(operation.line_selection)
-        line_data = data.squeeze(drop=True)
-        if operation.line_y:
-            line_data = line_data[operation.line_y]
-        line_data = _reduced_line_iter_data(line_data, operation)
-        if operation.line_iter_dim and operation.line_iter_dim in line_data.dims:
-            line_items = [
-                (
-                    item.squeeze(drop=True),
-                    tool._source_display_name(operation.line_source),
-                )
-                for item in line_data.transpose(operation.line_iter_dim, ...)
-            ]
-        else:
-            line_items = [(line_data, tool._source_display_name(operation.line_source))]
     else:
-        return []
+        line_items = [(line_data, tool._source_display_name(operation.line_source))]
 
     profiles: list[tuple[xr.DataArray, str | None]] = []
     for line_data, source in line_items:
@@ -1463,8 +1465,6 @@ def _line_text_values(
 
 
 def _line_code(tool: FigureComposerTool, operation: FigureOperationState) -> list[str]:
-    if operation.map_selections:
-        return _line_selection_code(tool, operation)
     source_expression = _line_source_expression_and_data(tool, operation)
     if source_expression is None:
         return []
@@ -1535,27 +1535,6 @@ def _line_stack_transform_code(
     return profile_stack_transform_code(
         operation, data_name="profile_data", line_data=line_data
     )
-
-
-def _line_selection_code(
-    tool: FigureComposerTool, operation: FigureOperationState
-) -> list[str]:
-    selected_items = tuple(
-        (selection, selected)
-        for selection in operation.map_selections
-        if (selected := _selected_data(tool._source_data, selection)) is not None
-    )
-    lines = ["profiles = ["]
-    lines.extend(
-        f"    {_maybe_squeeze_drop_code(_selection_code(selection), selected)},"
-        for selection, selected in selected_items
-    )
-    lines.append("]")
-    if operation.line_placement == "one_per_axis":
-        lines.extend(_one_profile_per_axis_code(tool, operation))
-        return lines
-    lines.extend(_regular_line_code(tool, operation))
-    return lines
 
 
 def _regular_line_code(
@@ -2082,11 +2061,8 @@ def _default_profile_x_dim(
 
 def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
     prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
-    source = (
-        tool._source_display_name(operation.line_source)
-        if operation.line_source is not None
-        else "missing source"
-    )
+    source_names = _line_selection_sources(operation)
+    source = ", ".join(tool._source_display_names(source_names)) or "missing source"
     return f"{prefix}Line/profile: {source}"
 
 
@@ -2105,7 +2081,7 @@ def _has_invalid_target(
 
 
 def _source_names(operation: FigureOperationState) -> tuple[str, ...]:
-    return (operation.line_source,) if operation.line_source is not None else ()
+    return _line_selection_sources(operation)
 
 
 def _build_source_editor(

--- a/src/erlab/interactive/_figurecomposer/_operations/_method.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method.py
@@ -2589,8 +2589,7 @@ def _has_invalid_target(
 
 
 def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
-    prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
-    return f"{prefix}{_method_display(operation)}"
+    return _method_display(operation)
 
 
 def _method_plain_text_edit(

--- a/src/erlab/interactive/_figurecomposer/_operations/_method.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method.py
@@ -312,7 +312,10 @@ def _int_arg(
 
 
 def _text_arg(
-    label: str, index: int, object_name: str, tooltip: str
+    label: str,
+    index: int,
+    object_name: str,
+    tooltip: str,
 ) -> MethodControlSpec:
     return MethodControlSpec(
         kind=MethodControlKind.TEXT_ARG,
@@ -2590,6 +2593,24 @@ def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> 
     return f"{prefix}{_method_display(operation)}"
 
 
+def _method_plain_text_edit(
+    tool: FigureComposerTool,
+    text: str,
+    *,
+    mixed: bool,
+    object_name: str,
+    parent: QtWidgets.QWidget | None,
+) -> QtWidgets.QPlainTextEdit:
+    edit = QtWidgets.QPlainTextEdit(parent)
+    edit.setPlainText(text)
+    tool._apply_mixed_plain_text_edit(edit, mixed)
+    edit.setMaximumHeight(70)
+    edit.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+    edit.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+    edit.setObjectName(object_name)
+    return edit
+
+
 def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:
     spec = _method_spec(operation)
     return f"{spec.tooltip}\nTargets: {_target_text(tool, operation)}"
@@ -2967,10 +2988,14 @@ def _add_method_control_row(
                 lambda target: _method_arg_value(target, spec, index, ""),
                 str,
             )
-            edit = tool._line_edit(text, parent=layout.parentWidget())
-            tool._apply_mixed_line_edit(edit, mixed)
-            edit.setObjectName(control.object_name)
-            tool._connect_line_edit_finished(
+            edit = _method_plain_text_edit(
+                tool,
+                text,
+                mixed=mixed,
+                object_name=control.object_name,
+                parent=layout.parentWidget(),
+            )
+            tool._connect_plain_text_changed(
                 edit,
                 _method_arg_update_callback(tool, index),
             )

--- a/src/erlab/interactive/_figurecomposer/_operations/_photon_energy.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_photon_energy.py
@@ -493,13 +493,12 @@ def _create_operation(tool: FigureComposerTool) -> FigureOperationState:
 
 
 def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
-    prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
     source = (
         tool._source_display_name(operation.hv_overlay_source)
         if operation.hv_overlay_source is not None
         else "missing source"
     )
-    return f"{prefix}Photon Energy Overlay: {source}"
+    return f"Photon Energy Overlay: {source}"
 
 
 def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -8,11 +8,7 @@ from qtpy import QtCore, QtWidgets
 
 import erlab
 import erlab.plotting as eplt
-from erlab.interactive._figurecomposer._code import (
-    _axes_code,
-    _maybe_squeeze_drop_code,
-    _selection_code,
-)
+from erlab.interactive._figurecomposer._code import _axes_code, _maybe_squeeze_drop_code
 from erlab.interactive._figurecomposer._defaults import _styled_rcparams_value
 from erlab.interactive._figurecomposer._editor_controls import (
     MIXED_VALUE,
@@ -46,16 +42,13 @@ from erlab.interactive._figurecomposer._rendering import (
 )
 from erlab.interactive._figurecomposer._sources import (
     _public_source_data,
-    _selected_data,
     _valid_source_variable,
 )
 from erlab.interactive._figurecomposer._state import (
-    FigureDataSelectionState,
     FigureOperationKind,
     FigureOperationState,
 )
 from erlab.interactive._figurecomposer._text import (
-    FigureComposerInputError,
     _code_kwargs,
     _dict_from_text,
     _format_dict,
@@ -86,15 +79,10 @@ def _source_names(operation: FigureOperationState) -> tuple[str, ...]:
     for source_name in operation.sources:
         if source_name not in names:
             names.append(source_name)
-    for selection in operation.map_selections:
-        if selection.source not in names:
-            names.append(selection.source)
     return tuple(names)
 
 
 def _primary_source(operation: FigureOperationState) -> str | None:
-    if operation.map_selections:
-        return operation.map_selections[0].source
     if operation.sources:
         return operation.sources[0]
     return None
@@ -106,11 +94,6 @@ def _selected_plot_array_data(
     *,
     squeeze: bool = True,
 ) -> xr.DataArray | None:
-    if operation.map_selections:
-        data = _selected_data(tool._source_data, operation.map_selections[0])
-        if data is None:
-            return None
-        return data.squeeze(drop=True) if squeeze else data
     source_name = _primary_source(operation)
     if source_name is None or source_name not in tool._source_data:
         return None
@@ -130,21 +113,6 @@ def _safe_selected_plot_array_data(
         return None
 
 
-def _primary_selection(operation: FigureOperationState) -> FigureDataSelectionState:
-    if operation.map_selections:
-        return operation.map_selections[0]
-    return FigureDataSelectionState(source=_primary_source(operation) or "")
-
-
-def _plot_array_source_data(
-    tool: FigureComposerTool, operation: FigureOperationState
-) -> xr.DataArray | None:
-    source_name = _primary_source(operation)
-    if source_name is None or source_name not in tool._source_data:
-        return None
-    return _public_source_data(tool._source_data[source_name])
-
-
 def _plot_array_selection_error(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> str | None:
@@ -155,324 +123,16 @@ def _plot_array_selection_error(
     return None
 
 
-def _selection_summary(
-    tool: FigureComposerTool, operation: FigureOperationState
-) -> str:
-    source_data = _plot_array_source_data(tool, operation)
-    selection_error = _plot_array_selection_error(tool, operation)
-    selected = (
-        None
-        if selection_error is not None
-        else (_safe_selected_plot_array_data(tool, operation))
-    )
-    input_dims = (
-        "missing"
-        if source_data is None
-        else ", ".join(str(dim) for dim in source_data.dims) or "none"
-    )
-    plotted_dims = (
-        "missing"
-        if selected is None
-        else ", ".join(str(dim) for dim in selected.dims) or "scalar"
-    )
-    text = f"Input dims: {input_dims}\nPlotted dims: {plotted_dims}"
-    if selection_error is not None:
-        text += f"\nSelection error: {selection_error}"
-    return text
-
-
-def _plot_array_operation_with_selection(
-    operation: FigureOperationState,
-    selection: FigureDataSelectionState,
-) -> FigureOperationState:
-    map_selections = (
-        (selection,) if selection.isel or selection.qsel or selection.mean_dims else ()
-    )
-    return operation.model_copy(
-        update={
-            "sources": (selection.source,),
-            "map_selections": map_selections,
-        }
-    )
-
-
-def _update_current_selection_source(
-    tool: FigureComposerTool, source: str | None
-) -> None:
-    if source is None:
-        return
-
-    def update_operation(
-        _index: int, target: FigureOperationState
-    ) -> FigureOperationState:
-        selection = _primary_selection(target).model_copy(update={"source": source})
-        return _plot_array_operation_with_selection(target, selection)
-
-    tool._update_operations(update_operation, rebuild_editor=True)
-
-
-_PLOT_ARRAY_SELECTION_MODE_LABELS = {
-    "keep": "None",
-    "isel": "isel",
-    "qsel": "qsel",
-    "mean": "Mean",
-}
-_PLOT_ARRAY_SELECTION_VALUE_MODES = {"isel", "qsel"}
-_PLOT_ARRAY_SELECTION_VALUE_MESSAGE = (
-    "Enter a selection value, such as 0 or slice(0, 2)."
-)
-_PLOT_ARRAY_SELECTION_WIDTH_MESSAGE = "Enter a qsel width, such as 0.1."
-_PLOT_ARRAY_SELECTION_MODE_TOOLTIP = (
-    "Choose whether this dimension stays, is selected, or is averaged."
-)
-_PLOT_ARRAY_SELECTION_VALUE_TOOLTIP = (
-    "Selection value. Use integer positions or slices for isel; use coordinate "
-    "values or slices for qsel."
-)
-_PLOT_ARRAY_SELECTION_WIDTH_TOOLTIP = (
-    "Optional qsel width centered on the value. Leave blank for nearest "
-    "coordinate selection."
-)
-
-
-def _plot_array_selection_dim_mode(
-    selection: FigureDataSelectionState, dim: str
-) -> str:
-    if dim in selection.isel:
-        return "isel"
-    if dim in selection.qsel or _plot_array_selection_width_key(dim) in selection.qsel:
-        return "qsel"
-    if dim in selection.mean_dims:
-        return "mean"
-    return "keep"
-
-
-def _plot_array_selection_dim_value_text(
-    selection: FigureDataSelectionState, dim: str
-) -> str:
-    if dim in selection.isel:
-        return erlab.interactive.utils._parse_single_arg(selection.isel[dim])
-    if dim in selection.qsel:
-        return erlab.interactive.utils._parse_single_arg(selection.qsel[dim])
-    return ""
-
-
-def _plot_array_selection_width_key(dim: str) -> str:
-    return f"{dim}_width"
-
-
-def _plot_array_selection_dim_width_text(
-    selection: FigureDataSelectionState, dim: str
-) -> str:
-    width_key = _plot_array_selection_width_key(dim)
-    if width_key in selection.qsel:
-        return erlab.interactive.utils._parse_single_arg(selection.qsel[width_key])
-    return ""
-
-
-def _plot_array_selection_value_from_text(text: str) -> typing.Any:
-    stripped = text.strip()
-    if not stripped:
-        raise FigureComposerInputError(_PLOT_ARRAY_SELECTION_VALUE_MESSAGE)
-    try:
-        return _dict_from_text(f"value={stripped}", allow_slice=True)["value"]
-    except FigureComposerInputError as exc:
-        raise FigureComposerInputError(_PLOT_ARRAY_SELECTION_VALUE_MESSAGE) from exc
-
-
-def _plot_array_selection_width_from_text(text: str) -> typing.Any:
-    stripped = text.strip()
-    if not stripped:
-        return None
-    try:
-        value = _dict_from_text(f"value={stripped}", allow_slice=True)["value"]
-    except FigureComposerInputError as exc:
-        raise FigureComposerInputError(_PLOT_ARRAY_SELECTION_WIDTH_MESSAGE) from exc
-    if isinstance(value, slice):
-        raise FigureComposerInputError(_PLOT_ARRAY_SELECTION_WIDTH_MESSAGE)
-    return value
-
-
-def _plot_array_selection_with_dimension(
-    selection: FigureDataSelectionState,
-    dim: str,
-    mode: str,
-    value: typing.Any = None,
-    width: typing.Any = None,
-) -> FigureDataSelectionState:
-    isel = dict(selection.isel)
-    qsel = dict(selection.qsel)
-    mean_dims = [target for target in selection.mean_dims if target != dim]
-    isel.pop(dim, None)
-    qsel.pop(dim, None)
-    qsel.pop(_plot_array_selection_width_key(dim), None)
-    if mode == "isel":
-        isel[dim] = value
-    elif mode == "qsel":
-        if isinstance(value, slice) and width is not None:
-            raise FigureComposerInputError(
-                "A qsel slice cannot also use a width argument."
-            )
-        qsel[dim] = value
-        if width is not None:
-            qsel[_plot_array_selection_width_key(dim)] = width
-    elif mode == "mean":
-        mean_dims.append(dim)
-    return selection.model_copy(
-        update={
-            "isel": isel,
-            "qsel": qsel,
-            "mean_dims": tuple(mean_dims),
-        }
-    )
-
-
-def _update_current_selection_dimension(
-    tool: FigureComposerTool,
-    dim: str,
-    mode: str,
-    value_text: str = "",
-    width_text: str = "",
-) -> None:
-    if mode not in _PLOT_ARRAY_SELECTION_MODE_LABELS:
-        return
-    value = (
-        _plot_array_selection_value_from_text(value_text)
-        if mode in _PLOT_ARRAY_SELECTION_VALUE_MODES
-        else None
-    )
-    width = (
-        _plot_array_selection_width_from_text(width_text) if mode == "qsel" else None
-    )
-
-    def update_operation(
-        _index: int, target: FigureOperationState
-    ) -> FigureOperationState:
-        selection = _plot_array_selection_with_dimension(
-            _primary_selection(target),
-            dim,
-            mode,
-            value,
-            width,
-        )
-        return _plot_array_operation_with_selection(target, selection)
-
-    tool._update_operations(update_operation, rebuild_editor=True)
-
-
-def _plot_array_selection_mode_combo(
-    tool: FigureComposerTool,
-    *,
-    current: str | None,
-    mixed: bool,
-    parent: QtWidgets.QWidget,
-) -> QtWidgets.QComboBox:
-    combo = QtWidgets.QComboBox(parent)
-    tool._mark_editor_control(combo)
-    if mixed:
-        combo.addItem(MIXED_VALUES_TEXT, MIXED_VALUE)
-    for mode, label in _PLOT_ARRAY_SELECTION_MODE_LABELS.items():
-        combo.addItem(label, mode)
-    if mixed:
-        item = typing.cast("typing.Any", combo.model()).item(0)
-        if item is not None:
-            item.setEnabled(False)
-        combo.setCurrentIndex(0)
-    elif current is not None:
-        for index in range(combo.count()):
-            if combo.itemData(index) == current:
-                combo.setCurrentIndex(index)
-                break
-    return combo
-
-
-def _connect_plot_array_selection_dimension_controls(
-    tool: FigureComposerTool,
-    dim: str,
-    mode_combo: QtWidgets.QComboBox,
-    value_edit: QtWidgets.QLineEdit,
-    width_edit: QtWidgets.QLineEdit,
-) -> None:
-    def set_control_visibility(mode: str) -> None:
-        value_edit.setVisible(mode in _PLOT_ARRAY_SELECTION_VALUE_MODES)
-        width_edit.setVisible(mode == "qsel")
-
-    def current_value_text() -> str:
-        return value_edit.text()
-
-    def current_width_text() -> str:
-        return width_edit.text()
-
-    def clear_hidden_controls(mode: str) -> None:
-        if mode not in _PLOT_ARRAY_SELECTION_VALUE_MODES:
-            value_edit.clear()
-            value_edit.setModified(False)
-            tool._clear_editor_input_error(value_edit)
-        if mode != "qsel":
-            width_edit.clear()
-            width_edit.setModified(False)
-            tool._clear_editor_input_error(width_edit)
-
-    def mode_changed(value: typing.Any) -> None:
-        mode = value if isinstance(value, str) else ""
-        set_control_visibility(mode)
-        clear_hidden_controls(mode)
-        value_mode = mode in _PLOT_ARRAY_SELECTION_VALUE_MODES
-        if value_mode:
-            if current_value_text().strip():
-                _update_current_selection_dimension(
-                    tool,
-                    dim,
-                    mode,
-                    current_value_text(),
-                    current_width_text(),
-                )
-            return
-        _update_current_selection_dimension(tool, dim, mode)
-
-    def value_changed(text: str) -> None:
-        mode = mode_combo.currentData()
-        if isinstance(mode, str) and mode in _PLOT_ARRAY_SELECTION_VALUE_MODES:
-            _update_current_selection_dimension(
-                tool,
-                dim,
-                mode,
-                text,
-                current_width_text(),
-            )
-
-    def width_changed(text: str) -> None:
-        mode = mode_combo.currentData()
-        if isinstance(mode, str) and mode == "qsel":
-            _update_current_selection_dimension(
-                tool,
-                dim,
-                mode,
-                current_value_text(),
-                text,
-            )
-
-    ComboBoxDataControlAdapter(mode_combo).connect_commit(
-        tool._connect_editor_signal,
-        mode_changed,
-    )
-    tool._connect_line_edit_finished(value_edit, value_changed)
-    tool._connect_line_edit_finished(width_edit, width_changed)
-
-
 def _plot_array_source_code(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> str | None:
     data = _selected_plot_array_data(tool, operation, squeeze=False)
     if data is None:
         return None
-    if operation.map_selections:
-        code = _selection_code(operation.map_selections[0])
-    else:
-        source_name = _primary_source(operation)
-        if source_name is None:
-            return None
-        code = _valid_source_variable(source_name)
+    source_name = _primary_source(operation)
+    if source_name is None:
+        return None
+    code = _valid_source_variable(source_name)
     code = _maybe_squeeze_drop_code(code, data)
     if operation.transpose:
         code = f"{code}.T"
@@ -532,13 +192,7 @@ def _update_current_source(tool: FigureComposerTool, source: str | None) -> None
     def update_operation(
         _index: int, target: FigureOperationState
     ) -> FigureOperationState:
-        updates: dict[str, typing.Any] = {"sources": (source,)}
-        if target.map_selections:
-            updates["map_selections"] = tuple(
-                selection.model_copy(update={"source": source})
-                for selection in target.map_selections
-            )
-        return target.model_copy(update=updates)
+        return target.model_copy(update={"sources": (source,), "map_selections": ()})
 
     tool._update_operations(update_operation, rebuild_editor=True)
 
@@ -561,169 +215,6 @@ def _build_source_editor(
         source_combo,
         "Data array plotted by this Image Plot step.",
     )
-
-
-def _build_plot_array_selection_page(
-    tool: FigureComposerTool, operation: FigureOperationState
-) -> QtWidgets.QWidget:
-    page, layout = tool._new_step_form_page("figureComposerPlotArraySelectionPage")
-    selection = _primary_selection(operation)
-
-    tool._add_form_section(
-        layout,
-        "Data",
-        object_name="figureComposerPlotArraySelectionDataSection",
-    )
-    summary = QtWidgets.QLabel(_selection_summary(tool, operation), page)
-    summary.setObjectName("figureComposerPlotArraySelectionSummary")
-    summary.setWordWrap(True)
-    tool._add_form_row(
-        layout,
-        "Summary",
-        summary,
-        "Shows the original dimensions and the dimensions plotted by this image step.",
-    )
-
-    source_mixed = tool._batch_is_mixed(operation, _primary_source)
-    source_combo = tool._source_combo(
-        tool._source_names(),
-        None if source_mixed else selection.source or _primary_source(operation),
-        lambda source: _update_current_selection_source(tool, source),
-        parent=page,
-        mixed=source_mixed,
-    )
-    source_combo.setObjectName("figureComposerPlotArraySelectionSourceCombo")
-    tool._add_form_row(
-        layout,
-        "Image data",
-        source_combo,
-        "Data array selected before plot_array draws this image.",
-    )
-
-    tool._add_form_section(
-        layout,
-        "Dimensions",
-        object_name="figureComposerPlotArraySelectionDimensionsSection",
-    )
-    source_data = None if source_mixed else _plot_array_source_data(tool, operation)
-    if source_mixed or source_data is None:
-        dimensions_message = QtWidgets.QLabel(
-            "Choose an image data source to edit dimension selections."
-            if source_mixed
-            else "No source dimensions are available.",
-            page,
-        )
-        dimensions_message.setObjectName(
-            "figureComposerPlotArraySelectionDimensionsMessage"
-        )
-        dimensions_message.setWordWrap(True)
-        tool._add_form_row(
-            layout,
-            "Dimensions",
-            dimensions_message,
-            "Dimension controls are available after the source data is known.",
-        )
-        return page
-
-    if not source_data.dims:
-        dimensions_message = QtWidgets.QLabel("No dimensions.", page)
-        dimensions_message.setObjectName(
-            "figureComposerPlotArraySelectionDimensionsMessage"
-        )
-        tool._add_form_row(
-            layout,
-            "Dimensions",
-            dimensions_message,
-            "This source is scalar, so no dimension selections are available.",
-        )
-        return page
-
-    for dim_index, dim in enumerate(source_data.dims):
-        dim_name = str(dim)
-
-        def mode_getter(target: FigureOperationState, dim_name: str = dim_name) -> str:
-            return _plot_array_selection_dim_mode(_primary_selection(target), dim_name)
-
-        def value_getter(target: FigureOperationState, dim_name: str = dim_name) -> str:
-            return _plot_array_selection_dim_value_text(
-                _primary_selection(target), dim_name
-            )
-
-        def width_getter(target: FigureOperationState, dim_name: str = dim_name) -> str:
-            return _plot_array_selection_dim_width_text(
-                _primary_selection(target), dim_name
-            )
-
-        mode_mixed = tool._batch_is_mixed(operation, mode_getter)
-        value_text, value_mixed = tool._batch_text(
-            operation,
-            value_getter,
-            str,
-        )
-        width_text, width_mixed = tool._batch_text(
-            operation,
-            width_getter,
-            str,
-        )
-        current_mode = (
-            None if mode_mixed else _plot_array_selection_dim_mode(selection, dim_name)
-        )
-        row = QtWidgets.QWidget(page)
-        row.setObjectName(f"figureComposerPlotArraySelectionDimRow{dim_index}")
-        row.setProperty("figure_composer_plot_array_dim", dim_name)
-        row_layout = QtWidgets.QHBoxLayout(row)
-        row_layout.setContentsMargins(0, 0, 0, 0)
-        row_layout.setSpacing(4)
-
-        mode_combo = _plot_array_selection_mode_combo(
-            tool,
-            current=current_mode,
-            mixed=mode_mixed,
-            parent=row,
-        )
-        mode_combo.setObjectName(
-            f"figureComposerPlotArraySelectionModeCombo{dim_index}"
-        )
-        mode_combo.setProperty("figure_composer_plot_array_dim", dim_name)
-        mode_combo.setToolTip(_PLOT_ARRAY_SELECTION_MODE_TOOLTIP)
-        value_edit = tool._line_edit(value_text, parent=row)
-        value_edit.setObjectName(
-            f"figureComposerPlotArraySelectionValueEdit{dim_index}"
-        )
-        value_edit.setProperty("figure_composer_plot_array_dim", dim_name)
-        value_edit.setProperty("figure_composer_plot_array_selection_field", "value")
-        value_edit.setPlaceholderText("value")
-        value_edit.setToolTip(_PLOT_ARRAY_SELECTION_VALUE_TOOLTIP)
-        value_edit.setVisible(current_mode in _PLOT_ARRAY_SELECTION_VALUE_MODES)
-        tool._apply_mixed_line_edit(value_edit, value_mixed)
-        width_edit = tool._line_edit(width_text, parent=row)
-        width_edit.setObjectName(
-            f"figureComposerPlotArraySelectionWidthEdit{dim_index}"
-        )
-        width_edit.setProperty("figure_composer_plot_array_dim", dim_name)
-        width_edit.setProperty("figure_composer_plot_array_selection_field", "width")
-        width_edit.setPlaceholderText("width")
-        width_edit.setToolTip(_PLOT_ARRAY_SELECTION_WIDTH_TOOLTIP)
-        width_edit.setVisible(current_mode == "qsel")
-        tool._apply_mixed_line_edit(width_edit, width_mixed)
-        _connect_plot_array_selection_dimension_controls(
-            tool,
-            dim_name,
-            mode_combo,
-            value_edit,
-            width_edit,
-        )
-
-        row_layout.addWidget(mode_combo)
-        row_layout.addWidget(value_edit, 1)
-        row_layout.addWidget(width_edit, 1)
-        tool._add_form_row(
-            layout,
-            dim_name,
-            row,
-            "Choose how this dimension is prepared before plotting.",
-        )
-    return page
 
 
 def _plot_array_kwargs(operation: FigureOperationState) -> dict[str, typing.Any]:
@@ -1333,12 +824,6 @@ def _editor_sections(
 ) -> tuple[StepSection, ...]:
     return (
         StepSection(
-            "selection",
-            "Selection",
-            _build_plot_array_selection_page(tool, operation),
-            "Choose the source data and selection reduced to one 2D image.",
-        ),
-        StepSection(
             "view",
             "View",
             _build_plot_array_view_page(tool, operation),
@@ -1368,20 +853,6 @@ def _section_summary(
             return tool._source_display_name(source_name) if source_name else "none"
         case "axes":
             return tool._axes_target_text(operation.axes)
-        case "selection":
-            if _plot_array_selection_error(tool, operation) is not None:
-                return "invalid"
-            selection = _primary_selection(operation)
-            labels = [
-                label
-                for label, value in (
-                    ("isel", selection.isel),
-                    ("qsel", selection.qsel),
-                    ("mean", selection.mean_dims),
-                )
-                if value
-            ]
-            return ", ".join(labels) if labels else "none"
         case "view":
             labels = [
                 label

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_array.py
@@ -158,7 +158,6 @@ def _has_invalid_target(
 
 
 def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
-    prefix = "Needs one axis: " if _has_invalid_target(tool, operation) else ""
     source_name = _primary_source(operation)
     source_text = (
         tool._source_display_name(source_name)
@@ -175,7 +174,7 @@ def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> 
             shape = "2D"
         else:
             shape = f"{data.ndim}D"
-    return f"{prefix}Image plot: {source_text}, {shape}"
+    return f"Image plot: {source_text}, {shape}"
 
 
 def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -11,11 +11,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.plotting as eplt
-from erlab.interactive._figurecomposer._code import (
-    _axes_code,
-    _maybe_squeeze_drop_code,
-    _selection_code,
-)
+from erlab.interactive._figurecomposer._code import _axes_code, _maybe_squeeze_drop_code
 from erlab.interactive._figurecomposer._defaults import (
     _current_options,
     _styled_rcparams_value,
@@ -100,7 +96,6 @@ from erlab.interactive._figurecomposer._rendering import (
 from erlab.interactive._figurecomposer._sources import (
     _available_source_dims,
     _public_source_data,
-    _selected_data,
     _valid_source_variable,
 )
 from erlab.interactive._figurecomposer._state import (
@@ -200,7 +195,11 @@ def _operation_dim_names(
                 dims.append(dim_text)
     if dims:
         return tuple(dims)
-    return tuple(_available_source_dims(tool._source_data, operation.sources))
+    return tuple(
+        _available_source_dims(
+            tool._source_data, _plot_slices_selection_sources(operation)
+        )
+    )
 
 
 def _slice_values_mode_text(mode: str) -> str:
@@ -300,8 +299,6 @@ def _all_coordinate_slice_values_summary(
 
 
 def _first_plot_slices_source_code(operation: FigureOperationState) -> str | None:
-    if operation.map_selections:
-        return _selection_code(operation.map_selections[0])
     if operation.sources:
         return _valid_source_variable(operation.sources[0])
     return None
@@ -377,13 +374,9 @@ def _plot_slices_panel_keys(
 ) -> tuple[_PlotSlicesPanelKey, ...]:
     operation = _normalized_selection_operation(tool, operation)
     maps = _operation_maps(tool, operation)
-    map_count = len(maps) or max(len(operation.sources), 1)
+    source_names = _plot_slices_selection_sources(operation)
+    map_count = len(maps) or max(len(source_names), 1)
     slice_count = _plot_slices_slice_count(tool, operation)
-    source_names = (
-        tuple(selection.source for selection in operation.map_selections)
-        if operation.map_selections
-        else operation.sources
-    )
     map_labels = tuple(
         tool._source_display_name(source_names[index])
         if index < len(source_names)
@@ -805,11 +798,7 @@ def _plot_slices_line_colormap_colors(
 def _plot_slices_source_labels(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> tuple[str, ...]:
-    source_names = (
-        tuple(selection.source for selection in operation.map_selections)
-        if operation.map_selections
-        else operation.sources
-    )
+    source_names = _plot_slices_selection_sources(operation)
     map_count = len(_operation_maps(tool, operation)) or max(len(source_names), 1)
     return tuple(
         tool._source_display_name(source_names[index])
@@ -2371,6 +2360,19 @@ def _normalized_selection_operation(
     return operation.model_copy(update=updates)
 
 
+def _plot_slices_selection_sources(
+    operation: FigureOperationState,
+) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(operation.sources))
+
+
+def _plot_slices_operation_with_sources(
+    operation: FigureOperationState,
+    sources: tuple[str, ...],
+) -> FigureOperationState:
+    return operation.model_copy(update={"sources": sources, "map_selections": ()})
+
+
 def _add_plot_slices_line_color_controls(
     tool: FigureComposerTool,
     operation: FigureOperationState,
@@ -2662,7 +2664,9 @@ def _build_plot_slices_editor(
         "Slice values",
         object_name="figureComposerPlotSlicesSelectionValuesSection",
     )
-    dims = _available_source_dims(tool._source_data, operation.sources)
+    dims = _available_source_dims(
+        tool._source_data, _plot_slices_selection_sources(operation)
+    )
     dim_mixed = tool._batch_is_mixed(operation, lambda target: target.slice_dim)
     dim_combo = tool._combo(
         ["", *dims],
@@ -4302,16 +4306,8 @@ def _plot_slices_selection_cache_key(
     operation: FigureOperationState, maps: Sequence[xr.DataArray]
 ) -> tuple[object, ...]:
     source_key = tuple(
-        (
-            selection.source,
-            repr(selection.isel),
-            repr(selection.qsel),
-            tuple(selection.mean_dims),
-        )
-        for selection in operation.map_selections
+        (source,) for source in _plot_slices_selection_sources(operation)
     )
-    if not source_key:
-        source_key = tuple((source,) for source in operation.sources)
     map_key = tuple(
         (id(data.data), tuple(data.dims), tuple(data.shape)) for data in maps
     )
@@ -4321,13 +4317,6 @@ def _plot_slices_selection_cache_key(
 def _operation_maps(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> list[xr.DataArray]:
-    if operation.map_selections:
-        return [
-            selected
-            for selection in operation.map_selections
-            if (selected := _selected_data(tool._source_data, selection)) is not None
-        ]
-
     return [
         _public_source_data(tool._source_data[name])
         for name in operation.sources
@@ -4339,17 +4328,10 @@ def _plot_slices_code(
     tool: FigureComposerTool, operation: FigureOperationState
 ) -> str | None:
     operation = _normalized_selection_operation(tool, operation)
-    if operation.map_selections:
-        maps_code = (
-            _selection_code(operation.map_selections[0])
-            if len(operation.map_selections) == 1
-            else "selected_maps"
-        )
-    else:
-        sources = [_valid_source_variable(source) for source in operation.sources]
-        if not sources:
-            return None
-        maps_code = sources[0] if len(sources) == 1 else f"[{', '.join(sources)}]"
+    sources = [_valid_source_variable(source) for source in operation.sources]
+    if not sources:
+        return None
+    maps_code = sources[0] if len(sources) == 1 else f"[{', '.join(sources)}]"
 
     kwargs = _plot_slices_code_kwargs(tool, operation)
     kwargs["axes"] = _RawCode(_axes_code(tool, operation.axes, for_plot_slices=True))
@@ -4360,10 +4342,6 @@ def _plot_slices_code(
 def _plot_slices_profile_source_codes(
     operation: FigureOperationState,
 ) -> tuple[str, ...]:
-    if operation.map_selections:
-        return tuple(
-            _selection_code(selection) for selection in operation.map_selections
-        )
     return tuple(_valid_source_variable(source) for source in operation.sources)
 
 
@@ -4504,18 +4482,7 @@ def _plot_slices_code_lines(
     if code is None:
         return []
     color_lines = _plot_slices_line_color_code_lines(tool, operation)
-    if not operation.map_selections:
-        return [*color_lines, code]
-    if len(operation.map_selections) == 1:
-        return [*color_lines, code]
-    lines = ["selected_maps = ["]
-    lines.extend(
-        f"    {_selection_code(selection)}," for selection in operation.map_selections
-    )
-    lines.append("]")
-    lines.extend(color_lines)
-    lines.append(code)
-    return lines
+    return [*color_lines, code]
 
 
 def _plot_slices_code_kwargs(
@@ -4570,7 +4537,9 @@ def _create_plot_slices_operation(tool: FigureComposerTool) -> FigureOperationSt
 def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
     operation = _normalized_selection_operation(tool, operation)
     prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
-    source_text = ", ".join(tool._source_display_names(operation.sources))
+    source_text = ", ".join(
+        tool._source_display_names(_plot_slices_selection_sources(operation))
+    )
     if not source_text:
         source_text = "missing source"
     shape = _plot_slices_shape(tool, operation)
@@ -4597,14 +4566,7 @@ def _has_invalid_target(
 
 
 def _source_names(operation: FigureOperationState) -> tuple[str, ...]:
-    names: list[str] = []
-    for source_name in operation.sources:
-        if source_name not in names:
-            names.append(source_name)
-    for selection in operation.map_selections:
-        if selection.source not in names:
-            names.append(selection.source)
-    return tuple(names)
+    return _plot_slices_selection_sources(operation)
 
 
 def _plot_source_check_state(
@@ -4616,10 +4578,13 @@ def _plot_source_check_state(
     if len(editable) <= 1:
         return (
             QtCore.Qt.CheckState.Checked
-            if source_name in operation.sources
+            if source_name in _plot_slices_selection_sources(operation)
             else QtCore.Qt.CheckState.Unchecked
         )
-    selected_count = sum(source_name in target.sources for _index, target in editable)
+    selected_count = sum(
+        source_name in _plot_slices_selection_sources(target)
+        for _index, target in editable
+    )
     if selected_count == 0:
         return QtCore.Qt.CheckState.Unchecked
     if selected_count == len(editable):
@@ -4644,22 +4609,25 @@ def _plot_source_check_changed(
         _index: int, target: FigureOperationState
     ) -> FigureOperationState:
         if checked:
-            if source_name in target.sources:
+            target_sources = _plot_slices_selection_sources(target)
+            if source_name in target_sources:
                 return target
-            source_set = {*target.sources, source_name}
+            source_set = {*target_sources, source_name}
             ordered_sources = tuple(
                 source for source in row_order if source in source_set
             )
             missing_sources = tuple(
-                source for source in target.sources if source not in row_order
+                source for source in target_sources if source not in row_order
             )
-            return target.model_copy(
-                update={"sources": (*ordered_sources, *missing_sources)}
+            return _plot_slices_operation_with_sources(
+                target, (*ordered_sources, *missing_sources)
             )
         next_sources = tuple(
-            source for source in target.sources if source != source_name
+            source
+            for source in _plot_slices_selection_sources(target)
+            if source != source_name
         )
-        return target.model_copy(update={"sources": next_sources})
+        return _plot_slices_operation_with_sources(target, next_sources)
 
     tool._update_operations(
         update_operation,
@@ -4681,7 +4649,9 @@ def _plot_source_move(
         _index: int, target: FigureOperationState
     ) -> FigureOperationState:
         ordered_sources = [
-            source for source in target.sources if source in available_sources
+            source
+            for source in _plot_slices_selection_sources(target)
+            if source in available_sources
         ]
         if source_name not in ordered_sources:
             return target
@@ -4694,10 +4664,12 @@ def _plot_source_move(
             ordered_sources[source_index],
         )
         missing_sources = tuple(
-            source for source in target.sources if source not in available_sources
+            source
+            for source in _plot_slices_selection_sources(target)
+            if source not in available_sources
         )
-        return target.model_copy(
-            update={"sources": (*ordered_sources, *missing_sources)}
+        return _plot_slices_operation_with_sources(
+            target, (*ordered_sources, *missing_sources)
         )
 
     tool._update_operations(
@@ -4715,10 +4687,16 @@ def _plot_source_order_matches(
         return True
     available_sources = set(tool._source_names())
     expected = tuple(
-        source for source in operation.sources if source in available_sources
+        source
+        for source in _plot_slices_selection_sources(operation)
+        if source in available_sources
     )
     return all(
-        tuple(source for source in target.sources if source in available_sources)
+        tuple(
+            source
+            for source in _plot_slices_selection_sources(target)
+            if source in available_sources
+        )
         == expected
         for _index, target in editable
     )
@@ -4729,7 +4707,9 @@ def _plot_source_row_names(
 ) -> tuple[str, ...]:
     source_names = tool._source_names()
     selected_sources = tuple(
-        source for source in operation.sources if source in source_names
+        source
+        for source in _plot_slices_selection_sources(operation)
+        if source in source_names
     )
     unselected_sources = tuple(
         source for source in source_names if source not in selected_sources
@@ -4871,7 +4851,9 @@ def _build_source_editor(
     layout.setVerticalSpacing(2)
     row_names = _plot_source_row_names(tool, operation)
     selected_sources = tuple(
-        source for source in operation.sources if source in tool._source_names()
+        source
+        for source in _plot_slices_selection_sources(operation)
+        if source in tool._source_names()
     )
     order_controls_enabled = _plot_source_order_matches(tool, operation)
     if row_names:
@@ -4920,7 +4902,14 @@ def _section_summary(
     operation = _normalized_selection_operation(tool, operation)
     match key:
         case "sources":
-            return ", ".join(tool._source_display_names(operation.sources)) or "none"
+            return (
+                ", ".join(
+                    tool._source_display_names(
+                        _plot_slices_selection_sources(operation)
+                    )
+                )
+                or "none"
+            )
         case "axes":
             return tool._axes_target_text(operation.axes)
         case "selection":

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -4536,7 +4536,6 @@ def _create_plot_slices_operation(tool: FigureComposerTool) -> FigureOperationSt
 
 def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> str:
     operation = _normalized_selection_operation(tool, operation)
-    prefix = "Needs axes: " if _has_invalid_target(tool, operation) else ""
     source_text = ", ".join(
         tool._source_display_names(_plot_slices_selection_sources(operation))
     )
@@ -4549,7 +4548,7 @@ def _display_text(tool: FigureComposerTool, operation: FigureOperationState) -> 
         selection_text = f"{operation.slice_dim} = {len(slice_values)} values"
     else:
         selection_text = "current selection"
-    return f"{prefix}{plot_kind}: {source_text}, {selection_text}"
+    return f"{plot_kind}: {source_text}, {selection_text}"
 
 
 def _tooltip(tool: FigureComposerTool, operation: FigureOperationState) -> str:

--- a/src/erlab/interactive/_figurecomposer/_operations/_source_selection.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_source_selection.py
@@ -1,0 +1,462 @@
+"""Shared Figure Composer source-selection editor helpers."""
+
+from __future__ import annotations
+
+import typing
+from collections.abc import Callable
+
+from qtpy import QtWidgets
+
+import erlab
+from erlab.interactive._figurecomposer._editor_controls import (
+    MIXED_VALUE,
+    MIXED_VALUES_TEXT,
+    ComboBoxDataControlAdapter,
+)
+from erlab.interactive._figurecomposer._state import (
+    FigureDataSelectionState,
+    FigureOperationState,
+)
+from erlab.interactive._figurecomposer._text import (
+    FigureComposerInputError,
+    _dict_from_text,
+)
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from erlab.interactive._figurecomposer._tool import FigureComposerTool
+
+
+SelectionSourceGetter = Callable[[FigureOperationState], tuple[str, ...]]
+SelectionOperationFactory = Callable[
+    [FigureOperationState, tuple[str, ...], tuple[FigureDataSelectionState, ...]],
+    FigureOperationState,
+]
+
+_SELECTION_MODE_LABELS = {
+    "keep": "None",
+    "isel": "isel",
+    "qsel": "qsel",
+    "mean": "Mean",
+}
+_SELECTION_VALUE_MODES = {"isel", "qsel"}
+_SELECTION_VALUE_MESSAGE = "Enter a selection value, such as 0 or slice(0, 2)."
+_SELECTION_WIDTH_MESSAGE = "Enter a qsel width, such as 0.1."
+_SELECTION_MODE_TOOLTIP = (
+    "Choose whether this dimension stays, is selected, or is averaged."
+)
+_SELECTION_VALUE_TOOLTIP = (
+    "Selection value. Use integer positions or slices for isel; use coordinate "
+    "values or slices for qsel."
+)
+_SELECTION_WIDTH_TOOLTIP = (
+    "Optional qsel width centered on the value. Leave blank for nearest "
+    "coordinate selection."
+)
+
+
+def selection_has_effect(selection: FigureDataSelectionState) -> bool:
+    return bool(selection.isel or selection.qsel or selection.mean_dims)
+
+
+def selection_content_equal(
+    first: FigureDataSelectionState, second: FigureDataSelectionState
+) -> bool:
+    return (
+        first.isel == second.isel
+        and first.qsel == second.qsel
+        and first.mean_dims == second.mean_dims
+    )
+
+
+def shared_selection(
+    selections: Sequence[FigureDataSelectionState],
+) -> FigureDataSelectionState | None:
+    if not selections:
+        return FigureDataSelectionState(source="")
+    first = selections[0].model_copy(update={"source": ""})
+    if all(selection_content_equal(first, selection) for selection in selections[1:]):
+        return first
+    return None
+
+
+def selection_for_source(
+    operation: FigureOperationState,
+    source: str,
+    fallback: FigureDataSelectionState,
+) -> FigureDataSelectionState:
+    for selection in operation.map_selections:
+        if selection.source == source:
+            return selection
+    return fallback.model_copy(update={"source": source})
+
+
+def source_selection_per_source_enabled(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    *,
+    attr_name: str,
+) -> bool:
+    if shared_selection(operation.map_selections) is None:
+        return True
+    return operation.operation_id in typing.cast(
+        "set[str]", getattr(tool, attr_name, set())
+    )
+
+
+def set_source_selection_per_source_enabled(
+    tool: FigureComposerTool,
+    operation: FigureOperationState,
+    enabled: bool,
+    *,
+    attr_name: str,
+    source_getter: SelectionSourceGetter,
+    operation_factory: SelectionOperationFactory,
+    keep_source_only: bool,
+) -> None:
+    enabled_ids = set(getattr(tool, attr_name, set()))
+    if enabled:
+        enabled_ids.add(operation.operation_id)
+        setattr(tool, attr_name, enabled_ids)
+        tool._update_operation_editor()
+        return
+
+    enabled_ids.discard(operation.operation_id)
+    setattr(tool, attr_name, enabled_ids)
+    shared = shared_selection(operation.map_selections)
+    if shared is None and operation.map_selections:
+        shared = operation.map_selections[0].model_copy(update={"source": ""})
+    if shared is None:
+        shared = FigureDataSelectionState(source="")
+
+    def update_operation(
+        _index: int, target: FigureOperationState
+    ) -> FigureOperationState:
+        sources = source_getter(target)
+        return operation_with_shared_source_selection(
+            target,
+            sources,
+            shared,
+            operation_factory=operation_factory,
+            keep_source_only=keep_source_only,
+        )
+
+    tool._update_operations(
+        update_operation,
+        rebuild_editor=True,
+        defer_editor_rebuild=True,
+    )
+
+
+def operation_with_shared_source_selection(
+    operation: FigureOperationState,
+    sources: tuple[str, ...],
+    selection: FigureDataSelectionState,
+    *,
+    operation_factory: SelectionOperationFactory,
+    keep_source_only: bool,
+) -> FigureOperationState:
+    map_selections = _selection_tuple_for_sources(
+        sources,
+        selection,
+        keep_source_only=keep_source_only,
+    )
+    return operation_factory(operation, sources, map_selections)
+
+
+def operation_with_per_source_selection(
+    operation: FigureOperationState,
+    source: str,
+    selection: FigureDataSelectionState,
+    *,
+    source_getter: SelectionSourceGetter,
+    operation_factory: SelectionOperationFactory,
+    keep_source_only: bool,
+) -> FigureOperationState:
+    sources = source_getter(operation)
+    if source not in sources:
+        return operation
+    shared = shared_selection(operation.map_selections)
+    if shared is None:
+        shared = FigureDataSelectionState(source="")
+    selections = tuple(
+        (
+            selection.model_copy(update={"source": source_name})
+            if source_name == source
+            else selection_for_source(operation, source_name, shared)
+        )
+        for source_name in sources
+    )
+    if not keep_source_only and not any(
+        selection_has_effect(source_selection) for source_selection in selections
+    ):
+        selections = ()
+    return operation_factory(operation, sources, tuple(selections))
+
+
+def _selection_tuple_for_sources(
+    sources: tuple[str, ...],
+    selection: FigureDataSelectionState,
+    *,
+    keep_source_only: bool,
+) -> tuple[FigureDataSelectionState, ...]:
+    if not keep_source_only and not selection_has_effect(selection):
+        return ()
+    return tuple(selection.model_copy(update={"source": source}) for source in sources)
+
+
+def selection_dim_mode(selection: FigureDataSelectionState, dim: str) -> str:
+    if dim in selection.isel:
+        return "isel"
+    if dim in selection.qsel or selection_width_key(dim) in selection.qsel:
+        return "qsel"
+    if dim in selection.mean_dims:
+        return "mean"
+    return "keep"
+
+
+def selection_dim_value_text(selection: FigureDataSelectionState, dim: str) -> str:
+    if dim in selection.isel:
+        return erlab.interactive.utils._parse_single_arg(selection.isel[dim])
+    if dim in selection.qsel:
+        return erlab.interactive.utils._parse_single_arg(selection.qsel[dim])
+    return ""
+
+
+def selection_width_key(dim: str) -> str:
+    return f"{dim}_width"
+
+
+def selection_dim_width_text(selection: FigureDataSelectionState, dim: str) -> str:
+    width_key = selection_width_key(dim)
+    if width_key in selection.qsel:
+        return erlab.interactive.utils._parse_single_arg(selection.qsel[width_key])
+    return ""
+
+
+def selection_value_from_text(text: str) -> typing.Any:
+    stripped = text.strip()
+    if not stripped:
+        raise FigureComposerInputError(_SELECTION_VALUE_MESSAGE)
+    try:
+        return _dict_from_text(f"value={stripped}", allow_slice=True)["value"]
+    except FigureComposerInputError as exc:
+        raise FigureComposerInputError(_SELECTION_VALUE_MESSAGE) from exc
+
+
+def selection_width_from_text(text: str) -> typing.Any:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        value = _dict_from_text(f"value={stripped}", allow_slice=True)["value"]
+    except FigureComposerInputError as exc:
+        raise FigureComposerInputError(_SELECTION_WIDTH_MESSAGE) from exc
+    if isinstance(value, slice):
+        raise FigureComposerInputError(_SELECTION_WIDTH_MESSAGE)
+    return value
+
+
+def selection_with_dimension(
+    selection: FigureDataSelectionState,
+    dim: str,
+    mode: str,
+    value: typing.Any = None,
+    width: typing.Any = None,
+) -> FigureDataSelectionState:
+    isel = dict(selection.isel)
+    qsel = dict(selection.qsel)
+    mean_dims = [target for target in selection.mean_dims if target != dim]
+    isel.pop(dim, None)
+    qsel.pop(dim, None)
+    qsel.pop(selection_width_key(dim), None)
+    if mode == "isel":
+        isel[dim] = value
+    elif mode == "qsel":
+        if isinstance(value, slice) and width is not None:
+            raise FigureComposerInputError(
+                "A qsel slice cannot also use a width argument."
+            )
+        qsel[dim] = value
+        if width is not None:
+            qsel[selection_width_key(dim)] = width
+    elif mode == "mean":
+        mean_dims.append(dim)
+    return selection.model_copy(
+        update={
+            "isel": isel,
+            "qsel": qsel,
+            "mean_dims": tuple(mean_dims),
+        }
+    )
+
+
+def selection_mode_combo(
+    tool: FigureComposerTool,
+    *,
+    current: str | None,
+    mixed: bool,
+    parent: QtWidgets.QWidget,
+) -> QtWidgets.QComboBox:
+    combo = QtWidgets.QComboBox(parent)
+    tool._mark_editor_control(combo)
+    if mixed:
+        combo.addItem(MIXED_VALUES_TEXT, MIXED_VALUE)
+    for mode, label in _SELECTION_MODE_LABELS.items():
+        combo.addItem(label, mode)
+    if mixed:
+        item = typing.cast("typing.Any", combo.model()).item(0)
+        if item is not None:
+            item.setEnabled(False)
+        combo.setCurrentIndex(0)
+    elif current is not None:
+        for index in range(combo.count()):
+            if combo.itemData(index) == current:
+                combo.setCurrentIndex(index)
+                break
+    return combo
+
+
+def connect_selection_dimension_controls(
+    tool: FigureComposerTool,
+    *,
+    dim: str,
+    mode_combo: QtWidgets.QComboBox,
+    value_edit: QtWidgets.QLineEdit,
+    width_edit: QtWidgets.QLineEdit,
+    update_dimension: Callable[[str, str, str, str], None],
+) -> None:
+    def set_control_visibility(mode: str) -> None:
+        value_edit.setVisible(mode in _SELECTION_VALUE_MODES)
+        width_edit.setVisible(mode == "qsel")
+
+    def current_value_text() -> str:
+        return value_edit.text()
+
+    def current_width_text() -> str:
+        return width_edit.text()
+
+    def clear_hidden_controls(mode: str) -> None:
+        if mode not in _SELECTION_VALUE_MODES:
+            value_edit.clear()
+            value_edit.setModified(False)
+            tool._clear_editor_input_error(value_edit)
+        if mode != "qsel":
+            width_edit.clear()
+            width_edit.setModified(False)
+            tool._clear_editor_input_error(width_edit)
+
+    def mode_changed(value: typing.Any) -> None:
+        mode = value if isinstance(value, str) else ""
+        set_control_visibility(mode)
+        clear_hidden_controls(mode)
+        value_mode = mode in _SELECTION_VALUE_MODES
+        if value_mode:
+            if current_value_text().strip():
+                update_dimension(dim, mode, current_value_text(), current_width_text())
+            return
+        update_dimension(dim, mode, "", "")
+
+    def value_changed(text: str) -> None:
+        mode = mode_combo.currentData()
+        if isinstance(mode, str) and mode in _SELECTION_VALUE_MODES:
+            update_dimension(dim, mode, text, current_width_text())
+
+    def width_changed(text: str) -> None:
+        mode = mode_combo.currentData()
+        if isinstance(mode, str) and mode == "qsel":
+            update_dimension(dim, mode, current_value_text(), text)
+
+    ComboBoxDataControlAdapter(mode_combo).connect_commit(
+        tool._connect_editor_signal,
+        mode_changed,
+    )
+    tool._connect_line_edit_finished(value_edit, value_changed)
+    tool._connect_line_edit_finished(width_edit, width_changed)
+
+
+def add_selection_dimension_rows(
+    tool: FigureComposerTool,
+    *,
+    operation: FigureOperationState,
+    layout: QtWidgets.QFormLayout,
+    page: QtWidgets.QWidget,
+    dimensions: Sequence[str],
+    selection_getter: Callable[[FigureOperationState], FigureDataSelectionState],
+    update_dimension: Callable[[str, str, str, str], None],
+    object_prefix: str,
+    property_prefix: str,
+) -> None:
+    if not dimensions:
+        dimensions_message = QtWidgets.QLabel("No dimensions.", page)
+        dimensions_message.setObjectName(f"{object_prefix}DimensionsMessage")
+        layout.addRow("Dimensions", dimensions_message)
+        return
+
+    selection = selection_getter(operation)
+    for dim_index, dim_name in enumerate(dimensions):
+
+        def mode_getter(target: FigureOperationState, dim_name: str = dim_name) -> str:
+            return selection_dim_mode(selection_getter(target), dim_name)
+
+        def value_getter(target: FigureOperationState, dim_name: str = dim_name) -> str:
+            return selection_dim_value_text(selection_getter(target), dim_name)
+
+        def width_getter(target: FigureOperationState, dim_name: str = dim_name) -> str:
+            return selection_dim_width_text(selection_getter(target), dim_name)
+
+        mode_mixed = tool._batch_is_mixed(operation, mode_getter)
+        value_text, value_mixed = tool._batch_text(operation, value_getter, str)
+        width_text, width_mixed = tool._batch_text(operation, width_getter, str)
+        current_mode = None if mode_mixed else selection_dim_mode(selection, dim_name)
+        row = QtWidgets.QWidget(page)
+        row.setObjectName(f"{object_prefix}DimRow{dim_index}")
+        row.setProperty(f"{property_prefix}_dim", dim_name)
+        row_layout = QtWidgets.QHBoxLayout(row)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.setSpacing(4)
+
+        mode_combo = selection_mode_combo(
+            tool,
+            current=current_mode,
+            mixed=mode_mixed,
+            parent=row,
+        )
+        mode_combo.setObjectName(f"{object_prefix}ModeCombo{dim_index}")
+        mode_combo.setProperty(f"{property_prefix}_dim", dim_name)
+        mode_combo.setToolTip(_SELECTION_MODE_TOOLTIP)
+        value_edit = tool._line_edit(value_text, parent=row)
+        value_edit.setObjectName(f"{object_prefix}ValueEdit{dim_index}")
+        value_edit.setProperty(f"{property_prefix}_dim", dim_name)
+        value_edit.setProperty(f"{property_prefix}_selection_field", "value")
+        value_edit.setPlaceholderText("value")
+        value_edit.setToolTip(_SELECTION_VALUE_TOOLTIP)
+        value_edit.setVisible(current_mode in _SELECTION_VALUE_MODES)
+        tool._apply_mixed_line_edit(value_edit, value_mixed)
+        width_edit = tool._line_edit(width_text, parent=row)
+        width_edit.setObjectName(f"{object_prefix}WidthEdit{dim_index}")
+        width_edit.setProperty(f"{property_prefix}_dim", dim_name)
+        width_edit.setProperty(f"{property_prefix}_selection_field", "width")
+        width_edit.setPlaceholderText("width")
+        width_edit.setToolTip(_SELECTION_WIDTH_TOOLTIP)
+        width_edit.setVisible(current_mode == "qsel")
+        tool._apply_mixed_line_edit(width_edit, width_mixed)
+        connect_selection_dimension_controls(
+            tool,
+            dim=dim_name,
+            mode_combo=mode_combo,
+            value_edit=value_edit,
+            width_edit=width_edit,
+            update_dimension=update_dimension,
+        )
+
+        row_layout.addWidget(mode_combo)
+        row_layout.addWidget(value_edit, 1)
+        row_layout.addWidget(width_edit, 1)
+        tool._add_form_row(
+            layout,
+            dim_name,
+            row,
+            "Choose how this dimension is prepared before plotting.",
+        )

--- a/src/erlab/interactive/_figurecomposer/_provenance.py
+++ b/src/erlab/interactive/_figurecomposer/_provenance.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import ast
 import typing
 
+import erlab.interactive._figurecomposer._codegen
 from erlab.interactive.imagetool import provenance
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from erlab.interactive._figurecomposer._tool import FigureComposerTool
 
 
@@ -41,9 +44,18 @@ def _code_assigns_name(code: str, name: str) -> bool:
     return False
 
 
-def _figure_build_code(tool: FigureComposerTool) -> str | None:
+def _figure_build_code(
+    tool: FigureComposerTool,
+    *,
+    skip_source_selection_names: frozenset[str] = frozenset(),
+    source_name_map: Mapping[str, str] | None = None,
+) -> str | None:
     try:
-        code = tool.generated_code()
+        code = erlab.interactive._figurecomposer._codegen.generated_code(
+            tool,
+            skip_source_selection_names=skip_source_selection_names,
+            source_name_map=source_name_map,
+        )
     except Exception:
         # Details-panel refreshes happen while the user is editing. Temporarily
         # invalid recipes should make replay code unavailable, not crash metadata UI.
@@ -58,8 +70,15 @@ def _figure_build_code(tool: FigureComposerTool) -> str | None:
 
 def _figure_build_operation(
     tool: FigureComposerTool,
+    *,
+    skip_source_selection_names: frozenset[str] = frozenset(),
+    source_name_map: Mapping[str, str] | None = None,
 ) -> provenance.ScriptCodeOperation:
-    code = _figure_build_code(tool)
+    code = _figure_build_code(
+        tool,
+        skip_source_selection_names=skip_source_selection_names,
+        source_name_map=source_name_map,
+    )
     return provenance.ScriptCodeOperation(
         label="Build figure",
         code=code,

--- a/src/erlab/interactive/_figurecomposer/_provenance.py
+++ b/src/erlab/interactive/_figurecomposer/_provenance.py
@@ -14,6 +14,10 @@ if typing.TYPE_CHECKING:
     from erlab.interactive._figurecomposer._tool import FigureComposerTool
 
 
+class _FigureBuildCodeOperation(provenance.ScriptCodeOperation):
+    hoist_imports: typing.ClassVar[bool] = True
+
+
 def _code_assigns_name(code: str, name: str) -> bool:
     module = ast.parse(code, mode="exec")
 
@@ -79,7 +83,7 @@ def _figure_build_operation(
         skip_source_selection_names=skip_source_selection_names,
         source_name_map=source_name_map,
     )
-    return provenance.ScriptCodeOperation(
+    return _FigureBuildCodeOperation(
         label="Build figure",
         code=code,
         copyable=code is not None,

--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -366,6 +366,15 @@ def _render_error_text(error: Exception) -> str:
     return type(error).__name__
 
 
+def _set_preview_draw_error(tool: FigureComposerTool, error: Exception) -> None:
+    current = tool._current_operation()
+    if current is None:
+        return
+    errors = dict(tool._operation_render_errors)
+    errors[current[1].operation_id] = _render_error_text(error)
+    tool._set_operation_render_errors(errors)
+
+
 def _render_preview(
     tool: FigureComposerTool, *, show_window: bool | None = None
 ) -> None:
@@ -386,8 +395,12 @@ def _render_preview(
             tool._mark_preview_pixmap_stale()
             return
         if show_window:
-            tool.canvas.draw()
-            tool.canvas.flush_events()
+            try:
+                tool.canvas.draw()
+            except Exception as exc:
+                _set_preview_draw_error(tool, exc)
+            else:
+                tool.canvas.flush_events()
         elif (window := _valid_figure_window(tool)) is not None and window.isVisible():
             window.canvas.draw_idle()
     finally:

--- a/src/erlab/interactive/_figurecomposer/_source_inspector.py
+++ b/src/erlab/interactive/_figurecomposer/_source_inspector.py
@@ -152,25 +152,21 @@ def _source_details_html(data: xr.DataArray) -> str:
 
 
 class SourceInspectorWidget(QtWidgets.QWidget):
-    """Compact, source-tab-local inspector for Figure Composer source data."""
+    """Source metadata summary with lazily rendered coordinate details."""
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("figureComposerSourceInspector")
         self._source_name: str | None = None
+        self._data: xr.DataArray | None = None
+        self._details_key: tuple[str, int] | None = None
+        self._details_html: str | None = None
         self._build_ui()
 
     def _build_ui(self) -> None:
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
-
-        self.title_label = QtWidgets.QLabel("No source selected", self)
-        self.title_label.setObjectName("figureComposerSourceInspectorTitle")
-        self.title_label.setTextInteractionFlags(
-            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
-        )
-        layout.addWidget(self.title_label)
 
         self.subtitle_label = QtWidgets.QLabel("", self)
         self.subtitle_label.setObjectName("figureComposerSourceInspectorSubtitle")
@@ -198,12 +194,7 @@ class SourceInspectorWidget(QtWidgets.QWidget):
         self.details_button.toggled.connect(self._set_details_visible)
         layout.addWidget(self.details_button)
 
-        self.details_scroll = QtWidgets.QScrollArea(self)
-        self.details_scroll.setObjectName("figureComposerSourceInspectorDetailsScroll")
-        self.details_scroll.setWidgetResizable(True)
-        self.details_scroll.setMaximumHeight(180)
-        self.details_scroll.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
-        self.details_label = QtWidgets.QLabel(self.details_scroll)
+        self.details_label = QtWidgets.QLabel(self)
         self.details_label.setObjectName("figureComposerSourceInspectorDetails")
         self.details_label.setTextFormat(QtCore.Qt.TextFormat.RichText)
         self.details_label.setWordWrap(True)
@@ -211,17 +202,34 @@ class SourceInspectorWidget(QtWidgets.QWidget):
             QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
         )
         self.details_label.setMargin(6)
-        self.details_scroll.setWidget(self.details_label)
-        self.details_scroll.setVisible(False)
-        layout.addWidget(self.details_scroll)
+        self.details_label.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+        self.details_label.setVisible(False)
+        layout.addWidget(self.details_label)
 
     @QtCore.Slot(bool)
     def _set_details_visible(self, visible: bool) -> None:
+        if visible:
+            self._ensure_details_html()
         self.details_button.setArrowType(
             QtCore.Qt.ArrowType.DownArrow if visible else QtCore.Qt.ArrowType.RightArrow
         )
-        self.details_scroll.setVisible(visible)
+        self.details_label.setVisible(visible)
         self.setProperty("figureComposerSourceDetailsExpanded", visible)
+
+    def _ensure_details_html(self) -> None:
+        if self._data is None or self._details_key is None:
+            self.details_label.clear()
+            return
+        if self._details_html is None:
+            self._details_html = erlab.interactive.utils._apply_qt_accent_color(
+                _source_details_html(self._data)
+            )
+        self.details_label.setText(self._details_html)
+
+    def invalidate_details(self) -> None:
+        """Discard cached metadata after source data changes."""
+        self._details_html = None
+        self.details_label.clear()
 
     def source_name(self) -> str | None:
         return self._source_name
@@ -233,43 +241,62 @@ class SourceInspectorWidget(QtWidgets.QWidget):
         self,
         *,
         source_name: str | None,
-        source_state: FigureSourceState | None,
         data: xr.DataArray | None,
+        context_lines: Sequence[str] = (),
     ) -> None:
         self._source_name = source_name
         self.setProperty("figureComposerSourceAlias", source_name or "")
         if source_name is None:
-            self.title_label.setText("No source selected")
-            self.subtitle_label.setText("Select a source in this tab.")
+            self._data = None
+            self._details_key = None
+            self._details_html = None
+            self.subtitle_label.clear()
             self.details_label.clear()
             self.details_button.setEnabled(False)
             self.setProperty("figureComposerSourceDims", ())
+            self.setProperty("figureComposerSourceDtype", "")
+            self.setProperty("figureComposerSourceSize", "")
             return
-        self.title_label.setText(_source_display_label(source_state, source_name))
+        context_html = tuple(html.escape(line) for line in context_lines)
         if data is None:
-            self.subtitle_label.setText(f"Alias: {source_name}<br>Unavailable")
+            self._data = None
+            self._details_key = None
+            self._details_html = None
+            self.subtitle_label.setText(
+                "<br>".join(("Data unavailable", *context_html))
+            )
             self.details_label.clear()
             self.details_button.setEnabled(False)
             self.setProperty("figureComposerSourceDims", ())
+            self.setProperty("figureComposerSourceDtype", "")
+            self.setProperty("figureComposerSourceSize", "")
             return
         public = _public_source_data(data)
-        summary_html = erlab.utils.formatting.format_darr_shape_html(
+        details_key = (source_name, id(data))
+        if details_key != self._details_key:
+            self._details_html = None
+            self.details_label.clear()
+        self._data = public.rename(None)
+        self._details_key = details_key
+        shape_html = erlab.utils.formatting.format_darr_shape_html(
             public.rename(None),
             show_size=True,
         )
-        if original := _original_source_name(data, source_name):
-            summary_html = (
-                f"Original name: <code>{html.escape(original)}</code><br>{summary_html}"
-            )
-        self.subtitle_label.setText(
-            erlab.interactive.utils._apply_qt_accent_color(summary_html)
+        shape_html = (
+            shape_html.removeprefix("<p>")
+            .removesuffix("</p>")
+            .replace("</p><p>", "<br>")
         )
-        self.details_label.setText(
-            erlab.interactive.utils._apply_qt_accent_color(
-                _source_details_html(public.rename(None))
-            )
+        summary_lines: list[str] = []
+        if original := _original_source_name(data, source_name):
+            summary_lines.append(html.escape(original))
+        summary_lines.extend((shape_html, *context_html))
+        self.subtitle_label.setText(
+            erlab.interactive.utils._apply_qt_accent_color("<br>".join(summary_lines))
         )
         self.details_button.setEnabled(True)
+        if self.details_button.isChecked():
+            self._ensure_details_html()
         self.setProperty(
             "figureComposerSourceDims",
             tuple(str(dim) for dim in public.dims),

--- a/src/erlab/interactive/_figurecomposer/_source_inspector.py
+++ b/src/erlab/interactive/_figurecomposer/_source_inspector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import logging
 import typing
 
@@ -22,6 +23,13 @@ if typing.TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _original_source_name(data: xr.DataArray | None, alias: str) -> str | None:
+    if data is None or data.name is None:
+        return None
+    original = str(data.name)
+    return original if original and original != alias else None
 
 
 def _dims_text(dims: Sequence[typing.Hashable]) -> str:
@@ -46,6 +54,8 @@ def source_metadata_tooltip(
     if data is None:
         lines.append("DataArray: unavailable")
         return "\n".join(lines)
+    if original := _original_source_name(data, name):
+        lines.append(f"Original name: {original}")
     public = _public_source_data(data)
     lines.extend(
         (
@@ -247,6 +257,10 @@ class SourceInspectorWidget(QtWidgets.QWidget):
             public.rename(None),
             show_size=True,
         )
+        if original := _original_source_name(data, source_name):
+            summary_html = (
+                f"Original name: <code>{html.escape(original)}</code><br>{summary_html}"
+            )
         self.subtitle_label.setText(
             erlab.interactive.utils._apply_qt_accent_color(summary_html)
         )

--- a/src/erlab/interactive/_figurecomposer/_source_inspector.py
+++ b/src/erlab/interactive/_figurecomposer/_source_inspector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import typing
 
 from qtpy import QtCore, QtWidgets
@@ -18,6 +19,9 @@ if typing.TYPE_CHECKING:
     import xarray as xr
 
     from erlab.interactive._figurecomposer._state import FigureSourceState
+
+
+logger = logging.getLogger(__name__)
 
 
 def _dims_text(dims: Sequence[typing.Hashable]) -> str:
@@ -39,8 +43,6 @@ def source_metadata_tooltip(
 ) -> str:
     """Return a compact source tooltip with public DataArray metadata."""
     lines = [_source_display_label(source, name, disambiguate=False)]
-    if source is not None and (source.label.strip() or name) != name:
-        lines.append(f"Alias: {name}")
     if data is None:
         lines.append("DataArray: unavailable")
         return "\n".join(lines)
@@ -110,6 +112,33 @@ def _coord_by_name(data: xr.DataArray, name: str | None) -> xr.DataArray | None:
         if str(coord_name) == name:
             return coord_data
     return None
+
+
+def _source_data_with_loaded_coords(data: xr.DataArray) -> xr.DataArray:
+    loaded_coords = {
+        key: coord.copy(deep=False).load() for key, coord in data.coords.items()
+    }
+    return data.copy(deep=False).assign_coords(loaded_coords)
+
+
+def _source_details_html(data: xr.DataArray) -> str:
+    try:
+        return erlab.utils.formatting.format_darr_html(
+            _source_data_with_loaded_coords(data),
+            show_size=True,
+            show_summary=False,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to load coordinates for Figure Composer source details",
+            exc_info=True,
+        )
+        return erlab.utils.formatting.format_darr_html(
+            data,
+            show_size=True,
+            show_summary=False,
+            load_values=False,
+        )
 
 
 class SourceInspectorWidget(QtWidgets.QWidget):
@@ -196,7 +225,6 @@ class SourceInspectorWidget(QtWidgets.QWidget):
         source_name: str | None,
         source_state: FigureSourceState | None,
         data: xr.DataArray | None,
-        operation_source_names: Sequence[str],
     ) -> None:
         self._source_name = source_name
         self.setProperty("figureComposerSourceAlias", source_name or "")
@@ -206,11 +234,8 @@ class SourceInspectorWidget(QtWidgets.QWidget):
             self.details_label.clear()
             self.details_button.setEnabled(False)
             self.setProperty("figureComposerSourceDims", ())
-            self.setProperty("figureComposerSourceUsedByStep", False)
             return
         self.title_label.setText(_source_display_label(source_state, source_name))
-        used_by_step = source_name in set(operation_source_names)
-        self.setProperty("figureComposerSourceUsedByStep", used_by_step)
         if data is None:
             self.subtitle_label.setText(f"Alias: {source_name}<br>Unavailable")
             self.details_label.clear()
@@ -227,12 +252,7 @@ class SourceInspectorWidget(QtWidgets.QWidget):
         )
         self.details_label.setText(
             erlab.interactive.utils._apply_qt_accent_color(
-                erlab.utils.formatting.format_darr_html(
-                    public.rename(None),
-                    show_size=True,
-                    show_summary=False,
-                    load_values=False,
-                )
+                _source_details_html(public.rename(None))
             )
         )
         self.details_button.setEnabled(True)

--- a/src/erlab/interactive/_figurecomposer/_sources.py
+++ b/src/erlab/interactive/_figurecomposer/_sources.py
@@ -20,18 +20,63 @@ from erlab.interactive._figurecomposer._state import (
     FigureOperationState,
     FigureSourceState,
     FigureSubplotsState,
+    _restore_slice_mapping,
 )
 
-_FIGURE_CODE_RESERVED_NAMES = frozenset(
+# Keep every binding emitted by Figure Composer code generation here. Source aliases
+# share the generated module namespace, so missing one can silently replace source data.
+_FIGURE_CODE_IMPORT_BINDINGS = frozenset(
     {
-        "axs",
+        "_erlab_stylesheets",
         "eplt",
-        "fig",
+        "erlab",
+        "mcolors",
+        "mtransforms",
         "np",
         "plt",
+        "sns",
         "xr",
         "xarray",
     }
+)
+_FIGURE_CODE_SETUP_BINDINGS = frozenset({"ax", "axs", "fig", "gs0"})
+_FIGURE_CODE_OPERATION_BINDINGS = frozenset(
+    {
+        "_",
+        "_line",
+        "avec",
+        "bvec",
+        "color",
+        "i",
+        "index",
+        "kz",
+        "kz_values",
+        "label",
+        "line_color_values",
+        "line_color_values_norm",
+        "line_color_values_vmax",
+        "line_color_values_vmin",
+        "line_colors",
+        "map_index",
+        "offset",
+        "plot_maps",
+        "profile",
+        "profile_data",
+        "profiles",
+        "scale",
+        "slice_index",
+        "slice_value",
+        "source",
+        "target_axes",
+    }
+)
+_FIGURE_CODE_RESERVED_NAMES = (
+    _FIGURE_CODE_IMPORT_BINDINGS
+    | _FIGURE_CODE_SETUP_BINDINGS
+    | _FIGURE_CODE_OPERATION_BINDINGS
+)
+_FIGURE_CODE_RESERVED_NAME_PATTERN = re.compile(
+    r"(?:ax\d+|gs\d+(?:_\d+)*|_line(?:_\d+)?)"
 )
 _CAMEL_CASE_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
 
@@ -54,7 +99,7 @@ def _source_alias_candidate(data: xr.DataArray) -> str | None:
 
 
 def _source_name(data: xr.DataArray) -> str:
-    return _source_alias_candidate(data) or "data"
+    return _source_unique_name(_source_alias_candidate(data) or "data", set())
 
 
 def _source_label(data: xr.DataArray) -> str:
@@ -89,18 +134,27 @@ def _source_alias_error(alias: str) -> str | None:
         _valid_source_variable(alias)
     except ValueError:
         return f"{alias!r} is not a valid Python variable name."
-    if alias == erlab.interactive.utils._SAVED_TOOL_DATA_NAME:
-        return "This alias is reserved for saved tool data."
-    if alias in _FIGURE_CODE_RESERVED_NAMES:
-        return f"{alias!r} is reserved for generated figure code."
+    if (
+        alias in _FIGURE_CODE_RESERVED_NAMES
+        or _FIGURE_CODE_RESERVED_NAME_PATTERN.fullmatch(alias) is not None
+    ):
+        return (
+            f"{alias!r} is used internally by generated Figure Composer code. "
+            "Choose a different source alias."
+        )
     return None
 
 
 def _source_unique_name(source_name: str, reserved: set[str]) -> str:
-    alias = source_name
+    base = (
+        f"{source_name}_source"
+        if _FIGURE_CODE_RESERVED_NAME_PATTERN.fullmatch(source_name) is not None
+        else source_name
+    )
+    alias = base
     suffix = 2
     while _source_alias_error(alias) is not None or alias in reserved:
-        alias = f"{source_name}_{suffix}"
+        alias = f"{base}_{suffix}"
         suffix += 1
     reserved.add(alias)
     return alias
@@ -134,7 +188,7 @@ def _selected_data(
     if selection.isel:
         selected = selected.isel(_decode_indexers(selection.isel))
     if selection.qsel:
-        selected = selected.qsel(selection.qsel)
+        selected = selected.qsel(_decode_indexers(selection.qsel))
     if selection.mean_dims:
         mean_arg: str | tuple[str, ...]
         if len(selection.mean_dims) == 1:
@@ -239,11 +293,5 @@ def _default_setup_for_data(data: xr.DataArray) -> FigureSubplotsState:
     return FigureSubplotsState(nrows=1, ncols=1)
 
 
-def _decode_indexer(value: typing.Any) -> typing.Any:
-    if isinstance(value, dict) and value.get("kind") == "slice":
-        return slice(value.get("start"), value.get("stop"), value.get("step"))
-    return value
-
-
 def _decode_indexers(indexers: Mapping[str, typing.Any]) -> dict[str, typing.Any]:
-    return {key: _decode_indexer(value) for key, value in indexers.items()}
+    return _restore_slice_mapping(indexers, allow_legacy=True)

--- a/src/erlab/interactive/_figurecomposer/_sources.py
+++ b/src/erlab/interactive/_figurecomposer/_sources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import keyword
 import typing
 
 if typing.TYPE_CHECKING:
@@ -36,34 +37,18 @@ def _source_label(data: xr.DataArray) -> str:
 def _source_display_label(
     source: FigureSourceState | None, name: str, *, disambiguate: bool = False
 ) -> str:
-    """Return the user-facing source label for a recipe source alias."""
-    label = name if source is None else source.label.strip() or name
-    if source is not None and disambiguate and label != name:
-        return f"{label} ({name})"
-    return label
-
-
-def _source_duplicate_labels(
-    sources: Sequence[FigureSourceState],
-) -> frozenset[str]:
-    counts: dict[str, int] = {}
-    for source in sources:
-        label = source.label.strip() or source.name
-        counts[label] = counts.get(label, 0) + 1
-    return frozenset(label for label, count in counts.items() if count > 1)
+    """Return the user-facing source alias."""
+    del source, disambiguate
+    return name
 
 
 def _source_display_tooltip(source: FigureSourceState | None, name: str) -> str:
-    if source is None:
-        return f"Alias: {name}"
-    label = source.label.strip() or name
-    if label == name:
-        return f"Alias: {name}"
-    return f"{label}\nAlias: {name}"
+    del source
+    return f"Alias: {name}"
 
 
 def _valid_source_variable(name: str) -> str:
-    if not name.isidentifier():
+    if not name.isidentifier() or keyword.iskeyword(name):
         raise ValueError(f"Figure source name {name!r} is not a valid variable name")
     return name
 
@@ -104,6 +89,44 @@ def _selected_data(
         else:
             mean_arg = selection.mean_dims
         selected = selected.qsel.mean(mean_arg)
+    return selected
+
+
+def _source_selection(source: FigureSourceState) -> FigureDataSelectionState:
+    return FigureDataSelectionState(
+        source=source.name,
+        isel=dict(source.isel),
+        qsel=dict(source.qsel),
+        mean_dims=tuple(source.mean_dims),
+    )
+
+
+def _source_has_selection(source: FigureSourceState) -> bool:
+    return bool(source.isel or source.qsel or source.mean_dims)
+
+
+def _source_with_selection(
+    source: FigureSourceState, selection: FigureDataSelectionState
+) -> FigureSourceState:
+    has_selection = bool(selection.isel or selection.qsel or selection.mean_dims)
+    return source.model_copy(
+        update={
+            "isel": dict(selection.isel),
+            "qsel": dict(selection.qsel),
+            "mean_dims": tuple(selection.mean_dims),
+            "selection_source": (
+                (source.selection_source or source.name) if has_selection else None
+            ),
+        }
+    )
+
+
+def _selected_source_data(
+    data: xr.DataArray, source: FigureSourceState
+) -> xr.DataArray:
+    selected = _selected_data({source.name: data}, _source_selection(source))
+    if selected is None:  # pragma: no cover
+        raise KeyError(source.name)
     return selected
 
 

--- a/src/erlab/interactive/_figurecomposer/_sources.py
+++ b/src/erlab/interactive/_figurecomposer/_sources.py
@@ -225,14 +225,15 @@ def _source_with_selection(
     source: FigureSourceState, selection: FigureDataSelectionState
 ) -> FigureSourceState:
     has_selection = bool(selection.isel or selection.qsel or selection.mean_dims)
+    selection_source = source.selection_source
+    if selection_source == source.name:
+        selection_source = None
     return source.model_copy(
         update={
             "isel": dict(selection.isel),
             "qsel": dict(selection.qsel),
             "mean_dims": tuple(selection.mean_dims),
-            "selection_source": (
-                (source.selection_source or source.name) if has_selection else None
-            ),
+            "selection_source": selection_source if has_selection else None,
         }
     )
 

--- a/src/erlab/interactive/_figurecomposer/_sources.py
+++ b/src/erlab/interactive/_figurecomposer/_sources.py
@@ -70,10 +70,14 @@ _FIGURE_CODE_OPERATION_BINDINGS = frozenset(
         "target_axes",
     }
 )
+_FIGURE_CODE_BUILTIN_BINDINGS = frozenset(
+    {"enumerate", "float", "len", "list", "max", "min", "range", "zip"}
+)
 _FIGURE_CODE_RESERVED_NAMES = (
     _FIGURE_CODE_IMPORT_BINDINGS
     | _FIGURE_CODE_SETUP_BINDINGS
     | _FIGURE_CODE_OPERATION_BINDINGS
+    | _FIGURE_CODE_BUILTIN_BINDINGS
 )
 _FIGURE_CODE_RESERVED_NAME_PATTERN = re.compile(
     r"(?:ax\d+|gs\d+(?:_\d+)*|_line(?:_\d+)?)"
@@ -138,6 +142,11 @@ def _source_alias_error(alias: str) -> str | None:
         alias in _FIGURE_CODE_RESERVED_NAMES
         or _FIGURE_CODE_RESERVED_NAME_PATTERN.fullmatch(alias) is not None
     ):
+        if alias in _FIGURE_CODE_BUILTIN_BINDINGS:
+            return (
+                f"{alias!r} is a Python builtin used by generated Figure Composer "
+                "code. Choose a different source alias."
+            )
         return (
             f"{alias!r} is used internally by generated Figure Composer code. "
             "Choose a different source alias."

--- a/src/erlab/interactive/_figurecomposer/_sources.py
+++ b/src/erlab/interactive/_figurecomposer/_sources.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-import keyword
+import re
 import typing
 
 if typing.TYPE_CHECKING:
@@ -12,6 +12,7 @@ if typing.TYPE_CHECKING:
     import xarray as xr
 
 import erlab.interactive.imagetool.slicer
+import erlab.interactive.utils
 from erlab.interactive._figurecomposer._axes import _all_axes
 from erlab.interactive._figurecomposer._state import (
     FigureAxesSelectionState,
@@ -21,11 +22,39 @@ from erlab.interactive._figurecomposer._state import (
     FigureSubplotsState,
 )
 
+_FIGURE_CODE_RESERVED_NAMES = frozenset(
+    {
+        "axs",
+        "eplt",
+        "fig",
+        "np",
+        "plt",
+        "xr",
+        "xarray",
+    }
+)
+_CAMEL_CASE_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
+def _source_alias_candidate(data: xr.DataArray) -> str | None:
+    if data.name is None:
+        return None
+    text = str(data.name).strip()
+    if not text:
+        return None
+    if erlab.interactive.utils._is_kwarg_name(text):
+        return text
+    if not any(character.isalnum() for character in text):
+        return None
+    snake_text = _CAMEL_CASE_BOUNDARY.sub("_", text).lower()
+    alias = erlab.interactive.utils.IdentifierValidator().fixup(snake_text)
+    if not erlab.interactive.utils._is_kwarg_name(alias):
+        return None
+    return alias
+
 
 def _source_name(data: xr.DataArray) -> str:
-    if isinstance(data.name, str) and data.name.isidentifier():
-        return data.name
-    return "data"
+    return _source_alias_candidate(data) or "data"
 
 
 def _source_label(data: xr.DataArray) -> str:
@@ -48,9 +77,33 @@ def _source_display_tooltip(source: FigureSourceState | None, name: str) -> str:
 
 
 def _valid_source_variable(name: str) -> str:
-    if not name.isidentifier() or keyword.iskeyword(name):
+    if not erlab.interactive.utils._is_kwarg_name(name):
         raise ValueError(f"Figure source name {name!r} is not a valid variable name")
     return name
+
+
+def _source_alias_error(alias: str) -> str | None:
+    if not alias:
+        return "Source alias must not be empty."
+    try:
+        _valid_source_variable(alias)
+    except ValueError:
+        return f"{alias!r} is not a valid Python variable name."
+    if alias == erlab.interactive.utils._SAVED_TOOL_DATA_NAME:
+        return "This alias is reserved for saved tool data."
+    if alias in _FIGURE_CODE_RESERVED_NAMES:
+        return f"{alias!r} is reserved for generated figure code."
+    return None
+
+
+def _source_unique_name(source_name: str, reserved: set[str]) -> str:
+    alias = source_name
+    suffix = 2
+    while _source_alias_error(alias) is not None or alias in reserved:
+        alias = f"{source_name}_{suffix}"
+        suffix += 1
+    reserved.add(alias)
+    return alias
 
 
 def _public_source_data(data: xr.DataArray) -> xr.DataArray:

--- a/src/erlab/interactive/_figurecomposer/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_state.py
@@ -189,12 +189,16 @@ class FigureSourceState(pydantic.BaseModel):
 
     @pydantic.model_validator(mode="before")
     @classmethod
-    def _default_label_from_name(cls, value: typing.Any) -> typing.Any:
-        if isinstance(value, Mapping) and (
-            "label" not in value or value.get("label") is None
-        ):
+    def _normalize_source_defaults(cls, value: typing.Any) -> typing.Any:
+        if not isinstance(value, Mapping):
+            return value
+        if "label" not in value or value.get("label") is None:
             value = dict(value)
             value["label"] = value.get("name")
+        if value.get("selection_source") == value.get("name"):
+            if not isinstance(value, dict):
+                value = dict(value)
+            value["selection_source"] = None
         return value
 
     @pydantic.field_validator("isel", "qsel", mode="before")

--- a/src/erlab/interactive/_figurecomposer/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_state.py
@@ -168,10 +168,19 @@ class FigureSourceState(pydantic.BaseModel):
     """A named data source used by a figure recipe."""
 
     name: str
-    isel: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
-    qsel: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
-    mean_dims: tuple[str, ...] = ()
-    selection_source: str | None = None
+    label: str = ""
+    isel: dict[str, typing.Any] = pydantic.Field(
+        default_factory=dict, exclude_if=lambda value: not value
+    )
+    qsel: dict[str, typing.Any] = pydantic.Field(
+        default_factory=dict, exclude_if=lambda value: not value
+    )
+    mean_dims: tuple[str, ...] = pydantic.Field(
+        default=(), exclude_if=lambda value: not value
+    )
+    selection_source: str | None = pydantic.Field(
+        default=None, exclude_if=lambda value: value is None
+    )
     node_uid: str | None = None
     node_snapshot_token: str | None = None
     provenance_spec: dict[str, typing.Any] | None = None
@@ -180,10 +189,12 @@ class FigureSourceState(pydantic.BaseModel):
 
     @pydantic.model_validator(mode="before")
     @classmethod
-    def _drop_legacy_label(cls, value: typing.Any) -> typing.Any:
-        if isinstance(value, Mapping) and "label" in value:
+    def _default_label_from_name(cls, value: typing.Any) -> typing.Any:
+        if isinstance(value, Mapping) and (
+            "label" not in value or value.get("label") is None
+        ):
             value = dict(value)
-            value.pop("label", None)
+            value["label"] = value.get("name")
         return value
 
     @pydantic.field_validator("isel", "qsel", mode="before")
@@ -203,6 +214,7 @@ class FigureSourceState(pydantic.BaseModel):
     ) -> FigureSourceState:
         return cls(
             name=script_input.name,
+            label=script_input.label,
             node_uid=script_input.node_uid,
             node_snapshot_token=script_input.node_snapshot_token,
             provenance_spec=script_input.provenance_spec,
@@ -213,6 +225,7 @@ class FigureSourceState(pydantic.BaseModel):
             return None
         return provenance.ScriptInput(
             name=self.name,
+            label=self.label,
             node_uid=self.node_uid,
             node_snapshot_token=self.node_snapshot_token,
             provenance_spec=self.provenance_spec,

--- a/src/erlab/interactive/_figurecomposer/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_state.py
@@ -99,6 +99,71 @@ class FigureGridSpecLayoutState(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="forbid")
 
 
+_SLICE_MARKER_KEY = "__erlab_figure_composer_slice__"
+_LEGACY_SLICE_INDEXER_KIND = "slice"
+_LEGACY_SLICE_INDEXER_KEYS = frozenset(("kind", "start", "stop", "step"))
+
+
+def _jsonable_slice_value(value: typing.Any) -> typing.Any:
+    if isinstance(value, slice):
+        return {_SLICE_MARKER_KEY: [value.start, value.stop, value.step]}
+    if isinstance(value, Mapping):
+        return {key: _jsonable_slice_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return tuple(_jsonable_slice_value(item) for item in value)
+    if isinstance(value, list):
+        return [_jsonable_slice_value(item) for item in value]
+    return value
+
+
+def _jsonable_slice_mapping(value: Mapping[str, typing.Any]) -> dict[str, typing.Any]:
+    return {key: _jsonable_slice_value(item) for key, item in value.items()}
+
+
+def _is_legacy_slice_indexer_marker(
+    value: Mapping[typing.Any, typing.Any],
+) -> bool:
+    return value.get("kind") == _LEGACY_SLICE_INDEXER_KIND and set(value).issubset(
+        _LEGACY_SLICE_INDEXER_KEYS
+    )
+
+
+def _restore_slice_value(
+    value: typing.Any, *, allow_legacy: bool = False
+) -> typing.Any:
+    if isinstance(value, Mapping):
+        if set(value) == {_SLICE_MARKER_KEY}:
+            parts = value[_SLICE_MARKER_KEY]
+            if isinstance(parts, list | tuple) and len(parts) == 3:
+                return slice(*parts)
+        if allow_legacy and _is_legacy_slice_indexer_marker(value):
+            return slice(value.get("start"), value.get("stop"), value.get("step"))
+        return {
+            key: _restore_slice_value(item, allow_legacy=allow_legacy)
+            for key, item in value.items()
+        }
+    if isinstance(value, tuple):
+        return tuple(
+            _restore_slice_value(item, allow_legacy=allow_legacy) for item in value
+        )
+    if isinstance(value, list):
+        return [_restore_slice_value(item, allow_legacy=allow_legacy) for item in value]
+    return value
+
+
+def _restore_slice_mapping(
+    value: typing.Any, *, allow_legacy: bool = False
+) -> typing.Any:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return {
+            str(key): _restore_slice_value(item, allow_legacy=allow_legacy)
+            for key, item in value.items()
+        }
+    return value
+
+
 class FigureSourceState(pydantic.BaseModel):
     """A named data source used by a figure recipe."""
 
@@ -120,6 +185,17 @@ class FigureSourceState(pydantic.BaseModel):
             value = dict(value)
             value.pop("label", None)
         return value
+
+    @pydantic.field_validator("isel", "qsel", mode="before")
+    @classmethod
+    def _restore_slice_indexers(cls, value: typing.Any) -> typing.Any:
+        return _restore_slice_mapping(value, allow_legacy=True)
+
+    @pydantic.field_serializer("isel", "qsel", when_used="json")
+    def _serialize_slice_indexers(
+        self, value: dict[str, typing.Any]
+    ) -> dict[str, typing.Any]:
+        return _jsonable_slice_mapping(value)
 
     @classmethod
     def from_script_input(
@@ -295,6 +371,17 @@ class FigureDataSelectionState(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(extra="forbid")
 
+    @pydantic.field_validator("isel", "qsel", mode="before")
+    @classmethod
+    def _restore_slice_indexers(cls, value: typing.Any) -> typing.Any:
+        return _restore_slice_mapping(value, allow_legacy=True)
+
+    @pydantic.field_serializer("isel", "qsel", when_used="json")
+    def _serialize_slice_indexers(
+        self, value: dict[str, typing.Any]
+    ) -> dict[str, typing.Any]:
+        return _jsonable_slice_mapping(value)
+
 
 class FigureMethodPlotValueState(pydantic.BaseModel):
     """Source-backed value selected for an ``ax.plot`` method step."""
@@ -323,6 +410,17 @@ class FigurePlotSlicesPanelStyleState(pydantic.BaseModel):
     line_kw: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
 
     model_config = pydantic.ConfigDict(extra="forbid")
+
+    @pydantic.field_validator("norm_kwargs", "line_kw", mode="before")
+    @classmethod
+    def _restore_slice_kwargs(cls, value: typing.Any) -> typing.Any:
+        return _restore_slice_mapping(value)
+
+    @pydantic.field_serializer("norm_kwargs", "line_kw", when_used="json")
+    def _serialize_slice_kwargs(
+        self, value: dict[str, typing.Any]
+    ) -> dict[str, typing.Any]:
+        return _jsonable_slice_mapping(value)
 
 
 class FigureOperationState(pydantic.BaseModel):
@@ -463,6 +561,62 @@ class FigureOperationState(pydantic.BaseModel):
     trusted: bool = False
 
     model_config = pydantic.ConfigDict(extra="forbid")
+
+    @pydantic.field_validator(
+        "norm_kwargs",
+        "slice_kwargs",
+        "extra_kwargs",
+        "line_kw",
+        "bz_vertex_kw",
+        "bz_midpoint_kw",
+        "legend_kw",
+        "method_kwargs",
+        "gradient_kw",
+        "subplot_kw",
+        "annotate_kw",
+        "colorbar_kw",
+        mode="before",
+    )
+    @classmethod
+    def _restore_slice_kwargs(cls, value: typing.Any) -> typing.Any:
+        return _restore_slice_mapping(value)
+
+    @pydantic.field_validator("line_selection", mode="before")
+    @classmethod
+    def _restore_line_selection(cls, value: typing.Any) -> typing.Any:
+        return _restore_slice_mapping(value, allow_legacy=True)
+
+    @pydantic.field_validator("method_args", mode="before")
+    @classmethod
+    def _restore_slice_args(cls, value: typing.Any) -> typing.Any:
+        return _restore_slice_value(value)
+
+    @pydantic.field_serializer(
+        "norm_kwargs",
+        "slice_kwargs",
+        "extra_kwargs",
+        "line_kw",
+        "line_selection",
+        "bz_vertex_kw",
+        "bz_midpoint_kw",
+        "legend_kw",
+        "method_kwargs",
+        "gradient_kw",
+        "subplot_kw",
+        "annotate_kw",
+        "colorbar_kw",
+        when_used="json",
+    )
+    def _serialize_slice_kwargs(
+        self, value: dict[str, typing.Any]
+    ) -> dict[str, typing.Any]:
+        return _jsonable_slice_mapping(value)
+
+    @pydantic.field_serializer("method_args", when_used="json")
+    def _serialize_slice_args(
+        self, value: tuple[typing.Any, ...]
+    ) -> tuple[typing.Any, ...]:
+        return typing.cast("tuple[typing.Any, ...]", _jsonable_slice_value(value))
 
     @classmethod
     def set_palette(cls, *, label: str = "set palette") -> FigureOperationState:

--- a/src/erlab/interactive/_figurecomposer/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import enum
 import typing
 import uuid
+from collections.abc import Mapping
 
 import pydantic
 
@@ -19,7 +20,7 @@ from erlab.interactive._figurecomposer._defaults import (
 from erlab.interactive.imagetool import provenance
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 
 
 class FigureGridSpecSpanState(pydantic.BaseModel):
@@ -102,12 +103,23 @@ class FigureSourceState(pydantic.BaseModel):
     """A named data source used by a figure recipe."""
 
     name: str
-    label: str
+    isel: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    qsel: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    mean_dims: tuple[str, ...] = ()
+    selection_source: str | None = None
     node_uid: str | None = None
     node_snapshot_token: str | None = None
     provenance_spec: dict[str, typing.Any] | None = None
 
     model_config = pydantic.ConfigDict(extra="forbid")
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _drop_legacy_label(cls, value: typing.Any) -> typing.Any:
+        if isinstance(value, Mapping) and "label" in value:
+            value = dict(value)
+            value.pop("label", None)
+        return value
 
     @classmethod
     def from_script_input(
@@ -115,7 +127,6 @@ class FigureSourceState(pydantic.BaseModel):
     ) -> FigureSourceState:
         return cls(
             name=script_input.name,
-            label=script_input.label,
             node_uid=script_input.node_uid,
             node_snapshot_token=script_input.node_snapshot_token,
             provenance_spec=script_input.provenance_spec,
@@ -126,7 +137,6 @@ class FigureSourceState(pydantic.BaseModel):
             return None
         return provenance.ScriptInput(
             name=self.name,
-            label=self.label,
             node_uid=self.node_uid,
             node_snapshot_token=self.node_snapshot_token,
             provenance_spec=self.provenance_spec,
@@ -334,7 +344,11 @@ class FigureOperationState(pydantic.BaseModel):
     palette_color_codes: bool = False
 
     sources: tuple[str, ...] = ()
-    map_selections: tuple[FigureDataSelectionState, ...] = ()
+    # Legacy load-only source selections. Live recipes normalize these into
+    # source-level selections before user-visible editing or saving.
+    map_selections: tuple[FigureDataSelectionState, ...] = pydantic.Field(
+        default=(), exclude=True
+    )
     slice_dim: str | None = None
     slice_values_mode: typing.Literal["manual", "all"] = "manual"
     slice_values: tuple[float, ...] = ()

--- a/src/erlab/interactive/_figurecomposer/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_state.py
@@ -455,10 +455,11 @@ class FigureOperationState(pydantic.BaseModel):
     palette_color_codes: bool = False
 
     sources: tuple[str, ...] = ()
-    # Legacy load-only source selections. Live recipes normalize these into
-    # source-level selections before user-visible editing or saving.
+    # Legacy source selections. Live recipes normalize the usual single-selection
+    # form into source-level selections; the multi-profile Line compatibility form
+    # remains nonempty so it can round-trip without losing cursor multiplicity.
     map_selections: tuple[FigureDataSelectionState, ...] = pydantic.Field(
-        default=(), exclude=True
+        default=(), exclude_if=lambda value: not value
     )
     slice_dim: str | None = None
     slice_values_mode: typing.Literal["manual", "all"] = "manual"

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -116,17 +116,19 @@ from erlab.interactive._figurecomposer._source_inspector import (
     source_metadata_tooltip,
 )
 from erlab.interactive._figurecomposer._sources import (
+    _FIGURE_CODE_RESERVED_NAMES,
     _default_plot_operation,
     _default_setup_for_data,
     _public_source_data,
     _selected_data,
     _selected_source_data,
+    _source_alias_error,
     _source_display_label,
     _source_has_selection,
     _source_name,
     _source_selection,
+    _source_unique_name,
     _source_with_selection,
-    _valid_source_variable,
 )
 from erlab.interactive._figurecomposer._state import (
     FigureAxesSelectionState,
@@ -197,17 +199,6 @@ _SOURCE_LIST_ACTION_COLUMN = 2
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
-_FIGURE_CODE_RESERVED_NAMES = frozenset(
-    {
-        "axs",
-        "eplt",
-        "fig",
-        "np",
-        "plt",
-        "xr",
-        "xarray",
-    }
-)
 logger = logging.getLogger(__name__)
 
 
@@ -2191,6 +2182,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             [display, "missing" if data is None else "", ""]
         )
         item.setData(_SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole, name)
+        tooltip = self._source_tooltip(name)
+        item.setToolTip(_SOURCE_LIST_SOURCE_COLUMN, tooltip)
+        item.setToolTip(_SOURCE_LIST_SHAPE_COLUMN, tooltip)
         item.setFlags(
             QtCore.Qt.ItemFlag.ItemIsEnabled
             | QtCore.Qt.ItemFlag.ItemIsSelectable
@@ -2562,16 +2556,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _source_alias_error(
         self, alias: str, *, current: str | None = None
     ) -> str | None:
-        if not alias:
-            return "Source alias must not be empty."
-        try:
-            _valid_source_variable(alias)
-        except ValueError:
-            return f"{alias!r} is not a valid Python variable name."
-        if alias == erlab.interactive.utils._SAVED_TOOL_DATA_NAME:
-            return "This alias is reserved for saved tool data."
-        if alias in _FIGURE_CODE_RESERVED_NAMES:
-            return f"{alias!r} is reserved for generated figure code."
+        if error := _source_alias_error(alias):
+            return error
         if alias != current and (
             alias in {source.name for source in self._recipe.sources}
             or alias in self._source_data
@@ -2580,6 +2566,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return None
 
     def _source_unique_alias(self, source_name: str, reserved: set[str]) -> str:
+        return _source_unique_name(source_name, reserved)
+
+    def _source_copy_alias(self, source_name: str, reserved: set[str]) -> str:
         stem = f"{source_name}_copy"
         alias = stem
         suffix = 2
@@ -2701,7 +2690,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         duplicated_names: set[str] = set()
         for index in indices:
             source = sources[index]
-            alias = self._source_unique_alias(source.name, reserved)
+            alias = self._source_copy_alias(source.name, reserved)
             duplicates.append(source.model_copy(update={"name": alias}))
             duplicated_names.add(alias)
             if source.name in self._source_data:

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -654,7 +654,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._source_drop_callback: Callable[[QtCore.QMimeData], bool] | None = None
         self._source_inspector_target: str | None = None
         self._updating_source_selection = False
-        self._recipe = recipe or self._default_recipe(data)
+        initial_recipe = recipe or self._default_recipe(data)
+        self._recipe = initial_recipe.model_copy(
+            update={"sources": self._normalized_source_states(initial_recipe.sources)}
+        )
         self._active_gridspec_grid_id = self._recipe.setup.gridspec.root.grid_id
         self._gridspec_breadcrumb_buttons: list[QtWidgets.QToolButton] = []
         self._figure_window: _FigureComposerDisplayWindow | None = None
@@ -2816,12 +2819,36 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     @staticmethod
     def _source_with_name(source: FigureSourceState, name: str) -> FigureSourceState:
-        if source.name == name:
+        selection_source = source.selection_source
+        if selection_source == source.name:
+            selection_source = None
+        if source.name == name and selection_source == source.selection_source:
             return source
-        updates = {"name": name}
+        updates: dict[str, typing.Any] = {
+            "name": name,
+            "selection_source": selection_source,
+        }
         if source.label == source.name:
             updates["label"] = name
         return source.model_copy(update=updates)
+
+    @classmethod
+    def _source_with_renamed_references(
+        cls,
+        source: FigureSourceState,
+        rename_map: Mapping[str, str],
+    ) -> FigureSourceState:
+        """Rename one source and every explicit parent reference atomically."""
+        old_name = source.name
+        renamed = cls._source_with_name(source, rename_map.get(old_name, old_name))
+        parent_name = source.selection_source
+        if parent_name == old_name:
+            parent_name = None
+        elif parent_name is not None:
+            parent_name = rename_map.get(parent_name, parent_name)
+        if renamed.selection_source == parent_name:
+            return renamed
+        return renamed.model_copy(update={"selection_source": parent_name})
 
     def _source_unique_alias(self, source_name: str, reserved: set[str]) -> str:
         return _source_unique_name(source_name, reserved)
@@ -2897,13 +2924,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         sources: list[FigureSourceState] = []
         changed = False
         for source in self._recipe.sources:
-            updated_source = source
-            if source.name == old_name:
-                updated_source = self._source_with_name(source, new_name)
-            if source.selection_source == old_name:
-                updated_source = updated_source.model_copy(
-                    update={"selection_source": new_name}
-                )
+            updated_source = self._source_with_renamed_references(source, rename_map)
             if updated_source is not source:
                 changed = True
                 sources.append(updated_source)
@@ -3651,6 +3672,89 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if data is not None:
                 return data
         return self._source_data.get(source_name)
+
+    @staticmethod
+    def _source_lineage_names(
+        source_name: str,
+        source_by_name: Mapping[str, FigureSourceState],
+    ) -> tuple[str, ...]:
+        """Return one source lineage from its available root to the requested leaf."""
+        lineage: list[str] = []
+        seen: set[str] = set()
+        current_name = source_name
+        while True:
+            if current_name in seen:
+                raise ValueError(
+                    f"source selection dependency cycle includes {current_name!r}"
+                )
+            seen.add(current_name)
+            lineage.append(current_name)
+            current = source_by_name.get(current_name)
+            if current is None or current.selection_source is None:
+                break
+            parent_name = current.selection_source
+            if parent_name not in source_by_name:
+                break
+            current_name = parent_name
+        lineage.reverse()
+        return tuple(lineage)
+
+    @staticmethod
+    def _source_states_with_propagated_link_metadata(
+        source_by_name: Mapping[str, FigureSourceState],
+        changed_names: Iterable[str],
+    ) -> dict[str, FigureSourceState]:
+        """Propagate origin-link metadata through every selected descendant."""
+        sources = dict(source_by_name)
+        queue: collections.deque[str] = collections.deque(changed_names)
+        visited = set(queue)
+        while queue:
+            parent_name = queue.popleft()
+            parent = sources.get(parent_name)
+            if parent is None:
+                continue
+            for source_name, source in tuple(sources.items()):
+                if (
+                    source_name in visited
+                    or source.selection_source != parent_name
+                    or source_name == parent_name
+                ):
+                    continue
+                updates = {
+                    field: getattr(parent, field)
+                    for field in (
+                        "node_uid",
+                        "node_snapshot_token",
+                        "provenance_spec",
+                    )
+                    if getattr(source, field) != getattr(parent, field)
+                }
+                if updates:
+                    source = source.model_copy(update=updates)
+                    sources[source_name] = source
+                visited.add(source_name)
+                queue.append(source_name)
+        return sources
+
+    @classmethod
+    def _normalized_source_states(
+        cls, sources: Sequence[FigureSourceState]
+    ) -> tuple[FigureSourceState, ...]:
+        """Return source states satisfying the canonical selection graph invariants."""
+        canonical = tuple(
+            cls._source_with_name(source, source.name) for source in sources
+        )
+        source_by_name = {source.name: source for source in canonical}
+        roots = tuple(
+            source.name
+            for source in canonical
+            if source.selection_source is None
+            or source.selection_source not in source_by_name
+        )
+        propagated = cls._source_states_with_propagated_link_metadata(
+            source_by_name, roots
+        )
+        return tuple(propagated[source.name] for source in canonical)
 
     def _source_data_with_recomputed_dependents(
         self,
@@ -6333,15 +6437,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         renamed_source_data: dict[str, xr.DataArray] = {}
         for source in unique_sources:
             pasted_name = rename_map[source.name]
-            renamed_source = self._source_with_name(source, pasted_name)
-            if source.selection_source is not None:
-                renamed_source = renamed_source.model_copy(
-                    update={
-                        "selection_source": rename_map.get(
-                            source.selection_source, source.selection_source
-                        )
-                    }
-                )
+            renamed_source = self._source_with_renamed_references(source, rename_map)
             if pasted_name not in existing_source_names:
                 renamed_sources.append(renamed_source)
                 existing_source_names.add(pasted_name)
@@ -6760,8 +6856,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         keep_selection_source: bool,
     ) -> tuple[FigureSourceState, xr.DataArray]:
         replacement = self._source_with_name(source, alias)
-        if source.selection_source == source.name:
-            replacement = replacement.model_copy(update={"selection_source": alias})
         if (
             existing_source is not None
             and _source_has_selection(existing_source)
@@ -6773,7 +6867,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                         "selection_source": (
                             existing_source.selection_source
                             if keep_selection_source
-                            else alias
+                            else None
                         )
                     }
                 ),
@@ -7708,7 +7802,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             _registry.spec_for(operation.kind).loaded_operation(operation)
             for operation in status.operations
         )
-        self._recipe = status.model_copy(update={"operations": operations})
+        sources = self._normalized_source_states(status.sources)
+        self._recipe = status.model_copy(
+            update={"sources": sources, "operations": operations}
+        )
         self._ensure_primary_source_data()
         self._normalize_operation_source_selections()
         self._apply_recipe_to_controls()

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -86,6 +86,7 @@ from erlab.interactive._figurecomposer._operations._base import (
     StepSection,
 )
 from erlab.interactive._figurecomposer._operations._custom_code import (
+    _custom_code_bound_names,
     _custom_code_names,
     _renamed_source_loads,
 )
@@ -8410,6 +8411,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             enabled_only=True, executable_only=True
         )
         used_code_names = set(_FIGURE_CODE_RESERVED_NAMES)
+        used_code_names.update(
+            bound_name
+            for operation in self._recipe.operations
+            if operation.enabled
+            and operation.kind == FigureOperationKind.CUSTOM
+            and operation.trusted
+            for bound_name in _custom_code_bound_names(operation.code)
+        )
         if self._recipe.setup.layout_mode == "gridspec":
             source_names = self._source_names()
             used_code_names.update(

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -3659,6 +3659,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
 
         if len(operation.map_selections) != 1:
+            # A legacy Line/Profile step can contain one picked profile per cursor.
+            # Keep that compatibility representation intact so rendering, styling,
+            # offsets, and placement still see every profile in cursor order.
+            if operation.kind == FigureOperationKind.LINE:
+                return operation
             return self._operation_without_map_selections(operation, None)
 
         selection = operation.map_selections[0]

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -86,6 +86,7 @@ from erlab.interactive._figurecomposer._operations._base import (
     StepSection,
 )
 from erlab.interactive._figurecomposer._operations._custom_code import (
+    _custom_code_names,
     _renamed_source_loads,
 )
 from erlab.interactive._figurecomposer._operations._plot_slices import (
@@ -231,11 +232,15 @@ class _FigureComposerStepMimeData(QtCore.QMimeData):
         payload_text: str,
         step_code_text: str,
         source_data: Mapping[str, xr.DataArray],
+        selection_base_data: Mapping[str, xr.DataArray],
         *,
         cut_source_tool_id: str | None = None,
     ) -> None:
         super().__init__()
         self.figure_composer_source_data: dict[str, xr.DataArray] = dict(source_data)
+        self.figure_composer_selection_base_data: dict[str, xr.DataArray] = dict(
+            selection_base_data
+        )
         self.figure_composer_cut_source_tool_id = cut_source_tool_id
         self.setData(_STEPS_CLIPBOARD_MIME, payload_text.encode("utf-8"))
         self.setText(step_code_text)
@@ -507,6 +512,7 @@ def _step_clipboard_payload(
         tuple[FigureOperationState, ...],
         tuple[FigureSourceState, ...],
         dict[str, xr.DataArray],
+        dict[str, xr.DataArray],
     ]
     | None
 ):
@@ -547,7 +553,10 @@ def _step_clipboard_payload(
     source_data = getattr(mime, "figure_composer_source_data", {})
     if not isinstance(source_data, dict):
         source_data = {}
-    return operations, sources, dict(source_data)
+    selection_base_data = getattr(mime, "figure_composer_selection_base_data", {})
+    if not isinstance(selection_base_data, dict):
+        selection_base_data = {}
+    return operations, sources, dict(source_data), dict(selection_base_data)
 
 
 def _target_axes_count_text(count: int) -> str:
@@ -614,7 +623,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._flush_pending_figure_resize_history_write
         )
         self._figure_resize_history_state: FigureRecipeState | None = None
-        self._figure_resize_history_source_data: dict[str, xr.DataArray] | None = None
+        self._figure_resize_history_source_data: (
+            tuple[dict[str, xr.DataArray], dict[str, xr.DataArray]] | None
+        ) = None
         self._preview_pixmap_cache: QtGui.QPixmap | None = None
         self._preview_pixmap_generation = 0
         self._preview_thumbnail_cache: dict[
@@ -652,12 +663,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._source_context_menu: QtWidgets.QMenu | None = None
         self._connected_step_clipboard: QtGui.QClipboard | None = None
         self._step_clipboard_tool_id = uuid.uuid4().hex
-        self._prev_source_data_states: collections.deque[dict[str, xr.DataArray]] = (
-            collections.deque(maxlen=self._prev_states.maxlen)
-        )
-        self._next_source_data_states: collections.deque[dict[str, xr.DataArray]] = (
-            collections.deque(maxlen=self._next_states.maxlen)
-        )
+        self._prev_source_data_states: collections.deque[
+            tuple[dict[str, xr.DataArray], dict[str, xr.DataArray]]
+        ] = collections.deque(maxlen=self._prev_states.maxlen)
+        self._next_source_data_states: collections.deque[
+            tuple[dict[str, xr.DataArray], dict[str, xr.DataArray]]
+        ] = collections.deque(maxlen=self._next_states.maxlen)
 
         if source_data is not None:
             self.set_source_data(source_data)
@@ -2687,15 +2698,69 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._refresh_source_controls()
         self._refresh_source_detail_panel()
 
+    def _operation_source_names(
+        self, operation: FigureOperationState
+    ) -> tuple[str, ...]:
+        names = list(_registry.spec_for(operation.kind).source_names(operation))
+        if operation.kind == FigureOperationKind.CUSTOM:
+            loaded_names = _custom_code_names(operation.code)
+            names.extend(
+                source_name
+                for source_name in self._source_names()
+                if source_name in loaded_names
+            )
+        return tuple(dict.fromkeys(names))
+
+    def _source_dependency_names(self, names: Iterable[str]) -> tuple[str, ...]:
+        source_by_name = self._source_by_name()
+        ordered: list[str] = []
+        resolved: set[str] = set()
+        resolving: set[str] = set()
+
+        def add_dependencies(name: str) -> None:
+            if name in resolved or name in resolving:
+                return
+            resolving.add(name)
+            source = source_by_name.get(name)
+            if source is not None:
+                base_name = source.selection_source
+                if base_name is not None and base_name != name:
+                    add_dependencies(base_name)
+            resolving.remove(name)
+            resolved.add(name)
+            ordered.append(name)
+
+        for name in names:
+            add_dependencies(name)
+        return tuple(ordered)
+
+    def _operation_source_dependency_names(
+        self, operation: FigureOperationState
+    ) -> tuple[str, ...]:
+        return self._source_dependency_names(self._operation_source_names(operation))
+
+    def _direct_sources_used_by_recipe(
+        self, *, enabled_only: bool = False, executable_only: bool = False
+    ) -> set[str]:
+        return {
+            source_name
+            for operation in self._recipe.operations
+            if not enabled_only or operation.enabled
+            if not executable_only
+            or operation.kind != FigureOperationKind.CUSTOM
+            or operation.trusted
+            for source_name in self._operation_source_names(operation)
+        }
+
     def _source_used_by_operation(self, name: str) -> bool:
         return any(
-            name in self._operation_source_names(operation)
+            name in self._operation_source_dependency_names(operation)
             for operation in self._recipe.operations
         )
 
     def _source_usage_count(self, name: str) -> int:
         return sum(
-            name in self._operation_source_names(operation)
+            name in self._operation_source_dependency_names(operation)
             for operation in self._recipe.operations
         )
 
@@ -2703,7 +2768,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return {
             source_name
             for operation in self._recipe.operations
-            for source_name in self._operation_source_names(operation)
+            for source_name in self._operation_source_dependency_names(operation)
         }
 
     def _source_removable(self, name: str) -> bool:
@@ -2711,6 +2776,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             name in self._source_by_name()
             and len(self._recipe.sources) > 1
             and not self._source_used_by_operation(name)
+            and not any(
+                source.name != name and source.selection_source == name
+                for source in self._recipe.sources
+            )
         )
 
     @QtCore.Slot()
@@ -5420,14 +5489,18 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             with contextlib.suppress(TypeError, RuntimeError):
                 clipboard.dataChanged.disconnect(self._update_step_action_buttons)
 
-    def _source_data_history_state(self) -> dict[str, xr.DataArray]:
-        return dict(self._source_data)
+    def _source_data_history_state(
+        self,
+    ) -> tuple[dict[str, xr.DataArray], dict[str, xr.DataArray]]:
+        return dict(self._source_data), dict(self._source_selection_base_data)
 
     def _restore_source_data_history_state(
-        self, source_data: Mapping[str, xr.DataArray]
+        self,
+        state: tuple[Mapping[str, xr.DataArray], Mapping[str, xr.DataArray]],
     ) -> None:
+        source_data, selection_base_data = state
         self._source_data = dict(source_data)
-        self._source_selection_base_data.clear()
+        self._source_selection_base_data = dict(selection_base_data)
         self._mark_preview_pixmap_stale()
 
     def _clear_pending_figure_resize_history_write(self) -> None:
@@ -5455,7 +5528,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _append_history_state(
         self,
         state: FigureRecipeState | None = None,
-        source_data: dict[str, xr.DataArray] | None = None,
+        source_data: (
+            tuple[dict[str, xr.DataArray], dict[str, xr.DataArray]] | None
+        ) = None,
     ) -> bool:
         curr_state = self.tool_status if state is None else state
         curr_source_data = (
@@ -5992,10 +6067,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.sigInfoChanged.emit()
         self._write_state()
 
-    @staticmethod
-    def _operation_source_names(operation: FigureOperationState) -> tuple[str, ...]:
-        return _registry.spec_for(operation.kind).source_names(operation)
-
     def _clipboard(self) -> QtGui.QClipboard | None:
         application = QtWidgets.QApplication.instance()
         if not isinstance(application, QtWidgets.QApplication):
@@ -6008,6 +6079,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         tuple[
             tuple[FigureOperationState, ...],
             tuple[FigureSourceState, ...],
+            dict[str, xr.DataArray],
             dict[str, xr.DataArray],
         ]
         | None
@@ -6028,7 +6100,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             dict.fromkeys(
                 source_name
                 for operation in operations
-                for source_name in self._operation_source_names(operation)
+                for source_name in self._operation_source_dependency_names(operation)
             )
         )
         source_by_name = {source.name: source for source in self._recipe.sources}
@@ -6041,6 +6113,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             for source_name in source_names
             if source_name in self._source_data
         }
+        selection_base_data = {
+            source_name: self._source_selection_base_data[source_name].copy(deep=False)
+            for source_name in source_names
+            if source_name in self._source_selection_base_data
+        }
         clipboard = self._clipboard()
         if clipboard is None:
             return None
@@ -6049,6 +6126,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 _step_clipboard_payload_text(operations, sources),
                 _step_clipboard_code_text(self, operations),
                 source_data,
+                selection_base_data,
                 cut_source_tool_id=self._step_clipboard_tool_id if cut else None,
             )
         )
@@ -6080,21 +6158,18 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         existing_source_names = {source.name for source in self._recipe.sources}
         reserved = {source.name for source in self._recipe.sources}
         reserved.update(self._source_data)
-        rename_map: dict[str, str] = {}
-        renamed_sources: list[FigureSourceState] = []
-        renamed_source_data: dict[str, xr.DataArray] = {}
+        unique_sources: list[FigureSourceState] = []
         seen_sources: set[str] = set()
         for source in sources:
             if source.name in seen_sources:
                 continue
             seen_sources.add(source.name)
+            unique_sources.append(source)
+
+        rename_map: dict[str, str] = {}
+        for source in unique_sources:
             if preserve_existing and source.name in reserved:
                 rename_map[source.name] = source.name
-                if source.name not in existing_source_names:
-                    renamed_sources.append(source)
-                    existing_source_names.add(source.name)
-                if source.name in source_data and source.name not in self._source_data:
-                    renamed_source_data[source.name] = source_data[source.name]
                 continue
             pasted_name = source.name
             if pasted_name in reserved:
@@ -6106,8 +6181,23 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                     suffix += 1
             reserved.add(pasted_name)
             rename_map[source.name] = pasted_name
-            renamed_sources.append(source.model_copy(update={"name": pasted_name}))
-            if source.name in source_data:
+
+        renamed_sources: list[FigureSourceState] = []
+        renamed_source_data: dict[str, xr.DataArray] = {}
+        for source in unique_sources:
+            pasted_name = rename_map[source.name]
+            updates: dict[str, typing.Any] = {"name": pasted_name}
+            if source.selection_source is not None:
+                updates["selection_source"] = rename_map.get(
+                    source.selection_source, source.selection_source
+                )
+            renamed_source = source.model_copy(update=updates)
+            if pasted_name not in existing_source_names:
+                renamed_sources.append(renamed_source)
+                existing_source_names.add(pasted_name)
+            if source.name in source_data and (
+                pasted_name not in self._source_data or not preserve_existing
+            ):
                 renamed_source_data[pasted_name] = source_data[source.name]
         return tuple(renamed_sources), rename_map, renamed_source_data
 
@@ -6162,7 +6252,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         payload = _step_clipboard_payload(mime)
         if payload is None:
             return
-        operations, sources, source_data = payload
+        operations, sources, source_data, selection_base_data = payload
         renamed_sources, rename_map, renamed_source_data = self._renamed_pasted_sources(
             sources,
             source_data,
@@ -6197,6 +6287,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             source_names.add(source.name)
             source_list.append(source)
         self._source_data.update(renamed_source_data)
+        renamed_selection_base_data = {
+            rename_map.get(source_name, source_name): data
+            for source_name, data in selection_base_data.items()
+            if rename_map.get(source_name, source_name) in source_names
+        }
+        self._source_selection_base_data.update(renamed_selection_base_data)
         self._recipe = self._recipe.model_copy(
             update={
                 "sources": tuple(source_list),
@@ -6205,7 +6301,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         self._normalize_operation_source_selections()
         self._refresh_source_list()
-        if renamed_source_data:
+        if renamed_source_data or renamed_selection_base_data:
             self.sigDataChanged.emit()
         self._finish_operation_structure_change(
             {operation.operation_id for operation in pasted_operations},
@@ -6412,16 +6508,30 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         clear_selection_bases: set[str] = set()
         skipped: list[str] = []
         for source in sources:
-            data = source_data.get(source.name)
+            incoming_name = source.name
+            data = source_data.get(incoming_name)
             if data is None:
                 continue
-            target_name = source.name
+            linked_matches = (
+                [
+                    candidate
+                    for candidate in existing.values()
+                    if candidate.node_uid == source.node_uid
+                ]
+                if source.node_uid is not None
+                else []
+            )
+            target_name = incoming_name
             existing_source = existing.get(target_name)
             same_linked_source = (
                 existing_source is not None
                 and existing_source.node_uid is not None
                 and existing_source.node_uid == source.node_uid
             )
+            if not same_linked_source and len(linked_matches) == 1:
+                existing_source = linked_matches[0]
+                target_name = existing_source.name
+                same_linked_source = True
             if existing_source is not None and not same_linked_source:
                 target_name = self._source_unique_alias(target_name, reserved)
                 source = source.model_copy(update={"name": target_name})
@@ -8079,7 +8189,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         dict[str, str],
     ]:
         source_by_name = self._source_by_name()
-        used_sources = self._sources_used_by_recipe()
+        used_sources = self._direct_sources_used_by_recipe(
+            enabled_only=True, executable_only=True
+        )
         used_code_names = set(_FIGURE_CODE_RESERVED_NAMES)
         if self._recipe.setup.layout_mode == "gridspec":
             source_names = self._source_names()

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -7955,16 +7955,49 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 continue
             source_data[source.name] = restored_source_data(source, source_data_item)
             changed = True
-        for source in self._recipe.sources:
-            if source.name in source_data or not _source_has_selection(source):
-                continue
-            if source.selection_source is None:
-                continue
-            source_data_item = source_data.get(source.selection_source)
-            if source_data_item is None:
-                continue
-            source_data[source.name] = restored_source_data(source, source_data_item)
-            changed = True
+        pending = [
+            source
+            for source in self._recipe.sources
+            if source.name not in source_data
+            and _source_has_selection(source)
+            and source.selection_source is not None
+        ]
+        while pending:
+            next_pending: list[FigureSourceState] = []
+            restored_this_pass = False
+            for source in pending:
+                selection_source = source.selection_source
+                if selection_source is None:  # pragma: no cover - filtered above.
+                    continue
+                source_data_item = source_data.get(selection_source)
+                if source_data_item is None:
+                    next_pending.append(source)
+                    continue
+                try:
+                    selected = self._source_data_from_selection(
+                        source.name, source_data_item, source
+                    )
+                except (IndexError, KeyError, TypeError, ValueError):
+                    logger.debug(
+                        "Could not rebuild saved Figure Composer source %s from %s",
+                        source.name,
+                        selection_source,
+                        exc_info=True,
+                    )
+                    continue
+                source_data[source.name] = selected
+                selection_base_data[source.name] = source_data_item
+                changed = True
+                restored_this_pass = True
+            if not restored_this_pass:
+                if next_pending:
+                    logger.debug(
+                        "Could not resolve saved Figure Composer source "
+                        "dependencies: %s",
+                        ", ".join(source.name for source in next_pending),
+                    )
+                break
+            pending = next_pending
         if not changed:
             self._restore_persisted_preview_cache(ds)
             self._queue_post_restore_redraw_if_needed(ds)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -2803,6 +2803,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             return f"Source alias {alias!r} is already in use."
         return None
 
+    @staticmethod
+    def _source_with_name(source: FigureSourceState, name: str) -> FigureSourceState:
+        if source.name == name:
+            return source
+        updates = {"name": name}
+        if source.label == source.name:
+            updates["label"] = name
+        return source.model_copy(update=updates)
+
     def _source_unique_alias(self, source_name: str, reserved: set[str]) -> str:
         return _source_unique_name(source_name, reserved)
 
@@ -2877,14 +2886,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         sources: list[FigureSourceState] = []
         changed = False
         for source in self._recipe.sources:
-            source_updates: dict[str, typing.Any] = {}
+            updated_source = source
             if source.name == old_name:
-                source_updates["name"] = new_name
+                updated_source = self._source_with_name(source, new_name)
             if source.selection_source == old_name:
-                source_updates["selection_source"] = new_name
-            if source_updates:
+                updated_source = updated_source.model_copy(
+                    update={"selection_source": new_name}
+                )
+            if updated_source is not source:
                 changed = True
-                sources.append(source.model_copy(update=source_updates))
+                sources.append(updated_source)
             else:
                 sources.append(source)
         if not changed:
@@ -2943,7 +2954,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         for index in indices:
             source = sources[index]
             alias = self._source_copy_alias(source.name, reserved)
-            duplicates.append(source.model_copy(update={"name": alias}))
+            duplicates.append(self._source_with_name(source, alias))
             duplicated_names.add(alias)
             if source.name in self._source_data:
                 self._source_data[alias] = self._source_data[source.name].copy(
@@ -3816,11 +3827,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             source_name, FigureSourceState(name=source_name)
         )
         selected_source = _source_with_selection(
-            base_source.model_copy(
-                update={
-                    "name": alias,
-                    "selection_source": source_name,
-                }
+            self._source_with_name(base_source, alias).model_copy(
+                update={"selection_source": source_name}
             ),
             selection.model_copy(update={"source": alias}),
         )
@@ -6186,12 +6194,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         renamed_source_data: dict[str, xr.DataArray] = {}
         for source in unique_sources:
             pasted_name = rename_map[source.name]
-            updates: dict[str, typing.Any] = {"name": pasted_name}
+            renamed_source = self._source_with_name(source, pasted_name)
             if source.selection_source is not None:
-                updates["selection_source"] = rename_map.get(
-                    source.selection_source, source.selection_source
+                renamed_source = renamed_source.model_copy(
+                    update={
+                        "selection_source": rename_map.get(
+                            source.selection_source, source.selection_source
+                        )
+                    }
                 )
-            renamed_source = source.model_copy(update=updates)
             if pasted_name not in existing_source_names:
                 renamed_sources.append(renamed_source)
                 existing_source_names.add(pasted_name)
@@ -6593,10 +6604,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         *,
         keep_selection_source: bool,
     ) -> tuple[FigureSourceState, xr.DataArray]:
-        updates: dict[str, typing.Any] = {"name": alias}
+        replacement = self._source_with_name(source, alias)
         if source.selection_source == source.name:
-            updates["selection_source"] = alias
-        replacement = source.model_copy(update=updates)
+            replacement = replacement.model_copy(update={"selection_source": alias})
         if (
             existing_source is not None
             and _source_has_selection(existing_source)
@@ -6640,7 +6650,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if alias not in self._source_data:
                 return False
             existing_source = None
-            source_list.append(source.model_copy(update={"name": alias}))
+            source_list.append(self._source_with_name(source, alias))
             existing_index = len(source_list) - 1
 
         if existing_index is None:  # pragma: no cover
@@ -8143,7 +8153,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     ) -> provenance.ScriptInput:
         if script_input.name == name:
             return script_input
-        return script_input.model_copy(update={"name": name})
+        updates = {"name": name}
+        if script_input.label == script_input.name:
+            updates["label"] = name
+        return script_input.model_copy(update=updates)
 
     def _selected_source_script_input(
         self,

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -3540,13 +3540,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._set_source_validation_text(str(exc))
             return
 
+        candidate_data = dict(self._source_data)
+        candidate_bases = dict(self._source_selection_base_data)
+        candidate_sources = self._source_by_name()
         changed = False
         skipped: list[str] = []
-        source_by_name = self._source_by_name()
-        source_list = list(self._recipe.sources)
         for source_name in self._selected_source_names():
-            source = source_by_name.get(source_name)
-            if source is None or source_name not in self._source_data:
+            source = candidate_sources.get(source_name)
+            if source is None or source_name not in candidate_data:
                 skipped.append(source_name)
                 continue
             try:
@@ -3557,7 +3558,13 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                     value,
                     width,
                 )
-                raw_data = self._source_selection_input_data(source_name, source)
+                raw_data = candidate_bases.get(source_name)
+                if raw_data is None:
+                    selection_source = source.selection_source
+                    if selection_source is not None and selection_source != source_name:
+                        raw_data = candidate_data.get(selection_source)
+                    else:
+                        raw_data = candidate_data.get(source_name)
                 if raw_data is None:
                     skipped.append(source_name)
                     continue
@@ -3571,15 +3578,29 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 message = str(exc) or exc.__class__.__name__
                 skipped.append(f"{source_name} ({message})")
                 continue
+
+            trial_sources = dict(candidate_sources)
+            trial_sources[source_name] = updated_source
+            trial_data = dict(candidate_data)
+            trial_data[source_name] = selected_data
+            trial_bases = dict(candidate_bases)
             if selection_has_effect(selection):
-                self._source_selection_base_data[source_name] = raw_data
+                trial_bases[source_name] = raw_data
             else:
-                self._source_selection_base_data.pop(source_name, None)
-            self._source_data[source_name] = selected_data
-            for index, candidate in enumerate(source_list):
-                if candidate.name == source_name:
-                    source_list[index] = updated_source
-                    break
+                trial_bases.pop(source_name, None)
+            try:
+                trial_data, trial_bases = self._source_data_with_recomputed_dependents(
+                    trial_data,
+                    trial_bases,
+                    (source_name,),
+                    source_by_name=trial_sources,
+                )
+            except ValueError as exc:
+                skipped.append(f"{source_name} ({exc})")
+                continue
+            candidate_sources = trial_sources
+            candidate_data = trial_data
+            candidate_bases = trial_bases
             changed = True
 
         status_text = (
@@ -3589,7 +3610,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._set_source_validation_text(status_text)
             self._refresh_source_selection_editor()
             return
-        self._recipe = self._recipe.model_copy(update={"sources": tuple(source_list)})
+        self._source_data = candidate_data
+        self._source_selection_base_data = candidate_bases
+        self._recipe = self._recipe.model_copy(
+            update={
+                "sources": tuple(
+                    candidate_sources[source.name] for source in self._recipe.sources
+                )
+            }
+        )
         self._refresh_operation_list()
         self._refresh_step_section_button_texts()
         self._refresh_source_list()
@@ -3621,6 +3650,64 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if data is not None:
                 return data
         return self._source_data.get(source_name)
+
+    def _source_data_with_recomputed_dependents(
+        self,
+        source_data: Mapping[str, xr.DataArray],
+        selection_base_data: Mapping[str, xr.DataArray],
+        changed_names: Iterable[str],
+        *,
+        source_by_name: Mapping[str, FigureSourceState] | None = None,
+    ) -> tuple[dict[str, xr.DataArray], dict[str, xr.DataArray]]:
+        """Return candidate source mappings with selected dependents refreshed.
+
+        A selected source stores the raw data to which its complete source-level
+        selection applies separately from the selected payload. When an origin is
+        refreshed, propagate that raw input through every dependent alias before any
+        caller commits the candidate mappings.
+        """
+        sources = dict(source_by_name or self._source_by_name())
+        candidate_data = dict(source_data)
+        candidate_bases = dict(selection_base_data)
+        explicit_names = set(changed_names)
+        queue: collections.deque[str] = collections.deque(explicit_names)
+        refreshed = set(explicit_names)
+
+        while queue:
+            parent_name = queue.popleft()
+            parent_data = candidate_data.get(parent_name)
+
+            for source in sources.values():
+                source_name = source.name
+                if (
+                    source_name in refreshed
+                    or source.selection_source != parent_name
+                    or source_name == parent_name
+                ):
+                    continue
+                if parent_data is None:
+                    raise ValueError(
+                        f"source {source_name!r} depends on unavailable source "
+                        f"{parent_name!r}"
+                    )
+                try:
+                    selected_data = self._source_data_from_selection(
+                        source_name, parent_data, source
+                    )
+                except (IndexError, KeyError, TypeError, ValueError) as exc:
+                    message = str(exc) or exc.__class__.__name__
+                    raise ValueError(
+                        f"could not update dependent source {source_name!r}: {message}"
+                    ) from exc
+                candidate_data[source_name] = selected_data
+                if _source_has_selection(source):
+                    candidate_bases[source_name] = parent_data
+                else:
+                    candidate_bases.pop(source_name, None)
+                refreshed.add(source_name)
+                queue.append(source_name)
+
+        return candidate_data, candidate_bases
 
     def _normalize_operation_source_selections(self) -> None:
         operations: list[FigureOperationState] = []
@@ -6563,14 +6650,13 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         updated together so workspace saves include the new source data.
         """
         existing = {source.name: source for source in self._recipe.sources}
-        reserved = set(existing)
-        reserved.update(self._source_data)
-        source_data_updates: dict[str, xr.DataArray] = {}
-        selection_base_updates: dict[str, xr.DataArray] = {}
-        clear_selection_bases: set[str] = set()
+        candidate_data = dict(self._source_data)
+        candidate_bases = dict(self._source_selection_base_data)
+        accepted = False
         skipped: list[str] = []
-        for source in sources:
-            incoming_name = source.name
+        for incoming_source in sources:
+            source = incoming_source
+            incoming_name = incoming_source.name
             data = source_data.get(incoming_name)
             if data is None:
                 continue
@@ -6594,9 +6680,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 existing_source = linked_matches[0]
                 target_name = existing_source.name
                 same_linked_source = True
+            reserved = set(existing)
+            reserved.update(candidate_data)
             if existing_source is not None and not same_linked_source:
                 target_name = self._source_unique_alias(target_name, reserved)
-                source = source.model_copy(update={"name": target_name})
+                source = self._source_with_name(source, target_name)
                 selected_data = data
             else:
                 reserved.add(target_name)
@@ -6615,22 +6703,37 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                         message = str(exc) or exc.__class__.__name__
                         skipped.append(f"{target_name} ({message})")
                         continue
-            existing[target_name] = source
-            source_data_updates[target_name] = selected_data
+            trial_existing = dict(existing)
+            trial_existing[target_name] = source
+            trial_data = dict(candidate_data)
+            trial_data[target_name] = selected_data
+            trial_bases = dict(candidate_bases)
             if same_linked_source and _source_has_selection(source):
-                selection_base_updates[target_name] = data
+                trial_bases[target_name] = data
             else:
-                clear_selection_bases.add(target_name)
-        if not source_data_updates:
+                trial_bases.pop(target_name, None)
+            try:
+                trial_data, trial_bases = self._source_data_with_recomputed_dependents(
+                    trial_data,
+                    trial_bases,
+                    (target_name,),
+                    source_by_name=trial_existing,
+                )
+            except ValueError as exc:
+                skipped.append(f"{target_name} ({exc})")
+                continue
+            existing = trial_existing
+            candidate_data = trial_data
+            candidate_bases = trial_bases
+            accepted = True
+        if not accepted:
             if skipped:
                 self._set_source_status_text(
                     "Could not update source data for: " + ", ".join(skipped)
                 )
             return
-        self._source_data.update(source_data_updates)
-        self._source_selection_base_data.update(selection_base_updates)
-        for source_name in clear_selection_bases - selection_base_updates.keys():
-            self._source_selection_base_data.pop(source_name, None)
+        self._source_data = candidate_data
+        self._source_selection_base_data = candidate_bases
         ordered_sources = tuple(existing[name] for name in existing)
         self._recipe = self._recipe.model_copy(update={"sources": ordered_sources})
         self._normalize_operation_source_selections()
@@ -6722,11 +6825,28 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             return False
         source_list[existing_index] = replacement
 
-        self._source_data[alias] = selected_data
+        candidate_data = dict(self._source_data)
+        candidate_data[alias] = selected_data
+        candidate_bases = dict(self._source_selection_base_data)
         if _source_has_selection(replacement):
-            self._source_selection_base_data[alias] = data
+            candidate_bases[alias] = data
         else:
-            self._source_selection_base_data.pop(alias, None)
+            candidate_bases.pop(alias, None)
+        source_by_name = {candidate.name: candidate for candidate in source_list}
+        try:
+            candidate_data, candidate_bases = (
+                self._source_data_with_recomputed_dependents(
+                    candidate_data,
+                    candidate_bases,
+                    (alias,),
+                    source_by_name=source_by_name,
+                )
+            )
+        except ValueError as exc:
+            self._set_source_status_text(f"Could not refresh source “{alias}”: {exc}")
+            return False
+        self._source_data = candidate_data
+        self._source_selection_base_data = candidate_bases
         self._recipe = self._recipe.model_copy(update={"sources": tuple(source_list)})
         self._refresh_operation_list()
         self._refresh_step_section_button_texts()
@@ -8354,28 +8474,42 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def refresh_from_sources(self, source_data: Mapping[str, xr.DataArray]) -> None:
         source_by_name = self._source_by_name()
+        candidate_data = dict(self._source_data)
+        candidate_bases = dict(self._source_selection_base_data)
         skipped: list[str] = []
         changed = False
         for source_name, data in source_data.items():
             source = source_by_name.get(source_name)
             if source is None:
-                self._source_data[source_name] = data
-                self._source_selection_base_data.pop(source_name, None)
-                changed = True
-                continue
-            try:
-                selected_data = self._source_data_from_selection(
-                    source_name, data, source
-                )
-            except (IndexError, KeyError, TypeError, ValueError) as exc:
-                message = str(exc) or exc.__class__.__name__
-                skipped.append(f"{source_name} ({message})")
-                continue
-            self._source_data[source_name] = selected_data
-            if _source_has_selection(source):
-                self._source_selection_base_data[source_name] = data
+                selected_data = data
             else:
-                self._source_selection_base_data.pop(source_name, None)
+                try:
+                    selected_data = self._source_data_from_selection(
+                        source_name, data, source
+                    )
+                except (IndexError, KeyError, TypeError, ValueError) as exc:
+                    message = str(exc) or exc.__class__.__name__
+                    skipped.append(f"{source_name} ({message})")
+                    continue
+            trial_data = dict(candidate_data)
+            trial_data[source_name] = selected_data
+            trial_bases = dict(candidate_bases)
+            if source is not None and _source_has_selection(source):
+                trial_bases[source_name] = data
+            else:
+                trial_bases.pop(source_name, None)
+            try:
+                trial_data, trial_bases = self._source_data_with_recomputed_dependents(
+                    trial_data,
+                    trial_bases,
+                    (source_name,),
+                    source_by_name=source_by_name,
+                )
+            except ValueError as exc:
+                skipped.append(f"{source_name} ({exc})")
+                continue
+            candidate_data = trial_data
+            candidate_bases = trial_bases
             changed = True
         if skipped:
             self._set_source_status_text(
@@ -8386,6 +8520,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if not changed:
             self._refresh_source_controls()
             return
+        self._source_data = candidate_data
+        self._source_selection_base_data = candidate_bases
         self._refresh_source_list()
         self._update_source_section()
         self._maybe_redraw_plot()

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -72,6 +72,7 @@ from erlab.interactive._figurecomposer._gridspec import (
     _gridspec_region_valid,
     _gridspec_remove_region,
     _gridspec_replace_grid,
+    _gridspec_reserved_axis_code_names,
     _gridspec_setup_from_subplots,
     _gridspec_update_axis_variable_name,
     _gridspec_valid_axes_ids,
@@ -82,6 +83,9 @@ from erlab.interactive._figurecomposer._operations._base import (
     COMMON_AXES_SECTION_TOOLTIP,
     COMMON_SOURCE_SECTION_TOOLTIP,
     StepSection,
+)
+from erlab.interactive._figurecomposer._operations._custom_code import (
+    _renamed_source_loads,
 )
 from erlab.interactive._figurecomposer._operations._plot_slices import (
     _PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
@@ -185,6 +189,7 @@ _FIGURE_RESIZE_HISTORY_DELAY_MS = 250
 _PREVIEW_PIXMAP_UPDATE_DELAY_MS = 250
 _PERSISTED_PREVIEW_CACHE_ATTR = "figure_composer_preview_cache_png"
 _PERSISTED_PREVIEW_CACHE_STALE_ATTR = "figure_composer_preview_cache_stale"
+_PERSISTED_SELECTED_SOURCE_DATA_ATTR = "figure_composer_selected_source_data"
 _PERSISTED_PREVIEW_CACHE_SIZE = QtCore.QSize(512, 384)
 _PERSISTED_PREVIEW_CACHE_MAX_BYTES = 384_000
 _COMBO_POPUP_REBUILD_GRACE_MS = 150
@@ -2595,7 +2600,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._set_source_status_text(error)
             edit.setText(original)
             return
-        self._rename_source_alias(original, alias)
+        if not self._rename_source_alias(original, alias):
+            edit.setText(original)
 
     @QtCore.Slot()
     def _focus_source_alias_editor(self) -> None:
@@ -2639,7 +2645,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.sigInfoChanged.emit()
         self._write_state()
 
-    def _rename_source_alias(self, old_name: str, new_name: str) -> None:
+    def _rename_source_alias(self, old_name: str, new_name: str) -> bool:
+        self._flush_pending_editor_commits()
         rename_map = {old_name: new_name}
         sources: list[FigureSourceState] = []
         changed = False
@@ -2656,7 +2663,29 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 sources.append(source)
         if not changed:
             self._refresh_source_controls()
-            return
+            return False
+
+        operations: list[FigureOperationState] = []
+        try:
+            for operation in self._recipe.operations:
+                updated = self._operation_with_renamed_sources(operation, rename_map)
+                if (
+                    operation.kind == FigureOperationKind.CUSTOM
+                    and re.search(rf"\b{re.escape(old_name)}\b", operation.code)
+                    is not None
+                ):
+                    updated = updated.model_copy(
+                        update={
+                            "code": _renamed_source_loads(operation.code, rename_map)
+                        }
+                    )
+                operations.append(updated)
+        except ValueError as exc:
+            self._set_source_status_text(
+                f"Could not rename source “{old_name}”: {operation.label}: {exc}."
+            )
+            self._refresh_source_selection_editor()
+            return False
 
         self._source_data = {
             rename_map.get(name, name): data for name, data in self._source_data.items()
@@ -2665,18 +2694,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             rename_map.get(name, name): data
             for name, data in self._source_selection_base_data.items()
         }
-        operations = tuple(
-            self._operation_with_renamed_sources(operation, rename_map)
-            for operation in self._recipe.operations
-        )
         updates: dict[str, typing.Any] = {
             "sources": tuple(sources),
-            "operations": operations,
+            "operations": tuple(operations),
         }
         if self._recipe.primary_source == old_name:
             updates["primary_source"] = new_name
         self._recipe = self._recipe.model_copy(update=updates)
         self._finish_source_structure_change({new_name}, new_name)
+        return True
 
     @QtCore.Slot()
     def _duplicate_selected_sources(self) -> None:
@@ -5970,6 +5996,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         reserved = set(existing)
         reserved.update(self._source_data)
         source_data_updates: dict[str, xr.DataArray] = {}
+        selection_base_updates: dict[str, xr.DataArray] = {}
+        clear_selection_bases: set[str] = set()
+        skipped: list[str] = []
         for source in sources:
             data = source_data.get(source.name)
             if data is None:
@@ -5984,14 +6013,40 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if existing_source is not None and not same_linked_source:
                 target_name = self._source_unique_alias(target_name, reserved)
                 source = source.model_copy(update={"name": target_name})
+                selected_data = data
             else:
                 reserved.add(target_name)
+                if existing_source is None:
+                    selected_data = data
+                else:
+                    try:
+                        source, selected_data = self._replacement_source_data(
+                            target_name,
+                            source,
+                            data,
+                            existing_source,
+                            keep_selection_source=True,
+                        )
+                    except (IndexError, KeyError, TypeError, ValueError) as exc:
+                        message = str(exc) or exc.__class__.__name__
+                        skipped.append(f"{target_name} ({message})")
+                        continue
             existing[target_name] = source
-            source_data_updates[target_name] = data
-            self._source_selection_base_data.pop(target_name, None)
+            source_data_updates[target_name] = selected_data
+            if same_linked_source and _source_has_selection(source):
+                selection_base_updates[target_name] = data
+            else:
+                clear_selection_bases.add(target_name)
         if not source_data_updates:
+            if skipped:
+                self._set_source_status_text(
+                    "Could not update source data for: " + ", ".join(skipped)
+                )
             return
         self._source_data.update(source_data_updates)
+        self._source_selection_base_data.update(selection_base_updates)
+        for source_name in clear_selection_bases - selection_base_updates.keys():
+            self._source_selection_base_data.pop(source_name, None)
         ordered_sources = tuple(existing[name] for name in existing)
         self._recipe = self._recipe.model_copy(update={"sources": ordered_sources})
         self._normalize_operation_source_selections()
@@ -6001,6 +6056,43 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.sigDataChanged.emit()
         self.sigInfoChanged.emit()
         self._write_state()
+        self._set_source_status_text(
+            "Could not update source data for: " + ", ".join(skipped)
+            if skipped
+            else None
+        )
+
+    def _replacement_source_data(
+        self,
+        alias: str,
+        source: FigureSourceState,
+        data: xr.DataArray,
+        existing_source: FigureSourceState | None,
+        *,
+        keep_selection_source: bool,
+    ) -> tuple[FigureSourceState, xr.DataArray]:
+        updates: dict[str, typing.Any] = {"name": alias}
+        if source.selection_source == source.name:
+            updates["selection_source"] = alias
+        replacement = source.model_copy(update=updates)
+        if (
+            existing_source is not None
+            and _source_has_selection(existing_source)
+            and not _source_has_selection(replacement)
+        ):
+            replacement = _source_with_selection(
+                replacement.model_copy(
+                    update={
+                        "selection_source": (
+                            existing_source.selection_source
+                            if keep_selection_source
+                            else alias
+                        )
+                    }
+                ),
+                _source_selection(existing_source),
+            )
+        return replacement, self._source_data_from_selection(alias, data, replacement)
 
     def replace_source(
         self,
@@ -6031,16 +6123,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
         if existing_index is None:  # pragma: no cover
             raise RuntimeError("source replacement index was not resolved")
-        replacement = source.model_copy(update={"name": alias})
-        if existing_source is not None and not _source_has_selection(replacement):
-            replacement = _source_with_selection(
-                replacement.model_copy(
-                    update={"selection_source": existing_source.selection_source}
-                ),
-                _source_selection(existing_source),
-            )
         try:
-            selected_data = self._source_data_from_selection(alias, data, replacement)
+            replacement, selected_data = self._replacement_source_data(
+                alias,
+                source,
+                data,
+                existing_source,
+                keep_selection_source=False,
+            )
         except (IndexError, KeyError, TypeError, ValueError) as exc:
             message = str(exc) or exc.__class__.__name__
             self._set_source_status_text(
@@ -6998,16 +7088,74 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
 
     def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
-        items = {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: self.tool_data}
-        for source_name, data in self._source_data.items():
+        primary_source = self._recipe.primary_source
+        if primary_source in self._source_data:
+            primary_data, _already_selected = self._persistence_source_data(
+                primary_source
+            )
+        else:
+            primary_data = self.tool_data
+        items = {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: primary_data}
+        for source_name in self._source_data:
             if source_name == self._recipe.primary_source:
                 continue
             if source_name == erlab.interactive.utils._SAVED_TOOL_DATA_NAME:
                 raise ValueError(
                     "Figure source names cannot use the reserved saved-tool data name"
                 )
+            data, _already_selected = self._persistence_source_data(source_name)
             items[source_name] = data
         return items
+
+    def _persistence_source_data(self, source_name: str) -> tuple[xr.DataArray, bool]:
+        data = self._source_data[source_name]
+        source = self._recipe_source(source_name)
+        if source is None or not _source_has_selection(source):
+            return data, False
+        base_data = self._source_selection_base_data.get(source_name)
+        if base_data is not None:
+            return base_data, False
+        if (
+            source.selection_source is not None
+            and source.selection_source != source_name
+        ):
+            base_data = self._source_data.get(source.selection_source)
+            if base_data is not None:
+                return base_data, False
+        return data, True
+
+    def _embedded_selected_source_names(self, ds: xr.Dataset) -> tuple[str, ...]:
+        references = self._saved_tool_data_references(ds)
+        selected_names: list[str] = []
+        for source in self._recipe.sources:
+            if source.name not in self._source_data:
+                continue
+            _data, already_selected = self._persistence_source_data(source.name)
+            variable_name = (
+                erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+                if source.name == self._recipe.primary_source
+                else source.name
+            )
+            if already_selected and variable_name not in references:
+                selected_names.append(source.name)
+        return tuple(selected_names)
+
+    @staticmethod
+    def _persisted_selected_source_names(ds: xr.Dataset) -> frozenset[str]:
+        payload = ds.attrs.get(_PERSISTED_SELECTED_SOURCE_DATA_ATTR)
+        if payload is None:
+            return frozenset()
+        try:
+            decoded = json.loads(payload)
+        except (TypeError, json.JSONDecodeError):
+            logger.debug("Ignoring invalid persisted selected-source metadata")
+            return frozenset()
+        if not isinstance(decoded, list) or not all(
+            isinstance(name, str) for name in decoded
+        ):
+            logger.debug("Ignoring invalid persisted selected-source metadata")
+            return frozenset()
+        return frozenset(decoded)
 
     def _persistence_reference_node_uids(self) -> frozenset[str]:
         return frozenset(
@@ -7037,11 +7185,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     ) -> None:
         source_data = dict(self._source_data)
         selection_base_data: dict[str, xr.DataArray] = {}
+        embedded_selected_names = self._persisted_selected_source_names(ds)
 
         def restored_source_data(
             source: FigureSourceState, data: xr.DataArray
         ) -> xr.DataArray:
-            if not _source_has_selection(source):
+            if (
+                not _source_has_selection(source)
+                or source.name in embedded_selected_names
+            ):
                 return data
             try:
                 selected = self._source_data_from_selection(source.name, data, source)
@@ -7149,6 +7301,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return QtGui.QPixmap(preview)
 
     def _append_persistence_payload(self, ds: xr.Dataset) -> xr.Dataset:
+        selected_names = self._embedded_selected_source_names(ds)
+        if selected_names:
+            ds = ds.copy(deep=False)
+            ds.attrs[_PERSISTED_SELECTED_SOURCE_DATA_ATTR] = json.dumps(selected_names)
+
         preview = self._persisted_preview_cache_pixmap()
         if preview is None:
             return ds
@@ -7437,17 +7594,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         else:
             name = "source"
 
-        base = name
-        index = 2
-        while (
-            name in used_names
-            or name in _FIGURE_CODE_RESERVED_NAMES
-            or keyword.iskeyword(name)
-        ):
-            name = f"{base}_{index}"
-            index += 1
-        used_names.add(name)
-        return name
+        return _source_unique_name(name, used_names)
 
     @staticmethod
     def _script_input_with_name(
@@ -7504,6 +7651,18 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         source_by_name = self._source_by_name()
         used_sources = self._sources_used_by_recipe()
         used_code_names = set(_FIGURE_CODE_RESERVED_NAMES)
+        if self._recipe.setup.layout_mode == "gridspec":
+            source_names = self._source_names()
+            used_code_names.update(
+                _gridspec_reserved_axis_code_names(
+                    self._recipe.setup, reserved_names=source_names
+                )
+            )
+            used_code_names.update(
+                _gridspec_axis_code_names(
+                    self._recipe.setup, reserved_names=source_names
+                ).values()
+            )
         script_inputs: list[provenance.ScriptInput] = []
         script_input_names: set[str] = set()
         skip_source_selection_names: set[str] = set()

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -2811,18 +2811,21 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _remove_selected_sources(self) -> None:
         pending = list(self._selected_source_names())
         removed = False
-        while pending:
-            next_pending: list[str] = []
-            removed_this_pass = False
-            for name in pending:
-                if self.remove_source(name):
-                    removed = True
-                    removed_this_pass = True
-                else:
-                    next_pending.append(name)
-            if not removed_this_pass:
-                break
-            pending = next_pending
+        with self._history_suppressed():
+            while pending:
+                next_pending: list[str] = []
+                removed_this_pass = False
+                for name in pending:
+                    if self.remove_source(name):
+                        removed = True
+                        removed_this_pass = True
+                    else:
+                        next_pending.append(name)
+                if not removed_this_pass:
+                    break
+                pending = next_pending
+        if removed:
+            self._write_state()
         if not removed:
             self._refresh_source_controls()
 

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -2715,22 +2715,43 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
         return tuple(dict.fromkeys(names))
 
-    def _source_dependency_names(self, names: Iterable[str]) -> tuple[str, ...]:
+    def _source_dependency_names(
+        self,
+        names: Iterable[str],
+        *,
+        stop_at: frozenset[str] = frozenset(),
+        reject_cycles: bool = False,
+    ) -> tuple[str, ...]:
+        """Return source names in dependency order, with parents before children.
+
+        Names in ``stop_at`` are treated as already materialized inputs, so their
+        own dependencies are not traversed. Set ``reject_cycles`` at boundaries
+        that require a valid topological order, such as generated code.
+        """
         source_by_name = self._source_by_name()
         ordered: list[str] = []
         resolved: set[str] = set()
-        resolving: set[str] = set()
+        resolving: list[str] = []
 
         def add_dependencies(name: str) -> None:
-            if name in resolved or name in resolving:
+            if name in resolved:
                 return
-            resolving.add(name)
+            if name in resolving:
+                if reject_cycles:
+                    cycle_start = resolving.index(name)
+                    cycle = (*resolving[cycle_start:], name)
+                    raise FigureComposerInputError(
+                        "Cannot generate code because source selections contain a "
+                        f"dependency cycle: {' -> '.join(cycle)}."
+                    )
+                return
+            resolving.append(name)
             source = source_by_name.get(name)
-            if source is not None:
+            if source is not None and name not in stop_at:
                 base_name = source.selection_source
                 if base_name is not None and base_name != name:
                     add_dependencies(base_name)
-            resolving.remove(name)
+            resolving.pop()
             resolved.add(name)
             ordered.append(name)
 

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -2958,18 +2958,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         operations: list[FigureOperationState] = []
         try:
             for operation in self._recipe.operations:
-                updated = self._operation_with_renamed_sources(operation, rename_map)
-                if (
-                    operation.kind == FigureOperationKind.CUSTOM
-                    and re.search(rf"\b{re.escape(old_name)}\b", operation.code)
-                    is not None
-                ):
-                    updated = updated.model_copy(
-                        update={
-                            "code": _renamed_source_loads(operation.code, rename_map)
-                        }
-                    )
-                operations.append(updated)
+                operations.append(
+                    self._operation_with_renamed_sources(operation, rename_map)
+                )
         except ValueError as exc:
             self._set_source_validation_text(
                 f"Could not rename source “{old_name}”: {operation.label}: {exc}."
@@ -6473,24 +6464,37 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         operation: FigureOperationState, rename_map: Mapping[str, str]
     ) -> FigureOperationState:
         updates: dict[str, typing.Any] = {}
+        if operation.kind == FigureOperationKind.CUSTOM:
+            try:
+                code = _renamed_source_loads(operation.code, dict(rename_map))
+            except ValueError as exc:
+                raise FigureComposerInputError(
+                    "Could not rename source references in Python step "
+                    f"{operation.label!r}: {exc}."
+                ) from exc
+            if code != operation.code:
+                updates["code"] = code
         if operation.sources:
-            updates["sources"] = tuple(
+            sources = tuple(
                 rename_map.get(source_name, source_name)
                 for source_name in operation.sources
             )
+            if sources != operation.sources:
+                updates["sources"] = sources
         if operation.map_selections:
-            updates["map_selections"] = tuple(
-                selection.model_copy(
-                    update={
-                        "source": rename_map.get(selection.source, selection.source),
-                    }
-                )
+            map_selections = tuple(
+                selection.model_copy(update={"source": source})
+                if (source := rename_map.get(selection.source, selection.source))
+                != selection.source
+                else selection
                 for selection in operation.map_selections
             )
+            if map_selections != operation.map_selections:
+                updates["map_selections"] = map_selections
         if operation.line_source is not None:
-            updates["line_source"] = rename_map.get(
-                operation.line_source, operation.line_source
-            )
+            line_source = rename_map.get(operation.line_source, operation.line_source)
+            if line_source != operation.line_source:
+                updates["line_source"] = line_source
         for field in (
             "method_plot_x",
             "method_plot_y",
@@ -6499,13 +6503,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         ):
             state = getattr(operation, field)
             if state is not None:
-                updates[field] = state.model_copy(
-                    update={"source": rename_map.get(state.source, state.source)}
-                )
+                source = rename_map.get(state.source, state.source)
+                if source != state.source:
+                    updates[field] = state.model_copy(update={"source": source})
         if operation.hv_overlay_source is not None:
-            updates["hv_overlay_source"] = rename_map.get(
+            hv_overlay_source = rename_map.get(
                 operation.hv_overlay_source, operation.hv_overlay_source
             )
+            if hv_overlay_source != operation.hv_overlay_source:
+                updates["hv_overlay_source"] = hv_overlay_source
         if not updates:
             return operation
         return operation.model_copy(update=updates)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -8,10 +8,14 @@ import collections
 import contextlib
 import functools
 import json
+import keyword
+import logging
 import math
+import re
 import textwrap
 import traceback
 import typing
+import unicodedata
 import uuid
 import weakref
 
@@ -21,6 +25,8 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 from matplotlib.figure import Figure
 # isort: on
+
+import pydantic
 
 import erlab
 import erlab.interactive._figurecomposer._codegen
@@ -82,6 +88,15 @@ from erlab.interactive._figurecomposer._operations._plot_slices import (
     _PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
     _plot_slices_panel_keys,
 )
+from erlab.interactive._figurecomposer._operations._source_selection import (
+    selection_dim_mode,
+    selection_dim_value_text,
+    selection_dim_width_text,
+    selection_has_effect,
+    selection_value_from_text,
+    selection_width_from_text,
+    selection_with_dimension,
+)
 from erlab.interactive._figurecomposer._rendering import (
     _live_layout_axes,
     _render_into_figure,
@@ -96,13 +111,18 @@ from erlab.interactive._figurecomposer._sources import (
     _default_plot_operation,
     _default_setup_for_data,
     _public_source_data,
+    _selected_data,
+    _selected_source_data,
     _source_display_label,
-    _source_duplicate_labels,
-    _source_label,
+    _source_has_selection,
     _source_name,
+    _source_selection,
+    _source_with_selection,
+    _valid_source_variable,
 )
 from erlab.interactive._figurecomposer._state import (
     FigureAxesSelectionState,
+    FigureDataSelectionState,
     FigureGridSpecAxesState,
     FigureGridSpecGridState,
     FigureGridSpecSpanState,
@@ -164,12 +184,23 @@ _COMBO_POPUP_GUARD_ID_PROPERTY = "figure_composer_combo_popup_guard_id"
 _RESTORE_OPERATION_EDITOR_KEY = "figure_composer_operation_editor"
 _RESTORE_REDRAW_KEY = "figure_composer_restored_redraw"
 _SOURCE_LIST_SOURCE_COLUMN = 0
-_SOURCE_LIST_ALIAS_COLUMN = 1
-_SOURCE_LIST_SHAPE_COLUMN = 2
-_SOURCE_LIST_ACTION_COLUMN = 3
+_SOURCE_LIST_SHAPE_COLUMN = 1
+_SOURCE_LIST_ACTION_COLUMN = 2
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
+_FIGURE_CODE_RESERVED_NAMES = frozenset(
+    {
+        "axs",
+        "eplt",
+        "fig",
+        "np",
+        "plt",
+        "xr",
+        "xarray",
+    }
+)
+logger = logging.getLogger(__name__)
 
 
 class _FigureComposerStepMimeData(QtCore.QMimeData):
@@ -188,6 +219,13 @@ class _FigureComposerStepMimeData(QtCore.QMimeData):
         self.figure_composer_cut_source_tool_id = cut_source_tool_id
         self.setData(_STEPS_CLIPBOARD_MIME, payload_text.encode("utf-8"))
         self.setText(step_code_text)
+
+
+def _event_requests_context_menu(event: QtGui.QKeyEvent) -> bool:
+    return event.key() == QtCore.Qt.Key.Key_Menu or (
+        event.key() == QtCore.Qt.Key.Key_F10
+        and bool(event.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier)
+    )
 
 
 class _FigureComposerOperationList(QtWidgets.QListWidget):
@@ -227,6 +265,12 @@ class _FigureComposerOperationList(QtWidgets.QListWidget):
     def keyPressEvent(self, event: QtGui.QKeyEvent | None) -> None:
         if event is None:
             return
+        if _event_requests_context_menu(event):
+            item = self.currentItem()
+            rect = self.visualItemRect(item) if item is not None else QtCore.QRect()
+            self.context_menu_requested.emit(rect.center())
+            event.accept()
+            return
         if event.matches(QtGui.QKeySequence.StandardKey.Copy):
             self.copy_requested.emit()
             event.accept()
@@ -264,6 +308,91 @@ class _FigureComposerOperationList(QtWidgets.QListWidget):
             selected_ids,
             current_id if isinstance(current_id, str) else None,
         )
+
+
+class _FigureComposerSourceList(QtWidgets.QTreeWidget):
+    context_menu_requested = QtCore.Signal(QtCore.QPoint)
+    rows_reordered = QtCore.Signal(object, object, object)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.context_menu_requested)
+        self.setDragEnabled(True)
+        self.setAcceptDrops(True)
+        self.setDropIndicatorShown(True)
+        self.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
+        self.setDefaultDropAction(QtCore.Qt.DropAction.MoveAction)
+        self.setDragDropOverwriteMode(False)
+        model = self.model()
+        if model is None:
+            raise RuntimeError("Figure Composer source list has no item model")
+        model.rowsMoved.connect(self._model_rows_moved)
+
+    def _source_names(self) -> tuple[str, ...]:
+        source_names: list[str] = []
+        for row in range(self.topLevelItemCount()):
+            item = self.topLevelItem(row)
+            source_name = (
+                None
+                if item is None
+                else item.data(
+                    _SOURCE_LIST_SOURCE_COLUMN,
+                    QtCore.Qt.ItemDataRole.UserRole,
+                )
+            )
+            if not isinstance(source_name, str):
+                return ()
+            source_names.append(source_name)
+        return tuple(source_names)
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent | None) -> None:
+        if event is None:
+            return
+        if _event_requests_context_menu(event):
+            item = self.currentItem()
+            rect = self.visualItemRect(item) if item is not None else QtCore.QRect()
+            self.context_menu_requested.emit(rect.center())
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    def _model_rows_moved(self, *_args: object) -> None:
+        self._emit_rows_reordered()
+
+    def dropEvent(self, event: QtGui.QDropEvent | None) -> None:
+        if event is None:
+            return
+        before = self._source_names()
+        super().dropEvent(event)
+        if self._source_names() != before:
+            self._emit_rows_reordered()
+
+    def _emit_rows_reordered(self) -> None:
+        source_names = self._source_names()
+        if not source_names or len(set(source_names)) != len(source_names):
+            return
+        current_name = None
+        current_item = self.currentItem()
+        if current_item is not None:
+            candidate = current_item.data(
+                _SOURCE_LIST_SOURCE_COLUMN,
+                QtCore.Qt.ItemDataRole.UserRole,
+            )
+            if isinstance(candidate, str):
+                current_name = candidate
+        selected_names = frozenset(
+            source_name
+            for item in self.selectedItems()
+            if isinstance(
+                source_name := item.data(
+                    _SOURCE_LIST_SOURCE_COLUMN,
+                    QtCore.Qt.ItemDataRole.UserRole,
+                ),
+                str,
+            )
+        )
+        self.rows_reordered.emit(source_names, selected_names, current_name)
 
 
 def _step_clipboard_payload_text(
@@ -427,10 +556,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             str, weakref.ReferenceType[QtWidgets.QWidget]
         ] = {}
         self._source_data: dict[str, xr.DataArray] = {}
+        self._source_selection_base_data: dict[str, xr.DataArray] = {}
         self._source_refresh_available_callback: Callable[[str], bool] | None = None
         self._source_refresh_callback: Callable[[str], bool] | None = None
         self._source_refresh_many_callback: Callable[[Sequence[str]], int] | None = None
         self._source_refresh_label_callback: Callable[[str], str | None] | None = None
+        self._source_add_available_callback: Callable[[], bool] | None = None
+        self._source_add_callback: Callable[[], bool] | None = None
+        self._source_drop_available_callback: (
+            Callable[[QtCore.QMimeData], bool] | None
+        ) = None
+        self._source_drop_callback: Callable[[QtCore.QMimeData], bool] | None = None
         self._source_inspector_target: str | None = None
         self._updating_source_selection = False
         self._recipe = recipe or self._default_recipe(data)
@@ -440,6 +576,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._subplot_adjust_dialog: QtWidgets.QDialog | None = None
         self._axes_customize_dialog: QtWidgets.QDialog | None = None
         self._operation_context_menu: QtWidgets.QMenu | None = None
+        self._source_context_menu: QtWidgets.QMenu | None = None
         self._connected_step_clipboard: QtGui.QClipboard | None = None
         self._step_clipboard_tool_id = uuid.uuid4().hex
         self._prev_source_data_states: collections.deque[dict[str, xr.DataArray]] = (
@@ -462,8 +599,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if self._recipe.primary_source not in self._source_data:
             self._source_data[self._recipe.primary_source] = data
 
+        self._normalize_operation_source_selections()
         self._current_step_section_key = "sources"
         self._build_ui()
+        self.setAcceptDrops(True)
         self._apply_recipe_to_controls()
         self._write_state()
 
@@ -483,7 +622,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _default_recipe(data: xr.DataArray) -> FigureRecipeState:
         source_name = _source_name(data)
         setup = _default_setup_for_data(data)
-        source = FigureSourceState(name=source_name, label=_source_label(data))
+        source = FigureSourceState(name=source_name)
         return FigureRecipeState(
             setup=setup,
             sources=(source,),
@@ -546,6 +685,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 redo_callback=self.redo,
                 undoable_callback=lambda: self.undoable,
                 redoable_callback=lambda: self.redoable,
+                source_drop_available_callback=self._source_drop_available,
+                source_drop_callback=self._add_sources_from_mime,
             )
             window_ref = weakref.ref(self._figure_window)
             tool_ref = weakref.ref(self)
@@ -1122,15 +1263,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             "Remove the selected recipe step or steps.",
         )
         self.remove_operation_button.clicked.connect(self._remove_current_operation)
-        self.duplicate_operation_button = _step_toolbar_button(
-            recipe_page,
-            "figureComposerDuplicateStepButton",
-            "Duplicate",
-            "Copy the selected step or steps after the last selected step.",
-        )
-        self.duplicate_operation_button.clicked.connect(
-            self._duplicate_current_operation
-        )
         self.copy_operation_button = _step_toolbar_button(
             recipe_page,
             "figureComposerCopyStepButton",
@@ -1153,22 +1285,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         self.paste_operation_button.clicked.connect(
             self._paste_operations_from_clipboard
-        )
-        self.move_operation_up_button = _step_toolbar_button(
-            recipe_page,
-            "figureComposerMoveStepUpButton",
-            "Up",
-            "Move the selected recipe step or steps earlier.",
-        )
-        self.move_operation_up_button.clicked.connect(self._move_current_operation_up)
-        self.move_operation_down_button = _step_toolbar_button(
-            recipe_page,
-            "figureComposerMoveStepDownButton",
-            "Down",
-            "Move the selected recipe step or steps later.",
-        )
-        self.move_operation_down_button.clicked.connect(
-            self._move_current_operation_down
         )
         self.show_figure_button = QtWidgets.QPushButton("Show Plot", root)
         self.show_figure_button.setObjectName("figureComposerShowFigureButton")
@@ -1220,9 +1336,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         selected_step_action_layout.addWidget(self.copy_operation_button)
         selected_step_action_layout.addWidget(self.cut_operation_button)
         selected_step_action_layout.addWidget(self.paste_operation_button)
-        selected_step_action_layout.addWidget(self.duplicate_operation_button)
-        selected_step_action_layout.addWidget(self.move_operation_up_button)
-        selected_step_action_layout.addWidget(self.move_operation_down_button)
         selected_step_action_layout.addWidget(self.remove_operation_button)
         selected_step_action_layout.addStretch(1)
         recipe_layout.addLayout(selected_step_action_layout)
@@ -1290,9 +1403,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
         self.step_sources_page = QtWidgets.QWidget(self.step_editor_stack)
         self.step_sources_page.setObjectName("figureComposerStepSourcesPage")
-        sources_layout = QtWidgets.QVBoxLayout(self.step_sources_page)
-        sources_layout.setContentsMargins(6, 6, 6, 6)
-        sources_layout.setSpacing(4)
+        step_sources_layout = QtWidgets.QVBoxLayout(self.step_sources_page)
+        step_sources_layout.setContentsMargins(6, 6, 6, 6)
+        step_sources_layout.setSpacing(4)
         self.step_source_controls = QtWidgets.QWidget(self.step_sources_page)
         self.step_source_controls_layout = QtWidgets.QFormLayout(
             self.step_source_controls
@@ -1302,16 +1415,45 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.step_source_controls_layout.setFieldGrowthPolicy(
             QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
         )
-        sources_layout.addWidget(self.step_source_controls)
-        self.source_status_label = QtWidgets.QLabel(self.step_sources_page)
+        step_sources_layout.addWidget(self.step_source_controls)
+        self.step_source_status_label = QtWidgets.QLabel(self.step_sources_page)
+        self.step_source_status_label.setObjectName("figureComposerStepSourceStatus")
+        self.step_source_status_label.setWordWrap(True)
+        self.step_source_status_label.setVisible(False)
+        step_sources_layout.addWidget(self.step_source_status_label)
+
+        self.sources_page = QtWidgets.QWidget(self.editor_tabs)
+        self.sources_page.setObjectName("figureComposerSourcesPage")
+        sources_layout = QtWidgets.QVBoxLayout(self.sources_page)
+        sources_layout.setContentsMargins(6, 6, 6, 6)
+        sources_layout.setSpacing(4)
+        self.source_status_label = QtWidgets.QLabel(self.sources_page)
         self.source_status_label.setObjectName("figureComposerSourceStatus")
         self.source_status_label.setWordWrap(True)
-        sources_layout.addWidget(self.source_status_label)
-        self.source_actions = QtWidgets.QWidget(self.step_sources_page)
+        self.source_status_label.setVisible(False)
+        self.source_actions = QtWidgets.QWidget(self.sources_page)
         self.source_actions.setObjectName("figureComposerSourceActions")
         source_actions_layout = QtWidgets.QHBoxLayout(self.source_actions)
         source_actions_layout.setContentsMargins(0, 0, 0, 0)
         source_actions_layout.setSpacing(4)
+        self.add_source_button = _step_toolbar_button(
+            self.source_actions,
+            "figureComposerAddSourceButton",
+            "Add…",
+            "Add ImageTool data from the manager as figure sources.",
+        )
+        self.add_source_button.clicked.connect(self._request_add_sources_from_button)
+        source_actions_layout.addWidget(self.add_source_button)
+        self.remove_selected_source_button = _step_toolbar_button(
+            self.source_actions,
+            "figureComposerRemoveSelectedSourceButton",
+            "Remove",
+            "Remove the selected unused source or sources.",
+        )
+        self.remove_selected_source_button.clicked.connect(
+            self._remove_selected_sources
+        )
+        source_actions_layout.addWidget(self.remove_selected_source_button)
         source_actions_layout.addStretch(1)
         self.refresh_sources_button = QtWidgets.QToolButton(self.source_actions)
         self.refresh_sources_button.setObjectName("figureComposerRefreshSourcesButton")
@@ -1325,16 +1467,19 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.refresh_sources_button.clicked.connect(self._refresh_sources_from_button)
         source_actions_layout.addWidget(self.refresh_sources_button)
         sources_layout.addWidget(self.source_actions)
-        self.source_list = QtWidgets.QTreeWidget(self.step_sources_page)
+        sources_layout.addWidget(self.source_status_label)
+        self.source_list = _FigureComposerSourceList(self.sources_page)
         self.source_list.setObjectName("figureComposerSourceList")
-        self.source_list.setColumnCount(4)
-        self.source_list.setHeaderLabels(("Source", "Alias", "Shape", ""))
+        self.source_list.setColumnCount(3)
+        self.source_list.setHeaderLabels(("Alias", "Shape", ""))
+        self.source_list.context_menu_requested.connect(self._show_source_context_menu)
+        self.source_list.rows_reordered.connect(self._source_list_reordered)
         self.source_list.setRootIsDecorated(False)
         self.source_list.setIndentation(0)
         self.source_list.setUniformRowHeights(True)
         self.source_list.setAlternatingRowColors(True)
         self.source_list.setSelectionMode(
-            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
         )
         self.source_list.setSelectionBehavior(
             QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
@@ -1342,11 +1487,22 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.source_list.currentItemChanged.connect(
             self._source_list_current_item_changed
         )
+        self.source_list.itemSelectionChanged.connect(
+            self._source_list_selection_changed
+        )
+        self.source_list.itemDoubleClicked.connect(
+            self._source_list_item_double_clicked
+        )
+        self.rename_source_shortcut = QtGui.QShortcut(
+            QtGui.QKeySequence(QtCore.Qt.Key.Key_F2), self.source_list
+        )
+        self.rename_source_shortcut.setObjectName("figureComposerRenameSourceShortcut")
+        self.rename_source_shortcut.activated.connect(self._focus_source_alias_editor)
         self.source_list.setVerticalScrollBarPolicy(
-            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
         )
         self.source_list.setHorizontalScrollBarPolicy(
-            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
         )
         source_header = self.source_list.header()
         if source_header is not None:
@@ -1354,10 +1510,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             source_header.setSectionResizeMode(
                 _SOURCE_LIST_SOURCE_COLUMN,
                 QtWidgets.QHeaderView.ResizeMode.Stretch,
-            )
-            source_header.setSectionResizeMode(
-                _SOURCE_LIST_ALIAS_COLUMN,
-                QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
             )
             source_header.setSectionResizeMode(
                 _SOURCE_LIST_SHAPE_COLUMN,
@@ -1368,8 +1520,33 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
             )
         sources_layout.addWidget(self.source_list, 1)
-        self.source_inspector = SourceInspectorWidget(self.step_sources_page)
+        self.source_inspector = SourceInspectorWidget(self.sources_page)
+        self.source_inspector.setAcceptDrops(True)
         sources_layout.addWidget(self.source_inspector)
+        self.source_selection_controls = QtWidgets.QWidget(self.sources_page)
+        self.source_selection_controls.setObjectName(
+            "figureComposerSourceSelectionControls"
+        )
+        self.source_selection_controls_layout = QtWidgets.QFormLayout(
+            self.source_selection_controls
+        )
+        self.source_selection_controls_layout.setContentsMargins(0, 0, 0, 0)
+        self.source_selection_controls_layout.setSpacing(4)
+        self.source_selection_controls_layout.setFieldGrowthPolicy(
+            QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
+        )
+        self.source_selection_controls.setAcceptDrops(True)
+        sources_layout.addWidget(self.source_selection_controls)
+        for drop_target in (
+            self.sources_page,
+            self.source_list,
+            self.source_list.viewport(),
+            self.source_inspector,
+            self.source_selection_controls,
+        ):
+            if drop_target is not None:
+                drop_target.setAcceptDrops(True)
+                drop_target.installEventFilter(self)
 
         self.target_axes_page = QtWidgets.QWidget(self.step_editor_stack)
         self.target_axes_page.setObjectName("figureComposerTargetAxesPage")
@@ -1763,6 +1940,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         setup_layout.setRowStretch(9, 1)
 
+        sources_index = self.editor_tabs.addTab(self.sources_page, "Sources")
+        self.editor_tabs.setTabToolTip(
+            sources_index, "Named data variables captured for this figure."
+        )
         layout_index = self.editor_tabs.addTab(layout_page, "Layout")
         self.editor_tabs.setTabToolTip(
             layout_index, "Subplot grid, figure size, and shared axes."
@@ -1855,6 +2036,59 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._source_refresh_label_callback = source_label
         self._refresh_source_controls()
 
+    def _set_source_add_callbacks(
+        self,
+        *,
+        can_add_sources: Callable[[], bool] | None = None,
+        add_sources: Callable[[], bool] | None = None,
+        can_drop_sources: Callable[[QtCore.QMimeData], bool] | None = None,
+        drop_sources: Callable[[QtCore.QMimeData], bool] | None = None,
+    ) -> None:
+        self._source_add_available_callback = can_add_sources
+        self._source_add_callback = add_sources
+        self._source_drop_available_callback = can_drop_sources
+        self._source_drop_callback = drop_sources
+        if self._figure_window is not None and erlab.interactive.utils.qt_is_valid(
+            self._figure_window
+        ):
+            self._figure_window.set_source_drop_callbacks(
+                can_drop=self._source_drop_available,
+                drop=self._add_sources_from_mime,
+            )
+        self._refresh_source_controls()
+
+    def _source_add_available(self) -> bool:
+        if self._source_add_callback is None:
+            return False
+        if self._source_add_available_callback is None:
+            return True
+        with contextlib.suppress(LookupError, RuntimeError, ValueError):
+            return bool(self._source_add_available_callback())
+        return False
+
+    @QtCore.Slot()
+    def _request_add_sources_from_button(self) -> None:
+        callback = self._source_add_callback
+        if callback is None or not self._source_add_available():
+            self._refresh_source_controls()
+            return
+        callback()
+        self._refresh_source_controls()
+
+    def _source_drop_available(self, mime: QtCore.QMimeData | None) -> bool:
+        if mime is None or self._source_drop_available_callback is None:
+            return False
+        with contextlib.suppress(LookupError, RuntimeError, ValueError):
+            return bool(self._source_drop_available_callback(mime))
+        return False
+
+    def _add_sources_from_mime(self, mime: QtCore.QMimeData | None) -> bool:
+        if mime is None or self._source_drop_callback is None:
+            return False
+        with contextlib.suppress(LookupError, RuntimeError, ValueError):
+            return bool(self._source_drop_callback(mime))
+        return False
+
     def _sync_size_mm_controls(self, figsize: tuple[float, float]) -> None:
         self.width_mm_spin.setValue(figsize[0] * _MM_PER_INCH)
         self.height_mm_spin.setValue(figsize[1] * _MM_PER_INCH)
@@ -1890,53 +2124,36 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _refresh_source_list(self) -> None:
         self._clear_source_list_widgets()
         source_by_name = {source.name: source for source in self._recipe.sources}
-        duplicate_labels = _source_duplicate_labels(self._recipe.sources)
-        current = self._current_operation()
-        used_sources = (
-            set(self._selected_sources_for_operation(current[1]))
-            if current is not None
-            else set()
-        )
-        for name, data in self._source_data.items():
-            source = source_by_name.get(name)
-            display = _source_display_label(
-                source,
+        used_sources = self._sources_used_by_recipe()
+        shown: set[str] = set()
+        for source in self._recipe.sources:
+            name = source.name
+            shown.add(name)
+            display = _source_display_label(source, name)
+            self._add_source_list_row(
+                display,
                 name,
-                disambiguate=(
-                    source is not None
-                    and (source.label.strip() or name) in duplicate_labels
-                ),
+                data=self._source_data.get(name),
+                missing=name not in self._source_data,
+                used=name in used_sources,
             )
+
+        for name, data in self._source_data.items():
+            if name in shown:
+                continue
+            display = _source_display_label(source_by_name.get(name), name)
             self._add_source_list_row(
                 display,
                 name,
                 data=data,
-                missing=source is None,
+                missing=name not in source_by_name,
                 used=name in used_sources,
             )
-
-        missing = [
-            source
-            for source in self._recipe.sources
-            if source.name not in self._source_data
-        ]
-        for source in missing:
-            display = _source_display_label(
-                source,
-                source.name,
-                disambiguate=(source.label.strip() or source.name) in duplicate_labels,
-            )
-            self._add_source_list_row(
-                display,
-                source.name,
-                missing=True,
-                used=source.name in used_sources,
-            )
-        self.source_list.resizeColumnToContents(_SOURCE_LIST_ALIAS_COLUMN)
         self.source_list.resizeColumnToContents(_SOURCE_LIST_SHAPE_COLUMN)
         self.source_list.resizeColumnToContents(_SOURCE_LIST_ACTION_COLUMN)
         self._refresh_source_controls()
         self._refresh_source_inspector()
+        self._refresh_source_selection_editor()
 
     def _clear_source_list_widgets(self) -> None:
         for row in range(self.source_list.topLevelItemCount()):
@@ -1963,18 +2180,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         used: bool = False,
     ) -> None:
         item = QtWidgets.QTreeWidgetItem(
-            [display, name, "missing" if data is None else "", ""]
+            [display, "missing" if data is None else "", ""]
         )
         item.setData(_SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole, name)
         item.setFlags(
-            QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsSelectable
+            QtCore.Qt.ItemFlag.ItemIsEnabled
+            | QtCore.Qt.ItemFlag.ItemIsSelectable
+            | QtCore.Qt.ItemFlag.ItemIsDragEnabled
         )
         if missing:
             item.setForeground(
                 _SOURCE_LIST_SOURCE_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
-            )
-            item.setForeground(
-                _SOURCE_LIST_ALIAS_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
             )
             item.setForeground(
                 _SOURCE_LIST_SHAPE_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
@@ -2026,6 +2242,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             return
         self._source_inspector_target = source_name
         self._refresh_source_inspector()
+        self._refresh_source_selection_editor()
+
+    @QtCore.Slot()
+    def _source_list_selection_changed(self) -> None:
+        if self._updating_source_selection:
+            return
+        self._refresh_source_controls()
+        self._refresh_source_selection_editor()
 
     @staticmethod
     def _source_name_from_list_item(
@@ -2037,6 +2261,66 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
         )
         return source_name if isinstance(source_name, str) else None
+
+    def _selected_source_names(self) -> tuple[str, ...]:
+        names: list[str] = []
+        for item in self.source_list.selectedItems():
+            source_name = self._source_name_from_list_item(item)
+            if source_name is not None and source_name not in names:
+                names.append(source_name)
+        current = self._source_name_from_list_item(self.source_list.currentItem())
+        if not names and current is not None:
+            names.append(current)
+        return tuple(names)
+
+    def _selected_source_indices(self) -> tuple[int, ...]:
+        selected = set(self._selected_source_names())
+        return tuple(
+            index
+            for index, source in enumerate(self._recipe.sources)
+            if source.name in selected
+        )
+
+    def _source_move_possible(self, offset: int) -> bool:
+        indices = self._selected_source_indices()
+        if not indices:
+            return False
+        index_set = set(indices)
+        if offset < 0:
+            return any(index > 0 and index - 1 not in index_set for index in indices)
+        return any(
+            index < len(self._recipe.sources) - 1 and index + 1 not in index_set
+            for index in indices
+        )
+
+    def _source_duplicate_possible(self) -> bool:
+        return bool(self._selected_source_indices())
+
+    def _set_selected_source_names_silent(
+        self, selected_names: set[str], current_name: str | None
+    ) -> None:
+        self._updating_source_selection = True
+        try:
+            self.source_list.clearSelection()
+            current_item: QtWidgets.QTreeWidgetItem | None = None
+            for row in range(self.source_list.topLevelItemCount()):
+                item = self.source_list.topLevelItem(row)
+                if item is None:  # pragma: no cover
+                    continue
+                source_name = self._source_name_from_list_item(item)
+                if source_name == current_name:
+                    current_item = item
+            if current_item is not None:
+                self.source_list.setCurrentItem(current_item)
+            for row in range(self.source_list.topLevelItemCount()):
+                item = self.source_list.topLevelItem(row)
+                if item is None:  # pragma: no cover
+                    continue
+                item.setSelected(
+                    self._source_name_from_list_item(item) in selected_names
+                )
+        finally:
+            self._updating_source_selection = False
 
     def _source_refresh_button(self, name: str) -> QtWidgets.QToolButton:
         button = QtWidgets.QToolButton(self.source_list)
@@ -2130,6 +2414,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _refresh_source_controls(self) -> None:
         has_refreshable_source = False
+        selected_names = self._selected_source_names()
+        add_enabled = self._source_add_available()
+        self.add_source_button.setEnabled(add_enabled)
+        add_tip = (
+            "Add ImageTool data from the manager as figure sources"
+            if add_enabled
+            else "Open this Figure Composer from ImageTool Manager to add sources"
+        )
+        self.add_source_button.setToolTip(add_tip)
+        self.add_source_button.setStatusTip(add_tip)
         for row in range(self.source_list.topLevelItemCount()):
             item = self.source_list.topLevelItem(row)
             if item is None:  # pragma: no cover
@@ -2168,12 +2462,29 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.refresh_sources_button.setToolTip(tooltip)
         self.refresh_sources_button.setStatusTip(tooltip)
 
+        removable_selected = [
+            name for name in selected_names if self._source_removable(name)
+        ]
+        remove_enabled = bool(removable_selected)
+        self.remove_selected_source_button.setEnabled(remove_enabled)
+        remove_tip = (
+            "Remove the selected unused source or sources"
+            if remove_enabled
+            else "Selected sources are in use or cannot be removed"
+        )
+        self.remove_selected_source_button.setToolTip(remove_tip)
+        self.remove_selected_source_button.setStatusTip(remove_tip)
+
     def refresh_source_controls(self) -> None:
         self._refresh_source_controls()
 
     def _set_source_status_text(self, text: str | None) -> None:
         self.source_status_label.setText("" if text is None else text)
         self.source_status_label.setVisible(bool(text))
+
+    def _set_step_source_status_text(self, text: str | None) -> None:
+        self.step_source_status_label.setText("" if text is None else text)
+        self.step_source_status_label.setVisible(bool(text))
 
     def _refresh_source_from_button(self, name: str, _checked: bool = False) -> None:
         callback = self._source_refresh_callback
@@ -2197,6 +2508,13 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             name in self._operation_source_names(operation)
             for operation in self._recipe.operations
         )
+
+    def _sources_used_by_recipe(self) -> set[str]:
+        return {
+            source_name
+            for operation in self._recipe.operations
+            for source_name in self._operation_source_names(operation)
+        }
 
     def _source_removable(self, name: str) -> bool:
         return (
@@ -2224,6 +2542,324 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if not self.remove_source(name):
             self._refresh_source_controls()
 
+    @QtCore.Slot()
+    def _remove_selected_sources(self) -> None:
+        removed = False
+        for name in tuple(self._selected_source_names()):
+            if self.remove_source(name):
+                removed = True
+        if not removed:
+            self._refresh_source_controls()
+
+    def _source_alias_error(
+        self, alias: str, *, current: str | None = None
+    ) -> str | None:
+        if not alias:
+            return "Source alias must not be empty."
+        try:
+            _valid_source_variable(alias)
+        except ValueError:
+            return f"{alias!r} is not a valid Python variable name."
+        if alias == erlab.interactive.utils._SAVED_TOOL_DATA_NAME:
+            return "This alias is reserved for saved tool data."
+        if alias in _FIGURE_CODE_RESERVED_NAMES:
+            return f"{alias!r} is reserved for generated figure code."
+        if alias != current and (
+            alias in {source.name for source in self._recipe.sources}
+            or alias in self._source_data
+        ):
+            return f"Source alias {alias!r} is already in use."
+        return None
+
+    def _source_unique_alias(self, source_name: str, reserved: set[str]) -> str:
+        stem = f"{source_name}_copy"
+        alias = stem
+        suffix = 2
+        while self._source_alias_error(alias) is not None or alias in reserved:
+            alias = f"{stem}_{suffix}"
+            suffix += 1
+        reserved.add(alias)
+        return alias
+
+    @QtCore.Slot()
+    def _commit_source_alias_edit(self) -> None:
+        edit = self.sender()
+        if not isinstance(edit, QtWidgets.QLineEdit):
+            return
+        original = edit.property("figure_composer_source_alias_original")
+        if not isinstance(original, str):
+            return
+        alias = edit.text().strip()
+        if alias == original:
+            edit.setText(original)
+            return
+        error = self._source_alias_error(alias, current=original)
+        if error is not None:
+            self._set_source_status_text(error)
+            edit.setText(original)
+            return
+        self._rename_source_alias(original, alias)
+
+    @QtCore.Slot()
+    def _focus_source_alias_editor(self) -> None:
+        if len(self._selected_source_names()) != 1:
+            return
+        editor = self.source_selection_controls.findChild(
+            QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
+        )
+        if editor is None:
+            self._refresh_source_selection_editor()
+            editor = self.source_selection_controls.findChild(
+                QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
+            )
+        if editor is None:
+            return
+        editor.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+        editor.selectAll()
+
+    @QtCore.Slot(QtWidgets.QTreeWidgetItem, int)
+    def _source_list_item_double_clicked(
+        self, _item: QtWidgets.QTreeWidgetItem, column: int
+    ) -> None:
+        if column == _SOURCE_LIST_SOURCE_COLUMN:
+            self._focus_source_alias_editor()
+
+    def _finish_source_structure_change(
+        self, selected_names: set[str], current_name: str | None
+    ) -> None:
+        self._refresh_operation_list()
+        self._refresh_step_section_button_texts()
+        self._refresh_source_list()
+        self._set_selected_source_names_silent(selected_names, current_name)
+        self._refresh_source_controls()
+        self._source_inspector_target = current_name
+        self._refresh_source_inspector()
+        self._refresh_source_selection_editor()
+        self._update_source_section()
+        self._maybe_redraw_plot()
+        self._set_source_status_text(None)
+        self.sigDataChanged.emit()
+        self.sigInfoChanged.emit()
+        self._write_state()
+
+    def _rename_source_alias(self, old_name: str, new_name: str) -> None:
+        rename_map = {old_name: new_name}
+        sources: list[FigureSourceState] = []
+        changed = False
+        for source in self._recipe.sources:
+            source_updates: dict[str, typing.Any] = {}
+            if source.name == old_name:
+                source_updates["name"] = new_name
+            if source.selection_source == old_name:
+                source_updates["selection_source"] = new_name
+            if source_updates:
+                changed = True
+                sources.append(source.model_copy(update=source_updates))
+            else:
+                sources.append(source)
+        if not changed:
+            self._refresh_source_controls()
+            return
+
+        self._source_data = {
+            rename_map.get(name, name): data for name, data in self._source_data.items()
+        }
+        self._source_selection_base_data = {
+            rename_map.get(name, name): data
+            for name, data in self._source_selection_base_data.items()
+        }
+        operations = tuple(
+            self._operation_with_renamed_sources(operation, rename_map)
+            for operation in self._recipe.operations
+        )
+        updates: dict[str, typing.Any] = {
+            "sources": tuple(sources),
+            "operations": operations,
+        }
+        if self._recipe.primary_source == old_name:
+            updates["primary_source"] = new_name
+        self._recipe = self._recipe.model_copy(update=updates)
+        self._finish_source_structure_change({new_name}, new_name)
+
+    @QtCore.Slot()
+    def _duplicate_selected_sources(self) -> None:
+        indices = self._selected_source_indices()
+        if not indices:
+            return
+        sources = list(self._recipe.sources)
+        reserved = {source.name for source in sources}
+        reserved.update(self._source_data)
+        duplicates: list[FigureSourceState] = []
+        duplicated_names: set[str] = set()
+        for index in indices:
+            source = sources[index]
+            alias = self._source_unique_alias(source.name, reserved)
+            duplicates.append(source.model_copy(update={"name": alias}))
+            duplicated_names.add(alias)
+            if source.name in self._source_data:
+                self._source_data[alias] = self._source_data[source.name].copy(
+                    deep=False
+                )
+            if source.name in self._source_selection_base_data:
+                self._source_selection_base_data[alias] = (
+                    self._source_selection_base_data[source.name].copy(deep=False)
+                )
+        insert_index = max(indices) + 1
+        sources[insert_index:insert_index] = duplicates
+        self._recipe = self._recipe.model_copy(update={"sources": tuple(sources)})
+        self._finish_source_structure_change(duplicated_names, duplicates[0].name)
+
+    def _move_selected_sources(self, offset: int) -> None:
+        indices = self._selected_source_indices()
+        if not indices:
+            return
+        sources = list(self._recipe.sources)
+        index_set = set(indices)
+        selected_names = {sources[index].name for index in indices}
+        moved = False
+        if offset < 0:
+            for index in indices:
+                if index > 0 and index - 1 not in index_set:
+                    sources[index - 1], sources[index] = (
+                        sources[index],
+                        sources[index - 1],
+                    )
+                    index_set.remove(index)
+                    index_set.add(index - 1)
+                    moved = True
+        else:
+            for index in reversed(indices):
+                if index < len(sources) - 1 and index + 1 not in index_set:
+                    sources[index + 1], sources[index] = (
+                        sources[index],
+                        sources[index + 1],
+                    )
+                    index_set.remove(index)
+                    index_set.add(index + 1)
+                    moved = True
+        if not moved:
+            self._refresh_source_controls()
+            return
+        current = self._source_name_from_list_item(self.source_list.currentItem())
+        current_name = (
+            current if current in selected_names else next(iter(selected_names))
+        )
+        self._recipe = self._recipe.model_copy(update={"sources": tuple(sources)})
+        self._finish_source_structure_change(selected_names, current_name)
+
+    @QtCore.Slot()
+    def _move_selected_sources_up(self) -> None:
+        self._move_selected_sources(-1)
+
+    @QtCore.Slot()
+    def _move_selected_sources_down(self) -> None:
+        self._move_selected_sources(1)
+
+    @QtCore.Slot(object, object, object)
+    def _source_list_reordered(
+        self,
+        source_names: object,
+        selected_names: object,
+        current_name: object,
+    ) -> None:
+        if not isinstance(source_names, (tuple, list)):
+            self._refresh_source_list()
+            return
+        ordered_names = tuple(name for name in source_names if isinstance(name, str))
+        source_by_name = {source.name: source for source in self._recipe.sources}
+        if (
+            len(ordered_names) != len(source_names)
+            or len(ordered_names) != len(source_by_name)
+            or set(ordered_names) != set(source_by_name)
+        ):
+            self._refresh_source_list()
+            return
+        current_order = tuple(source.name for source in self._recipe.sources)
+        if ordered_names == current_order:
+            return
+        selected_name_set: set[str] = set()
+        if isinstance(selected_names, (set, frozenset, tuple, list)):
+            selected_name_set = {
+                name
+                for name in selected_names
+                if isinstance(name, str) and name in source_by_name
+            }
+        current_source_name = (
+            current_name
+            if isinstance(current_name, str) and current_name in source_by_name
+            else None
+        )
+        if not selected_name_set and current_source_name is not None:
+            selected_name_set = {current_source_name}
+        if current_source_name is None:
+            current_source_name = next(
+                iter(selected_name_set),
+                ordered_names[0] if ordered_names else None,
+            )
+
+        sources = tuple(source_by_name[name] for name in ordered_names)
+        self._recipe = self._recipe.model_copy(update={"sources": sources})
+        self._finish_source_structure_change(selected_name_set, current_source_name)
+
+    @QtCore.Slot(QtCore.QPoint)
+    def _show_source_context_menu(self, position: QtCore.QPoint) -> None:
+        menu = QtWidgets.QMenu("Sources", self.source_list)
+        self._source_context_menu = menu
+        add_action = QtGui.QAction("Add…", menu)
+        add_action.setObjectName("figureComposerContextAddSourceAction")
+        add_action.setEnabled(self.add_source_button.isEnabled())
+        add_action.triggered.connect(self._request_add_sources_from_button)
+        menu.addAction(add_action)
+
+        menu.addSeparator()
+        rename_action = QtGui.QAction("Rename Alias", menu)
+        rename_action.setObjectName("figureComposerContextRenameSourceAction")
+        rename_action.setEnabled(len(self._selected_source_indices()) == 1)
+        rename_action.triggered.connect(self._focus_source_alias_editor)
+        menu.addAction(rename_action)
+
+        duplicate_action = QtGui.QAction("Duplicate", menu)
+        duplicate_action.setObjectName("figureComposerContextDuplicateSourceAction")
+        duplicate_action.setEnabled(self._source_duplicate_possible())
+        duplicate_action.triggered.connect(self._duplicate_selected_sources)
+        menu.addAction(duplicate_action)
+
+        move_up_action = QtGui.QAction("Move Up", menu)
+        move_up_action.setObjectName("figureComposerContextMoveSourceUpAction")
+        move_up_action.setEnabled(self._source_move_possible(-1))
+        move_up_action.triggered.connect(self._move_selected_sources_up)
+        menu.addAction(move_up_action)
+
+        move_down_action = QtGui.QAction("Move Down", menu)
+        move_down_action.setObjectName("figureComposerContextMoveSourceDownAction")
+        move_down_action.setEnabled(self._source_move_possible(1))
+        move_down_action.triggered.connect(self._move_selected_sources_down)
+        menu.addAction(move_down_action)
+
+        menu.addSeparator()
+        refresh_action = QtGui.QAction("Refresh", menu)
+        refresh_action.setObjectName("figureComposerContextRefreshSourceAction")
+        selected_names = self._selected_source_names()
+        refresh_action.setEnabled(
+            len(selected_names) == 1
+            and self._source_refresh_available(selected_names[0])
+        )
+        if len(selected_names) == 1:
+            refresh_action.triggered.connect(
+                functools.partial(self._refresh_source_from_button, selected_names[0])
+            )
+        menu.addAction(refresh_action)
+
+        remove_action = QtGui.QAction("Remove", menu)
+        remove_action.setObjectName("figureComposerContextRemoveSourceAction")
+        remove_action.setEnabled(self.remove_selected_source_button.isEnabled())
+        remove_action.triggered.connect(self._remove_selected_sources)
+        menu.addAction(remove_action)
+
+        viewport = self.source_list.viewport()
+        if viewport is not None:  # pragma: no branch
+            menu.popup(viewport.mapToGlobal(position))
+
     def _set_source_list_row_used(
         self, item: QtWidgets.QTreeWidgetItem, used: bool
     ) -> None:
@@ -2246,12 +2882,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 )
 
     def _sync_source_list_used_state(self) -> None:
-        current = self._current_operation()
-        used_sources = (
-            set(self._selected_sources_for_operation(current[1]))
-            if current is not None
-            else set()
-        )
+        used_sources = self._sources_used_by_recipe()
         for row in range(self.source_list.topLevelItemCount()):
             item = self.source_list.topLevelItem(row)
             if item is None:  # pragma: no cover
@@ -2261,15 +2892,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
             )
             self._set_source_list_row_used(item, source_name in used_sources)
-        self._refresh_source_inspector()
 
     def _default_source_inspector_target(self) -> str | None:
-        current = self._current_operation()
-        source_states = self._source_by_name()
-        if current is not None:
-            for source_name in self._selected_sources_for_operation(current[1]):
-                if source_name in self._source_data or source_name in source_states:
-                    return source_name
         source_name = self._source_name_from_list_item(self.source_list.currentItem())
         if source_name is not None:
             return source_name
@@ -2294,22 +2918,550 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         ):
             target = self._default_source_inspector_target()
         self._source_inspector_target = target
-        self._select_source_list_row_silent(target)
-        current = self._current_operation()
-        operation = None if current is None else current[1]
-        operation_sources = (
-            () if operation is None else self._selected_sources_for_operation(operation)
-        )
+        if target not in self._selected_source_names():
+            self._select_source_list_row_silent(target)
         inspector.set_context(
             source_name=target,
             source_state=None if target is None else source_states.get(target),
             data=None if target is None else self._source_data.get(target),
-            operation_source_names=operation_sources,
         )
+
+    def _refresh_source_selection_editor(self) -> None:
+        layout = getattr(self, "source_selection_controls_layout", None)
+        if not isinstance(layout, QtWidgets.QFormLayout):
+            return
+        self._clear_form_layout(layout)
+        selected_names = self._selected_source_names()
+        if not selected_names:
+            label = QtWidgets.QLabel("Select a source to edit its selection.", self)
+            label.setWordWrap(True)
+            layout.addRow(label)
+            return
+
+        source_by_name = self._source_by_name()
+        self._add_source_alias_editor(layout, selected_names, source_by_name)
+        available_names = tuple(
+            name
+            for name in selected_names
+            if name in source_by_name and name in self._source_data
+        )
+        self._add_form_section(
+            layout,
+            "Selection",
+            object_name="figureComposerSourceSelectionSection",
+        )
+        if not available_names:
+            label = QtWidgets.QLabel("No selected source data is available.", self)
+            label.setObjectName("figureComposerSourceSelectionMessage")
+            label.setWordWrap(True)
+            self._add_form_row(
+                layout,
+                "Dimensions",
+                label,
+                "Source selections can be edited after source data is available.",
+            )
+            return
+
+        dimensions = self._common_source_selection_dims(available_names)
+        if not dimensions:
+            label = QtWidgets.QLabel("No common dimensions.", self)
+            label.setObjectName("figureComposerSourceSelectionMessage")
+            self._add_form_row(
+                layout,
+                "Dimensions",
+                label,
+                "The selected source data has no common editable dimensions.",
+            )
+            return
+
+        for dim_index, dim_name in enumerate(dimensions):
+            selections = tuple(
+                _source_selection(source_by_name[name]) for name in available_names
+            )
+            modes = tuple(
+                selection_dim_mode(selection, dim_name) for selection in selections
+            )
+            mode_mixed = len(set(modes)) > 1
+            value_texts = tuple(
+                selection_dim_value_text(selection, dim_name)
+                for selection in selections
+            )
+            value_mixed = len(set(value_texts)) > 1
+            width_texts = tuple(
+                selection_dim_width_text(selection, dim_name)
+                for selection in selections
+            )
+            width_mixed = len(set(width_texts)) > 1
+            current_mode = None if mode_mixed else modes[0]
+
+            row = QtWidgets.QWidget(self.source_selection_controls)
+            row.setObjectName(f"figureComposerSourceSelectionDimRow{dim_index}")
+            row_layout = QtWidgets.QHBoxLayout(row)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+            row_layout.setSpacing(4)
+
+            mode_combo = self._source_selection_mode_combo(
+                current=current_mode,
+                mixed=mode_mixed,
+                parent=row,
+            )
+            mode_combo.setObjectName(
+                f"figureComposerSourceSelectionModeCombo{dim_index}"
+            )
+            mode_combo.setProperty("figure_composer_source_selection_dim", dim_name)
+            mode_combo.setToolTip(
+                "Choose whether this source dimension stays, is selected, or averaged."
+            )
+            value_edit = QtWidgets.QLineEdit(row)
+            value_edit.setObjectName(
+                f"figureComposerSourceSelectionValueEdit{dim_index}"
+            )
+            value_edit.setProperty("figure_composer_source_selection_dim", dim_name)
+            value_edit.setProperty("figure_composer_source_selection_field", "value")
+            value_edit.setPlaceholderText("value")
+            value_edit.setToolTip(
+                "Selection value. Use integer positions or slices for isel; use "
+                "coordinate values or slices for qsel."
+            )
+            value_edit.setText("" if value_mixed else value_texts[0])
+            self._apply_mixed_line_edit(value_edit, value_mixed)
+            width_edit = QtWidgets.QLineEdit(row)
+            width_edit.setObjectName(
+                f"figureComposerSourceSelectionWidthEdit{dim_index}"
+            )
+            width_edit.setProperty("figure_composer_source_selection_dim", dim_name)
+            width_edit.setProperty("figure_composer_source_selection_field", "width")
+            width_edit.setPlaceholderText("width")
+            width_edit.setToolTip(
+                "Optional qsel width centered on the value. Leave blank for nearest "
+                "coordinate selection."
+            )
+            width_edit.setText("" if width_mixed else width_texts[0])
+            self._apply_mixed_line_edit(width_edit, width_mixed)
+            value_edit.setVisible(current_mode in {"isel", "qsel"})
+            width_edit.setVisible(current_mode == "qsel")
+            self._connect_source_selection_dimension_controls(
+                dim_name,
+                mode_combo,
+                value_edit,
+                width_edit,
+            )
+            row_layout.addWidget(mode_combo)
+            row_layout.addWidget(value_edit, 1)
+            row_layout.addWidget(width_edit, 1)
+            self._add_form_row(
+                layout,
+                dim_name,
+                row,
+                "Choose how this source variable is selected before plotting.",
+            )
+
+    def _add_source_alias_editor(
+        self,
+        layout: QtWidgets.QFormLayout,
+        selected_names: Sequence[str],
+        source_by_name: Mapping[str, FigureSourceState],
+    ) -> None:
+        self._add_form_section(
+            layout,
+            "Source",
+            object_name="figureComposerSourceAliasSection",
+        )
+        if len(selected_names) != 1:
+            label = QtWidgets.QLabel("Select one source to rename its alias.", self)
+            label.setObjectName("figureComposerSourceAliasMessage")
+            label.setWordWrap(True)
+            self._add_form_row(
+                layout,
+                "Alias",
+                label,
+                "Source aliases are edited one at a time.",
+            )
+            return
+        source_name = selected_names[0]
+        if source_name not in source_by_name:
+            label = QtWidgets.QLabel("This source is missing from the recipe.", self)
+            label.setObjectName("figureComposerSourceAliasMessage")
+            label.setWordWrap(True)
+            self._add_form_row(
+                layout,
+                "Alias",
+                label,
+                "Missing recipe sources cannot be renamed.",
+            )
+            return
+        edit = QtWidgets.QLineEdit(self.source_selection_controls)
+        edit.setObjectName("figureComposerSourceAliasEdit")
+        edit.setText(source_name)
+        edit.setProperty("figure_composer_source_alias_original", source_name)
+        edit.setToolTip("Rename this source variable.")
+        edit.editingFinished.connect(self._commit_source_alias_edit)
+        self._add_form_row(
+            layout,
+            "Alias",
+            edit,
+            "Rename this source variable.",
+        )
+
+    def _source_selection_mode_combo(
+        self,
+        *,
+        current: str | None,
+        mixed: bool,
+        parent: QtWidgets.QWidget,
+    ) -> QtWidgets.QComboBox:
+        combo = QtWidgets.QComboBox(parent)
+        if mixed:
+            combo.addItem(_MIXED_VALUES_TEXT, _MIXED_VALUE)
+        for mode, label in (
+            ("keep", "None"),
+            ("isel", "isel"),
+            ("qsel", "qsel"),
+            ("mean", "Mean"),
+        ):
+            combo.addItem(label, mode)
+        if mixed:
+            item = typing.cast("typing.Any", combo.model()).item(0)
+            if item is not None:
+                item.setEnabled(False)
+            combo.setCurrentIndex(0)
+        elif current is not None:
+            index = combo.findData(current)
+            combo.setCurrentIndex(max(index, 0))
+        self._track_combo_interaction(combo)
+        return combo
+
+    def _connect_source_selection_dimension_controls(
+        self,
+        dim: str,
+        mode_combo: QtWidgets.QComboBox,
+        value_edit: QtWidgets.QLineEdit,
+        width_edit: QtWidgets.QLineEdit,
+    ) -> None:
+        def set_control_visibility(mode: str) -> None:
+            value_edit.setVisible(mode in {"isel", "qsel"})
+            width_edit.setVisible(mode == "qsel")
+
+        def update_from_controls() -> None:
+            mode = mode_combo.currentData()
+            if not isinstance(mode, str) or mode not in {
+                "keep",
+                "isel",
+                "qsel",
+                "mean",
+            }:
+                return
+            if LineEditControlAdapter(value_edit).unchanged_mixed() and mode in {
+                "isel",
+                "qsel",
+            }:
+                return
+            if LineEditControlAdapter(width_edit).unchanged_mixed() and mode == "qsel":
+                return
+            self._update_selected_source_dimension(
+                dim,
+                mode,
+                value_edit.text(),
+                width_edit.text(),
+            )
+
+        def mode_changed(_index: int) -> None:
+            mode = mode_combo.currentData()
+            mode_text = mode if isinstance(mode, str) else ""
+            set_control_visibility(mode_text)
+            previous_mode = mode_combo.property(
+                "figure_composer_source_selection_previous_mode"
+            )
+            mode_changed_from_previous = previous_mode != mode_text
+            if mode_changed_from_previous or mode_text not in {"isel", "qsel"}:
+                value_edit.clear()
+                value_edit.setModified(False)
+            if mode_changed_from_previous or mode_text != "qsel":
+                width_edit.clear()
+                width_edit.setModified(False)
+            mode_combo.setProperty(
+                "figure_composer_source_selection_previous_mode", mode_text
+            )
+            if mode_text in {"isel", "qsel"} and not value_edit.text().strip():
+                return
+            update_from_controls()
+
+        mode_combo.setProperty(
+            "figure_composer_source_selection_previous_mode",
+            mode_combo.currentData(),
+        )
+        mode_combo.activated.connect(mode_changed)
+        value_edit.editingFinished.connect(update_from_controls)
+        width_edit.editingFinished.connect(update_from_controls)
+
+    def _common_source_selection_dims(
+        self, source_names: Sequence[str]
+    ) -> tuple[str, ...]:
+        source_by_name = self._source_by_name()
+        common: list[str] | None = None
+        for source_name in source_names:
+            data = self._source_selection_input_data(
+                source_name, source_by_name.get(source_name)
+            )
+            if data is None:
+                continue
+            dims = [str(dim) for dim in _public_source_data(data).dims]
+            if common is None:
+                common = dims
+            else:
+                dim_set = set(dims)
+                common = [dim for dim in common if dim in dim_set]
+        return tuple(common or ())
+
+    def _update_selected_source_dimension(
+        self,
+        dim: str,
+        mode: str,
+        value_text: str,
+        width_text: str,
+    ) -> None:
+        try:
+            value = (
+                selection_value_from_text(value_text)
+                if mode in {"isel", "qsel"}
+                else None
+            )
+            width = selection_width_from_text(width_text) if mode == "qsel" else None
+        except FigureComposerInputError as exc:
+            self._set_source_status_text(str(exc))
+            return
+
+        changed = False
+        skipped: list[str] = []
+        source_by_name = self._source_by_name()
+        source_list = list(self._recipe.sources)
+        for source_name in self._selected_source_names():
+            source = source_by_name.get(source_name)
+            if source is None or source_name not in self._source_data:
+                skipped.append(source_name)
+                continue
+            try:
+                selection = selection_with_dimension(
+                    _source_selection(source),
+                    dim,
+                    mode,
+                    value,
+                    width,
+                )
+                raw_data = self._source_selection_input_data(source_name, source)
+                if raw_data is None:
+                    skipped.append(source_name)
+                    continue
+                updated_source = _source_with_selection(source, selection)
+                selected_data = self._source_data_from_selection(
+                    source_name,
+                    raw_data,
+                    updated_source,
+                )
+            except (IndexError, KeyError, TypeError, ValueError) as exc:
+                message = str(exc) or exc.__class__.__name__
+                skipped.append(f"{source_name} ({message})")
+                continue
+            if selection_has_effect(selection):
+                self._source_selection_base_data[source_name] = raw_data
+            else:
+                self._source_selection_base_data.pop(source_name, None)
+            self._source_data[source_name] = selected_data
+            for index, candidate in enumerate(source_list):
+                if candidate.name == source_name:
+                    source_list[index] = updated_source
+                    break
+            changed = True
+
+        status_text = (
+            "Selection was not applied to: " + ", ".join(skipped) if skipped else None
+        )
+        if not changed:
+            self._set_source_status_text(status_text)
+            self._refresh_source_selection_editor()
+            return
+        self._recipe = self._recipe.model_copy(update={"sources": tuple(source_list)})
+        self._refresh_operation_list()
+        self._refresh_step_section_button_texts()
+        self._refresh_source_list()
+        self._update_source_section()
+        self._maybe_redraw_plot()
+        self._set_source_status_text(status_text)
+        self.sigDataChanged.emit()
+        self.sigInfoChanged.emit()
+        self._write_state()
+
+    @staticmethod
+    def _source_data_from_selection(
+        source_name: str,
+        data: xr.DataArray,
+        source: FigureSourceState,
+    ) -> xr.DataArray:
+        selected = _selected_source_data(data, source)
+        return selected.rename(data.name).copy(deep=False)
+
+    def _source_selection_input_data(
+        self, source_name: str, source: FigureSourceState | None
+    ) -> xr.DataArray | None:
+        data = self._source_selection_base_data.get(source_name)
+        if data is not None:
+            return data
+        selection_source = None if source is None else source.selection_source
+        if selection_source is not None and selection_source != source_name:
+            data = self._source_data.get(selection_source)
+            if data is not None:
+                return data
+        return self._source_data.get(source_name)
+
+    def _normalize_operation_source_selections(self) -> None:
+        operations: list[FigureOperationState] = []
+        source_list = list(self._recipe.sources)
+        source_by_name = {source.name: source for source in source_list}
+        reserved = set(source_by_name)
+        reserved.update(self._source_data)
+        changed = False
+        for operation in self._recipe.operations:
+            if not operation.map_selections:
+                operations.append(operation)
+                continue
+            if len(operation.map_selections) != 1:
+                updated = self._operation_without_map_selections(operation, None)
+                operations.append(updated)
+                changed = changed or updated != operation
+                continue
+            selection = operation.map_selections[0]
+            source_name = selection.source
+            if not selection_has_effect(selection):
+                updated = self._operation_without_map_selections(
+                    operation,
+                    self._legacy_selection_fallback_source(operation, source_name),
+                )
+                operations.append(updated)
+                changed = changed or updated != operation
+                continue
+            alias = self._source_alias_for_legacy_selection(
+                selection,
+                source_list=source_list,
+                source_by_name=source_by_name,
+                reserved=reserved,
+            )
+            operations.append(self._operation_without_map_selections(operation, alias))
+            changed = True
+        if not changed:
+            return
+        self._recipe = self._recipe.model_copy(
+            update={"sources": tuple(source_list), "operations": tuple(operations)}
+        )
+
+    @staticmethod
+    def _legacy_selection_fallback_source(
+        operation: FigureOperationState,
+        source_name: str,
+    ) -> str | None:
+        if operation.kind == FigureOperationKind.LINE:
+            return source_name if operation.line_source is None else None
+        if operation.kind in {
+            FigureOperationKind.PLOT_ARRAY,
+            FigureOperationKind.PLOT_SLICES,
+        }:
+            return source_name if not operation.sources else None
+        return None
+
+    def _source_alias_for_legacy_selection(
+        self,
+        selection: FigureDataSelectionState,
+        *,
+        source_list: list[FigureSourceState],
+        source_by_name: dict[str, FigureSourceState],
+        reserved: set[str],
+    ) -> str:
+        source_name = selection.source
+        for source in source_list:
+            if source.selection_source != source_name:
+                continue
+            if (
+                source.isel == selection.isel
+                and source.qsel == selection.qsel
+                and source.mean_dims == selection.mean_dims
+            ):
+                if source.name not in self._source_data:
+                    base_data = self._source_data.get(source_name)
+                    if base_data is not None:
+                        self._source_selection_base_data[source.name] = base_data
+                        try:
+                            selected = self._source_data_from_selection(
+                                source.name, base_data, source
+                            )
+                        except (IndexError, KeyError, TypeError, ValueError):
+                            pass
+                        else:
+                            self._source_data[source.name] = selected
+                return source.name
+
+        alias = self._selected_source_alias(source_name, reserved)
+        reserved.add(alias)
+        base_source = source_by_name.get(
+            source_name, FigureSourceState(name=source_name)
+        )
+        selected_source = _source_with_selection(
+            base_source.model_copy(
+                update={
+                    "name": alias,
+                    "selection_source": source_name,
+                }
+            ),
+            selection.model_copy(update={"source": alias}),
+        )
+        source_by_name[alias] = selected_source
+        source_list.append(selected_source)
+        base_data = self._source_data.get(source_name)
+        if base_data is None:
+            return alias
+        self._source_selection_base_data[alias] = base_data
+        try:
+            selected = _selected_data(self._source_data, selection)
+        except (IndexError, KeyError, TypeError, ValueError):
+            return alias
+        if selected is not None:
+            self._source_data[alias] = selected.copy(deep=False)
+        return alias
+
+    @staticmethod
+    def _operation_without_map_selections(
+        operation: FigureOperationState,
+        source_name: str | None,
+    ) -> FigureOperationState:
+        updates: dict[str, typing.Any] = {"map_selections": ()}
+        if operation.kind == FigureOperationKind.LINE:
+            if source_name is not None:
+                updates["line_source"] = source_name
+            return operation.model_copy(update=updates)
+        if operation.kind == FigureOperationKind.PLOT_ARRAY:
+            if source_name is not None:
+                updates["sources"] = (source_name,)
+            elif operation.sources:
+                updates["sources"] = operation.sources[:1]
+            return operation.model_copy(update=updates)
+        if operation.kind == FigureOperationKind.PLOT_SLICES:
+            if source_name is not None:
+                updates["sources"] = (source_name,)
+            return operation.model_copy(update=updates)
+        return operation.model_copy(update=updates)
+
+    @staticmethod
+    def _selected_source_alias(source_name: str, reserved: set[str]) -> str:
+        stem = f"{source_name}_selected"
+        alias = stem
+        suffix = 2
+        while alias in reserved:
+            alias = f"{stem}_{suffix}"
+            suffix += 1
+        return alias
 
     def _select_source_list_row_silent(self, source_name: str | None) -> None:
         self._updating_source_selection = True
         try:
+            self._source_inspector_target = source_name
             if source_name is None:
                 self.source_list.clearSelection()
                 self.source_list.setCurrentIndex(QtCore.QModelIndex())
@@ -2907,6 +4059,21 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if operation.operation_id in selected_ids
         )
 
+    def _operation_duplicate_possible(self) -> bool:
+        return bool(self._selected_operation_indices())
+
+    def _operation_move_possible(self, offset: int) -> bool:
+        indices = self._selected_operation_indices()
+        if not indices:
+            return False
+        index_set = set(indices)
+        if offset < 0:
+            return any(index > 0 and index - 1 not in index_set for index in indices)
+        return any(
+            index < len(self._recipe.operations) - 1 and index + 1 not in index_set
+            for index in indices
+        )
+
     @staticmethod
     def _operation_editor_schema_key(
         operation: FigureOperationState,
@@ -3227,28 +4394,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         can_paste = self._clipboard_step_payload() is not None
         if not indices:
             self.remove_operation_button.setEnabled(False)
-            self.duplicate_operation_button.setEnabled(False)
             self.copy_operation_button.setEnabled(False)
             self.cut_operation_button.setEnabled(False)
             self.paste_operation_button.setEnabled(can_paste)
-            self.move_operation_up_button.setEnabled(False)
-            self.move_operation_down_button.setEnabled(False)
             return
-        index_set = set(indices)
         self.remove_operation_button.setEnabled(True)
-        self.duplicate_operation_button.setEnabled(True)
         self.copy_operation_button.setEnabled(True)
         self.cut_operation_button.setEnabled(True)
         self.paste_operation_button.setEnabled(can_paste)
-        self.move_operation_up_button.setEnabled(
-            any(index > 0 and index - 1 not in index_set for index in indices)
-        )
-        self.move_operation_down_button.setEnabled(
-            any(
-                index < len(self._recipe.operations) - 1 and index + 1 not in index_set
-                for index in indices
-            )
-        )
 
     @QtCore.Slot()
     @QtCore.Slot(int)
@@ -3546,7 +4699,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 operation_id = self._operation_id_for_item(item)
                 if operation_id is not None:
                     self._set_selected_operation_ids_silent({operation_id})
-        self._source_inspector_target = None
         self._sync_axes_selector()
         self._refresh_operation_editor()
 
@@ -3562,6 +4714,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def eventFilter(
         self, watched: QtCore.QObject | None, event: QtCore.QEvent | None
     ) -> bool:
+        if self._handle_source_drag_event(event):
+            return True
         self._handle_combo_interaction_event(watched, event)
         operation_list_viewport = self._operation_list_viewport
         if (
@@ -3585,6 +4739,48 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 self, 0, self._clear_operation_multi_select_event
             )
         return super().eventFilter(watched, event)
+
+    def _handle_source_drag_event(self, event: QtCore.QEvent | None) -> bool:
+        if event is None or event.type() not in {
+            QtCore.QEvent.Type.DragEnter,
+            QtCore.QEvent.Type.DragMove,
+            QtCore.QEvent.Type.Drop,
+        }:
+            return False
+        if not isinstance(
+            event, (QtGui.QDragEnterEvent, QtGui.QDragMoveEvent, QtGui.QDropEvent)
+        ):
+            return False
+        mime = event.mimeData()
+        if mime is None:
+            return False
+        if not self._source_drop_available(mime):
+            return False
+        if event.type() == QtCore.QEvent.Type.Drop and not self._add_sources_from_mime(
+            mime
+        ):
+            return False
+        event.setDropAction(QtCore.Qt.DropAction.CopyAction)
+        event.accept()
+        return True
+
+    def dragEnterEvent(self, event: QtGui.QDragEnterEvent | None) -> None:
+        if self._handle_source_drag_event(event):
+            return
+        if event is not None:
+            super().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event: QtGui.QDragMoveEvent | None) -> None:
+        if self._handle_source_drag_event(event):
+            return
+        if event is not None:
+            super().dragMoveEvent(event)
+
+    def dropEvent(self, event: QtGui.QDropEvent | None) -> None:
+        if self._handle_source_drag_event(event):
+            return
+        if event is not None:
+            super().dropEvent(event)
 
     def _handle_combo_interaction_event(
         self, watched: QtCore.QObject | None, event: QtCore.QEvent | None
@@ -3708,6 +4904,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self, source_data: Mapping[str, xr.DataArray]
     ) -> None:
         self._source_data = dict(source_data)
+        self._source_selection_base_data.clear()
         self._mark_preview_pixmap_stale()
 
     def _clear_pending_figure_resize_history_write(self) -> None:
@@ -3928,13 +5125,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _source_display_name(self, name: str) -> str:
         sources = self._source_by_name()
         source = sources.get(name)
-        duplicate_labels = _source_duplicate_labels(tuple(sources.values()))
-        return _source_display_label(
-            source,
-            name,
-            disambiguate=source is not None
-            and (source.label.strip() or name) in duplicate_labels,
-        )
+        return _source_display_label(source, name)
 
     def _source_display_names(self, names: Sequence[str]) -> tuple[str, ...]:
         return tuple(self._source_display_name(name) for name in names)
@@ -4208,19 +5399,19 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         menu.addSeparator()
         duplicate_action = QtGui.QAction("Duplicate", menu)
         duplicate_action.setObjectName("figureComposerContextDuplicateStepAction")
-        duplicate_action.setEnabled(self.duplicate_operation_button.isEnabled())
+        duplicate_action.setEnabled(self._operation_duplicate_possible())
         duplicate_action.triggered.connect(self._duplicate_current_operation)
         menu.addAction(duplicate_action)
 
-        move_up_action = QtGui.QAction("Up", menu)
+        move_up_action = QtGui.QAction("Move Up", menu)
         move_up_action.setObjectName("figureComposerContextMoveStepUpAction")
-        move_up_action.setEnabled(self.move_operation_up_button.isEnabled())
+        move_up_action.setEnabled(self._operation_move_possible(-1))
         move_up_action.triggered.connect(self._move_current_operation_up)
         menu.addAction(move_up_action)
 
-        move_down_action = QtGui.QAction("Down", menu)
+        move_down_action = QtGui.QAction("Move Down", menu)
         move_down_action.setObjectName("figureComposerContextMoveStepDownAction")
-        move_down_action.setEnabled(self.move_operation_down_button.isEnabled())
+        move_down_action.setEnabled(self._operation_move_possible(1))
         move_down_action.triggered.connect(self._move_current_operation_down)
         menu.addAction(move_down_action)
 
@@ -4285,9 +5476,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         source_by_name = {source.name: source for source in self._recipe.sources}
         sources = tuple(
-            source_by_name.get(
-                source_name, FigureSourceState(name=source_name, label=source_name)
-            )
+            source_by_name.get(source_name, FigureSourceState(name=source_name))
             for source_name in source_names
         )
         source_data = {
@@ -4457,6 +5646,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 "operations": tuple(operation_list),
             }
         )
+        self._normalize_operation_source_selections()
         self._refresh_source_list()
         if renamed_source_data:
             self.sigDataChanged.emit()
@@ -4637,6 +5827,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._recipe = self._recipe.model_copy(
             update={"operations": (*self._recipe.operations, operation)}
         )
+        self._normalize_operation_source_selections()
         self._apply_recipe_to_controls()
         self.operation_list.setCurrentRow(len(self._recipe.operations) - 1)
         self._maybe_redraw_plot()
@@ -4655,11 +5846,34 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         updated together so workspace saves include the new source data.
         """
         existing = {source.name: source for source in self._recipe.sources}
+        reserved = set(existing)
+        reserved.update(self._source_data)
+        source_data_updates: dict[str, xr.DataArray] = {}
         for source in sources:
-            existing[source.name] = source
-        self._source_data.update(source_data)
+            data = source_data.get(source.name)
+            if data is None:
+                continue
+            target_name = source.name
+            existing_source = existing.get(target_name)
+            same_linked_source = (
+                existing_source is not None
+                and existing_source.node_uid is not None
+                and existing_source.node_uid == source.node_uid
+            )
+            if existing_source is not None and not same_linked_source:
+                target_name = self._source_unique_alias(target_name, reserved)
+                source = source.model_copy(update={"name": target_name})
+            else:
+                reserved.add(target_name)
+            existing[target_name] = source
+            source_data_updates[target_name] = data
+            self._source_selection_base_data.pop(target_name, None)
+        if not source_data_updates:
+            return
+        self._source_data.update(source_data_updates)
         ordered_sources = tuple(existing[name] for name in existing)
         self._recipe = self._recipe.model_copy(update={"sources": ordered_sources})
+        self._normalize_operation_source_selections()
         self._refresh_source_list()
         self._update_source_section()
         self._maybe_redraw_plot()
@@ -4680,16 +5894,45 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         Returns ``False`` when no matching stored source or backing data slot exists.
         """
         source_list = list(self._recipe.sources)
-        for index, existing_source in enumerate(source_list):
-            if existing_source.name == alias:
-                source_list[index] = source.model_copy(update={"name": alias})
+        existing_source: FigureSourceState | None = None
+        existing_index: int | None = None
+        for candidate_index, candidate_source in enumerate(source_list):
+            if candidate_source.name == alias:
+                existing_source = candidate_source
+                existing_index = candidate_index
                 break
         else:
             if alias not in self._source_data:
                 return False
+            existing_source = None
             source_list.append(source.model_copy(update={"name": alias}))
+            existing_index = len(source_list) - 1
 
-        self._source_data[alias] = data
+        if existing_index is None:  # pragma: no cover
+            raise RuntimeError("source replacement index was not resolved")
+        replacement = source.model_copy(update={"name": alias})
+        if existing_source is not None and not _source_has_selection(replacement):
+            replacement = _source_with_selection(
+                replacement.model_copy(
+                    update={"selection_source": existing_source.selection_source}
+                ),
+                _source_selection(existing_source),
+            )
+        try:
+            selected_data = self._source_data_from_selection(alias, data, replacement)
+        except (IndexError, KeyError, TypeError, ValueError) as exc:
+            message = str(exc) or exc.__class__.__name__
+            self._set_source_status_text(
+                f"Could not refresh source “{alias}”: {message}"
+            )
+            return False
+        source_list[existing_index] = replacement
+
+        self._source_data[alias] = selected_data
+        if _source_has_selection(replacement):
+            self._source_selection_base_data[alias] = data
+        else:
+            self._source_selection_base_data.pop(alias, None)
         self._recipe = self._recipe.model_copy(update={"sources": tuple(source_list)})
         self._refresh_operation_list()
         self._refresh_step_section_button_texts()
@@ -4699,6 +5942,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.sigDataChanged.emit()
         self.sigInfoChanged.emit()
         self._write_state()
+        self._set_source_status_text(None)
         return True
 
     def remove_source(self, name: str) -> bool:
@@ -4714,6 +5958,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             updates["primary_source"] = source_list[0].name
         self._recipe = self._recipe.model_copy(update=updates)
         self._source_data.pop(name, None)
+        self._source_selection_base_data.pop(name, None)
         self._refresh_operation_list()
         self._refresh_step_section_button_texts()
         self._refresh_source_list()
@@ -4951,9 +6196,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self.copy_operation_button,
             self.cut_operation_button,
             self.paste_operation_button,
-            self.duplicate_operation_button,
-            self.move_operation_up_button,
-            self.move_operation_down_button,
             self.remove_operation_button,
             self.operation_list,
         )
@@ -4987,28 +6229,28 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _update_source_status(self, operation: FigureOperationState | None) -> None:
         if operation is None:
-            self._set_source_status_text("Select a step to choose data sources.")
+            self._set_step_source_status_text("Select a step to choose data sources.")
             return
         if (input_error := self._operation_input_error_text(operation)) is not None:
-            self._set_source_status_text(f"Invalid input: {input_error}")
+            self._set_step_source_status_text(f"Invalid input: {input_error}")
             return
         if (
             render_error := self._operation_render_errors.get(operation.operation_id)
         ) is not None:
-            self._set_source_status_text(f"Render error: {render_error}")
+            self._set_step_source_status_text(f"Render error: {render_error}")
             return
         selected_sources = self._selected_sources_for_operation(operation)
         missing = [
             source for source in selected_sources if source not in self._source_data
         ]
         if missing:
-            self._set_source_status_text(
+            self._set_step_source_status_text(
                 "Missing sources: " + ", ".join(self._source_display_names(missing))
             )
         elif selected_sources:
-            self._set_source_status_text(None)
+            self._set_step_source_status_text(None)
         else:
-            self._set_source_status_text("This step does not read a data source.")
+            self._set_step_source_status_text("This step does not read a data source.")
 
     def _update_source_section(self) -> None:
         self._clear_step_source_controls()
@@ -5535,6 +6777,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         self._recipe = status.model_copy(update={"operations": operations})
         self._ensure_primary_source_data()
+        self._normalize_operation_source_selections()
         self._apply_recipe_to_controls()
         self._sync_figure_window_to_recipe_setup()
         if self._dataset_restore_in_progress:
@@ -5544,6 +6787,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def set_source_data(self, source_data: Mapping[str, xr.DataArray]) -> None:
         self._source_data = dict(source_data)
+        self._source_selection_base_data.clear()
         self._mark_preview_pixmap_stale()
 
     def rebase_source_node_uids(self, uid_map: Mapping[str, str]) -> None:
@@ -5671,12 +6915,42 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
     ) -> None:
         source_data = dict(self._source_data)
+        selection_base_data: dict[str, xr.DataArray] = {}
+
+        def restored_source_data(
+            source: FigureSourceState, data: xr.DataArray
+        ) -> xr.DataArray:
+            if not _source_has_selection(source):
+                return data
+            try:
+                selected = self._source_data_from_selection(source.name, data, source)
+            except (IndexError, KeyError, TypeError, ValueError):
+                logger.debug(
+                    "Could not apply saved Figure Composer source selection for %s",
+                    source.name,
+                    exc_info=True,
+                )
+                return data
+            selection_base_data[source.name] = data
+            return selected
+
         primary_data = data_items.get(erlab.interactive.utils._SAVED_TOOL_DATA_NAME)
         changed = False
-        if primary_data is not None:
+        if (
+            primary_data is not None
+            and source_data.get(self._recipe.primary_source) is not primary_data
+        ):
             current_primary = source_data.get(self._recipe.primary_source)
             if current_primary is not None:
                 primary_data = primary_data.rename(current_primary.name)
+            else:
+                tool_data_name = ds.attrs.get("tool_data_name", "<none-value>")
+                if tool_data_name == "<none-value>":
+                    tool_data_name = None
+                primary_data = primary_data.rename(tool_data_name)
+            primary_source = self._recipe_source(self._recipe.primary_source)
+            if primary_source is not None:
+                primary_data = restored_source_data(primary_source, primary_data)
             source_data[self._recipe.primary_source] = primary_data
             changed = True
         for source in self._recipe.sources:
@@ -5685,13 +6959,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             source_data_item = data_items.get(source.name)
             if source_data_item is None:
                 continue
-            source_data[source.name] = source_data_item
+            source_data[source.name] = restored_source_data(source, source_data_item)
             changed = True
         if not changed:
             self._restore_persisted_preview_cache(ds)
             self._queue_post_restore_redraw_if_needed(ds)
             return
         self.set_source_data(source_data)
+        self._source_selection_base_data.update(selection_base_data)
+        self._normalize_operation_source_selections()
         self._apply_recipe_to_controls()
         self._restore_persisted_preview_cache(ds)
         self._queue_post_restore_redraw_if_needed(ds)
@@ -5960,19 +7236,210 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def source_data(self) -> dict[str, xr.DataArray]:
         return dict(self._source_data)
 
+    @staticmethod
+    def _source_selection_replay_operations(
+        source: FigureSourceState,
+    ) -> tuple[provenance.ToolProvenanceOperation, ...]:
+        operations: list[provenance.ToolProvenanceOperation] = []
+        if source.isel:
+            operations.append(
+                provenance.IselOperation(
+                    kwargs=typing.cast(
+                        "dict[Hashable, typing.Any]",
+                        dict(source.isel),
+                    )
+                )
+            )
+        if source.qsel:
+            operations.append(
+                provenance.QSelOperation(
+                    kwargs=typing.cast(
+                        "dict[Hashable, typing.Any]",
+                        dict(source.qsel),
+                    )
+                )
+            )
+        if source.mean_dims:
+            operations.append(
+                provenance.QSelAggregationOperation(
+                    dims=tuple(source.mean_dims),
+                    func="mean",
+                )
+            )
+        return tuple(operations)
+
+    @staticmethod
+    def _source_code_name_candidate(text: str) -> str | None:
+        text = re.sub(r"^\s*ImageTool\s+\d+\s*:\s*", "", text.strip())
+        text = (
+            unicodedata.normalize("NFKD", text)
+            .encode("ascii", "ignore")
+            .decode("ascii")
+        )
+        text = re.sub(r"[^0-9A-Za-z_]+", "_", text).strip("_").lower()
+        text = re.sub(r"_+", "_", text)
+        if text.startswith("data_"):
+            text = f"source_{text.removeprefix('data_')}"
+        if not text:
+            return None
+        if text[0].isdigit():
+            text = f"source_{text}"
+        if not text.isidentifier() or keyword.iskeyword(text):
+            return None
+        return text
+
+    def _source_display_code_name(
+        self,
+        source: FigureSourceState,
+        *,
+        used_names: set[str],
+    ) -> str:
+        candidates: list[str] = []
+        data = self._source_data.get(source.name)
+        if data is not None and isinstance(data.name, str):
+            candidates.append(data.name)
+        candidates.append(source.name)
+        for candidate in candidates:
+            name = self._source_code_name_candidate(candidate)
+            if name is not None:
+                break
+        else:
+            name = "source"
+
+        base = name
+        index = 2
+        while (
+            name in used_names
+            or name in _FIGURE_CODE_RESERVED_NAMES
+            or keyword.iskeyword(name)
+        ):
+            name = f"{base}_{index}"
+            index += 1
+        used_names.add(name)
+        return name
+
+    @staticmethod
+    def _script_input_with_name(
+        script_input: provenance.ScriptInput,
+        name: str,
+    ) -> provenance.ScriptInput:
+        if script_input.name == name:
+            return script_input
+        return script_input.model_copy(update={"name": name})
+
+    def _selected_source_script_input(
+        self,
+        source: FigureSourceState,
+        *,
+        display_name: str,
+        source_by_name: Mapping[str, FigureSourceState],
+    ) -> provenance.ScriptInput | None:
+        base_source = source_by_name.get(source.selection_source or source.name)
+        base_input = None if base_source is None else base_source.to_script_input()
+        if base_input is None:
+            base_input = source.to_script_input()
+        if base_input is None:
+            return None
+        base_spec = base_input.parsed_provenance_spec()
+        if base_spec is None:
+            return None
+
+        operations = self._source_selection_replay_operations(source)
+        if not operations:
+            return self._script_input_with_name(base_input, display_name)
+        try:
+            base_replay_spec = provenance.to_replay_provenance_spec(base_spec)
+            if base_replay_spec is None:
+                return None
+            selected_spec = base_replay_spec.append_replay_stage(
+                provenance.public_data(*operations)
+            )
+        except (TypeError, ValueError, pydantic.ValidationError):
+            return None
+        return provenance.ScriptInput(
+            name=display_name,
+            node_uid=base_input.node_uid,
+            node_snapshot_token=base_input.node_snapshot_token,
+            provenance_spec=selected_spec.model_dump(mode="json"),
+        )
+
+    def _display_code_source_plan(
+        self,
+    ) -> tuple[
+        tuple[provenance.ScriptInput, ...],
+        frozenset[str],
+        dict[str, str],
+    ]:
+        source_by_name = self._source_by_name()
+        used_sources = self._sources_used_by_recipe()
+        used_code_names = set(_FIGURE_CODE_RESERVED_NAMES)
+        script_inputs: list[provenance.ScriptInput] = []
+        script_input_names: set[str] = set()
+        skip_source_selection_names: set[str] = set()
+        source_name_map: dict[str, str] = {}
+
+        def append_script_input(script_input: provenance.ScriptInput | None) -> None:
+            if script_input is None or script_input.name in script_input_names:
+                return
+            script_inputs.append(script_input)
+            script_input_names.add(script_input.name)
+
+        for source in self._recipe.sources:
+            if source.name not in used_sources:
+                continue
+            display_name = self._source_display_code_name(
+                source,
+                used_names=used_code_names,
+            )
+            script_input: provenance.ScriptInput | None = None
+            if _source_has_selection(source):
+                script_input = self._selected_source_script_input(
+                    source,
+                    display_name=display_name,
+                    source_by_name=source_by_name,
+                )
+                if script_input is not None:
+                    skip_source_selection_names.add(source.name)
+                    source_name_map[source.name] = display_name
+                else:
+                    used_code_names.discard(display_name)
+                    base_source = source_by_name.get(
+                        source.selection_source or source.name
+                    )
+                    append_script_input(
+                        None if base_source is None else base_source.to_script_input()
+                    )
+            else:
+                script_input = source.to_script_input()
+                if script_input is not None:
+                    script_input = self._script_input_with_name(
+                        script_input,
+                        display_name,
+                    )
+                    source_name_map[source.name] = display_name
+            append_script_input(script_input)
+
+        return (
+            tuple(script_inputs),
+            frozenset(skip_source_selection_names),
+            source_name_map,
+        )
+
     def current_provenance_spec(
         self, *, flush_deferred_restore: bool = True
     ) -> provenance.ToolProvenanceSpec | None:
         del flush_deferred_restore
-        script_inputs = tuple(
-            script_input
-            for source in self._recipe.sources
-            if (script_input := source.to_script_input()) is not None
+        script_inputs, skip_source_selection_names, source_name_map = (
+            self._display_code_source_plan()
         )
         if not script_inputs:
             return None
         return provenance.script(
-            erlab.interactive._figurecomposer._provenance._figure_build_operation(self),
+            erlab.interactive._figurecomposer._provenance._figure_build_operation(
+                self,
+                skip_source_selection_names=skip_source_selection_names,
+                source_name_map=source_name_map,
+            ),
             start_label="Figure",
             active_name="fig",
             script_inputs=script_inputs,
@@ -5984,12 +7451,45 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         for source in self._recipe.sources:
             if source.name in names:
                 self._source_data.pop(source.name, None)
+                self._source_selection_base_data.pop(source.name, None)
         self._refresh_source_list()
         self._update_source_section()
         self._maybe_redraw_plot()
 
     def refresh_from_sources(self, source_data: Mapping[str, xr.DataArray]) -> None:
-        self._source_data.update(source_data)
+        source_by_name = self._source_by_name()
+        skipped: list[str] = []
+        changed = False
+        for source_name, data in source_data.items():
+            source = source_by_name.get(source_name)
+            if source is None:
+                self._source_data[source_name] = data
+                self._source_selection_base_data.pop(source_name, None)
+                changed = True
+                continue
+            try:
+                selected_data = self._source_data_from_selection(
+                    source_name, data, source
+                )
+            except (IndexError, KeyError, TypeError, ValueError) as exc:
+                message = str(exc) or exc.__class__.__name__
+                skipped.append(f"{source_name} ({message})")
+                continue
+            self._source_data[source_name] = selected_data
+            if _source_has_selection(source):
+                self._source_selection_base_data[source_name] = data
+            else:
+                self._source_selection_base_data.pop(source_name, None)
+            changed = True
+        if skipped:
+            self._set_source_status_text(
+                "Could not refresh source data for: " + ", ".join(skipped)
+            )
+        elif changed:
+            self._set_source_status_text(None)
+        if not changed:
+            self._refresh_source_controls()
+            return
         self._refresh_source_list()
         self._update_source_section()
         self._maybe_redraw_plot()

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -26,6 +26,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 from matplotlib.figure import Figure
 # isort: on
 
+import numpy as np
 import pydantic
 
 import erlab
@@ -33,7 +34,7 @@ import erlab.interactive._figurecomposer._codegen
 import erlab.interactive._figurecomposer._provenance
 import erlab.interactive._figurecomposer._toolbar_dialogs
 import erlab.interactive._qt_state as _qt_state
-from erlab.interactive._figurecomposer._axes import _all_axes
+from erlab.interactive._figurecomposer._axes import _all_axes, _axes_expression_value
 from erlab.interactive._figurecomposer._defaults import (
     _MM_PER_INCH,
     _figure_draw_context,
@@ -156,10 +157,13 @@ from erlab.interactive._figurecomposer._text import (
 )
 from erlab.interactive._figurecomposer._widgets import (
     _AxesSelectorWidget,
+    _AxesTargetItemDelegate,
     _FigureComposerDisplayWindow,
+    _gridspec_target_preview_descriptor,
     _GridSpecRegionInfo,
     _GridSpecViewWidget,
     _step_toolbar_button,
+    _subplot_target_preview_descriptor,
 )
 from erlab.interactive.imagetool import provenance
 
@@ -198,13 +202,25 @@ _COMBO_TRACKED_PROPERTY = "figure_composer_combo_tracked"
 _COMBO_POPUP_GUARD_ID_PROPERTY = "figure_composer_combo_popup_guard_id"
 _RESTORE_OPERATION_EDITOR_KEY = "figure_composer_operation_editor"
 _RESTORE_REDRAW_KEY = "figure_composer_restored_redraw"
+_OPERATION_LIST_STEP_COLUMN = 0
+_OPERATION_LIST_TARGET_COLUMN = 1
+_OPERATION_LIST_STATUS_COLUMN = 2
+_OPERATION_LIST_TARGET_ROLE = QtCore.Qt.ItemDataRole.UserRole + 1
+_OPERATION_LIST_STATUS_ROLE = QtCore.Qt.ItemDataRole.UserRole + 2
 _SOURCE_LIST_SOURCE_COLUMN = 0
 _SOURCE_LIST_SHAPE_COLUMN = 1
-_SOURCE_LIST_ACTION_COLUMN = 2
+_SOURCE_LIST_USED_ROLE = QtCore.Qt.ItemDataRole.UserRole + 1
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
 logger = logging.getLogger(__name__)
+
+_OPERATION_STATUS_LABELS = {
+    "invalid_target": "Invalid target",
+    "missing_source": "Missing source",
+    "invalid_input": "Invalid input",
+    "render_error": "Render error",
+}
 
 
 class _FigureComposerStepMimeData(QtCore.QMimeData):
@@ -232,39 +248,176 @@ def _event_requests_context_menu(event: QtGui.QKeyEvent) -> bool:
     )
 
 
-class _FigureComposerOperationList(QtWidgets.QListWidget):
-    copy_requested = QtCore.Signal()
-    cut_requested = QtCore.Signal()
-    paste_requested = QtCore.Signal()
-    context_menu_requested = QtCore.Signal(QtCore.QPoint)
+class _FigureComposerStepEditorScroll(QtWidgets.QScrollArea):
+    """Scroll vertically without allowing the editor content to clip horizontally."""
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        hint = super().minimumSizeHint()
+        content = self.widget()
+        if content is None:
+            return hint
+        width = content.minimumSizeHint().width() + 2 * self.frameWidth()
+        if (
+            self.verticalScrollBarPolicy()
+            != QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        ):
+            scrollbar = self.verticalScrollBar()
+            if scrollbar is not None:  # pragma: no branch
+                width += scrollbar.sizeHint().width()
+        return QtCore.QSize(max(hint.width(), width), hint.height())
+
+
+class _FigureComposerStepEditorPage(QtWidgets.QWidget):
+    """Editor page that clears itself with the enclosing tab pane background."""
+
+    def __init__(
+        self,
+        editor_tabs: QtWidgets.QTabWidget,
+        parent: QtWidgets.QWidget,
+    ) -> None:
+        super().__init__(parent)
+        self._editor_tabs = editor_tabs
+        self._background_color = self.palette().color(QtGui.QPalette.ColorRole.Window)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_OpaquePaintEvent, True)
+
+    def _refresh_background(self) -> None:
+        source = self._editor_tabs
+        sample_point = source.rect().center()
+        background = QtGui.QPixmap(1, 1)
+        background.fill(self._background_color)
+        source.render(
+            background,
+            QtCore.QPoint(),
+            QtGui.QRegion(QtCore.QRect(sample_point, QtCore.QSize(1, 1))),
+            QtWidgets.QWidget.RenderFlag.DrawWindowBackground,
+        )
+        color = background.toImage().pixelColor(0, 0)
+        if color.isValid() and color.alpha() != 0:
+            self._background_color = color
+            self.update()
+
+    def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
+        painter = QtGui.QPainter(self)
+        try:
+            painter.fillRect(self.rect(), self._background_color)
+        finally:
+            painter.end()
+        if event is not None:
+            super().paintEvent(event)
+
+    def changeEvent(self, event: QtCore.QEvent | None) -> None:
+        if event is not None:
+            super().changeEvent(event)
+        if event is not None and event.type() in {
+            QtCore.QEvent.Type.ApplicationPaletteChange,
+            QtCore.QEvent.Type.PaletteChange,
+            QtCore.QEvent.Type.StyleChange,
+        }:
+            self._background_color = self.palette().color(
+                QtGui.QPalette.ColorRole.Window
+            )
+            erlab.interactive.utils.single_shot(self, 0, self._refresh_background)
+
+
+class _FigureComposerReorderList(QtWidgets.QTreeWidget):
     rows_reordered = QtCore.Signal(object, object, object)
 
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+    def __init__(self, id_column: int, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)
-        self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
-        self.customContextMenuRequested.connect(self.context_menu_requested)
+        self._reorder_id_column = id_column
+        self._rows_reordered_pending = False
         self.setDragEnabled(True)
         self.setAcceptDrops(True)
         self.setDropIndicatorShown(True)
         self.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
         self.setDefaultDropAction(QtCore.Qt.DropAction.MoveAction)
         self.setDragDropOverwriteMode(False)
-        model = self.model()
-        if model is None:
-            raise RuntimeError("Figure Composer operation list has no item model")
-        model.rowsMoved.connect(self._model_rows_moved)
+
+    def _row_ids(self) -> tuple[str, ...]:
+        row_ids: list[str] = []
+        for row in range(self.topLevelItemCount()):
+            item = self.topLevelItem(row)
+            row_id = (
+                None
+                if item is None
+                else item.data(
+                    self._reorder_id_column,
+                    QtCore.Qt.ItemDataRole.UserRole,
+                )
+            )
+            if not isinstance(row_id, str):
+                return ()
+            row_ids.append(row_id)
+        return tuple(row_ids)
+
+    def _queue_rows_reordered(self, *_args: object) -> None:
+        if self._rows_reordered_pending:
+            return
+        self._rows_reordered_pending = True
+        # Let QTreeWidget finish transferring ownership of the dragged items before
+        # the recipe refreshes this view.
+        erlab.interactive.utils.single_shot(self, 0, self._emit_rows_reordered)
+
+    def _emit_rows_reordered(self) -> None:
+        self._rows_reordered_pending = False
+        row_ids = self._row_ids()
+        if not row_ids or len(set(row_ids)) != len(row_ids):
+            return
+        current_id = None
+        current_item = self.currentItem()
+        if current_item is not None:
+            candidate = current_item.data(
+                self._reorder_id_column,
+                QtCore.Qt.ItemDataRole.UserRole,
+            )
+            if isinstance(candidate, str):
+                current_id = candidate
+        selected_ids = frozenset(
+            row_id
+            for item in self.selectedItems()
+            if isinstance(
+                row_id := item.data(
+                    self._reorder_id_column,
+                    QtCore.Qt.ItemDataRole.UserRole,
+                ),
+                str,
+            )
+        )
+        self.rows_reordered.emit(row_ids, selected_ids, current_id)
+
+    def dropEvent(self, event: QtGui.QDropEvent | None) -> None:
+        if event is None:
+            return
+        if event.source() is not self:
+            event.ignore()
+            return
+        super().dropEvent(event)
+        if event.isAccepted():
+            self._queue_rows_reordered()
+
+
+class _FigureComposerOperationList(_FigureComposerReorderList):
+    copy_requested = QtCore.Signal()
+    cut_requested = QtCore.Signal()
+    paste_requested = QtCore.Signal()
+    context_menu_requested = QtCore.Signal(QtCore.QPoint)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(_OPERATION_LIST_STEP_COLUMN, parent)
+        self.setColumnCount(3)
+        self.setHeaderLabels(("Step", "Target", "Status"))
+        self.setRootIsDecorated(False)
+        self.setItemsExpandable(False)
+        self.setIndentation(0)
+        self.setUniformRowHeights(True)
+        self.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.context_menu_requested)
 
     def _operation_ids(self) -> tuple[str, ...]:
-        operation_ids: list[str] = []
-        for row in range(self.count()):
-            item = self.item(row)
-            operation_id = (
-                None if item is None else item.data(QtCore.Qt.ItemDataRole.UserRole)
-            )
-            if not isinstance(operation_id, str):
-                return ()
-            operation_ids.append(operation_id)
-        return tuple(operation_ids)
+        return self._row_ids()
 
     def keyPressEvent(self, event: QtGui.QKeyEvent | None) -> None:
         if event is None:
@@ -289,66 +442,17 @@ class _FigureComposerOperationList(QtWidgets.QListWidget):
             return
         super().keyPressEvent(event)
 
-    def _model_rows_moved(self, *_args: object) -> None:
-        operation_ids = self._operation_ids()
-        if not operation_ids or len(set(operation_ids)) != len(operation_ids):
-            return
-        current_item = self.currentItem()
-        current_id = (
-            None
-            if current_item is None
-            else current_item.data(QtCore.Qt.ItemDataRole.UserRole)
-        )
-        selected_ids = frozenset(
-            operation_id
-            for item in self.selectedItems()
-            if isinstance(
-                operation_id := item.data(QtCore.Qt.ItemDataRole.UserRole),
-                str,
-            )
-        )
-        self.rows_reordered.emit(
-            operation_ids,
-            selected_ids,
-            current_id if isinstance(current_id, str) else None,
-        )
 
-
-class _FigureComposerSourceList(QtWidgets.QTreeWidget):
+class _FigureComposerSourceList(_FigureComposerReorderList):
     context_menu_requested = QtCore.Signal(QtCore.QPoint)
-    rows_reordered = QtCore.Signal(object, object, object)
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
-        super().__init__(parent)
+        super().__init__(_SOURCE_LIST_SOURCE_COLUMN, parent)
         self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self.context_menu_requested)
-        self.setDragEnabled(True)
-        self.setAcceptDrops(True)
-        self.setDropIndicatorShown(True)
-        self.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
-        self.setDefaultDropAction(QtCore.Qt.DropAction.MoveAction)
-        self.setDragDropOverwriteMode(False)
-        model = self.model()
-        if model is None:
-            raise RuntimeError("Figure Composer source list has no item model")
-        model.rowsMoved.connect(self._model_rows_moved)
 
     def _source_names(self) -> tuple[str, ...]:
-        source_names: list[str] = []
-        for row in range(self.topLevelItemCount()):
-            item = self.topLevelItem(row)
-            source_name = (
-                None
-                if item is None
-                else item.data(
-                    _SOURCE_LIST_SOURCE_COLUMN,
-                    QtCore.Qt.ItemDataRole.UserRole,
-                )
-            )
-            if not isinstance(source_name, str):
-                return ()
-            source_names.append(source_name)
-        return tuple(source_names)
+        return self._row_ids()
 
     def keyPressEvent(self, event: QtGui.QKeyEvent | None) -> None:
         if event is None:
@@ -360,43 +464,6 @@ class _FigureComposerSourceList(QtWidgets.QTreeWidget):
             event.accept()
             return
         super().keyPressEvent(event)
-
-    def _model_rows_moved(self, *_args: object) -> None:
-        self._emit_rows_reordered()
-
-    def dropEvent(self, event: QtGui.QDropEvent | None) -> None:
-        if event is None:
-            return
-        before = self._source_names()
-        super().dropEvent(event)
-        if self._source_names() != before:
-            self._emit_rows_reordered()
-
-    def _emit_rows_reordered(self) -> None:
-        source_names = self._source_names()
-        if not source_names or len(set(source_names)) != len(source_names):
-            return
-        current_name = None
-        current_item = self.currentItem()
-        if current_item is not None:
-            candidate = current_item.data(
-                _SOURCE_LIST_SOURCE_COLUMN,
-                QtCore.Qt.ItemDataRole.UserRole,
-            )
-            if isinstance(candidate, str):
-                current_name = candidate
-        selected_names = frozenset(
-            source_name
-            for item in self.selectedItems()
-            if isinstance(
-                source_name := item.data(
-                    _SOURCE_LIST_SOURCE_COLUMN,
-                    QtCore.Qt.ItemDataRole.UserRole,
-                ),
-                str,
-            )
-        )
-        self.rows_reordered.emit(source_names, selected_names, current_name)
 
 
 def _step_clipboard_payload_text(
@@ -518,6 +585,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._rendering = False
         self._auto_redraw_dirty = False
         self._operation_editor_update_pending = False
+        self._operation_axes_sync_pending = False
         self._preview_render_update_pending = False
         self._preview_render_update_generation = 0
         self._step_tab_order_update_pending = False
@@ -526,6 +594,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._next_combo_popup_guard_token = 0
         self._tracked_combo_refs: list[weakref.ReferenceType[QtWidgets.QComboBox]] = []
         self._operation_multi_select_event = False
+        self._operation_selection_input_event = False
+        self._operation_selection_state: tuple[str | None, frozenset[str]] | None = None
         self._operation_list_viewport: QtWidgets.QWidget | None = None
         self._retired_editor_widgets: list[QtWidgets.QWidget] = []
         self._operation_render_errors: dict[str, str] = {}
@@ -563,7 +633,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._source_selection_base_data: dict[str, xr.DataArray] = {}
         self._source_refresh_available_callback: Callable[[str], bool] | None = None
         self._source_refresh_callback: Callable[[str], bool] | None = None
-        self._source_refresh_many_callback: Callable[[Sequence[str]], int] | None = None
         self._source_refresh_label_callback: Callable[[str], str | None] | None = None
         self._source_add_available_callback: Callable[[], bool] | None = None
         self._source_add_callback: Callable[[], bool] | None = None
@@ -933,7 +1002,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._update_step_action_buttons()
         self._refresh_step_section_button_texts()
         self._update_source_status(current_operation[1] if current_operation else None)
-        self._refresh_source_inspector()
+        self._refresh_source_detail_panel()
         if current_operation is not None and (
             current_operation[1].operation_id in changed_operation_ids
         ):
@@ -1185,6 +1254,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def showEvent(self, event: QtGui.QShowEvent | None) -> None:
         if event is not None:
             super().showEvent(event)
+        current_page = self.step_editor_stack.currentWidget()
+        if isinstance(current_page, _FigureComposerStepEditorPage):
+            current_page._refresh_background()
         self._request_show_figure_window(activate=False)
 
     def hideEvent(self, event: QtGui.QHideEvent | None) -> None:
@@ -1360,10 +1432,18 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._show_operation_context_menu
         )
         self.operation_list.rows_reordered.connect(self._operation_list_reordered)
+        self.operation_target_delegate = _AxesTargetItemDelegate(
+            int(_OPERATION_LIST_TARGET_ROLE), self.operation_list
+        )
+        self.operation_list.setItemDelegateForColumn(
+            _OPERATION_LIST_TARGET_COLUMN, self.operation_target_delegate
+        )
         self._operation_list_viewport = self.operation_list.viewport()
         if self._operation_list_viewport is not None:
             self._operation_list_viewport.installEventFilter(self)
-        self.operation_list.currentRowChanged.connect(self._operation_selection_changed)
+        self.operation_list.currentItemChanged.connect(
+            self._operation_current_item_changed
+        )
         self.operation_list.itemSelectionChanged.connect(
             self._operation_selection_changed
         )
@@ -1371,24 +1451,43 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.operation_list.setSelectionMode(
             QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
         )
-        self.operation_list.setMinimumHeight(72)
+        self.operation_list.setMinimumHeight(140)
         self.operation_list.setVerticalScrollBarPolicy(
-            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
         )
         self.operation_list.setHorizontalScrollBarPolicy(
-            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
         )
+        operation_header = self.operation_list.header()
+        if operation_header is not None:  # pragma: no branch
+            operation_header.setStretchLastSection(False)
+            operation_header.setMinimumSectionSize(48)
+            operation_header.setSectionResizeMode(
+                _OPERATION_LIST_STEP_COLUMN,
+                QtWidgets.QHeaderView.ResizeMode.Stretch,
+            )
+            operation_header.setSectionResizeMode(
+                _OPERATION_LIST_TARGET_COLUMN,
+                QtWidgets.QHeaderView.ResizeMode.Interactive,
+            )
+            operation_header.setSectionResizeMode(
+                _OPERATION_LIST_STATUS_COLUMN,
+                QtWidgets.QHeaderView.ResizeMode.Interactive,
+            )
+            operation_header.resizeSection(_OPERATION_LIST_TARGET_COLUMN, 72)
+            operation_header.resizeSection(_OPERATION_LIST_STATUS_COLUMN, 88)
         self.recipe_splitter.addWidget(self.operation_list)
 
         self.step_inspector = QtWidgets.QWidget(recipe_page)
         self.step_inspector.setObjectName("figureComposerStepInspector")
+        self.step_inspector.setAutoFillBackground(False)
         step_inspector_layout = QtWidgets.QHBoxLayout(self.step_inspector)
         step_inspector_layout.setContentsMargins(0, 0, 0, 0)
         step_inspector_layout.setSpacing(6)
         self.recipe_splitter.addWidget(self.step_inspector)
         self.recipe_splitter.setStretchFactor(0, 0)
         self.recipe_splitter.setStretchFactor(1, 1)
-        self.recipe_splitter.setSizes((130, 420))
+        self.recipe_splitter.setSizes((140, 410))
 
         self.step_navigator = QtWidgets.QWidget(self.step_inspector)
         self.step_navigator.setObjectName("figureComposerStepNavigator")
@@ -1400,12 +1499,32 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.step_section_keys: list[str] = []
         step_inspector_layout.addWidget(self.step_navigator)
 
-        self.step_editor_stack = QtWidgets.QStackedWidget(self.step_inspector)
+        self.step_editor_scroll = _FigureComposerStepEditorScroll(self.step_inspector)
+        self.step_editor_scroll.setObjectName("figureComposerStepEditorScroll")
+        self.step_editor_scroll.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self.step_editor_scroll.setWidgetResizable(True)
+        self.step_editor_scroll.setHorizontalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self.step_editor_scroll.setVerticalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        self.step_editor_scroll.setAutoFillBackground(False)
+        step_editor_viewport = self.step_editor_scroll.viewport()
+        if step_editor_viewport is not None:  # pragma: no branch
+            step_editor_viewport.setObjectName("figureComposerStepEditorViewport")
+            step_editor_viewport.setAutoFillBackground(False)
+        step_inspector_layout.addWidget(self.step_editor_scroll, 1)
+
+        self.step_editor_stack = QtWidgets.QStackedWidget()
         self.step_editor_stack.setObjectName("figureComposerStepSectionStack")
-        step_inspector_layout.addWidget(self.step_editor_stack, 1)
+        self.step_editor_scroll.setWidget(self.step_editor_stack)
+        self.step_editor_stack.setAutoFillBackground(False)
         self._operation_editor_pages: list[QtWidgets.QWidget] = []
 
-        self.step_sources_page = QtWidgets.QWidget(self.step_editor_stack)
+        self.step_sources_page = _FigureComposerStepEditorPage(
+            self.editor_tabs, self.step_editor_stack
+        )
         self.step_sources_page.setObjectName("figureComposerStepSourcesPage")
         step_sources_layout = QtWidgets.QVBoxLayout(self.step_sources_page)
         step_sources_layout.setContentsMargins(6, 6, 6, 6)
@@ -1461,21 +1580,30 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         source_actions_layout.addStretch(1)
         self.refresh_sources_button = QtWidgets.QToolButton(self.source_actions)
         self.refresh_sources_button.setObjectName("figureComposerRefreshSourcesButton")
-        self.refresh_sources_button.setText("Refresh Sources")
-        self.refresh_sources_button.setAccessibleName("Refresh Sources")
+        self.refresh_sources_button.setText("Refresh")
+        self.refresh_sources_button.setAccessibleName("Refresh Selected Sources")
         self.refresh_sources_button.setIcon(QtGui.QIcon.fromTheme("view-refresh"))
         self.refresh_sources_button.setToolButtonStyle(
             QtCore.Qt.ToolButtonStyle.ToolButtonTextBesideIcon
         )
         self.refresh_sources_button.setAutoRaise(True)
-        self.refresh_sources_button.clicked.connect(self._refresh_sources_from_button)
+        self.refresh_sources_button.clicked.connect(
+            self._refresh_selected_sources_from_button
+        )
         source_actions_layout.addWidget(self.refresh_sources_button)
         sources_layout.addWidget(self.source_actions)
         sources_layout.addWidget(self.source_status_label)
-        self.source_list = _FigureComposerSourceList(self.sources_page)
+
+        self.source_splitter = QtWidgets.QSplitter(
+            QtCore.Qt.Orientation.Horizontal, self.sources_page
+        )
+        self.source_splitter.setObjectName("figureComposerSourceSplitter")
+        self.source_splitter.setChildrenCollapsible(False)
+        self.source_list = _FigureComposerSourceList(self.source_splitter)
         self.source_list.setObjectName("figureComposerSourceList")
-        self.source_list.setColumnCount(3)
-        self.source_list.setHeaderLabels(("Alias", "Shape", ""))
+        self.source_list.setAccessibleName("Figure Sources")
+        self.source_list.setColumnCount(2)
+        self.source_list.setHeaderLabels(("Alias", "Shape"))
         self.source_list.context_menu_requested.connect(self._show_source_context_menu)
         self.source_list.rows_reordered.connect(self._source_list_reordered)
         self.source_list.setRootIsDecorated(False)
@@ -1511,23 +1639,57 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         source_header = self.source_list.header()
         if source_header is not None:
             source_header.setStretchLastSection(False)
+            source_header.setMinimumSectionSize(80)
             source_header.setSectionResizeMode(
                 _SOURCE_LIST_SOURCE_COLUMN,
                 QtWidgets.QHeaderView.ResizeMode.Stretch,
             )
             source_header.setSectionResizeMode(
                 _SOURCE_LIST_SHAPE_COLUMN,
-                QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
+                QtWidgets.QHeaderView.ResizeMode.Interactive,
             )
-            source_header.setSectionResizeMode(
-                _SOURCE_LIST_ACTION_COLUMN,
-                QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
-            )
-        sources_layout.addWidget(self.source_list, 1)
-        self.source_inspector = SourceInspectorWidget(self.sources_page)
+            source_header.resizeSection(_SOURCE_LIST_SHAPE_COLUMN, 150)
+        self.source_splitter.addWidget(self.source_list)
+
+        self.source_detail_scroll = QtWidgets.QScrollArea(self.source_splitter)
+        self.source_detail_scroll.setObjectName("figureComposerSourceDetailScroll")
+        self.source_detail_scroll.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self.source_detail_scroll.setWidgetResizable(True)
+        self.source_detail_scroll.setHorizontalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self.source_detail_content = QtWidgets.QWidget(self.source_detail_scroll)
+        self.source_detail_content.setObjectName("figureComposerSourceDetailContent")
+        source_detail_layout = QtWidgets.QVBoxLayout(self.source_detail_content)
+        source_detail_layout.setContentsMargins(8, 0, 0, 0)
+        source_detail_layout.setSpacing(6)
+
+        self.source_editor_state_label = QtWidgets.QLabel(
+            "Select a source to inspect or edit it.", self.source_detail_content
+        )
+        self.source_editor_state_label.setObjectName("figureComposerSourceEditorState")
+        self.source_editor_state_label.setWordWrap(True)
+        source_detail_layout.addWidget(self.source_editor_state_label)
+
+        self.source_alias_controls = QtWidgets.QWidget(self.source_detail_content)
+        self.source_alias_controls.setObjectName("figureComposerSourceAliasControls")
+        source_alias_layout = QtWidgets.QFormLayout(self.source_alias_controls)
+        source_alias_layout.setContentsMargins(0, 0, 0, 0)
+        source_alias_layout.setSpacing(4)
+        source_alias_layout.setFieldGrowthPolicy(
+            QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
+        )
+        self.source_alias_edit = QtWidgets.QLineEdit(self.source_alias_controls)
+        self.source_alias_edit.setObjectName("figureComposerSourceAliasEdit")
+        self.source_alias_edit.setToolTip("Rename this source variable.")
+        self.source_alias_edit.editingFinished.connect(self._commit_source_alias_edit)
+        source_alias_layout.addRow("Alias", self.source_alias_edit)
+        source_detail_layout.addWidget(self.source_alias_controls)
+
+        self.source_inspector = SourceInspectorWidget(self.source_detail_content)
         self.source_inspector.setAcceptDrops(True)
-        sources_layout.addWidget(self.source_inspector)
-        self.source_selection_controls = QtWidgets.QWidget(self.sources_page)
+        source_detail_layout.addWidget(self.source_inspector)
+        self.source_selection_controls = QtWidgets.QWidget(self.source_detail_content)
         self.source_selection_controls.setObjectName(
             "figureComposerSourceSelectionControls"
         )
@@ -1540,11 +1702,32 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
         )
         self.source_selection_controls.setAcceptDrops(True)
-        sources_layout.addWidget(self.source_selection_controls)
+        source_detail_layout.addWidget(self.source_selection_controls)
+        self.source_validation_label = QtWidgets.QLabel(self.source_detail_content)
+        self.source_validation_label.setObjectName(
+            "figureComposerSourceValidationStatus"
+        )
+        self.source_validation_label.setWordWrap(True)
+        self.source_validation_label.setVisible(False)
+        source_detail_layout.addWidget(self.source_validation_label)
+        source_detail_layout.addStretch(1)
+        self.source_detail_scroll.setWidget(self.source_detail_content)
+        self.source_detail_content.setAutoFillBackground(False)
+        source_detail_viewport = self.source_detail_scroll.viewport()
+        if source_detail_viewport is not None:  # pragma: no branch
+            source_detail_viewport.setAutoFillBackground(False)
+        self.source_splitter.addWidget(self.source_detail_scroll)
+        self.source_splitter.setStretchFactor(0, 2)
+        self.source_splitter.setStretchFactor(1, 3)
+        self.source_splitter.setSizes((400, 600))
+        sources_layout.addWidget(self.source_splitter, 1)
         for drop_target in (
             self.sources_page,
             self.source_list,
             self.source_list.viewport(),
+            self.source_detail_scroll,
+            self.source_detail_scroll.viewport(),
+            self.source_detail_content,
             self.source_inspector,
             self.source_selection_controls,
         ):
@@ -1552,7 +1735,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 drop_target.setAcceptDrops(True)
                 drop_target.installEventFilter(self)
 
-        self.target_axes_page = QtWidgets.QWidget(self.step_editor_stack)
+        self.target_axes_page = _FigureComposerStepEditorPage(
+            self.editor_tabs, self.step_editor_stack
+        )
         self.target_axes_page.setObjectName("figureComposerTargetAxesPage")
         target_axes_layout = QtWidgets.QVBoxLayout(self.target_axes_page)
         target_axes_layout.setContentsMargins(6, 6, 6, 6)
@@ -2015,8 +2200,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._refresh_source_list()
             self._rebuild_axes_grid()
             self._refresh_operation_list()
-            if self.operation_list.count() and self.operation_list.currentRow() < 0:
-                self.operation_list.setCurrentRow(0)
+            if (
+                self.operation_list.topLevelItemCount()
+                and self.operation_list.currentItem() is None
+            ):
+                self.operation_list.setCurrentItem(self.operation_list.topLevelItem(0))
             self._refresh_operation_editor()
         finally:
             self._updating_controls = False
@@ -2031,14 +2219,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         *,
         can_refresh_source: Callable[[str], bool] | None = None,
         refresh_source: Callable[[str], bool] | None = None,
-        refresh_sources: Callable[[Sequence[str]], int] | None = None,
         source_label: Callable[[str], str | None] | None = None,
     ) -> None:
         self._source_refresh_available_callback = can_refresh_source
         self._source_refresh_callback = refresh_source
-        self._source_refresh_many_callback = refresh_sources
         self._source_refresh_label_callback = source_label
-        self._refresh_source_controls()
+        self.refresh_source_controls()
 
     def _set_source_add_callbacks(
         self,
@@ -2126,6 +2312,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return values
 
     def _refresh_source_list(self) -> None:
+        inspector = getattr(self, "source_inspector", None)
+        if isinstance(inspector, SourceInspectorWidget):
+            inspector.invalidate_details()
+        selected_names = set(self._selected_source_names())
+        current_name = self._source_name_from_list_item(self.source_list.currentItem())
         self._clear_source_list_widgets()
         source_by_name = {source.name: source for source in self._recipe.sources}
         used_sources = self._sources_used_by_recipe()
@@ -2153,10 +2344,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 missing=name not in source_by_name,
                 used=name in used_sources,
             )
-        self.source_list.resizeColumnToContents(_SOURCE_LIST_SHAPE_COLUMN)
-        self.source_list.resizeColumnToContents(_SOURCE_LIST_ACTION_COLUMN)
+        available_names = set(self._source_names())
+        selected_names.intersection_update(available_names)
+        if current_name not in available_names:
+            current_name = (
+                self._source_inspector_target
+                if self._source_inspector_target in available_names
+                else self._default_source_inspector_target()
+            )
+        if not selected_names and current_name is not None:
+            selected_names.add(current_name)
+        self._set_selected_source_names_silent(selected_names, current_name)
+        self._source_inspector_target = current_name
         self._refresh_source_controls()
-        self._refresh_source_inspector()
+        self._refresh_source_detail_panel()
         self._refresh_source_selection_editor()
 
     def _clear_source_list_widgets(self) -> None:
@@ -2184,12 +2385,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         used: bool = False,
     ) -> None:
         item = QtWidgets.QTreeWidgetItem(
-            [display, "missing" if data is None else "", ""]
+            [display, "Data unavailable" if data is None else ""]
         )
         item.setData(_SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole, name)
-        tooltip = self._source_tooltip(name)
-        item.setToolTip(_SOURCE_LIST_SOURCE_COLUMN, tooltip)
-        item.setToolTip(_SOURCE_LIST_SHAPE_COLUMN, tooltip)
+        item.setData(_SOURCE_LIST_SOURCE_COLUMN, _SOURCE_LIST_USED_ROLE, used)
         item.setFlags(
             QtCore.Qt.ItemFlag.ItemIsEnabled
             | QtCore.Qt.ItemFlag.ItemIsSelectable
@@ -2203,10 +2402,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 _SOURCE_LIST_SHAPE_COLUMN, QtGui.QBrush(QtGui.QColor("darkRed"))
             )
         self.source_list.addTopLevelItem(item)
-        self._set_source_list_row_used(item, used)
-        action_widget = self._source_action_widget(name, display)
-        item.setSizeHint(_SOURCE_LIST_ACTION_COLUMN, action_widget.sizeHint())
-        self.source_list.setItemWidget(item, _SOURCE_LIST_ACTION_COLUMN, action_widget)
+        self._update_source_list_item(item)
         if data is None:
             return
 
@@ -2236,6 +2432,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         item.setSizeHint(_SOURCE_LIST_SHAPE_COLUMN, shape_label.sizeHint())
         self.source_list.setItemWidget(item, _SOURCE_LIST_SHAPE_COLUMN, shape_label)
 
+    def _update_source_list_item(self, item: QtWidgets.QTreeWidgetItem) -> None:
+        name = self._source_name_from_list_item(item)
+        if name is None:
+            return
+        item.setIcon(_SOURCE_LIST_SOURCE_COLUMN, QtGui.QIcon())
+        tooltip = self._source_tooltip(name)
+        item.setToolTip(_SOURCE_LIST_SOURCE_COLUMN, tooltip)
+        item.setToolTip(_SOURCE_LIST_SHAPE_COLUMN, tooltip)
+        item.setData(
+            _SOURCE_LIST_SOURCE_COLUMN,
+            QtCore.Qt.ItemDataRole.AccessibleDescriptionRole,
+            tooltip,
+        )
+
     @QtCore.Slot(QtWidgets.QTreeWidgetItem, QtWidgets.QTreeWidgetItem)
     def _source_list_current_item_changed(
         self,
@@ -2245,17 +2455,18 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if self._updating_source_selection:
             return
         source_name = self._source_name_from_list_item(current)
-        if source_name is None:
-            return
         self._source_inspector_target = source_name
-        self._refresh_source_inspector()
+        self._set_source_validation_text(None)
+        self._refresh_source_detail_panel()
         self._refresh_source_selection_editor()
 
     @QtCore.Slot()
     def _source_list_selection_changed(self) -> None:
         if self._updating_source_selection:
             return
+        self._set_source_validation_text(None)
         self._refresh_source_controls()
+        self._refresh_source_detail_panel()
         self._refresh_source_selection_editor()
 
     @staticmethod
@@ -2275,9 +2486,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             source_name = self._source_name_from_list_item(item)
             if source_name is not None and source_name not in names:
                 names.append(source_name)
-        current = self._source_name_from_list_item(self.source_list.currentItem())
-        if not names and current is not None:
-            names.append(current)
         return tuple(names)
 
     def _selected_source_indices(self) -> tuple[int, ...]:
@@ -2309,6 +2517,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._updating_source_selection = True
         try:
             self.source_list.clearSelection()
+            if current_name is None:
+                self.source_list.setCurrentIndex(QtCore.QModelIndex())
             current_item: QtWidgets.QTreeWidgetItem | None = None
             for row in range(self.source_list.topLevelItemCount()):
                 item = self.source_list.topLevelItem(row)
@@ -2329,53 +2539,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         finally:
             self._updating_source_selection = False
 
-    def _source_refresh_button(self, name: str) -> QtWidgets.QToolButton:
-        button = QtWidgets.QToolButton(self.source_list)
-        button.setObjectName("figureComposerRefreshSourceButton")
-        button.setProperty("figure_source_name", name)
-        button.setAccessibleName("Refresh Source")
-        button.setIcon(QtGui.QIcon.fromTheme("view-refresh"))
-        button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly)
-        button.setAutoRaise(True)
-        button.clicked.connect(
-            functools.partial(self._refresh_source_from_button, name)
-        )
-        return button
-
-    def _source_remove_button(self, name: str) -> QtWidgets.QToolButton:
-        button = QtWidgets.QToolButton(self.source_list)
-        button.setObjectName("figureComposerRemoveSourceButton")
-        button.setProperty("figure_source_name", name)
-        button.setAccessibleName("Remove Source")
-        button.setIcon(QtGui.QIcon.fromTheme("edit-delete"))
-        button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly)
-        button.setAutoRaise(True)
-        button.clicked.connect(functools.partial(self._remove_source_from_button, name))
-        return button
-
-    def _source_action_widget(self, name: str, display: str) -> QtWidgets.QWidget:
-        widget = QtWidgets.QWidget(self.source_list)
-        layout = QtWidgets.QHBoxLayout(widget)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(2)
-        refresh_button = self._source_refresh_button(name)
-        remove_button = self._source_remove_button(name)
-        layout.addWidget(refresh_button)
-        layout.addWidget(remove_button)
-        self._set_source_refresh_button_state(refresh_button, name, display)
-        self._set_source_remove_button_state(remove_button, name, display)
-        return widget
-
-    def _source_list_row_button(
-        self, item: QtWidgets.QTreeWidgetItem, object_name: str
-    ) -> QtWidgets.QToolButton | None:
-        widget = self.source_list.itemWidget(item, _SOURCE_LIST_ACTION_COLUMN)
-        if isinstance(widget, QtWidgets.QToolButton):
-            return widget if widget.objectName() == object_name else None
-        if isinstance(widget, QtWidgets.QWidget):
-            return widget.findChild(QtWidgets.QToolButton, object_name)
-        return None
-
     def _source_refresh_available(self, name: str) -> bool:
         if (
             self._source_refresh_available_callback is None
@@ -2394,24 +2557,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             return label or None
         return None
 
-    def _set_source_refresh_button_state(
-        self, button: QtWidgets.QToolButton, name: str, display: str
-    ) -> bool:
-        enabled = self._source_refresh_available(name)
-        button.setEnabled(enabled)
-        if enabled:
-            source_label = self._source_refresh_label(name)
-            tooltip = (
-                f"Refresh “{display}” from {source_label}"
-                if source_label
-                else f"Refresh “{display}”"
-            )
-        else:
-            tooltip = "This source is not linked to an open ImageTool"
-        button.setToolTip(tooltip)
-        button.setStatusTip(tooltip)
-        return enabled
-
     def _refreshable_source_names(self) -> tuple[str, ...]:
         return tuple(
             name
@@ -2420,7 +2565,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
 
     def _refresh_source_controls(self) -> None:
-        has_refreshable_source = False
         selected_names = self._selected_source_names()
         add_enabled = self._source_add_available()
         self.add_source_button.setEnabled(add_enabled)
@@ -2431,43 +2575,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         self.add_source_button.setToolTip(add_tip)
         self.add_source_button.setStatusTip(add_tip)
-        for row in range(self.source_list.topLevelItemCount()):
-            item = self.source_list.topLevelItem(row)
-            if item is None:  # pragma: no cover
-                # Qt can report stale rows during teardown.
-                continue
-            source_name = item.data(
-                _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
-            )
-            if not isinstance(source_name, str):
-                continue
-            display = item.text(_SOURCE_LIST_SOURCE_COLUMN)
-            refresh_button = self._source_list_row_button(
-                item, "figureComposerRefreshSourceButton"
-            )
-            if refresh_button is not None:
-                has_refreshable_source |= self._set_source_refresh_button_state(
-                    refresh_button, source_name, display
-                )
-            remove_button = self._source_list_row_button(
-                item, "figureComposerRemoveSourceButton"
-            )
-            if remove_button is not None:
-                self._set_source_remove_button_state(
-                    remove_button, source_name, display
-                )
-
-        enabled = (
-            has_refreshable_source and self._source_refresh_many_callback is not None
+        selected_refreshable = tuple(
+            name for name in selected_names if self._source_refresh_available(name)
         )
-        self.refresh_sources_button.setEnabled(enabled)
-        tooltip = (
-            "Refresh all sources linked to open ImageTools"
-            if enabled
-            else "No sources are linked to open ImageTools"
+        selected_tip = (
+            "Refresh selected sources from their ImageTools"
+            if selected_refreshable
+            else "No selected sources can be refreshed"
         )
-        self.refresh_sources_button.setToolTip(tooltip)
-        self.refresh_sources_button.setStatusTip(tooltip)
+        self.refresh_sources_button.setEnabled(bool(selected_refreshable))
+        self.refresh_sources_button.setToolTip(selected_tip)
+        self.refresh_sources_button.setStatusTip(self.refresh_sources_button.toolTip())
 
         removable_selected = [
             name for name in selected_names if self._source_removable(name)
@@ -2483,35 +2601,100 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.remove_selected_source_button.setStatusTip(remove_tip)
 
     def refresh_source_controls(self) -> None:
+        for row in range(self.source_list.topLevelItemCount()):
+            item = self.source_list.topLevelItem(row)
+            if item is not None:
+                self._update_source_list_item(item)
         self._refresh_source_controls()
+        self._refresh_source_detail_panel()
 
     def _set_source_status_text(self, text: str | None) -> None:
         self.source_status_label.setText("" if text is None else text)
         self.source_status_label.setVisible(bool(text))
 
+    def _set_source_validation_text(self, text: str | None) -> None:
+        self.source_validation_label.setText("" if text is None else text)
+        self.source_validation_label.setVisible(bool(text))
+
     def _set_step_source_status_text(self, text: str | None) -> None:
         self.step_source_status_label.setText("" if text is None else text)
         self.step_source_status_label.setVisible(bool(text))
 
-    def _refresh_source_from_button(self, name: str, _checked: bool = False) -> None:
-        callback = self._source_refresh_callback
-        if callback is None or not self._source_refresh_available(name):
-            self._refresh_source_controls()
-            return
-        callback(name)
-        self._refresh_source_controls()
+    @QtCore.Slot()
+    def _refresh_selected_sources_from_button(self) -> None:
+        self._refresh_source_names(self._selected_source_names())
 
-    def _refresh_sources_from_button(self, _checked: bool = False) -> None:
-        callback = self._source_refresh_many_callback
-        source_names = self._refreshable_source_names()
-        if callback is None or not source_names:
+    @QtCore.Slot()
+    def _refresh_all_sources_from_button(self) -> None:
+        self._refresh_source_names(self._source_names())
+
+    def _refresh_source_names(self, source_names: Sequence[str]) -> None:
+        callback = self._source_refresh_callback
+        requested = tuple(dict.fromkeys(source_names))
+        refreshable = tuple(
+            name for name in requested if self._source_refresh_available(name)
+        )
+        unavailable = tuple(name for name in requested if name not in refreshable)
+        if callback is None or not refreshable:
+            if unavailable:
+                self._set_source_status_text(
+                    "Unavailable: " + ", ".join(unavailable) + "."
+                )
             self._refresh_source_controls()
             return
-        callback(source_names)
+
+        refreshed: list[str] = []
+        failed: list[str] = []
+        failure_messages: list[str] = []
+        self._set_source_status_text(None)
+        for name in refreshable:
+            self._set_source_status_text(None)
+            try:
+                refreshed_source = callback(name)
+            except Exception as exc:
+                logger.exception(
+                    "Failed to refresh Figure Composer source %r",
+                    name,
+                    extra={"suppress_ui_alert": True},
+                )
+                failed.append(name)
+                message = str(exc) or exc.__class__.__name__
+                failure_messages.append(f"Could not refresh {name}: {message}.")
+                continue
+            if refreshed_source:
+                refreshed.append(name)
+                continue
+            failed.append(name)
+            if message := self.source_status_label.text().strip():
+                failure_messages.append(message)
+
+        if len(failed) == 1 and not refreshed and not unavailable and failure_messages:
+            status = failure_messages[0]
+        else:
+            parts: list[str] = []
+            if refreshed:
+                suffix = "source" if len(refreshed) == 1 else "sources"
+                parts.append(f"Refreshed {len(refreshed)} {suffix}.")
+            if failed:
+                if failure_messages:
+                    parts.extend(dict.fromkeys(failure_messages))
+                else:
+                    parts.append("Could not refresh: " + ", ".join(failed) + ".")
+            if unavailable:
+                parts.append("Unavailable: " + ", ".join(unavailable) + ".")
+            status = " ".join(parts)
+        self._set_source_status_text(status or None)
         self._refresh_source_controls()
+        self._refresh_source_detail_panel()
 
     def _source_used_by_operation(self, name: str) -> bool:
         return any(
+            name in self._operation_source_names(operation)
+            for operation in self._recipe.operations
+        )
+
+    def _source_usage_count(self, name: str) -> int:
+        return sum(
             name in self._operation_source_names(operation)
             for operation in self._recipe.operations
         )
@@ -2529,25 +2712,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             and len(self._recipe.sources) > 1
             and not self._source_used_by_operation(name)
         )
-
-    def _set_source_remove_button_state(
-        self, button: QtWidgets.QToolButton, name: str, display: str
-    ) -> bool:
-        enabled = self._source_removable(name)
-        button.setEnabled(enabled)
-        if enabled:
-            tooltip = f"Remove “{display}” from this figure"
-        elif self._source_used_by_operation(name):
-            tooltip = "This source is used by one or more steps"
-        else:
-            tooltip = "This source cannot be removed"
-        button.setToolTip(tooltip)
-        button.setStatusTip(tooltip)
-        return enabled
-
-    def _remove_source_from_button(self, name: str, _checked: bool = False) -> None:
-        if not self.remove_source(name):
-            self._refresh_source_controls()
 
     @QtCore.Slot()
     def _remove_selected_sources(self) -> None:
@@ -2594,12 +2758,13 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         alias = edit.text().strip()
         if alias == original:
             edit.setText(original)
+            self._set_source_validation_text(None)
             return
         error = self._source_alias_error(alias, current=original)
         if error is not None:
-            self._set_source_status_text(error)
-            edit.setText(original)
+            self._set_source_validation_text(error)
             return
+        self._set_source_validation_text(None)
         if not self._rename_source_alias(original, alias):
             edit.setText(original)
 
@@ -2607,18 +2772,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _focus_source_alias_editor(self) -> None:
         if len(self._selected_source_names()) != 1:
             return
-        editor = self.source_selection_controls.findChild(
-            QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
-        )
-        if editor is None:
-            self._refresh_source_selection_editor()
-            editor = self.source_selection_controls.findChild(
-                QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
-            )
-        if editor is None:
+        if not self.source_alias_edit.isEnabled():
             return
-        editor.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
-        editor.selectAll()
+        self.source_alias_edit.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+        self.source_alias_edit.selectAll()
 
     @QtCore.Slot(QtWidgets.QTreeWidgetItem, int)
     def _source_list_item_double_clicked(
@@ -2636,7 +2793,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._set_selected_source_names_silent(selected_names, current_name)
         self._refresh_source_controls()
         self._source_inspector_target = current_name
-        self._refresh_source_inspector()
+        self._refresh_source_detail_panel()
         self._refresh_source_selection_editor()
         self._update_source_section()
         self._maybe_redraw_plot()
@@ -2681,7 +2838,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                     )
                 operations.append(updated)
         except ValueError as exc:
-            self._set_source_status_text(
+            self._set_source_validation_text(
                 f"Could not rename source “{old_name}”: {operation.label}: {exc}."
             )
             self._refresh_source_selection_editor()
@@ -2860,18 +3017,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         menu.addAction(move_down_action)
 
         menu.addSeparator()
-        refresh_action = QtGui.QAction("Refresh", menu)
+        refresh_action = QtGui.QAction("Refresh Selected", menu)
         refresh_action.setObjectName("figureComposerContextRefreshSourceAction")
         selected_names = self._selected_source_names()
         refresh_action.setEnabled(
-            len(selected_names) == 1
-            and self._source_refresh_available(selected_names[0])
+            any(self._source_refresh_available(name) for name in selected_names)
         )
-        if len(selected_names) == 1:
-            refresh_action.triggered.connect(
-                functools.partial(self._refresh_source_from_button, selected_names[0])
-            )
+        refresh_action.triggered.connect(self._refresh_selected_sources_from_button)
         menu.addAction(refresh_action)
+
+        refresh_all_action = QtGui.QAction("Refresh All", menu)
+        refresh_all_action.setObjectName("figureComposerContextRefreshAllSourcesAction")
+        refresh_all_action.setEnabled(bool(self._refreshable_source_names()))
+        refresh_all_action.triggered.connect(self._refresh_all_sources_from_button)
+        menu.addAction(refresh_all_action)
 
         remove_action = QtGui.QAction("Remove", menu)
         remove_action.setObjectName("figureComposerContextRemoveSourceAction")
@@ -2886,23 +3045,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _set_source_list_row_used(
         self, item: QtWidgets.QTreeWidgetItem, used: bool
     ) -> None:
-        item.setData(
-            _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole + 1, used
-        )
-        font = item.font(_SOURCE_LIST_SOURCE_COLUMN)
-        font.setBold(used)
-        item.setFont(_SOURCE_LIST_SOURCE_COLUMN, font)
-        source_name = item.data(
-            _SOURCE_LIST_SOURCE_COLUMN, QtCore.Qt.ItemDataRole.UserRole
-        )
-        if isinstance(source_name, str):
-            remove_button = self._source_list_row_button(
-                item, "figureComposerRemoveSourceButton"
-            )
-            if remove_button is not None:
-                self._set_source_remove_button_state(
-                    remove_button, source_name, item.text(_SOURCE_LIST_SOURCE_COLUMN)
-                )
+        item.setData(_SOURCE_LIST_SOURCE_COLUMN, _SOURCE_LIST_USED_ROLE, used)
+        self._update_source_list_item(item)
 
     def _sync_source_list_used_state(self) -> None:
         used_sources = self._sources_used_by_recipe()
@@ -2926,27 +3070,76 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             return self._recipe.sources[0].name
         return next(iter(self._source_data), None)
 
-    def _refresh_source_inspector(self) -> None:
+    def _refresh_source_detail_panel(self) -> None:
         inspector = getattr(self, "source_inspector", None)
         if not isinstance(inspector, SourceInspectorWidget):
             return
+        selected_names = self._selected_source_names()
+        if not selected_names:
+            self.source_detail_content.setProperty(
+                "figureComposerSourceEditorMode", "empty"
+            )
+            self.source_detail_content.setProperty(
+                "figureComposerSourceSelectionCount", 0
+            )
+            self.source_detail_content.setProperty("figureComposerSourceUsageCount", 0)
+            self.source_detail_content.setProperty("figureComposerSourceOrigin", "")
+            self.source_editor_state_label.setText(
+                "Select a source to inspect or edit it."
+            )
+            self.source_editor_state_label.setVisible(True)
+            self.source_alias_controls.setVisible(False)
+            inspector.setVisible(False)
+            self.source_selection_controls.setVisible(False)
+            inspector.set_context(source_name=None, data=None)
+            return
+        if len(selected_names) > 1:
+            self.source_detail_content.setProperty(
+                "figureComposerSourceEditorMode", "multiple"
+            )
+            self.source_detail_content.setProperty(
+                "figureComposerSourceSelectionCount", len(selected_names)
+            )
+            self.source_detail_content.setProperty("figureComposerSourceUsageCount", 0)
+            self.source_detail_content.setProperty("figureComposerSourceOrigin", "")
+            self.source_editor_state_label.setText(
+                f"{len(selected_names)} sources selected\n"
+                "Selection changes apply to all compatible selected sources."
+            )
+            self.source_editor_state_label.setVisible(True)
+            self.source_alias_controls.setVisible(False)
+            inspector.setVisible(False)
+            self.source_selection_controls.setVisible(True)
+            inspector.set_context(source_name=None, data=None)
+            return
+
+        target = selected_names[0]
         source_states = self._source_by_name()
-        target = self._source_inspector_target
-        if target is None:
-            target = self._default_source_inspector_target()
-        if (
-            target is not None
-            and target not in self._source_data
-            and target not in source_states
-        ):
-            target = self._default_source_inspector_target()
         self._source_inspector_target = target
-        if target not in self._selected_source_names():
-            self._select_source_list_row_silent(target)
+        source = source_states.get(target)
+        self.source_detail_content.setProperty(
+            "figureComposerSourceEditorMode", "single"
+        )
+        self.source_detail_content.setProperty("figureComposerSourceSelectionCount", 1)
+        self.source_detail_content.setProperty(
+            "figureComposerSourceUsageCount", self._source_usage_count(target)
+        )
+        self.source_detail_content.setProperty(
+            "figureComposerSourceOrigin", self._source_refresh_label(target) or ""
+        )
+        self.source_editor_state_label.setVisible(False)
+        self.source_alias_controls.setVisible(True)
+        self.source_alias_edit.setEnabled(source is not None)
+        self.source_alias_edit.setText(target)
+        self.source_alias_edit.setProperty(
+            "figure_composer_source_alias_original", target
+        )
+        inspector.setVisible(True)
+        self.source_selection_controls.setVisible(True)
         inspector.set_context(
             source_name=target,
-            source_state=None if target is None else source_states.get(target),
-            data=None if target is None else self._source_data.get(target),
+            data=self._source_data.get(target),
+            context_lines=self._source_detail_context_lines(target),
         )
 
     def _refresh_source_selection_editor(self) -> None:
@@ -2956,13 +3149,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._clear_form_layout(layout)
         selected_names = self._selected_source_names()
         if not selected_names:
-            label = QtWidgets.QLabel("Select a source to edit its selection.", self)
-            label.setWordWrap(True)
-            layout.addRow(label)
             return
 
         source_by_name = self._source_by_name()
-        self._add_source_alias_editor(layout, selected_names, source_by_name)
         available_names = tuple(
             name
             for name in selected_names
@@ -2998,6 +3187,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             return
 
         for dim_index, dim_name in enumerate(dimensions):
+            dimension_context = self._source_selection_dimension_tooltip(
+                dim_name, available_names
+            )
             selections = tuple(
                 _source_selection(source_by_name[name]) for name in available_names
             )
@@ -3033,7 +3225,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
             mode_combo.setProperty("figure_composer_source_selection_dim", dim_name)
             mode_combo.setToolTip(
-                "Choose whether this source dimension stays, is selected, or averaged."
+                f"{dimension_context}\n\nChoose None, isel, qsel, or Mean for this "
+                "dimension."
             )
             value_edit = QtWidgets.QLineEdit(row)
             value_edit.setObjectName(
@@ -3043,8 +3236,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             value_edit.setProperty("figure_composer_source_selection_field", "value")
             value_edit.setPlaceholderText("value")
             value_edit.setToolTip(
-                "Selection value. Use integer positions or slices for isel; use "
-                "coordinate values or slices for qsel."
+                f"{dimension_context}\n\nisel accepts integer positions and index "
+                "slices. qsel accepts coordinate values and coordinate slices."
             )
             value_edit.setText("" if value_mixed else value_texts[0])
             self._apply_mixed_line_edit(value_edit, value_mixed)
@@ -3056,8 +3249,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             width_edit.setProperty("figure_composer_source_selection_field", "width")
             width_edit.setPlaceholderText("width")
             width_edit.setToolTip(
-                "Optional qsel width centered on the value. Leave blank for nearest "
-                "coordinate selection."
+                f"{dimension_context}\n\nOptional qsel width for centered averaging. "
+                "Leave blank to select the nearest coordinate."
             )
             width_edit.setText("" if width_mixed else width_texts[0])
             self._apply_mixed_line_edit(width_edit, width_mixed)
@@ -3076,55 +3269,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 layout,
                 dim_name,
                 row,
-                "Choose how this source variable is selected before plotting.",
+                dimension_context,
             )
-
-    def _add_source_alias_editor(
-        self,
-        layout: QtWidgets.QFormLayout,
-        selected_names: Sequence[str],
-        source_by_name: Mapping[str, FigureSourceState],
-    ) -> None:
-        self._add_form_section(
-            layout,
-            "Source",
-            object_name="figureComposerSourceAliasSection",
-        )
-        if len(selected_names) != 1:
-            label = QtWidgets.QLabel("Select one source to rename its alias.", self)
-            label.setObjectName("figureComposerSourceAliasMessage")
-            label.setWordWrap(True)
-            self._add_form_row(
-                layout,
-                "Alias",
-                label,
-                "Source aliases are edited one at a time.",
-            )
-            return
-        source_name = selected_names[0]
-        if source_name not in source_by_name:
-            label = QtWidgets.QLabel("This source is missing from the recipe.", self)
-            label.setObjectName("figureComposerSourceAliasMessage")
-            label.setWordWrap(True)
-            self._add_form_row(
-                layout,
-                "Alias",
-                label,
-                "Missing recipe sources cannot be renamed.",
-            )
-            return
-        edit = QtWidgets.QLineEdit(self.source_selection_controls)
-        edit.setObjectName("figureComposerSourceAliasEdit")
-        edit.setText(source_name)
-        edit.setProperty("figure_composer_source_alias_original", source_name)
-        edit.setToolTip("Rename this source variable.")
-        edit.editingFinished.connect(self._commit_source_alias_edit)
-        self._add_form_row(
-            layout,
-            "Alias",
-            edit,
-            "Rename this source variable.",
-        )
 
     def _source_selection_mode_combo(
         self,
@@ -3136,13 +3282,24 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         combo = QtWidgets.QComboBox(parent)
         if mixed:
             combo.addItem(_MIXED_VALUES_TEXT, _MIXED_VALUE)
-        for mode, label in (
-            ("keep", "None"),
-            ("isel", "isel"),
-            ("qsel", "qsel"),
-            ("mean", "Mean"),
+        for mode, label, tooltip in (
+            ("keep", "None", "Leave this dimension unchanged."),
+            (
+                "isel",
+                "isel",
+                "Select this dimension by integer position or index slice.",
+            ),
+            (
+                "qsel",
+                "qsel",
+                "Select this dimension by coordinate value or coordinate slice.",
+            ),
+            ("mean", "Mean", "Average over and remove this dimension."),
         ):
             combo.addItem(label, mode)
+            combo.setItemData(
+                combo.count() - 1, tooltip, QtCore.Qt.ItemDataRole.ToolTipRole
+            )
         if mixed:
             item = typing.cast("typing.Any", combo.model()).item(0)
             if item is not None:
@@ -3153,6 +3310,45 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             combo.setCurrentIndex(max(index, 0))
         self._track_combo_interaction(combo)
         return combo
+
+    def _source_selection_dimension_tooltip(
+        self, dim: str, source_names: Sequence[str]
+    ) -> str:
+        source_by_name = self._source_by_name()
+        sizes: set[int] = set()
+        dtypes: set[str] = set()
+        endpoints: set[tuple[str, str]] = set()
+        for source_name in source_names:
+            data = self._source_selection_input_data(
+                source_name, source_by_name.get(source_name)
+            )
+            if data is None:
+                continue
+            public = _public_source_data(data)
+            if dim not in public.dims:
+                continue
+            sizes.add(public.sizes[dim])
+            coord = public.coords.get(dim)
+            if coord is None:
+                continue
+            dtypes.add(str(coord.dtype))
+            if coord.ndim != 1 or coord.size == 0 or coord.dims != (dim,):
+                continue
+            with contextlib.suppress(Exception):
+                first = erlab.utils.formatting.format_value(coord.isel({dim: 0}).item())
+                last = erlab.utils.formatting.format_value(coord.isel({dim: -1}).item())
+                endpoints.add((first, last))
+
+        lines = [f"Dimension {dim!r}."]
+        if sizes:
+            sizes_text = ", ".join(str(size) for size in sorted(sizes))
+            lines.append(f"Size: {sizes_text}.")
+        if dtypes:
+            lines.append(f"Coordinate dtype: {', '.join(sorted(dtypes))}.")
+        if len(endpoints) == 1:
+            first, last = next(iter(endpoints))
+            lines.append(f"Coordinate range: {first} to {last}.")
+        return " ".join(lines)
 
     def _connect_source_selection_dimension_controls(
         self,
@@ -3251,7 +3447,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
             width = selection_width_from_text(width_text) if mode == "qsel" else None
         except FigureComposerInputError as exc:
-            self._set_source_status_text(str(exc))
+            self._set_source_validation_text(str(exc))
             return
 
         changed = False
@@ -3300,7 +3496,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             "Selection was not applied to: " + ", ".join(skipped) if skipped else None
         )
         if not changed:
-            self._set_source_status_text(status_text)
+            self._set_source_validation_text(status_text)
             self._refresh_source_selection_editor()
             return
         self._recipe = self._recipe.model_copy(update={"sources": tuple(source_list)})
@@ -3309,7 +3505,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._refresh_source_list()
         self._update_source_section()
         self._maybe_redraw_plot()
-        self._set_source_status_text(status_text)
+        self._set_source_validation_text(status_text)
         self.sigDataChanged.emit()
         self.sigInfoChanged.emit()
         self._write_state()
@@ -3847,8 +4043,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self.axes_selector.setVisible(not grid_mode)
             self.axes_expression_edit.setVisible(not grid_mode)
             self.gridspec_axes_selector.setVisible(grid_mode)
-            self.axes_selector.set_selected_axes(tuple(sorted(selected_axes)))
-            self._refresh_gridspec_axes_selector()
+            if grid_mode:
+                self._refresh_gridspec_axes_selector()
+            else:
+                self.axes_selector.set_selected_axes(tuple(sorted(selected_axes)))
             if self.axes_expression_edit.text() != expression:
                 blocker = QtCore.QSignalBlocker(self.axes_expression_edit)
                 self.axes_expression_edit.setText(expression)
@@ -3904,49 +4102,111 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         selected_ids = self._selected_operation_ids()
         if not selected_ids and current_id is not None:
             selected_ids = {current_id}
+        operation_ids = tuple(
+            operation.operation_id for operation in self._recipe.operations
+        )
+        current_item_ids = self.operation_list._operation_ids()
+        reuse_items = current_item_ids == operation_ids
         self.operation_list.blockSignals(True)
         try:
-            self.operation_list.clear()
-            for operation in self._recipe.operations:
-                render_error = self._operation_render_errors.get(operation.operation_id)
-                input_error = self._operation_input_error_text(operation)
-                text = self._operation_display_text(operation)
-                if input_error is not None:
-                    text = f"{text} (invalid input)"
-                if render_error is not None:
-                    text = f"{text} (render error)"
-                item = QtWidgets.QListWidgetItem(text)
-                item.setFlags(
-                    item.flags()
-                    | QtCore.Qt.ItemFlag.ItemIsUserCheckable
-                    | QtCore.Qt.ItemFlag.ItemIsDragEnabled
-                    | QtCore.Qt.ItemFlag.ItemIsDropEnabled
+            if not reuse_items:
+                self.operation_list.clear()
+                self.operation_list.addTopLevelItems(
+                    [
+                        QtWidgets.QTreeWidgetItem()
+                        for _operation in self._recipe.operations
+                    ]
                 )
-                item.setCheckState(
-                    QtCore.Qt.CheckState.Checked
-                    if operation.enabled
-                    else QtCore.Qt.CheckState.Unchecked
-                )
-                item.setData(QtCore.Qt.ItemDataRole.UserRole, operation.operation_id)
-                tooltip = self._operation_tooltip(operation)
-                if input_error is not None:
-                    tooltip = f"{tooltip}\n\nInvalid input: {input_error}"
-                if render_error is not None:
-                    tooltip = f"{tooltip}\n\nRender error: {render_error}"
-                item.setToolTip(tooltip)
-                if (
-                    self._operation_has_invalid_axes(operation)
-                    or input_error is not None
-                    or render_error is not None
-                ):
-                    item.setForeground(QtGui.QBrush(QtGui.QColor("darkRed")))
-                self.operation_list.addItem(item)
-                if operation.operation_id in selected_ids:
-                    item.setSelected(True)
-                if operation.operation_id == current_id:
-                    self.operation_list.setCurrentItem(item)
+            for row, operation in enumerate(self._recipe.operations):
+                item = self.operation_list.topLevelItem(row)
+                if item is not None:  # pragma: no branch
+                    self._update_operation_list_item(item, operation)
+            if not reuse_items:
+                self._set_selected_operation_ids_silent(selected_ids)
+                if current_id is not None:
+                    for row, operation in enumerate(self._recipe.operations):
+                        if operation.operation_id == current_id:
+                            self.operation_list.setCurrentItem(
+                                self.operation_list.topLevelItem(row)
+                            )
+                            break
         finally:
             self.operation_list.blockSignals(False)
+        self._sync_source_list_used_state()
+
+    def _update_operation_list_item(
+        self,
+        item: QtWidgets.QTreeWidgetItem,
+        operation: FigureOperationState,
+    ) -> None:
+        issues = self._operation_issues(operation)
+        item.setText(
+            _OPERATION_LIST_STEP_COLUMN, self._operation_display_text(operation)
+        )
+        item.setText(
+            _OPERATION_LIST_STATUS_COLUMN,
+            self._operation_status_text(issues),
+        )
+        item.setFlags(
+            (
+                item.flags()
+                | QtCore.Qt.ItemFlag.ItemIsUserCheckable
+                | QtCore.Qt.ItemFlag.ItemIsDragEnabled
+            )
+            & ~QtCore.Qt.ItemFlag.ItemIsDropEnabled
+        )
+        item.setCheckState(
+            _OPERATION_LIST_STEP_COLUMN,
+            QtCore.Qt.CheckState.Checked
+            if operation.enabled
+            else QtCore.Qt.CheckState.Unchecked,
+        )
+        item.setData(
+            _OPERATION_LIST_STEP_COLUMN,
+            QtCore.Qt.ItemDataRole.UserRole,
+            operation.operation_id,
+        )
+        item.setData(
+            _OPERATION_LIST_TARGET_COLUMN,
+            _OPERATION_LIST_TARGET_ROLE,
+            self._operation_target_preview_descriptor(operation),
+        )
+        item.setData(
+            _OPERATION_LIST_STATUS_COLUMN,
+            _OPERATION_LIST_STATUS_ROLE,
+            tuple(code for code, _detail in issues),
+        )
+        item.setSizeHint(_OPERATION_LIST_STEP_COLUMN, QtCore.QSize(0, 22))
+        tooltip = self._operation_tooltip(operation)
+        item.setToolTip(_OPERATION_LIST_STEP_COLUMN, tooltip)
+        item.setData(
+            _OPERATION_LIST_STEP_COLUMN,
+            QtCore.Qt.ItemDataRole.AccessibleDescriptionRole,
+            tooltip,
+        )
+        target_text = _registry.spec_for(operation.kind).target_text(self, operation)
+        target_description = (
+            "No target" if target_text.casefold() == "none" else target_text
+        )
+        item.setToolTip(_OPERATION_LIST_TARGET_COLUMN, target_description)
+        item.setData(
+            _OPERATION_LIST_TARGET_COLUMN,
+            QtCore.Qt.ItemDataRole.AccessibleDescriptionRole,
+            target_description,
+        )
+        status_tooltip = "\n".join(
+            f"{_OPERATION_STATUS_LABELS[code]}: {detail}" for code, detail in issues
+        )
+        item.setToolTip(_OPERATION_LIST_STATUS_COLUMN, status_tooltip)
+        item.setData(
+            _OPERATION_LIST_STATUS_COLUMN,
+            QtCore.Qt.ItemDataRole.AccessibleDescriptionRole,
+            status_tooltip,
+        )
+        item.setForeground(
+            _OPERATION_LIST_STATUS_COLUMN,
+            QtGui.QBrush(QtGui.QColor("darkRed")) if issues else QtGui.QBrush(),
+        )
 
     def _set_current_operation_row_silent(
         self, index: int, *, preserve_selection: bool = True
@@ -3954,14 +4214,24 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         selected_ids = self._selected_operation_ids() if preserve_selection else set()
         was_blocked = self.operation_list.blockSignals(True)
         try:
-            self.operation_list.setCurrentRow(index)
+            item = self.operation_list.topLevelItem(index)
+            if item is None:
+                self.operation_list.setCurrentIndex(QtCore.QModelIndex())
+            else:
+                self.operation_list.setCurrentItem(item)
             if preserve_selection and selected_ids:
                 self._set_selected_operation_ids_silent(selected_ids)
         finally:
             self.operation_list.blockSignals(was_blocked)
 
-    def _operation_id_for_item(self, item: QtWidgets.QListWidgetItem) -> str | None:
-        operation_id = item.data(QtCore.Qt.ItemDataRole.UserRole)
+    @staticmethod
+    def _operation_id_for_item(
+        item: QtWidgets.QTreeWidgetItem,
+    ) -> str | None:
+        operation_id = item.data(
+            _OPERATION_LIST_STEP_COLUMN,
+            QtCore.Qt.ItemDataRole.UserRole,
+        )
         return operation_id if isinstance(operation_id, str) else None
 
     def _selected_operation_ids(self) -> set[str]:
@@ -3974,8 +4244,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _set_selected_operation_ids_silent(self, operation_ids: set[str]) -> None:
         was_blocked = self.operation_list.blockSignals(True)
         try:
-            for row in range(self.operation_list.count()):
-                item = self.operation_list.item(row)
+            for row in range(self.operation_list.topLevelItemCount()):
+                item = self.operation_list.topLevelItem(row)
                 if item is None:
                     continue
                 item.setSelected(self._operation_id_for_item(item) in operation_ids)
@@ -3987,6 +4257,90 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _operation_tooltip(self, operation: FigureOperationState) -> str:
         return _registry.spec_for(operation.kind).tooltip(self, operation)
+
+    def _operation_target_preview_descriptor(
+        self, operation: FigureOperationState
+    ) -> tuple[object, ...]:
+        spec = _registry.spec_for(operation.kind)
+        if not spec.uses_axes(operation):
+            target_text = spec.target_text(self, operation)
+            return (
+                "text",
+                "—" if target_text.casefold() == "none" else target_text,
+            )
+        setup = self._recipe.setup
+        if setup.layout_mode == "gridspec":
+            return _gridspec_target_preview_descriptor(
+                setup.gridspec.root,
+                _gridspec_valid_axes_ids(setup, operation.axes.axes_ids),
+            )
+        unresolved = False
+        selected_axes = operation.axes.valid_axes(setup)
+        if operation.axes.expression:
+            try:
+                tokens = np.arange(setup.nrows * setup.ncols).reshape(
+                    setup.nrows, setup.ncols
+                )
+                resolved = np.asarray(
+                    _axes_expression_value(operation.axes.expression, tokens)
+                )
+                flat_indices = tuple(
+                    dict.fromkeys(int(value) for value in resolved.flat)
+                )
+            except (TypeError, ValueError):
+                selected_axes = ()
+                unresolved = True
+            else:
+                if flat_indices and all(
+                    0 <= value < tokens.size for value in flat_indices
+                ):
+                    selected_axes = tuple(
+                        divmod(value, setup.ncols) for value in flat_indices
+                    )
+                else:
+                    selected_axes = ()
+                    unresolved = True
+        return _subplot_target_preview_descriptor(
+            setup.nrows,
+            setup.ncols,
+            selected_axes,
+            unresolved=unresolved,
+        )
+
+    def _operation_issues(
+        self, operation: FigureOperationState
+    ) -> tuple[tuple[str, str], ...]:
+        issues: list[tuple[str, str]] = []
+        spec = _registry.spec_for(operation.kind)
+        if spec.has_invalid_target(self, operation):
+            issues.append(("invalid_target", spec.target_text(self, operation)))
+        missing_sources = tuple(
+            source
+            for source in spec.source_names(operation)
+            if source not in self._source_data
+        )
+        if missing_sources:
+            issues.append(
+                (
+                    "missing_source",
+                    ", ".join(self._source_display_names(missing_sources)),
+                )
+            )
+        input_error = self._operation_input_error_text(operation)
+        if input_error is not None:
+            issues.append(("invalid_input", input_error))
+        render_error = self._operation_render_errors.get(operation.operation_id)
+        if render_error is not None:
+            issues.append(("render_error", render_error))
+        return tuple(issues)
+
+    @staticmethod
+    def _operation_status_text(issues: Sequence[tuple[str, str]]) -> str:
+        if not issues:
+            return ""
+        if len(issues) == 1:
+            return _OPERATION_STATUS_LABELS[issues[0][0]]
+        return f"{len(issues)} issues"
 
     def _set_operation_render_errors(self, errors: Mapping[str, str]) -> None:
         render_errors = dict(errors)
@@ -4178,7 +4532,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if not indices:
             return False
         self.editor_tabs.setCurrentWidget(self.recipe_page)
-        self.operation_list.setCurrentRow(indices[0])
+        self.operation_list.setCurrentItem(self.operation_list.topLevelItem(indices[0]))
         self._select_step_section("axes")
         QtWidgets.QMessageBox.warning(
             self,
@@ -4190,10 +4544,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return True
 
     def _current_operation(self) -> tuple[int, FigureOperationState] | None:
-        row = self.operation_list.currentRow()
+        row = self._current_operation_index()
         if row < 0 or row >= len(self._recipe.operations):
             return None
         return row, self._recipe.operations[row]
+
+    def _current_operation_index(self) -> int:
+        item = self.operation_list.currentItem()
+        return -1 if item is None else self.operation_list.indexOfTopLevelItem(item)
 
     def _selected_operation_indices(self) -> tuple[int, ...]:
         selected_ids = self._selected_operation_ids()
@@ -4837,15 +5195,30 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         erlab.interactive.utils.single_shot(self, 0, self._sync_axes_selector)
 
+    @QtCore.Slot(QtWidgets.QTreeWidgetItem, QtWidgets.QTreeWidgetItem)
+    def _operation_current_item_changed(
+        self,
+        current: QtWidgets.QTreeWidgetItem | None,
+        _previous: QtWidgets.QTreeWidgetItem | None,
+    ) -> None:
+        if current is not None and not self._operation_multi_select_event:
+            operation_id = self._operation_id_for_item(current)
+            if operation_id is not None:
+                self._set_selected_operation_ids_silent({operation_id})
+        self._operation_selection_changed()
+
     @QtCore.Slot()
-    @QtCore.Slot(int)
-    def _operation_selection_changed(self, _row: int | None = None) -> None:
-        if _row is not None and not self._operation_multi_select_event:
-            item = self.operation_list.item(_row)
-            if item is not None:
-                operation_id = self._operation_id_for_item(item)
-                if operation_id is not None:
-                    self._set_selected_operation_ids_silent({operation_id})
+    def _operation_selection_changed(self) -> None:
+        current = self.operation_list.currentItem()
+        current_id = None if current is None else self._operation_id_for_item(current)
+        state = (current_id, frozenset(self._selected_operation_ids()))
+        if state == self._operation_selection_state:
+            return
+        self._operation_selection_state = state
+        if self._operation_selection_input_event:
+            self._operation_axes_sync_pending = True
+            self._queue_operation_editor_update()
+            return
         self._sync_axes_selector()
         self._refresh_operation_editor()
 
@@ -4877,13 +5250,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             }
         ):
             input_event = typing.cast("QtGui.QInputEvent", event)
+            self._operation_selection_input_event = True
             self._operation_multi_select_event = (
                 self._operation_modifiers_enable_multi_selection(
                     input_event.modifiers()
                 )
             )
             erlab.interactive.utils.single_shot(
-                self, 0, self._clear_operation_multi_select_event
+                self, 0, self._clear_operation_selection_input_state
             )
         return super().eventFilter(watched, event)
 
@@ -5034,6 +5408,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         viewport = self._operation_list_viewport
         self._operation_list_viewport = None
         self._operation_multi_select_event = False
+        self._operation_selection_input_event = False
+        self._operation_axes_sync_pending = False
         if viewport is not None and erlab.interactive.utils.qt_is_valid(self, viewport):
             viewport.removeEventFilter(self)
 
@@ -5167,10 +5543,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self.tool_status = next_state
         self._update_history_actions()
 
-    def _clear_operation_multi_select_event(self) -> None:
+    def _clear_operation_selection_input_state(self) -> None:
         if not erlab.interactive.utils.qt_is_valid(self):
             return
         self._operation_multi_select_event = False
+        self._operation_selection_input_event = False
 
     @staticmethod
     def _operation_modifiers_enable_multi_selection(
@@ -5183,24 +5560,29 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         return bool(modifiers & multi_modifiers)
 
-    @QtCore.Slot(QtWidgets.QListWidgetItem)
-    def _operation_item_changed(self, item: QtWidgets.QListWidgetItem) -> None:
-        if self._updating_controls:
+    @QtCore.Slot(QtWidgets.QTreeWidgetItem, int)
+    def _operation_item_changed(
+        self, item: QtWidgets.QTreeWidgetItem, column: int
+    ) -> None:
+        if self._updating_controls or column != _OPERATION_LIST_STEP_COLUMN:
             return
-        operation_id = item.data(QtCore.Qt.ItemDataRole.UserRole)
+        operation_id = self._operation_id_for_item(item)
         for index, operation in enumerate(self._recipe.operations):
             if operation.operation_id == operation_id:
                 updated = operation.model_copy(
                     update={
-                        "enabled": item.checkState() == QtCore.Qt.CheckState.Checked,
+                        "enabled": item.checkState(_OPERATION_LIST_STEP_COLUMN)
+                        == QtCore.Qt.CheckState.Checked,
                     }
                 )
+                if updated == operation:
+                    return
                 operations = list(self._recipe.operations)
                 operations[index] = updated
                 self._recipe = self._recipe.model_copy(
                     update={"operations": tuple(operations)}
                 )
-                if index == self.operation_list.currentRow():
+                if index == self._current_operation_index():
                     self._sync_axes_selector()
                     self._update_source_status(updated)
                 self._refresh_step_section_button_texts()
@@ -5277,10 +5659,36 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _source_display_names(self, names: Sequence[str]) -> tuple[str, ...]:
         return tuple(self._source_display_name(name) for name in names)
 
+    def _source_detail_context_lines(self, name: str) -> tuple[str, ...]:
+        source = self._source_by_name().get(name)
+        lines: list[str] = []
+        if source is None:
+            lines.append("This source is missing from the recipe")
+        else:
+            if source.selection_source is not None and source.selection_source != name:
+                lines.append(f"Selected from {source.selection_source}")
+            if origin := self._source_refresh_label(name):
+                lines.append(f"From ImageTool {origin}")
+            elif source.node_uid is not None:
+                lines.append("Original ImageTool is no longer available")
+        usage_count = self._source_usage_count(name)
+        if usage_count:
+            suffix = "step" if usage_count == 1 else "steps"
+            lines.append(f"Used by {usage_count} recipe {suffix}")
+        else:
+            lines.append("Not used by any recipe steps")
+        return tuple(lines)
+
     def _source_tooltip(self, name: str) -> str:
-        return source_metadata_tooltip(
-            self._source_by_name().get(name), name, self._source_data.get(name)
-        )
+        lines = [
+            source_metadata_tooltip(
+                self._source_by_name().get(name), name, self._source_data.get(name)
+            ),
+            *self._source_detail_context_lines(name),
+        ]
+        if self._source_refresh_available(name):
+            lines.append("Can refresh from the linked ImageTool")
+        return "\n".join(lines)
 
     def _selected_axes_state(self) -> FigureAxesSelectionState:
         if self._recipe.setup.layout_mode == "gridspec":
@@ -5577,7 +5985,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         operations = (*self._recipe.operations, operation)
         self._recipe = self._recipe.model_copy(update={"operations": operations})
         self._refresh_operation_list()
-        self.operation_list.setCurrentRow(len(operations) - 1)
+        self.operation_list.setCurrentItem(
+            self.operation_list.topLevelItem(len(operations) - 1)
+        )
         self._maybe_redraw_plot()
         self.sigInfoChanged.emit()
         self._write_state()
@@ -5976,7 +6386,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         self._normalize_operation_source_selections()
         self._apply_recipe_to_controls()
-        self.operation_list.setCurrentRow(len(self._recipe.operations) - 1)
+        self.operation_list.setCurrentItem(
+            self.operation_list.topLevelItem(len(self._recipe.operations) - 1)
+        )
         self._maybe_redraw_plot()
         self.sigInfoChanged.emit()
         self._write_state()
@@ -6269,7 +6681,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _new_step_form_page(
         self, object_name: str
     ) -> tuple[QtWidgets.QWidget, QtWidgets.QFormLayout]:
-        page = QtWidgets.QWidget(self.step_editor_stack)
+        page = _FigureComposerStepEditorPage(self.editor_tabs, self.step_editor_stack)
         page.setObjectName(object_name)
         layout = QtWidgets.QFormLayout(page)
         layout.setContentsMargins(6, 6, 6, 6)
@@ -6292,7 +6704,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.step_section_keys = [section.key for section in sections]
 
         while self.step_editor_stack.count():
-            self.step_editor_stack.removeWidget(self.step_editor_stack.widget(0))
+            page = self.step_editor_stack.widget(0)
+            if page is None:  # pragma: no cover - guarded by count()
+                break
+            page.hide()
+            self.step_editor_stack.removeWidget(page)
 
         for index, section in enumerate(sections):
             self.step_editor_stack.addWidget(section.page)
@@ -6324,6 +6740,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         )
         if key:
             self._select_step_section(key)
+        self.step_editor_scroll.updateGeometry()
+        self.step_inspector.updateGeometry()
 
     def _select_step_section(self, key: str) -> None:
         if key not in self.step_section_keys:
@@ -6337,6 +6755,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if font.bold() != selected:
                 font.setBold(selected)
                 button.setFont(font)
+        current_page = self.step_editor_stack.currentWidget()
+        if isinstance(current_page, _FigureComposerStepEditorPage):
+            current_page._refresh_background()
         self._queue_step_tab_order_refresh()
 
     def _refresh_step_section_button_texts(self) -> None:
@@ -6442,6 +6863,9 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if operation is None:
             self._set_step_source_status_text("Select a step to choose data sources.")
             return
+        if not _registry.spec_for(operation.kind).uses_source_section(operation):
+            self._set_step_source_status_text(None)
+            return
         if (input_error := self._operation_input_error_text(operation)) is not None:
             self._set_step_source_status_text(f"Invalid input: {input_error}")
             return
@@ -6465,7 +6889,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _update_source_section(self) -> None:
         self._clear_step_source_controls()
-        self._sync_source_list_used_state()
         current = self._current_operation()
         if current is None:
             self._update_source_status(None)
@@ -6564,7 +6987,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return any(root is sender or root.isAncestorOf(sender) for root in editor_roots)
 
     def _queue_operation_editor_update(self) -> None:
-        if self._operation_editor_update_pending:
+        if self._operation_editor_update_pending or self._closing:
             return
         self._operation_editor_update_pending = True
         self._schedule_queued_operation_editor_update()
@@ -6579,10 +7002,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _run_queued_operation_editor_update(self) -> None:
         if not erlab.interactive.utils.qt_is_valid(self):
             return
+        if self._closing:
+            self._operation_editor_update_pending = False
+            self._operation_axes_sync_pending = False
+            return
         if self._operation_editor_rebuild_must_wait():
             self._schedule_queued_operation_editor_update()
             return
         self._operation_editor_update_pending = False
+        if self._operation_axes_sync_pending:
+            self._operation_axes_sync_pending = False
+            self._sync_axes_selector()
         self._update_operation_editor()
 
     def _operation_editor_rebuild_must_wait(self) -> bool:

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -2784,10 +2784,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     @QtCore.Slot()
     def _remove_selected_sources(self) -> None:
+        pending = list(self._selected_source_names())
         removed = False
-        for name in tuple(self._selected_source_names()):
-            if self.remove_source(name):
-                removed = True
+        while pending:
+            next_pending: list[str] = []
+            removed_this_pass = False
+            for name in pending:
+                if self.remove_source(name):
+                    removed = True
+                    removed_this_pass = True
+                else:
+                    next_pending.append(name)
+            if not removed_this_pass:
+                break
+            pending = next_pending
         if not removed:
             self._refresh_source_controls()
 

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -86,7 +86,14 @@ from erlab.interactive._figurecomposer._operations._base import (
 from erlab.interactive._figurecomposer._operations._plot_slices import (
     _PLOT_SLICES_MAPPABLE_OPERATION_ID_ATTR,
     _PLOT_SLICES_MAPPABLE_PANEL_KEY_ATTR,
+    _effective_extra_kwargs,
+    _effective_slice_kwargs,
+    _is_slice_kwarg_key,
+    _operation_dim_names,
     _plot_slices_panel_keys,
+    _selection_updates_from_kwargs,
+    _selection_values,
+    _selection_width,
 )
 from erlab.interactive._figurecomposer._operations._source_selection import (
     selection_dim_mode,
@@ -96,6 +103,7 @@ from erlab.interactive._figurecomposer._operations._source_selection import (
     selection_value_from_text,
     selection_width_from_text,
     selection_with_dimension,
+    shared_selection,
 )
 from erlab.interactive._figurecomposer._rendering import (
     _live_layout_axes,
@@ -3324,33 +3332,157 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if not operation.map_selections:
                 operations.append(operation)
                 continue
-            if len(operation.map_selections) != 1:
-                updated = self._operation_without_map_selections(operation, None)
-                operations.append(updated)
-                changed = changed or updated != operation
-                continue
-            selection = operation.map_selections[0]
-            source_name = selection.source
-            if not selection_has_effect(selection):
-                updated = self._operation_without_map_selections(
-                    operation,
-                    self._legacy_selection_fallback_source(operation, source_name),
-                )
-                operations.append(updated)
-                changed = changed or updated != operation
-                continue
-            alias = self._source_alias_for_legacy_selection(
-                selection,
+            updated = self._operation_with_legacy_source_selections(
+                operation,
                 source_list=source_list,
                 source_by_name=source_by_name,
                 reserved=reserved,
             )
-            operations.append(self._operation_without_map_selections(operation, alias))
-            changed = True
+            operations.append(updated)
+            changed = changed or updated != operation
         if not changed:
             return
         self._recipe = self._recipe.model_copy(
             update={"sources": tuple(source_list), "operations": tuple(operations)}
+        )
+
+    def _operation_with_legacy_source_selections(
+        self,
+        operation: FigureOperationState,
+        *,
+        source_list: list[FigureSourceState],
+        source_by_name: dict[str, FigureSourceState],
+        reserved: set[str],
+    ) -> FigureOperationState:
+        if operation.kind == FigureOperationKind.PLOT_SLICES:
+            updated = self._plot_slices_operation_with_shared_legacy_selection(
+                operation
+            )
+            if updated is not None:
+                return updated
+            return self._plot_slices_operation_with_legacy_source_aliases(
+                operation,
+                source_list=source_list,
+                source_by_name=source_by_name,
+                reserved=reserved,
+            )
+
+        if len(operation.map_selections) != 1:
+            return self._operation_without_map_selections(operation, None)
+
+        selection = operation.map_selections[0]
+        source_name = selection.source
+        if not selection_has_effect(selection):
+            return self._operation_without_map_selections(
+                operation,
+                self._legacy_selection_fallback_source(operation, source_name),
+            )
+        alias = self._source_alias_for_legacy_selection(
+            selection,
+            source_list=source_list,
+            source_by_name=source_by_name,
+            reserved=reserved,
+        )
+        return self._operation_without_map_selections(operation, alias)
+
+    def _plot_slices_operation_with_shared_legacy_selection(
+        self, operation: FigureOperationState
+    ) -> FigureOperationState | None:
+        selection = shared_selection(operation.map_selections)
+        if selection is None:
+            return None
+        if not selection_has_effect(selection):
+            fallback = (
+                self._legacy_selection_fallback_source(
+                    operation, operation.map_selections[0].source
+                )
+                if operation.map_selections
+                else None
+            )
+            return self._operation_without_map_selections(operation, fallback)
+        if selection.isel or selection.mean_dims:
+            return None
+
+        dims = _operation_dim_names(self, operation)
+        if not dims:
+            return self._plot_slices_operation_with_legacy_qsel(
+                operation, selection.qsel
+            )
+        if any(not _is_slice_kwarg_key(key, dims) for key in selection.qsel):
+            return None
+        updates = _selection_updates_from_kwargs(
+            self,
+            operation,
+            {**_effective_slice_kwargs(self, operation), **selection.qsel},
+            _effective_extra_kwargs(self, operation),
+        )
+        updates["map_selections"] = ()
+        return operation.model_copy(update=updates)
+
+    @staticmethod
+    def _plot_slices_operation_with_legacy_qsel(
+        operation: FigureOperationState, qsel: Mapping[str, typing.Any]
+    ) -> FigureOperationState:
+        slice_kwargs = {**operation.slice_kwargs, **qsel}
+        updates: dict[str, typing.Any] = {"map_selections": ()}
+        slice_dim = operation.slice_dim
+        if slice_dim is not None:
+            values = _selection_values(slice_kwargs.get(slice_dim))
+            if values:
+                updates["slice_values"] = values
+                slice_kwargs.pop(slice_dim, None)
+            width = _selection_width(slice_kwargs.get(f"{slice_dim}_width"))
+            if width is not None:
+                updates["slice_width"] = width
+                slice_kwargs.pop(f"{slice_dim}_width", None)
+        else:
+            candidates = [
+                (key, values)
+                for key, value in slice_kwargs.items()
+                if (not key.endswith("_width") and (values := _selection_values(value)))
+            ]
+            if len(candidates) == 1:
+                slice_dim, values = candidates[0]
+                updates["slice_dim"] = slice_dim
+                updates["slice_values"] = values
+                slice_kwargs.pop(slice_dim, None)
+                width = _selection_width(slice_kwargs.get(f"{slice_dim}_width"))
+                if width is not None:
+                    updates["slice_width"] = width
+                    slice_kwargs.pop(f"{slice_dim}_width", None)
+        updates["slice_kwargs"] = slice_kwargs
+        return operation.model_copy(update=updates)
+
+    def _plot_slices_operation_with_legacy_source_aliases(
+        self,
+        operation: FigureOperationState,
+        *,
+        source_list: list[FigureSourceState],
+        source_by_name: dict[str, FigureSourceState],
+        reserved: set[str],
+    ) -> FigureOperationState:
+        selection_by_source = {
+            selection.source: selection for selection in operation.map_selections
+        }
+        sources = operation.sources or tuple(
+            selection.source for selection in operation.map_selections
+        )
+        updated_sources: list[str] = []
+        for source_name in sources:
+            selection = selection_by_source.get(source_name)
+            if selection is None or not selection_has_effect(selection):
+                updated_sources.append(source_name)
+                continue
+            updated_sources.append(
+                self._source_alias_for_legacy_selection(
+                    selection,
+                    source_list=source_list,
+                    source_by_name=source_by_name,
+                    reserved=reserved,
+                )
+            )
+        return operation.model_copy(
+            update={"map_selections": (), "sources": tuple(updated_sources)}
         )
 
     @staticmethod
@@ -6957,6 +7089,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if source.name == self._recipe.primary_source:
                 continue
             source_data_item = data_items.get(source.name)
+            if source_data_item is None:
+                continue
+            source_data[source.name] = restored_source_data(source, source_data_item)
+            changed = True
+        for source in self._recipe.sources:
+            if source.name in source_data or not _source_has_selection(source):
+                continue
+            if source.selection_source is None:
+                continue
+            source_data_item = source_data.get(source.selection_source)
             if source_data_item is None:
                 continue
             source_data[source.name] = restored_source_data(source, source_data_item)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -225,6 +225,27 @@ _OPERATION_STATUS_LABELS = {
 }
 
 
+class FigureSourceAddResult(typing.NamedTuple):
+    """Outcome of adding or refreshing a batch of figure sources.
+
+    Accepted entries pair the requested source name with the stored recipe name. A
+    linked source refresh can keep an existing stored name instead of the incoming
+    name, so callers that create recipe steps need this mapping.
+    """
+
+    added: tuple[tuple[str, str], ...] = ()
+    updated: tuple[tuple[str, str], ...] = ()
+    skipped: tuple[tuple[str, str], ...] = ()
+
+    def __bool__(self) -> bool:
+        return bool(self.added or self.updated)
+
+    @property
+    def name_map(self) -> dict[str, str]:
+        """Map accepted requested names to their stored recipe names."""
+        return dict((*self.added, *self.updated))
+
+
 class _FigureComposerStepMimeData(QtCore.QMimeData):
     """Clipboard payload that can also carry live source data in one process."""
 
@@ -6783,23 +6804,29 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self,
         sources: Sequence[FigureSourceState],
         source_data: Mapping[str, xr.DataArray],
-    ) -> None:
+    ) -> FigureSourceAddResult:
         """Add or update source data without changing existing recipe steps.
 
         This supports appending operations and the manager's source-only workflow. The
         source list, backing data, preview, persistent state, and data-dirty signals are
-        updated together so workspace saves include the new source data.
+        updated together so workspace saves include the new source data. The result
+        identifies accepted additions and linked-source updates, including the stored
+        recipe name chosen for each requested source.
         """
         existing = {source.name: source for source in self._recipe.sources}
         candidate_data = dict(self._source_data)
         candidate_bases = dict(self._source_selection_base_data)
-        accepted = False
-        skipped: list[str] = []
+        added: list[tuple[str, str]] = []
+        updated: list[tuple[str, str]] = []
+        skipped: list[tuple[str, str]] = []
         for incoming_source in sources:
             source = incoming_source
             incoming_name = incoming_source.name
             data = source_data.get(incoming_name)
             if data is None:
+                skipped.append(
+                    (incoming_name, f"{incoming_name} (source data is unavailable)")
+                )
                 continue
             linked_matches = (
                 [
@@ -6853,7 +6880,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                         )
                     except (IndexError, KeyError, TypeError, ValueError) as exc:
                         message = str(exc) or exc.__class__.__name__
-                        skipped.append(f"{target_name} ({message})")
+                        skipped.append((incoming_name, f"{target_name} ({message})"))
                         continue
             trial_existing = dict(existing)
             trial_existing[target_name] = source
@@ -6878,18 +6905,28 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                     source_by_name=trial_existing,
                 )
             except ValueError as exc:
-                skipped.append(f"{target_name} ({exc})")
+                skipped.append((incoming_name, f"{target_name} ({exc})"))
                 continue
             existing = trial_existing
             candidate_data = trial_data
             candidate_bases = trial_bases
-            accepted = True
-        if not accepted:
+            accepted_entry = (incoming_name, target_name)
+            if same_linked_source:
+                updated.append(accepted_entry)
+            else:
+                added.append(accepted_entry)
+        result = FigureSourceAddResult(
+            added=tuple(added),
+            updated=tuple(updated),
+            skipped=tuple(skipped),
+        )
+        skipped_details = tuple(detail for _name, detail in skipped)
+        if not result:
             if skipped:
                 self._set_source_status_text(
-                    "Could not update source data for: " + ", ".join(skipped)
+                    "Could not update source data for: " + ", ".join(skipped_details)
                 )
-            return
+            return result
         self._source_data = candidate_data
         self._source_selection_base_data = candidate_bases
         ordered_sources = tuple(existing[name] for name in existing)
@@ -6902,10 +6939,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.sigInfoChanged.emit()
         self._write_state()
         self._set_source_status_text(
-            "Could not update source data for: " + ", ".join(skipped)
+            "Could not update source data for: " + ", ".join(skipped_details)
             if skipped
             else None
         )
+        return result
 
     def _replacement_source_data(
         self,

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -8370,32 +8370,73 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         display_name: str,
         source_by_name: Mapping[str, FigureSourceState],
     ) -> provenance.ScriptInput | None:
-        base_source = source_by_name.get(source.selection_source or source.name)
-        base_input = None if base_source is None else base_source.to_script_input()
-        if base_input is None:
-            base_input = source.to_script_input()
-        if base_input is None:
-            return None
-        base_spec = base_input.parsed_provenance_spec()
-        if base_spec is None:
-            return None
-
-        operations = self._source_selection_replay_operations(source)
-        if not operations:
-            return self._script_input_with_name(base_input, display_name)
-        try:
-            base_replay_spec = provenance.to_replay_provenance_spec(base_spec)
-            if base_replay_spec is None:
+        lineage: list[FigureSourceState] = []
+        seen: set[str] = set()
+        current = source
+        while True:
+            if current.name in seen:
                 return None
-            selected_spec = base_replay_spec.append_replay_stage(
-                provenance.public_data(*operations)
+            seen.add(current.name)
+            lineage.append(current)
+            parent_name = current.selection_source
+            if parent_name is None or parent_name == current.name:
+                break
+            parent = source_by_name.get(parent_name)
+            if parent is None:
+                break
+            current = parent
+
+        base_input: provenance.ScriptInput | None = None
+        base_index = -1
+        try:
+            for candidate_index in range(len(lineage) - 1, -1, -1):
+                candidate_input = lineage[candidate_index].to_script_input()
+                if candidate_input is None:
+                    continue
+                candidate_spec = candidate_input.parsed_provenance_spec()
+                if candidate_spec is None:
+                    continue
+                if provenance.to_replay_provenance_spec(candidate_spec) is None:
+                    continue
+                base_input = candidate_input
+                base_index = candidate_index
+                break
+            if base_input is None:
+                for candidate_index in range(len(lineage) - 1, -1, -1):
+                    candidate_input = lineage[candidate_index].to_script_input()
+                    if candidate_input is None or not candidate_input.node_uid:
+                        continue
+                    base_input = candidate_input
+                    base_index = candidate_index
+                    break
+            if base_input is None:
+                return None
+            source_label = " ".join(source.label.split())
+            selected_spec = provenance.script(
+                start_label=f"Select data for {source_label or source.name}",
+                seed_code=(
+                    None
+                    if base_input.name == display_name
+                    else f"{display_name} = {base_input.name}"
+                ),
+                active_name=display_name,
+                script_inputs=(base_input,),
             )
+            for selected_source in reversed(lineage[: base_index + 1]):
+                operations = self._source_selection_replay_operations(selected_source)
+                if operations:
+                    selected_spec = selected_spec.append_replay_stage(
+                        provenance.public_data(*operations)
+                    )
         except (TypeError, ValueError, pydantic.ValidationError):
             return None
         return provenance.ScriptInput(
             name=display_name,
-            node_uid=base_input.node_uid,
-            node_snapshot_token=base_input.node_snapshot_token,
+            label=(
+                source_label
+                if source_label and source_label != source.name
+                else display_name
+            ),
             provenance_spec=selected_spec.model_dump(mode="json"),
         )
 

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -8047,99 +8047,164 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
     ) -> None:
         source_data = dict(self._source_data)
-        selection_base_data: dict[str, xr.DataArray] = {}
+        selection_base_data = dict(self._source_selection_base_data)
         embedded_selected_names = self._persisted_selected_source_names(ds)
+        source_by_name = self._source_by_name()
+        persisted_inputs: dict[str, tuple[xr.DataArray, bool]] = {}
+        changed = False
 
-        def restored_source_data(
-            source: FigureSourceState, data: xr.DataArray
-        ) -> xr.DataArray:
-            if (
-                not _source_has_selection(source)
-                or source.name in embedded_selected_names
-            ):
+        def persisted_data(source: FigureSourceState) -> xr.DataArray | None:
+            variable_name = (
+                erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+                if source.name == self._recipe.primary_source
+                else source.name
+            )
+            data = data_items.get(variable_name)
+            if data is None:
+                return None
+            if source.name != self._recipe.primary_source:
                 return data
+            current_primary = source_data.get(source.name)
+            if current_primary is not None:
+                return data.rename(current_primary.name)
+            tool_data_name = ds.attrs.get("tool_data_name", "<none-value>")
+            if tool_data_name == "<none-value>":
+                tool_data_name = None
+            return data.rename(tool_data_name)
+
+        for source in self._recipe.sources:
+            data = persisted_data(source)
+            if data is None:
+                continue
+            changed = True
+            source_data.pop(source.name, None)
+            selection_base_data.pop(source.name, None)
+            already_selected = source.name in embedded_selected_names
+            if source.selection_source is not None:
+                persisted_inputs[source.name] = (data, already_selected)
+                continue
+            if not _source_has_selection(source) or already_selected:
+                source_data[source.name] = data
+                continue
             try:
-                selected = self._source_data_from_selection(source.name, data, source)
+                source_data[source.name] = self._source_data_from_selection(
+                    source.name, data, source
+                )
             except (IndexError, KeyError, TypeError, ValueError):
                 logger.debug(
                     "Could not apply saved Figure Composer source selection for %s",
                     source.name,
                     exc_info=True,
                 )
-                return data
-            selection_base_data[source.name] = data
-            return selected
-
-        primary_data = data_items.get(erlab.interactive.utils._SAVED_TOOL_DATA_NAME)
-        changed = False
-        if (
-            primary_data is not None
-            and source_data.get(self._recipe.primary_source) is not primary_data
-        ):
-            current_primary = source_data.get(self._recipe.primary_source)
-            if current_primary is not None:
-                primary_data = primary_data.rename(current_primary.name)
+                source_data[source.name] = data
             else:
-                tool_data_name = ds.attrs.get("tool_data_name", "<none-value>")
-                if tool_data_name == "<none-value>":
-                    tool_data_name = None
-                primary_data = primary_data.rename(tool_data_name)
-            primary_source = self._recipe_source(self._recipe.primary_source)
-            if primary_source is not None:
-                primary_data = restored_source_data(primary_source, primary_data)
-            source_data[self._recipe.primary_source] = primary_data
-            changed = True
-        for source in self._recipe.sources:
-            if source.name == self._recipe.primary_source:
-                continue
-            source_data_item = data_items.get(source.name)
-            if source_data_item is None:
-                continue
-            source_data[source.name] = restored_source_data(source, source_data_item)
-            changed = True
+                selection_base_data[source.name] = data
+
+        resolved = {
+            source.name
+            for source in self._recipe.sources
+            if source.selection_source is None and source.name in source_data
+        }
+        queue: collections.deque[str] = collections.deque(resolved)
+
+        def rebuild_descendants() -> None:
+            nonlocal changed
+            while queue:
+                parent_name = queue.popleft()
+                parent_data = source_data.get(parent_name)
+                if parent_data is None:
+                    continue
+                for source in self._recipe.sources:
+                    if (
+                        source.name in resolved
+                        or source.selection_source != parent_name
+                        or source.name == parent_name
+                    ):
+                        continue
+                    source_data.pop(source.name, None)
+                    selection_base_data.pop(source.name, None)
+                    try:
+                        selected = self._source_data_from_selection(
+                            source.name, parent_data, source
+                        )
+                    except (IndexError, KeyError, TypeError, ValueError):
+                        logger.debug(
+                            "Could not rebuild saved Figure Composer source %s from %s",
+                            source.name,
+                            parent_name,
+                            exc_info=True,
+                        )
+                        continue
+                    source_data[source.name] = selected
+                    if _source_has_selection(source):
+                        selection_base_data[source.name] = parent_data
+                    resolved.add(source.name)
+                    queue.append(source.name)
+                    changed = True
+
+        rebuild_descendants()
+
         pending = [
             source
             for source in self._recipe.sources
-            if source.name not in source_data
-            and _source_has_selection(source)
-            and source.selection_source is not None
+            if source.name not in resolved and source.name in persisted_inputs
         ]
         while pending:
             next_pending: list[FigureSourceState] = []
             restored_this_pass = False
             for source in pending:
-                selection_source = source.selection_source
-                if selection_source is None:  # pragma: no cover - filtered above.
+                if source.name in resolved:
                     continue
-                source_data_item = source_data.get(selection_source)
-                if source_data_item is None:
+                parent_name = source.selection_source
+                if parent_name in persisted_inputs and parent_name not in resolved:
                     next_pending.append(source)
                     continue
-                try:
-                    selected = self._source_data_from_selection(
-                        source.name, source_data_item, source
-                    )
-                except (IndexError, KeyError, TypeError, ValueError):
-                    logger.debug(
-                        "Could not rebuild saved Figure Composer source %s from %s",
-                        source.name,
-                        selection_source,
-                        exc_info=True,
-                    )
+                if parent_name is not None and parent_name in source_data:
+                    # A resolved parent would already have visited this source.  Do
+                    # not mask a failed current selection with an older payload.
                     continue
+                try:
+                    self._source_lineage_names(source.name, source_by_name)
+                except ValueError:
+                    continue
+                data, already_selected = persisted_inputs[source.name]
+                if already_selected or not _source_has_selection(source):
+                    selected = data
+                else:
+                    try:
+                        selected = self._source_data_from_selection(
+                            source.name, data, source
+                        )
+                    except (IndexError, KeyError, TypeError, ValueError):
+                        logger.debug(
+                            "Could not restore saved Figure Composer source %s "
+                            "without %s",
+                            source.name,
+                            parent_name,
+                            exc_info=True,
+                        )
+                        continue
+                    selection_base_data[source.name] = data
                 source_data[source.name] = selected
-                selection_base_data[source.name] = source_data_item
+                resolved.add(source.name)
+                queue.append(source.name)
                 changed = True
                 restored_this_pass = True
+                rebuild_descendants()
             if not restored_this_pass:
-                if next_pending:
-                    logger.debug(
-                        "Could not resolve saved Figure Composer source "
-                        "dependencies: %s",
-                        ", ".join(source.name for source in next_pending),
-                    )
                 break
             pending = next_pending
+
+        unresolved = tuple(
+            source.name
+            for source in self._recipe.sources
+            if source.selection_source is not None and source.name not in source_data
+        )
+        if unresolved:
+            logger.debug(
+                "Could not resolve saved Figure Composer source dependencies: %s",
+                ", ".join(unresolved),
+            )
         if not changed:
             self._restore_persisted_preview_cache(ds)
             self._queue_post_restore_redraw_if_needed(ds)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -4111,6 +4111,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     ) -> FigureOperationState:
         updates: dict[str, typing.Any] = {"map_selections": ()}
         if operation.kind == FigureOperationKind.LINE:
+            if operation.map_selections:
+                # The legacy map-selection rendering branch bypassed these input
+                # extraction controls.  Activating stale values while converting a
+                # single cursor to a source alias changes the saved figure.
+                updates.update(
+                    {
+                        "line_selection": {},
+                        "line_y": None,
+                        "line_iter_dim": None,
+                        "line_reduce": "disabled",
+                        "line_reduce_coarsen": 2,
+                        "line_reduce_thin": 2,
+                    }
+                )
             if source_name is not None:
                 updates["line_source"] = source_name
             return operation.model_copy(update=updates)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -1468,12 +1468,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._show_operation_context_menu
         )
         self.operation_list.rows_reordered.connect(self._operation_list_reordered)
-        self.operation_target_delegate = _AxesTargetItemDelegate(
-            int(_OPERATION_LIST_TARGET_ROLE), self.operation_list
-        )
-        self.operation_list.setItemDelegateForColumn(
-            _OPERATION_LIST_TARGET_COLUMN, self.operation_target_delegate
-        )
         self._operation_list_viewport = self.operation_list.viewport()
         if self._operation_list_viewport is not None:
             self._operation_list_viewport.installEventFilter(self)
@@ -1783,6 +1777,14 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.axes_selector.sigAddRowRequested.connect(self._add_subplot_row)
         self.axes_selector.sigAddColumnRequested.connect(self._add_subplot_column)
         target_axes_layout.addWidget(self.axes_selector)
+        self.operation_target_delegate = _AxesTargetItemDelegate(
+            int(_OPERATION_LIST_TARGET_ROLE),
+            self.axes_selector,
+            self.operation_list,
+        )
+        self.operation_list.setItemDelegateForColumn(
+            _OPERATION_LIST_TARGET_COLUMN, self.operation_target_delegate
+        )
         self.gridspec_axes_selector = _GridSpecViewWidget(
             self.target_axes_page, mode="select"
         )

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -3684,6 +3684,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _plot_slices_operation_with_shared_legacy_selection(
         self, operation: FigureOperationState
     ) -> FigureOperationState | None:
+        selection_sources = tuple(
+            selection.source for selection in operation.map_selections
+        )
+        if operation.sources and selection_sources != operation.sources:
+            return None
+        legacy_sources = operation.sources or selection_sources
+
+        def preserve_legacy_sources(
+            updated: FigureOperationState,
+        ) -> FigureOperationState:
+            if not legacy_sources:
+                return updated
+            return updated.model_copy(update={"sources": legacy_sources})
+
         selection = shared_selection(operation.map_selections)
         if selection is None:
             return None
@@ -3695,14 +3709,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 if operation.map_selections
                 else None
             )
-            return self._operation_without_map_selections(operation, fallback)
+            return preserve_legacy_sources(
+                self._operation_without_map_selections(operation, fallback)
+            )
         if selection.isel or selection.mean_dims:
             return None
 
         dims = _operation_dim_names(self, operation)
         if not dims:
-            return self._plot_slices_operation_with_legacy_qsel(
-                operation, selection.qsel
+            return preserve_legacy_sources(
+                self._plot_slices_operation_with_legacy_qsel(operation, selection.qsel)
             )
         if any(not _is_slice_kwarg_key(key, dims) for key in selection.qsel):
             return None
@@ -3713,7 +3729,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             _effective_extra_kwargs(self, operation),
         )
         updates["map_selections"] = ()
-        return operation.model_copy(update=updates)
+        return preserve_legacy_sources(operation.model_copy(update=updates))
 
     @staticmethod
     def _plot_slices_operation_with_legacy_qsel(
@@ -3757,26 +3773,46 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         source_by_name: dict[str, FigureSourceState],
         reserved: set[str],
     ) -> FigureOperationState:
-        selection_by_source = {
-            selection.source: selection for selection in operation.map_selections
-        }
-        sources = operation.sources or tuple(
-            selection.source for selection in operation.map_selections
-        )
+        indexed_by_source: dict[
+            str, collections.deque[tuple[int, FigureDataSelectionState]]
+        ] = {}
+        for index, selection in enumerate(operation.map_selections):
+            indexed_by_source.setdefault(selection.source, collections.deque()).append(
+                (index, selection)
+            )
+        source_counts = collections.Counter(operation.sources)
+
+        def source_for_selection(selection: FigureDataSelectionState) -> str:
+            if not selection_has_effect(selection):
+                return selection.source
+            return self._source_alias_for_legacy_selection(
+                selection,
+                source_list=source_list,
+                source_by_name=source_by_name,
+                reserved=reserved,
+            )
+
         updated_sources: list[str] = []
-        for source_name in sources:
-            selection = selection_by_source.get(source_name)
-            if selection is None or not selection_has_effect(selection):
+        for source_name in operation.sources:
+            selections = indexed_by_source.get(source_name)
+            if not selections:
                 updated_sources.append(source_name)
                 continue
-            updated_sources.append(
-                self._source_alias_for_legacy_selection(
-                    selection,
-                    source_list=source_list,
-                    source_by_name=source_by_name,
-                    reserved=reserved,
-                )
-            )
+            if source_counts[source_name] == 1:
+                while selections:
+                    _index, selection = selections.popleft()
+                    updated_sources.append(source_for_selection(selection))
+            else:
+                _index, selection = selections.popleft()
+                updated_sources.append(source_for_selection(selection))
+
+        remaining = sorted(
+            (entry for entries in indexed_by_source.values() for entry in entries),
+            key=lambda entry: entry[0],
+        )
+        updated_sources.extend(
+            source_for_selection(selection) for _index, selection in remaining
+        )
         return operation.model_copy(
             update={"map_selections": (), "sources": tuple(updated_sources)}
         )

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -6812,15 +6812,26 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
             target_name = incoming_name
             existing_source = existing.get(target_name)
-            same_linked_source = (
-                existing_source is not None
-                and existing_source.node_uid is not None
-                and existing_source.node_uid == source.node_uid
-            )
-            if not same_linked_source and len(linked_matches) == 1:
-                existing_source = linked_matches[0]
-                target_name = existing_source.name
-                same_linked_source = True
+            same_linked_source = False
+            if linked_matches:
+                linked_roots: list[str] = []
+                for linked_source in linked_matches:
+                    try:
+                        root_name = self._source_lineage_names(
+                            linked_source.name, existing
+                        )[0]
+                    except ValueError:
+                        continue
+                    if root_name not in linked_roots:
+                        linked_roots.append(root_name)
+                if linked_roots:
+                    target_name = (
+                        incoming_name
+                        if incoming_name in linked_roots
+                        else linked_roots[0]
+                    )
+                    existing_source = existing[target_name]
+                    same_linked_source = True
             reserved = set(existing)
             reserved.update(candidate_data)
             if existing_source is not None and not same_linked_source:
@@ -6846,6 +6857,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                         continue
             trial_existing = dict(existing)
             trial_existing[target_name] = source
+            normalized_sources = self._normalized_source_states(
+                tuple(trial_existing.values())
+            )
+            trial_existing = {
+                candidate.name: candidate for candidate in normalized_sources
+            }
             trial_data = dict(candidate_data)
             trial_data[target_name] = selected_data
             trial_bases = dict(candidate_bases)
@@ -6948,13 +6965,35 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
         if existing_index is None:  # pragma: no cover
             raise RuntimeError("source replacement index was not resolved")
+        replacement_name = alias
+        preserve_selection_parent = False
+        if (
+            existing_source is not None
+            and existing_source.node_uid is not None
+            and existing_source.node_uid == source.node_uid
+        ):
+            source_by_name = {candidate.name: candidate for candidate in source_list}
+            try:
+                root_name = self._source_lineage_names(alias, source_by_name)[0]
+            except ValueError:
+                root_name = alias
+            root_source = source_by_name[root_name]
+            if root_source.selection_source is None:
+                replacement_name = root_name
+                existing_source = root_source
+                existing_index = next(
+                    index
+                    for index, candidate in enumerate(source_list)
+                    if candidate.name == root_name
+                )
+                preserve_selection_parent = True
         try:
             replacement, selected_data = self._replacement_source_data(
-                alias,
+                replacement_name,
                 source,
                 data,
                 existing_source,
-                keep_selection_source=False,
+                keep_selection_source=preserve_selection_parent,
             )
         except (IndexError, KeyError, TypeError, ValueError) as exc:
             message = str(exc) or exc.__class__.__name__
@@ -6963,21 +7002,22 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
             return False
         source_list[existing_index] = replacement
+        source_list = list(self._normalized_source_states(source_list))
 
         candidate_data = dict(self._source_data)
-        candidate_data[alias] = selected_data
+        candidate_data[replacement_name] = selected_data
         candidate_bases = dict(self._source_selection_base_data)
         if _source_has_selection(replacement):
-            candidate_bases[alias] = data
+            candidate_bases[replacement_name] = data
         else:
-            candidate_bases.pop(alias, None)
+            candidate_bases.pop(replacement_name, None)
         source_by_name = {candidate.name: candidate for candidate in source_list}
         try:
             candidate_data, candidate_bases = (
                 self._source_data_with_recomputed_dependents(
                     candidate_data,
                     candidate_bases,
-                    (alias,),
+                    (replacement_name,),
                     source_by_name=source_by_name,
                 )
             )

--- a/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
+++ b/src/erlab/interactive/_figurecomposer/_toolbar_dialogs.py
@@ -375,12 +375,13 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
     curves_tab_index = tab_widget.addTab(curves_page, "Curves")
     images_tab_index = tab_widget.addTab(images_page, "Images")
 
-    title_edit = QtWidgets.QLineEdit(axes_page)
-    title_edit.setObjectName("figureComposerToolbarAxesTitleEdit")
-    xlabel_edit = QtWidgets.QLineEdit(axes_page)
-    xlabel_edit.setObjectName("figureComposerToolbarAxesXLabelEdit")
-    ylabel_edit = QtWidgets.QLineEdit(axes_page)
-    ylabel_edit.setObjectName("figureComposerToolbarAxesYLabelEdit")
+    title_edit = _axis_plain_text_edit(axes_page, "figureComposerToolbarAxesTitleEdit")
+    xlabel_edit = _axis_plain_text_edit(
+        axes_page, "figureComposerToolbarAxesXLabelEdit"
+    )
+    ylabel_edit = _axis_plain_text_edit(
+        axes_page, "figureComposerToolbarAxesYLabelEdit"
+    )
     xlim_edit = QtWidgets.QLineEdit(axes_page)
     xlim_edit.setObjectName("figureComposerToolbarAxesXLimEdit")
     ylim_edit = QtWidgets.QLineEdit(axes_page)
@@ -683,14 +684,9 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
         try:
             if not axes:
                 unavailable_state = _AxisValueState()
-                for widget in (
-                    title_edit,
-                    xlabel_edit,
-                    ylabel_edit,
-                    xlim_edit,
-                    ylim_edit,
-                    aspect_edit,
-                ):
+                for widget in (title_edit, xlabel_edit, ylabel_edit):
+                    _apply_axis_plain_text_edit_state(widget, unavailable_state)
+                for widget in (xlim_edit, ylim_edit, aspect_edit):
                     _apply_axis_line_edit_state(widget, unavailable_state)
                 for combo in (xscale_combo, yscale_combo):
                     _apply_axis_combo_state(combo, unavailable_state)
@@ -700,13 +696,13 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
                 tick_params_editor.setEnabled(False)
                 _apply_axis_check_state(grid_check, unavailable_state)
                 return
-            _apply_axis_line_edit_state(
+            _apply_axis_plain_text_edit_state(
                 title_edit, _axis_value_state(axes, lambda axis: axis.get_title())
             )
-            _apply_axis_line_edit_state(
+            _apply_axis_plain_text_edit_state(
                 xlabel_edit, _axis_value_state(axes, lambda axis: axis.get_xlabel())
             )
-            _apply_axis_line_edit_state(
+            _apply_axis_plain_text_edit_state(
                 ylabel_edit, _axis_value_state(axes, lambda axis: axis.get_ylabel())
             )
             _apply_axis_line_edit_state(
@@ -744,24 +740,23 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
                     ),
                 ),
             )
-            for edit in (
-                title_edit,
-                xlabel_edit,
-                ylabel_edit,
-                xlim_edit,
-                ylim_edit,
-                aspect_edit,
-            ):
+            for edit in (xlim_edit, ylim_edit, aspect_edit):
                 edit.setModified(False)
         finally:
             updating = False
         refresh_style_targets()
 
-    def update_text_method(edit: QtWidgets.QLineEdit, name: str) -> None:
-        if updating or _line_edit_mixed_unchanged(edit) or not edit.isModified():
+    def update_text_method(edit: QtWidgets.QPlainTextEdit, name: str) -> None:
+        document = edit.document()
+        if (
+            updating
+            or _plain_text_edit_mixed_unchanged(edit)
+            or document is None
+            or not document.isModified()
+        ):
             return
-        upsert_axis_method(name, args=(edit.text(),))
-        edit.setModified(False)
+        upsert_axis_method(name, args=(edit.toPlainText(),))
+        document.setModified(False)
 
     def update_limit_method(edit: QtWidgets.QLineEdit, name: str) -> None:
         if updating or _line_edit_mixed_unchanged(edit) or not edit.isModified():
@@ -845,9 +840,9 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
     def selection_changed(_selection: object) -> None:
         refresh_from_axis()
 
-    title_edit.editingFinished.connect(title_finished)
-    xlabel_edit.editingFinished.connect(xlabel_finished)
-    ylabel_edit.editingFinished.connect(ylabel_finished)
+    title_edit.textChanged.connect(title_finished)
+    xlabel_edit.textChanged.connect(xlabel_finished)
+    ylabel_edit.textChanged.connect(ylabel_finished)
     xlim_edit.editingFinished.connect(xlim_finished)
     ylim_edit.editingFinished.connect(ylim_finished)
     aspect_edit.editingFinished.connect(update_aspect)
@@ -2223,8 +2218,48 @@ def _apply_axis_line_edit_state(
         edit.setModified(False)
 
 
+def _axis_plain_text_edit(
+    parent: QtWidgets.QWidget, object_name: str
+) -> QtWidgets.QPlainTextEdit:
+    edit = QtWidgets.QPlainTextEdit(parent)
+    edit.setObjectName(object_name)
+    edit.setMaximumHeight(70)
+    edit.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+    edit.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+    return edit
+
+
+def _apply_axis_plain_text_edit_state(
+    edit: QtWidgets.QPlainTextEdit, state: _AxisValueState
+) -> None:
+    with QtCore.QSignalBlocker(edit):
+        edit.setEnabled(state.available)
+        edit.setProperty("batch_mixed", state.mixed)
+        if not state.available:
+            edit.clear()
+            edit.setPlaceholderText("")
+        elif state.mixed:
+            edit.clear()
+            edit.setPlaceholderText(MIXED_VALUES_TEXT)
+        else:
+            edit.setPlaceholderText("")
+            edit.setPlainText(str(state.value))
+        document = edit.document()
+        if document is not None:
+            document.setModified(False)
+
+
 def _line_edit_mixed_unchanged(edit: QtWidgets.QLineEdit) -> bool:
     return bool(edit.property("batch_mixed")) and not edit.isModified()
+
+
+def _plain_text_edit_mixed_unchanged(edit: QtWidgets.QPlainTextEdit) -> bool:
+    document = edit.document()
+    return (
+        bool(edit.property("batch_mixed"))
+        and document is not None
+        and not document.isModified()
+    )
 
 
 def _apply_axis_combo_state(combo: QtWidgets.QComboBox, state: _AxisValueState) -> None:

--- a/src/erlab/interactive/_figurecomposer/_widgets.py
+++ b/src/erlab/interactive/_figurecomposer/_widgets.py
@@ -348,10 +348,12 @@ class _AxesTargetItemDelegate(QtWidgets.QStyledItemDelegate):
     def __init__(
         self,
         descriptor_role: int,
+        color_source: QtWidgets.QWidget,
         parent: QtCore.QObject | None = None,
     ) -> None:
         super().__init__(parent)
         self._descriptor_role = descriptor_role
+        self._color_source_ref = weakref.ref(color_source)
 
     def sizeHint(
         self,
@@ -406,7 +408,12 @@ class _AxesTargetItemDelegate(QtWidgets.QStyledItemDelegate):
             )
             if target.isEmpty():
                 return
-            colors = _selector_colors(widget)
+            color_source = self._color_source_ref()
+            if color_source is None or not erlab.interactive.utils.qt_is_valid(
+                color_source
+            ):
+                color_source = widget
+            colors = _selector_colors(color_source)
             _draw_selector_rect(
                 painter,
                 target,

--- a/src/erlab/interactive/_figurecomposer/_widgets.py
+++ b/src/erlab/interactive/_figurecomposer/_widgets.py
@@ -140,7 +140,7 @@ def _selector_colors(widget: QtWidgets.QWidget) -> _SelectorColors:
 
 def _draw_selector_rect(
     painter: QtGui.QPainter,
-    rect: QtCore.QRect,
+    rect: QtCore.QRect | QtCore.QRectF,
     *,
     facecolor: QtGui.QColor,
     edgecolor: QtGui.QColor,
@@ -174,6 +174,313 @@ def _centered_rect(
     rect = QtCore.QRect(0, 0, width, height)
     rect.moveCenter(available.center())
     return rect
+
+
+def _ratio_edges(
+    start: float, size: float, count: int, ratios: Sequence[float]
+) -> tuple[float, ...]:
+    if count <= 0:
+        return (start,)
+    if len(ratios) != count or sum(ratios) <= 0:
+        ratios = tuple(1.0 for _index in range(count))
+    total = float(sum(ratios))
+    edges = [start]
+    current = start
+    for ratio in ratios:
+        current += size * float(ratio) / total
+        edges.append(current)
+    return tuple(edges)
+
+
+def _grid_span_within(
+    grid: FigureGridSpecGridState, span: FigureGridSpecSpanState
+) -> bool:
+    return (
+        0 <= span.row_start < span.row_stop <= grid.nrows
+        and 0 <= span.col_start < span.col_stop <= grid.ncols
+    )
+
+
+def _grid_span_rect(
+    grid: FigureGridSpecGridState,
+    grid_rect: QtCore.QRectF,
+    span: FigureGridSpecSpanState,
+    *,
+    gap: float,
+) -> QtCore.QRectF:
+    x_edges = _ratio_edges(
+        grid_rect.left(), grid_rect.width(), grid.ncols, grid.width_ratios
+    )
+    y_edges = _ratio_edges(
+        grid_rect.top(), grid_rect.height(), grid.nrows, grid.height_ratios
+    )
+    left = x_edges[span.col_start] + (gap / 2 if span.col_start else 0)
+    right = x_edges[span.col_stop] - (gap / 2 if span.col_stop < grid.ncols else 0)
+    top = y_edges[span.row_start] + (gap / 2 if span.row_start else 0)
+    bottom = y_edges[span.row_stop] - (gap / 2 if span.row_stop < grid.nrows else 0)
+    return QtCore.QRectF(left, top, max(0.0, right - left), max(0.0, bottom - top))
+
+
+def _subplot_target_preview_descriptor(
+    nrows: int,
+    ncols: int,
+    selected_axes: Sequence[tuple[int, int]],
+    *,
+    unresolved: bool = False,
+) -> tuple[object, ...]:
+    selected = set(selected_axes)
+    if nrows == ncols == 1 and selected == {(0, 0)} and not unresolved:
+        return ("single_axes",)
+    entries = [
+        (
+            "axis",
+            col / ncols,
+            row / nrows,
+            1 / ncols,
+            1 / nrows,
+            (row, col) in selected,
+        )
+        for row in range(nrows)
+        for col in range(ncols)
+    ]
+    return ("layout", 1.55 * ncols / nrows, tuple(entries), unresolved)
+
+
+def _gridspec_target_preview_descriptor(
+    root: FigureGridSpecGridState,
+    selected_axes_ids: Sequence[str],
+) -> tuple[object, ...]:
+    selected = set(selected_axes_ids)
+    entries: list[tuple[object, ...]] = []
+
+    def add_grid(
+        grid: FigureGridSpecGridState,
+        rect: QtCore.QRectF,
+    ) -> None:
+        occupied: set[tuple[int, int]] = set()
+        for child in grid.child_grids:
+            if child.span is None or not _grid_span_within(grid, child.span):
+                continue
+            occupied.update(
+                (row, col)
+                for row in range(child.span.row_start, child.span.row_stop)
+                for col in range(child.span.col_start, child.span.col_stop)
+            )
+        for axis in grid.axes:
+            if not _grid_span_within(grid, axis.span):
+                continue
+            occupied.update(
+                (row, col)
+                for row in range(axis.span.row_start, axis.span.row_stop)
+                for col in range(axis.span.col_start, axis.span.col_stop)
+            )
+        for row in range(grid.nrows):
+            for col in range(grid.ncols):
+                if (row, col) in occupied:
+                    continue
+                cell = _grid_span_rect(
+                    grid,
+                    rect,
+                    FigureGridSpecSpanState(
+                        row_start=row,
+                        row_stop=row + 1,
+                        col_start=col,
+                        col_stop=col + 1,
+                    ),
+                    gap=0.01,
+                )
+                entries.append(
+                    (
+                        "empty",
+                        cell.x(),
+                        cell.y(),
+                        cell.width(),
+                        cell.height(),
+                        False,
+                    )
+                )
+        for child in grid.child_grids:
+            if child.span is None or not _grid_span_within(grid, child.span):
+                continue
+            child_rect = _grid_span_rect(grid, rect, child.span, gap=0.01)
+            entries.append(
+                (
+                    "grid",
+                    child_rect.x(),
+                    child_rect.y(),
+                    child_rect.width(),
+                    child_rect.height(),
+                    False,
+                )
+            )
+            inset = min(child_rect.width(), child_rect.height()) * 0.08
+            nested_rect = child_rect.adjusted(inset, inset, -inset, -inset)
+            if nested_rect.width() > 0 and nested_rect.height() > 0:
+                add_grid(child, nested_rect)
+        for axis in grid.axes:
+            if not _grid_span_within(grid, axis.span):
+                continue
+            axis_rect = _grid_span_rect(grid, rect, axis.span, gap=0.01)
+            entries.append(
+                (
+                    "axis",
+                    axis_rect.x(),
+                    axis_rect.y(),
+                    axis_rect.width(),
+                    axis_rect.height(),
+                    axis.axes_id in selected,
+                )
+            )
+
+    add_grid(root, QtCore.QRectF(0.0, 0.0, 1.0, 1.0))
+    axis_entries = tuple(entry for entry in entries if entry[0] == "axis")
+    if len(axis_entries) == 1 and axis_entries[0][-1]:
+        return ("single_axes",)
+    width_units = sum(root.width_ratios) if root.width_ratios else root.ncols
+    height_units = sum(root.height_ratios) if root.height_ratios else root.nrows
+    aspect = 1.55 * float(width_units) / float(height_units)
+    return ("layout", aspect, tuple(entries), False)
+
+
+class _AxesTargetItemDelegate(QtWidgets.QStyledItemDelegate):
+    """Paint a compact, read-only target layout in an item-view cell."""
+
+    def __init__(
+        self,
+        descriptor_role: int,
+        parent: QtCore.QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._descriptor_role = descriptor_role
+
+    def sizeHint(
+        self,
+        option: QtWidgets.QStyleOptionViewItem,
+        index: QtCore.QModelIndex,
+    ) -> QtCore.QSize:
+        size = super().sizeHint(option, index)
+        size.setHeight(max(22, size.height()))
+        return size
+
+    def paint(
+        self,
+        painter: QtGui.QPainter | None,
+        option: QtWidgets.QStyleOptionViewItem,
+        index: QtCore.QModelIndex,
+    ) -> None:
+        if painter is None:  # pragma: no cover - Qt always supplies a painter.
+            return
+        display_option = QtWidgets.QStyleOptionViewItem(option)
+        self.initStyleOption(display_option, index)
+        display_option.text = ""
+        display_option.icon = QtGui.QIcon()
+        widget = typing.cast("QtWidgets.QWidget | None", display_option.widget)
+        if widget is None:  # pragma: no cover - item-view paints always own a widget.
+            return
+        style = widget.style()
+        if style is None:  # pragma: no cover - QWidget.style() is populated by Qt.
+            return
+        style.drawControl(
+            QtWidgets.QStyle.ControlElement.CE_ItemViewItem,
+            display_option,
+            painter,
+            widget,
+        )
+        descriptor = index.data(self._descriptor_role)
+        if not isinstance(descriptor, tuple) or not descriptor:
+            return
+        painter.save()
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+        try:
+            if descriptor[0] in {"single_axes", "text"}:
+                text = "Axes" if descriptor[0] == "single_axes" else str(descriptor[1])
+                self._draw_text(painter, display_option, text)
+                return
+            _, aspect_value, entries_value, unresolved = descriptor
+            entries = typing.cast(
+                "tuple[tuple[str, float, float, float, float, bool], ...]",
+                entries_value,
+            )
+            target = self._target_rect(
+                display_option.rect, typing.cast("float", aspect_value)
+            )
+            if target.isEmpty():
+                return
+            colors = _selector_colors(widget)
+            _draw_selector_rect(
+                painter,
+                target,
+                facecolor=colors.panel,
+                edgecolor=colors.border,
+                linewidth=0.8,
+                radius=1.5,
+            )
+            for entry in entries:
+                kind, x, y, width, height, selected = entry
+                rect = QtCore.QRectF(
+                    target.left() + float(x) * target.width(),
+                    target.top() + float(y) * target.height(),
+                    float(width) * target.width(),
+                    float(height) * target.height(),
+                )
+                inset = min(0.25, rect.width() / 4, rect.height() / 4)
+                rect.adjust(inset, inset, -inset, -inset)
+                if rect.width() <= 0 or rect.height() <= 0:
+                    continue
+                is_selected = bool(selected)
+                if kind == "grid":
+                    face = colors.nested_face
+                elif kind == "empty":
+                    face = colors.face
+                else:
+                    face = colors.selection_face if is_selected else colors.face
+                edge = colors.selection if is_selected else colors.border
+                _draw_selector_rect(
+                    painter,
+                    rect,
+                    facecolor=face,
+                    edgecolor=edge,
+                    linewidth=1.4 if is_selected else 0.7,
+                    radius=1.2,
+                )
+            if unresolved:
+                painter.setPen(colors.muted_text)
+                painter.drawText(target, QtCore.Qt.AlignmentFlag.AlignCenter, "?")
+        finally:
+            painter.restore()
+
+    @staticmethod
+    def _target_rect(rect: QtCore.QRect, aspect: float) -> QtCore.QRect:
+        available = rect.adjusted(4, 2, -4, -2)
+        if available.width() <= 0 or available.height() <= 0:
+            return QtCore.QRect()
+        aspect = min(max(aspect, 0.4), 4.5)
+        width = min(float(available.width()), available.height() * aspect)
+        height = min(float(available.height()), width / aspect)
+        target = QtCore.QRect(0, 0, max(1, round(width)), max(1, round(height)))
+        target.moveCenter(available.center())
+        return target
+
+    @staticmethod
+    def _draw_text(
+        painter: QtGui.QPainter,
+        option: QtWidgets.QStyleOptionViewItem,
+        text: str,
+    ) -> None:
+        selected = bool(option.state & QtWidgets.QStyle.StateFlag.State_Selected)
+        role = (
+            QtGui.QPalette.ColorRole.HighlightedText
+            if selected
+            else QtGui.QPalette.ColorRole.Text
+        )
+        painter.save()
+        painter.setPen(option.palette.color(role))
+        painter.drawText(
+            option.rect.adjusted(5, 0, -5, 0),
+            QtCore.Qt.AlignmentFlag.AlignCenter,
+            text,
+        )
+        painter.restore()
 
 
 def _step_toolbar_button(
@@ -2391,38 +2698,13 @@ class _GridSpecViewWidget(QtWidgets.QWidget):
         grid_rect: QtCore.QRect,
         span: FigureGridSpecSpanState,
     ) -> QtCore.QRect:
-        x_edges = self._axis_edges(
-            grid_rect.left(), grid_rect.width(), grid.ncols, grid.width_ratios
-        )
-        y_edges = self._axis_edges(
-            grid_rect.top(), grid_rect.height(), grid.nrows, grid.height_ratios
-        )
-        gap = self._CELL_GAP
-        left = x_edges[span.col_start] + (gap / 2 if span.col_start else 0)
-        right = x_edges[span.col_stop] - (gap / 2 if span.col_stop < grid.ncols else 0)
-        top = y_edges[span.row_start] + (gap / 2 if span.row_start else 0)
-        bottom = y_edges[span.row_stop] - (gap / 2 if span.row_stop < grid.nrows else 0)
+        rect = _grid_span_rect(grid, QtCore.QRectF(grid_rect), span, gap=self._CELL_GAP)
         return QtCore.QRect(
-            round(left),
-            round(top),
-            max(1, round(right - left)),
-            max(1, round(bottom - top)),
+            round(rect.x()),
+            round(rect.y()),
+            max(1, round(rect.width())),
+            max(1, round(rect.height())),
         )
-
-    def _axis_edges(
-        self, start: int, size: int, count: int, ratios: Sequence[float]
-    ) -> tuple[float, ...]:
-        if count <= 0:
-            return (float(start),)
-        if len(ratios) != count or sum(ratios) <= 0:
-            ratios = tuple(1.0 for _index in range(count))
-        total = float(sum(ratios))
-        edges = [float(start)]
-        current = float(start)
-        for ratio in ratios:
-            current += size * float(ratio) / total
-            edges.append(current)
-        return tuple(edges)
 
     def _axis_at(self, pos: QtCore.QPoint) -> str | None:
         for axes_id, rect in reversed(self._axis_rect_items()):
@@ -2769,10 +3051,7 @@ class _GridSpecViewWidget(QtWidgets.QWidget):
     def _span_within_grid(
         grid: FigureGridSpecGridState, span: FigureGridSpecSpanState
     ) -> bool:
-        return (
-            0 <= span.row_start < span.row_stop <= grid.nrows
-            and 0 <= span.col_start < span.col_stop <= grid.ncols
-        )
+        return _grid_span_within(grid, span)
 
     @staticmethod
     def _has_toggle_modifier(modifiers: QtCore.Qt.KeyboardModifier) -> bool:

--- a/src/erlab/interactive/_figurecomposer/_widgets.py
+++ b/src/erlab/interactive/_figurecomposer/_widgets.py
@@ -745,6 +745,10 @@ def _false_toolbar_state() -> bool:
     return False
 
 
+def _false_mime_state(_mime: QtCore.QMimeData) -> bool:
+    return False
+
+
 def _axis_limit_pair(axis: object, getter_name: str) -> tuple[float, float] | None:
     getter = getattr(axis, getter_name, None)
     if getter is None:
@@ -1064,6 +1068,10 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
         redo_callback: Callable[[], None] = _noop_toolbar_callback,
         undoable_callback: Callable[[], bool] = _false_toolbar_state,
         redoable_callback: Callable[[], bool] = _false_toolbar_state,
+        source_drop_available_callback: Callable[
+            [QtCore.QMimeData], bool
+        ] = _false_mime_state,
+        source_drop_callback: Callable[[QtCore.QMimeData], bool] = _false_mime_state,
     ) -> None:
         super().__init__(None)
         erlab.interactive.utils.patch_macos_matplotlib_qt_cursor()
@@ -1071,6 +1079,8 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
         self._suppress_resize_signal = False
         self._resize_signal_pending = False
         self._resize_signal_generation = 0
+        self._source_drop_available_callback = source_drop_available_callback
+        self._source_drop_callback = source_drop_callback
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, False)
 
         with _figure_style_context():
@@ -1104,6 +1114,7 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
         self.setCentralWidget(root)
         self.setWindowTitle("Figure")
         for widget in (self, root, self.toolbar, self.canvas):
+            widget.setAcceptDrops(True)
             widget.installEventFilter(self)
         self._close_shortcut = erlab.interactive.utils._install_close_shortcut(
             self, self.hide
@@ -1123,6 +1134,39 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
             with contextlib.suppress(RuntimeError):
                 target.removeEventFilter(self)
 
+    def set_source_drop_callbacks(
+        self,
+        *,
+        can_drop: Callable[[QtCore.QMimeData], bool] = _false_mime_state,
+        drop: Callable[[QtCore.QMimeData], bool] = _false_mime_state,
+    ) -> None:
+        self._source_drop_available_callback = can_drop
+        self._source_drop_callback = drop
+
+    def _handle_source_drag_event(self, event: QtCore.QEvent | None) -> bool:
+        if event is None or event.type() not in {
+            QtCore.QEvent.Type.DragEnter,
+            QtCore.QEvent.Type.DragMove,
+            QtCore.QEvent.Type.Drop,
+        }:
+            return False
+        if not isinstance(
+            event, (QtGui.QDragEnterEvent, QtGui.QDragMoveEvent, QtGui.QDropEvent)
+        ):
+            return False
+        mime = event.mimeData()
+        if mime is None:
+            return False
+        if not self._source_drop_available_callback(mime):
+            return False
+        if event.type() == QtCore.QEvent.Type.Drop:
+            accepted = self._source_drop_callback(mime)
+            if not accepted:
+                return False
+        event.setDropAction(QtCore.Qt.DropAction.CopyAction)
+        event.accept()
+        return True
+
     def _cancel_resize_callbacks(self, *, suppress: bool) -> None:
         self._suppress_resize_signal = suppress
         self._resize_signal_pending = False
@@ -1133,6 +1177,8 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
         watched: QtCore.QObject | None,
         event: QtCore.QEvent | None,
     ) -> bool:
+        if self._handle_source_drag_event(event):
+            return True
         if self._is_workspace_save_shortcut_event(event) and (
             shortcut := self._workspace_save_shortcut()
         ):

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -1576,15 +1576,20 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         self._ensure_serializable_state()
         return super().duplicate(**kwargs)
 
-    def _stop_server(self) -> bool:
+    def _stop_server(self, *, timeout_ms: int | None = None) -> bool:
         """Stop the fitter thread properly."""
         self._pending_update_request = None
         self._pending_update_timer.stop()
         self._abort_fit_task()
+        if timeout_ms is None:
+            timeout_ms = self.BACKGROUND_TASK_TIMEOUT_MS
         return self._wait_for_threadpool(
             self._threadpool,
-            timeout_ms=self.BACKGROUND_TASK_TIMEOUT_MS,
+            timeout_ms=timeout_ms,
         )
+
+    def _cancel_background_work(self, *, timeout_ms: int) -> bool:
+        return self._stop_server(timeout_ms=timeout_ms)
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """Overridden close event to ensure proper cleanup."""

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -21,9 +21,9 @@ set of source forms:
      and replayed through structured :class:`ReplayStage` operations.
 
    - Use :func:`script` for console-derived and other multi-input results. Script
-   specs may reference any number of :class:`ScriptInput` records. Each input stores
-   an immutable replay name, optional live manager node identity and
-   ``node_snapshot_token``, and an optional nested provenance snapshot.
+     specs may reference any number of :class:`ScriptInput` records. Each input stores
+     an immutable replay name, a historical display label, optional live manager node
+     identity and ``node_snapshot_token``, and an optional nested provenance snapshot.
 
 Each transformation is represented by an immutable
 :class:`ToolProvenanceOperation` subclass whose serialized fields are safe to persist
@@ -428,6 +428,7 @@ class ScriptInputDependencyRef:
     """Live manager dependency captured by a script input."""
 
     name: str
+    label: str
     node_uid: str
     node_snapshot_token: str | None = None
 
@@ -2458,13 +2459,14 @@ class FileLoadSource(pydantic.BaseModel):
 class ScriptInput(pydantic.BaseModel):
     """Named input captured by script or multi-tool provenance.
 
-    ``name`` is the immutable replay variable, ``node_uid`` and
-    ``node_snapshot_token`` identify the live manager input that was used, and
-    ``provenance_spec`` stores the historical replay source used when that live input
-    is unavailable.
+    ``name`` is the immutable replay variable, ``label`` is the historical display
+    label, ``node_uid`` and ``node_snapshot_token`` identify the live manager input
+    that was used, and ``provenance_spec`` stores the historical replay source used
+    when that live input is unavailable. When omitted, ``label`` defaults to ``name``.
     """
 
     name: str
+    label: str = ""
     node_uid: str | None = None
     node_snapshot_token: str | None = None
     provenance_spec: dict[str, typing.Any] | None = None
@@ -2477,10 +2479,12 @@ class ScriptInput(pydantic.BaseModel):
 
     @pydantic.model_validator(mode="before")
     @classmethod
-    def _drop_legacy_label(cls, value: typing.Any) -> typing.Any:
-        if isinstance(value, Mapping) and "label" in value:
+    def _default_label_from_name(cls, value: typing.Any) -> typing.Any:
+        if isinstance(value, Mapping) and (
+            "label" not in value or value.get("label") is None
+        ):
             value = dict(value)
-            value.pop("label", None)
+            value["label"] = value.get("name")
         return value
 
     @pydantic.field_validator("name", mode="before")
@@ -2490,6 +2494,16 @@ class ScriptInput(pydantic.BaseModel):
         if name is None:
             raise ValueError("script input name must not be None")
         return name
+
+    @pydantic.field_validator("label", mode="before")
+    @classmethod
+    def _validate_label(cls, value: typing.Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("script input label must be a string")
+        label = " ".join(value.split())
+        if not label:
+            raise ValueError("script input label must not be empty")
+        return label
 
     @pydantic.field_validator("node_uid", mode="before")
     @classmethod
@@ -2525,6 +2539,12 @@ class ScriptInput(pydantic.BaseModel):
 
     def parsed_provenance_spec(self) -> ToolProvenanceSpec | None:
         return parse_tool_provenance_spec(self.provenance_spec)
+
+
+def _script_input_reference_text(script_input: ScriptInput) -> str:
+    if script_input.label == script_input.name:
+        return script_input.name
+    return f"{script_input.name} from {script_input.label}"
 
 
 class _ScriptContextBinding(pydantic.BaseModel):
@@ -3163,7 +3183,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         if self.kind == "script":
             entries.extend(
                 DerivationEntry(
-                    f"Use {script_input.name}",
+                    f"Use {_script_input_reference_text(script_input)}",
                     None,
                     False,
                 )
@@ -3223,7 +3243,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         entries = [self._start_entry()]
         entries.extend(
             DerivationEntry(
-                f"Use {script_input.name}",
+                f"Use {_script_input_reference_text(script_input)}",
                 None,
                 False,
             )
@@ -3332,7 +3352,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 rows.append(
                     _ProvenanceDisplayRow(
                         DerivationEntry(
-                            f"Use {script_input.name}",
+                            f"Use {_script_input_reference_text(script_input)}",
                             None,
                             False,
                         ),
@@ -3597,10 +3617,11 @@ def script_input_dependency_refs(
 
     def _collect(current: ToolProvenanceSpec) -> None:
         for script_input in current.script_inputs:
-            if script_input.node_uid is not None:
+            if script_input.node_uid:
                 refs.append(
                     ScriptInputDependencyRef(
                         name=script_input.name,
+                        label=script_input.label,
                         node_uid=script_input.node_uid,
                         node_snapshot_token=script_input.node_snapshot_token,
                     )

--- a/src/erlab/interactive/imagetool/_provenance_framework.py
+++ b/src/erlab/interactive/imagetool/_provenance_framework.py
@@ -21,9 +21,9 @@ set of source forms:
      and replayed through structured :class:`ReplayStage` operations.
 
    - Use :func:`script` for console-derived and other multi-input results. Script
-     specs may reference any number of :class:`ScriptInput` records. Each input stores
-     an immutable replay name, a historical display label, optional live manager node
-     identity and ``node_snapshot_token``, and an optional nested provenance snapshot.
+   specs may reference any number of :class:`ScriptInput` records. Each input stores
+   an immutable replay name, optional live manager node identity and
+   ``node_snapshot_token``, and an optional nested provenance snapshot.
 
 Each transformation is represented by an immutable
 :class:`ToolProvenanceOperation` subclass whose serialized fields are safe to persist
@@ -428,7 +428,6 @@ class ScriptInputDependencyRef:
     """Live manager dependency captured by a script input."""
 
     name: str
-    label: str
     node_uid: str
     node_snapshot_token: str | None = None
 
@@ -2459,14 +2458,13 @@ class FileLoadSource(pydantic.BaseModel):
 class ScriptInput(pydantic.BaseModel):
     """Named input captured by script or multi-tool provenance.
 
-    ``name`` is the immutable replay variable, ``label`` is the historical display
-    label, ``node_uid`` and ``node_snapshot_token`` identify the live manager input
-    that was used, and ``provenance_spec`` stores the historical replay source used
-    when that live input is unavailable.
+    ``name`` is the immutable replay variable, ``node_uid`` and
+    ``node_snapshot_token`` identify the live manager input that was used, and
+    ``provenance_spec`` stores the historical replay source used when that live input
+    is unavailable.
     """
 
     name: str
-    label: str
     node_uid: str | None = None
     node_snapshot_token: str | None = None
     provenance_spec: dict[str, typing.Any] | None = None
@@ -2477,6 +2475,14 @@ class ScriptInput(pydantic.BaseModel):
         extra="forbid",
     )
 
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _drop_legacy_label(cls, value: typing.Any) -> typing.Any:
+        if isinstance(value, Mapping) and "label" in value:
+            value = dict(value)
+            value.pop("label", None)
+        return value
+
     @pydantic.field_validator("name", mode="before")
     @classmethod
     def _validate_name(cls, value: typing.Any) -> str:
@@ -2484,16 +2490,6 @@ class ScriptInput(pydantic.BaseModel):
         if name is None:
             raise ValueError("script input name must not be None")
         return name
-
-    @pydantic.field_validator("label", mode="before")
-    @classmethod
-    def _validate_label(cls, value: typing.Any) -> str:
-        if not isinstance(value, str):
-            raise TypeError("script input label must be a string")
-        label = " ".join(value.split())
-        if not label:
-            raise ValueError("script input label must not be empty")
-        return label
 
     @pydantic.field_validator("node_uid", mode="before")
     @classmethod
@@ -3167,7 +3163,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         if self.kind == "script":
             entries.extend(
                 DerivationEntry(
-                    f"Use {script_input.name} from {script_input.label}",
+                    f"Use {script_input.name}",
                     None,
                     False,
                 )
@@ -3227,7 +3223,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         entries = [self._start_entry()]
         entries.extend(
             DerivationEntry(
-                f"Use {script_input.name} from {script_input.label}",
+                f"Use {script_input.name}",
                 None,
                 False,
             )
@@ -3336,7 +3332,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 rows.append(
                     _ProvenanceDisplayRow(
                         DerivationEntry(
-                            f"Use {script_input.name} from {script_input.label}",
+                            f"Use {script_input.name}",
                             None,
                             False,
                         ),
@@ -3605,7 +3601,6 @@ def script_input_dependency_refs(
                 refs.append(
                     ScriptInputDependencyRef(
                         name=script_input.name,
-                        label=script_input.label,
                         node_uid=script_input.node_uid,
                         node_snapshot_token=script_input.node_snapshot_token,
                     )

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -1689,21 +1689,173 @@ def _leading_top_level_imports(code: str) -> tuple[list[tuple[str, str]], str]:
     return imports, body
 
 
+def _import_binding_targets(code: str) -> dict[str, str] | None:
+    """Return names bound by one import and their canonical targets.
+
+    Star imports cannot be reasoned about locally, so callers must leave them in place.
+    """
+    statement = ast.parse(code, mode="exec").body[0]
+    if isinstance(statement, ast.Import):
+        targets: dict[str, str] = {}
+        for alias in statement.names:
+            if alias.asname is None:
+                name = alias.name.partition(".")[0]
+                target = f"module:{name}"
+            else:
+                name = alias.asname
+                target = f"module:{alias.name}"
+            if name in targets and targets[name] != target:
+                return None
+            targets[name] = target
+        return targets
+    if not isinstance(statement, ast.ImportFrom):  # pragma: no cover - caller contract.
+        return None
+    if statement.module == "__future__":
+        return {}
+    targets = {}
+    module = "." * statement.level + (statement.module or "")
+    for alias in statement.names:
+        if alias.name == "*":
+            return None
+        name = alias.asname or alias.name
+        target = f"from:{module}:{alias.name}"
+        if name in targets and targets[name] != target:
+            return None
+        targets[name] = target
+    return targets
+
+
+def _code_name_accesses(code: str) -> tuple[set[str], set[str]]:
+    """Return conservatively accessed and rebound names in a code chunk."""
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        # Invalid generated code is diagnosed by the normal replay-code path. Treat it
+        # as opaque so import grouping cannot make its behavior less predictable.
+        return {"*"}, {"*"}
+
+    accessed: set[str] = set()
+    rebound: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Name):
+            accessed.add(node.id)
+            if isinstance(node.ctx, ast.Store | ast.Del):
+                rebound.add(node.id)
+        elif isinstance(node, ast.AsyncFunctionDef | ast.ClassDef | ast.FunctionDef):
+            accessed.add(node.name)
+            rebound.add(node.name)
+        elif isinstance(node, ast.Import | ast.ImportFrom):
+            bindings = _import_binding_targets(ast.unparse(node))
+            if bindings is None:
+                accessed.add("*")
+                rebound.add("*")
+            else:
+                accessed.update(bindings)
+                rebound.update(bindings)
+        elif isinstance(node, ast.ExceptHandler | ast.MatchAs | ast.MatchStar):
+            if node.name is not None:
+                accessed.add(node.name)
+                rebound.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest is not None:
+            accessed.add(node.rest)
+            rebound.add(node.rest)
+    return accessed, rebound
+
+
+def _is_future_import(code: str) -> bool:
+    statement = ast.parse(code, mode="exec").body[0]
+    return isinstance(statement, ast.ImportFrom) and statement.module == "__future__"
+
+
 def _group_framework_imports(chunks: Sequence[tuple[str, bool]]) -> str:
+    """Group canonical framework imports without changing Python name resolution.
+
+    Framework code producers should use one canonical import target for each alias. If
+    independently generated chunks violate that invariant, keep the imports beside the
+    code that uses them instead of silently changing the program by hoisting them.
+    """
+    parsed_chunks: list[tuple[str, bool, list[tuple[str, str]], str]] = []
+    targets_by_name: dict[str, set[str]] = {}
+    for code, group_imports in chunks:
+        leading_imports, import_body = (
+            _leading_top_level_imports(code) if group_imports else ([], code)
+        )
+        parsed_chunks.append((code, group_imports, leading_imports, import_body))
+        for canonical, _source in leading_imports:
+            bindings = _import_binding_targets(canonical)
+            if bindings is None:
+                continue
+            for name, target in bindings.items():
+                targets_by_name.setdefault(name, set()).add(target)
+    conflicting_names = {
+        name for name, targets in targets_by_name.items() if len(targets) > 1
+    }
+
+    future_imports: list[str] = []
     imports: list[str] = []
     import_codes: set[str] = set()
+    hoisted_bindings: dict[str, str] = {}
+    seen_accesses: set[str] = set()
+    seen_rebindings: set[str] = set()
     body: list[str] = []
-    for code, group_imports in chunks:
-        if group_imports:
-            leading_imports, code = _leading_top_level_imports(code)
-            for canonical, source in leading_imports:
-                if canonical in import_codes:
-                    continue
-                import_codes.add(canonical)
-                imports.append(source)
+    for original_code, group_imports, leading_imports, import_body in parsed_chunks:
+        code = original_code
+        if group_imports and leading_imports:
+            regular_imports = [
+                item for item in leading_imports if not _is_future_import(item[0])
+            ]
+            future_items = [
+                item for item in leading_imports if _is_future_import(item[0])
+            ]
+            for canonical, source in future_items:
+                if canonical not in import_codes:
+                    import_codes.add(canonical)
+                    future_imports.append(source)
+
+            regular_bindings: dict[str, str] = {}
+            safe_to_hoist = True
+            for canonical, _source in regular_imports:
+                bindings = _import_binding_targets(canonical)
+                if bindings is None:
+                    safe_to_hoist = False
+                    break
+                for name, target in bindings.items():
+                    existing_target = hoisted_bindings.get(name)
+                    if (
+                        name in conflicting_names
+                        or "*" in seen_accesses
+                        or (existing_target is None and name in seen_accesses)
+                        or (
+                            existing_target is not None
+                            and (existing_target != target or name in seen_rebindings)
+                        )
+                    ):
+                        safe_to_hoist = False
+                        break
+                    regular_bindings[name] = target
+                if not safe_to_hoist:
+                    break
+
+            if safe_to_hoist:
+                code = import_body
+                hoisted_bindings.update(regular_bindings)
+                for canonical, source in regular_imports:
+                    if canonical in import_codes:
+                        continue
+                    import_codes.add(canonical)
+                    imports.append(source)
+            elif future_items:
+                # Future imports must remain at the beginning of the combined module;
+                # retain every ordinary import next to its original body.
+                code = "\n".join(
+                    (*[source for _canonical, source in regular_imports], import_body)
+                ).strip("\n")
         if code.strip():
             body.append(code)
-    return "\n".join((*imports, *body))
+        accesses, rebindings = _code_name_accesses(code)
+        seen_accesses.update(accesses)
+        seen_rebindings.update(rebindings)
+    return "\n".join((*future_imports, *imports, *body))
 
 
 def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> str:

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -934,9 +934,14 @@ def _compile_spec(
                 else:
                     input_spec = script_input.parsed_provenance_spec()
                     if input_spec is None:
+                        input_reference = (
+                            _provenance_framework._script_input_reference_text(
+                                script_input
+                            )
+                        )
                         raise ReplayGraphError(
-                            f"{script_input.name} does not contain recorded source "
-                            "provenance"
+                            f"{input_reference} "
+                            "does not contain recorded source provenance"
                         )
                     input_key = _compile_spec(
                         graph,
@@ -1852,7 +1857,8 @@ def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) ->
         input_spec = script_input.parsed_provenance_spec()
         if input_spec is None:
             raise ReplayGraphError(
-                f"{script_input.name} does not contain recorded source provenance"
+                f"{_provenance_framework._script_input_reference_text(script_input)} "
+                "does not contain recorded source provenance"
             )
         input_key = _compile_spec(
             graph,
@@ -2158,8 +2164,12 @@ def rebuild_script_provenance(
 
             input_spec = script_input.parsed_provenance_spec()
             if input_spec is None:
+                input_reference = _provenance_framework._script_input_reference_text(
+                    script_input
+                )
                 raise ReplayGraphError(
-                    f"{script_input.name} is not open and "
+                    f"{input_reference} "
+                    "is not open and "
                     "does not contain recorded source provenance."
                 )
             if input_spec.kind == "file":
@@ -2197,7 +2207,8 @@ def rebuild_script_provenance(
                 )
                 continue
             raise ReplayGraphError(
-                f"{script_input.name} is not open and "
+                f"{_provenance_framework._script_input_reference_text(script_input)} "
+                "is not open and "
                 "does not contain reloadable script or file provenance."
             )
         return current.model_copy(update={"script_inputs": tuple(resolved_inputs)})

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -935,8 +935,8 @@ def _compile_spec(
                     input_spec = script_input.parsed_provenance_spec()
                     if input_spec is None:
                         raise ReplayGraphError(
-                            f"{script_input.name} from {script_input.label} "
-                            "does not contain recorded source provenance"
+                            f"{script_input.name} does not contain recorded source "
+                            "provenance"
                         )
                     input_key = _compile_spec(
                         graph,
@@ -1641,6 +1641,36 @@ def _cleanup_emitted_replay_code(code: str) -> str:
     return _compact_replay_temp_names(code)
 
 
+def _hoist_top_level_imports(code: str) -> str:
+    try:
+        module = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return code
+
+    imports: list[ast.stmt] = []
+    import_codes: set[str] = set()
+    body: list[ast.stmt] = []
+    changed = False
+    seen_non_import = False
+    for statement in module.body:
+        if isinstance(statement, ast.Import | ast.ImportFrom):
+            import_code = ast.unparse(statement)
+            if import_code not in import_codes:
+                imports.append(statement)
+                import_codes.add(import_code)
+            else:
+                changed = True
+            changed = changed or seen_non_import
+            continue
+        seen_non_import = True
+        body.append(statement)
+
+    if not changed:
+        return code
+    module.body = [*imports, *body]
+    return ast.unparse(ast.fix_missing_locations(module))
+
+
 def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> str:
     names = _node_names(graph, output_name=output_name)
     node_by_key = {node.key: node for node in graph.nodes}
@@ -1764,7 +1794,10 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
         planned_name = names[key]
         if public_name != planned_name:
             lines.append(f"{public_name} = {planned_name}")
-    return _cleanup_emitted_replay_code("\n".join(lines))
+    code = _cleanup_emitted_replay_code("\n".join(lines))
+    if graph.display:
+        code = _hoist_top_level_imports(code)
+    return code
 
 
 def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) -> str:
@@ -1779,8 +1812,7 @@ def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) ->
         input_spec = script_input.parsed_provenance_spec()
         if input_spec is None:
             raise ReplayGraphError(
-                f"{script_input.name} from {script_input.label} "
-                "does not contain recorded source provenance"
+                f"{script_input.name} does not contain recorded source provenance"
             )
         input_key = _compile_spec(
             graph,
@@ -2087,7 +2119,7 @@ def rebuild_script_provenance(
             input_spec = script_input.parsed_provenance_spec()
             if input_spec is None:
                 raise ReplayGraphError(
-                    f"{script_input.name} from {script_input.label} is not open and "
+                    f"{script_input.name} is not open and "
                     "does not contain recorded source provenance."
                 )
             if input_spec.kind == "file":
@@ -2125,7 +2157,7 @@ def rebuild_script_provenance(
                 )
                 continue
             raise ReplayGraphError(
-                f"{script_input.name} from {script_input.label} is not open and "
+                f"{script_input.name} is not open and "
                 "does not contain reloadable script or file provenance."
             )
         return current.model_copy(update={"script_inputs": tuple(resolved_inputs)})

--- a/src/erlab/interactive/imagetool/_replay_graph.py
+++ b/src/erlab/interactive/imagetool/_replay_graph.py
@@ -964,6 +964,7 @@ def _compile_spec(
         current_name: str | None = None
         current_bindings = tuple(bindings)
         pending_codes: list[str] = []
+        pending_code_hoist_imports: list[bool] = []
 
         def relay_key(source_key: str) -> str:
             return graph.add_node(
@@ -1028,7 +1029,8 @@ def _compile_spec(
             return False
 
         def flush_script() -> None:
-            nonlocal current_bindings, current_name, pending_codes, script_current_key
+            nonlocal current_bindings, current_name, pending_code_hoist_imports
+            nonlocal pending_codes, script_current_key
             if not pending_codes:
                 return
             output_name = _provenance_framework._script_codes_output_name(
@@ -1045,6 +1047,7 @@ def _compile_spec(
                         "active_name": output_name,
                         "bindings": current_bindings,
                         "codes": tuple(pending_codes),
+                        "hoist_imports": tuple(pending_code_hoist_imports),
                     },
                 ),
                 "script",
@@ -1054,11 +1057,13 @@ def _compile_spec(
                     "active_name": output_name,
                     "bindings": current_bindings,
                     "codes": tuple(pending_codes),
+                    "hoist_imports": tuple(pending_code_hoist_imports),
                 },
             )
             current_name = output_name
             current_bindings = bind_name(output_name, script_current_key)
             pending_codes = []
+            pending_code_hoist_imports = []
 
         def apply_context_binding(names: Sequence[str]) -> None:
             nonlocal current_bindings, current_name, script_current_key
@@ -1082,6 +1087,7 @@ def _compile_spec(
             if seed_file_load_parts is None:
                 if not apply_simple_alias(parsed.seed_code):
                     pending_codes.append(parsed.seed_code)
+                    pending_code_hoist_imports.append(False)
             else:
                 seed_setup_code, seed_load_code, seed_output_name = seed_file_load_parts
                 script_current_key = _add_file_load_node(
@@ -1132,6 +1138,9 @@ def _compile_spec(
                     )
                 if not apply_simple_alias(operation_code):
                     pending_codes.append(operation_code)
+                    pending_code_hoist_imports.append(
+                        bool(getattr(operation, "hoist_imports", False))
+                    )
                 continue
 
             if pending_codes:
@@ -1149,6 +1158,7 @@ def _compile_spec(
                         context_name=pending_output_name,
                     )
                 )
+                pending_code_hoist_imports.append(False)
                 continue
 
             ensure_script_current_key()
@@ -1641,41 +1651,64 @@ def _cleanup_emitted_replay_code(code: str) -> str:
     return _compact_replay_temp_names(code)
 
 
-def _hoist_top_level_imports(code: str) -> str:
+def _leading_top_level_imports(code: str) -> tuple[list[tuple[str, str]], str]:
     try:
         module = ast.parse(code, mode="exec")
     except SyntaxError:
-        return code
+        return [], code
 
-    imports: list[ast.stmt] = []
-    import_codes: set[str] = set()
-    body: list[ast.stmt] = []
-    changed = False
-    seen_non_import = False
+    lines = code.splitlines()
+    imports: list[tuple[str, str]] = []
+    removed_lines: set[int] = set()
     for statement in module.body:
-        if isinstance(statement, ast.Import | ast.ImportFrom):
-            import_code = ast.unparse(statement)
-            if import_code not in import_codes:
-                imports.append(statement)
-                import_codes.add(import_code)
-            else:
-                changed = True
-            changed = changed or seen_non_import
-            continue
-        seen_non_import = True
-        body.append(statement)
+        if not isinstance(statement, ast.Import | ast.ImportFrom):
+            break
+        if statement.end_lineno is None or statement.end_col_offset is None:
+            break
+        start_index = statement.lineno - 1
+        end_index = statement.end_lineno - 1
+        if (
+            lines[start_index][: statement.col_offset].strip()
+            or lines[end_index][statement.end_col_offset :].strip()
+        ):
+            break
+        source = "\n".join(lines[start_index : end_index + 1]).strip()
+        imports.append((ast.unparse(statement), source))
+        removed_lines.update(range(start_index, end_index + 1))
 
-    if not changed:
-        return code
-    module.body = [*imports, *body]
-    return ast.unparse(ast.fix_missing_locations(module))
+    if not imports:
+        return [], code
+    body = "\n".join(
+        line for index, line in enumerate(lines) if index not in removed_lines
+    ).strip("\n")
+    return imports, body
+
+
+def _group_framework_imports(chunks: Sequence[tuple[str, bool]]) -> str:
+    imports: list[str] = []
+    import_codes: set[str] = set()
+    body: list[str] = []
+    for code, group_imports in chunks:
+        if group_imports:
+            leading_imports, code = _leading_top_level_imports(code)
+            for canonical, source in leading_imports:
+                if canonical in import_codes:
+                    continue
+                import_codes.add(canonical)
+                imports.append(source)
+        if code.strip():
+            body.append(code)
+    return "\n".join((*imports, *body))
 
 
 def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> str:
     names = _node_names(graph, output_name=output_name)
     node_by_key = {node.key: node for node in graph.nodes}
-    lines: list[str] = []
+    chunks: list[tuple[str, bool]] = []
     active_setup_key: str | None = None
+
+    def append_code(code: str, *, group_imports: bool = False) -> None:
+        chunks.append((code, graph.display and group_imports))
 
     for node in graph.nodes:
         if node.kind == "setup":
@@ -1689,7 +1722,10 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
             setup_key = node.parents[0] if node.parents else None
             if setup_key is not None and active_setup_key != setup_key:
                 setup_node = node_by_key[setup_key]
-                lines.append(typing.cast("str", setup_node.payload["code"]))
+                append_code(
+                    typing.cast("str", setup_node.payload["code"]),
+                    group_imports=True,
+                )
                 active_setup_key = setup_key
             try:
                 code = _provenance_framework._replace_code_identifiers(
@@ -1699,14 +1735,14 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
                 raise ReplayGraphError("File replay code is not valid Python") from exc
             if not _provenance_framework._code_stores_name(code, name):
                 raise ReplayGraphError("File replay code does not assign its output")
-            lines.append(code)
+            append_code(code, group_imports=True)
         elif node.kind == "live_input":
             raise ReplayGraphError("Live inputs cannot be emitted as replay code")
         elif node.kind == "source_view":
             parent_name = names[node.parents[0]]
             if not _source_view_emits_code(graph, node):
                 continue
-            lines.append(
+            append_code(
                 f"{name} = erlab.interactive.imagetool.slicer."
                 f"restore_nonuniform_dims({parent_name})"
             )
@@ -1714,7 +1750,7 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
             parent_name = names[node.parents[0]]
             context_name = names[node.parents[1]]
             operation = node.payload["operation"]
-            lines.append(
+            append_code(
                 _operation_replay_code(
                     operation,
                     active_name=name,
@@ -1724,6 +1760,12 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
             )
         elif node.kind == "script":
             codes = list(typing.cast("tuple[str, ...]", node.payload["codes"]))
+            hoist_imports = list(
+                typing.cast(
+                    "tuple[bool, ...]",
+                    node.payload.get("hoist_imports", (False,) * len(codes)),
+                )
+            )
             active_name = typing.cast("str", node.payload["active_name"])
             input_replacements: dict[str, str] = {}
             input_names: set[str] = set()
@@ -1745,7 +1787,7 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
                 ):
                     input_replacements[input_name] = input_value_name
                 else:
-                    lines.append(f"{input_name} = {input_value_name}")
+                    append_code(f"{input_name} = {input_value_name}")
             if input_replacements:
                 try:
                     codes = [
@@ -1776,9 +1818,10 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
                         "Script replay code is not valid Python"
                     ) from exc
                 active_name = name
-            lines.extend(codes)
+            for code, group_imports in zip(codes, hoist_imports, strict=True):
+                append_code(code, group_imports=group_imports)
             if active_name != name:
-                lines.append(f"{name} = {active_name}")
+                append_code(f"{name} = {active_name}")
             active_setup_key = None
         else:
             raise ReplayGraphError(f"Unknown replay graph node kind {node.kind!r}")
@@ -1793,11 +1836,8 @@ def emit_replay_code(graph: ReplayGraph, *, output_name: str | None = None) -> s
     for public_name, key in aliases:
         planned_name = names[key]
         if public_name != planned_name:
-            lines.append(f"{public_name} = {planned_name}")
-    code = _cleanup_emitted_replay_code("\n".join(lines))
-    if graph.display:
-        code = _hoist_top_level_imports(code)
-    return code
+            append_code(f"{public_name} = {planned_name}")
+    return _cleanup_emitted_replay_code(_group_framework_imports(chunks))
 
 
 def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) -> str:

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -354,13 +354,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         return selected
 
     def _selected_figure_source_targets(self) -> list[int | str]:
-        targets: list[int | str] = list(self._selected_imagetool_targets())
-        targets.extend(
-            uid
-            for uid in self.tree_view.selected_childtool_uids
-            if not self._is_imagetool_target(uid) and not self._is_figure_uid(uid)
-        )
-        return targets
+        return list(self._selected_imagetool_targets())
 
     def _selected_promotable_child_imagetool_uid(self) -> str | None:
         child_imagetool_uids = [

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -1289,6 +1289,9 @@ class ToolNamespace(_ConsoleDataHandleBase):
     def _script_input(
         self,
     ) -> provenance.ScriptInput:
+        label = self._console_label
+        if self._wrapper.name:
+            label += f": {self._wrapper.name}"
         wrapper_provenance = self._wrapper.displayed_provenance_spec
         provenance_spec = (
             wrapper_provenance.model_dump(mode="json")
@@ -1297,6 +1300,7 @@ class ToolNamespace(_ConsoleDataHandleBase):
         )
         return provenance.ScriptInput(
             name=self._console_input_name,
+            label=label,
             node_uid=self._wrapper.uid,
             node_snapshot_token=self._wrapper.snapshot_token,
             provenance_spec=provenance_spec,
@@ -1680,6 +1684,7 @@ class _DerivedDataNamespace(_ConsoleDataHandleBase):
             (
                 provenance.ScriptInput(
                     name=self._console_name,
+                    label=f"console variable {self._console_name!r}",
                     provenance_spec=provenance_payload,
                 ),
             ),

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -1289,9 +1289,6 @@ class ToolNamespace(_ConsoleDataHandleBase):
     def _script_input(
         self,
     ) -> provenance.ScriptInput:
-        label = self._console_label
-        if self._wrapper.name:
-            label += f": {self._wrapper.name}"
         wrapper_provenance = self._wrapper.displayed_provenance_spec
         provenance_spec = (
             wrapper_provenance.model_dump(mode="json")
@@ -1300,7 +1297,6 @@ class ToolNamespace(_ConsoleDataHandleBase):
         )
         return provenance.ScriptInput(
             name=self._console_input_name,
-            label=label,
             node_uid=self._wrapper.uid,
             node_snapshot_token=self._wrapper.snapshot_token,
             provenance_spec=provenance_spec,
@@ -1684,7 +1680,6 @@ class _DerivedDataNamespace(_ConsoleDataHandleBase):
             (
                 provenance.ScriptInput(
                     name=self._console_name,
-                    label=f"console variable {self._console_name!r}",
                     provenance_spec=provenance_payload,
                 ),
             ),

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -298,6 +298,7 @@ class _DetailsPanelController:
         *,
         include_history: bool,
     ) -> str:
+        del include_history
         graph = getattr(self._manager, "_tool_graph", None)
         node_uid = script_input.node_uid
         if graph is not None and node_uid is not None:
@@ -307,11 +308,8 @@ class _DetailsPanelController:
                     f"Use {script_input.name} from "
                     f"{self._script_input_current_node_label(node)}"
                 )
-            label = f"Missing source for {script_input.name}"
-            if include_history:
-                label += f" (recorded as {script_input.label})"
-            return label
-        return f"Use {script_input.name} from {script_input.label}"
+            return f"Missing source for {script_input.name}"
+        return f"Use {script_input.name}"
 
     @staticmethod
     def _script_input_for_row(

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -298,7 +298,6 @@ class _DetailsPanelController:
         *,
         include_history: bool,
     ) -> str:
-        del include_history
         graph = getattr(self._manager, "_tool_graph", None)
         node_uid = script_input.node_uid
         if graph is not None and node_uid is not None:
@@ -308,8 +307,13 @@ class _DetailsPanelController:
                     f"Use {script_input.name} from "
                     f"{self._script_input_current_node_label(node)}"
                 )
-            return f"Missing source for {script_input.name}"
-        return f"Use {script_input.name}"
+            label = f"Missing source for {script_input.name}"
+            if include_history and script_input.label != script_input.name:
+                label += f" (recorded as {script_input.label})"
+            return label
+        if script_input.label == script_input.name:
+            return f"Use {script_input.name}"
+        return f"Use {script_input.name} from {script_input.label}"
 
     @staticmethod
     def _script_input_for_row(

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -156,10 +156,9 @@ class _LineageController:
                 if self._manager._dependency_ref_has_recorded_file(spec, ref):
                     current += "; recorded source file found"
             name = " ".join(ref.name.split())
-            label = " ".join(ref.label.split())
             current = " ".join(current.split())
-            if name and label and current:
-                parts.append(f"{name}: {label} ({current})")
+            if name and current:
+                parts.append(f"{name} ({current})")
         if not parts:
             return None
         return "\n".join(parts)
@@ -331,26 +330,13 @@ class _LineageController:
             if input_provenance is not None
             else None
         )
-        if isinstance(node, _ImageToolWrapper):
-            label = f"ImageTool {node.index}"
-        else:
-            fallback_label = (
-                "ImageTool child"
-                if node.is_imagetool
-                else node.type_badge_text or "Tool"
-            )
-            label = node.display_text or fallback_label
-        if isinstance(node, _ImageToolWrapper) and node.name:
-            label += f": {node.name}"
         if node.uid == detached_input_uid:
             return provenance.ScriptInput(
                 name=self._manager._script_input_name_for_node(node),
-                label=label,
                 provenance_spec=provenance_spec,
             )
         return provenance.ScriptInput(
             name=self._manager._script_input_name_for_node(node),
-            label=label,
             node_uid=node.uid,
             node_snapshot_token=node.snapshot_token,
             provenance_spec=provenance_spec,
@@ -512,25 +498,25 @@ class _LineageController:
                 return None
         if spec is None:
             return (
-                f"{script_input.label} has no recorded reload source. Reopen the "
+                f"{script_input.name} has no recorded reload source. Reopen the "
                 "input or recreate the result from reloadable inputs, then try "
                 "again."
             )
         if spec.kind == "file" or provenance.has_file_load_source(spec):
-            reason = self._file_load_source_unavailable_reason(spec, script_input.label)
+            reason = self._file_load_source_unavailable_reason(spec, script_input.name)
             if reason is not None:
                 return reason
             if spec.kind == "file":
                 return None
         if spec.kind != "script":
             return (
-                f"{script_input.label} has recorded provenance that cannot be "
+                f"{script_input.name} has recorded provenance that cannot be "
                 "reloaded. Reopen the input or recreate the result from "
                 "reloadable inputs, then try again."
             )
         if not self._script_provenance_runnable(spec):
             return (
-                f"{script_input.label} was created from recorded code that "
+                f"{script_input.name} was created from recorded code that "
                 "cannot be replayed. Recreate the result from reloadable "
                 "inputs to enable reload."
             )

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -156,9 +156,13 @@ class _LineageController:
                 if self._manager._dependency_ref_has_recorded_file(spec, ref):
                     current += "; recorded source file found"
             name = " ".join(ref.name.split())
+            label = " ".join(ref.label.split())
             current = " ".join(current.split())
-            if name and current:
-                parts.append(f"{name} ({current})")
+            if name and label and current:
+                if label == name:
+                    parts.append(f"{name} ({current})")
+                else:
+                    parts.append(f"{name}: {label} ({current})")
         if not parts:
             return None
         return "\n".join(parts)
@@ -330,13 +334,26 @@ class _LineageController:
             if input_provenance is not None
             else None
         )
+        if isinstance(node, _ImageToolWrapper):
+            label = f"ImageTool {node.index}"
+        else:
+            fallback_label = (
+                "ImageTool child"
+                if node.is_imagetool
+                else node.type_badge_text or "Tool"
+            )
+            label = node.display_text or fallback_label
+        if isinstance(node, _ImageToolWrapper) and node.name:
+            label += f": {node.name}"
         if node.uid == detached_input_uid:
             return provenance.ScriptInput(
                 name=self._manager._script_input_name_for_node(node),
+                label=label,
                 provenance_spec=provenance_spec,
             )
         return provenance.ScriptInput(
             name=self._manager._script_input_name_for_node(node),
+            label=label,
             node_uid=node.uid,
             node_snapshot_token=node.snapshot_token,
             provenance_spec=provenance_spec,
@@ -498,25 +515,25 @@ class _LineageController:
                 return None
         if spec is None:
             return (
-                f"{script_input.name} has no recorded reload source. Reopen the "
+                f"{script_input.label} has no recorded reload source. Reopen the "
                 "input or recreate the result from reloadable inputs, then try "
                 "again."
             )
         if spec.kind == "file" or provenance.has_file_load_source(spec):
-            reason = self._file_load_source_unavailable_reason(spec, script_input.name)
+            reason = self._file_load_source_unavailable_reason(spec, script_input.label)
             if reason is not None:
                 return reason
             if spec.kind == "file":
                 return None
         if spec.kind != "script":
             return (
-                f"{script_input.name} has recorded provenance that cannot be "
+                f"{script_input.label} has recorded provenance that cannot be "
                 "reloaded. Reopen the input or recreate the result from "
                 "reloadable inputs, then try again."
             )
         if not self._script_provenance_runnable(spec):
             return (
-                f"{script_input.name} was created from recorded code that "
+                f"{script_input.label} was created from recorded code that "
                 "cannot be replayed. Recreate the result from reloadable "
                 "inputs to enable reload."
             )

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2854,40 +2854,11 @@ class ImageToolManager(_ImageToolManagerBase):
     ) -> typing.Any:
         if not source_name_map:
             return operation
+        from erlab.interactive._figurecomposer import FigureComposerTool
 
-        def mapped(source: str | None) -> str | None:
-            return None if source is None else source_name_map.get(source, source)
-
-        updates: dict[str, typing.Any] = {}
-        sources = tuple(mapped(source) for source in operation.sources)
-        if sources != operation.sources:
-            updates["sources"] = sources
-        map_selections = tuple(
-            selection.model_copy(update={"source": new_source})
-            if (new_source := mapped(selection.source)) != selection.source
-            else selection
-            for selection in operation.map_selections
+        return FigureComposerTool._operation_with_renamed_sources(
+            operation, source_name_map
         )
-        if map_selections != operation.map_selections:
-            updates["map_selections"] = map_selections
-        for field in ("line_source", "hv_overlay_source"):
-            value = getattr(operation, field)
-            new_value = mapped(value)
-            if new_value != value:
-                updates[field] = new_value
-        for field in (
-            "method_plot_x",
-            "method_plot_y",
-            "method_plot_xerr",
-            "method_plot_yerr",
-        ):
-            value = getattr(operation, field)
-            if value is None:
-                continue
-            new_source = mapped(value.source)
-            if new_source != value.source:
-                updates[field] = value.model_copy(update={"source": new_source})
-        return operation if not updates else operation.model_copy(update=updates)
 
     def _figure_source_uid_for_target(self, target: int | str) -> str | None:
         try:
@@ -3209,10 +3180,13 @@ class ImageToolManager(_ImageToolManagerBase):
         )
         if not resolved_targets:
             return None
+        source_name_map = self._figure_source_name_map_for_targets(
+            resolved_targets, sources
+        )
         if operation is not None:
             operation = self._figure_operation_with_source_names(
                 operation,
-                self._figure_source_name_map_for_targets(resolved_targets, sources),
+                source_name_map,
             )
 
         primary_source = sources[0].name
@@ -3271,13 +3245,15 @@ class ImageToolManager(_ImageToolManagerBase):
                     operation = operation.model_copy(update={"axes": all_axes})
                 operations = (operation,)
             elif custom_code is not None:
-                operations = (
+                custom_operation = self._figure_operation_with_source_names(
                     FigureOperationState.custom(
                         label=title or "custom code",
                         code=custom_code,
                         trusted=True,
                     ),
+                    source_name_map,
                 )
+                operations = (custom_operation,)
             elif auto_operations:
                 operations = self._figure_operations_with_append_axes(
                     auto_operations, all_axes

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2767,6 +2767,57 @@ class ImageToolManager(_ImageToolManagerBase):
             sources.append(source)
         return resolved_targets, tuple(sources), source_data
 
+    def _figure_source_name_map_for_targets(
+        self, targets: Iterable[int | str], sources: Iterable[typing.Any]
+    ) -> dict[str, str]:
+        source_name_map: dict[str, str] = {}
+        for target, source in zip(targets, sources, strict=True):
+            old_name = self._script_input_name_for_node(self._node_for_target(target))
+            if old_name != source.name:
+                source_name_map[old_name] = source.name
+        return source_name_map
+
+    @staticmethod
+    def _figure_operation_with_source_names(
+        operation: typing.Any, source_name_map: Mapping[str, str]
+    ) -> typing.Any:
+        if not source_name_map:
+            return operation
+
+        def mapped(source: str | None) -> str | None:
+            return None if source is None else source_name_map.get(source, source)
+
+        updates: dict[str, typing.Any] = {}
+        sources = tuple(mapped(source) for source in operation.sources)
+        if sources != operation.sources:
+            updates["sources"] = sources
+        map_selections = tuple(
+            selection.model_copy(update={"source": new_source})
+            if (new_source := mapped(selection.source)) != selection.source
+            else selection
+            for selection in operation.map_selections
+        )
+        if map_selections != operation.map_selections:
+            updates["map_selections"] = map_selections
+        for field in ("line_source", "hv_overlay_source"):
+            value = getattr(operation, field)
+            new_value = mapped(value)
+            if new_value != value:
+                updates[field] = new_value
+        for field in (
+            "method_plot_x",
+            "method_plot_y",
+            "method_plot_xerr",
+            "method_plot_yerr",
+        ):
+            value = getattr(operation, field)
+            if value is None:
+                continue
+            new_source = mapped(value.source)
+            if new_source != value.source:
+                updates[field] = value.model_copy(update={"source": new_source})
+        return operation if not updates else operation.model_copy(update=updates)
+
     def _figure_source_uid_for_target(self, target: int | str) -> str | None:
         try:
             node = self._node_for_target(target)
@@ -3095,6 +3146,11 @@ class ImageToolManager(_ImageToolManagerBase):
         )
         if not resolved_targets:
             return None
+        if operation is not None:
+            operation = self._figure_operation_with_source_names(
+                operation,
+                self._figure_source_name_map_for_targets(resolved_targets, sources),
+            )
 
         primary_source = sources[0].name
         source_names = tuple(source.name for source in sources)
@@ -3327,6 +3383,14 @@ class ImageToolManager(_ImageToolManagerBase):
             return False
 
         _, sources, source_data = self._figure_sources_from_targets(resolved_targets)
+        prompt_operation = (
+            None
+            if operation is None
+            else self._figure_operation_with_source_names(
+                operation,
+                self._figure_source_name_map_for_targets(resolved_targets, sources),
+            )
+        )
 
         source_names = tuple(source.name for source in sources)
         auto_operations: tuple[FigureOperationState, ...] = ()
@@ -3349,7 +3413,6 @@ class ImageToolManager(_ImageToolManagerBase):
             except FigureComposerPlotSlicesSelectionError as exc:
                 self._show_figure_plot_slices_selection_error(exc)
                 return False
-        prompt_operation = operation
         if prompt_operation is None and len(auto_operations) == 1:
             prompt_operation = auto_operations[0]
 
@@ -3377,6 +3440,14 @@ class ImageToolManager(_ImageToolManagerBase):
             resolved_targets,
             reserved_sources=existing_source_names,
         )
+        append_operation = (
+            None
+            if operation is None
+            else self._figure_operation_with_source_names(
+                operation,
+                self._figure_source_name_map_for_targets(resolved_targets, sources),
+            )
+        )
         source_names = tuple(source.name for source in sources)
         auto_operations = ()
         if operation is None and all(
@@ -3402,8 +3473,8 @@ class ImageToolManager(_ImageToolManagerBase):
         tool.add_sources(tuple(sources), source_data)
         with figure_options_context(self.effective_interactive_options):
             operations = (
-                (operation,)
-                if operation is not None
+                (append_operation,)
+                if append_operation is not None
                 else auto_operations
                 or self._make_figure_operations_for_sources(
                     source_data, setup=tool.tool_status.setup

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2731,20 +2731,38 @@ class ImageToolManager(_ImageToolManagerBase):
             )
         return FigureSubplotsState(nrows=max(len(squeezed), 1), ncols=1)
 
-    def _figure_sources_from_targets(
-        self, targets: Iterable[int | str]
-    ) -> tuple[tuple[int | str, ...], tuple[typing.Any, ...], dict[str, xr.DataArray]]:
+    def _figure_source_from_node(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        data: xr.DataArray,
+        reserved: set[str],
+    ) -> typing.Any:
         from erlab.interactive._figurecomposer import FigureSourceState
+        from erlab.interactive._figurecomposer._sources import (
+            _source_alias_candidate,
+            _source_unique_name,
+        )
 
+        source = FigureSourceState.from_script_input(self._script_input_for_node(node))
+        alias = _source_unique_name(
+            _source_alias_candidate(data) or source.name, reserved
+        )
+        return source.model_copy(update={"name": alias})
+
+    def _figure_sources_from_targets(
+        self,
+        targets: Iterable[int | str],
+        *,
+        reserved_sources: Iterable[str] = (),
+    ) -> tuple[tuple[int | str, ...], tuple[typing.Any, ...], dict[str, xr.DataArray]]:
         resolved_targets = self._figure_imagetool_targets(targets)
         source_data: dict[str, xr.DataArray] = {}
         sources = []
+        reserved = set(reserved_sources)
         for target in resolved_targets:
             node = self._node_for_target(target)
             data = node.current_source_data()
-            source = FigureSourceState.from_script_input(
-                self._script_input_for_node(node)
-            )
+            source = self._figure_source_from_node(node, data, reserved)
             source_data[source.name] = data
             sources.append(source)
         return resolved_targets, tuple(sources), source_data
@@ -3068,25 +3086,15 @@ class ImageToolManager(_ImageToolManagerBase):
             FigureComposerTool,
             FigureOperationKind,
             FigureOperationState,
-            FigureSourceState,
         )
         from erlab.interactive._figurecomposer._defaults import figure_options_context
         from erlab.interactive._figurecomposer._sources import _public_source_data
 
-        resolved_targets = self._figure_imagetool_targets(targets)
+        resolved_targets, sources, source_data = self._figure_sources_from_targets(
+            targets
+        )
         if not resolved_targets:
             return None
-
-        source_data: dict[str, xr.DataArray] = {}
-        sources: list[FigureSourceState] = []
-
-        for target in resolved_targets:
-            node = self._node_for_target(target)
-            data = node.current_source_data()
-            script_input = self._script_input_for_node(node)
-            source = FigureSourceState.from_script_input(script_input)
-            source_data[source.name] = data
-            sources.append(source)
 
         primary_source = sources[0].name
         source_names = tuple(source.name for source in sources)
@@ -3310,7 +3318,6 @@ class ImageToolManager(_ImageToolManagerBase):
             FigureAxesSelectionState,
             FigureComposerTool,
             FigureOperationState,
-            FigureSourceState,
         )
         from erlab.interactive._figurecomposer._defaults import figure_options_context
         from erlab.interactive._figurecomposer._sources import _public_source_data
@@ -3319,15 +3326,7 @@ class ImageToolManager(_ImageToolManagerBase):
         if not resolved_targets:
             return False
 
-        source_data: dict[str, xr.DataArray] = {}
-        sources = []
-        for target in resolved_targets:
-            source_node = self._node_for_target(target)
-            data = source_node.current_source_data()
-            source = self._script_input_for_node(source_node)
-            source_model = FigureSourceState.from_script_input(source)
-            source_data[source_model.name] = data
-            sources.append(source_model)
+        _, sources, source_data = self._figure_sources_from_targets(resolved_targets)
 
         source_names = tuple(source.name for source in sources)
         auto_operations: tuple[FigureOperationState, ...] = ()
@@ -3370,6 +3369,35 @@ class ImageToolManager(_ImageToolManagerBase):
         tool = node.tool_window
         if not isinstance(tool, FigureComposerTool):
             return False
+
+        existing_source_names = tuple(tool.source_data()) + tuple(
+            source.name for source in tool.source_states()
+        )
+        _, sources, source_data = self._figure_sources_from_targets(
+            resolved_targets,
+            reserved_sources=existing_source_names,
+        )
+        source_names = tuple(source.name for source in sources)
+        auto_operations = ()
+        if operation is None and all(
+            _public_source_data(data).squeeze(drop=True).ndim > 1
+            for data in source_data.values()
+        ):
+            from erlab.interactive._figurecomposer._exceptions import (
+                FigureComposerPlotSlicesSelectionError,
+            )
+
+            try:
+                auto_operations = typing.cast(
+                    "tuple[FigureOperationState, ...]",
+                    self._figure_operations_from_image_targets(
+                        resolved_targets, source_names
+                    )
+                    or (),
+                )
+            except FigureComposerPlotSlicesSelectionError as exc:
+                self._show_figure_plot_slices_selection_error(exc)
+                return False
 
         tool.add_sources(tuple(sources), source_data)
         with figure_options_context(self.effective_interactive_options):

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -641,11 +641,19 @@ class _FigureSourcePickerDialog(QtWidgets.QDialog):
         super().__init__(manager)
         self._manager = manager
         self._prechecked_uids = set(prechecked_uids)
+        self._expanded_before_search: set[str] | None = None
         self.setObjectName("managerFigureSourcePickerDialog")
         self.setWindowTitle("Add Figure Sources")
         self.setModal(True)
 
         layout = QtWidgets.QVBoxLayout(self)
+        self.search_edit = QtWidgets.QLineEdit(self)
+        self.search_edit.setObjectName("managerFigureSourcePickerSearch")
+        self.search_edit.setAccessibleName("Search ImageTools")
+        self.search_edit.setPlaceholderText("Search ImageTools")
+        self.search_edit.setClearButtonEnabled(True)
+        self.search_edit.textChanged.connect(self._filter_tree)
+        layout.addWidget(self.search_edit)
         self.tree = QtWidgets.QTreeWidget(self)
         self.tree.setObjectName("managerFigureSourcePickerTree")
         self.tree.setColumnCount(1)
@@ -675,7 +683,8 @@ class _FigureSourcePickerDialog(QtWidgets.QDialog):
         layout.addWidget(self.button_box)
 
         self._populate_tree()
-        self.tree.expandAll()
+        self.tree.collapseAll()
+        self._expand_prechecked_ancestors()
         self._refresh_ok_state()
 
     def _populate_tree(self) -> None:
@@ -742,6 +751,68 @@ class _FigureSourcePickerDialog(QtWidgets.QDialog):
             child = item.child(row)
             if child is not None:
                 self._collect_checked_targets(child, output)
+
+    def _tree_items(self) -> Iterator[QtWidgets.QTreeWidgetItem]:
+        iterator = QtWidgets.QTreeWidgetItemIterator(self.tree)
+        while (item := iterator.value()) is not None:
+            yield item
+            iterator += 1
+
+    def _expanded_uids(self) -> set[str]:
+        return {
+            uid
+            for item in self._tree_items()
+            if item.isExpanded()
+            and isinstance(uid := item.data(0, QtCore.Qt.ItemDataRole.UserRole), str)
+        }
+
+    def _restore_expanded_uids(self, expanded_uids: set[str]) -> None:
+        for item in self._tree_items():
+            uid = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+            item.setExpanded(isinstance(uid, str) and uid in expanded_uids)
+
+    def _expand_prechecked_ancestors(self) -> None:
+        for item in self._tree_items():
+            if item.checkState(0) != QtCore.Qt.CheckState.Checked:
+                continue
+            parent = item.parent()
+            while parent is not None:
+                parent.setExpanded(True)
+                parent = parent.parent()
+
+    @QtCore.Slot(str)
+    def _filter_tree(self, text: str) -> None:
+        query = text.strip().casefold()
+        root = self.tree.invisibleRootItem()
+        if root is None:  # pragma: no cover
+            return
+        if not query:
+            for item in self._tree_items():
+                item.setHidden(False)
+            if self._expanded_before_search is not None:
+                expanded = self._expanded_before_search
+                self._expanded_before_search = None
+                self.tree.collapseAll()
+                self._restore_expanded_uids(expanded)
+            return
+        if self._expanded_before_search is None:
+            self._expanded_before_search = self._expanded_uids()
+        for row in range(root.childCount()):
+            child = root.child(row)
+            if child is not None:
+                self._filter_tree_item(child, query)
+
+    def _filter_tree_item(self, item: QtWidgets.QTreeWidgetItem, query: str) -> bool:
+        child_match = False
+        for row in range(item.childCount()):
+            child = item.child(row)
+            if child is not None:
+                child_match |= self._filter_tree_item(child, query)
+        matches = query in item.text(0).casefold()
+        visible = matches or child_match
+        item.setHidden(not visible)
+        item.setExpanded(child_match)
+        return visible
 
     @QtCore.Slot(QtWidgets.QTreeWidgetItem, int)
     def _item_changed(self, _item: QtWidgets.QTreeWidgetItem, _column: int) -> None:
@@ -2980,9 +3051,6 @@ class ImageToolManager(_ImageToolManagerBase):
             refresh_source=lambda source_name: self._refresh_figure_source(
                 figure_uid, source_name
             ),
-            refresh_sources=lambda source_names: self._refresh_figure_sources(
-                figure_uid, source_names
-            ),
             source_label=lambda source_name: self._figure_source_refresh_label(
                 figure_uid, source_name
             ),
@@ -3041,7 +3109,7 @@ class ImageToolManager(_ImageToolManagerBase):
                 return source
         return None
 
-    def _figure_source_live_node(
+    def _figure_source_node(
         self, figure_uid: str, source_name: str
     ) -> _ImageToolWrapper | _ManagedWindowNode | None:
         from erlab.interactive._figurecomposer import FigureComposerTool
@@ -3055,7 +3123,12 @@ class ImageToolManager(_ImageToolManagerBase):
         source = self._figure_source_state(tool, source_name)
         if source is None or source.node_uid is None:
             return None
-        node = self._tool_graph.nodes.get(source.node_uid)
+        return self._tool_graph.nodes.get(source.node_uid)
+
+    def _figure_source_live_node(
+        self, figure_uid: str, source_name: str
+    ) -> _ImageToolWrapper | _ManagedWindowNode | None:
+        node = self._figure_source_node(figure_uid, source_name)
         if node is None:
             return None
         window = node.window
@@ -3070,7 +3143,7 @@ class ImageToolManager(_ImageToolManagerBase):
     def _figure_source_refresh_label(
         self, figure_uid: str, source_name: str
     ) -> str | None:
-        node = self._figure_source_live_node(figure_uid, source_name)
+        node = self._figure_source_node(figure_uid, source_name)
         return None if node is None else node.display_text
 
     def _refresh_figure_source(self, figure_uid: str, source_name: str) -> bool:
@@ -3097,16 +3170,6 @@ class ImageToolManager(_ImageToolManagerBase):
         self._mark_workspace_dirty(uid=figure_uid, data=True, state=True)
         self._update_figure_gallery_icon(figure_uid)
         return True
-
-    def _refresh_figure_sources(
-        self, figure_uid: str, source_names: Iterable[str]
-    ) -> int:
-        """Refresh all linked figure sources named in ``source_names``."""
-        refreshed = 0
-        for source_name in tuple(source_names):
-            if self._refresh_figure_source(figure_uid, source_name):
-                refreshed += 1
-        return refreshed
 
     def _refresh_figure_source_controls(self) -> None:
         if self._workspace_ui_refresh_defer_depth > 0:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -75,6 +75,7 @@ if typing.TYPE_CHECKING:
     import numpy as np
     import xarray as xr
 
+    from erlab.interactive._figurecomposer._tool import FigureSourceAddResult
     from erlab.interactive._options.schema import WorkspaceCompressionMode
     from erlab.interactive.imagetool import provenance
     from erlab.interactive.imagetool._load_source import _LoadSourceDetails
@@ -2912,22 +2913,24 @@ class ImageToolManager(_ImageToolManagerBase):
         source_data: Mapping[str, xr.DataArray],
         *,
         show: bool = True,
-    ) -> bool:
+    ) -> FigureSourceAddResult | None:
         """Add or update figure sources without appending recipe operations."""
         from erlab.interactive._figurecomposer import FigureComposerTool
 
         if not self._is_figure_uid(figure_uid):
-            return False
+            return None
         node = self._child_node(figure_uid)
         tool = node.tool_window
         if not isinstance(tool, FigureComposerTool):
-            return False
-        tool.add_sources(sources, source_data)
+            return None
+        result = tool.add_sources(sources, source_data)
+        if not result:
+            return result
         self._mark_workspace_dirty(uid=figure_uid, state=True)
         self._select_figure_uid(figure_uid)
         if show:
             node.show()
-        return True
+        return result
 
     def _add_imagetool_sources_to_figure(
         self,
@@ -2950,24 +2953,16 @@ class ImageToolManager(_ImageToolManagerBase):
         node = self._child_node(figure_uid) if self._is_figure_uid(figure_uid) else None
         from erlab.interactive._figurecomposer import FigureComposerTool
 
-        tool_before = node.tool_window if node is not None else None
-        existing_source_uids: set[str] = (
-            {
-                source.node_uid
-                for source in tool_before.source_states()
-                if source.node_uid is not None
-            }
-            if isinstance(tool_before, FigureComposerTool)
-            else set()
+        result = self._add_sources_to_figure(
+            figure_uid, sources, source_data, show=show
         )
-        if not self._add_sources_to_figure(figure_uid, sources, source_data, show=show):
+        if not result:
             return False
         tool = node.tool_window if node is not None else None
         if isinstance(tool, FigureComposerTool):
-            updated = sum(
-                1 for source in sources if source.node_uid in existing_source_uids
-            )
-            added = len(sources) - updated
+            source_error = tool.source_status_label.text() if result.skipped else ""
+            added = len(result.added)
+            updated = len(result.updated)
             parts: list[str] = []
             if added:
                 suffix = "source" if added == 1 else "sources"
@@ -2975,10 +2970,17 @@ class ImageToolManager(_ImageToolManagerBase):
             if updated:
                 suffix = "source" if updated == 1 else "sources"
                 parts.append(f"Updated {updated} ImageTool {suffix}")
+            if result.skipped:
+                skipped = len(result.skipped)
+                suffix = "update" if skipped == 1 else "updates"
+                parts.append(f"Skipped {skipped} ImageTool source {suffix}")
             if skipped_targets:
                 suffix = "selection" if skipped_targets == 1 else "selections"
                 parts.append(f"Skipped {skipped_targets} unsupported {suffix}")
-            tool._set_source_status_text("; ".join(parts) + ".")
+            status = "; ".join(parts) + "."
+            if source_error:
+                status = f"{status} {source_error}"
+            tool._set_source_status_text(status)
         return True
 
     def _replace_figure_source(
@@ -3509,7 +3511,15 @@ class ImageToolManager(_ImageToolManagerBase):
                 self._show_figure_plot_slices_selection_error(exc)
                 return False
 
-        tool.add_sources(tuple(sources), source_data)
+        add_result = tool.add_sources(tuple(sources), source_data)
+        if not add_result:
+            return False
+        if add_result.skipped:
+            self._mark_workspace_dirty(uid=resolved_figure_uid, state=True)
+            self._select_figure_uid(resolved_figure_uid)
+            if show:
+                node.show()
+            return True
         with figure_options_context(self.effective_interactive_options):
             operations = (
                 (append_operation,)
@@ -3527,6 +3537,16 @@ class ImageToolManager(_ImageToolManagerBase):
                 )
                 if bz_operation is not None:
                     operations = (*operations, bz_operation)
+        source_name_map = {
+            requested: stored
+            for requested, stored in add_result.name_map.items()
+            if requested != stored
+        }
+        if source_name_map:
+            operations = tuple(
+                self._figure_operation_with_source_names(appended, source_name_map)
+                for appended in operations
+            )
         for appended in self._figure_operations_with_append_axes(
             operations,
             typing.cast("FigureAxesSelectionState", axes_selection),

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -632,6 +632,134 @@ class _AppendFigureTargetDialog(QtWidgets.QDialog):
         return self._operation.kind == FigureOperationKind.PLOT_SLICES
 
 
+class _FigureSourcePickerDialog(QtWidgets.QDialog):
+    """Select live ImageTool manager rows to add as Figure Composer sources."""
+
+    def __init__(
+        self, manager: ImageToolManager, *, prechecked_uids: Iterable[str] = ()
+    ) -> None:
+        super().__init__(manager)
+        self._manager = manager
+        self._prechecked_uids = set(prechecked_uids)
+        self.setObjectName("managerFigureSourcePickerDialog")
+        self.setWindowTitle("Add Figure Sources")
+        self.setModal(True)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        self.tree = QtWidgets.QTreeWidget(self)
+        self.tree.setObjectName("managerFigureSourcePickerTree")
+        self.tree.setColumnCount(1)
+        self.tree.setHeaderHidden(True)
+        self.tree.setUniformRowHeights(True)
+        self.tree.setAlternatingRowColors(True)
+        self.tree.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.tree.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.NoSelection
+        )
+        self.tree.itemChanged.connect(self._item_changed)
+        layout.addWidget(self.tree)
+
+        self.status_label = QtWidgets.QLabel(self)
+        self.status_label.setObjectName("managerFigureSourcePickerStatus")
+        layout.addWidget(self.status_label)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+        self._populate_tree()
+        self.tree.expandAll()
+        self._refresh_ok_state()
+
+    def _populate_tree(self) -> None:
+        for index in self._manager._tool_graph.root_indices_for_workspace():
+            wrapper = self._manager._tool_graph.root_wrappers.get(index)
+            if wrapper is None:
+                continue
+            item = self._add_node_item(self.tree.invisibleRootItem(), wrapper)
+            self._populate_child_items(item, wrapper)
+
+    def _populate_child_items(
+        self,
+        parent_item: QtWidgets.QTreeWidgetItem,
+        parent_node: _ImageToolWrapper | _ManagedWindowNode,
+    ) -> None:
+        for uid in parent_node._childtool_indices:
+            node = self._manager._tool_graph.nodes.get(uid)
+            if not isinstance(node, _ManagedWindowNode):
+                continue
+            if self._manager._is_figure_node(node):
+                continue
+            item = self._add_node_item(parent_item, node)
+            self._populate_child_items(item, node)
+
+    def _add_node_item(
+        self,
+        parent: QtWidgets.QTreeWidget | QtWidgets.QTreeWidgetItem | None,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+    ) -> QtWidgets.QTreeWidgetItem:
+        item = QtWidgets.QTreeWidgetItem(parent, [node.display_text])
+        item.setData(0, QtCore.Qt.ItemDataRole.UserRole, node.uid)
+        flags = QtCore.Qt.ItemFlag.ItemIsEnabled
+        if node.is_imagetool:
+            flags |= QtCore.Qt.ItemFlag.ItemIsUserCheckable
+            item.setCheckState(
+                0,
+                QtCore.Qt.CheckState.Checked
+                if node.uid in self._prechecked_uids
+                else QtCore.Qt.CheckState.Unchecked,
+            )
+        else:
+            item.setToolTip(0, "Only ImageTool rows can be added as figure sources.")
+            item.setForeground(0, QtGui.QBrush(QtGui.QColor("gray")))
+        item.setFlags(flags)
+        return item
+
+    def selected_targets(self) -> tuple[str, ...]:
+        output: list[str] = []
+        root = self.tree.invisibleRootItem()
+        if root is None:  # pragma: no cover
+            return ()
+        self._collect_checked_targets(root, output)
+        return tuple(output)
+
+    def _collect_checked_targets(
+        self, item: QtWidgets.QTreeWidgetItem, output: list[str]
+    ) -> None:
+        uid = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        if isinstance(uid, str) and item.checkState(0) == QtCore.Qt.CheckState.Checked:
+            node = self._manager._tool_graph.nodes.get(uid)
+            if node is not None and node.is_imagetool and uid not in output:
+                output.append(uid)
+        for row in range(item.childCount()):
+            child = item.child(row)
+            if child is not None:
+                self._collect_checked_targets(child, output)
+
+    @QtCore.Slot(QtWidgets.QTreeWidgetItem, int)
+    def _item_changed(self, _item: QtWidgets.QTreeWidgetItem, _column: int) -> None:
+        self._refresh_ok_state()
+
+    def _refresh_ok_state(self) -> None:
+        selected = self.selected_targets()
+        ok_button = self.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        if ok_button is not None:
+            ok_button.setEnabled(bool(selected))
+        count = len(selected)
+        if count:
+            suffix = "source" if count == 1 else "sources"
+            self.status_label.setText(f"{count} ImageTool {suffix} selected.")
+        else:
+            self.status_label.setText("Select at least one ImageTool source.")
+
+
 class ImageToolManager(_ImageToolManagerBase):
     """The ImageToolManager window.
 
@@ -2608,7 +2736,7 @@ class ImageToolManager(_ImageToolManagerBase):
     ) -> tuple[tuple[int | str, ...], tuple[typing.Any, ...], dict[str, xr.DataArray]]:
         from erlab.interactive._figurecomposer import FigureSourceState
 
-        resolved_targets = tuple(dict.fromkeys(targets))
+        resolved_targets = self._figure_imagetool_targets(targets)
         source_data: dict[str, xr.DataArray] = {}
         sources = []
         for target in resolved_targets:
@@ -2620,6 +2748,45 @@ class ImageToolManager(_ImageToolManagerBase):
             source_data[source.name] = data
             sources.append(source)
         return resolved_targets, tuple(sources), source_data
+
+    def _figure_source_uid_for_target(self, target: int | str) -> str | None:
+        try:
+            node = self._node_for_target(target)
+        except KeyError:
+            return None
+        return node.uid if node.is_imagetool else None
+
+    def _figure_imagetool_targets(
+        self, targets: Iterable[int | str]
+    ) -> tuple[int | str, ...]:
+        resolved: list[int | str] = []
+        seen_uids: set[str] = set()
+        for target in targets:
+            uid = self._figure_source_uid_for_target(target)
+            if uid is None or uid in seen_uids:
+                continue
+            resolved.append(target)
+            seen_uids.add(uid)
+        return tuple(resolved)
+
+    def _selected_figure_source_uids(self) -> tuple[str, ...]:
+        uids: list[str] = []
+        for target in self._selected_imagetool_targets():
+            uid = self._figure_source_uid_for_target(target)
+            if uid is not None and uid not in uids:
+                uids.append(uid)
+        return tuple(uids)
+
+    def _figure_source_uids_from_mime(
+        self, mime: QtCore.QMimeData | None
+    ) -> tuple[str, ...]:
+        uids = self.tree_view.figure_source_uids_from_mime(mime)
+        return tuple(
+            uid
+            for uid in uids
+            if (node := self._tool_graph.nodes.get(uid)) is not None
+            and node.is_imagetool
+        )
 
     def _selected_figure_uid_for_figure_dialog(self) -> str | None:
         selected_uids = self._selected_figure_uids()
@@ -2649,6 +2816,58 @@ class ImageToolManager(_ImageToolManagerBase):
         self._select_figure_uid(figure_uid)
         if show:
             node.show()
+        return True
+
+    def _add_imagetool_sources_to_figure(
+        self,
+        figure_uid: str,
+        targets: Iterable[int | str],
+        *,
+        show: bool = False,
+    ) -> bool:
+        requested_targets = tuple(targets)
+        skipped_targets = sum(
+            1
+            for target in requested_targets
+            if self._figure_source_uid_for_target(target) is None
+        )
+        resolved_targets, sources, source_data = self._figure_sources_from_targets(
+            requested_targets
+        )
+        if not resolved_targets:
+            return False
+        node = self._child_node(figure_uid) if self._is_figure_uid(figure_uid) else None
+        from erlab.interactive._figurecomposer import FigureComposerTool
+
+        tool_before = node.tool_window if node is not None else None
+        existing_source_uids: set[str] = (
+            {
+                source.node_uid
+                for source in tool_before.source_states()
+                if source.node_uid is not None
+            }
+            if isinstance(tool_before, FigureComposerTool)
+            else set()
+        )
+        if not self._add_sources_to_figure(figure_uid, sources, source_data, show=show):
+            return False
+        tool = node.tool_window if node is not None else None
+        if isinstance(tool, FigureComposerTool):
+            updated = sum(
+                1 for source in sources if source.node_uid in existing_source_uids
+            )
+            added = len(sources) - updated
+            parts: list[str] = []
+            if added:
+                suffix = "source" if added == 1 else "sources"
+                parts.append(f"Added {added} ImageTool {suffix}")
+            if updated:
+                suffix = "source" if updated == 1 else "sources"
+                parts.append(f"Updated {updated} ImageTool {suffix}")
+            if skipped_targets:
+                suffix = "selection" if skipped_targets == 1 else "selections"
+                parts.append(f"Skipped {skipped_targets} unsupported {suffix}")
+            tool._set_source_status_text("; ".join(parts) + ".")
         return True
 
     def _replace_figure_source(
@@ -2699,6 +2918,52 @@ class ImageToolManager(_ImageToolManagerBase):
                 figure_uid, source_name
             ),
         )
+        tool._set_source_add_callbacks(
+            can_add_sources=functools.partial(
+                self._can_request_add_sources_to_figure, figure_uid
+            ),
+            add_sources=functools.partial(
+                self._request_add_sources_to_figure, figure_uid
+            ),
+            can_drop_sources=functools.partial(
+                self._can_add_figure_sources_from_mime, figure_uid
+            ),
+            drop_sources=functools.partial(
+                self._add_figure_sources_from_mime, figure_uid
+            ),
+        )
+
+    def _can_request_add_sources_to_figure(self, figure_uid: str) -> bool:
+        return self._is_figure_uid(figure_uid) and any(
+            node.is_imagetool for node in self._tool_graph.nodes.values()
+        )
+
+    def _request_add_sources_to_figure(self, figure_uid: str) -> bool:
+        if not self._is_figure_uid(figure_uid):
+            return False
+        dialog = _FigureSourcePickerDialog(
+            self, prechecked_uids=self._selected_figure_source_uids()
+        )
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return False
+        return self._add_imagetool_sources_to_figure(
+            figure_uid, dialog.selected_targets(), show=False
+        )
+
+    def _can_add_figure_sources_from_mime(
+        self, figure_uid: str, mime: QtCore.QMimeData | None
+    ) -> bool:
+        return self._is_figure_uid(figure_uid) and bool(
+            self._figure_source_uids_from_mime(mime)
+        )
+
+    def _add_figure_sources_from_mime(
+        self, figure_uid: str, mime: QtCore.QMimeData | None
+    ) -> bool:
+        targets = self._figure_source_uids_from_mime(mime)
+        if not targets:
+            return False
+        return self._add_imagetool_sources_to_figure(figure_uid, targets, show=False)
 
     @staticmethod
     def _figure_source_state(tool: typing.Any, source_name: str) -> typing.Any | None:
@@ -2808,7 +3073,7 @@ class ImageToolManager(_ImageToolManagerBase):
         from erlab.interactive._figurecomposer._defaults import figure_options_context
         from erlab.interactive._figurecomposer._sources import _public_source_data
 
-        resolved_targets = tuple(dict.fromkeys(targets))
+        resolved_targets = self._figure_imagetool_targets(targets)
         if not resolved_targets:
             return None
 
@@ -3050,7 +3315,7 @@ class ImageToolManager(_ImageToolManagerBase):
         from erlab.interactive._figurecomposer._defaults import figure_options_context
         from erlab.interactive._figurecomposer._sources import _public_source_data
 
-        resolved_targets = tuple(dict.fromkeys(targets))
+        resolved_targets = self._figure_imagetool_targets(targets)
         if not resolved_targets:
             return False
 

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -1029,6 +1029,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
 
 
 _MIME = "application/x-imagetool-manager-internal-move"
+_FIGURE_SOURCE_MIME = "application/x-erlab-imagetool-manager-figure-sources"
 
 
 class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
@@ -1299,7 +1300,7 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
         )
 
     def supportedDragActions(self) -> QtCore.Qt.DropAction:
-        return QtCore.Qt.DropAction.MoveAction
+        return QtCore.Qt.DropAction.MoveAction | QtCore.Qt.DropAction.CopyAction
 
     def supportedDropActions(self) -> QtCore.Qt.DropAction:
         return QtCore.Qt.DropAction.MoveAction
@@ -1414,11 +1415,13 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
         return False
 
     def mimeTypes(self) -> list[str]:
-        return [_MIME]
+        return [_MIME, _FIGURE_SOURCE_MIME]
 
     def mimeData(self, indexes: Iterable[QtCore.QModelIndex]) -> QtCore.QMimeData:
         # Collect unique sibling rows from a single parent.
         rows: list[int] = []
+        source_uids: list[str] = []
+        internal_move_valid = True
         parent_pointer: str | None = None
 
         for idx in indexes:
@@ -1426,43 +1429,63 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
                 continue
             node = idx.internalPointer()
             if isinstance(node, _ImageToolWrapper):
+                if node.uid not in source_uids:
+                    source_uids.append(node.uid)
                 current_parent_pointer = None
             else:
+                child_node = self._node_from_uid(typing.cast("str", node))
+                if (
+                    child_node is not None
+                    and child_node.is_imagetool
+                    and child_node.uid not in source_uids
+                ):
+                    source_uids.append(child_node.uid)
                 parent_index = self.parent(idx)
                 if not parent_index.isValid():
-                    return QtCore.QMimeData()
+                    internal_move_valid = False
+                    continue
                 current_parent = parent_index.internalPointer()
                 if isinstance(current_parent, _ImageToolWrapper):
                     current_parent_pointer = current_parent.uid
                 elif isinstance(current_parent, str):
                     current_parent_pointer = current_parent
                 else:
-                    return QtCore.QMimeData()
+                    internal_move_valid = False
+                    continue
 
             if parent_pointer is None and current_parent_pointer is None:
                 parent_pointer = None
             elif rows and current_parent_pointer != parent_pointer:
-                return QtCore.QMimeData()
+                internal_move_valid = False
+                continue
             else:
                 parent_pointer = current_parent_pointer
 
             rows.append(idx.row())
 
-        if not rows:
+        if not rows and not source_uids:
             return QtCore.QMimeData()
 
         mime_data = QtCore.QMimeData()
-        mime_data.setData(
-            _MIME,
-            QtCore.QByteArray(
-                json.dumps(
-                    {
-                        "parent_id": parent_pointer,
-                        "rows": sorted(set(rows)),
-                    }
-                ).encode("utf-8")
-            ),
-        )
+        if rows and internal_move_valid:
+            mime_data.setData(
+                _MIME,
+                QtCore.QByteArray(
+                    json.dumps(
+                        {
+                            "parent_id": parent_pointer,
+                            "rows": sorted(set(rows)),
+                        }
+                    ).encode("utf-8")
+                ),
+            )
+        if source_uids:
+            mime_data.setData(
+                _FIGURE_SOURCE_MIME,
+                QtCore.QByteArray(
+                    json.dumps({"uids": tuple(source_uids)}).encode("utf-8")
+                ),
+            )
         return mime_data
 
     @staticmethod
@@ -1488,6 +1511,26 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
         if len(set(rows)) != len(rows):
             return None
         return {"parent_id": parent_id, "rows": sorted(rows)}
+
+    @staticmethod
+    def decode_figure_source_mime(mime: QtCore.QMimeData | None) -> tuple[str, ...]:
+        if mime is None or _FIGURE_SOURCE_MIME not in mime.formats():
+            return ()
+        raw: bytes = mime.data(_FIGURE_SOURCE_MIME).data()
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except Exception:
+            return ()
+        if not isinstance(payload, dict):
+            return ()
+        uids = payload.get("uids")
+        if not isinstance(uids, list):
+            return ()
+        output: list[str] = []
+        for uid in uids:
+            if isinstance(uid, str) and uid not in output:
+                output.append(uid)
+        return tuple(output)
 
     @staticmethod
     def _contiguous_runs(rows: list[int]) -> list[tuple[int, int]]:
@@ -1708,7 +1751,7 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
         self.setDragEnabled(True)
         self.setAcceptDrops(True)
         self.setDropIndicatorShown(True)
-        self.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
+        self.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.DragDrop)
         self.setDefaultDropAction(QtCore.Qt.DropAction.MoveAction)
         self.setDragDropOverwriteMode(False)
         self.setUniformRowHeights(True)
@@ -1785,6 +1828,11 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
             for index in self.selectedIndexes()
             if isinstance(index.internalPointer(), str)
         ]
+
+    def figure_source_uids_from_mime(
+        self, mime: QtCore.QMimeData | None
+    ) -> tuple[str, ...]:
+        return self._model.decode_figure_source_mime(mime)
 
     @QtCore.Slot()
     def deselect_all(self) -> None:

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -1569,7 +1569,7 @@ class _ProvenanceEditController:
                 scope,
                 nested,
                 script_input_path=(*script_input_path, index),
-                display_label=f"{display_label}: {script_input.name}",
+                display_label=f"{display_label}: {script_input.label}",
             )
 
     def _file_load_target_for_path(

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit.py
@@ -1569,7 +1569,7 @@ class _ProvenanceEditController:
                 scope,
                 nested,
                 script_input_path=(*script_input_path, index),
-                display_label=f"{display_label}: {script_input.label}",
+                display_label=f"{display_label}: {script_input.name}",
             )
 
     def _file_load_target_for_path(

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -461,6 +461,57 @@ class _WorkspaceIOController:
         return ds[_ITOOL_DATA_NAME]
 
     @staticmethod
+    def _pending_workspace_data_with_saved_dim_order(
+        data: xr.DataArray, attrs: Mapping[typing.Any, typing.Any]
+    ) -> xr.DataArray:
+        raw_state = attrs.get("itool_state")
+        if isinstance(raw_state, bytes):
+            with contextlib.suppress(UnicodeDecodeError):
+                raw_state = raw_state.decode()
+        if not isinstance(raw_state, str):
+            return data
+        try:
+            state = json.loads(raw_state)
+        except Exception:
+            logger.debug("Ignoring invalid pending ImageTool state", exc_info=True)
+            return data
+        if not isinstance(state, collections.abc.Mapping):
+            return data
+        slice_state = state.get("slice")
+        if not isinstance(slice_state, collections.abc.Mapping):
+            return data
+        raw_dims = slice_state.get("dims")
+        if not isinstance(raw_dims, (list, tuple)):
+            return data
+
+        saved_dims = tuple(str(dim) for dim in raw_dims)
+        dims_by_text = {str(dim): dim for dim in data.dims}
+        if (
+            len(saved_dims) != data.ndim
+            or len(dims_by_text) != data.ndim
+            or set(saved_dims) != set(dims_by_text)
+        ):
+            logger.debug(
+                "Ignoring incompatible saved pending ImageTool dimension order %s "
+                "for data dims %s",
+                saved_dims,
+                data.dims,
+            )
+            return data
+        ordered_dims = tuple(dims_by_text[dim] for dim in saved_dims)
+        if ordered_dims == data.dims:
+            return data
+        try:
+            return data.transpose(*ordered_dims, transpose_coords=True)
+        except ValueError:
+            logger.debug(
+                "Could not apply saved pending ImageTool dimension order %s",
+                saved_dims,
+                exc_info=True,
+            )
+            return data
+
+    @staticmethod
     def _apply_pending_workspace_filter(
         data: xr.DataArray, filter_payload: object
     ) -> xr.DataArray:
@@ -502,15 +553,21 @@ class _WorkspaceIOController:
         attrs = node.pending_workspace_payload_attrs
         if attrs is None:
             attrs = ds.attrs
+        data = self._pending_workspace_data_with_saved_dim_order(data, attrs)
         raw_state = attrs.get("itool_state")
         if isinstance(raw_state, bytes):
-            raw_state = raw_state.decode()
+            with contextlib.suppress(UnicodeDecodeError):
+                raw_state = raw_state.decode()
         if isinstance(raw_state, str):
-            state = json.loads(raw_state)
-            if isinstance(state, collections.abc.Mapping):
-                data = self._apply_pending_workspace_filter(
-                    data, state.get("filter_operation")
-                )
+            try:
+                state = json.loads(raw_state)
+            except Exception:
+                logger.debug("Ignoring invalid pending ImageTool state", exc_info=True)
+            else:
+                if isinstance(state, collections.abc.Mapping):
+                    data = self._apply_pending_workspace_filter(
+                        data, state.get("filter_operation")
+                    )
         if isinstance(node, _ImageToolWrapper) and node.source_input_ndim == 1:
             data = provenance.mark_promoted_1d_source(data)
         return data.copy(deep=False)
@@ -617,6 +674,10 @@ class _WorkspaceIOController:
                     return None
                 name = None if node.name == "" else node.name
                 data = ds[_ITOOL_DATA_NAME].rename(name)
+                attrs = node.pending_workspace_payload_attrs
+                if attrs is None:
+                    attrs = ds.attrs
+                data = cls._pending_workspace_data_with_saved_dim_order(data, attrs)
                 additional_info = [f"Added {node.added_time_display}"]
                 try:
                     metadata_data = cls._pending_workspace_data_with_loaded_coords(data)
@@ -2581,6 +2642,9 @@ class _WorkspaceIOController:
                 if _ITOOL_DATA_NAME not in ds:
                     return False
                 target_data = ds[_ITOOL_DATA_NAME]
+                target_data = self._pending_workspace_data_with_saved_dim_order(
+                    target_data, attrs
+                )
                 array_slicer = erlab.interactive.imagetool.slicer.ArraySlicer(
                     target_data,
                     self._manager,

--- a/src/erlab/interactive/imagetool/manager/_workspace_io.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace_io.py
@@ -485,6 +485,8 @@ class _WorkspaceIOController:
             return data
 
         saved_dims = tuple(str(dim) for dim in raw_dims)
+        # Match ArraySlicer dimension promotion before applying its saved order.
+        data = erlab.interactive.imagetool.slicer.make_dims_uniform(data)
         dims_by_text = {str(dim): dim for dim in data.dims}
         if (
             len(saved_dims) != data.ndim
@@ -678,6 +680,7 @@ class _WorkspaceIOController:
                 if attrs is None:
                     attrs = ds.attrs
                 data = cls._pending_workspace_data_with_saved_dim_order(data, attrs)
+                data = erlab.interactive.imagetool.slicer.restore_nonuniform_dims(data)
                 additional_info = [f"Added {node.added_time_display}"]
                 try:
                     metadata_data = cls._pending_workspace_data_with_loaded_coords(data)

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -272,6 +272,12 @@ def set_widget_cursor(
     current_key = widget.property(_ERLAB_CURSOR_SHAPE_PROPERTY)
     if current_key == shape_key:
         return
+    if sys.platform == "darwin":
+        # Qt/Cocoa can crash inside QImage::toCGImage() while applying cursor
+        # images. Keep hover cursor changes as a nonessential affordance on
+        # macOS instead of risking a process abort.
+        widget.setProperty(_ERLAB_CURSOR_SHAPE_PROPERTY, shape_key)
+        return
     if shape is None:
         if widget.testAttribute(QtCore.Qt.WidgetAttribute.WA_SetCursor):
             widget.unsetCursor()

--- a/tests/interactive/imagetool/manager/figurecomposer/_common.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/_common.py
@@ -457,51 +457,6 @@ def _plot_source_move_buttons(
     }
 
 
-def _plot_array_dimension_widget(
-    tool: FigureComposerTool,
-    widget_type: type[QtWidgets.QWidget],
-    dim: str,
-    *,
-    field: str | None = None,
-) -> QtWidgets.QWidget:
-    widget = next(
-        (
-            candidate
-            for candidate in tool.findChildren(widget_type)
-            if candidate.property("figure_composer_plot_array_dim") == dim
-            if candidate.property("figure_composer_editor_generation")
-            == tool._operation_editor_generation
-            if field is None
-            or candidate.property("figure_composer_plot_array_selection_field") == field
-        ),
-        None,
-    )
-    assert widget is not None
-    return widget
-
-
-def _plot_array_dimension_edit(
-    tool: FigureComposerTool, dim: str, field: str
-) -> QtWidgets.QLineEdit:
-    return typing.cast(
-        "QtWidgets.QLineEdit",
-        _plot_array_dimension_widget(tool, QtWidgets.QLineEdit, dim, field=field),
-    )
-
-
-def _activate_plot_array_dimension_mode(
-    tool: FigureComposerTool, dim: str, mode: str
-) -> None:
-    combo = typing.cast(
-        "QtWidgets.QComboBox",
-        _plot_array_dimension_widget(tool, QtWidgets.QComboBox, dim),
-    )
-    index = combo.findData(mode)
-    assert index >= 0
-    combo.setCurrentIndex(index)
-    combo.activated.emit(index)
-
-
 def _render_figure_composer_rgba(tool: FigureComposerTool) -> np.ndarray:
     with figurecomposer_defaults._figure_style_context():
         figure = Figure(

--- a/tests/interactive/imagetool/manager/figurecomposer/_common.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/_common.py
@@ -280,25 +280,39 @@ def _file_load_provenance(path: Path) -> provenance.ToolProvenanceSpec:
 
 
 def _select_operation_rows(tool: FigureComposerTool, rows: tuple[int, ...]) -> None:
-    if not rows:
+    was_blocked = tool.operation_list.blockSignals(True)
+    try:
         tool.operation_list.clearSelection()
-        tool._operation_selection_changed()
-        return
-    tool.operation_list.setCurrentRow(rows[0])
-    tool.operation_list.clearSelection()
-    for row in rows:
-        item = tool.operation_list.item(row)
-        assert item is not None
-        item.setSelected(True)
+        if rows:
+            tool.operation_list.setCurrentItem(
+                tool.operation_list.topLevelItem(rows[0])
+            )
+            for row in rows:
+                item = tool.operation_list.topLevelItem(row)
+                assert item is not None
+                item.setSelected(True)
+    finally:
+        tool.operation_list.blockSignals(was_blocked)
     tool._operation_selection_changed()
 
 
 def _selected_operation_rows(tool: FigureComposerTool) -> tuple[int, ...]:
     return tuple(
         row
-        for row in range(tool.operation_list.count())
-        if tool.operation_list.item(row).isSelected()
+        for row in range(tool.operation_list.topLevelItemCount())
+        if tool.operation_list.topLevelItem(row).isSelected()
     )
+
+
+def _operation_status_codes(tool: FigureComposerTool, row: int) -> tuple[str, ...]:
+    item = tool.operation_list.topLevelItem(row)
+    assert item is not None
+    value = item.data(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_ROLE,
+    )
+    assert isinstance(value, tuple)
+    return value
 
 
 def _clear_clipboard() -> InMemoryClipboard:
@@ -387,30 +401,6 @@ def _plot_source_checks(tool: FigureComposerTool) -> dict[str, QtWidgets.QCheckB
         str(source_name): check
         for check in tool.step_source_controls.findChildren(QtWidgets.QCheckBox)
         if (source_name := check.property("figure_source_name")) is not None
-    }
-
-
-def _source_refresh_buttons(
-    tool: FigureComposerTool,
-) -> dict[str, QtWidgets.QToolButton]:
-    return {
-        str(source_name): button
-        for button in tool.source_list.findChildren(
-            QtWidgets.QToolButton, "figureComposerRefreshSourceButton"
-        )
-        if (source_name := button.property("figure_source_name")) is not None
-    }
-
-
-def _source_remove_buttons(
-    tool: FigureComposerTool,
-) -> dict[str, QtWidgets.QToolButton]:
-    return {
-        str(source_name): button
-        for button in tool.source_list.findChildren(
-            QtWidgets.QToolButton, "figureComposerRemoveSourceButton"
-        )
-        if (source_name := button.property("figure_source_name")) is not None
     }
 
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -346,7 +346,7 @@ def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
     )
 
     _select_operation_rows(tool, (3,))
-    assert tool.operation_list.item(3).text() == "eplt.clean_labels"
+    assert tool.operation_list.topLevelItem(3).text(0) == "eplt.clean_labels"
     assert tool.step_section_buttons["method"].text() == "eplt.clean_labels"
     tool._select_step_section("method")
     erlab_method_page = tool.step_editor_stack.currentWidget()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -367,3 +367,26 @@ def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
     exec(tool.generated_code(), namespace)  # noqa: S102
     assert namespace["axs"].shape == (1, 2)
     assert namespace["axs"][0, 0].get_xlim() == pytest.approx((0.25, 0.75))
+
+
+def test_figure_composer_generated_code_skips_disabled_operations(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(
+                FigureOperationState.custom(
+                    label="disabled Python",
+                    code="raise RuntimeError('must not run')",
+                    trusted=True,
+                ).model_copy(update={"enabled": False}),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    code = tool.generated_code()
+
+    assert "must not run" not in code

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -214,6 +214,23 @@ def test_figure_composer_redraw_and_preview_cache_edges(qtbot, monkeypatch) -> N
     )
 
 
+def test_figure_composer_preview_draw_error_ignores_missing_operation(qtbot) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    figurecomposer_rendering._set_preview_draw_error(tool, RuntimeError("boom"))
+
+    assert tool._operation_render_errors == {}
+
+
 def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
     data = xr.DataArray(
         np.arange(12.0).reshape(3, 2, 2),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -693,12 +693,14 @@ def test_figure_composer_custom_code_sources_drive_usage_and_full_replay(
                 FigureOperationState.custom(
                     label="custom",
                     code=(
-                        "fig.source_total = float(custom_source.sum())\n"
+                        "custom_source = custom_source.mean()\n"
+                        "fig.source_total = float(custom_source)\n"
                         "import statistics\n"
-                        "fig.source_mean = statistics.fmean(custom_source.values)"
+                        "fig.source_mean = statistics.fmean([float(custom_source)])"
                     ),
                     trusted=True,
                 ),
+                FigureOperationState.line(label="line", source="custom_source"),
             ),
             primary_source="custom_source",
         ),
@@ -706,7 +708,7 @@ def test_figure_composer_custom_code_sources_drive_usage_and_full_replay(
     )
     qtbot.addWidget(tool)
 
-    assert tool._source_usage_count("custom_source") == 1
+    assert tool._source_usage_count("custom_source") == 2
     assert not tool.remove_source("custom_source")
     _select_operation_rows(tool, (0,))
     tool._copy_selected_operations()
@@ -715,16 +717,18 @@ def test_figure_composer_custom_code_sources_drive_usage_and_full_replay(
     assert tuple(source.name for source in clipboard_payload[1]) == ("custom_source",)
     spec = tool.current_provenance_spec()
     assert spec is not None
-    assert tuple(script_input.name for script_input in spec.script_inputs) == (
-        "custom_source",
-    )
+    [replay_input] = spec.script_inputs
+    assert replay_input.name != "custom_source"
 
     code = spec.display_code()
     assert code is not None
     assert code.index("fig, axs") < code.index("import statistics")
-    namespace = _exec_generated_code(code, {})
-    assert namespace["fig"].source_total == 6.0
+    assert f"custom_source = {replay_input.name}" in code
+    namespace: dict[str, typing.Any] = {}
+    exec(code, namespace)  # noqa: S102
+    assert namespace["fig"].source_total == 1.5
     assert namespace["fig"].source_mean == 1.5
+    np.testing.assert_allclose(namespace["fig"].axes[0].lines[-1].get_ydata(), data)
 
 
 def test_figure_composer_source_name_map_does_not_rewrite_custom_locals(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -1,5 +1,7 @@
 # ruff: noqa: F403, F405
 
+import erlab.interactive._figurecomposer._codegen as figurecomposer_codegen
+
 from ._common import *
 
 
@@ -392,6 +394,44 @@ def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
     exec(code, namespace)  # noqa: S102
     assert namespace["fig"].axes[0].get_title() == "1"
     assert namespace["fig"].__dict__["_eplt_name"] == "erlab.plotting"
+
+
+def test_figure_composer_source_name_map_does_not_rewrite_custom_locals(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="sample_map",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data_0", label="sample map"),),
+            operations=(
+                FigureOperationState.custom(
+                    label="custom",
+                    code=("data_0 = 1\nfig.__dict__['custom_data_0'] = data_0"),
+                    trusted=True,
+                ),
+            ),
+            primary_source="data_0",
+        ),
+        source_data={"data_0": data},
+    )
+    qtbot.addWidget(tool)
+
+    code = figurecomposer_codegen.generated_code(
+        tool, source_name_map={"data_0": "sample_map"}
+    )
+
+    assert "data_0 = sample_map" in code
+    assert "fig.__dict__['custom_data_0'] = data_0" in code
+    assert "fig.__dict__['custom_data_0'] = sample_map" not in code
+    namespace: dict[str, typing.Any] = {"sample_map": data}
+    exec(code, namespace)  # noqa: S102
+    assert namespace["fig"].__dict__["custom_data_0"] == 1
 
 
 def test_figure_composer_custom_code_codegen_gridspec_axes_alias(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -434,6 +434,19 @@ def test_figure_composer_source_name_map_does_not_rewrite_custom_locals(
     assert namespace["fig"].__dict__["custom_data_0"] == 1
 
 
+def test_figure_composer_source_name_replacement_fallback_edges() -> None:
+    assert (
+        figurecomposer_codegen._replace_source_load_names("bad code !", {"data": "map"})
+        == "bad code !"
+    )
+    assert (
+        figurecomposer_codegen._replace_source_load_names(
+            "value = data", {"data": "not valid"}
+        )
+        == "value = data"
+    )
+
+
 def test_figure_composer_custom_code_codegen_gridspec_axes_alias(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -478,7 +478,7 @@ def test_figure_composer_untrusted_custom_code_reports_render_error(qtbot) -> No
     assert item is not None
     assert "(render error)" in item.text()
     assert "Custom code is not trusted" in item.toolTip()
-    assert "Enable Trusted to render it" in tool.source_status_label.text()
+    assert "Enable Trusted to render it" in tool.step_source_status_label.text()
 
     tool.operation_list.setCurrentRow(0)
     tool._select_step_section("code")
@@ -496,4 +496,4 @@ def test_figure_composer_untrusted_custom_code_reports_render_error(qtbot) -> No
     assert item is not None
     assert "(render error)" not in item.text()
     assert "Custom code is not trusted" not in item.toolTip()
-    assert "Render error" not in tool.source_status_label.text()
+    assert "Render error" not in tool.step_source_status_label.text()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -147,7 +147,7 @@ def test_figure_composer_source_rename_rejects_ambiguous_python(
     assert not tool._rename_source_alias("data", "renamed")
     assert tool.tool_status.sources[0].name == "data"
     assert tool.tool_status.operations[0].code == code
-    assert not tool.source_status_label.isHidden()
+    assert not tool.source_validation_label.isHidden()
 
 
 def test_figure_composer_custom_code_editor_is_multiline_and_debounced(
@@ -169,7 +169,7 @@ def test_figure_composer_custom_code_editor_is_multiline_and_debounced(
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("code")
 
     current_page = tool.step_editor_stack.currentWidget()
@@ -227,7 +227,7 @@ def test_figure_composer_custom_code_editor_skips_render_until_valid_python(
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("code")
 
     current_page = tool.step_editor_stack.currentWidget()
@@ -291,7 +291,7 @@ def test_figure_composer_custom_code_pending_edit_survives_step_switch(
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("code")
 
     current_page = tool.step_editor_stack.currentWidget()
@@ -303,7 +303,7 @@ def test_figure_composer_custom_code_pending_edit_survives_step_switch(
 
     new_code = "ax.set_title('pending')\nax.set_ylabel('counts')"
     code_edit.setPlainText(new_code)
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
 
     qtbot.waitUntil(
         lambda: tool.tool_status.operations[0].code == new_code,
@@ -328,7 +328,7 @@ def test_figure_composer_custom_code_pending_edit_flushes_on_close(qtbot) -> Non
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("code")
 
     current_page = tool.step_editor_stack.currentWidget()
@@ -378,9 +378,9 @@ def test_figure_composer_custom_code_uses_public_nonuniform_dims(qtbot) -> None:
 
     figurecomposer_rendering._render_preview(tool, show_window=False)
 
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    assert "(render error)" not in item.text()
+    assert _operation_status_codes(tool, 0) == ()
 
 
 def test_figure_composer_recipe_codegen_and_loaded_custom_code_trust(qtbot) -> None:
@@ -584,28 +584,16 @@ def test_figure_composer_source_alias_editor_rejects_ambiguous_python(qtbot) -> 
     )
     qtbot.addWidget(tool)
     tool._set_selected_source_names_silent({"data"}, "data")
+    tool._refresh_source_detail_panel()
     tool._refresh_source_selection_editor()
-    alias_edit = next(
-        item.widget()
-        for row in range(tool.source_selection_controls_layout.rowCount())
-        if (
-            (
-                item := tool.source_selection_controls_layout.itemAt(
-                    row, QtWidgets.QFormLayout.ItemRole.FieldRole
-                )
-            )
-            is not None
-            and isinstance(item.widget(), QtWidgets.QLineEdit)
-            and item.widget().objectName() == "figureComposerSourceAliasEdit"
-        )
-    )
+    alias_edit = tool.source_alias_edit
 
     alias_edit.setText("renamed")
     alias_edit.editingFinished.emit()
 
     assert alias_edit.text() == "data"
     assert tool.tool_status.sources[0].name == "data"
-    assert not tool.source_status_label.isHidden()
+    assert not tool.source_validation_label.isHidden()
 
 
 def test_figure_composer_custom_code_codegen_gridspec_axes_alias(qtbot) -> None:
@@ -688,13 +676,15 @@ def test_figure_composer_untrusted_custom_code_reports_render_error(qtbot) -> No
     qtbot.addWidget(tool)
     tool.show_figure_window(activate=False)
 
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    assert "(render error)" in item.text()
-    assert "Custom code is not trusted" in item.toolTip()
-    assert "Enable Trusted to render it" in tool.step_source_status_label.text()
+    assert _operation_status_codes(tool, 0) == ("render_error",)
+    assert "Custom code is not trusted" in item.toolTip(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN
+    )
+    assert tool.step_source_status_label.isHidden()
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("code")
     trusted_check = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QCheckBox, "figureComposerCustomCodeTrustedCheck"
@@ -706,8 +696,10 @@ def test_figure_composer_untrusted_custom_code_reports_render_error(qtbot) -> No
 
     assert tool.tool_status.operations[0].trusted is True
     qtbot.waitUntil(lambda: not tool._operation_render_errors, timeout=1000)
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    assert "(render error)" not in item.text()
-    assert "Custom code is not trusted" not in item.toolTip()
-    assert "Render error" not in tool.step_source_status_label.text()
+    assert _operation_status_codes(tool, 0) == ()
+    assert "Custom code is not trusted" not in item.toolTip(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN
+    )
+    assert tool.step_source_status_label.isHidden()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -31,6 +31,42 @@ def test_figure_composer_custom_code_helpers_cover_codegen_paths(qtbot) -> None:
         "import erlab.plotting as eplt",
     )
     assert figurecomposer_custom_code._custom_code_names("bad code !!") == frozenset()
+    assert "data" in figurecomposer_custom_code._custom_code_names("data = data.mean()")
+    assert "data" in figurecomposer_custom_code._custom_code_names("data += 1")
+    assert "data" in figurecomposer_custom_code._custom_code_names(
+        "def update():\n    global data\n    data += 1"
+    )
+    assert "data" in figurecomposer_custom_code._custom_code_names(
+        "def remove():\n    global data\n    del data"
+    )
+    assert "data" not in figurecomposer_custom_code._custom_code_names(
+        "data = 1\nfig.result = data"
+    )
+    assert "data" in figurecomposer_custom_code._custom_code_names(
+        "def f():\n    return data\nresult = f()\ndata = 1"
+    )
+    assert "data" in figurecomposer_custom_code._custom_code_names(
+        "if condition:\n    data = 1\nfig.result = data"
+    )
+    assert (
+        figurecomposer_custom_code._custom_code_names(
+            "import data\ndef identity(data):\n    return data\nvalue = data"
+        )
+        == frozenset()
+    )
+    assert figurecomposer_custom_code._custom_code_bound_names(
+        "value = 1\n"
+        "import numpy as array_module\n"
+        "def identity(item):\n"
+        "    return item\n"
+        "def overwrite():\n"
+        "    global replay_input\n"
+        "    del replay_input"
+    ) == frozenset({"value", "array_module", "identity", "overwrite", "replay_input"})
+    assert (
+        figurecomposer_custom_code._custom_code_bound_names("bad code !!")
+        == frozenset()
+    )
     assert figurecomposer_custom_code._custom_axes_alias_lines(tool) == []
     assert (
         figurecomposer_custom_code._code_lines(
@@ -80,6 +116,143 @@ def test_figure_composer_custom_code_helpers_cover_codegen_paths(qtbot) -> None:
         "}",
     ]
     assert figurecomposer_custom_code._custom_first_axis_code(grid_tool) == "ax0"
+
+
+def test_figure_composer_custom_code_names_cover_nested_class_and_flow() -> None:
+    nested_class_source = (
+        "def build():\n"
+        "    class Result:\n"
+        "        data = data.mean()\n"
+        "    return Result\n"
+        "build()"
+    )
+    nested_class_import = nested_class_source.replace(
+        "data = data.mean()", "np = np.asarray([1.0])"
+    )
+    assert "data" in figurecomposer_custom_code._custom_code_names(nested_class_source)
+    assert "np" in figurecomposer_custom_code._custom_code_names(nested_class_import)
+
+    class_local = nested_class_source.replace(
+        "data = data.mean()", "data = 1\n        result = data"
+    )
+    class_import = nested_class_source.replace(
+        "data = data.mean()",
+        "import numpy as np\n        result = np.asarray([1.0])",
+    )
+    assert "data" not in figurecomposer_custom_code._custom_code_names(class_local)
+    assert "np" not in figurecomposer_custom_code._custom_code_names(class_import)
+
+    for module_bound_nested_scope in (
+        "data = 1\nclass C:\n    data = data + 1",
+        "import data\nclass C:\n    data = data.value",
+        "data = 1\ndef f():\n    return data",
+        "data = 1\ndef f():\n    global data\n    data += 1",
+        (
+            "data = 2\n"
+            "class Outer:\n"
+            "    data = 1\n"
+            "    class Inner:\n"
+            "        data = data + 1"
+        ),
+    ):
+        assert "data" not in figurecomposer_custom_code._custom_code_names(
+            module_bound_nested_scope
+        )
+
+    for late_or_class_local_binding in (
+        "class C:\n    data = data + 1\ndata = 1",
+        "def f():\n    global data\n    data += 1\nf()\ndata = 1",
+        ("class Outer:\n    data = 1\n    class Inner:\n        data = data + 1"),
+    ):
+        assert "data" in figurecomposer_custom_code._custom_code_names(
+            late_or_class_local_binding
+        )
+
+    plain_global_assignment = "def set_data():\n    global data\n    data = 1"
+    assert "data" not in figurecomposer_custom_code._custom_code_names(
+        plain_global_assignment
+    )
+
+    for conditional_binding in (
+        "match flag:\n    case 0:\n        data = 1\nprint(data)",
+        "flag and (data := 1)\nprint(data)",
+        "(data := 1) if flag else 0\nprint(data)",
+    ):
+        assert "data" in figurecomposer_custom_code._custom_code_names(
+            conditional_binding
+        )
+
+    for definite_binding in (
+        "(data := 1) and print(data)\nprint(data)",
+        "(data := 1) if flag else (data := 2)\nprint(data)",
+    ):
+        assert "data" not in figurecomposer_custom_code._custom_code_names(
+            definite_binding
+        )
+
+    assert "data" in figurecomposer_custom_code._custom_code_names(
+        "values = [data for _ in range(1)]"
+    )
+    for local_comprehension_data in (
+        "data = 1\nvalues = [data for _ in range(1)]",
+        "values = [data for data in range(1)]",
+    ):
+        assert "data" not in figurecomposer_custom_code._custom_code_names(
+            local_comprehension_data
+        )
+
+    assert {"data", "other"} <= figurecomposer_custom_code._custom_code_names(
+        "f, g = (lambda: data, lambda: other)"
+    )
+    assert {"data", "other"} <= figurecomposer_custom_code._custom_code_names(
+        "x = [data for _ in ()]; y = [other for _ in ()]"
+    )
+    assert not {
+        "data",
+        "other",
+    } & figurecomposer_custom_code._custom_code_names(
+        "data = 1\nother = 2\nf, g = (lambda: data, lambda: other)"
+    )
+
+
+@pytest.mark.parametrize(
+    "code",
+    (
+        "data = data.mean()",
+        "data += 1",
+        "def update():\n    global data\n    data += 1",
+        "def remove():\n    global data\n    del data",
+        (
+            "def build():\n"
+            "    class Result:\n"
+            "        data = data.mean()\n"
+            "    return Result\n"
+            "build()"
+        ),
+    ),
+)
+def test_figure_composer_custom_code_read_write_source_is_dependency(
+    qtbot, code: str
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), name="data")
+    operation = FigureOperationState.custom(
+        label="read-write source",
+        code=code,
+        trusted=True,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    assert tool._operation_source_names(operation) == ("data",)
+    assert tool._source_usage_count("data") == 1
+    assert not tool.remove_source("data")
 
 
 def test_figure_composer_source_rename_refactors_custom_python(qtbot) -> None:
@@ -464,6 +637,38 @@ def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
     assert namespace["fig"].__dict__["_eplt_name"] == "erlab.plotting"
 
 
+def test_figure_composer_custom_code_codegen_nested_class_import(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(
+                FigureOperationState.custom(
+                    label="nested class",
+                    code=(
+                        "def build():\n"
+                        "    class Result:\n"
+                        "        np = np.asarray([1.0, 2.0])\n"
+                        "        total = float(np.sum())\n"
+                        "    return Result\n"
+                        "fig.custom_total = build().total"
+                    ),
+                    trusted=True,
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    code = tool.generated_code()
+    assert "import numpy as np" in code
+    namespace: dict[str, typing.Any] = {"data": data}
+    exec(code, namespace)  # noqa: S102
+    assert namespace["fig"].custom_total == 3.0
+
+
 def test_figure_composer_custom_code_sources_drive_usage_and_full_replay(
     qtbot, tmp_path
 ) -> None:
@@ -691,7 +896,12 @@ def test_figure_composer_custom_code_codegen_gridspec_axes_alias(qtbot) -> None:
                 FigureOperationState.custom(
                     label="custom",
                     code=(
-                        "ax.set_title('main')\naxs['main-axis'].set_xlabel('energy')"
+                        "axs = dict(axs)\n"
+                        "ax = ax.twinx()\n"
+                        "np = np.asarray([1.0, 2.0])\n"
+                        "ax.set_title('main')\n"
+                        "axs['main-axis'].set_xlabel('energy')\n"
+                        "fig.custom_total = float(np.sum())"
                     ),
                     trusted=True,
                 ),
@@ -702,13 +912,15 @@ def test_figure_composer_custom_code_codegen_gridspec_axes_alias(qtbot) -> None:
     qtbot.addWidget(tool)
 
     code = tool.generated_code()
+    assert "import numpy as np" in code
     assert "axs = {" in code
     assert "'main-axis': main_axis" in code
     assert "ax = main_axis" in code
     namespace: dict[str, typing.Any] = {"data": data}
     exec(code, namespace)  # noqa: S102
-    assert namespace["fig"].axes[0].get_title() == "main"
+    assert namespace["fig"].axes[1].get_title() == "main"
     assert namespace["fig"].axes[0].get_xlabel() == "energy"
+    assert namespace["fig"].custom_total == 3.0
 
 
 def test_figure_composer_untrusted_custom_code_reports_render_error(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -82,6 +82,74 @@ def test_figure_composer_custom_code_helpers_cover_codegen_paths(qtbot) -> None:
     assert figurecomposer_custom_code._custom_first_axis_code(grid_tool) == "ax0"
 
 
+def test_figure_composer_source_rename_refactors_custom_python(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), name="data")
+    code = (
+        "# Keep source comments and formatting intact.\n"
+        "fig.source_label = 'μ data'; "
+        "fig.renamed_source_mean = float(data.mean())  # data remains in comments\n"
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(
+                FigureOperationState.custom(
+                    label="summary",
+                    code=code,
+                    trusted=True,
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    assert tool._rename_source_alias("data", "renamed")
+    renamed_code = tool.tool_status.operations[0].code
+    assert renamed_code == code.replace("float(data.mean())", "float(renamed.mean())")
+
+    namespace: dict[str, typing.Any] = {"renamed": data}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    assert namespace["fig"].renamed_source_mean == 1.5
+    assert namespace["fig"].source_label == "μ data"
+
+
+@pytest.mark.parametrize(
+    "code",
+    (
+        "data = data.mean()",
+        "def summarize(data):\n    return data.mean()\nfig.result = summarize(data)",
+        "data += 1",
+        "del data",
+        "fig.result = data.mean(\n",
+    ),
+)
+def test_figure_composer_source_rename_rejects_ambiguous_python(
+    qtbot, code: str
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), name="data")
+    operation = FigureOperationState.custom(
+        label="summary",
+        code=code,
+        trusted=True,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    assert not tool._rename_source_alias("data", "renamed")
+    assert tool.tool_status.sources[0].name == "data"
+    assert tool.tool_status.operations[0].code == code
+    assert not tool.source_status_label.isHidden()
+
+
 def test_figure_composer_custom_code_editor_is_multiline_and_debounced(
     qtbot,
     monkeypatch,
@@ -434,7 +502,46 @@ def test_figure_composer_source_name_map_does_not_rewrite_custom_locals(
     assert namespace["fig"].__dict__["custom_data_0"] == 1
 
 
+def test_figure_composer_source_name_map_assigns_custom_aliases_simultaneously(
+    qtbot,
+) -> None:
+    source_a = xr.DataArray(np.array([1.0]), dims=("x",), name="a")
+    source_b = xr.DataArray(np.array([2.0]), dims=("x",), name="b")
+    tool = FigureComposerTool(
+        source_a,
+        recipe=FigureRecipeState(
+            sources=(
+                FigureSourceState(name="a", label="a"),
+                FigureSourceState(name="b", label="b"),
+            ),
+            operations=(
+                FigureOperationState.custom(
+                    label="custom",
+                    code=(
+                        "fig.__dict__['custom_values'] = "
+                        "(float(a.values[0]), float(b.values[0]))"
+                    ),
+                    trusted=True,
+                ),
+            ),
+            primary_source="a",
+        ),
+        source_data={"a": source_a, "b": source_b},
+    )
+    qtbot.addWidget(tool)
+
+    code = figurecomposer_codegen.generated_code(
+        tool, source_name_map={"a": "b", "b": "a"}
+    )
+
+    assert "a, b = b, a" in code
+    namespace: dict[str, typing.Any] = {"a": source_b, "b": source_a}
+    exec(code, namespace)  # noqa: S102
+    assert namespace["fig"].__dict__["custom_values"] == (1.0, 2.0)
+
+
 def test_figure_composer_source_name_replacement_fallback_edges() -> None:
+    assert figurecomposer_codegen._source_alias_assignment_lines({}) == []
     assert (
         figurecomposer_codegen._replace_source_load_names("bad code !", {"data": "map"})
         == "bad code !"
@@ -445,6 +552,60 @@ def test_figure_composer_source_name_replacement_fallback_edges() -> None:
         )
         == "value = data"
     )
+    assert (
+        figurecomposer_custom_code._renamed_source_loads(
+            "value = 1", {"data": "renamed"}
+        )
+        == "value = 1"
+    )
+    assert (
+        figurecomposer_custom_code._renamed_source_loads(
+            "value = data", {"data": "data"}
+        )
+        == "value = data"
+    )
+
+
+def test_figure_composer_source_alias_editor_rejects_ambiguous_python(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(
+                FigureOperationState.custom(
+                    label="summary",
+                    code="data = data.mean()",
+                    trusted=True,
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"data"}, "data")
+    tool._refresh_source_selection_editor()
+    alias_edit = next(
+        item.widget()
+        for row in range(tool.source_selection_controls_layout.rowCount())
+        if (
+            (
+                item := tool.source_selection_controls_layout.itemAt(
+                    row, QtWidgets.QFormLayout.ItemRole.FieldRole
+                )
+            )
+            is not None
+            and isinstance(item.widget(), QtWidgets.QLineEdit)
+            and item.widget().objectName() == "figureComposerSourceAliasEdit"
+        )
+    )
+
+    alias_edit.setText("renamed")
+    alias_edit.editingFinished.emit()
+
+    assert alias_edit.text() == "data"
+    assert tool.tool_status.sources[0].name == "data"
+    assert not tool.source_status_label.isHidden()
 
 
 def test_figure_composer_custom_code_codegen_gridspec_axes_alias(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -831,6 +831,18 @@ def test_figure_composer_source_name_replacement_fallback_edges() -> None:
         )
         == "value = data"
     )
+    assert (
+        figurecomposer_custom_code._renamed_source_loads(
+            "bad code !!", {"data": "renamed"}
+        )
+        == "bad code !!"
+    )
+    assert (
+        figurecomposer_custom_code._renamed_source_loads(
+            "bad code !!  # data", {"data": "renamed"}
+        )
+        == "bad code !!  # data"
+    )
 
 
 def test_figure_composer_source_alias_editor_rejects_ambiguous_python(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -1,5 +1,7 @@
 # ruff: noqa: F403, F405
 
+import textwrap
+
 import erlab.interactive._figurecomposer._codegen as figurecomposer_codegen
 
 from ._common import *
@@ -212,6 +214,204 @@ def test_figure_composer_custom_code_names_cover_nested_class_and_flow() -> None
         "other",
     } & figurecomposer_custom_code._custom_code_names(
         "data = 1\nother = 2\nf, g = (lambda: data, lambda: other)"
+    )
+
+
+def test_figure_composer_custom_code_names_cover_structured_python() -> None:
+    code = textwrap.dedent(
+        """\
+        @decorator
+        def function(
+            positional: annotation,
+            /,
+            regular: annotation = default,
+            *args: annotation,
+            required_keyword: annotation,
+            keyword: annotation = default,
+            **kwargs: annotation,
+        ) -> annotation:
+            return child_source
+
+        @decorator
+        async def async_function(
+            positional: annotation,
+            /,
+            regular: annotation = default,
+            *args: annotation,
+            required_keyword: annotation,
+            keyword: annotation = default,
+            **kwargs: annotation,
+        ) -> annotation:
+            return child_source
+
+        callable_value = lambda item=default: child_source
+        keyword_callable_value = lambda *, required, optional=default: child_source
+
+        @decorator
+        class Result(base, metaclass=metaclass):
+            class_value = class_value + child_source
+
+        import package.submodule
+        from package import imported as local_import
+        from package import *
+        annotation_only: annotation
+        container.attribute: annotation
+        value: annotation = source
+        result += source
+        container.attribute += source
+        (walrus := source)
+        del result
+        del container.attribute
+
+        if condition:
+            branch = source
+        else:
+            branch = source
+        conditional = source if condition else alternate
+        condition and (short_circuit := source)
+
+        match subject:
+            case [head, *tail] as matched if guard:
+                match_result = source
+            case {"item": mapping_value, **remaining}:
+                mapping_result = source
+
+        for first, *tail in iterable:
+            loop_result = source
+        else:
+            loop_else = source
+        while condition:
+            while_result = source
+        else:
+            while_else = source
+        with context:
+            bare_with_result = source
+        with context as (left, right):
+            with_result = source
+
+        try:
+            success = source
+        except exception_type as error:
+            failure = source
+        else:
+            after_success = source
+        finally:
+            cleanup = source
+        try:
+            star_success = source
+        except* exception_type as grouped:
+            star_failure = source
+        try:
+            bare_success = source
+        except:
+            bare_failure = source
+
+        list_result = [
+            item for item in iterable if condition for child in child_iterable if child
+        ]
+        set_result = {item for item in iterable if condition}
+        dict_result = {item: source for item in iterable}
+        generator_result = (item for item in iterable)
+
+        def mutation_scope():
+            global mutation_target, object_target
+            mutation_target += source
+            object_target.value += source
+            del mutation_target, object_target.value
+            def nested():
+                return None
+            async def nested_async():
+                return None
+            class Nested:
+                pass
+            ignored = lambda: None
+        """
+    )
+
+    names = figurecomposer_custom_code._custom_code_names(code)
+
+    assert {
+        "annotation",
+        "alternate",
+        "base",
+        "child_iterable",
+        "child_source",
+        "class_value",
+        "condition",
+        "container",
+        "context",
+        "decorator",
+        "default",
+        "exception_type",
+        "guard",
+        "iterable",
+        "metaclass",
+        "mutation_target",
+        "source",
+        "subject",
+    } <= names
+    assert "local_import" not in names
+
+    if sys.version_info >= (3, 12):
+        assert "source" in figurecomposer_custom_code._custom_code_names(
+            "def generic[T](value: T) -> T:\n    return source"
+        )
+        assert "source" in figurecomposer_custom_code._custom_code_names(
+            "class Generic[T]:\n    value: T = source"
+        )
+
+
+def test_figure_composer_custom_code_analyzer_handles_async_blocks() -> None:
+    tree = ast.parse(
+        textwrap.dedent(
+            """\
+            async def process():
+                async for item in async_iterable:
+                    current = item
+                else:
+                    current = fallback
+                async with async_context as context_value:
+                    current = context_value
+            """
+        )
+    )
+    [function] = tree.body
+    assert isinstance(function, ast.AsyncFunctionDef)
+    analyzer = figurecomposer_custom_code._TopLevelExternalNameAnalyzer()
+
+    analyzer._analyze_block(function.body, set())
+
+    assert {"async_context", "async_iterable", "fallback"} <= analyzer.external
+
+
+def test_figure_composer_custom_code_analyzer_handles_partial_ast_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class_tree = ast.parse("class Result:\n    value = source")
+    root = figurecomposer_custom_code.symtable.symtable(
+        "class Result:\n    value = source", "<test>", "exec"
+    )
+    monkeypatch.setattr(
+        figurecomposer_custom_code, "_scope_symbol_tables", lambda *_args: {}
+    )
+    assert (
+        figurecomposer_custom_code._class_local_external_names(class_tree, root, {})
+        == set()
+    )
+
+    analyzer = figurecomposer_custom_code._TopLevelExternalNameAnalyzer()
+    analyzer.bound.add("already_bound")
+    analyzer.visit(ast.BoolOp(op=ast.And(), values=[]))
+    assert analyzer.bound == {"already_bound"}
+    assert analyzer.external == set()
+
+    incomplete_comprehension = ast.ListComp(
+        elt=ast.Name(id="source", ctx=ast.Load()), generators=[]
+    )
+    analyzer.visit(incomplete_comprehension)
+    assert analyzer.external == {"source"}
+    assert analyzer.scope_bindings[id(incomplete_comprehension)] == frozenset(
+        {"already_bound"}
     )
 
 
@@ -842,6 +1042,68 @@ def test_figure_composer_source_name_replacement_fallback_edges() -> None:
             "bad code !!  # data", {"data": "renamed"}
         )
         == "bad code !!  # data"
+    )
+
+
+def test_figure_composer_source_rename_preserves_multibyte_custom_code() -> None:
+    code = (
+        "label = 'μ source'\n"
+        "total = data.mean() + other.mean()\n"
+        "# data and other stay comments\n"
+    )
+
+    renamed = figurecomposer_custom_code._renamed_source_loads(
+        code, {"data": "renamed_data", "other": "renamed_other", "unused": "x"}
+    )
+
+    assert renamed == (
+        "label = 'μ source'\n"
+        "total = renamed_data.mean() + renamed_other.mean()\n"
+        "# data and other stay comments\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "code",
+    (
+        "import package as data\nresult = data.value",
+        "def summarize(data):\n    return data.mean()",
+        (
+            "def outer():\n"
+            "    data = 1\n"
+            "    def inner():\n"
+            "        nonlocal data\n"
+            "        return data\n"
+            "    return inner()"
+        ),
+        "def read_global():\n    global data\n    return data",
+    ),
+)
+def test_figure_composer_source_rename_rejects_every_local_binding_kind(
+    code: str,
+) -> None:
+    with pytest.raises(ValueError, match="also binds 'data'"):
+        figurecomposer_custom_code._renamed_source_loads(code, {"data": "renamed"})
+
+
+def test_figure_composer_source_rename_rejects_unparseable_source_tokens() -> None:
+    with pytest.raises(ValueError, match="valid code"):
+        figurecomposer_custom_code._renamed_source_loads(
+            "text = '''\ndata", {"data": "renamed"}
+        )
+
+    with pytest.raises(ValueError, match="valid code"):
+        figurecomposer_custom_code._renamed_source_loads(
+            "    invalid\n  data", {"data": "renamed"}
+        )
+
+
+def test_figure_composer_source_rename_ignores_non_load_declarations() -> None:
+    code = "def configure():\n    global data"
+
+    assert (
+        figurecomposer_custom_code._renamed_source_loads(code, {"data": "renamed"})
+        == code
     )
 
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -464,6 +464,64 @@ def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
     assert namespace["fig"].__dict__["_eplt_name"] == "erlab.plotting"
 
 
+def test_figure_composer_custom_code_sources_drive_usage_and_full_replay(
+    qtbot, tmp_path
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="custom_source",
+    )
+    path = tmp_path / "custom-source.nc"
+    data.to_netcdf(path)
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(
+                FigureSourceState(
+                    name="custom_source",
+                    provenance_spec=_file_load_provenance(path).model_dump(mode="json"),
+                ),
+            ),
+            operations=(
+                FigureOperationState.custom(
+                    label="custom",
+                    code=(
+                        "fig.source_total = float(custom_source.sum())\n"
+                        "import statistics\n"
+                        "fig.source_mean = statistics.fmean(custom_source.values)"
+                    ),
+                    trusted=True,
+                ),
+            ),
+            primary_source="custom_source",
+        ),
+        source_data={"custom_source": data},
+    )
+    qtbot.addWidget(tool)
+
+    assert tool._source_usage_count("custom_source") == 1
+    assert not tool.remove_source("custom_source")
+    _select_operation_rows(tool, (0,))
+    tool._copy_selected_operations()
+    clipboard_payload = tool._clipboard_step_payload()
+    assert clipboard_payload is not None
+    assert tuple(source.name for source in clipboard_payload[1]) == ("custom_source",)
+    spec = tool.current_provenance_spec()
+    assert spec is not None
+    assert tuple(script_input.name for script_input in spec.script_inputs) == (
+        "custom_source",
+    )
+
+    code = spec.display_code()
+    assert code is not None
+    assert code.index("fig, axs") < code.index("import statistics")
+    namespace = _exec_generated_code(code, {})
+    assert namespace["fig"].source_total == 6.0
+    assert namespace["fig"].source_mean == 1.5
+
+
 def test_figure_composer_source_name_map_does_not_rewrite_custom_locals(
     qtbot,
 ) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
@@ -277,17 +277,6 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
 
     tool.operation_list.setCurrentRow(4)
     tool._update_operation_editor()
-    tool._select_step_section("selection")
-    plot_array_selection_page = tool.step_editor_stack.currentWidget()
-    assert plot_array_selection_page is not None
-    _assert_step_editor_section(
-        plot_array_selection_page,
-        "figureComposerPlotArraySelectionDataSection",
-    )
-    _assert_step_editor_section(
-        plot_array_selection_page,
-        "figureComposerPlotArraySelectionDimensionsSection",
-    )
     tool._select_step_section("view")
     plot_array_view_page = tool.step_editor_stack.currentWidget()
     assert plot_array_view_page is not None

--- a/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
@@ -76,7 +76,7 @@ def test_figure_composer_line_style_helpers_update_recipe(qtbot) -> None:
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
 
     tool._updating_controls = True
     figurecomposer_line_style.update_current_line_kw(
@@ -155,7 +155,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._update_operation_editor()
     tool._select_step_section("selection")
     line_selection_page = tool.step_editor_stack.currentWidget()
@@ -193,7 +193,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         is None
     )
 
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool._update_operation_editor()
     tool._select_step_section("selection")
     line_slices_selection_page = tool.step_editor_stack.currentWidget()
@@ -248,7 +248,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         is None
     )
 
-    tool.operation_list.setCurrentRow(2)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(2))
     tool._update_operation_editor()
     tool._select_step_section("colors")
     image_slices_colors_page = tool.step_editor_stack.currentWidget()
@@ -266,7 +266,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         "figureComposerPlotSlicesColorsPanelOverridesSection",
     )
 
-    tool.operation_list.setCurrentRow(3)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(3))
     tool._update_operation_editor()
     tool._select_step_section("method")
     method_page = tool.step_editor_stack.currentWidget()
@@ -275,7 +275,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
     _assert_step_editor_section(method_page, "figureComposerMethodValuesSection")
     _assert_step_editor_section(method_page, "figureComposerMethodAdvancedSection")
 
-    tool.operation_list.setCurrentRow(4)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(4))
     tool._update_operation_editor()
     tool._select_step_section("view")
     plot_array_view_page = tool.step_editor_stack.currentWidget()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -50,6 +50,83 @@ def test_figure_composer_line_migrates_single_map_selection_to_source_alias(
     )
 
 
+def test_figure_composer_line_preserves_multi_cursor_legacy_selections(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("cut", "kx"),
+        coords={"cut": [0.0, 1.0, 2.0], "kx": [-1.0, -0.5, 0.5, 1.0]},
+        name="profile",
+    )
+    selections = (
+        FigureDataSelectionState(source="profile", qsel={"cut": 0.0}),
+        FigureDataSelectionState(source="profile", qsel={"cut": 2.0}),
+    )
+    operation = FigureOperationState.line(
+        label="profiles", source="profile"
+    ).model_copy(
+        update={
+            "map_selections": selections,
+            "line_x": "kx",
+            "line_labels": ("first", "second"),
+        }
+    )
+    tool = FigureComposerTool.from_sources(
+        {"profile": data},
+        sources=(FigureSourceState(name="profile"),),
+        operations=(operation,),
+        primary_source="profile",
+    )
+    qtbot.addWidget(tool)
+
+    [loaded_operation] = tool.tool_status.operations
+    assert loaded_operation.map_selections == selections
+    assert figurecomposer_line_profile._source_names(loaded_operation) == ("profile",)
+    profiles = figurecomposer_line_profile._line_data_items(tool, loaded_operation)
+    assert len(profiles) == 2
+    xr.testing.assert_identical(profiles[0], data.qsel(cut=0.0))
+    xr.testing.assert_identical(profiles[1], data.qsel(cut=2.0))
+
+    figure = plt.figure()
+    try:
+        figurecomposer_rendering._render_into_figure(tool, figure, sync_visible=False)
+        rendered_lines = figure.axes[0].lines
+        assert len(rendered_lines) == 2
+        np.testing.assert_allclose(rendered_lines[0].get_ydata(), data.qsel(cut=0.0))
+        np.testing.assert_allclose(rendered_lines[1].get_ydata(), data.qsel(cut=2.0))
+    finally:
+        plt.close(figure)
+
+    namespace = _exec_generated_code(tool.generated_code(), {"profile": data})
+    generated_lines = namespace["fig"].axes[0].lines
+    assert len(generated_lines) == 2
+    np.testing.assert_allclose(generated_lines[0].get_ydata(), data.qsel(cut=0.0))
+    np.testing.assert_allclose(generated_lines[1].get_ydata(), data.qsel(cut=2.0))
+
+    operation_payload = loaded_operation.model_dump(mode="json")
+    assert operation_payload["map_selections"] == [
+        selection.model_dump(mode="json") for selection in selections
+    ]
+    assert "map_selections" not in FigureOperationState.line(
+        label="plain", source="profile"
+    ).model_dump(mode="json")
+    restored_operation = FigureOperationState.model_validate_json(
+        loaded_operation.model_dump_json()
+    )
+    assert restored_operation.map_selections == selections
+
+    restored_tool = erlab.interactive.utils.ToolWindow.from_dataset(tool.to_dataset())
+    assert isinstance(restored_tool, FigureComposerTool)
+    qtbot.addWidget(restored_tool)
+    assert restored_tool.tool_status.operations[0].map_selections == selections
+    restored_profiles = figurecomposer_line_profile._line_data_items(
+        restored_tool, restored_tool.tool_status.operations[0]
+    )
+    xr.testing.assert_identical(restored_profiles[0], data.qsel(cut=0.0))
+    xr.testing.assert_identical(restored_profiles[1], data.qsel(cut=2.0))
+
+
 def test_imagetool_line_profile_seeds_public_nonuniform_coordinate(qtbot) -> None:
     public = xr.DataArray(
         np.arange(24.0).reshape(4, 2, 3),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -40,7 +40,7 @@ def test_figure_composer_line_migrates_single_map_selection_to_source_alias(
         tool.source_data()["profile_selected"], data.qsel(cut=0.0)
     )
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("selection")
 
     assert tool.findChild(QtWidgets.QLineEdit, "figureComposerLineSelectionEdit")
@@ -371,7 +371,7 @@ def test_figure_composer_line_profile_helper_contracts(qtbot) -> None:
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
 
     figurecomposer_line_profile._line_limit_update_callback(tool, "xlim")("0, 1")
     assert tool.tool_status.operations[0].xlim == (0.0, 1.0)
@@ -1469,7 +1469,7 @@ def test_figure_composer_line_label_help_button_opens_structured_dialog(
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("style")
     editor = tool.step_editor_stack.currentWidget()
     labels_edit = editor.findChild(QtWidgets.QLineEdit, "figureComposerLineLabelsEdit")
@@ -2315,7 +2315,7 @@ def test_figure_composer_line_labels_auto_add_axes_legend_step(
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("style")
     labels_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QLineEdit, "figureComposerLineLabelsEdit"
@@ -2332,7 +2332,7 @@ def test_figure_composer_line_labels_auto_add_axes_legend_step(
     labels_edit.editingFinished.emit()
 
     assert rebuild_calls == []
-    assert tool.operation_list.currentRow() == 0
+    assert tool._current_operation_index() == 0
     assert len(tool.tool_status.operations) == 2
     line_operation, legend_operation = tool.tool_status.operations
     assert line_operation.line_label_text == "profile A"
@@ -2376,7 +2376,7 @@ def test_figure_composer_disabled_line_labels_do_not_add_legend_or_render(
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("style")
     labels_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QLineEdit, "figureComposerLineLabelsEdit"

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -20,6 +20,12 @@ def test_figure_composer_line_migrates_single_map_selection_to_source_alias(
                 FigureDataSelectionState(source="profile", qsel={"cut": 0.0}),
             ),
             "line_x": "kx",
+            "line_y": "cut",
+            "line_selection": {"kx": 0.5},
+            "line_iter_dim": "cut",
+            "line_reduce": "both",
+            "line_reduce_coarsen": 3,
+            "line_reduce_thin": 4,
         }
     )
     tool = FigureComposerTool.from_sources(
@@ -33,12 +39,20 @@ def test_figure_composer_line_migrates_single_map_selection_to_source_alias(
     [loaded_operation] = tool.tool_status.operations
     assert loaded_operation.line_source == "profile_selected"
     assert loaded_operation.map_selections == ()
+    assert loaded_operation.line_y is None
+    assert loaded_operation.line_selection == {}
+    assert loaded_operation.line_iter_dim is None
+    assert loaded_operation.line_reduce == "disabled"
+    assert loaded_operation.line_reduce_coarsen == 2
+    assert loaded_operation.line_reduce_thin == 2
     source_by_name = {source.name: source for source in tool.source_states()}
     assert source_by_name["profile_selected"].selection_source == "profile"
     assert source_by_name["profile_selected"].qsel == {"cut": 0.0}
     xr.testing.assert_identical(
         tool.source_data()["profile_selected"], data.qsel(cut=0.0)
     )
+    [profile] = figurecomposer_line_profile._line_data_items(tool, loaded_operation)
+    xr.testing.assert_identical(profile, data.qsel(cut=0.0))
 
     tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("selection")

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -128,6 +128,18 @@ def test_figure_composer_line_profile_uses_public_nonuniform_dims(qtbot) -> None
     assert line_items[0].dims == ("alpha",)
 
 
+def test_figure_composer_line_offset_coords_empty_without_iter_dim() -> None:
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("cut", "kx"),
+        coords={"cut": [0.0, 1.0], "kx": [0.0, 0.5, 1.0]},
+        name="profiles",
+    )
+    operation = FigureOperationState.line(label="line", source="profiles")
+
+    assert figurecomposer_line_profile._line_offset_coord_names(data, operation) == []
+
+
 def test_figure_composer_line_profile_operation_uses_semantic_sections(
     qtbot,
 ) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -1271,6 +1271,12 @@ def test_figure_composer_line_profile_helper_edges() -> None:
     )
     assert figurecomposer_line_profile._line_color_mode_from_text("Manual") == "manual"
     assert (
+        figurecomposer_line_profile._line_selection_sources(
+            operation.model_copy(update={"line_source": None})
+        )
+        == ()
+    )
+    assert (
         figurecomposer_line_profile._available_line_value_names(
             tool, operation.model_copy(update={"line_source": None})
         )
@@ -1288,6 +1294,12 @@ def test_figure_composer_line_profile_helper_edges() -> None:
     assert figurecomposer_line_profile._available_line_offset_coords(
         tool, operation
     ) == ["offset"]
+    assert (
+        figurecomposer_line_profile._available_line_offset_coords(
+            tool, operation.model_copy(update={"line_iter_dim": None})
+        )
+        == []
+    )
 
     updates: list[dict[str, object]] = []
     cmap_tool = types.SimpleNamespace(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -3,6 +3,53 @@
 from ._common import *
 
 
+def test_figure_composer_line_migrates_single_map_selection_to_source_alias(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("cut", "kx"),
+        coords={"cut": [0.0, 1.0, 2.0], "kx": [-1.0, -0.5, 0.5, 1.0]},
+        name="profile",
+    )
+    operation = FigureOperationState.line(
+        label="profiles", source="profile"
+    ).model_copy(
+        update={
+            "map_selections": (
+                FigureDataSelectionState(source="profile", qsel={"cut": 0.0}),
+            ),
+            "line_x": "kx",
+        }
+    )
+    tool = FigureComposerTool.from_sources(
+        {"profile": data},
+        sources=(FigureSourceState(name="profile", label="profile"),),
+        operations=(operation,),
+        primary_source="profile",
+    )
+    qtbot.addWidget(tool)
+
+    [loaded_operation] = tool.tool_status.operations
+    assert loaded_operation.line_source == "profile_selected"
+    assert loaded_operation.map_selections == ()
+    source_by_name = {source.name: source for source in tool.source_states()}
+    assert source_by_name["profile_selected"].selection_source == "profile"
+    assert source_by_name["profile_selected"].qsel == {"cut": 0.0}
+    xr.testing.assert_identical(
+        tool.source_data()["profile_selected"], data.qsel(cut=0.0)
+    )
+
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("selection")
+
+    assert tool.findChild(QtWidgets.QLineEdit, "figureComposerLineSelectionEdit")
+    assert (
+        tool.findChild(QtWidgets.QWidget, "figureComposerLineInputSelectionSection")
+        is None
+    )
+
+
 def test_imagetool_line_profile_seeds_public_nonuniform_coordinate(qtbot) -> None:
     public = xr.DataArray(
         np.arange(24.0).reshape(4, 2, 3),
@@ -365,7 +412,7 @@ def test_figure_composer_line_profile_helper_contracts(qtbot) -> None:
         }
     )
     assert (
-        len(figurecomposer_line_profile._line_data_items(tool, selected_operation)) == 1
+        len(figurecomposer_line_profile._line_data_items(tool, selected_operation)) == 2
     )
     assert (
         figurecomposer_line_profile._line_data_items(
@@ -419,8 +466,8 @@ def test_figure_composer_line_profile_helper_contracts(qtbot) -> None:
         == []
     )
     selection_lines = figurecomposer_line_profile._line_code(tool, selected_operation)
-    assert selection_lines[0] == "profiles = ["
-    assert any(".qsel(cut=0.0)" in line for line in selection_lines)
+    assert not any(line == "profiles = [" for line in selection_lines)
+    assert any(".qsel(kx=slice(-1.0, 1.0))" in line for line in selection_lines)
     one_per_axis_lines = figurecomposer_line_profile._line_code(
         tool, operation.model_copy(update={"line_placement": "one_per_axis"})
     )
@@ -1616,15 +1663,10 @@ def test_figure_composer_plot_slices_line_color_codegen_helper_variants() -> Non
 
     missing_key_operation = FigureOperationState.plot_slices(
         label="missing-key",
-        sources=("a",),
+        sources=("missing",),
         slice_dim="eV",
         slice_values=(0.1,),
-    ).model_copy(
-        update={
-            "line_color_mode": "coordinate",
-            "map_selections": (FigureDataSelectionState(source="missing"),),
-        }
-    )
+    ).model_copy(update={"line_color_mode": "coordinate"})
     assert (
         figurecomposer_plot_slices._plot_slices_line_color_code_lines(
             tool, missing_key_operation

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -102,6 +102,18 @@ def test_figure_composer_line_preserves_multi_cursor_legacy_selections(
     xr.testing.assert_identical(profiles[0], data.qsel(cut=0.0))
     xr.testing.assert_identical(profiles[1], data.qsel(cut=2.0))
 
+    one_per_axis_operation = loaded_operation.model_copy(
+        update={
+            "axes": FigureAxesSelectionState(axes=((0, 0),)),
+            "line_placement": "one_per_axis",
+        }
+    )
+    selection_code = figurecomposer_line_profile._line_selection_code(
+        tool, one_per_axis_operation
+    )
+    assert "profiles = [" in selection_code
+    assert "for profile, label in zip(" in selection_code
+
     figure = plt.figure()
     try:
         figurecomposer_rendering._render_into_figure(tool, figure, sync_visible=False)

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -52,6 +52,45 @@ def _source_picker_item(
     raise AssertionError(f"missing picker row for {uid!r}")
 
 
+def test_manager_figure_operation_source_name_mapping_updates_all_fields() -> None:
+    method_x = FigureMethodPlotValueState(source="old", kind="data")
+    method_y = FigureMethodPlotValueState(source="other", kind="data")
+    operation = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="plot",
+    ).model_copy(
+        update={
+            "sources": ("old", "other"),
+            "map_selections": (
+                FigureDataSelectionState(source="old", qsel={"x": 0.0}),
+            ),
+            "line_source": "old",
+            "hv_overlay_source": "old",
+            "method_plot_x": method_x,
+            "method_plot_y": method_y,
+        }
+    )
+
+    assert (
+        manager_mainwindow.ImageToolManager._figure_operation_with_source_names(
+            operation, {}
+        )
+        is operation
+    )
+    renamed = manager_mainwindow.ImageToolManager._figure_operation_with_source_names(
+        operation, {"old": "new"}
+    )
+
+    assert renamed.sources == ("new", "other")
+    assert renamed.map_selections == (
+        FigureDataSelectionState(source="new", qsel={"x": 0.0}),
+    )
+    assert renamed.line_source == "new"
+    assert renamed.hv_overlay_source == "new"
+    assert renamed.method_plot_x == method_x.model_copy(update={"source": "new"})
+    assert renamed.method_plot_y is method_y
+
+
 def test_manager_default_figure_seed_uses_public_nonuniform_dims(
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -3798,6 +3837,7 @@ def test_figure_sources_add_button_adds_imagetool_sources(
 
 def test_figure_sources_drag_mime_adds_root_and_child_imagetools(
     qtbot,
+    monkeypatch: pytest.MonkeyPatch,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -3853,6 +3893,31 @@ def test_figure_sources_drag_mime_adds_root_and_child_imagetools(
         )
         xr.testing.assert_identical(
             figure_tool.source_data()[child_source_name], child_data.rename("child")
+        )
+
+        assert not manager._add_imagetool_sources_to_figure(
+            figure_uid, (figure_uid,), show=False
+        )
+        assert not manager._request_add_sources_to_figure("missing-figure")
+        assert not manager._add_figure_sources_from_mime(figure_uid, QtCore.QMimeData())
+
+        original_add_sources = manager._add_sources_to_figure
+        monkeypatch.setattr(
+            manager,
+            "_add_sources_to_figure",
+            lambda *_args, **_kwargs: False,
+        )
+        assert not manager._add_imagetool_sources_to_figure(
+            figure_uid, (second_uid,), show=False
+        )
+        monkeypatch.setattr(manager, "_add_sources_to_figure", original_add_sources)
+
+        assert manager._add_imagetool_sources_to_figure(
+            figure_uid, (second_uid, figure_uid), show=False
+        )
+        assert "Updated 1 ImageTool source" in figure_tool.source_status_label.text()
+        assert (
+            "Skipped 1 unsupported selection" in figure_tool.source_status_label.text()
         )
 
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -3251,11 +3251,11 @@ def test_manager_figure_source_row_refresh_updates_only_selected_source(
         with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
             itool(updated_second, manager=True, replace=1)
 
-        buttons = _source_refresh_buttons(figure_tool)
-        assert buttons["first"].isEnabled()
-        assert buttons["second"].isEnabled()
+        figure_tool._set_selected_source_names_silent({"first"}, "first")
+        figure_tool._refresh_source_controls()
+        assert figure_tool.refresh_sources_button.isEnabled()
         with qtbot.wait_signal(figure_tool.sigDataChanged, timeout=5000):
-            buttons["first"].click()
+            figure_tool.refresh_sources_button.click()
 
         source_data = figure_tool.source_data()
         xr.testing.assert_identical(source_data["first"], updated_first)
@@ -3278,12 +3278,11 @@ def test_manager_figure_source_row_refresh_updates_only_selected_source(
         assert figure_uid in snapshot["dirty_state"]
 
         manager.remove_imagetool(0)
-        buttons = _source_refresh_buttons(figure_tool)
-        assert not buttons["first"].isEnabled()
-        assert (
-            buttons["first"].toolTip()
-            == "This source is not linked to an open ImageTool"
-        )
+        figure_tool._refresh_source_controls()
+        assert not figure_tool.refresh_sources_button.isEnabled()
+        first_item = figure_tool.source_list.topLevelItem(0)
+        assert first_item is not None
+        assert first_item.icon(0).isNull()
 
 
 def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
@@ -3335,10 +3334,10 @@ def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
         with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
             itool(updated_second, manager=True, replace=1)
 
-        buttons = _source_refresh_buttons(figure_tool)
-        assert buttons["first"].isEnabled()
-        assert buttons["second"].isEnabled()
-        assert not buttons["detached"].isEnabled()
+        figure_tool._set_selected_source_names_silent(
+            {"first", "second", "detached"}, "first"
+        )
+        figure_tool._refresh_source_controls()
         assert figure_tool.refresh_sources_button.isEnabled()
         figure_tool.refresh_sources_button.click()
 
@@ -3347,8 +3346,7 @@ def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
         xr.testing.assert_identical(source_data["second"], updated_second)
         xr.testing.assert_identical(source_data["detached"], detached)
         assert figure_tool.tool_status.operations == operations
-        assert figure_tool.source_status_label.text() == ""
-        assert figure_tool.source_status_label.isHidden()
+        assert not figure_tool.source_status_label.isHidden()
         assert figure_tool._operation_render_errors == {}
         snapshot = manager._workspace_state_snapshot()
         assert figure_uid in snapshot["dirty_data"]
@@ -3742,6 +3740,19 @@ def test_manager_figure_source_picker_selects_imagetool_rows_only(
         assert child_item.checkState(0) == QtCore.Qt.CheckState.Checked
         assert dialog.selected_targets() == (root_uid, child_uid)
 
+        assert dummy_item.isExpanded()
+        dummy_item.setExpanded(False)
+        dialog.search_edit.setText("child")
+        assert not root_item.isHidden()
+        assert not dummy_item.isHidden()
+        assert not child_item.isHidden()
+        assert dummy_item.isExpanded()
+        assert dialog.selected_targets() == (root_uid, child_uid)
+        dialog.search_edit.clear()
+        assert not dummy_item.isExpanded()
+        assert root_item.checkState(0) == QtCore.Qt.CheckState.Checked
+        assert child_item.checkState(0) == QtCore.Qt.CheckState.Checked
+
         root_item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
         child_item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
         ok_button = dialog.button_box.button(
@@ -3957,10 +3968,11 @@ def test_manager_figure_remove_unused_source_persists_workspace(
         assert source.name in figure_tool.source_data()
         manager._mark_workspace_clean()
 
-        buttons = _source_remove_buttons(figure_tool)
-        assert buttons[source.name].isEnabled()
+        figure_tool._set_selected_source_names_silent({source.name}, source.name)
+        figure_tool._refresh_source_controls()
+        assert figure_tool.remove_selected_source_button.isEnabled()
         with qtbot.wait_signal(figure_tool.sigDataChanged, timeout=5000):
-            buttons[source.name].click()
+            figure_tool.remove_selected_source_button.click()
 
         assert source.name not in figure_tool.source_data()
         assert source.name not in {

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -2842,6 +2842,70 @@ def test_manager_explicit_figure_operations_use_readable_source_aliases(
         assert figure.tool_status.operations[-1].sources == ("sample_map",)
 
 
+def test_manager_custom_figure_code_uses_readable_source_aliases(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        data = xr.DataArray(
+            np.arange(8.0).reshape(2, 4),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": np.arange(4.0)},
+            name="sample map",
+        )
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        script_name = manager._script_input_name_for_node(manager._node_for_target(0))
+        assert script_name != "sample_map"
+        for argument in ("operation", "custom_code"):
+            code = f"fig.__dict__['{argument}_total'] = float({script_name}.sum())"
+            kwargs: dict[str, typing.Any]
+            if argument == "operation":
+                kwargs = {
+                    "operation": FigureOperationState.custom(
+                        label="summary",
+                        code=code,
+                        trusted=True,
+                    )
+                }
+            else:
+                kwargs = {"custom_code": code}
+
+            figure_uid = manager.create_figure_from_targets((0,), show=False, **kwargs)
+
+            assert figure_uid is not None
+            figure = manager._child_node(figure_uid).tool_window
+            assert isinstance(figure, FigureComposerTool)
+            [custom_operation] = figure.tool_status.operations
+            assert script_name not in custom_operation.code
+            assert "sample_map" in custom_operation.code
+            figurecomposer_rendering._render_into_figure(
+                figure, figure.figure, sync_visible=False
+            )
+            assert figure._operation_render_errors == {}
+            assert figure.figure.__dict__[f"{argument}_total"] == float(data.sum())
+
+        ambiguous_code = f"{script_name} = {script_name}.mean()"
+        for kwargs in (
+            {
+                "operation": FigureOperationState.custom(
+                    label="ambiguous",
+                    code=ambiguous_code,
+                    trusted=True,
+                )
+            },
+            {"custom_code": ambiguous_code},
+        ):
+            with pytest.raises(
+                figurecomposer_text.FigureComposerInputError,
+                match="also binds",
+            ):
+                manager.create_figure_from_targets((0,), show=False, **kwargs)
+
+
 def test_manager_append_explicit_operation_uses_conflict_free_source_alias(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -1686,10 +1686,14 @@ def test_manager_create_figure_uses_first_selected_main_image_state(
             levels_locked=True,
             levels=(-2.0, 4.0),
         )
-        manager.get_imagetool(1).slicer_area.set_colormap("viridis", gamma=0.25)
+        second_tool = manager.get_imagetool(1)
+        second_tool.slicer_area.set_colormap("viridis", gamma=0.25)
         vmin, vmax = first_tool.slicer_area.colormap_properties["levels"]
-        expected = first_tool.slicer_area.images[0].figure_composer_operation(
+        expected_first = first_tool.slicer_area.images[0].figure_composer_operation(
             source_name="data_0"
+        )
+        expected_second = second_tool.slicer_area.images[0].figure_composer_operation(
+            source_name="data_1"
         )
 
         figure_uid = manager.create_figure_from_targets((0, 1), show=False)
@@ -1698,19 +1702,24 @@ def test_manager_create_figure_uses_first_selected_main_image_state(
             "FigureComposerTool", manager._child_node(figure_uid).tool_window
         )
         operation = figure_tool.tool_status.operations[0]
-        assert operation.sources == ("data_0", "data_1")
+        assert operation.sources == ("data_0_selected", "data_1_selected")
+        sources = {source.name: source for source in figure_tool.source_states()}
+        assert sources["data_0_selected"].selection_source == "data_0"
+        assert sources["data_0_selected"].qsel == expected_first.map_selections[0].qsel
+        assert sources["data_1_selected"].selection_source == "data_1"
+        assert sources["data_1_selected"].qsel == expected_second.map_selections[0].qsel
         assert operation.order == "F"
         assert figure_tool.tool_status.setup.nrows == 1
         assert figure_tool.tool_status.setup.ncols == 2
-        assert operation.slice_dim == expected.slice_dim
-        assert operation.slice_values == expected.slice_values
-        assert operation.slice_width == expected.slice_width
-        assert operation.slice_kwargs == expected.slice_kwargs
-        assert operation.transpose == expected.transpose
-        assert operation.xlim == expected.xlim
-        assert operation.ylim == expected.ylim
-        assert operation.crop == expected.crop
-        assert operation.axis == expected.axis
+        assert operation.slice_dim is None
+        assert operation.slice_values == ()
+        assert operation.slice_width is None
+        assert operation.slice_kwargs == {}
+        assert operation.transpose == expected_first.transpose
+        assert operation.xlim == expected_first.xlim
+        assert operation.ylim == expected_first.ylim
+        assert operation.crop == expected_first.crop
+        assert operation.axis == expected_first.axis
         assert operation.cmap is None
         assert operation.same_limits is False
         assert operation.norm_name == "PowerNorm"

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -2772,6 +2772,79 @@ def test_manager_append_operation_to_existing_figure(
         assert figure.tool_status.operations[-1].kind.value == "line"
 
 
+def test_manager_explicit_figure_operations_use_readable_source_aliases(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        data = xr.DataArray(
+            np.arange(8.0).reshape(2, 4),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": np.arange(4.0)},
+            name="sample map",
+        )
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        script_name = manager._script_input_name_for_node(manager._node_for_target(0))
+        assert script_name != "sample_map"
+        figure_uid = manager.create_figure_from_targets(
+            (0,),
+            operation=FigureOperationState.plot_array(label="plot", source=script_name),
+            show=False,
+        )
+
+        assert figure_uid is not None
+        figure = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure, FigureComposerTool)
+        assert tuple(figure.source_data()) == ("sample_map",)
+        assert figure.tool_status.operations[-1].sources == ("sample_map",)
+
+
+def test_manager_append_explicit_operation_uses_conflict_free_source_alias(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        for offset in (0.0, 10.0):
+            itool(
+                xr.DataArray(
+                    np.arange(8.0).reshape(2, 4) + offset,
+                    dims=("x", "y"),
+                    coords={"x": [0.0, 1.0], "y": np.arange(4.0)},
+                    name="sample map",
+                ),
+                manager=True,
+            )
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure, FigureComposerTool)
+        assert tuple(figure.source_data()) == ("sample_map",)
+
+        script_name = manager._script_input_name_for_node(manager._node_for_target(1))
+        assert script_name != "sample_map_2"
+        appended = manager.append_figure_from_targets(
+            (1,),
+            figure_uid=figure_uid,
+            axes_selection=FigureAxesSelectionState(axes=((0, 0),)),
+            operation=FigureOperationState.plot_array(
+                label="overlay", source=script_name
+            ),
+            show=False,
+        )
+
+        assert appended is True
+        assert tuple(figure.source_data()) == ("sample_map", "sample_map_2")
+        assert figure.tool_status.operations[-1].sources == ("sample_map_2",)
+
+
 def test_manager_append_momentum_source_seeds_bz_overlay(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -2809,6 +2809,7 @@ def test_manager_append_operation_to_existing_figure(
         assert appended is True
         assert len(figure.tool_status.operations) == operation_count + 1
         assert figure.tool_status.operations[-1].kind.value == "line"
+        assert figure.tool_status.operations[-1].line_source == source_name
 
 
 def test_manager_explicit_figure_operations_use_readable_source_aliases(
@@ -3908,6 +3909,134 @@ def test_figure_sources_add_button_adds_imagetool_sources(
         snapshot = manager._workspace_state_snapshot()
         assert figure_uid in snapshot["dirty_data"]
         assert figure_uid in snapshot["dirty_state"]
+
+
+def test_manager_figure_source_add_reports_partial_rejection(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    first = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="first",
+    )
+    second = first.copy(data=np.arange(4.0, 8.0).reshape(2, 2)).rename("second")
+    incompatible = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("z", "y"),
+        coords={"z": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="replacement",
+    )
+    with manager_context() as manager:
+        itool(first, manager=True)
+        itool(second, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        figure_tool._set_selected_source_names_silent({"first"}, "first")
+        figure_tool._update_selected_source_dimension("x", "qsel", "0.0", "")
+        original_first = figure_tool.source_data()["first"]
+        original_operations = figure_tool.tool_status.operations
+
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            itool(incompatible, manager=True, replace=0)
+        manager._mark_workspace_clean()
+
+        assert manager._add_imagetool_sources_to_figure(figure_uid, (0, 1), show=False)
+
+        xr.testing.assert_identical(figure_tool.source_data()["first"], original_first)
+        xr.testing.assert_identical(figure_tool.source_data()["second"], second)
+        assert figure_tool.tool_status.operations == original_operations
+        status = figure_tool.source_status_label.text()
+        assert "Added 1 ImageTool source" in status
+        assert "Skipped 1 ImageTool source update" in status
+        assert "Could not update source data for: first" in status
+        assert "Updated 1 ImageTool source" not in status
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid in snapshot["dirty_data"]
+        assert figure_uid in snapshot["dirty_state"]
+
+        manager._mark_workspace_clean()
+        assert manager.append_figure_from_targets(
+            (0, 1),
+            figure_uid=figure_uid,
+            axes_selection=FigureAxesSelectionState(axes=((0, 0),)),
+            show=False,
+        )
+        assert figure_tool.tool_status.operations == original_operations
+        assert "Could not update source data for: first" in (
+            figure_tool.source_status_label.text()
+        )
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid in snapshot["dirty_data"]
+        assert figure_uid in snapshot["dirty_state"]
+
+
+def test_manager_rejected_source_update_does_not_mark_dirty_or_add_step(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="data",
+    )
+    incompatible = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("z", "y"),
+        coords={"z": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="replacement",
+    )
+    with manager_context() as manager:
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        figure_tool._set_selected_source_names_silent({"data"}, "data")
+        figure_tool._update_selected_source_dimension("x", "qsel", "0.0", "")
+        original_data = figure_tool.source_data()["data"]
+        original_operations = figure_tool.tool_status.operations
+
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            itool(incompatible, manager=True, replace=0)
+        manager._mark_workspace_clean()
+
+        assert not manager._add_imagetool_sources_to_figure(
+            figure_uid, (0,), show=False
+        )
+        xr.testing.assert_identical(figure_tool.source_data()["data"], original_data)
+        assert "Could not update source data for: data" in (
+            figure_tool.source_status_label.text()
+        )
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid not in snapshot["dirty_data"]
+        assert figure_uid not in snapshot["dirty_state"]
+
+        assert not manager.append_figure_from_targets(
+            (0,),
+            figure_uid=figure_uid,
+            axes_selection=FigureAxesSelectionState(axes=((0, 0),)),
+            show=False,
+        )
+
+        xr.testing.assert_identical(figure_tool.source_data()["data"], original_data)
+        assert figure_tool.tool_status.operations == original_operations
+        assert "Could not update source data for: data" in (
+            figure_tool.source_status_label.text()
+        )
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid not in snapshot["dirty_data"]
+        assert figure_uid not in snapshot["dirty_state"]
 
 
 def test_figure_sources_drag_mime_adds_root_and_child_imagetools(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -1,6 +1,55 @@
 # ruff: noqa: F403, F405
 
+from collections.abc import Iterable
+
+import h5py
+import pydantic
+
 from ._common import *
+
+
+class _SourcePickerDummyState(pydantic.BaseModel):
+    value: int = 0
+
+
+class _SourcePickerDummyTool(
+    erlab.interactive.utils.ToolWindow[_SourcePickerDummyState]
+):
+    StateModel = _SourcePickerDummyState
+    tool_name = "source-picker-dummy"
+
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__()
+        self._data = data
+        self._status = _SourcePickerDummyState()
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    @property
+    def tool_status(self) -> _SourcePickerDummyState:
+        return self._status
+
+    @tool_status.setter
+    def tool_status(self, status: _SourcePickerDummyState) -> None:
+        self._status = status
+
+
+def _source_picker_item(
+    dialog: QtWidgets.QDialog, uid: str
+) -> QtWidgets.QTreeWidgetItem:
+    tree = dialog.findChild(QtWidgets.QTreeWidget, "managerFigureSourcePickerTree")
+    assert tree is not None
+    root = tree.invisibleRootItem()
+    stack = [root.child(index) for index in range(root.childCount())]
+    while stack:
+        item = stack.pop()
+        assert item is not None
+        if item.data(0, QtCore.Qt.ItemDataRole.UserRole) == uid:
+            return item
+        stack.extend(item.child(index) for index in range(item.childCount()))
+    raise AssertionError(f"missing picker row for {uid!r}")
 
 
 def test_manager_default_figure_seed_uses_public_nonuniform_dims(
@@ -899,9 +948,15 @@ def test_manager_workspace_restores_figure_gallery_preview_cache(
         )
         loaded_node = manager._child_node(figure_uid)
         assert loaded_node.tool_window is None
+        assert loaded_node.pending_workspace_tool_payload is not None
         pending_preview = loaded_node.pending_workspace_tool_preview_image()
         assert pending_preview is not None
         assert not pending_preview[1].isNull()
+        loaded_node.show()
+        loaded_tool = loaded_node.tool_window
+        assert isinstance(loaded_tool, FigureComposerTool)
+        assert loaded_tool.preview_pixmap is not None
+        assert not loaded_tool.preview_pixmap_stale
 
         manager.figure_view_gallery_button.click()
         item = manager._figure_list_item_for_uid(figure_uid)
@@ -1806,6 +1861,8 @@ def test_manager_workspace_figure_sources_save_as_references(
                 mark_dirty=False,
                 select=False,
             )
+            loaded_node = manager._tool_graph.nodes[figure_uid]
+            assert loaded_node.pending_workspace_tool_payload is not None
             loaded_tool = _materialized_figure_tool(manager, figure_uid)
             xr.testing.assert_identical(loaded_tool._source_data["data_1"], second)
         finally:
@@ -1815,6 +1872,78 @@ def test_manager_workspace_figure_sources_save_as_references(
         source_data = restored.source_data()
         xr.testing.assert_identical(source_data["data_0"], first)
         xr.testing.assert_identical(source_data["data_1"], second)
+
+
+def test_manager_pending_figure_source_reference_uses_saved_imagetool_dim_order(
+    qtbot,
+    tmp_path: Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(2 * 3 * 4, dtype=np.float64).reshape((2, 3, 4)),
+        dims=("x", "hv", "y"),
+        coords={
+            "x": np.array([0.0, 1.0]),
+            "hv": np.array([10.0, 20.0, 30.0]),
+            "y": np.array([-1.0, 0.0, 1.0, 2.0]),
+        },
+        name="pending_order",
+    )
+
+    with manager_context() as manager:
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root.hide()
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+
+        workspace_path = tmp_path / "pending-figure-source-order.itws"
+        manager._save_workspace_document(workspace_path, force_full=True)
+        saved_ds = manager_workspace._read_workspace_dataset_group_h5py(
+            workspace_path,
+            "0/imagetool",
+            preferred_data_name=manager_workspace_io._ITOOL_DATA_NAME,
+        )
+        assert saved_ds is not None
+        stored = xr.Dataset(
+            {
+                manager_workspace_io._ITOOL_DATA_NAME: saved_ds[
+                    manager_workspace_io._ITOOL_DATA_NAME
+                ].transpose("hv", "y", "x")
+            },
+            attrs=dict(saved_ds.attrs),
+        )
+        with h5py.File(workspace_path, "r+") as h5_file:
+            del h5_file["0/imagetool"]
+        assert manager_workspace._write_workspace_dataset_group_h5py(
+            workspace_path, "0/imagetool", stored
+        )
+
+        assert manager._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+
+        source_node = manager._tool_graph.root_wrappers[0]
+        assert source_node.pending_workspace_memory_payload is not None
+        figure_node = manager._child_node(figure_uid)
+        assert figure_node.pending_workspace_tool_payload is not None
+        figure_node.show()
+        loaded_figure = figure_node.tool_window
+        assert isinstance(loaded_figure, FigureComposerTool)
+        source = loaded_figure.source_data()[loaded_figure.tool_status.primary_source]
+        assert source.dims == data.dims
+        assert source.chunks is not None
+        np.testing.assert_array_equal(source.values, data.values)
+        assert source_node.pending_workspace_memory_payload is not None
 
 
 def test_manager_workspace_delta_snapshot_rewrites_stale_figure_source_references(
@@ -2090,7 +2219,6 @@ def test_manager_append_to_gridspec_figure_uses_axes_ids(
         dialog = manager_mainwindow._AppendFigureTargetDialog(
             manager, (figure_uid,), operation
         )
-        qtbot.addWidget(dialog)
 
         assert dialog.selector_stack.currentWidget() is dialog.gridspec_axes_selector
         assert dialog.gridspec_axes_selector.axes_ids() == ("axis-a", "axis-b")
@@ -2131,7 +2259,6 @@ def test_manager_append_to_subplots_figure_uses_axes_selector(
         dialog = manager_mainwindow._AppendFigureTargetDialog(
             manager, (figure_uid,), operation
         )
-        qtbot.addWidget(dialog)
 
         assert dialog.selector_stack.currentWidget() is dialog.axes_selector
         assert dialog.axes_selector.selected_axes() == ((0, 0), (0, 1))
@@ -2187,7 +2314,6 @@ def test_manager_figure_target_dialog_defaults_to_add_step_without_selected_figu
             None,
             allow_new_figure=True,
         )
-        qtbot.addWidget(dialog)
 
         assert dialog.selected_action() == manager_mainwindow._FIGURE_DIALOG_ADD_STEP
         assert not dialog.is_new_figure()
@@ -2238,7 +2364,6 @@ def test_manager_figure_target_dialog_defaults_to_replace_selected_single_source
             source_count=1,
             selected_figure_uid=figure_uid,
         )
-        qtbot.addWidget(dialog)
 
         assert (
             dialog.selected_action() == manager_mainwindow._FIGURE_DIALOG_REPLACE_SOURCE
@@ -2289,8 +2414,6 @@ def test_manager_figure_target_dialog_switches_and_repairs_axes_selection(
                 primary_source="line",
             ),
         )
-        qtbot.addWidget(first_tool)
-        qtbot.addWidget(second_tool)
         first_uid = manager.add_figuretool(first_tool, show=False)
         second_uid = manager.add_figuretool(second_tool, show=False)
 
@@ -2300,7 +2423,6 @@ def test_manager_figure_target_dialog_switches_and_repairs_axes_selection(
             FigureOperationState.line(label="line", source="line"),
             allow_new_figure=True,
         )
-        qtbot.addWidget(dialog)
 
         assert dialog.selected_action() == manager_mainwindow._FIGURE_DIALOG_ADD_STEP
         assert not dialog.is_new_figure()
@@ -2400,7 +2522,6 @@ def test_manager_figure_target_dialog_disables_replace_for_multiple_sources(
             source_count=2,
             selected_figure_uid=figure_uid,
         )
-        qtbot.addWidget(dialog)
 
         dialog.action_combo.setCurrentIndex(
             dialog.action_combo.findData(
@@ -2434,7 +2555,6 @@ def test_manager_prompt_append_figure_target_auto_and_cancel_paths(
                 primary_source="line",
             ),
         )
-        qtbot.addWidget(single_tool)
         single_uid = manager.add_figuretool(single_tool, show=False)
         assert manager._append_single_axis_selection(single_uid) == (
             FigureAxesSelectionState(axes=((0, 0),))
@@ -2453,7 +2573,6 @@ def test_manager_prompt_append_figure_target_auto_and_cancel_paths(
                 primary_source="line",
             ),
         )
-        qtbot.addWidget(wide_tool)
         wide_uid = manager.add_figuretool(wide_tool, show=False)
 
         class RejectDialog:
@@ -3363,9 +3482,213 @@ def test_manager_figure_action_add_source_only_keeps_recipe_steps(
             mark_dirty=False,
             select=False,
         )
-        loaded_tool = manager._child_node(figure_uid).tool_window
+        loaded_node = manager._child_node(figure_uid)
+        loaded_tool = loaded_node.tool_window
+        if loaded_tool is None:
+            assert loaded_node.pending_workspace_tool_payload is not None
+            loaded_node.show()
+            loaded_tool = loaded_node.tool_window
         assert isinstance(loaded_tool, FigureComposerTool)
         xr.testing.assert_identical(loaded_tool.source_data()["data_1"], second)
+
+
+def test_manager_figure_source_picker_selects_imagetool_rows_only(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    root_data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="root",
+    )
+    child_data = root_data + 10.0
+    with manager_context() as manager:
+        itool(root_data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        root_uid = manager._tool_graph.root_wrappers[0].uid
+        dummy_uid = manager.add_childtool(
+            _SourcePickerDummyTool(root_data.rename("dummy")),
+            0,
+            show=False,
+        )
+        child_uid = manager.add_imagetool_child(
+            erlab.interactive.imagetool.ImageTool(
+                child_data.rename("child"), _in_manager=True
+            ),
+            dummy_uid,
+            show=False,
+        )
+
+        dialog = manager_mainwindow._FigureSourcePickerDialog(
+            manager, prechecked_uids=(root_uid, child_uid)
+        )
+        qtbot.addWidget(dialog)
+        root_item = _source_picker_item(dialog, root_uid)
+        dummy_item = _source_picker_item(dialog, dummy_uid)
+        child_item = _source_picker_item(dialog, child_uid)
+
+        checkable = QtCore.Qt.ItemFlag.ItemIsUserCheckable
+        assert root_item.flags() & checkable
+        assert child_item.flags() & checkable
+        assert not dummy_item.flags() & checkable
+        assert root_item.checkState(0) == QtCore.Qt.CheckState.Checked
+        assert child_item.checkState(0) == QtCore.Qt.CheckState.Checked
+        assert dialog.selected_targets() == (root_uid, child_uid)
+
+        root_item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
+        child_item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
+        ok_button = dialog.button_box.button(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
+        assert ok_button is not None
+        assert not ok_button.isEnabled()
+
+        assert manager.create_figure_from_targets((dummy_uid,), show=False) is None
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        assert not manager.append_figure_from_targets(
+            (dummy_uid,), figure_uid=figure_uid, show=False
+        )
+        resolved_targets, sources, source_data = manager._figure_sources_from_targets(
+            (dummy_uid, child_uid)
+        )
+        assert resolved_targets == (child_uid,)
+        assert len(sources) == len(source_data) == 1
+
+
+def test_figure_sources_add_button_adds_imagetool_sources(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    first = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="first",
+    )
+    second = first + 10.0
+    with manager_context() as manager:
+        itool(first, manager=True)
+        itool(second.rename("second"), manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        operation_count = len(figure_tool.tool_status.operations)
+        second_uid = manager._tool_graph.root_wrappers[1].uid
+        select_tools(manager, [1])
+        manager._mark_workspace_clean()
+
+        class RejectingPicker:
+            def __init__(
+                self,
+                _manager: erlab.interactive.imagetool.manager.ImageToolManager,
+                *,
+                prechecked_uids: Iterable[str] = (),
+            ) -> None:
+                assert tuple(prechecked_uids) == (second_uid,)
+
+            def exec(self) -> QtWidgets.QDialog.DialogCode:
+                return QtWidgets.QDialog.DialogCode.Rejected
+
+        monkeypatch.setattr(
+            manager_mainwindow, "_FigureSourcePickerDialog", RejectingPicker
+        )
+        figure_tool.add_source_button.click()
+
+        assert len(figure_tool.tool_status.operations) == operation_count
+        assert {source.name for source in figure_tool.source_states()} == {"data_0"}
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid not in snapshot["dirty_data"]
+        assert figure_uid not in snapshot["dirty_state"]
+
+        class AcceptingPicker(RejectingPicker):
+            def exec(self) -> QtWidgets.QDialog.DialogCode:
+                return QtWidgets.QDialog.DialogCode.Accepted
+
+            def selected_targets(self) -> tuple[str, ...]:
+                return (second_uid,)
+
+        monkeypatch.setattr(
+            manager_mainwindow, "_FigureSourcePickerDialog", AcceptingPicker
+        )
+        with qtbot.wait_signal(figure_tool.sigDataChanged, timeout=5000):
+            figure_tool.add_source_button.click()
+
+        assert len(figure_tool.tool_status.operations) == operation_count
+        xr.testing.assert_identical(
+            figure_tool.source_data()["data_1"], second.rename("second")
+        )
+        snapshot = manager._workspace_state_snapshot()
+        assert figure_uid in snapshot["dirty_data"]
+        assert figure_uid in snapshot["dirty_state"]
+
+
+def test_figure_sources_drag_mime_adds_root_and_child_imagetools(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    first = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="first",
+    )
+    second = first + 10.0
+    child_data = first + 20.0
+    with manager_context() as manager:
+        itool(first, manager=True)
+        itool(second.rename("second"), manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        child_uid = manager.add_imagetool_child(
+            erlab.interactive.imagetool.ImageTool(
+                child_data.rename("child"), _in_manager=True
+            ),
+            0,
+            show=False,
+        )
+        model = typing.cast("_ImageToolWrapperItemModel", manager.tree_view.model())
+        second_uid = manager._tool_graph.root_wrappers[1].uid
+        second_mime = model.mimeData([model.index(1, 0)])
+
+        assert manager.tree_view.figure_source_uids_from_mime(second_mime) == (
+            second_uid,
+        )
+        assert figure_tool._source_drop_available(second_mime)
+        assert figure_tool._add_sources_from_mime(second_mime)
+        xr.testing.assert_identical(
+            figure_tool.source_data()["data_1"], second.rename("second")
+        )
+
+        child_mime = model.mimeData([model._row_index(child_uid)])
+        assert manager.tree_view.figure_source_uids_from_mime(child_mime) == (
+            child_uid,
+        )
+        window = figure_tool.figure_window
+        assert window._handle_source_drag_event(None) is False
+        assert figure_tool._source_drop_available(child_mime)
+        assert figure_tool._add_sources_from_mime(child_mime)
+        child_source_name = next(
+            source.name
+            for source in figure_tool.source_states()
+            if source.node_uid == child_uid
+        )
+        xr.testing.assert_identical(
+            figure_tool.source_data()[child_source_name], child_data.rename("child")
+        )
 
 
 def test_manager_figure_remove_unused_source_persists_workspace(
@@ -3428,6 +3751,8 @@ def test_manager_figure_remove_unused_source_persists_workspace(
             mark_dirty=False,
             select=False,
         )
+        loaded_node = manager._child_node(figure_uid)
+        assert loaded_node.pending_workspace_tool_payload is not None
         loaded_tool = _materialized_figure_tool(manager, figure_uid)
         assert source.name not in loaded_tool.source_data()
         assert source.name not in {

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -1690,10 +1690,10 @@ def test_manager_create_figure_uses_first_selected_main_image_state(
         second_tool.slicer_area.set_colormap("viridis", gamma=0.25)
         vmin, vmax = first_tool.slicer_area.colormap_properties["levels"]
         expected_first = first_tool.slicer_area.images[0].figure_composer_operation(
-            source_name="data_0"
+            source_name="first"
         )
         expected_second = second_tool.slicer_area.images[0].figure_composer_operation(
-            source_name="data_1"
+            source_name="second"
         )
 
         figure_uid = manager.create_figure_from_targets((0, 1), show=False)
@@ -1702,12 +1702,12 @@ def test_manager_create_figure_uses_first_selected_main_image_state(
             "FigureComposerTool", manager._child_node(figure_uid).tool_window
         )
         operation = figure_tool.tool_status.operations[0]
-        assert operation.sources == ("data_0_selected", "data_1_selected")
+        assert operation.sources == ("first_selected", "second_selected")
         sources = {source.name: source for source in figure_tool.source_states()}
-        assert sources["data_0_selected"].selection_source == "data_0"
-        assert sources["data_0_selected"].qsel == expected_first.map_selections[0].qsel
-        assert sources["data_1_selected"].selection_source == "data_1"
-        assert sources["data_1_selected"].qsel == expected_second.map_selections[0].qsel
+        assert sources["first_selected"].selection_source == "first"
+        assert sources["first_selected"].qsel == expected_first.map_selections[0].qsel
+        assert sources["second_selected"].selection_source == "second"
+        assert sources["second_selected"].qsel == expected_second.map_selections[0].qsel
         assert operation.order == "F"
         assert figure_tool.tool_status.setup.nrows == 1
         assert figure_tool.tool_status.setup.ncols == 2
@@ -1821,18 +1821,18 @@ def test_manager_workspace_figure_sources_save_as_references(
             )
 
             assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in references
-            assert "data_1" in references
+            assert "second" in references
             assert ds[erlab.interactive.utils._SAVED_TOOL_DATA_NAME].size == 0
-            assert ds["data_1"].size == 0
+            assert ds["second"].size == 0
             assert manager_workspace._workspace_dataset_can_write_h5py(ds)
 
             source_data_by_uid = {
                 references[erlab.interactive.utils._SAVED_TOOL_DATA_NAME][
                     "node_uid"
                 ]: first,
-                references["data_1"]["node_uid"]: second,
+                references["second"]["node_uid"]: second,
             }
-            corrupt_ds = ds.drop_vars("data_1")
+            corrupt_ds = ds.drop_vars("second")
             restored_from_reference = erlab.interactive.utils.ToolWindow.from_dataset(
                 corrupt_ds,
                 _tool_data_reference_resolver=lambda reference: source_data_by_uid.get(
@@ -1842,7 +1842,7 @@ def test_manager_workspace_figure_sources_save_as_references(
             qtbot.addWidget(restored_from_reference)
             assert isinstance(restored_from_reference, FigureComposerTool)
             xr.testing.assert_identical(
-                restored_from_reference.source_data()["data_1"], second
+                restored_from_reference.source_data()["second"], second
             )
 
             fname = tmp_path / "figure-source-references.itws"
@@ -1853,7 +1853,7 @@ def test_manager_workspace_figure_sources_save_as_references(
                 preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
             )
             assert saved_ds is not None
-            assert "data_1" in saved_ds
+            assert "second" in saved_ds
 
             manager.remove_all_tools()
             qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
@@ -1873,14 +1873,14 @@ def test_manager_workspace_figure_sources_save_as_references(
             loaded_node = manager._tool_graph.nodes[figure_uid]
             assert loaded_node.pending_workspace_tool_payload is not None
             loaded_tool = _materialized_figure_tool(manager, figure_uid)
-            xr.testing.assert_identical(loaded_tool._source_data["data_1"], second)
+            xr.testing.assert_identical(loaded_tool._source_data["second"], second)
         finally:
             tree.close()
 
         restored = _materialized_figure_tool(manager, figure_uid)
         source_data = restored.source_data()
-        xr.testing.assert_identical(source_data["data_0"], first)
-        xr.testing.assert_identical(source_data["data_1"], second)
+        xr.testing.assert_identical(source_data["first"], first)
+        xr.testing.assert_identical(source_data["second"], second)
 
 
 def test_manager_pending_figure_source_reference_uses_saved_imagetool_dim_order(
@@ -1993,8 +1993,8 @@ def test_manager_workspace_delta_snapshot_rewrites_stale_figure_source_reference
             saved_refs = json.loads(
                 saved_ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
             )
-            assert "data_1" in saved_refs
-            assert saved_ds["data_1"].size == 0
+            assert "second" in saved_refs
+            assert saved_ds["second"].size == 0
         finally:
             tree.close()
 
@@ -2004,7 +2004,7 @@ def test_manager_workspace_delta_snapshot_rewrites_stale_figure_source_reference
             update={
                 "sources": tuple(
                     source.model_copy(update={"node_uid": stale_uid})
-                    if source.name == "data_1"
+                    if source.name == "second"
                     else source
                     for source in current_recipe.sources
                 )
@@ -2028,13 +2028,13 @@ def test_manager_workspace_delta_snapshot_rewrites_stale_figure_source_reference
                 reference.get("node_uid") != stale_uid
                 for reference in rewritten_refs.values()
             )
-            assert "data_1" not in rewritten_refs
-            assert rewritten_ds["data_1"].size > 0
+            assert "second" not in rewritten_refs
+            assert rewritten_ds["second"].size > 0
             rewritten_state = FigureRecipeState.model_validate_json(
                 rewritten_ds.attrs["tool_state"]
             )
             rewritten_source = next(
-                source for source in rewritten_state.sources if source.name == "data_1"
+                source for source in rewritten_state.sources if source.name == "second"
             )
             assert rewritten_source.node_uid is None
             assert rewritten_source.node_snapshot_token is None
@@ -3083,7 +3083,7 @@ def test_manager_figure_action_replace_source_keeps_recipe_steps(
                 return figure_uid
 
             def selected_source_alias(self) -> str:
-                return "data_0"
+                return "first"
 
         monkeypatch.setattr(
             manager_mainwindow, "_AppendFigureTargetDialog", FakeReplaceDialog
@@ -3092,11 +3092,11 @@ def test_manager_figure_action_replace_source_keeps_recipe_steps(
         manager.create_figure_action.trigger()
 
         assert len(figure_tool.tool_status.operations) == operation_count
-        xr.testing.assert_identical(figure_tool.source_data()["data_0"], second)
+        xr.testing.assert_identical(figure_tool.source_data()["first"], second)
         [source] = figure_tool.source_states()
-        assert source.name == "data_0"
+        assert source.name == "first"
         assert source.node_uid == manager._node_for_target(1).uid
-        assert "data_1" not in figure_tool.source_data()
+        assert "second" not in figure_tool.source_data()
 
 
 def test_manager_figure_source_row_refresh_updates_only_selected_source(
@@ -3126,7 +3126,7 @@ def test_manager_figure_source_row_refresh_updates_only_selected_source(
         assert figure_uid is not None
         figure_tool = manager._child_node(figure_uid).tool_window
         assert isinstance(figure_tool, FigureComposerTool)
-        original_second = figure_tool.source_data()["data_1"]
+        original_second = figure_tool.source_data()["second"]
         operations = figure_tool.tool_status.operations
         manager._mark_workspace_clean()
 
@@ -3140,25 +3140,25 @@ def test_manager_figure_source_row_refresh_updates_only_selected_source(
             itool(updated_second, manager=True, replace=1)
 
         buttons = _source_refresh_buttons(figure_tool)
-        assert buttons["data_0"].isEnabled()
-        assert buttons["data_1"].isEnabled()
+        assert buttons["first"].isEnabled()
+        assert buttons["second"].isEnabled()
         with qtbot.wait_signal(figure_tool.sigDataChanged, timeout=5000):
-            buttons["data_0"].click()
+            buttons["first"].click()
 
         source_data = figure_tool.source_data()
-        xr.testing.assert_identical(source_data["data_0"], updated_first)
-        xr.testing.assert_identical(source_data["data_1"], original_second)
+        xr.testing.assert_identical(source_data["first"], updated_first)
+        xr.testing.assert_identical(source_data["second"], original_second)
         [source_0, source_1] = figure_tool.source_states()
-        assert source_0.name == "data_0"
+        assert source_0.name == "first"
         assert source_0.node_uid == manager._node_for_target(0).uid
-        assert source_1.name == "data_1"
+        assert source_1.name == "second"
         assert figure_tool.tool_status.operations == operations
-        assert "data_0" in figure_tool.generated_code()
+        assert "first" in figure_tool.generated_code()
 
         _render_figure_composer_rgba(figure_tool)
         namespace = _exec_generated_code(
             figure_tool.generated_code(),
-            {"data_0": updated_first, "data_1": original_second},
+            {"first": updated_first, "second": original_second},
         )
         assert isinstance(namespace["fig"], Figure)
         snapshot = manager._workspace_state_snapshot()
@@ -3167,9 +3167,9 @@ def test_manager_figure_source_row_refresh_updates_only_selected_source(
 
         manager.remove_imagetool(0)
         buttons = _source_refresh_buttons(figure_tool)
-        assert not buttons["data_0"].isEnabled()
+        assert not buttons["first"].isEnabled()
         assert (
-            buttons["data_0"].toolTip()
+            buttons["first"].toolTip()
             == "This source is not linked to an open ImageTool"
         )
 
@@ -3224,15 +3224,15 @@ def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
             itool(updated_second, manager=True, replace=1)
 
         buttons = _source_refresh_buttons(figure_tool)
-        assert buttons["data_0"].isEnabled()
-        assert buttons["data_1"].isEnabled()
+        assert buttons["first"].isEnabled()
+        assert buttons["second"].isEnabled()
         assert not buttons["detached"].isEnabled()
         assert figure_tool.refresh_sources_button.isEnabled()
         figure_tool.refresh_sources_button.click()
 
         source_data = figure_tool.source_data()
-        xr.testing.assert_identical(source_data["data_0"], updated_first)
-        xr.testing.assert_identical(source_data["data_1"], updated_second)
+        xr.testing.assert_identical(source_data["first"], updated_first)
+        xr.testing.assert_identical(source_data["second"], updated_second)
         xr.testing.assert_identical(source_data["detached"], detached)
         assert figure_tool.tool_status.operations == operations
         assert figure_tool.source_status_label.text() == ""
@@ -3241,6 +3241,88 @@ def test_manager_figure_refresh_sources_updates_live_sources_and_skips_detached(
         snapshot = manager._workspace_state_snapshot()
         assert figure_uid in snapshot["dirty_data"]
         assert figure_uid in snapshot["dirty_state"]
+
+
+def test_manager_figure_sources_use_readable_unique_aliases(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    arrays = (
+        xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"), name="sample_map"),
+        xr.DataArray(
+            np.arange(4.0, 8.0).reshape(2, 2),
+            dims=("x", "y"),
+            name="reference map",
+        ),
+        xr.DataArray(
+            np.arange(8.0, 12.0).reshape(2, 2),
+            dims=("x", "y"),
+            name="sample_map",
+        ),
+        xr.DataArray(
+            np.arange(12.0, 16.0).reshape(2, 2),
+            dims=("x", "y"),
+            name=" !!! ",
+        ),
+    )
+
+    with manager_context() as manager:
+        for data in arrays:
+            itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == len(arrays), timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets(range(len(arrays)), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+
+        source_names = tuple(source.name for source in figure_tool.source_states())
+        assert source_names == (
+            "sample_map",
+            "reference_map",
+            "sample_map_2",
+            "data_3",
+        )
+        assert tuple(figure_tool.source_data()) == source_names
+        reference_item = figure_tool.source_list.topLevelItem(1)
+        assert reference_item is not None
+        assert reference_item.text(0) == "reference_map"
+        assert "Original name: reference map" in reference_item.toolTip(0)
+
+
+def test_manager_figure_source_only_append_uses_readable_conflict_suffix(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    first = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"), name="map")
+    second = xr.DataArray(
+        np.arange(4.0, 8.0).reshape(2, 2), dims=("x", "y"), name="map"
+    )
+
+    with manager_context() as manager:
+        itool(first, manager=True)
+        itool(second, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+
+        _resolved_targets, sources, source_data = manager._figure_sources_from_targets(
+            (1,)
+        )
+        manager._add_sources_to_figure(figure_uid, sources, source_data, show=False)
+
+        assert tuple(source.name for source in figure_tool.source_states()) == (
+            "map",
+            "map_2",
+        )
+        xr.testing.assert_identical(figure_tool.source_data()["map_2"], second)
 
 
 def test_manager_figure_source_helper_edge_contracts(
@@ -3273,6 +3355,7 @@ def test_manager_figure_source_helper_edge_contracts(
 
         source_states = figure_tool.source_states()
         source_data = figure_tool.source_data()
+        source_alias = source_states[0].name
         replacement_source = FigureSourceState(
             name="replacement",
             label="replacement",
@@ -3285,18 +3368,18 @@ def test_manager_figure_source_helper_edge_contracts(
             show=False,
         )
         assert manager._figure_source_state(figure_tool, "missing") is None
-        assert manager._figure_source_live_node("missing", "data_0") is None
+        assert manager._figure_source_live_node("missing", source_alias) is None
         assert not manager._refresh_figure_source(figure_uid, "missing")
         assert not manager._replace_figure_source(
             figure_uid,
-            "data_0",
+            source_alias,
             (),
             {},
             show=False,
         )
         assert not manager._replace_figure_source(
             figure_uid,
-            "data_0",
+            source_alias,
             (replacement_source,),
             {},
             show=False,
@@ -3316,24 +3399,24 @@ def test_manager_figure_source_helper_edge_contracts(
             )
             assert not manager._replace_figure_source(
                 child_uid,
-                "data_0",
+                source_alias,
                 (replacement_source,),
                 {"replacement": data},
                 show=False,
             )
-            assert manager._figure_source_live_node(child_uid, "data_0") is None
-            assert not manager._refresh_figure_source(child_uid, "data_0")
+            assert manager._figure_source_live_node(child_uid, source_alias) is None
+            assert not manager._refresh_figure_source(child_uid, source_alias)
 
         with monkeypatch.context() as context:
             context.setattr(figure_tool, "replace_source", lambda *_args: False)
             assert not manager._replace_figure_source(
                 figure_uid,
-                "data_0",
+                source_alias,
                 (replacement_source,),
                 {"replacement": data},
                 show=False,
             )
-            assert not manager._refresh_figure_source(figure_uid, "data_0")
+            assert not manager._refresh_figure_source(figure_uid, source_alias)
 
         with monkeypatch.context() as context:
             context.setattr(
@@ -3342,7 +3425,7 @@ def test_manager_figure_source_helper_edge_contracts(
                 lambda *_args: manager._node_for_target(0),
             )
             context.setattr(manager, "_is_figure_uid", lambda uid: uid == child_uid)
-            assert not manager._refresh_figure_source(child_uid, "data_0")
+            assert not manager._refresh_figure_source(child_uid, source_alias)
 
         with monkeypatch.context() as context:
             context.setattr(manager, "_figure_uids", lambda: ("missing",))
@@ -3474,10 +3557,10 @@ def test_manager_figure_action_add_source_only_keeps_recipe_steps(
         manager.create_figure_action.trigger()
 
         assert len(figure_tool.tool_status.operations) == operation_count
-        xr.testing.assert_identical(figure_tool.source_data()["data_1"], second)
+        xr.testing.assert_identical(figure_tool.source_data()["second"], second)
         assert {source.name for source in figure_tool.source_states()} == {
-            "data_0",
-            "data_1",
+            "first",
+            "second",
         }
         snapshot = manager._workspace_state_snapshot()
         assert figure_uid in snapshot["dirty_data"]
@@ -3498,7 +3581,7 @@ def test_manager_figure_action_add_source_only_keeps_recipe_steps(
             loaded_node.show()
             loaded_tool = loaded_node.tool_window
         assert isinstance(loaded_tool, FigureComposerTool)
-        xr.testing.assert_identical(loaded_tool.source_data()["data_1"], second)
+        xr.testing.assert_identical(loaded_tool.source_data()["second"], second)
 
 
 def test_manager_figure_source_picker_selects_imagetool_rows_only(
@@ -3613,7 +3696,7 @@ def test_figure_sources_add_button_adds_imagetool_sources(
         figure_tool.add_source_button.click()
 
         assert len(figure_tool.tool_status.operations) == operation_count
-        assert {source.name for source in figure_tool.source_states()} == {"data_0"}
+        assert {source.name for source in figure_tool.source_states()} == {"first"}
         snapshot = manager._workspace_state_snapshot()
         assert figure_uid not in snapshot["dirty_data"]
         assert figure_uid not in snapshot["dirty_state"]
@@ -3633,7 +3716,7 @@ def test_figure_sources_add_button_adds_imagetool_sources(
 
         assert len(figure_tool.tool_status.operations) == operation_count
         xr.testing.assert_identical(
-            figure_tool.source_data()["data_1"], second.rename("second")
+            figure_tool.source_data()["second"], second.rename("second")
         )
         snapshot = manager._workspace_state_snapshot()
         assert figure_uid in snapshot["dirty_data"]
@@ -3679,7 +3762,7 @@ def test_figure_sources_drag_mime_adds_root_and_child_imagetools(
         assert figure_tool._source_drop_available(second_mime)
         assert figure_tool._add_sources_from_mime(second_mime)
         xr.testing.assert_identical(
-            figure_tool.source_data()["data_1"], second.rename("second")
+            figure_tool.source_data()["second"], second.rename("second")
         )
 
         child_mime = model.mimeData([model._row_index(child_uid)])
@@ -3848,8 +3931,8 @@ def test_manager_figure_action_multi_source_append_preserves_image_colormaps(
             FigureOperationKind.PLOT_ARRAY,
         ]
         assert [operation.sources for operation in appended] == [
-            ("data_0",),
-            ("data_1",),
+            ("first",),
+            ("second",),
         ]
         assert [operation.axes.axes for operation in appended] == [
             ((0, 0),),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -89,7 +89,7 @@ def test_figure_composer_method_docs_button_opens_current_url(
             "#erlab.plotting.clean_labels",
         ),
     ):
-        tool.operation_list.setCurrentRow(row)
+        tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(row))
         tool._select_step_section("method")
         button = tool.step_editor_stack.currentWidget().findChild(
             QtWidgets.QToolButton, "figureComposerMethodDocsButton"
@@ -646,7 +646,7 @@ def test_figure_composer_method_helper_edge_contracts(
     qtbot.addWidget(no_operation_tool)
     figurecomposer_method._update_current_method_name(no_operation_tool, "plot")
 
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool._select_step_section("method")
     figure_method_combo = tool.findChild(
         QtWidgets.QComboBox, "figureComposerFigureMethodCombo"
@@ -692,7 +692,7 @@ def test_figure_composer_method_helper_edge_contracts(
     assert tool.tool_status.operations[1].method_family == FigureMethodFamily.AXES
     figurecomposer_method._update_current_method_family(tool, FigureMethodFamily.FIGURE)
     assert tool.tool_status.operations[1].method_family == FigureMethodFamily.FIGURE
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool._select_step_section("method")
     figurecomposer_method._update_current_method_name(tool, "set_layout_engine")
     assert tool.tool_status.operations[1].method_name == "set_layout_engine"
@@ -1178,7 +1178,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("method")
     method_combo = tool.findChild(QtWidgets.QComboBox, "figureComposerAxesMethodCombo")
     transform_combo = tool.findChild(
@@ -1199,7 +1199,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     assert kwargs_edit.text() == 'ha="left", va="top"'
     assert tool.step_section_buttons["method"].text() == "ax.text"
 
-    tool.operation_list.setCurrentRow(4)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(4))
     tool._select_step_section("method")
     grid_visible_combo = tool.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodGridVisibleCombo"
@@ -1219,7 +1219,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
 
     scale_names = tuple(mscale.get_scale_names())
     assert "log" in scale_names
-    tool.operation_list.setCurrentRow(6)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(6))
     tool._select_step_section("method")
     xscale_combo = tool.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodXScaleCombo"
@@ -1232,7 +1232,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     assert xscale_combo.currentText() == "log"
     assert tool.tool_status.operations[6].method_args == ()
 
-    tool.operation_list.setCurrentRow(7)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(7))
     tool._select_step_section("method")
     yscale_combo = tool.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodYScaleCombo"
@@ -1246,7 +1246,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     _activate_combo_text(yscale_combo, y_scale)
     assert tool.tool_status.operations[7].method_args == (y_scale,)
 
-    tool.operation_list.setCurrentRow(8)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(8))
     tool._select_step_section("method")
     title_edit = tool.findChild(
         QtWidgets.QPlainTextEdit, "figureComposerAxesMethodTitleEdit"
@@ -1264,7 +1264,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     assert title_loc_combo.currentText() == "left"
     assert title_pad_edit.value() == 2.0
 
-    tool.operation_list.setCurrentRow(11)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(11))
     tool._select_step_section("method")
     x_margin_edit = tool.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerAxesMethodXMarginEdit"
@@ -1282,7 +1282,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     assert y_margin_edit.value() == pytest.approx(0.2)
     assert tight_combo.currentText() == "False"
 
-    tool.operation_list.setCurrentRow(12)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(12))
     tool._select_step_section("method")
     aspect_edit = tool.findChild(
         QtWidgets.QLineEdit, "figureComposerAxesMethodAspectEdit"
@@ -1298,7 +1298,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     aspect_edit.editingFinished.emit()
     assert tool.tool_status.operations[12].method_args == (2.5,)
 
-    tool.operation_list.setCurrentRow(13)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(13))
     tool._select_step_section("method")
     tick_editor = tool.findChild(
         figurecomposer_tick_params.TickParamsEditorWidget,
@@ -1481,7 +1481,7 @@ def test_figure_composer_axes_plot_method_render_and_codegen(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("method")
     method_page = tool.step_editor_stack.currentWidget()
     method_combo = method_page.findChild(
@@ -1557,7 +1557,7 @@ def test_figure_composer_axes_plot_method_render_and_codegen(qtbot) -> None:
     assert tool.tool_status.operations[0].method_kwargs["clip_on"] is True
     assert tool.tool_status.operations[0].method_kwargs["transform"] == "ignored"
 
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool._select_step_section("method")
     method_page = tool.step_editor_stack.currentWidget()
     custom_transform_edit = method_page.findChild(
@@ -1650,7 +1650,7 @@ def test_figure_composer_axes_errorbar_method_render_and_codegen(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("method")
     method_page = tool.step_editor_stack.currentWidget()
     method_combo = method_page.findChild(
@@ -1814,7 +1814,7 @@ def test_figure_composer_axes_plot_data_mode_switches_editor(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("method")
     method_page = tool.step_editor_stack.currentWidget()
     mode_combo = method_page.findChild(
@@ -3006,7 +3006,7 @@ def test_figure_composer_method_selector_preserves_compatible_values(qtbot) -> N
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("method")
 
     method_page = tool.step_editor_stack.currentWidget()
@@ -3437,7 +3437,7 @@ def test_figure_composer_method_text_args_accept_real_newlines(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("method")
     label_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QPlainTextEdit, "figureComposerAxesMethodXLabelEdit"
@@ -3618,9 +3618,9 @@ def test_figure_composer_figure_method_has_no_axes_target(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     assert "axes" not in tool.step_section_buttons
-    assert tool.operation_list.item(0).text() == "fig.supxlabel"
+    assert tool.operation_list.topLevelItem(0).text(0) == "fig.supxlabel"
     assert tool.step_section_buttons["method"].text() == "fig.supxlabel"
 
     fig = tool.figure
@@ -3666,7 +3666,9 @@ def test_figure_composer_figure_layout_methods_render_and_codegen(qtbot) -> None
     )
     qtbot.addWidget(adjust_tool)
 
-    adjust_tool.operation_list.setCurrentRow(0)
+    adjust_tool.operation_list.setCurrentItem(
+        adjust_tool.operation_list.topLevelItem(0)
+    )
     adjust_tool._select_step_section("method")
     adjust_page = adjust_tool.step_editor_stack.currentWidget()
     left_spin = adjust_page.findChild(
@@ -3701,7 +3703,9 @@ def test_figure_composer_figure_layout_methods_render_and_codegen(qtbot) -> None
         ),
     )
     qtbot.addWidget(default_tool)
-    default_tool.operation_list.setCurrentRow(0)
+    default_tool.operation_list.setCurrentItem(
+        default_tool.operation_list.topLevelItem(0)
+    )
     default_tool._select_step_section("method")
     default_page = default_tool.step_editor_stack.currentWidget()
     default_left_spin = default_page.findChild(
@@ -3750,7 +3754,9 @@ def test_figure_composer_figure_layout_methods_render_and_codegen(qtbot) -> None
     )
     qtbot.addWidget(engine_tool)
 
-    engine_tool.operation_list.setCurrentRow(0)
+    engine_tool.operation_list.setCurrentItem(
+        engine_tool.operation_list.topLevelItem(0)
+    )
     engine_tool._select_step_section("method")
     engine_page = engine_tool.step_editor_stack.currentWidget()
     engine_combo = engine_page.findChild(
@@ -3955,7 +3961,7 @@ def test_figure_composer_legend_methods_render_and_codegen(qtbot) -> None:
     assert columns_edit.value() == 1
     assert title_edit.text() == "Axis legend"
 
-    tool.operation_list.setCurrentRow(2)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(2))
     tool._select_step_section("method")
     assert "axes" not in tool.step_section_buttons
     figure_loc_combo = tool.findChild(
@@ -4053,7 +4059,7 @@ def test_figure_composer_colorbar_method_target_policy(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool._select_step_section("method")
     policy_combo = tool.findChild(
         QtWidgets.QComboBox, "figureComposerMethodCallPolicyCombo"
@@ -4153,7 +4159,7 @@ def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
     qtbot.addWidget(tool)
 
     def select_method(row: int) -> QtWidgets.QWidget:
-        tool.operation_list.setCurrentRow(row)
+        tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(row))
         tool._select_step_section("method")
         page = tool.step_editor_stack.currentWidget()
         assert page is not None
@@ -4516,7 +4522,7 @@ def test_figure_composer_erlab_method_allows_empty_text_values(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("method")
     title_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QPlainTextEdit
@@ -4525,7 +4531,7 @@ def test_figure_composer_erlab_method_allows_empty_text_values(qtbot) -> None:
     title_edit.setPlainText("Left\n")
     assert tool.tool_status.operations[0].text_values == ("Left", "")
 
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool._select_step_section("method")
     xlabel_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QPlainTextEdit
@@ -4567,17 +4573,19 @@ def test_figure_composer_method_draw_time_text_error_is_non_modal(qtbot) -> None
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
 
     tool._redraw_plot(show_window=True)
 
     render_error = tool._operation_render_errors[title_operation.operation_id]
     assert "ValueError" in render_error
     assert "ParseException" in render_error
-    item = tool.operation_list.item(1)
+    item = tool.operation_list.topLevelItem(1)
     assert item is not None
-    assert "(render error)" in item.text()
-    assert "ParseException" in item.toolTip()
+    assert _operation_status_codes(tool, 1) == ("render_error",)
+    assert "ParseException" in item.toolTip(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN
+    )
 
     tool._replace_operation(
         1,
@@ -4586,6 +4594,6 @@ def test_figure_composer_method_draw_time_text_error_is_non_modal(qtbot) -> None
     tool._redraw_plot(show_window=True)
 
     assert title_operation.operation_id not in tool._operation_render_errors
-    item = tool.operation_list.item(1)
+    item = tool.operation_list.topLevelItem(1)
     assert item is not None
-    assert "(render error)" not in item.text()
+    assert _operation_status_codes(tool, 1) == ()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -1184,7 +1184,9 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     transform_combo = tool.findChild(
         QtWidgets.QComboBox, "figureComposerMethodTransformModeCombo"
     )
-    text_edit = tool.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodTextEdit")
+    text_edit = tool.findChild(
+        QtWidgets.QPlainTextEdit, "figureComposerAxesMethodTextEdit"
+    )
     kwargs_edit = tool.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
     assert method_combo is not None
     assert transform_combo is not None
@@ -1193,7 +1195,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     assert method_combo.currentText() == "text"
     assert method_combo.currentData() == "text"
     assert transform_combo.currentText() == "axes"
-    assert text_edit.text() == "Panel"
+    assert text_edit.toPlainText() == "Panel"
     assert kwargs_edit.text() == 'ha="left", va="top"'
     assert tool.step_section_buttons["method"].text() == "ax.text"
 
@@ -1247,7 +1249,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     tool.operation_list.setCurrentRow(8)
     tool._select_step_section("method")
     title_edit = tool.findChild(
-        QtWidgets.QLineEdit, "figureComposerAxesMethodTitleEdit"
+        QtWidgets.QPlainTextEdit, "figureComposerAxesMethodTitleEdit"
     )
     title_loc_combo = tool.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodTitleLocCombo"
@@ -1258,7 +1260,7 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     assert title_edit is not None
     assert title_loc_combo is not None
     assert title_pad_edit is not None
-    assert title_edit.text() == "Left title"
+    assert title_edit.toPlainText() == "Left title"
     assert title_loc_combo.currentText() == "left"
     assert title_pad_edit.value() == 2.0
 
@@ -3395,23 +3397,67 @@ def test_figure_composer_batch_same_method_edits_selected_steps(qtbot) -> None:
     tool._select_step_section("method")
     method_page = tool.step_editor_stack.currentWidget()
     title_edit = method_page.findChild(
-        QtWidgets.QLineEdit, "figureComposerAxesMethodTitleEdit"
+        QtWidgets.QPlainTextEdit, "figureComposerAxesMethodTitleEdit"
     )
     assert title_edit is not None
-    assert title_edit.text() == ""
+    assert title_edit.toPlainText() == ""
     assert title_edit.placeholderText() == "(multiple values)"
 
-    title_edit.editingFinished.emit()
+    title_edit.textChanged.emit()
     assert tool.tool_status.operations[0].method_args == ("left",)
     assert tool.tool_status.operations[1].method_args == ("right",)
 
-    title_edit.setText("shared")
-    title_edit.setModified(True)
-    title_edit.editingFinished.emit()
+    title_edit.setPlainText("shared")
     assert tool.tool_status.operations[0].method_args == ("shared",)
     assert tool.tool_status.operations[1].method_args == ("shared",)
     assert tool.tool_status.operations[2].method_args == ("unchanged",)
     assert _selected_operation_rows(tool) == (0, 1)
+
+
+def test_figure_composer_method_text_args_accept_real_newlines(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="set_xlabel",
+                    args=(r"h\nu",),
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("method")
+    label_edit = tool.step_editor_stack.currentWidget().findChild(
+        QtWidgets.QPlainTextEdit, "figureComposerAxesMethodXLabelEdit"
+    )
+    assert label_edit is not None
+    assert label_edit.toPlainText() == r"h\nu"
+
+    label_edit.setPlainText("Energy\n(eV)")
+    assert tool.tool_status.operations[0].method_args == ("Energy\n(eV)",)
+    restored_status = FigureRecipeState.model_validate_json(
+        tool.tool_status.model_dump_json()
+    )
+    assert restored_status.operations[0].method_args == ("Energy\n(eV)",)
+
+    namespace: dict[str, typing.Any] = {"data": data}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    assert namespace["fig"].axes[0].get_xlabel() == "Energy\n(eV)"
+
+    label_edit.setPlainText(r"h\nu")
+    assert tool.tool_status.operations[0].method_args == (r"h\nu",)
 
 
 def test_figure_composer_batch_same_plot_method_edits_selected_steps(qtbot) -> None:
@@ -3543,7 +3589,7 @@ def test_figure_composer_batch_incompatible_methods_disable_editor(qtbot) -> Non
     )
     assert (
         tool.step_editor_stack.currentWidget().findChild(
-            QtWidgets.QLineEdit, "figureComposerAxesMethodTitleEdit"
+            QtWidgets.QPlainTextEdit, "figureComposerAxesMethodTitleEdit"
         )
         is None
     )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -4497,3 +4497,49 @@ def test_figure_composer_erlab_method_allows_empty_text_values(qtbot) -> None:
     assert axs[0, 1].get_xlabel() == ""
     assert axs[0, 0].get_ylabel() == ""
     assert axs[0, 1].get_ylabel() == ""
+
+
+def test_figure_composer_method_draw_time_text_error_is_non_modal(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    plot_operation = FigureOperationState.plot_array(label="plot", source="data")
+    title_operation = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name="set_titles",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+    ).model_copy(update={"text_values": ("ALS, $$39.3 eV",)})
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(plot_operation, title_operation),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(1)
+
+    tool._redraw_plot(show_window=True)
+
+    render_error = tool._operation_render_errors[title_operation.operation_id]
+    assert "ValueError" in render_error
+    assert "ParseException" in render_error
+    item = tool.operation_list.item(1)
+    assert item is not None
+    assert "(render error)" in item.text()
+    assert "ParseException" in item.toolTip()
+
+    tool._replace_operation(
+        1,
+        title_operation.model_copy(update={"text_values": ("ALS, $39.3$ eV",)}),
+    )
+    tool._redraw_plot(show_window=True)
+
+    assert title_operation.operation_id not in tool._operation_render_errors
+    item = tool.operation_list.item(1)
+    assert item is not None
+    assert "(render error)" not in item.text()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
@@ -9,7 +9,7 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     )
     tool = _bz_tool(operation)
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
 
     tool._select_step_section("slice")
     page = tool.step_editor_stack.currentWidget()
@@ -360,7 +360,7 @@ def test_figure_composer_bz_overlay_helper_edges(qtbot, monkeypatch) -> None:
     )
     figurecomposer_bz_overlay._render_bz_overlay(tool, operation, None)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     created = figurecomposer_bz_overlay._create_operation(tool)
     assert created.kind == FigureOperationKind.BZ_OVERLAY
     assert figurecomposer_bz_overlay._section_summary(tool, "unknown", operation) == ""
@@ -593,7 +593,7 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
         extra_source_data={"other_kconv": other_data},
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
 
     source_combo = next(
         (
@@ -1065,7 +1065,7 @@ def test_figure_composer_photon_energy_overlay_add_step_seeds_source_and_binding
         primary_source="hvdep_kconv",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
 
     action = next(
         action
@@ -1117,7 +1117,7 @@ def test_figure_composer_photon_energy_overlay_seed_fallbacks(qtbot) -> None:
         primary_source="hvdep_kconv",
     )
     qtbot.addWidget(line_tool)
-    line_tool.operation_list.setCurrentRow(0)
+    line_tool.operation_list.setCurrentItem(line_tool.operation_list.topLevelItem(0))
 
     assert figurecomposer_photon_energy._seed_source(line_tool) == "hvdep_kconv"
     assert figurecomposer_photon_energy._seed_binding_energy(line_tool) is None

--- a/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
@@ -1158,9 +1158,10 @@ def test_figure_composer_photon_energy_overlay_tracks_source_ownership(
     source_tool.copy_operation_button.click()
     payload = source_tool._clipboard_step_payload()
     assert payload is not None
-    _operations, sources, source_data = payload
+    _operations, sources, source_data, selection_base_data = payload
     assert [source.name for source in sources] == ["hvdep_kconv"]
     xr.testing.assert_identical(source_data["hvdep_kconv"], data)
+    assert selection_base_data == {}
 
     destination._paste_operations_from_clipboard()
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
@@ -69,7 +69,7 @@ def test_figure_composer_plot_array_source_selector_clears_legacy_selection(
         primary_source="first_source",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("sources")
 
     combo = next(
@@ -260,13 +260,13 @@ def test_figure_composer_source_keep_clears_stale_qsel_input_error(
     qsel_edit = _source_selection_edit(tool, "eV", "value")
     qsel_edit.setText("")
     qsel_edit.editingFinished.emit()
-    assert "selection value" in tool.source_status_label.text()
+    assert "selection value" in tool.source_validation_label.text()
 
     _activate_source_selection_mode(tool, "eV", "keep")
 
     [source] = tool.source_states()
     assert source.qsel == {}
-    assert tool.source_status_label.text() == ""
+    assert tool.source_validation_label.text() == ""
 
 
 def test_figure_composer_source_qsel_width_editor_updates_selection(
@@ -471,7 +471,7 @@ def test_figure_composer_plot_array_selection_error_is_visible(qtbot) -> None:
         tool, normalized_operation
     )
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     assert "selection" not in tool.step_section_buttons
 
 
@@ -491,7 +491,7 @@ def test_figure_composer_plot_array_has_no_operation_selection_page(qtbot) -> No
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     assert tuple(tool.step_section_buttons) == (
         "sources",
         "axes",
@@ -538,7 +538,7 @@ def test_figure_composer_plot_array_colormap_activation_updates_recipe(
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("colors")
 
     cmap_combo = next(
@@ -583,7 +583,7 @@ def test_figure_composer_plot_array_colorcet_selection_uses_matplotlib_name(
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("colors")
 
     cmap_combo = next(
@@ -645,7 +645,7 @@ def test_figure_composer_plot_array_default_colormap_editor_uses_stylesheet(
             primary_source="data",
         )
         qtbot.addWidget(tool)
-        tool.operation_list.setCurrentRow(0)
+        tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
         tool._select_step_section("colors")
 
         cmap_combo = next(
@@ -708,7 +708,7 @@ def test_figure_composer_plot_array_colormap_editor_initialization_edges(
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("colors")
     cmap_combo = next(
         (
@@ -732,7 +732,9 @@ def test_figure_composer_plot_array_colormap_editor_initialization_edges(
         primary_source="data",
     )
     qtbot.addWidget(missing_cmap_tool)
-    missing_cmap_tool.operation_list.setCurrentRow(0)
+    missing_cmap_tool.operation_list.setCurrentItem(
+        missing_cmap_tool.operation_list.topLevelItem(0)
+    )
     missing_cmap_tool._select_step_section("colors")
     assert (
         missing_cmap_tool.findChild(
@@ -911,7 +913,7 @@ def test_figure_composer_plot_array_aspect_control_updates_recipe(qtbot) -> None
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("view")
 
     aspect_combo = next(
@@ -974,7 +976,7 @@ def test_figure_composer_plot_array_aspect_control_preserves_saved_custom_value(
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("view")
 
     aspect_combo = next(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
@@ -153,7 +153,7 @@ def test_figure_composer_source_selection_editor_updates_source_snapshot(
     assert source.qsel == {"eV": 1.0}
     assert source.isel == {}
     assert source.mean_dims == ()
-    assert source.selection_source == "data"
+    assert source.selection_source is None
     xr.testing.assert_identical(tool.source_data()["data"], data.qsel(eV=1.0))
     assert tool.tool_status.operations[0].map_selections == ()
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
@@ -3,7 +3,53 @@
 from ._common import *
 
 
-def test_figure_composer_plot_array_source_selector_updates_selection(qtbot) -> None:
+def _source_selection_widget(
+    tool: FigureComposerTool,
+    widget_type: type[QtWidgets.QWidget],
+    dim: str,
+    *,
+    field: str | None = None,
+) -> QtWidgets.QWidget:
+    widget = next(
+        (
+            candidate
+            for candidate in tool.source_selection_controls.findChildren(widget_type)
+            if not candidate.signalsBlocked()
+            if candidate.property("figure_composer_source_selection_dim") == dim
+            if field is None
+            or candidate.property("figure_composer_source_selection_field") == field
+        ),
+        None,
+    )
+    assert widget is not None
+    return widget
+
+
+def _source_selection_edit(
+    tool: FigureComposerTool, dim: str, field: str
+) -> QtWidgets.QLineEdit:
+    return typing.cast(
+        "QtWidgets.QLineEdit",
+        _source_selection_widget(tool, QtWidgets.QLineEdit, dim, field=field),
+    )
+
+
+def _activate_source_selection_mode(
+    tool: FigureComposerTool, dim: str, mode: str
+) -> None:
+    combo = typing.cast(
+        "QtWidgets.QComboBox",
+        _source_selection_widget(tool, QtWidgets.QComboBox, dim),
+    )
+    index = combo.findData(mode)
+    assert index >= 0
+    combo.setCurrentIndex(index)
+    combo.activated.emit(index)
+
+
+def test_figure_composer_plot_array_source_selector_clears_legacy_selection(
+    qtbot,
+) -> None:
     first = _figure_composer_image_source("first")
     second = _figure_composer_image_source("second")
     operation = FigureOperationState.plot_array(
@@ -45,12 +91,12 @@ def test_figure_composer_plot_array_source_selector_updates_selection(qtbot) -> 
 
     updated = tool.tool_status.operations[0]
     assert updated.sources == ("second_source",)
-    assert updated.map_selections == (
-        FigureDataSelectionState(source="second_source", qsel={"eV": 0.0}),
-    )
+    assert updated.map_selections == ()
 
 
-def test_figure_composer_plot_array_selection_editor_updates_selection(qtbot) -> None:
+def test_figure_composer_source_selection_editor_updates_source_snapshot(
+    qtbot,
+) -> None:
     data = xr.DataArray(
         np.arange(24.0).reshape(2, 3, 2, 2),
         dims=("hv", "eV", "beta", "alpha"),
@@ -62,17 +108,7 @@ def test_figure_composer_plot_array_selection_editor_updates_selection(qtbot) ->
         },
         name="map",
     )
-    operation = FigureOperationState.plot_array(
-        label="plot_array",
-        source="data",
-        map_selections=(
-            FigureDataSelectionState(
-                source="data",
-                qsel={"eV": 0.0},
-                mean_dims=("hv",),
-            ),
-        ),
-    )
+    operation = FigureOperationState.plot_array(label="plot_array", source="data")
     tool = FigureComposerTool.from_sources(
         {"data": data},
         sources=(FigureSourceState(name="data", label="data"),),
@@ -80,104 +116,48 @@ def test_figure_composer_plot_array_selection_editor_updates_selection(qtbot) ->
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("selection")
-
-    def current_dimension_widget(
-        widget_type: type[QtWidgets.QWidget], dim: str
-    ) -> QtWidgets.QWidget:
-        widget = next(
-            (
-                candidate
-                for candidate in tool.findChildren(widget_type)
-                if candidate.property("figure_composer_plot_array_dim") == dim
-                if candidate.property("figure_composer_editor_generation")
-                == tool._operation_editor_generation
-            ),
-            None,
-        )
-        assert widget is not None
-        return widget
-
-    def activate_dimension_mode(dim: str, mode: str) -> None:
-        combo = typing.cast(
-            "QtWidgets.QComboBox",
-            current_dimension_widget(QtWidgets.QComboBox, dim),
-        )
-        index = combo.findData(mode)
-        assert index >= 0
-        combo.setCurrentIndex(index)
-        combo.activated.emit(index)
-
-    def current_dimension_value(dim: str) -> QtWidgets.QLineEdit:
-        return typing.cast(
-            "QtWidgets.QLineEdit",
-            current_dimension_widget(QtWidgets.QLineEdit, dim),
-        )
-
-    summary = tool.findChild(
-        QtWidgets.QLabel, "figureComposerPlotArraySelectionSummary"
-    )
-    assert summary is not None
-    assert "Input dims: hv, eV, beta, alpha" in summary.text()
-    assert "Plotted dims: beta, alpha" in summary.text()
+    tool.editor_tabs.setCurrentWidget(tool.sources_page)
 
     eV_mode = typing.cast(
         "QtWidgets.QComboBox",
-        current_dimension_widget(QtWidgets.QComboBox, "eV"),
+        _source_selection_widget(tool, QtWidgets.QComboBox, "eV"),
     )
-    assert eV_mode.currentData() == "qsel"
-    qsel_edit = current_dimension_value("eV")
+    assert eV_mode.currentData() == "keep"
+    _activate_source_selection_mode(tool, "eV", "qsel")
+    qsel_edit = _source_selection_edit(tool, "eV", "value")
     qsel_edit.setText("1.0")
-    qsel_edit.setModified(True)
     qsel_edit.editingFinished.emit()
 
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(
-            source="data",
-            qsel={"eV": 1.0},
-            mean_dims=("hv",),
-        ),
-    )
+    [source] = tool.source_states()
+    assert source.qsel == {"eV": 1.0}
+    assert source.isel == {}
+    assert source.mean_dims == ()
+    assert source.selection_source == "data"
+    xr.testing.assert_identical(tool.source_data()["data"], data.qsel(eV=1.0))
+    assert tool.tool_status.operations[0].map_selections == ()
 
-    activate_dimension_mode("eV", "isel")
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(
-            source="data",
-            isel={"eV": 1.0},
-            mean_dims=("hv",),
-        ),
-    )
-    activate_dimension_mode("eV", "qsel")
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(
-            source="data",
-            qsel={"eV": 1.0},
-            mean_dims=("hv",),
-        ),
-    )
+    _activate_source_selection_mode(tool, "eV", "isel")
+    isel_eV_edit = _source_selection_edit(tool, "eV", "value")
+    isel_eV_edit.setText("1")
+    isel_eV_edit.editingFinished.emit()
+    [source] = tool.source_states()
+    assert source.isel == {"eV": 1}
+    assert source.qsel == {}
 
-    activate_dimension_mode("hv", "keep")
-    activate_dimension_mode("hv", "isel")
-    isel_edit = current_dimension_value("hv")
+    _activate_source_selection_mode(tool, "hv", "isel")
+    isel_edit = _source_selection_edit(tool, "hv", "value")
     isel_edit.setText("1")
-    isel_edit.setModified(True)
     isel_edit.editingFinished.emit()
 
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(
-            source="data",
-            isel={"hv": 1},
-            qsel={"eV": 1.0},
-        ),
+    [source] = tool.source_states()
+    assert source.isel == {"eV": 1, "hv": 1}
+    xr.testing.assert_identical(
+        tool.source_data()["data"],
+        data.isel(eV=1, hv=1),
     )
 
 
-def test_figure_composer_plot_array_qsel_to_keep_clears_selection(qtbot) -> None:
+def test_figure_composer_source_qsel_to_keep_clears_selection(qtbot) -> None:
     data = xr.DataArray(
         np.arange(12.0).reshape(3, 2, 2),
         dims=("eV", "beta", "alpha"),
@@ -196,65 +176,36 @@ def test_figure_composer_plot_array_qsel_to_keep_clears_selection(qtbot) -> None
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("selection")
+    tool.editor_tabs.setCurrentWidget(tool.sources_page)
 
-    def current_dimension_widget(
-        widget_type: type[QtWidgets.QWidget], dim: str
-    ) -> QtWidgets.QWidget:
-        widget = next(
-            (
-                candidate
-                for candidate in tool.findChildren(widget_type)
-                if candidate.property("figure_composer_plot_array_dim") == dim
-                if candidate.property("figure_composer_editor_generation")
-                == tool._operation_editor_generation
-            ),
-            None,
-        )
-        assert widget is not None
-        return widget
-
-    def activate_dimension_mode(dim: str, mode: str) -> None:
-        combo = typing.cast(
-            "QtWidgets.QComboBox",
-            current_dimension_widget(QtWidgets.QComboBox, dim),
-        )
-        index = combo.findData(mode)
-        assert index >= 0
-        combo.setCurrentIndex(index)
-        combo.activated.emit(index)
-
-    activate_dimension_mode("eV", "qsel")
-    qsel_edit = typing.cast(
-        "QtWidgets.QLineEdit",
-        current_dimension_widget(QtWidgets.QLineEdit, "eV"),
-    )
+    _activate_source_selection_mode(tool, "eV", "qsel")
+    qsel_edit = _source_selection_edit(tool, "eV", "value")
     assert qsel_edit.isEnabled()
-    assert not _plot_array_dimension_edit(tool, "eV", "value").isHidden()
-    assert not _plot_array_dimension_edit(tool, "eV", "width").isHidden()
+    assert not _source_selection_edit(tool, "eV", "value").isHidden()
+    assert not _source_selection_edit(tool, "eV", "width").isHidden()
     qsel_edit.setText("0.0")
-    qsel_edit.setModified(True)
     qsel_edit.editingFinished.emit()
 
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(source="data", qsel={"eV": 0.0}),
-    )
+    [source] = tool.source_states()
+    assert source.qsel == {"eV": 0.0}
+    xr.testing.assert_identical(tool.source_data()["data"], data.qsel(eV=0.0))
 
-    activate_dimension_mode("eV", "keep")
+    _activate_source_selection_mode(tool, "eV", "keep")
 
-    updated = tool.tool_status.operations[0]
-    assert updated.sources == ("data",)
-    assert updated.map_selections == ()
-    value_edit = _plot_array_dimension_edit(tool, "eV", "value")
-    width_edit = _plot_array_dimension_edit(tool, "eV", "width")
+    [source] = tool.source_states()
+    assert source.isel == {}
+    assert source.qsel == {}
+    assert source.mean_dims == ()
+    assert source.selection_source is None
+    xr.testing.assert_identical(tool.source_data()["data"], data)
+    value_edit = _source_selection_edit(tool, "eV", "value")
+    width_edit = _source_selection_edit(tool, "eV", "width")
     assert value_edit.isHidden()
     assert width_edit.isHidden()
     assert value_edit.text() == ""
 
 
-def test_figure_composer_plot_array_keep_clears_stale_qsel_input_error(
+def test_figure_composer_source_keep_clears_stale_qsel_input_error(
     qtbot,
 ) -> None:
     data = xr.DataArray(
@@ -275,35 +226,29 @@ def test_figure_composer_plot_array_keep_clears_stale_qsel_input_error(
         primary_source="data",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("selection")
+    tool.editor_tabs.setCurrentWidget(tool.sources_page)
 
-    _activate_plot_array_dimension_mode(tool, "eV", "qsel")
-    qsel_edit = _plot_array_dimension_edit(tool, "eV", "value")
+    _activate_source_selection_mode(tool, "eV", "qsel")
+    qsel_edit = _source_selection_edit(tool, "eV", "value")
     qsel_edit.setText("slice(-0.5, 0.5)")
-    qsel_edit.setModified(True)
     qsel_edit.editingFinished.emit()
 
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(source="data", qsel={"eV": slice(-0.5, 0.5)}),
-    )
+    [source] = tool.source_states()
+    assert source.qsel == {"eV": slice(-0.5, 0.5)}
 
-    qsel_edit = _plot_array_dimension_edit(tool, "eV", "value")
+    qsel_edit = _source_selection_edit(tool, "eV", "value")
     qsel_edit.setText("")
-    qsel_edit.setModified(True)
     qsel_edit.editingFinished.emit()
-    assert tool._operation_input_errors
+    assert "selection value" in tool.source_status_label.text()
 
-    _activate_plot_array_dimension_mode(tool, "eV", "keep")
+    _activate_source_selection_mode(tool, "eV", "keep")
 
-    updated = tool.tool_status.operations[0]
-    assert updated.sources == ("data",)
-    assert updated.map_selections == ()
-    assert tool._operation_input_errors == {}
+    [source] = tool.source_states()
+    assert source.qsel == {}
+    assert tool.source_status_label.text() == ""
 
 
-def test_figure_composer_plot_array_qsel_width_editor_updates_selection(
+def test_figure_composer_source_qsel_width_editor_updates_selection(
     qtbot,
 ) -> None:
     data = _figure_composer_image_source("data")
@@ -325,19 +270,30 @@ def test_figure_composer_plot_array_qsel_width_editor_updates_selection(
     )
     qtbot.addWidget(tool)
 
-    selected = figurecomposer_plot_array._safe_selected_plot_array_data(tool, operation)
+    normalized_operation = tool.tool_status.operations[0]
+    assert normalized_operation.sources == ("data_selected",)
+    assert normalized_operation.map_selections == ()
+    [raw_source, selected_source] = tool.source_states()
+    assert raw_source.name == "data"
+    assert selected_source.name == "data_selected"
+    assert selected_source.qsel == {"eV": 0.0, "eV_width": 0.2}
+    assert selected_source.selection_source == "data"
+    selected = figurecomposer_plot_array._safe_selected_plot_array_data(
+        tool, normalized_operation
+    )
     assert selected is not None
     xr.testing.assert_identical(selected, data.qsel(eV=0.0, eV_width=0.2))
-    assert "data.qsel(eV=0.0, eV_width=0.2)" in tool.generated_code()
+    assert "data_selected = data.qsel(eV=0.0, eV_width=0.2)" in tool.generated_code()
 
-    tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("selection")
+    tool.editor_tabs.setCurrentWidget(tool.sources_page)
+    tool._select_source_list_row_silent("data_selected")
+    tool._refresh_source_selection_editor()
     mode_combo = typing.cast(
         "QtWidgets.QComboBox",
-        _plot_array_dimension_widget(tool, QtWidgets.QComboBox, "eV"),
+        _source_selection_widget(tool, QtWidgets.QComboBox, "eV"),
     )
-    value_edit = _plot_array_dimension_edit(tool, "eV", "value")
-    width_edit = _plot_array_dimension_edit(tool, "eV", "width")
+    value_edit = _source_selection_edit(tool, "eV", "value")
+    width_edit = _source_selection_edit(tool, "eV", "width")
     assert not value_edit.isHidden()
     assert not width_edit.isHidden()
     assert value_edit.text() == "0.0"
@@ -348,44 +304,122 @@ def test_figure_composer_plot_array_qsel_width_editor_updates_selection(
     assert len({mode_combo.toolTip(), value_edit.toolTip(), width_edit.toolTip()}) == 3
 
     width_edit.setText("0.5")
-    width_edit.setModified(True)
     width_edit.editingFinished.emit()
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(
-            source="data",
-            qsel={"eV": 0.0, "eV_width": 0.5},
-        ),
+    selected_source = tool.source_states()[1]
+    assert selected_source.qsel == {"eV": 0.0, "eV_width": 0.5}
+    xr.testing.assert_identical(
+        tool.source_data()["data_selected"],
+        data.qsel(eV=0.0, eV_width=0.5),
     )
 
-    _activate_plot_array_dimension_mode(tool, "eV", "isel")
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(source="data", isel={"eV": 0.0}),
-    )
-    assert not _plot_array_dimension_edit(tool, "eV", "value").isHidden()
-    assert _plot_array_dimension_edit(tool, "eV", "width").isHidden()
+    _activate_source_selection_mode(tool, "eV", "isel")
+    value_edit = _source_selection_edit(tool, "eV", "value")
+    value_edit.setText("1")
+    value_edit.editingFinished.emit()
+    selected_source = tool.source_states()[1]
+    assert selected_source.isel == {"eV": 1}
+    assert not _source_selection_edit(tool, "eV", "value").isHidden()
+    assert _source_selection_edit(tool, "eV", "width").isHidden()
 
-    _activate_plot_array_dimension_mode(tool, "eV", "qsel")
-    width_edit = _plot_array_dimension_edit(tool, "eV", "width")
+    _activate_source_selection_mode(tool, "eV", "qsel")
+    value_edit = _source_selection_edit(tool, "eV", "value")
+    value_edit.setText("0.0")
+    value_edit.editingFinished.emit()
+    width_edit = _source_selection_edit(tool, "eV", "width")
     width_edit.setText("0.1")
-    width_edit.setModified(True)
     width_edit.editingFinished.emit()
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(
-            source="data",
-            qsel={"eV": 0.0, "eV_width": 0.1},
-        ),
+    selected_source = tool.source_states()[1]
+    assert selected_source.qsel == {"eV": 0.0, "eV_width": 0.1}
+
+    _activate_source_selection_mode(tool, "eV", "mean")
+    selected_source = tool.source_states()[1]
+    assert selected_source.mean_dims == ("eV",)
+    assert _source_selection_edit(tool, "eV", "value").isHidden()
+    assert _source_selection_edit(tool, "eV", "width").isHidden()
+
+
+def test_figure_composer_plot_array_add_operation_promotes_selection_to_source(
+    qtbot,
+) -> None:
+    first = _figure_composer_image_source("data_3")
+    second = _figure_composer_image_source("data_4")
+    initial_operation = FigureOperationState.plot_array(
+        label="plot_array",
+        source="data_3",
+        map_selections=(FigureDataSelectionState(source="data_3", qsel={"eV": 0.0}),),
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data_3": first},
+        sources=(FigureSourceState(name="data_3", label="data_3"),),
+        operations=(initial_operation,),
+        primary_source="data_3",
+    )
+    qtbot.addWidget(tool)
+    tool.add_sources(
+        (FigureSourceState(name="data_4", label="data_4"),),
+        {"data_4": second},
+    )
+    tool.add_operation(
+        FigureOperationState.plot_array(
+            label="plot_array",
+            source="data_4",
+            map_selections=(
+                FigureDataSelectionState(source="data_4", qsel={"eV": 0.5}),
+            ),
+        )
     )
 
-    _activate_plot_array_dimension_mode(tool, "eV", "mean")
-    updated = tool.tool_status.operations[0]
-    assert updated.map_selections == (
-        FigureDataSelectionState(source="data", mean_dims=("eV",)),
+    data_4_source = next(
+        source for source in tool.source_states() if source.name == "data_4_selected"
     )
-    assert _plot_array_dimension_edit(tool, "eV", "value").isHidden()
-    assert _plot_array_dimension_edit(tool, "eV", "width").isHidden()
+    assert data_4_source.selection_source == "data_4"
+    assert data_4_source.qsel == {"eV": 0.5}
+    assert tool.tool_status.operations[-1].sources == ("data_4_selected",)
+    assert tool.tool_status.operations[-1].map_selections == ()
+    xr.testing.assert_identical(
+        tool.source_data()["data_4_selected"], second.qsel(eV=0.5)
+    )
+
+
+def test_figure_composer_restored_selected_source_applies_source_selection(
+    qtbot,
+) -> None:
+    data = _figure_composer_image_source("data_3")
+    selected_source = FigureSourceState(
+        name="data_3_selected",
+        label="data_3 selection",
+        selection_source="data_3",
+        qsel={"eV": 0.0},
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data_3": data, "data_3_selected": data.qsel(eV=0.0)},
+        sources=(
+            FigureSourceState(name="data_3", label="data_3"),
+            selected_source,
+        ),
+        operations=(
+            FigureOperationState.plot_array(
+                label="plot_array",
+                source="data_3_selected",
+            ),
+        ),
+        primary_source="data_3",
+    )
+    qtbot.addWidget(tool)
+
+    tool._restore_persistence_data_items(
+        {"data_3_selected": data},
+        xr.Dataset(),
+    )
+
+    xr.testing.assert_identical(
+        tool.source_data()["data_3_selected"], data.qsel(eV=0.0)
+    )
+    xr.testing.assert_identical(
+        tool._source_selection_base_data["data_3_selected"], data
+    )
+    assert tool.tool_status.operations[0].sources == ("data_3_selected",)
+    assert tool.tool_status.operations[0].map_selections == ()
 
 
 def test_figure_composer_plot_array_selection_error_is_visible(qtbot) -> None:
@@ -410,121 +444,17 @@ def test_figure_composer_plot_array_selection_error_is_visible(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    assert "invalid selection" in figurecomposer_plot_array._display_text(
-        tool, operation
+    normalized_operation = tool.tool_status.operations[0]
+    assert normalized_operation.map_selections == ()
+    assert "missing" in figurecomposer_plot_array._display_text(
+        tool, normalized_operation
     )
 
     tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("selection")
-
-    summary = tool.findChild(
-        QtWidgets.QLabel, "figureComposerPlotArraySelectionSummary"
-    )
-    assert summary is not None
-    assert "missing" in summary.text()
+    assert "selection" not in tool.step_section_buttons
 
 
-def test_figure_composer_plot_array_selection_helper_edges(qtbot) -> None:
-    data = xr.DataArray(
-        np.arange(4.0).reshape(2, 2),
-        dims=("y", "x"),
-        coords={"y": [0.0, 1.0], "x": [0.0, 1.0]},
-        name="map",
-    )
-    tool = FigureComposerTool.from_sources(
-        {"data": data},
-        sources=(FigureSourceState(name="data", label="data"),),
-        operations=(
-            FigureOperationState.plot_array(label="plot_array", source="data"),
-        ),
-        primary_source="data",
-    )
-    qtbot.addWidget(tool)
-    figurecomposer_plot_array._update_current_selection_source(tool, "data")
-    assert tool.tool_status.operations[0].sources == ("data",)
-    assert tool.tool_status.operations[0].map_selections == ()
-
-    missing_operation = FigureOperationState.plot_array(
-        label="missing", source="missing"
-    )
-    assert (
-        figurecomposer_plot_array._plot_array_source_data(tool, missing_operation)
-        is None
-    )
-    assert "missing" in figurecomposer_plot_array._display_text(tool, missing_operation)
-
-    no_update_tool = types.SimpleNamespace(
-        _update_operations=lambda *_args, **_kwargs: pytest.fail(
-            "None source should not update"
-        )
-    )
-    figurecomposer_plot_array._update_current_selection_source(
-        typing.cast("FigureComposerTool", no_update_tool),
-        None,
-    )
-    figurecomposer_plot_array._update_current_selection_dimension(
-        typing.cast("FigureComposerTool", no_update_tool),
-        "x",
-        "bad",
-    )
-
-    with pytest.raises(figurecomposer_text.FigureComposerInputError):
-        figurecomposer_plot_array._plot_array_selection_value_from_text("")
-    with pytest.raises(figurecomposer_text.FigureComposerInputError):
-        figurecomposer_plot_array._plot_array_selection_value_from_text("slice(")
-    with pytest.raises(figurecomposer_text.FigureComposerInputError):
-        figurecomposer_plot_array._plot_array_selection_width_from_text("slice(0, 1)")
-
-    selection = FigureDataSelectionState(
-        source="data",
-        isel={"x": 0},
-        qsel={"y": 0.0},
-    )
-    assert figurecomposer_plot_array._plot_array_selection_with_dimension(
-        selection,
-        "x",
-        "mean",
-    ) == FigureDataSelectionState(
-        source="data",
-        qsel={"y": 0.0},
-        mean_dims=("x",),
-    )
-    assert figurecomposer_plot_array._plot_array_selection_with_dimension(
-        FigureDataSelectionState(source="data"),
-        "x",
-        "isel",
-        slice(0, 2),
-    ) == FigureDataSelectionState(source="data", isel={"x": slice(0, 2)})
-
-    empty_selection = FigureDataSelectionState(
-        source="data",
-        qsel={"x": 0.0, "x_width": 0.1},
-    )
-    assert figurecomposer_plot_array._plot_array_selection_with_dimension(
-        empty_selection,
-        "x",
-        "keep",
-    ) == FigureDataSelectionState(source="data")
-    width_only = FigureDataSelectionState(source="data", qsel={"x_width": 0.1})
-    assert (
-        figurecomposer_plot_array._plot_array_selection_dim_mode(width_only, "x")
-        == "qsel"
-    )
-    assert (
-        figurecomposer_plot_array._plot_array_selection_dim_width_text(width_only, "x")
-        == "0.1"
-    )
-
-    combo = figurecomposer_plot_array._plot_array_selection_mode_combo(
-        tool,
-        current=None,
-        mixed=True,
-        parent=tool,
-    )
-    assert combo.currentData() is _editor_controls.MIXED_VALUE
-
-
-def test_figure_composer_plot_array_selection_page_empty_sources(qtbot) -> None:
+def test_figure_composer_plot_array_has_no_operation_selection_page(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
         dims=("y", "x"),
@@ -541,31 +471,12 @@ def test_figure_composer_plot_array_selection_page_empty_sources(qtbot) -> None:
     )
     qtbot.addWidget(tool)
     tool.operation_list.setCurrentRow(0)
-    tool._select_step_section("selection")
-    assert (
-        tool.findChild(
-            QtWidgets.QLabel,
-            "figureComposerPlotArraySelectionDimensionsMessage",
-        )
-        is not None
-    )
-
-    scalar = xr.DataArray(1.0, name="scalar")
-    scalar_tool = FigureComposerTool.from_sources(
-        {"scalar": scalar},
-        sources=(FigureSourceState(name="scalar", label="scalar"),),
-        operations=(FigureOperationState.plot_array(label="scalar", source="scalar"),),
-        primary_source="scalar",
-    )
-    qtbot.addWidget(scalar_tool)
-    scalar_tool.operation_list.setCurrentRow(0)
-    scalar_tool._select_step_section("selection")
-    assert (
-        scalar_tool.findChild(
-            QtWidgets.QLabel,
-            "figureComposerPlotArraySelectionDimensionsMessage",
-        )
-        is not None
+    assert tuple(tool.step_section_buttons) == (
+        "sources",
+        "axes",
+        "view",
+        "colors",
+        "advanced",
     )
 
     mixed_tool = FigureComposerTool.from_sources(
@@ -585,13 +496,12 @@ def test_figure_composer_plot_array_selection_page_empty_sources(qtbot) -> None:
     )
     qtbot.addWidget(mixed_tool)
     _select_operation_rows(mixed_tool, (0, 1))
-    mixed_tool._select_step_section("selection")
-    assert (
-        mixed_tool.findChild(
-            QtWidgets.QLabel,
-            "figureComposerPlotArraySelectionDimensionsMessage",
-        )
-        is not None
+    assert tuple(mixed_tool.step_section_buttons) == (
+        "sources",
+        "axes",
+        "view",
+        "colors",
+        "advanced",
     )
 
 
@@ -961,7 +871,8 @@ def test_figure_composer_plot_array_render_and_generated_code(
     assert kwargs["aspect"] == "equal"
 
     code = tool.generated_code()
-    assert "eplt.plot_array(data.qsel(eV=0.0).T" in code
+    assert "data_selected = data.qsel(eV=0.0)" in code
+    assert "eplt.plot_array(data_selected.T" in code
     namespace = _exec_generated_code(code, {"data": data})
     assert "fig" in namespace
 
@@ -1169,7 +1080,7 @@ def test_figure_composer_plot_array_codegen_handles_spaced_dimension(qtbot) -> N
     qtbot.addWidget(tool)
 
     code = tool.generated_code()
-    assert 'data.qsel(**{"Track Shift": 1.0})' in code
+    assert 'data_selected = data.qsel(**{"Track Shift": 1.0})' in code
     namespace = _exec_generated_code(code, {"data": data})
     assert "fig" in namespace
 
@@ -1245,7 +1156,7 @@ def test_figure_composer_plot_array_helper_edges(qtbot, monkeypatch) -> None:
             FigureDataSelectionState(source="derived", qsel={"beta": 0.0}),
         ),
     )
-    assert figurecomposer_plot_array._source_names(operation) == ("image", "derived")
+    assert figurecomposer_plot_array._source_names(operation) == ("image",)
 
     empty_operation = FigureOperationState(
         kind=FigureOperationKind.PLOT_ARRAY,
@@ -1262,8 +1173,7 @@ def test_figure_composer_plot_array_helper_edges(qtbot, monkeypatch) -> None:
 
     missing_selection = FigureOperationState.plot_array(
         label="missing",
-        source="image",
-        map_selections=(FigureDataSelectionState(source="missing", qsel={"eV": 0.0}),),
+        source="missing",
     )
     assert (
         figurecomposer_plot_array._selected_plot_array_data(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
@@ -94,6 +94,27 @@ def test_figure_composer_plot_array_source_selector_clears_legacy_selection(
     assert updated.map_selections == ()
 
 
+def test_figure_composer_plot_array_source_code_handles_missing_primary(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data"),),
+        operations=(FigureOperationState.plot_array(label="array", source="data"),),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    operation = tool.tool_status.operations[0].model_copy(update={"sources": ()})
+    monkeypatch.setattr(
+        figurecomposer_plot_array,
+        "_selected_plot_array_data",
+        lambda *_args, **_kwargs: data,
+    )
+
+    assert figurecomposer_plot_array._plot_array_source_code(tool, operation) is None
+
+
 def test_figure_composer_source_selection_editor_updates_source_snapshot(
     qtbot,
 ) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -12,7 +12,7 @@ def _plot_slices_selection_migration_data() -> xr.DataArray:
     )
 
 
-def test_figure_composer_plot_slices_migrates_single_map_selection_to_source_alias(
+def test_figure_composer_plot_slices_migrates_shared_map_selection_to_slice_state(
     qtbot,
 ) -> None:
     data = _plot_slices_selection_migration_data()
@@ -31,12 +31,12 @@ def test_figure_composer_plot_slices_migrates_single_map_selection_to_source_ali
     qtbot.addWidget(tool)
 
     [loaded_operation] = tool.tool_status.operations
-    assert loaded_operation.sources == ("first_selected",)
+    assert loaded_operation.sources == ("first",)
     assert loaded_operation.map_selections == ()
-    source_by_name = {source.name: source for source in tool.source_states()}
-    assert source_by_name["first_selected"].selection_source == "first"
-    assert source_by_name["first_selected"].qsel == {"y": 0.0}
-    xr.testing.assert_identical(tool.source_data()["first_selected"], data.qsel(y=0.0))
+    assert loaded_operation.slice_dim == "y"
+    assert loaded_operation.slice_values == (0.0,)
+    assert loaded_operation.slice_kwargs == {}
+    assert figurecomposer_plot_slices._plot_slices_shape(tool, loaded_operation).valid
 
     tool.operation_list.setCurrentRow(0)
     tool._select_step_section("selection")
@@ -49,7 +49,85 @@ def test_figure_composer_plot_slices_migrates_single_map_selection_to_source_ali
     )
 
 
-def test_figure_composer_plot_slices_clears_unsupported_multi_map_selections(
+def test_figure_composer_plot_slices_migrates_shared_multi_map_selection_to_slice_state(
+    qtbot,
+) -> None:
+    first = _plot_slices_selection_migration_data()
+    second = first + 100.0
+    second.name = "second"
+    tool = FigureComposerTool.from_sources(
+        {"first": first, "second": second},
+        sources=(
+            FigureSourceState(name="first", label="first"),
+            FigureSourceState(name="second", label="second"),
+        ),
+        operations=(
+            FigureOperationState.plot_slices(
+                label="plot_slices",
+                sources=("first", "second"),
+                map_selections=(
+                    FigureDataSelectionState(source="first", qsel={"y": 0.0}),
+                    FigureDataSelectionState(source="second", qsel={"y": 0.0}),
+                ),
+                axes=FigureAxesSelectionState(),
+            ),
+        ),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+
+    [loaded_operation] = tool.tool_status.operations
+    assert loaded_operation.sources == ("first", "second")
+    assert loaded_operation.map_selections == ()
+    assert loaded_operation.slice_dim == "y"
+    assert loaded_operation.slice_values == (0.0,)
+    assert loaded_operation.slice_kwargs == {}
+    shape = figurecomposer_plot_slices._plot_slices_shape(tool, loaded_operation)
+    assert shape.valid
+    assert shape.plot_ndim == 2
+
+
+def test_figure_composer_plot_slices_migrates_shared_selection_before_sources_restore(
+    qtbot,
+) -> None:
+    first = _plot_slices_selection_migration_data()
+    second = first + 100.0
+    second.name = "second"
+    primary = first.rename("primary")
+    tool = FigureComposerTool.from_sources(
+        {"primary": primary},
+        sources=(
+            FigureSourceState(name="primary", label="primary"),
+            FigureSourceState(name="first", label="first"),
+            FigureSourceState(name="second", label="second"),
+        ),
+        operations=(
+            FigureOperationState.plot_slices(
+                label="plot_slices",
+                sources=("first", "second"),
+                map_selections=(
+                    FigureDataSelectionState(source="first", qsel={"y": 0.0}),
+                    FigureDataSelectionState(source="second", qsel={"y": 0.0}),
+                ),
+                axes=FigureAxesSelectionState(),
+            ),
+        ),
+        primary_source="primary",
+    )
+    qtbot.addWidget(tool)
+
+    [loaded_operation] = tool.tool_status.operations
+    assert loaded_operation.sources == ("first", "second")
+    assert loaded_operation.map_selections == ()
+    assert loaded_operation.slice_dim == "y"
+    assert loaded_operation.slice_values == (0.0,)
+    tool.set_source_data({"primary": primary, "first": first, "second": second})
+    shape = figurecomposer_plot_slices._plot_slices_shape(tool, loaded_operation)
+    assert shape.valid
+    assert shape.plot_ndim == 2
+
+
+def test_figure_composer_plot_slices_migrates_per_source_map_selections_to_aliases(
     qtbot,
 ) -> None:
     first = xr.DataArray(
@@ -82,11 +160,65 @@ def test_figure_composer_plot_slices_clears_unsupported_multi_map_selections(
     qtbot.addWidget(tool)
 
     [loaded_operation] = tool.tool_status.operations
-    assert loaded_operation.sources == ("first", "second")
+    assert loaded_operation.sources == ("first_selected", "second_selected")
     assert loaded_operation.map_selections == ()
+    source_by_name = {source.name: source for source in tool.source_states()}
+    assert source_by_name["first_selected"].selection_source == "first"
+    assert source_by_name["first_selected"].qsel == {"y": 0.0}
+    assert source_by_name["second_selected"].selection_source == "second"
+    assert source_by_name["second_selected"].qsel == {"y": 2.0}
+    xr.testing.assert_identical(tool.source_data()["first_selected"], first.qsel(y=0.0))
+    xr.testing.assert_identical(
+        tool.source_data()["second_selected"], second.qsel(y=2.0)
+    )
 
 
-def test_figure_composer_plot_slices_source_selector_updates_alias_sources(
+def test_figure_composer_plot_slices_restores_deferred_source_alias_data(
+    qtbot,
+) -> None:
+    first = _plot_slices_selection_migration_data()
+    second = first + 100.0
+    second.name = "second"
+    primary = first.rename("primary")
+    tool = FigureComposerTool.from_sources(
+        {"primary": primary},
+        sources=(
+            FigureSourceState(name="primary", label="primary"),
+            FigureSourceState(name="first", label="first"),
+            FigureSourceState(name="second", label="second"),
+        ),
+        operations=(
+            FigureOperationState.plot_slices(
+                label="plot_slices",
+                sources=("first", "second"),
+                map_selections=(
+                    FigureDataSelectionState(source="first", qsel={"y": 0.0}),
+                    FigureDataSelectionState(source="second", qsel={"y": 2.0}),
+                ),
+                axes=FigureAxesSelectionState(),
+            ),
+        ),
+        primary_source="primary",
+    )
+    qtbot.addWidget(tool)
+
+    [loaded_operation] = tool.tool_status.operations
+    assert loaded_operation.sources == ("first_selected", "second_selected")
+    assert "first_selected" not in tool.source_data()
+    tool._restore_persistence_data_items(
+        {"first": first, "second": second},
+        xr.Dataset(),
+    )
+    xr.testing.assert_identical(tool.source_data()["first_selected"], first.qsel(y=0.0))
+    xr.testing.assert_identical(
+        tool.source_data()["second_selected"], second.qsel(y=2.0)
+    )
+    shape = figurecomposer_plot_slices._plot_slices_shape(tool, loaded_operation)
+    assert shape.valid
+    assert shape.plot_ndim == 2
+
+
+def test_figure_composer_plot_slices_source_selector_updates_sliced_sources(
     qtbot,
 ) -> None:
     first = _figure_composer_image_source("first")
@@ -116,7 +248,7 @@ def test_figure_composer_plot_slices_source_selector_updates_alias_sources(
     checks["second"].setCheckState(QtCore.Qt.CheckState.Checked)
 
     updated = tool.tool_status.operations[0]
-    assert updated.sources == ("first_selected", "second")
+    assert updated.sources == ("first", "second")
     assert updated.map_selections == ()
 
     qtbot.waitUntil(
@@ -129,14 +261,14 @@ def test_figure_composer_plot_slices_source_selector_updates_alias_sources(
             tool.tool_status.operations[0].sources
             == (
                 "second",
-                "first_selected",
+                "first",
             )
         ),
         timeout=1000,
     )
 
     updated = tool.tool_status.operations[0]
-    assert updated.sources == ("second", "first_selected")
+    assert updated.sources == ("second", "first")
     assert updated.map_selections == ()
 
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -3,6 +3,143 @@
 from ._common import *
 
 
+def _plot_slices_selection_migration_data() -> xr.DataArray:
+    return xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 4),
+        dims=("x", "hv", "y"),
+        coords={"x": [0.0, 1.0], "hv": [10.0, 20.0, 30.0], "y": [-1.0, 0.0, 1.0, 2.0]},
+        name="first",
+    )
+
+
+def test_figure_composer_plot_slices_migrates_single_map_selection_to_source_alias(
+    qtbot,
+) -> None:
+    data = _plot_slices_selection_migration_data()
+    operation = FigureOperationState.plot_slices(
+        label="plot_slices",
+        sources=("first",),
+        map_selections=(FigureDataSelectionState(source="first", qsel={"y": 0.0}),),
+        axes=FigureAxesSelectionState(),
+    )
+    tool = FigureComposerTool.from_sources(
+        {"first": data},
+        sources=(FigureSourceState(name="first", label="first"),),
+        operations=(operation,),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+
+    [loaded_operation] = tool.tool_status.operations
+    assert loaded_operation.sources == ("first_selected",)
+    assert loaded_operation.map_selections == ()
+    source_by_name = {source.name: source for source in tool.source_states()}
+    assert source_by_name["first_selected"].selection_source == "first"
+    assert source_by_name["first_selected"].qsel == {"y": 0.0}
+    xr.testing.assert_identical(tool.source_data()["first_selected"], data.qsel(y=0.0))
+
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("selection")
+    assert (
+        tool.findChild(
+            QtWidgets.QWidget,
+            "figureComposerPlotSlicesInputSelectionSection",
+        )
+        is None
+    )
+
+
+def test_figure_composer_plot_slices_clears_unsupported_multi_map_selections(
+    qtbot,
+) -> None:
+    first = xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 4),
+        dims=("x", "hv", "y"),
+        coords={"x": [0.0, 1.0], "hv": [10.0, 20.0, 30.0], "y": [-1.0, 0.0, 1.0, 2.0]},
+        name="first",
+    )
+    second = first + 100.0
+    second.name = "second"
+    tool = FigureComposerTool.from_sources(
+        {"first": first, "second": second},
+        sources=(
+            FigureSourceState(name="first", label="first"),
+            FigureSourceState(name="second", label="second"),
+        ),
+        operations=(
+            FigureOperationState.plot_slices(
+                label="plot_slices",
+                sources=("first", "second"),
+                map_selections=(
+                    FigureDataSelectionState(source="first", qsel={"y": 0.0}),
+                    FigureDataSelectionState(source="second", qsel={"y": 2.0}),
+                ),
+                axes=FigureAxesSelectionState(),
+            ),
+        ),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+
+    [loaded_operation] = tool.tool_status.operations
+    assert loaded_operation.sources == ("first", "second")
+    assert loaded_operation.map_selections == ()
+
+
+def test_figure_composer_plot_slices_source_selector_updates_alias_sources(
+    qtbot,
+) -> None:
+    first = _figure_composer_image_source("first")
+    second = _figure_composer_image_source("second")
+    tool = FigureComposerTool.from_sources(
+        {"first": first, "second": second},
+        sources=(
+            FigureSourceState(name="first", label="first"),
+            FigureSourceState(name="second", label="second"),
+        ),
+        operations=(
+            FigureOperationState.plot_slices(
+                label="plot_slices",
+                sources=("first",),
+                map_selections=(
+                    FigureDataSelectionState(source="first", qsel={"eV": 0.0}),
+                ),
+            ),
+        ),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(0)
+    tool._select_step_section("sources")
+
+    checks = _plot_source_checks(tool)
+    checks["second"].setCheckState(QtCore.Qt.CheckState.Checked)
+
+    updated = tool.tool_status.operations[0]
+    assert updated.sources == ("first_selected", "second")
+    assert updated.map_selections == ()
+
+    qtbot.waitUntil(
+        lambda: _plot_source_move_buttons(tool)[("second", "up")].isEnabled(),
+        timeout=1000,
+    )
+    _plot_source_move_buttons(tool)[("second", "up")].click()
+    qtbot.waitUntil(
+        lambda: (
+            tool.tool_status.operations[0].sources
+            == (
+                "second",
+                "first_selected",
+            )
+        ),
+        timeout=1000,
+    )
+
+    updated = tool.tool_status.operations[0]
+    assert updated.sources == ("second", "first_selected")
+    assert updated.map_selections == ()
+
+
 def test_figure_composer_plot_slices_source_selector_updates_sources(
     qtbot, monkeypatch
 ) -> None:
@@ -918,13 +1055,13 @@ def test_figure_composer_plot_slices_edge_helper_contracts(
         ),
     )
     assert (
-        len(figurecomposer_plot_slices._operation_maps(tool, selection_operation)) == 2
+        len(figurecomposer_plot_slices._operation_maps(tool, selection_operation)) == 1
     )
     selection_lines = figurecomposer_plot_slices._plot_slices_code_lines(
         tool,
         selection_operation,
     )
-    assert selection_lines[0] == "selected_maps = ["
+    assert all("selected_maps" not in line for line in selection_lines)
     assert any("eplt.plot_slices" in line for line in selection_lines)
     single_selection_operation = FigureOperationState.plot_slices(
         label="single_selection",
@@ -937,7 +1074,7 @@ def test_figure_composer_plot_slices_edge_helper_contracts(
     )
     assert len(single_selection_lines) == 1
     assert "selected_maps" not in single_selection_lines[0]
-    assert "eplt.plot_slices(image.qsel(eV=1.0)" in single_selection_lines[0]
+    assert "eplt.plot_slices(image" in single_selection_lines[0]
     assert (
         figurecomposer_plot_slices._plot_slices_code_lines(
             tool,
@@ -1710,7 +1847,11 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     assert editor_tabs is tool.editor_tabs
     assert [
         editor_tabs.widget(index).objectName() for index in range(editor_tabs.count())
-    ] == ["figureComposerLayoutPage", "figureComposerRecipePage"]
+    ] == [
+        "figureComposerSourcesPage",
+        "figureComposerLayoutPage",
+        "figureComposerRecipePage",
+    ]
     assert editor_tabs.currentWidget() is tool.recipe_page
     assert isinstance(tool.layout_page.layout(), QtWidgets.QGridLayout)
     layout_grid = typing.cast("QtWidgets.QGridLayout", tool.layout_page.layout())
@@ -1780,9 +1921,9 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     )
     step_toolbar_buttons = (
         tool.add_step_button,
-        tool.duplicate_operation_button,
-        tool.move_operation_up_button,
-        tool.move_operation_down_button,
+        tool.copy_operation_button,
+        tool.cut_operation_button,
+        tool.paste_operation_button,
         tool.remove_operation_button,
     )
     assert all(button.styleSheet() == "" for button in step_toolbar_buttons)
@@ -2610,9 +2751,9 @@ def test_figure_composer_plot_slices_all_coordinate_helper_edges() -> None:
             )
         }
     )
-    assert ".qsel" in (
+    assert (
         figurecomposer_plot_slices._first_plot_slices_source_code(selection_operation)
-        or ""
+        == "data"
     )
     assert (
         figurecomposer_plot_slices._all_coordinate_slice_values_code(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -1564,6 +1564,18 @@ def test_figure_composer_plot_slices_shape_and_source_editor_contracts(
     )
     assert tool.tool_status.operations[0].sources == ("first", "second")
 
+    first_check.setCheckState(QtCore.Qt.CheckState.Unchecked)
+    figurecomposer_plot_slices._plot_source_check_changed(
+        tool, "first", first_check, ("first", "second")
+    )
+    assert tool.tool_status.operations[0].sources == ("second",)
+
+    first_check.setCheckState(QtCore.Qt.CheckState.Checked)
+    figurecomposer_plot_slices._plot_source_check_changed(
+        tool, "first", first_check, ("first", "second")
+    )
+    assert tool.tool_status.operations[0].sources == ("first", "second")
+
     figurecomposer_plot_slices._plot_source_move(tool, "first", 1)
     assert tool.tool_status.operations[0].sources[:2] == ("second", "first")
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -38,7 +38,7 @@ def test_figure_composer_plot_slices_migrates_shared_map_selection_to_slice_stat
     assert loaded_operation.slice_kwargs == {}
     assert figurecomposer_plot_slices._plot_slices_shape(tool, loaded_operation).valid
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("selection")
     assert (
         tool.findChild(
@@ -241,7 +241,7 @@ def test_figure_composer_plot_slices_source_selector_updates_sliced_sources(
         primary_source="first",
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("sources")
 
     checks = _plot_source_checks(tool)
@@ -378,7 +378,7 @@ def test_figure_composer_plot_slices_default_colormap_editor_uses_stylesheet(
             primary_source="data",
         )
         qtbot.addWidget(tool)
-        tool.operation_list.setCurrentRow(0)
+        tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
         tool._select_step_section("colors")
 
         cmap_combo = next(
@@ -526,7 +526,7 @@ def test_figure_composer_opens_plot_slices_selection_on_nonuniform_data(
     )
     qtbot.addWidget(tool)
 
-    assert tool.operation_list.count() == 1
+    assert tool.operation_list.topLevelItemCount() == 1
     assert "sample_temp_idx" not in tool.generated_code()
 
 
@@ -1286,7 +1286,7 @@ def test_figure_composer_plot_slices_edge_helper_contracts(
     assert figurecomposer_plot_slices._norm_clip_from_text("False") is False
     assert figurecomposer_plot_slices._norm_clip_from_text("default") is None
 
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     figurecomposer_plot_slices._update_current_norm_name(tool, "CenteredPowerNorm")
     assert tool.tool_status.operations[1].norm_name == "CenteredPowerNorm"
     figurecomposer_plot_slices._update_current_norm_gamma(tool, 0.75)
@@ -1396,7 +1396,7 @@ def test_figure_composer_plot_slices_all_coordinate_values_with_thin(
     )
     np.testing.assert_allclose(full_kwargs["eV"], data.coords["eV"].values)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._update_operation_editor()
     tool._select_step_section("selection")
     selection_page = tool.step_editor_stack.currentWidget()
@@ -1972,9 +1972,14 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
 
     assert tool.findChildren(FigureCanvasQTAgg) == []
     assert tool.findChildren(NavigationToolbar2QT) == []
-    assert tool.findChildren(QtWidgets.QSplitter) == [tool.recipe_splitter]
+    assert set(tool.findChildren(QtWidgets.QSplitter)) == {
+        tool.source_splitter,
+        tool.recipe_splitter,
+    }
     assert tool.recipe_splitter.widget(0) is tool.operation_list
     assert tool.recipe_splitter.widget(1) is tool.step_inspector
+    assert tool.step_editor_scroll.widget() is tool.step_editor_stack
+    assert not tool.step_editor_scroll.isAncestorOf(tool.step_navigator)
     editor_tabs = tool.findChild(QtWidgets.QTabWidget, "figureComposerEditorTabs")
     assert editor_tabs is tool.editor_tabs
     assert [
@@ -2250,14 +2255,14 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         tool.step_editor_stack.currentWidget().objectName()
         == "figureComposerPlotSlicesColorsPage"
     )
-    operation_item = tool.operation_list.item(0)
-    operation_item.setCheckState(QtCore.Qt.CheckState.Unchecked)
+    operation_item = tool.operation_list.topLevelItem(0)
+    operation_item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
     assert tool.tool_status.operations[0].enabled is False
     assert (
         tool.step_editor_stack.currentWidget().objectName()
         == "figureComposerPlotSlicesColorsPage"
     )
-    operation_item.setCheckState(QtCore.Qt.CheckState.Checked)
+    operation_item.setCheckState(0, QtCore.Qt.CheckState.Checked)
     assert tool.tool_status.operations[0].enabled is True
     assert (
         tool.step_editor_stack.currentWidget().objectName()
@@ -2441,6 +2446,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         QtCore.Qt.Key.Key_W,
         QtCore.Qt.KeyboardModifier.ControlModifier,
     )
+    qtbot.keyRelease(tool, QtCore.Qt.Key.Key_Control)
     qtbot.wait_until(lambda: not figure_window.isVisible(), timeout=5000)
     assert len(tool.tool_status.operations) == 1
     activation_count = len(show_activations)
@@ -3206,7 +3212,7 @@ def test_figure_composer_plot_slices_qsel_kwargs_display_in_selection(qtbot) -> 
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("selection")
     selection_page = tool.step_editor_stack.currentWidget()
     dimension_combo = selection_page.findChild(
@@ -3261,7 +3267,7 @@ def test_figure_composer_plot_slices_advanced_qsel_kwargs_move_to_selection(
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("advanced")
     extra_kwargs_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QLineEdit, "figureComposerExtraKwEdit"
@@ -3333,7 +3339,7 @@ def test_figure_composer_plot_slices_color_controls_do_not_commit_on_rebuild(
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("colors")
     first_page = tool.step_editor_stack.currentWidget()
     first_cmap_combo = first_page.findChild(
@@ -3342,7 +3348,7 @@ def test_figure_composer_plot_slices_color_controls_do_not_commit_on_rebuild(
     assert first_cmap_combo is not None
     assert first_cmap_combo.currentText() == "viridis"
 
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool._select_step_section("colors")
 
     assert tool.tool_status.operations[0].cmap == "viridis"
@@ -4132,7 +4138,7 @@ def test_figure_composer_dict_inputs_prefer_keyword_form(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("view")
     annotate_kwargs_edit = tool.findChild(
         QtWidgets.QLineEdit, "figureComposerAnnotateKwEdit"
@@ -4186,7 +4192,7 @@ def test_figure_composer_dict_inputs_prefer_keyword_form(qtbot) -> None:
         "kx": 0.0,
     }
 
-    tool.operation_list.setCurrentRow(3)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(3))
     tool._select_step_section("method")
     erlab_method_kwargs_edit = tool.findChild(
         QtWidgets.QLineEdit, "figureComposerERLabMethodKwEdit"

--- a/tests/interactive/imagetool/manager/figurecomposer/test_set_palette.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_set_palette.py
@@ -18,7 +18,7 @@ def test_figure_composer_set_palette_editor_preview_and_controls(
     )
     tool = FigureComposerTool(profile, recipe=recipe, source_data={"profile": profile})
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     page = tool.step_editor_stack.currentWidget()
     assert page is not None
 
@@ -129,7 +129,7 @@ def test_figure_composer_set_palette_custom_colors_editor_and_codegen(
     )
     tool = FigureComposerTool(profile, recipe=recipe, source_data={"profile": profile})
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     page = tool.step_editor_stack.currentWidget()
     assert page is not None
 
@@ -200,7 +200,7 @@ def test_figure_composer_set_palette_mode_switch_seeds_custom_colors(qtbot) -> N
     )
     tool = FigureComposerTool(profile, recipe=recipe, source_data={"profile": profile})
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     page = tool.step_editor_stack.currentWidget()
     assert page is not None
     mode_combo = page.findChild(
@@ -350,7 +350,7 @@ def test_figure_composer_set_palette_editor_disables_without_seaborn(
     )
     tool = FigureComposerTool(profile, recipe=recipe, source_data={"profile": profile})
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     page = tool.step_editor_stack.currentWidget()
     assert page is not None
 
@@ -384,9 +384,9 @@ def test_figure_composer_set_palette_editor_disables_without_seaborn(
     assert not preview.isEnabled()
     assert message is not None
     assert message.property("missing_dependency") == "seaborn"
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    assert item.text().startswith("Skipped Set Palette:")
+    assert item.text(0).startswith("Skipped Set Palette:")
 
     figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
     assert tool._operation_render_errors == {}

--- a/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
@@ -175,6 +175,19 @@ def test_source_selection_state_helpers_cover_shared_and_per_source_paths() -> N
     assert tool.update_flags == (True, True)
     assert tool.operation.map_selections == (first, first_for_b)
 
+    no_selection_operation = operation.model_copy(update={"map_selections": ()})
+    empty_tool = _FakeSelectionTool(no_selection_operation)
+    source_selection.set_source_selection_per_source_enabled(
+        empty_tool,
+        no_selection_operation,
+        False,
+        attr_name="_enabled_ids",
+        source_getter=lambda target: target.sources,
+        operation_factory=_operation_factory,
+        keep_source_only=False,
+    )
+    assert empty_tool.operation.map_selections == ()
+
 
 def test_source_selection_operation_helpers_cover_empty_and_effective_paths() -> None:
     operation = FigureOperationState.plot_slices(
@@ -336,6 +349,22 @@ def test_source_selection_combo_and_dimension_controls(qtbot) -> None:
     assert combo.currentData() == "qsel"
     assert tool.marked == [combo]
 
+    default_combo = source_selection.selection_mode_combo(
+        cast("Any", tool),
+        current=None,
+        mixed=False,
+        parent=parent,
+    )
+    assert default_combo.currentData() == "keep"
+
+    unknown_combo = source_selection.selection_mode_combo(
+        cast("Any", tool),
+        current="unknown",
+        mixed=False,
+        parent=parent,
+    )
+    assert unknown_combo.currentData() == "keep"
+
     mixed_combo = source_selection.selection_mode_combo(
         cast("Any", tool),
         current=None,
@@ -366,6 +395,11 @@ def test_source_selection_combo_and_dimension_controls(qtbot) -> None:
     assert not value_edit.isHidden()
     assert not width_edit.isHidden()
 
+    update_count = len(updates)
+    value_edit.setText("")
+    combo.activated.emit(combo.currentIndex())
+    assert len(updates) == update_count
+
     value_edit.setText("1.0")
     value_edit.editingFinished.emit()
     assert updates[-1] == ("eV", "qsel", "1.0", "0.1")
@@ -383,6 +417,11 @@ def test_source_selection_combo_and_dimension_controls(qtbot) -> None:
     assert not value_edit.isVisible()
     assert not width_edit.isVisible()
     assert tool.cleared[-2:] == [value_edit, width_edit]
+
+    update_count = len(updates)
+    value_edit.editingFinished.emit()
+    width_edit.editingFinished.emit()
+    assert len(updates) == update_count
 
 
 def test_add_selection_dimension_rows_builds_empty_and_dimensional_rows(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
 
+import pydantic
 import pytest
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -13,6 +14,8 @@ import erlab.interactive._figurecomposer._widgets as figurecomposer_widgets
 from erlab.interactive._figurecomposer import (
     FigureDataSelectionState,
     FigureOperationState,
+    FigurePlotSlicesPanelStyleState,
+    FigureSourceState,
     FigureSubplotsState,
 )
 from erlab.interactive._figurecomposer._editor_controls import MIXED_VALUE
@@ -351,6 +354,70 @@ def test_source_selection_dimension_parsing_and_updates() -> None:
         source_selection.selection_with_dimension(
             selection, "eV", "qsel", value=slice(0, 2), width=0.1
         )
+
+
+def test_figure_composer_state_serializes_slice_values() -> None:
+    source = FigureSourceState(
+        name="data",
+        isel={"kx": slice(1, 5, 2)},
+        qsel={"eV": slice(-0.5, 0.5)},
+    )
+    restored_source = FigureSourceState.model_validate_json(source.model_dump_json())
+    assert restored_source.isel["kx"] == slice(1, 5, 2)
+    assert restored_source.qsel["eV"] == slice(-0.5, 0.5)
+
+    selection = FigureDataSelectionState(
+        source="data",
+        isel={"kx": slice(None, 3)},
+        qsel={"eV": slice(-1.0, None)},
+    )
+    restored_selection = FigureDataSelectionState.model_validate_json(
+        selection.model_dump_json()
+    )
+    assert restored_selection.isel["kx"] == slice(None, 3)
+    assert restored_selection.qsel["eV"] == slice(-1.0, None)
+
+    operation = FigureOperationState.plot_slices(
+        label="slice",
+        sources=("data",),
+    ).model_copy(
+        update={
+            "slice_kwargs": {"beta": slice(-0.5, 0.5)},
+            "method_args": (slice(1, 3, 2), [slice(None, 1)]),
+            "method_kwargs": {"region": slice(None, 2)},
+        }
+    )
+    restored_operation = FigureOperationState.model_validate_json(
+        operation.model_dump_json()
+    )
+    assert restored_operation.slice_kwargs["beta"] == slice(-0.5, 0.5)
+    assert restored_operation.method_args == (slice(1, 3, 2), [slice(None, 1)])
+    assert restored_operation.method_kwargs["region"] == slice(None, 2)
+
+    panel_style = FigurePlotSlicesPanelStyleState(
+        map_index=0,
+        slice_index=0,
+        norm_kwargs={"region": slice(1, 2)},
+    )
+    restored_panel_style = FigurePlotSlicesPanelStyleState.model_validate_json(
+        panel_style.model_dump_json()
+    )
+    assert restored_panel_style.norm_kwargs["region"] == slice(1, 2)
+
+    empty_source = FigureSourceState.model_validate({"name": "empty", "isel": None})
+    assert empty_source.isel == {}
+    with pytest.raises(pydantic.ValidationError):
+        FigureSourceState.model_validate({"name": "invalid", "isel": "not-a-mapping"})
+
+    ordinary_kwargs = FigureOperationState.method(
+        family="axes",
+        name="plot",
+        kwargs={"kind": "slice", "start": 1},
+    )
+    restored_kwargs = FigureOperationState.model_validate(
+        ordinary_kwargs.model_dump(mode="json")
+    )
+    assert restored_kwargs.method_kwargs == {"kind": "slice", "start": 1}
 
 
 def test_source_selection_combo_and_dimension_controls(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
@@ -408,6 +408,15 @@ def test_figure_composer_state_serializes_slice_values() -> None:
     assert empty_source.isel == {}
     with pytest.raises(pydantic.ValidationError):
         FigureSourceState.model_validate({"name": "invalid", "isel": "not-a-mapping"})
+    malformed_slice_marker = FigureSourceState.model_validate(
+        {
+            "name": "malformed-marker",
+            "isel": {"x": {"__erlab_figure_composer_slice__": [0, 1]}},
+        }
+    )
+    assert malformed_slice_marker.isel == {
+        "x": {"__erlab_figure_composer_slice__": [0, 1]}
+    }
 
     ordinary_kwargs = FigureOperationState.method(
         family="axes",

--- a/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
@@ -113,7 +113,9 @@ class _FakeEditorTool:
         layout.addRow(label, widget)
 
 
-def test_source_selection_state_helpers_cover_shared_and_per_source_paths() -> None:
+def test_source_selection_state_helpers_cover_shared_and_per_source_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     empty = FigureDataSelectionState(source="data")
     first = FigureDataSelectionState(source="a", qsel={"eV": 0.0})
     first_for_b = first.model_copy(update={"source": "b"})
@@ -187,6 +189,22 @@ def test_source_selection_state_helpers_cover_shared_and_per_source_paths() -> N
         keep_source_only=False,
     )
     assert empty_tool.operation.map_selections == ()
+
+    monkeypatch.setattr(source_selection, "shared_selection", lambda _selections: None)
+    fallback_tool = _FakeSelectionTool(no_selection_operation)
+    source_selection.set_source_selection_per_source_enabled(
+        fallback_tool,
+        no_selection_operation,
+        False,
+        attr_name="_enabled_ids",
+        source_getter=lambda target: target.sources,
+        operation_factory=_operation_factory,
+        keep_source_only=True,
+    )
+    assert fallback_tool.operation.map_selections == (
+        FigureDataSelectionState(source="a"),
+        FigureDataSelectionState(source="b"),
+    )
 
 
 def test_source_selection_operation_helpers_cover_empty_and_effective_paths() -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+import pytest
+from qtpy import QtCore, QtGui, QtWidgets
+
+import erlab.interactive._figurecomposer._widgets as figurecomposer_widgets
+from erlab.interactive._figurecomposer import (
+    FigureDataSelectionState,
+    FigureOperationState,
+    FigureSubplotsState,
+)
+from erlab.interactive._figurecomposer._editor_controls import MIXED_VALUE
+from erlab.interactive._figurecomposer._operations import (
+    _source_selection as source_selection,
+)
+from erlab.interactive._figurecomposer._text import FigureComposerInputError
+
+
+def _operation_factory(
+    operation: FigureOperationState,
+    sources: tuple[str, ...],
+    selections: tuple[FigureDataSelectionState, ...],
+) -> FigureOperationState:
+    return operation.model_copy(
+        update={"sources": sources, "map_selections": selections}
+    )
+
+
+class _FakeSelectionTool:
+    def __init__(self, operation: FigureOperationState) -> None:
+        self.operation = operation
+        self.editor_updates = 0
+        self.update_flags: tuple[bool, bool] | None = None
+
+    def _update_operation_editor(self) -> None:
+        self.editor_updates += 1
+
+    def _update_operations(
+        self,
+        callback: Callable[[int, FigureOperationState], FigureOperationState],
+        *,
+        rebuild_editor: bool,
+        defer_editor_rebuild: bool,
+    ) -> None:
+        self.operation = callback(0, self.operation)
+        self.update_flags = (rebuild_editor, defer_editor_rebuild)
+
+
+class _FakeEditorTool:
+    def __init__(self) -> None:
+        self.marked: list[QtWidgets.QWidget] = []
+        self.cleared: list[QtWidgets.QWidget] = []
+        self.form_rows: list[tuple[str, QtWidgets.QWidget, str]] = []
+
+    def _mark_editor_control(self, widget: QtWidgets.QWidget) -> None:
+        self.marked.append(widget)
+
+    def _connect_editor_signal(
+        self,
+        _widget: QtWidgets.QWidget,
+        signal: Any,
+        callback: Callable[..., None],
+    ) -> None:
+        signal.connect(callback)
+
+    def _connect_line_edit_finished(
+        self,
+        edit: QtWidgets.QLineEdit,
+        callback: Callable[[str], None],
+    ) -> None:
+        edit.editingFinished.connect(lambda edit=edit: callback(edit.text()))
+
+    def _clear_editor_input_error(self, widget: QtWidgets.QWidget) -> None:
+        self.cleared.append(widget)
+
+    def _batch_is_mixed(
+        self,
+        _operation: FigureOperationState,
+        getter: Callable[[FigureOperationState], str],
+    ) -> bool:
+        return getter(self._alternate_operation) == "mean"
+
+    def _batch_text(
+        self,
+        operation: FigureOperationState,
+        getter: Callable[[FigureOperationState], str],
+        _converter: type[str],
+    ) -> tuple[str, bool]:
+        return getter(operation), getter(self._alternate_operation) != getter(operation)
+
+    @staticmethod
+    def _line_edit(text: str, *, parent: QtWidgets.QWidget) -> QtWidgets.QLineEdit:
+        return QtWidgets.QLineEdit(text, parent)
+
+    @staticmethod
+    def _apply_mixed_line_edit(edit: QtWidgets.QLineEdit, mixed: bool) -> None:
+        edit.setProperty("batch_mixed", mixed)
+
+    def _add_form_row(
+        self,
+        layout: QtWidgets.QFormLayout,
+        label: str,
+        widget: QtWidgets.QWidget,
+        tooltip: str,
+    ) -> None:
+        self.form_rows.append((label, widget, tooltip))
+        layout.addRow(label, widget)
+
+
+def test_source_selection_state_helpers_cover_shared_and_per_source_paths() -> None:
+    empty = FigureDataSelectionState(source="data")
+    first = FigureDataSelectionState(source="a", qsel={"eV": 0.0})
+    first_for_b = first.model_copy(update={"source": "b"})
+    second = FigureDataSelectionState(source="b", isel={"eV": 1})
+
+    assert not source_selection.selection_has_effect(empty)
+    assert source_selection.selection_has_effect(first)
+    assert source_selection.selection_content_equal(first, first_for_b)
+    assert source_selection.shared_selection(()) == FigureDataSelectionState(source="")
+    assert source_selection.shared_selection((first, first_for_b)) == first.model_copy(
+        update={"source": ""}
+    )
+    assert source_selection.shared_selection((first, second)) is None
+
+    operation = FigureOperationState.plot_slices(
+        label="plot_slices",
+        sources=("a", "b"),
+        map_selections=(first, second),
+    )
+    fallback = FigureDataSelectionState(source="", mean_dims=("kx",))
+    assert source_selection.selection_for_source(operation, "a", fallback) == first
+    assert source_selection.selection_for_source(
+        operation, "missing", fallback
+    ) == fallback.model_copy(update={"source": "missing"})
+
+    assert source_selection.source_selection_per_source_enabled(
+        _FakeSelectionTool(operation), operation, attr_name="_enabled_ids"
+    )
+    shared_operation = operation.model_copy(
+        update={"map_selections": (first, first_for_b)}
+    )
+    tool = _FakeSelectionTool(shared_operation)
+    assert not source_selection.source_selection_per_source_enabled(
+        tool, shared_operation, attr_name="_enabled_ids"
+    )
+
+    source_selection.set_source_selection_per_source_enabled(
+        tool,
+        shared_operation,
+        True,
+        attr_name="_enabled_ids",
+        source_getter=lambda target: target.sources,
+        operation_factory=_operation_factory,
+        keep_source_only=False,
+    )
+    assert shared_operation.operation_id in tool._enabled_ids
+    assert tool.editor_updates == 1
+
+    source_selection.set_source_selection_per_source_enabled(
+        tool,
+        operation,
+        False,
+        attr_name="_enabled_ids",
+        source_getter=lambda target: target.sources,
+        operation_factory=_operation_factory,
+        keep_source_only=False,
+    )
+    assert shared_operation.operation_id not in tool._enabled_ids
+    assert tool.update_flags == (True, True)
+    assert tool.operation.map_selections == (first, first_for_b)
+
+
+def test_source_selection_operation_helpers_cover_empty_and_effective_paths() -> None:
+    operation = FigureOperationState.plot_slices(
+        label="plot_slices",
+        sources=("a", "b"),
+    )
+    empty = FigureDataSelectionState(source="")
+    qsel = FigureDataSelectionState(source="", qsel={"eV": 0.0})
+
+    shared_empty = source_selection.operation_with_shared_source_selection(
+        operation,
+        ("a", "b"),
+        empty,
+        operation_factory=_operation_factory,
+        keep_source_only=False,
+    )
+    assert shared_empty.map_selections == ()
+
+    shared_source_only = source_selection.operation_with_shared_source_selection(
+        operation,
+        ("a", "b"),
+        empty,
+        operation_factory=_operation_factory,
+        keep_source_only=True,
+    )
+    assert shared_source_only.map_selections == (
+        FigureDataSelectionState(source="a"),
+        FigureDataSelectionState(source="b"),
+    )
+
+    shared_qsel = source_selection.operation_with_shared_source_selection(
+        operation,
+        ("a", "b"),
+        qsel,
+        operation_factory=_operation_factory,
+        keep_source_only=False,
+    )
+    assert shared_qsel.map_selections == (
+        qsel.model_copy(update={"source": "a"}),
+        qsel.model_copy(update={"source": "b"}),
+    )
+
+    assert (
+        source_selection.operation_with_per_source_selection(
+            operation,
+            "missing",
+            qsel,
+            source_getter=lambda target: target.sources,
+            operation_factory=_operation_factory,
+            keep_source_only=False,
+        )
+        is operation
+    )
+
+    per_source = source_selection.operation_with_per_source_selection(
+        operation.model_copy(
+            update={
+                "map_selections": (
+                    FigureDataSelectionState(source="a", isel={"kx": 1}),
+                    FigureDataSelectionState(source="b", qsel={"eV": 0.0}),
+                )
+            }
+        ),
+        "b",
+        FigureDataSelectionState(source="b", mean_dims=("kx",)),
+        source_getter=lambda target: target.sources,
+        operation_factory=_operation_factory,
+        keep_source_only=False,
+    )
+    assert per_source.map_selections == (
+        FigureDataSelectionState(source="a", isel={"kx": 1}),
+        FigureDataSelectionState(source="b", mean_dims=("kx",)),
+    )
+
+    cleared = source_selection.operation_with_per_source_selection(
+        operation,
+        "a",
+        FigureDataSelectionState(source="a"),
+        source_getter=lambda target: target.sources,
+        operation_factory=_operation_factory,
+        keep_source_only=False,
+    )
+    assert cleared.map_selections == ()
+
+
+def test_source_selection_dimension_parsing_and_updates() -> None:
+    selection = FigureDataSelectionState(
+        source="data",
+        isel={"kx": 1},
+        qsel={"eV": 0.0, "eV_width": 0.2},
+        mean_dims=("ky",),
+    )
+
+    assert source_selection.selection_dim_mode(selection, "kx") == "isel"
+    assert source_selection.selection_dim_mode(selection, "eV") == "qsel"
+    assert source_selection.selection_dim_mode(selection, "eV_width") == "qsel"
+    assert source_selection.selection_dim_mode(selection, "ky") == "mean"
+    assert source_selection.selection_dim_mode(selection, "missing") == "keep"
+    assert source_selection.selection_dim_value_text(selection, "kx") == "1"
+    assert source_selection.selection_dim_value_text(selection, "eV") == "0.0"
+    assert source_selection.selection_dim_value_text(selection, "missing") == ""
+    assert source_selection.selection_width_key("eV") == "eV_width"
+    assert source_selection.selection_dim_width_text(selection, "eV") == "0.2"
+    assert source_selection.selection_dim_width_text(selection, "kx") == ""
+
+    assert source_selection.selection_value_from_text(" slice(0, 2) ") == slice(0, 2)
+    assert source_selection.selection_width_from_text("") is None
+    assert source_selection.selection_width_from_text("0.5") == 0.5
+    with pytest.raises(FigureComposerInputError):
+        source_selection.selection_value_from_text("")
+    with pytest.raises(FigureComposerInputError):
+        source_selection.selection_value_from_text("slice(")
+    with pytest.raises(FigureComposerInputError):
+        source_selection.selection_width_from_text("slice(0, 2)")
+    with pytest.raises(FigureComposerInputError):
+        source_selection.selection_width_from_text("bad(")
+
+    assert source_selection.selection_with_dimension(
+        selection, "kx", "keep"
+    ) == FigureDataSelectionState(
+        source="data", qsel={"eV": 0.0, "eV_width": 0.2}, mean_dims=("ky",)
+    )
+    assert source_selection.selection_with_dimension(
+        selection, "eV", "isel", value=2
+    ) == FigureDataSelectionState(
+        source="data", isel={"kx": 1, "eV": 2}, mean_dims=("ky",)
+    )
+    assert source_selection.selection_with_dimension(
+        selection, "kx", "qsel", value=0.0, width=0.1
+    ) == FigureDataSelectionState(
+        source="data",
+        qsel={"eV": 0.0, "eV_width": 0.2, "kx": 0.0, "kx_width": 0.1},
+        mean_dims=("ky",),
+    )
+    assert source_selection.selection_with_dimension(
+        selection, "kx", "mean"
+    ) == FigureDataSelectionState(
+        source="data",
+        qsel={"eV": 0.0, "eV_width": 0.2},
+        mean_dims=("ky", "kx"),
+    )
+    with pytest.raises(FigureComposerInputError):
+        source_selection.selection_with_dimension(
+            selection, "eV", "qsel", value=slice(0, 2), width=0.1
+        )
+
+
+def test_source_selection_combo_and_dimension_controls(qtbot) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    tool = _FakeEditorTool()
+
+    combo = source_selection.selection_mode_combo(
+        cast("Any", tool),
+        current="qsel",
+        mixed=False,
+        parent=parent,
+    )
+    assert combo.currentData() == "qsel"
+    assert tool.marked == [combo]
+
+    mixed_combo = source_selection.selection_mode_combo(
+        cast("Any", tool),
+        current=None,
+        mixed=True,
+        parent=parent,
+    )
+    assert mixed_combo.currentData() is MIXED_VALUE
+    assert not mixed_combo.model().item(0).isEnabled()
+
+    value_edit = QtWidgets.QLineEdit(parent)
+    width_edit = QtWidgets.QLineEdit(parent)
+    updates: list[tuple[str, str, str, str]] = []
+    source_selection.connect_selection_dimension_controls(
+        cast("Any", tool),
+        dim="eV",
+        mode_combo=combo,
+        value_edit=value_edit,
+        width_edit=width_edit,
+        update_dimension=lambda dim, mode, value, width: updates.append(
+            (dim, mode, value, width)
+        ),
+    )
+
+    value_edit.setText("0.0")
+    width_edit.setText("0.1")
+    combo.activated.emit(combo.currentIndex())
+    assert updates[-1] == ("eV", "qsel", "0.0", "0.1")
+    assert not value_edit.isHidden()
+    assert not width_edit.isHidden()
+
+    value_edit.setText("1.0")
+    value_edit.editingFinished.emit()
+    assert updates[-1] == ("eV", "qsel", "1.0", "0.1")
+
+    width_edit.setText("0.2")
+    width_edit.editingFinished.emit()
+    assert updates[-1] == ("eV", "qsel", "1.0", "0.2")
+
+    keep_index = combo.findData("keep")
+    combo.setCurrentIndex(keep_index)
+    combo.activated.emit(keep_index)
+    assert updates[-1] == ("eV", "keep", "", "")
+    assert value_edit.text() == ""
+    assert width_edit.text() == ""
+    assert not value_edit.isVisible()
+    assert not width_edit.isVisible()
+    assert tool.cleared[-2:] == [value_edit, width_edit]
+
+
+def test_add_selection_dimension_rows_builds_empty_and_dimensional_rows(qtbot) -> None:
+    page = QtWidgets.QWidget()
+    qtbot.addWidget(page)
+    layout = QtWidgets.QFormLayout(page)
+    tool = _FakeEditorTool()
+    operation = FigureOperationState.plot_array(label="plot_array", source="data")
+    alternate = FigureDataSelectionState(source="data", mean_dims=("eV",))
+    tool._alternate_operation = operation.model_copy(
+        update={"map_selections": (alternate,)}
+    )
+    selection = FigureDataSelectionState(
+        source="data", qsel={"eV": 0.0, "eV_width": 0.1}
+    )
+
+    source_selection.add_selection_dimension_rows(
+        cast("Any", tool),
+        operation=operation,
+        layout=layout,
+        page=page,
+        dimensions=(),
+        selection_getter=lambda _operation: selection,
+        update_dimension=lambda *_args: None,
+        object_prefix="figureComposerTest",
+        property_prefix="figure_composer_test",
+    )
+    assert page.findChild(QtWidgets.QLabel, "figureComposerTestDimensionsMessage")
+
+    source_selection.add_selection_dimension_rows(
+        cast("Any", tool),
+        operation=operation,
+        layout=layout,
+        page=page,
+        dimensions=("eV", "kx"),
+        selection_getter=lambda target: (
+            target.map_selections[0] if target.map_selections else selection
+        ),
+        update_dimension=lambda *_args: None,
+        object_prefix="figureComposerTest",
+        property_prefix="figure_composer_test",
+    )
+
+    rows = page.findChildren(QtWidgets.QWidget, "figureComposerTestDimRow0")
+    assert rows
+    eV_value = page.findChild(QtWidgets.QLineEdit, "figureComposerTestValueEdit0")
+    eV_width = page.findChild(QtWidgets.QLineEdit, "figureComposerTestWidthEdit0")
+    kx_value = page.findChild(QtWidgets.QLineEdit, "figureComposerTestValueEdit1")
+    assert eV_value is not None
+    assert eV_value.text() == "0.0"
+    assert eV_value.property("figure_composer_test_dim") == "eV"
+    assert eV_value.property("figure_composer_test_selection_field") == "value"
+    assert eV_width is not None
+    assert eV_width.text() == "0.1"
+    assert kx_value is not None
+    assert not kx_value.isVisible()
+    assert [label for label, _widget, _tooltip in tool.form_rows] == ["eV", "kx"]
+
+
+def test_figure_display_window_source_drop_event_branches(qtbot) -> None:
+    window = figurecomposer_widgets._FigureComposerDisplayWindow(FigureSubplotsState())
+    qtbot.addWidget(window)
+    mime = QtCore.QMimeData()
+    assert figurecomposer_widgets._false_mime_state(mime) is False
+    assert window._handle_source_drag_event(None) is False
+    assert (
+        window._handle_source_drag_event(QtCore.QEvent(QtCore.QEvent.Type.DragEnter))
+        is False
+    )
+
+    def drag_event() -> QtGui.QDragEnterEvent:
+        return QtGui.QDragEnterEvent(
+            QtCore.QPoint(0, 0),
+            QtCore.Qt.DropAction.CopyAction,
+            mime,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+
+    def drop_event() -> QtGui.QDropEvent:
+        return QtGui.QDropEvent(
+            QtCore.QPointF(0.0, 0.0),
+            QtCore.Qt.DropAction.CopyAction,
+            mime,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+
+    assert window._handle_source_drag_event(drag_event()) is False
+
+    window.set_source_drop_callbacks(can_drop=lambda data: data is mime)
+    accepted_drag = drag_event()
+    assert window._handle_source_drag_event(accepted_drag)
+    assert accepted_drag.isAccepted()
+
+    window.set_source_drop_callbacks(
+        can_drop=lambda _data: True,
+        drop=lambda _data: False,
+    )
+    assert window._handle_source_drag_event(drop_event()) is False
+
+    window.set_source_drop_callbacks(
+        can_drop=lambda _data: True,
+        drop=lambda _data: True,
+    )
+    accepted_drop = drop_event()
+    assert window._handle_source_drag_event(accepted_drop)
+    assert accepted_drop.isAccepted()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -153,8 +153,8 @@ def test_figure_composer_source_ui_uses_shared_shape_formatter(
     assert isinstance(shape_widget, QtWidgets.QLabel)
     assert shape_widget.text() == "<p>formatted shape</p>"
     assert tool.source_list.toolTip() == ""
-    assert first_item.toolTip(0) == ""
-    assert first_item.toolTip(1) == ""
+    assert first_item.toolTip(0)
+    assert first_item.toolTip(1) == first_item.toolTip(0)
     assert first_item.toolTip(2) == ""
     assert shape_widget.toolTip() == ""
     assert (tuple(str(dim) for dim in data.dims), False, None) in calls
@@ -794,7 +794,9 @@ def test_figure_composer_source_structure_edge_paths(qtbot) -> None:
     assert tool._source_alias_error("fig") is not None
     assert tool._source_alias_error("second", current="first") is not None
     reserved = {"first_copy"}
-    assert tool._source_unique_alias("first", reserved) == "first_copy_2"
+    assert tool._source_copy_alias("first", reserved) == "first_copy_2"
+    reserved = {"first"}
+    assert tool._source_unique_alias("first", reserved) == "first_2"
 
     tool._refresh_source_selection_editor()
     alias_edit = tool.source_selection_controls.findChild(
@@ -959,7 +961,7 @@ def test_figure_composer_source_selection_helper_edges(qtbot) -> None:
     assert tuple(source.name for source in tool.source_states()) == (
         "data",
         "derived",
-        "data_copy",
+        "data_2",
     )
 
 
@@ -1285,11 +1287,34 @@ def test_figure_composer_batch_source_selection_skips_incompatible_sources(
 def test_figure_composer_source_helpers_cover_selection_contract() -> None:
     unnamed = xr.DataArray(np.arange(2.0), dims=("x",), name=None)
     invalid_name = xr.DataArray(np.arange(2.0), dims=("x",), name="bad name")
+    punct_name = xr.DataArray(np.arange(2.0), dims=("x",), name=" !!! ")
+    keyword_name = xr.DataArray(np.arange(2.0), dims=("x",), name="class")
+    leading_digit_name = xr.DataArray(np.arange(2.0), dims=("x",), name="2 sample")
+    mixed_name = xr.DataArray(np.arange(2.0), dims=("x",), name="Sample-Map")
     assert figurecomposer_sources._source_name(unnamed) == "data"
     assert figurecomposer_sources._source_label(unnamed) == "data"
-    assert figurecomposer_sources._source_name(invalid_name) == "data"
+    assert figurecomposer_sources._source_name(invalid_name) == "bad_name"
+    assert figurecomposer_sources._source_name(punct_name) == "data"
+    assert figurecomposer_sources._source_name(keyword_name) == "class_"
+    assert figurecomposer_sources._source_name(leading_digit_name) == "_2_sample"
+    assert figurecomposer_sources._source_name(mixed_name) == "sample_map"
+    reserved = {"sample_map"}
+    assert figurecomposer_sources._source_unique_name("sample_map", reserved) == (
+        "sample_map_2"
+    )
+    assert "sample_map_2" in reserved
+    reserved = set()
+    assert figurecomposer_sources._source_unique_name("fig", reserved) == "fig_2"
     assert figurecomposer_sources._source_display_tooltip(None, "data_0") == (
         "Alias: data_0"
+    )
+    assert (
+        "Original name: bad name"
+        in figurecomposer_source_inspector.source_metadata_tooltip(
+            FigureSourceState(name="bad_name"),
+            "bad_name",
+            invalid_name,
+        )
     )
     with pytest.raises(ValueError, match="not a valid variable"):
         figurecomposer_sources._valid_source_variable("bad name")

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -1419,6 +1419,18 @@ def test_figure_composer_source_selection_helper_edges(qtbot) -> None:
         "derived",
         "data_2",
     )
+    assert tool._source_by_name()["data_2"].label == "data_2"
+    tool.add_sources(
+        (FigureSourceState(name="data", label="Historical incoming"),),
+        {"data": data},
+    )
+    assert tuple(source.name for source in tool.source_states()) == (
+        "data",
+        "derived",
+        "data_2",
+        "data_3",
+    )
+    assert tool._source_by_name()["data_3"].label == "Historical incoming"
 
 
 def test_figure_composer_legacy_source_selection_normalization_edges(
@@ -1767,6 +1779,159 @@ def test_figure_composer_source_refresh_applies_saved_selection(
     tool.refresh_from_sources({"data": refreshed})
     xr.testing.assert_identical(tool.source_data()["data"], refreshed.qsel(eV=0.0))
     assert tool.source_status_label.text() == ""
+
+
+def _transitive_selected_source_tool() -> tuple[
+    FigureComposerTool,
+    xr.DataArray,
+    xr.DataArray,
+    xr.DataArray,
+]:
+    base = xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 4),
+        dims=("u", "v", "w"),
+        coords={"u": [0.0, 1.0], "v": [0.0, 1.0, 2.0], "w": np.arange(4)},
+        name="base",
+    )
+    selected_u = base.qsel(u=1.0)
+    selected_v = selected_u.qsel(v=2.0)
+    tool = FigureComposerTool.from_sources(
+        {"base": base, "selected_u": selected_u, "selected_v": selected_v},
+        sources=(
+            FigureSourceState(name="base", node_uid="base-node"),
+            FigureSourceState(
+                name="selected_u",
+                selection_source="base",
+                qsel={"u": 1.0},
+            ),
+            FigureSourceState(
+                name="selected_v",
+                selection_source="selected_u",
+                qsel={"v": 2.0},
+            ),
+        ),
+        operations=(FigureOperationState.line(label="line", source="selected_v"),),
+        primary_source="base",
+    )
+    tool._source_selection_base_data.update(
+        {"selected_u": base, "selected_v": selected_u}
+    )
+    return tool, base, selected_u, selected_v
+
+
+@pytest.mark.parametrize("mutation", ("replace", "add", "refresh"))
+def test_figure_composer_source_refresh_recomputes_transitive_selected_sources(
+    qtbot,
+    mutation: str,
+) -> None:
+    tool, base, _selected_u, _selected_v = _transitive_selected_source_tool()
+    qtbot.addWidget(tool)
+    replacement = base + 100.0
+
+    if mutation == "replace":
+        assert tool.replace_source(
+            "base",
+            FigureSourceState(name="incoming", node_uid="replacement-node"),
+            replacement,
+        )
+    elif mutation == "add":
+        tool.add_sources(
+            (FigureSourceState(name="base", node_uid="base-node"),),
+            {"base": replacement},
+        )
+    else:
+        tool.refresh_from_sources({"base": replacement})
+
+    expected_u = replacement.qsel(u=1.0)
+    expected_v = expected_u.qsel(v=2.0)
+    xr.testing.assert_identical(tool.source_data()["base"], replacement)
+    xr.testing.assert_identical(tool.source_data()["selected_u"], expected_u)
+    xr.testing.assert_identical(tool.source_data()["selected_v"], expected_v)
+    xr.testing.assert_identical(
+        tool._source_selection_base_data["selected_u"], replacement
+    )
+    xr.testing.assert_identical(
+        tool._source_selection_base_data["selected_v"], expected_u
+    )
+    assert tool.source_status_label.text() == ""
+
+
+@pytest.mark.parametrize("mutation", ("replace", "add", "refresh"))
+def test_figure_composer_source_refresh_is_atomic_when_dependent_selection_fails(
+    qtbot,
+    mutation: str,
+) -> None:
+    tool, base, _selected_u, _selected_v = _transitive_selected_source_tool()
+    qtbot.addWidget(tool)
+    original_status = tool.tool_status
+    original_data = dict(tool.source_data())
+    original_bases = dict(tool._source_selection_base_data)
+    incompatible = base.isel(v=0, drop=True) + 100.0
+
+    if mutation == "replace":
+        assert not tool.replace_source(
+            "base",
+            FigureSourceState(name="incoming", node_uid="replacement-node"),
+            incompatible,
+        )
+    elif mutation == "add":
+        tool.add_sources(
+            (FigureSourceState(name="base", node_uid="base-node"),),
+            {"base": incompatible},
+        )
+    else:
+        tool.refresh_from_sources({"base": incompatible})
+
+    assert tool.tool_status == original_status
+    assert set(tool.source_data()) == set(original_data)
+    for source_name, data in original_data.items():
+        xr.testing.assert_identical(tool.source_data()[source_name], data)
+    assert set(tool._source_selection_base_data) == set(original_bases)
+    for source_name, data in original_bases.items():
+        xr.testing.assert_identical(tool._source_selection_base_data[source_name], data)
+    assert tool.source_status_label.text()
+
+
+def test_figure_composer_selection_edit_recomputes_transitive_selected_sources(
+    qtbot,
+) -> None:
+    tool, base, _selected_u, _selected_v = _transitive_selected_source_tool()
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"selected_u"}, "selected_u")
+
+    tool._update_selected_source_dimension("u", "qsel", "0.0", "")
+
+    expected_u = base.qsel(u=0.0)
+    expected_v = expected_u.qsel(v=2.0)
+    assert tool._source_by_name()["selected_u"].qsel == {"u": 0.0}
+    xr.testing.assert_identical(tool.source_data()["selected_u"], expected_u)
+    xr.testing.assert_identical(tool.source_data()["selected_v"], expected_v)
+    xr.testing.assert_identical(tool._source_selection_base_data["selected_u"], base)
+    xr.testing.assert_identical(
+        tool._source_selection_base_data["selected_v"], expected_u
+    )
+    assert tool.source_validation_label.text() == ""
+
+
+def test_figure_composer_selection_edit_is_atomic_when_dependent_fails(
+    qtbot,
+) -> None:
+    tool, _base, _selected_u, _selected_v = _transitive_selected_source_tool()
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"selected_u"}, "selected_u")
+    original_status = tool.tool_status
+    original_data = dict(tool.source_data())
+    original_bases = dict(tool._source_selection_base_data)
+
+    tool._update_selected_source_dimension("v", "mean", "", "")
+
+    assert tool.tool_status == original_status
+    for source_name, data in original_data.items():
+        xr.testing.assert_identical(tool.source_data()[source_name], data)
+    for source_name, data in original_bases.items():
+        xr.testing.assert_identical(tool._source_selection_base_data[source_name], data)
+    assert "selected_u" in tool.source_validation_label.text()
+    assert "selected_v" in tool.source_validation_label.text()
 
 
 def test_figure_composer_readding_linked_source_preserves_selection(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -735,6 +735,68 @@ def test_figure_composer_source_list_edge_events(qtbot) -> None:
 
     assert emitted == []
 
+    event = QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_A,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    source_list.keyPressEvent(event)
+
+
+def test_figure_composer_source_alias_editor_commit_paths(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = {name: _figure_composer_profile_source(name) for name in ("first", "second")}
+    tool = FigureComposerTool.from_sources(
+        data,
+        sources=tuple(FigureSourceState(name=name) for name in data),
+        setup=FigureSubplotsState(),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"first"}, "first")
+    tool._refresh_source_selection_editor()
+    alias_edit = tool.source_selection_controls.findChild(
+        QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
+    )
+    assert alias_edit is not None
+
+    monkeypatch.setattr(tool, "sender", lambda: alias_edit)
+    alias_edit.setText("first")
+    tool._commit_source_alias_edit()
+    assert tuple(source.name for source in tool.source_states()) == ("first", "second")
+
+    alias_edit.setText("second")
+    tool._commit_source_alias_edit()
+    assert "already in use" in tool.source_status_label.text()
+    assert alias_edit.text() == "first"
+
+    alias_edit.setText("renamed")
+    tool._commit_source_alias_edit()
+    assert tuple(source.name for source in tool.source_states()) == (
+        "renamed",
+        "second",
+    )
+    assert "renamed" in tool._source_data
+
+
+def test_figure_composer_remove_selected_sources_removes_available_rows(qtbot) -> None:
+    data = {name: _figure_composer_profile_source(name) for name in ("first", "second")}
+    tool = FigureComposerTool.from_sources(
+        data,
+        sources=tuple(FigureSourceState(name=name) for name in data),
+        operations=(FigureOperationState.line(label="line", source="first"),),
+        setup=FigureSubplotsState(),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"second"}, "second")
+
+    tool._remove_selected_sources()
+
+    assert tuple(source.name for source in tool.source_states()) == ("first",)
+    assert "second" not in tool._source_data
+
 
 def test_figure_composer_source_add_callbacks_handle_unavailable_paths(
     qtbot,
@@ -1277,6 +1339,53 @@ def test_figure_composer_source_refresh_applies_saved_selection(
     assert tool.source_status_label.text() == ""
 
 
+def test_figure_composer_refresh_from_sources_covers_edge_paths(qtbot) -> None:
+    first = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "alpha"),
+        coords={"eV": [-1.0, 0.0], "alpha": [0.0, 1.0, 2.0]},
+        name="first",
+    )
+    second = xr.DataArray(
+        np.arange(3.0),
+        dims=("alpha",),
+        coords={"alpha": [0.0, 1.0, 2.0]},
+        name="second",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"first": first, "second": second},
+        sources=(
+            FigureSourceState(
+                name="first",
+                qsel={"eV": 0.0},
+                selection_source="first",
+            ),
+            FigureSourceState(name="second"),
+        ),
+        operations=(FigureOperationState.plot_array(label="array", source="first"),),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+
+    tool.refresh_from_sources({})
+    assert tool.source_status_label.text() == ""
+
+    incompatible = second + 10.0
+    tool.refresh_from_sources({"first": incompatible})
+    assert "Could not refresh source data for: first" in tool.source_status_label.text()
+
+    refreshed_second = second + 20.0
+    tool._source_selection_base_data["second"] = second
+    tool.refresh_from_sources({"second": refreshed_second})
+    xr.testing.assert_identical(tool.source_data()["second"], refreshed_second)
+    assert "second" not in tool._source_selection_base_data
+    assert tool.source_status_label.text() == ""
+
+    extra = xr.DataArray(np.arange(2.0), dims=("x",), name="extra")
+    tool.refresh_from_sources({"extra": extra})
+    xr.testing.assert_identical(tool.source_data()["extra"], extra)
+
+
 def test_figure_composer_batch_source_selection_skips_incompatible_sources(
     qtbot,
 ) -> None:
@@ -1319,6 +1428,104 @@ def test_figure_composer_batch_source_selection_skips_incompatible_sources(
     xr.testing.assert_identical(tool.source_data()["first"], first.isel(x=1))
     xr.testing.assert_identical(tool.source_data()["second"], second)
     assert "second" in tool.source_status_label.text()
+
+
+def test_figure_composer_source_provenance_helper_edges(qtbot) -> None:
+    base_data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "alpha"),
+        coords={"eV": [-1.0, 0.0], "alpha": [0.0, 1.0, 2.0]},
+        name="base",
+    )
+    base_spec = provenance.public_data().model_dump(mode="json")
+    base_source = FigureSourceState(
+        name="base",
+        node_uid="base-node",
+        provenance_spec=base_spec,
+    )
+    selected_source = FigureSourceState(
+        name="base_selected",
+        selection_source="base",
+        qsel={"eV": 0.0},
+        mean_dims=("alpha",),
+        provenance_spec=base_spec,
+    )
+    tool = FigureComposerTool.from_sources(
+        {"base": base_data, "base_selected": base_data.qsel(eV=0.0).mean("alpha")},
+        sources=(base_source, selected_source),
+        operations=(
+            FigureOperationState.plot_array(label="array", source="base_selected"),
+        ),
+        setup=FigureSubplotsState(),
+        primary_source="base",
+    )
+    qtbot.addWidget(tool)
+
+    operation_types = tuple(
+        type(operation)
+        for operation in tool._source_selection_replay_operations(
+            selected_source.model_copy(update={"isel": {"alpha": 1}})
+        )
+    )
+    assert operation_types == (
+        provenance.IselOperation,
+        provenance.QSelOperation,
+        provenance.QSelAggregationOperation,
+    )
+    assert tool._source_code_name_candidate("ImageTool 3: data_5") == "source_5"
+    assert tool._source_code_name_candidate("2 sample map") == "source_2_sample_map"
+    assert tool._source_code_name_candidate("class") is None
+    assert tool._source_code_name_candidate(" !!! ") is None
+
+    used_names = {"source"}
+    assert (
+        tool._source_display_code_name(
+            FigureSourceState(name=" !!! "), used_names=used_names
+        )
+        == "source_2"
+    )
+    assert "source_2" in used_names
+
+    script_input = provenance.ScriptInput(name="base", provenance_spec=base_spec)
+    assert tool._script_input_with_name(script_input, "base") is script_input
+    assert tool._script_input_with_name(script_input, "renamed").name == "renamed"
+
+    renamed_input = tool._selected_source_script_input(
+        base_source,
+        display_name="display_base",
+        source_by_name={"base": base_source},
+    )
+    assert renamed_input is not None
+    assert renamed_input.name == "display_base"
+
+    selected_input = tool._selected_source_script_input(
+        selected_source,
+        display_name="display_selected",
+        source_by_name={"base": base_source, "base_selected": selected_source},
+    )
+    assert selected_input is not None
+    assert selected_input.name == "display_selected"
+    selected_spec = selected_input.parsed_provenance_spec()
+    assert selected_spec is not None
+    assert len(selected_spec.replay_stages) == 1
+    assert len(selected_spec.replay_stages[0].operations) == 2
+
+    assert (
+        tool._selected_source_script_input(
+            FigureSourceState(name="live_selected", selection_source="missing"),
+            display_name="live_selected",
+            source_by_name={},
+        )
+        is None
+    )
+    assert (
+        tool._selected_source_script_input(
+            FigureSourceState(name="invalid", node_uid="node"),
+            display_name="invalid",
+            source_by_name={},
+        )
+        is None
+    )
 
 
 def test_figure_composer_source_helpers_cover_selection_contract() -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -2359,10 +2359,71 @@ def test_figure_composer_source_provenance_helper_edges(qtbot) -> None:
     )
     assert selected_input is not None
     assert selected_input.name == "display_selected"
+    assert selected_input.label == "display_selected"
     selected_spec = selected_input.parsed_provenance_spec()
     assert selected_spec is not None
     assert len(selected_spec.replay_stages) == 1
     assert len(selected_spec.replay_stages[0].operations) == 2
+
+    historical_selected_source = selected_source.model_copy(
+        update={"label": "ImageTool 7: gap scan"}
+    )
+    historical_selected_input = tool._selected_source_script_input(
+        historical_selected_source,
+        display_name="display_selected",
+        source_by_name={
+            "base": base_source,
+            "base_selected": historical_selected_source,
+        },
+    )
+    assert historical_selected_input is not None
+    assert historical_selected_input.label == "ImageTool 7: gap scan"
+
+    live_base = FigureSourceState(name="live_base", node_uid="live-node")
+    live_selected_source = FigureSourceState(
+        name="live_selected",
+        selection_source="live_base",
+        qsel={"eV": 0.0},
+    )
+    live_selected_input = tool._selected_source_script_input(
+        live_selected_source,
+        display_name="live_selected",
+        source_by_name={
+            "live_base": live_base,
+            "live_selected": live_selected_source,
+        },
+    )
+    assert live_selected_input is not None
+    assert live_selected_input.node_uid is None
+    live_selected_spec = live_selected_input.parsed_provenance_spec()
+    assert live_selected_spec is not None
+    [live_dependency] = provenance.script_input_dependency_refs(live_selected_spec)
+    assert live_dependency.node_uid == "live-node"
+    live_selected_graph = _replay_graph.compile_replay_graph(
+        live_selected_spec,
+        live_input_resolver=lambda script_input: (
+            (base_data, script_input) if script_input.node_uid == "live-node" else None
+        ),
+    )
+    xr.testing.assert_identical(
+        _replay_graph.execute_replay_graph(live_selected_graph),
+        base_data.qsel(eV=0.0),
+    )
+
+    cycle_a = selected_source.model_copy(
+        update={"name": "cycle_a", "selection_source": "cycle_b"}
+    )
+    cycle_b = selected_source.model_copy(
+        update={"name": "cycle_b", "selection_source": "cycle_a"}
+    )
+    assert (
+        tool._selected_source_script_input(
+            cycle_a,
+            display_name="cycle",
+            source_by_name={"cycle_a": cycle_a, "cycle_b": cycle_b},
+        )
+        is None
+    )
 
     assert (
         tool._selected_source_script_input(
@@ -2374,7 +2435,7 @@ def test_figure_composer_source_provenance_helper_edges(qtbot) -> None:
     )
     assert (
         tool._selected_source_script_input(
-            FigureSourceState(name="invalid", node_uid="node"),
+            FigureSourceState(name="invalid"),
             display_name="invalid",
             source_by_name={},
         )
@@ -3153,6 +3214,97 @@ def test_figure_composer_provenance_includes_sources_and_build_step(
     assert isinstance(namespace["fig"], Figure)
 
 
+def test_figure_composer_provenance_replays_transitive_selected_source_chain(
+    qtbot,
+    tmp_path: Path,
+) -> None:
+    base = xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 4),
+        dims=("u", "v", "w"),
+        coords={"u": [0.0, 1.0], "v": [0.0, 1.0, 2.0], "w": np.arange(4)},
+        name="sample_map",
+    )
+    selected_u = base.qsel(u=1.0)
+    selected_v = selected_u.qsel(v=2.0)
+    path = tmp_path / "sample_map.nc"
+    base.to_netcdf(path)
+    source_spec = _file_load_provenance(path).model_dump(mode="json")
+    tool = FigureComposerTool.from_sources(
+        {"base": base, "selected_u": selected_u, "selected_v": selected_v},
+        sources=(
+            FigureSourceState(
+                name="base", node_uid="base-node", provenance_spec=source_spec
+            ),
+            FigureSourceState(
+                name="selected_u",
+                selection_source="base",
+                qsel={"u": 1.0},
+                provenance_spec=source_spec,
+            ),
+            FigureSourceState(
+                name="selected_v",
+                selection_source="selected_u",
+                qsel={"v": 2.0},
+                provenance_spec=source_spec,
+            ),
+        ),
+        operations=(
+            FigureOperationState.custom(
+                label="reserve source name",
+                code="sample_map = -1",
+                trusted=True,
+            ),
+            FigureOperationState.line(label="profile", source="selected_v"),
+        ),
+        primary_source="base",
+    )
+    qtbot.addWidget(tool)
+
+    script_inputs, skipped_names, source_name_map = tool._display_code_source_plan()
+    assert skipped_names == {"selected_v"}
+    assert source_name_map == {"selected_v": "sample_map_2"}
+    assert len(script_inputs) == 1
+    assert script_inputs[0].name == "sample_map_2"
+    assert script_inputs[0].label == "sample_map_2"
+    assert script_inputs[0].node_uid is None
+    selected_spec = script_inputs[0].parsed_provenance_spec()
+    assert selected_spec is not None
+    assert len(selected_spec.replay_stages) == 2
+    assert all(len(stage.operations) == 1 for stage in selected_spec.replay_stages)
+    [dependency] = provenance.script_input_dependency_refs(selected_spec)
+    assert dependency.node_uid == "base-node"
+
+    resolved_names: list[str] = []
+
+    def resolve_live(
+        script_input: provenance.ScriptInput,
+    ) -> tuple[xr.DataArray, provenance.ScriptInput] | None:
+        if script_input.node_uid != "base-node":
+            return None
+        resolved_names.append(script_input.name)
+        return base, script_input
+
+    selected_graph = _replay_graph.compile_replay_graph(
+        selected_spec,
+        live_input_resolver=resolve_live,
+    )
+    live_selected = _replay_graph.execute_replay_graph(selected_graph)
+    xr.testing.assert_identical(live_selected, selected_v)
+    assert resolved_names == ["base"]
+
+    figure_spec = tool.current_provenance_spec()
+    assert figure_spec is not None
+    code = figure_spec.display_code()
+    assert code is not None
+    namespace = _exec_generated_code(code, {})
+
+    assert namespace["sample_map"] == -1
+    xr.testing.assert_identical(namespace["sample_map_2"], selected_v)
+    lines = namespace["fig"].axes[0].lines
+    assert len(lines) == 1
+    np.testing.assert_allclose(lines[0].get_ydata(), selected_v.values)
+
+
 def test_figure_composer_full_code_composes_selected_file_sources(
     qtbot,
     monkeypatch,
@@ -3355,9 +3507,7 @@ def test_figure_composer_full_code_falls_back_for_live_selected_source(
 
     spec = tool.current_provenance_spec()
     assert spec is not None
-    assert tuple(script_input.name for script_input in spec.script_inputs) == (
-        "data_3",
-    )
+    assert tuple(script_input.name for script_input in spec.script_inputs) == ("live",)
     assert spec.display_code() is None
 
     code = tool.generated_code()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -1084,6 +1084,56 @@ def test_figure_composer_remove_selected_sources_removes_available_rows(qtbot) -
     assert "second" not in tool._source_data
 
 
+def test_figure_composer_remove_selected_sources_resolves_dependencies(qtbot) -> None:
+    base = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0, 2.0]},
+        name="base",
+    )
+    selected = base.qsel(x=1.0)
+    other = xr.DataArray(np.arange(3.0), dims=("y",), name="other")
+    tool = FigureComposerTool.from_sources(
+        {"other": other, "base": base, "selected": selected},
+        sources=(
+            FigureSourceState(name="other"),
+            FigureSourceState(name="base"),
+            FigureSourceState(
+                name="selected", selection_source="base", qsel={"x": 1.0}
+            ),
+        ),
+        operations=(),
+        primary_source="other",
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"base", "selected"}, "base")
+
+    tool._remove_selected_sources()
+
+    assert tuple(source.name for source in tool.source_states()) == ("other",)
+    assert set(tool.source_data()) == {"other"}
+
+
+def test_figure_composer_remove_all_selected_sources_keeps_last_row(qtbot) -> None:
+    source_data = {
+        name: xr.DataArray(np.arange(2.0), dims=("x",), name=name)
+        for name in ("first", "second", "third")
+    }
+    tool = FigureComposerTool.from_sources(
+        source_data,
+        sources=tuple(FigureSourceState(name=name) for name in source_data),
+        operations=(),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent(set(source_data), "first")
+
+    tool._remove_selected_sources()
+
+    assert tuple(source.name for source in tool.source_states()) == ("third",)
+    assert set(tool.source_data()) == {"third"}
+
+
 def test_figure_composer_source_add_callbacks_handle_unavailable_paths(
     qtbot,
 ) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -1452,6 +1452,69 @@ def test_figure_composer_legacy_source_selection_normalization_edges(
     assert sources["data_selected_2"].isel == {"kx": 1}
 
 
+@pytest.mark.parametrize(
+    ("operation_sources", "selection_values", "expected"),
+    (
+        (("first",), (("first", 0.0), ("first", 2.0)), (0.0, 2.0)),
+        (
+            ("first", "second"),
+            (("first", 1.0),),
+            (1.0, "second"),
+        ),
+        (
+            ("first", "first"),
+            (("first", 0.0), ("first", 2.0)),
+            (0.0, 2.0),
+        ),
+        ((), (("first", 2.0), ("first", 0.0)), (2.0, 0.0)),
+    ),
+)
+def test_figure_composer_plot_slices_legacy_selections_preserve_source_order(
+    qtbot,
+    operation_sources: tuple[str, ...],
+    selection_values: tuple[tuple[str, float], ...],
+    expected: tuple[float | str, ...],
+) -> None:
+    first = xr.DataArray(
+        np.arange(12.0).reshape(3, 2, 2),
+        dims=("cut", "x", "y"),
+        coords={"cut": [0.0, 1.0, 2.0], "x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="first",
+    )
+    second = (first + 100.0).rename("second")
+    operation = FigureOperationState.plot_slices(
+        label="maps",
+        sources=operation_sources,
+        map_selections=tuple(
+            FigureDataSelectionState(source=source, qsel={"cut": value})
+            for source, value in selection_values
+        ),
+    )
+    tool = FigureComposerTool.from_sources(
+        {"first": first, "second": second},
+        sources=(FigureSourceState(name="first"), FigureSourceState(name="second")),
+        operations=(operation,),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+
+    [loaded_operation] = tool.tool_status.operations
+    assert loaded_operation.map_selections == ()
+    assert len(loaded_operation.sources) == len(expected)
+    for source_name, expected_value in zip(
+        loaded_operation.sources, expected, strict=True
+    ):
+        if expected_value == "second":
+            assert source_name == "second"
+            xr.testing.assert_identical(tool.source_data()[source_name], second)
+        else:
+            selected = first.qsel(cut=expected_value)
+            xr.testing.assert_identical(tool.source_data()[source_name], selected)
+            source = tool._source_by_name()[source_name]
+            assert source.selection_source == "first"
+            assert source.qsel == {"cut": expected_value}
+
+
 def test_figure_composer_source_display_helpers_use_alias_only() -> None:
     source = FigureSourceState(name="data_0", label="ImageTool 0: sample_map")
     assert figurecomposer_sources._source_display_label(source, "data_0") == "data_0"

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -287,6 +287,75 @@ def test_figure_composer_restore_rebuilds_selected_source_chain_out_of_order(
     )
 
 
+def test_figure_composer_restore_recomputes_cached_selected_descendants(qtbot) -> None:
+    tool, base, selected_u, selected_v = _transitive_selected_source_tool()
+    qtbot.addWidget(tool)
+    replacement = base + 100.0
+
+    tool._restore_persistence_data_items(
+        {
+            erlab.interactive.utils._SAVED_TOOL_DATA_NAME: replacement,
+            "selected_u": base,
+            "selected_v": selected_u,
+        },
+        xr.Dataset(),
+    )
+
+    expected_u = replacement.qsel(u=1.0)
+    expected_v = expected_u.qsel(v=2.0)
+    xr.testing.assert_identical(tool.source_data()["base"], replacement)
+    xr.testing.assert_identical(tool.source_data()["selected_u"], expected_u)
+    xr.testing.assert_identical(tool.source_data()["selected_v"], expected_v)
+    assert not tool.source_data()["selected_u"].identical(selected_u)
+    assert not tool.source_data()["selected_v"].identical(selected_v)
+    xr.testing.assert_identical(
+        tool._source_selection_base_data["selected_u"], replacement
+    )
+    xr.testing.assert_identical(
+        tool._source_selection_base_data["selected_v"], expected_u
+    )
+
+
+def test_figure_composer_restore_fallbacks_are_parent_first(qtbot) -> None:
+    stable = xr.DataArray(np.arange(2.0), dims=("x",), name="stable")
+    base = xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 4),
+        dims=("u", "v", "w"),
+        coords={"u": [0.0, 1.0], "v": [0.0, 1.0, 2.0], "w": np.arange(4)},
+        name="base",
+    )
+    selected_u = base.qsel(u=1.0)
+    tool = FigureComposerTool.from_sources(
+        {"stable": stable},
+        sources=(
+            FigureSourceState(
+                name="selected_v",
+                selection_source="selected_u",
+                qsel={"v": 2.0},
+            ),
+            FigureSourceState(
+                name="selected_u",
+                selection_source="missing_base",
+                qsel={"u": 1.0},
+            ),
+            FigureSourceState(name="missing_base"),
+            FigureSourceState(name="stable"),
+        ),
+        operations=(FigureOperationState.line(label="line", source="selected_v"),),
+        primary_source="stable",
+    )
+    qtbot.addWidget(tool)
+
+    tool._restore_persistence_data_items(
+        {"selected_v": selected_u, "selected_u": base}, xr.Dataset()
+    )
+
+    xr.testing.assert_identical(tool.source_data()["selected_u"], selected_u)
+    xr.testing.assert_identical(
+        tool.source_data()["selected_v"], selected_u.qsel(v=2.0)
+    )
+
+
 def test_figure_composer_restore_selected_source_cycle_stays_unresolved(qtbot) -> None:
     stable = xr.DataArray(np.arange(3.0), dims=("x",), name="stable")
     tool = FigureComposerTool.from_sources(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -2160,6 +2160,10 @@ def test_figure_composer_source_refresh_recomputes_transitive_selected_sources(
     xr.testing.assert_identical(
         tool._source_selection_base_data["selected_v"], expected_u
     )
+    if mutation == "replace":
+        assert {source.node_uid for source in tool.source_states()} == {
+            "replacement-node"
+        }
     assert tool.source_status_label.text() == ""
 
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -631,6 +631,39 @@ def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> 
     assert tool.source_list.findChildren(QtWidgets.QToolButton) == []
 
 
+def test_figure_composer_cannot_remove_source_used_by_selected_alias(qtbot) -> None:
+    base = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "x"),
+        coords={"eV": [-1.0, 0.0], "x": [0.0, 1.0, 2.0]},
+        name="base",
+    )
+    other = xr.DataArray(np.arange(3.0), dims=("x",), name="other")
+    tool = FigureComposerTool.from_sources(
+        {
+            "base": base,
+            "selected": base.qsel(eV=0.0),
+            "other": other,
+        },
+        sources=(
+            FigureSourceState(name="base"),
+            FigureSourceState(
+                name="selected",
+                qsel={"eV": 0.0},
+                selection_source="base",
+            ),
+            FigureSourceState(name="other"),
+        ),
+        operations=(FigureOperationState.line(label="line", source="other"),),
+        primary_source="other",
+    )
+    qtbot.addWidget(tool)
+
+    assert not tool.remove_source("base")
+    assert tool.remove_source("selected")
+    assert tool.remove_source("base")
+
+
 def test_figure_composer_source_alias_editor_renames_references(qtbot) -> None:
     first = _figure_composer_image_source("first")
     second = _figure_composer_image_source("second")
@@ -786,6 +819,66 @@ def test_figure_composer_source_duplicate_and_reorder_controls(qtbot) -> None:
     assert tool.source_list.currentItem().text(0) == "second_copy"
 
 
+def test_figure_composer_duplicate_selected_source_generated_code_uses_raw_base(
+    qtbot, monkeypatch
+) -> None:
+    base = xr.DataArray(
+        np.arange(8.0).reshape(2, 2, 2),
+        dims=("hv", "x", "y"),
+        coords={"hv": [40.0, 50.0], "x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="data",
+    )
+    selected = base.qsel(hv=40.0)
+    tool = FigureComposerTool.from_sources(
+        {"data": selected},
+        sources=(
+            FigureSourceState(
+                name="data",
+                qsel={"hv": 40.0},
+                selection_source="data",
+            ),
+        ),
+        operations=(
+            FigureOperationState.plot_array(
+                label="original",
+                source="data",
+                axes=FigureAxesSelectionState(axes=((0, 0),)),
+            ),
+        ),
+        setup=FigureSubplotsState(nrows=1, ncols=2),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool._source_selection_base_data["data"] = base
+    tool._set_selected_source_names_silent({"data"}, "data")
+    tool._duplicate_selected_sources()
+    tool._recipe = tool._recipe.model_copy(
+        update={
+            "operations": (
+                *tool._recipe.operations,
+                FigureOperationState.plot_array(
+                    label="copy",
+                    source="data_copy",
+                    axes=FigureAxesSelectionState(axes=((0, 1),)),
+                ),
+            )
+        }
+    )
+
+    captured: list[xr.DataArray] = []
+    monkeypatch.setattr(
+        eplt,
+        "plot_array",
+        lambda data, **_kwargs: captured.append(data),
+    )
+    namespace = _exec_generated_code(tool.generated_code(), {"data": base})
+
+    assert isinstance(namespace["fig"], Figure)
+    assert len(captured) == 2
+    xr.testing.assert_identical(captured[0], selected)
+    xr.testing.assert_identical(captured[1], selected)
+
+
 def test_figure_composer_source_list_internal_reorder_updates_recipe(qtbot) -> None:
     data = {
         name: _figure_composer_profile_source(name) for name in ("a", "b", "c", "d")
@@ -930,6 +1023,11 @@ def test_figure_composer_source_alias_editor_commit_paths(
     assert not tool.source_validation_label.isHidden()
     assert tool.source_status_label.isHidden()
     assert alias_edit.text() == "second"
+
+    alias_edit.setText("list")
+    tool._commit_source_alias_edit()
+    assert tuple(source.name for source in tool.source_states()) == ("first", "second")
+    assert not tool.source_validation_label.isHidden()
 
     alias_edit.setText("renamed")
     tool._commit_source_alias_edit()
@@ -1567,6 +1665,46 @@ def test_figure_composer_readding_linked_source_preserves_selection(qtbot) -> No
     assert not tool.source_status_label.isHidden()
 
 
+def test_figure_composer_readding_renamed_linked_source_updates_alias(qtbot) -> None:
+    original = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "x"),
+        coords={"eV": [-1.0, 0.0], "x": [0.0, 1.0, 2.0]},
+        name="map",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"custom_alias": original.qsel(eV=0.0)},
+        sources=(
+            FigureSourceState(
+                name="custom_alias",
+                qsel={"eV": 0.0},
+                selection_source="custom_alias",
+                node_uid="node",
+            ),
+        ),
+        operations=(
+            FigureOperationState.plot_array(label="array", source="custom_alias"),
+        ),
+        primary_source="custom_alias",
+    )
+    qtbot.addWidget(tool)
+
+    refreshed = original + 10.0
+    tool.add_sources(
+        (FigureSourceState(name="manager_default", node_uid="node"),),
+        {"manager_default": refreshed},
+    )
+
+    assert tuple(source.name for source in tool.source_states()) == ("custom_alias",)
+    assert tool.source_states()[0].qsel == {"eV": 0.0}
+    xr.testing.assert_identical(
+        tool.source_data()["custom_alias"], refreshed.qsel(eV=0.0)
+    )
+    xr.testing.assert_identical(
+        tool._source_selection_base_data["custom_alias"], refreshed
+    )
+
+
 def test_figure_composer_replace_different_source_preserves_compatible_selection(
     qtbot,
 ) -> None:
@@ -1869,7 +2007,10 @@ def test_figure_composer_source_helpers_cover_selection_contract() -> None:
     assert figurecomposer_sources._source_name(reserved_name) == "profiles_2"
     bvec_name = xr.DataArray(np.arange(2.0), dims=("x",), name="bvec")
     assert figurecomposer_sources._source_name(bvec_name) == "bvec_2"
+    builtin_name = xr.DataArray(np.arange(2.0), dims=("x",), name="list")
+    assert figurecomposer_sources._source_name(builtin_name) == "list_2"
     assert figurecomposer_sources._source_alias_error("erlab") is not None
+    assert figurecomposer_sources._source_alias_error("list") is not None
     assert (
         figurecomposer_sources._source_alias_error("line_color_values_norm") is not None
     )
@@ -2885,6 +3026,69 @@ def test_figure_composer_copy_paste_steps_carries_same_process_source_data(
     xr.testing.assert_identical(destination.source_data()["map"], source_data)
 
 
+def test_figure_composer_copy_paste_steps_carries_selection_dependencies(
+    qtbot, monkeypatch
+) -> None:
+    base = xr.DataArray(
+        np.arange(8.0).reshape(2, 2, 2),
+        dims=("hv", "x", "y"),
+        coords={"hv": [40.0, 50.0], "x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="base",
+    )
+    selected = base.qsel(hv=40.0)
+    source_tool = FigureComposerTool.from_sources(
+        {"base": base, "selected": selected},
+        sources=(
+            FigureSourceState(name="base"),
+            FigureSourceState(
+                name="selected",
+                qsel={"hv": 40.0},
+                selection_source="base",
+            ),
+        ),
+        operations=(FigureOperationState.plot_array(label="plot", source="selected"),),
+        primary_source="base",
+    )
+    source_tool._source_selection_base_data["selected"] = base
+
+    existing = xr.DataArray(np.zeros((2, 2)), dims=("x", "y"), name="existing")
+    destination = FigureComposerTool.from_sources(
+        {"base": existing, "selected": existing},
+        sources=(FigureSourceState(name="base"), FigureSourceState(name="selected")),
+        operations=(),
+        primary_source="base",
+    )
+    qtbot.addWidget(source_tool)
+    qtbot.addWidget(destination)
+    _clear_clipboard()
+
+    _select_operation_rows(source_tool, (0,))
+    source_tool._copy_selected_operations()
+    destination._paste_operations_from_clipboard()
+
+    source_by_name = destination._source_by_name()
+    assert source_by_name["selected_copy"].selection_source == "base_copy"
+    xr.testing.assert_identical(destination.source_data()["base_copy"], base)
+    xr.testing.assert_identical(destination.source_data()["selected_copy"], selected)
+    xr.testing.assert_identical(
+        destination._source_selection_base_data["selected_copy"], base
+    )
+    assert destination.tool_status.operations[-1].sources == ("selected_copy",)
+
+    captured: list[xr.DataArray] = []
+    monkeypatch.setattr(
+        eplt,
+        "plot_array",
+        lambda data, **_kwargs: captured.append(data),
+    )
+    namespace = _exec_generated_code(
+        destination.generated_code(),
+        {"base_copy": destination.source_data()["base_copy"]},
+    )
+    assert isinstance(namespace["fig"], Figure)
+    xr.testing.assert_identical(captured[-1], selected)
+
+
 def test_figure_composer_cut_paste_steps_preserves_same_composer_sources(
     qtbot,
 ) -> None:
@@ -3155,7 +3359,8 @@ def test_figure_composer_source_data_history_helpers(qtbot) -> None:
     qtbot.addWidget(tool)
 
     tool._reset_history_stack()
-    assert list(tool._prev_source_data_states[-1]) == ["data"]
+    assert list(tool._prev_source_data_states[-1][0]) == ["data"]
+    assert tool._prev_source_data_states[-1][1] == {}
     assert not tool.undoable
     assert not tool.redoable
     tool.undo()
@@ -3171,13 +3376,51 @@ def test_figure_composer_source_data_history_helpers(qtbot) -> None:
     replacement = data.copy(data=np.full(3, 2.0))
     tool.set_source_data({"data": replacement})
     tool._replace_last_state()
-    xr.testing.assert_identical(tool._prev_source_data_states[-1]["data"], replacement)
+    xr.testing.assert_identical(
+        tool._prev_source_data_states[-1][0]["data"], replacement
+    )
 
     tool._prev_states.clear()
     tool._prev_source_data_states.clear()
     tool._replace_last_state()
     assert len(tool._prev_states) == 1
-    xr.testing.assert_identical(tool._prev_source_data_states[-1]["data"], replacement)
+    xr.testing.assert_identical(
+        tool._prev_source_data_states[-1][0]["data"], replacement
+    )
+
+
+def test_figure_composer_history_restores_source_selection_backing(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "x"),
+        coords={"eV": [-1.0, 0.0], "x": [0.0, 1.0, 2.0]},
+        name="data",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data"),),
+        operations=(FigureOperationState.plot_array(label="plot", source="data"),),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"data"}, "data")
+
+    tool._update_selected_source_dimension("eV", "qsel", "0.0", "")
+    assert tool.source_data()["data"].dims == ("x",)
+    xr.testing.assert_identical(tool._source_selection_base_data["data"], data)
+
+    tool.undo()
+    assert tool.source_states()[0].qsel == {}
+    assert "data" not in tool._source_selection_base_data
+    xr.testing.assert_identical(tool.source_data()["data"], data)
+
+    tool.redo()
+    assert tool.source_states()[0].qsel == {"eV": 0.0}
+    xr.testing.assert_identical(tool._source_selection_base_data["data"], data)
+
+    tool._update_selected_source_dimension("eV", "keep", "", "")
+    assert tool.source_states()[0].qsel == {}
+    xr.testing.assert_identical(tool.source_data()["data"], data)
 
 
 def test_figure_composer_copy_paste_source_and_insert_fallbacks(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -231,6 +231,71 @@ def test_figure_composer_selected_alias_roundtrip_uses_source_alias_base(
     xr.testing.assert_identical(restored._source_selection_base_data["selected"], base)
 
 
+def test_figure_composer_restore_rebuilds_selected_source_chain_out_of_order(
+    qtbot,
+) -> None:
+    base = xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 4),
+        dims=("u", "v", "w"),
+        coords={"u": [0.0, 1.0], "v": [0.0, 1.0, 2.0], "w": np.arange(4)},
+        name="base",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"base": base},
+        sources=(
+            FigureSourceState(
+                name="selected_v",
+                selection_source="selected_u",
+                qsel={"v": 2.0},
+            ),
+            FigureSourceState(
+                name="selected_u",
+                selection_source="base",
+                qsel={"u": 1.0},
+            ),
+            FigureSourceState(name="base"),
+        ),
+        operations=(FigureOperationState.line(label="line", source="selected_v"),),
+        primary_source="base",
+    )
+    qtbot.addWidget(tool)
+
+    tool._restore_persistence_data_items({}, xr.Dataset())
+
+    selected_u = base.qsel(u=1.0)
+    selected_v = selected_u.qsel(v=2.0)
+    xr.testing.assert_identical(tool.source_data()["selected_u"], selected_u)
+    xr.testing.assert_identical(tool.source_data()["selected_v"], selected_v)
+    xr.testing.assert_identical(tool._source_selection_base_data["selected_u"], base)
+    xr.testing.assert_identical(
+        tool._source_selection_base_data["selected_v"], selected_u
+    )
+
+
+def test_figure_composer_restore_selected_source_cycle_stays_unresolved(qtbot) -> None:
+    stable = xr.DataArray(np.arange(3.0), dims=("x",), name="stable")
+    tool = FigureComposerTool.from_sources(
+        {"stable": stable},
+        sources=(
+            FigureSourceState(name="stable"),
+            FigureSourceState(
+                name="cycle_a", selection_source="cycle_b", isel={"x": 0}
+            ),
+            FigureSourceState(
+                name="cycle_b", selection_source="cycle_a", isel={"x": 0}
+            ),
+        ),
+        operations=(),
+        primary_source="stable",
+    )
+    qtbot.addWidget(tool)
+
+    tool._restore_persistence_data_items({}, xr.Dataset())
+
+    assert set(tool.source_data()) == {"stable"}
+    assert tool._source_selection_base_data == {}
+
+
 def test_figure_composer_persistence_metadata_fallbacks(qtbot) -> None:
     primary = xr.DataArray(np.arange(2.0), dims=("x",), name="primary")
     fallback = xr.DataArray(np.arange(2.0) + 2.0, dims=("x",), name="fallback")

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -16,6 +16,43 @@ def _source_context_action(
     return tool._source_context_menu, action
 
 
+def test_figure_composer_source_alias_candidate_rejects_unusable_names(
+    monkeypatch,
+) -> None:
+    assert (
+        figurecomposer_sources._source_alias_candidate(
+            xr.DataArray(np.arange(2), dims=("x",), name=" ")
+        )
+        is None
+    )
+    assert (
+        figurecomposer_sources._source_alias_candidate(
+            xr.DataArray(np.arange(2), dims=("x",), name="!!!")
+        )
+        is None
+    )
+    assert (
+        figurecomposer_sources._source_alias_error(
+            erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+        )
+        is not None
+    )
+
+    class InvalidIdentifierValidator:
+        def fixup(self, _text: str) -> str:
+            return "bad name"
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "IdentifierValidator", InvalidIdentifierValidator
+    )
+    assert (
+        figurecomposer_sources._source_alias_candidate(
+            xr.DataArray(np.arange(2), dims=("x",), name="bad name")
+        )
+        is None
+    )
+
+
 def test_figure_composer_plot_source_move_button_uses_disabled_icon_color(
     qtbot, monkeypatch
 ) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -3,6 +3,19 @@
 from ._common import *
 
 
+def _source_context_action(
+    tool: FigureComposerTool, object_name: str
+) -> tuple[QtWidgets.QMenu, QtGui.QAction]:
+    tool._show_source_context_menu(QtCore.QPoint(0, 0))
+    assert tool._source_context_menu is not None
+    action = next(
+        action
+        for action in tool._source_context_menu.actions()
+        if action.objectName() == object_name
+    )
+    return tool._source_context_menu, action
+
+
 def test_figure_composer_plot_source_move_button_uses_disabled_icon_color(
     qtbot, monkeypatch
 ) -> None:
@@ -102,11 +115,11 @@ def test_figure_composer_source_ui_keeps_aliases_as_internal_keys(qtbot) -> None
     assert first_item.data(0, QtCore.Qt.ItemDataRole.UserRole) == "data_0"
     assert first_item.data(0, QtCore.Qt.ItemDataRole.UserRole + 1) is True
     assert first_item.font(0).bold()
-    assert first_item.text(1) == "data_0"
+    assert first_item.text(0) == "data_0"
     second_item = tool.source_list.topLevelItem(1)
     assert second_item is not None
     assert second_item.data(0, QtCore.Qt.ItemDataRole.UserRole + 1) is False
-    assert second_item.text(1) == "data_1"
+    assert second_item.text(0) == "data_1"
 
     tool._select_step_section("sources")
     checks = _plot_source_checks(tool)
@@ -136,7 +149,7 @@ def test_figure_composer_source_ui_uses_shared_shape_formatter(
 
     first_item = tool.source_list.topLevelItem(0)
     assert first_item is not None
-    shape_widget = tool.source_list.itemWidget(first_item, 2)
+    shape_widget = tool.source_list.itemWidget(first_item, 1)
     assert isinstance(shape_widget, QtWidgets.QLabel)
     assert shape_widget.text() == "<p>formatted shape</p>"
     assert tool.source_list.toolTip() == ""
@@ -214,9 +227,7 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
 
     buttons = _source_refresh_buttons(tool)
     assert buttons["data_0"].isEnabled()
-    assert buttons["data_0"].toolTip() == (
-        "Refresh “ImageTool 0: image” from ImageTool 0: image"
-    )
+    assert buttons["data_0"].toolTip() == "Refresh “data_0” from ImageTool 0: image"
     assert not buttons["profile"].isEnabled()
     assert buttons["profile"].toolTip() == (
         "This source is not linked to an open ImageTool"
@@ -293,11 +304,11 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
     )
     assert tool._source_refresh_label("data_0") is None
 
-    direct_item = QtWidgets.QTreeWidgetItem(["direct", "", "", ""])
+    direct_item = QtWidgets.QTreeWidgetItem(["direct", "", ""])
     tool.source_list.addTopLevelItem(direct_item)
     direct_button = QtWidgets.QToolButton(tool.source_list)
     direct_button.setObjectName("figureComposerRefreshSourceButton")
-    tool.source_list.setItemWidget(direct_item, 3, direct_button)
+    tool.source_list.setItemWidget(direct_item, 2, direct_button)
     assert (
         tool._source_list_row_button(direct_item, "figureComposerRefreshSourceButton")
         is direct_button
@@ -357,7 +368,7 @@ def test_figure_composer_source_remove_controls_disable_used_sources(qtbot) -> N
     assert not buttons["profile"].isEnabled()
     assert buttons["profile"].toolTip() == "This source is used by one or more steps"
     assert buttons["unused"].isEnabled()
-    assert buttons["unused"].toolTip() == "Remove “Unused” from this figure"
+    assert buttons["unused"].toolTip() == "Remove “unused” from this figure"
 
     before_status = tool.tool_status
     before_source_data = tool.source_data()
@@ -452,31 +463,239 @@ def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> 
     assert set(_source_remove_buttons(tool)) == {"data_0"}
 
 
-def test_figure_composer_source_display_helpers_keep_alias_secondary() -> None:
-    source = FigureSourceState(name="data_0", label="ImageTool 0: sample_map")
-    assert (
-        figurecomposer_sources._source_display_label(source, "data_0")
-        == "ImageTool 0: sample_map"
+def test_figure_composer_source_alias_editor_renames_references(qtbot) -> None:
+    first = _figure_composer_image_source("first")
+    second = _figure_composer_image_source("second")
+    tool = FigureComposerTool(
+        first,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=1),
+            sources=(
+                FigureSourceState(name="data_0", label="Legacy first"),
+                FigureSourceState(name="data_1", label="Legacy second"),
+            ),
+            operations=(
+                FigureOperationState.plot_slices(
+                    label="plot_slices",
+                    sources=("data_0", "data_1"),
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                    slice_dim="eV",
+                    slice_values=(0.0,),
+                ),
+                FigureOperationState.line(
+                    label="profile",
+                    source="data_0",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ),
+            ),
+            primary_source="data_0",
+        ),
+        source_data={"data_0": first, "data_1": second},
     )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"data_0"}, "data_0")
+    tool._refresh_source_selection_editor()
+
+    alias_edit = tool.source_selection_controls.findChild(
+        QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
+    )
+    assert alias_edit is not None
+    assert alias_edit.text() == "data_0"
+    tool._rename_source_alias("data_0", "renamed")
+
+    assert tuple(source.name for source in tool.source_states()) == (
+        "renamed",
+        "data_1",
+    )
+    assert tool.tool_status.primary_source == "renamed"
+    assert tuple(tool.source_data()) == ("renamed", "data_1")
+    assert tool.tool_status.operations[0].sources == ("renamed", "data_1")
+    assert tool.tool_status.operations[1].line_source == "renamed"
+    assert tool.source_list.topLevelItem(0).text(0) == "renamed"
+    assert "Legacy" not in tool.source_list.topLevelItem(0).text(0)
+
+    assert tool._source_alias_error("data_1", current="renamed") is not None
+
+
+def test_figure_composer_source_duplicate_and_reorder_controls(qtbot) -> None:
+    first = _figure_composer_profile_source("first")
+    second = _figure_composer_profile_source("second")
+    third = _figure_composer_profile_source("third")
+    tool = FigureComposerTool.from_sources(
+        {"first": first, "second": second, "third": third},
+        sources=(
+            FigureSourceState(name="first"),
+            FigureSourceState(name="second", isel={"x": 0}, selection_source="first"),
+            FigureSourceState(name="third"),
+        ),
+        operations=(FigureOperationState.line(label="profile", source="first"),),
+        setup=FigureSubplotsState(),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+    tool._source_selection_base_data["second"] = first
+    tool._set_selected_source_names_silent({"second"}, "second")
+    tool._refresh_source_controls()
+    assert (
+        tool.findChild(QtWidgets.QToolButton, "figureComposerDuplicateSourceButton")
+        is None
+    )
+    assert (
+        tool.findChild(QtWidgets.QToolButton, "figureComposerMoveSourceUpButton")
+        is None
+    )
+    assert (
+        tool.findChild(QtWidgets.QToolButton, "figureComposerMoveSourceDownButton")
+        is None
+    )
+    assert (
+        tool.source_list.dragDropMode()
+        == QtWidgets.QAbstractItemView.DragDropMode.InternalMove
+    )
+    assert tool.source_list.defaultDropAction() == QtCore.Qt.DropAction.MoveAction
+    assert tool.source_list.showDropIndicator()
+
+    menu, move_up_action = _source_context_action(
+        tool, "figureComposerContextMoveSourceUpAction"
+    )
+    move_down_action = next(
+        action
+        for action in menu.actions()
+        if action.objectName() == "figureComposerContextMoveSourceDownAction"
+    )
+    assert move_up_action.text() == "Move Up"
+    assert move_down_action.text() == "Move Down"
+    assert move_up_action.isEnabled()
+    assert move_down_action.isEnabled()
+    menu.close()
+
+    menu, duplicate_action = _source_context_action(
+        tool, "figureComposerContextDuplicateSourceAction"
+    )
+    duplicate_action.trigger()
+    menu.close()
+
+    assert tuple(source.name for source in tool.source_states()) == (
+        "first",
+        "second",
+        "second_copy",
+        "third",
+    )
+    duplicate = tool._source_by_name()["second_copy"]
+    assert duplicate.isel == {"x": 0}
+    assert duplicate.selection_source == "first"
+    xr.testing.assert_identical(tool.source_data()["second_copy"], second)
+    xr.testing.assert_identical(tool._source_selection_base_data["second_copy"], first)
+    assert tool.source_list.currentItem().text(0) == "second_copy"
+
+    menu, move_up_action = _source_context_action(
+        tool, "figureComposerContextMoveSourceUpAction"
+    )
+    move_up_action.trigger()
+    menu.close()
+    assert tuple(source.name for source in tool.source_states()) == (
+        "first",
+        "second_copy",
+        "second",
+        "third",
+    )
+    assert tool.source_list.currentItem().text(0) == "second_copy"
+
+    menu, move_down_action = _source_context_action(
+        tool, "figureComposerContextMoveSourceDownAction"
+    )
+    move_down_action.trigger()
+    menu.close()
+    menu, move_down_action = _source_context_action(
+        tool, "figureComposerContextMoveSourceDownAction"
+    )
+    move_down_action.trigger()
+    menu.close()
+    assert tuple(source.name for source in tool.source_states()) == (
+        "first",
+        "second",
+        "third",
+        "second_copy",
+    )
+    assert tool.source_list.currentItem().text(0) == "second_copy"
+
+
+def test_figure_composer_source_list_internal_reorder_updates_recipe(qtbot) -> None:
+    data = {
+        name: _figure_composer_profile_source(name) for name in ("a", "b", "c", "d")
+    }
+    tool = FigureComposerTool.from_sources(
+        data,
+        sources=tuple(FigureSourceState(name=name) for name in data),
+        setup=FigureSubplotsState(),
+        primary_source="a",
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"b", "c"}, "b")
+
+    first_moved = tool.source_list.takeTopLevelItem(1)
+    second_moved = tool.source_list.takeTopLevelItem(1)
+    assert first_moved is not None
+    assert second_moved is not None
+    tool.source_list.insertTopLevelItem(2, first_moved)
+    tool.source_list.insertTopLevelItem(3, second_moved)
+    tool._set_selected_source_names_silent({"b", "c"}, "b")
+    tool.source_list._emit_rows_reordered()
+
+    assert tuple(source.name for source in tool.source_states()) == (
+        "a",
+        "d",
+        "b",
+        "c",
+    )
+    assert tool.source_list.currentItem().text(0) == "b"
+    assert {item.text(0) for item in tool.source_list.selectedItems()} == {"b", "c"}
+
+
+def test_figure_composer_source_list_keyboard_context_menu(qtbot) -> None:
+    data = {name: _figure_composer_profile_source(name) for name in ("a", "b")}
+    tool = FigureComposerTool.from_sources(
+        data,
+        sources=tuple(FigureSourceState(name=name) for name in data),
+        setup=FigureSubplotsState(),
+        primary_source="a",
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"b"}, "b")
+
+    event = QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_F10,
+        QtCore.Qt.KeyboardModifier.ShiftModifier,
+    )
+    tool.source_list.keyPressEvent(event)
+
+    assert event.isAccepted()
+    assert tool._source_context_menu is not None
+    action_names = {
+        action.objectName()
+        for action in tool._source_context_menu.actions()
+        if action.objectName()
+    }
+    assert "figureComposerContextMoveSourceUpAction" in action_names
+    assert "figureComposerContextMoveSourceDownAction" in action_names
+    tool._source_context_menu.close()
+
+
+def test_figure_composer_source_display_helpers_use_alias_only() -> None:
+    source = FigureSourceState(name="data_0", label="ImageTool 0: sample_map")
+    assert figurecomposer_sources._source_display_label(source, "data_0") == "data_0"
     assert (
         figurecomposer_sources._source_display_tooltip(source, "data_0")
-        == "ImageTool 0: sample_map\nAlias: data_0"
+        == "Alias: data_0"
     )
-
-    duplicates = figurecomposer_sources._source_duplicate_labels(
-        (
-            FigureSourceState(name="data_0", label="ImageTool"),
-            FigureSourceState(name="data_1", label="ImageTool"),
-        )
-    )
-    assert duplicates == frozenset(("ImageTool",))
     assert (
         figurecomposer_sources._source_display_label(
             FigureSourceState(name="data_0", label="ImageTool"),
             "data_0",
             disambiguate=True,
         )
-        == "ImageTool (data_0)"
+        == "data_0"
     )
 
 
@@ -533,11 +752,9 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
     qtbot.addWidget(tool)
     tool.operation_list.setCurrentRow(0)
 
-    assert "ImageTool 0: original" in tool.operation_list.item(0).text()
-    assert "ImageTool 0: original" in tool.operation_list.item(1).text()
-    assert tool.step_section_buttons["sources"].text() == (
-        "Sources: ImageTool 0: original"
-    )
+    assert "data_0" in tool.operation_list.item(0).text()
+    assert "data_0" in tool.operation_list.item(1).text()
+    assert tool.step_section_buttons["sources"].text() == "Sources: data_0"
 
     replaced = tool.replace_source(
         "data_0",
@@ -554,20 +771,17 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
     assert replaced is True
     [source] = tool.source_states()
     assert source.name == "data_0"
-    assert source.label == "ImageTool 1: replacement"
     assert source.node_uid == "new-node"
     assert source.node_snapshot_token == new_snapshot_id
     assert source.provenance_spec == {"source": "new"}
     xr.testing.assert_identical(tool.source_data()["data_0"], replacement)
     assert tool.tool_status.operations[0].sources == ("data_0",)
     assert tool.tool_status.operations[1].line_source == "data_0"
-    assert "ImageTool 1: replacement" in tool.operation_list.item(0).text()
-    assert "ImageTool 0: original" not in tool.operation_list.item(0).text()
-    assert "ImageTool 1: replacement" in tool.operation_list.item(1).text()
-    assert "ImageTool 0: original" not in tool.operation_list.item(1).text()
-    assert tool.step_section_buttons["sources"].text() == (
-        "Sources: ImageTool 1: replacement"
-    )
+    assert "data_0" in tool.operation_list.item(0).text()
+    assert "ImageTool 1: replacement" not in tool.operation_list.item(0).text()
+    assert "data_0" in tool.operation_list.item(1).text()
+    assert "ImageTool 1: replacement" not in tool.operation_list.item(1).text()
+    assert tool.step_section_buttons["sources"].text() == "Sources: data_0"
 
     _render_figure_composer_rgba(tool)
     assert tool._operation_render_errors == {}
@@ -602,7 +816,109 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
         "data_0",
         "orphan",
     )
-    assert tool.source_states()[-1].label == "Orphan"
+    assert not hasattr(tool.source_states()[-1], "label")
+
+
+def test_figure_composer_source_refresh_applies_saved_selection(
+    qtbot,
+) -> None:
+    original = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "alpha"),
+        coords={"eV": [-1.0, 0.0], "alpha": [0.0, 1.0, 2.0]},
+        name="map",
+    )
+    selected = original.qsel(eV=0.0)
+    tool = FigureComposerTool.from_sources(
+        {"data": selected},
+        sources=(
+            FigureSourceState(
+                name="data",
+                label="data",
+                qsel={"eV": 0.0},
+                selection_source="data",
+                node_uid="node",
+            ),
+        ),
+        operations=(FigureOperationState.plot_array(label="array", source="data"),),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+
+    replacement = original + 10.0
+    assert tool.replace_source(
+        "data",
+        FigureSourceState(name="data", label="replacement", node_uid="node"),
+        replacement,
+    )
+    xr.testing.assert_identical(tool.source_data()["data"], replacement.qsel(eV=0.0))
+    [source] = tool.source_states()
+    assert source.qsel == {"eV": 0.0}
+    assert source.selection_source == "data"
+
+    stale = tool.source_data()["data"]
+    incompatible = xr.DataArray(
+        np.arange(3.0),
+        dims=("alpha",),
+        coords={"alpha": [0.0, 1.0, 2.0]},
+        name="map",
+    )
+    assert not tool.replace_source(
+        "data",
+        FigureSourceState(name="data", label="bad", node_uid="node"),
+        incompatible,
+    )
+    xr.testing.assert_identical(tool.source_data()["data"], stale)
+    assert "Could not refresh source" in tool.source_status_label.text()
+
+    refreshed = original + 20.0
+    tool.refresh_from_sources({"data": refreshed})
+    xr.testing.assert_identical(tool.source_data()["data"], refreshed.qsel(eV=0.0))
+    assert tool.source_status_label.text() == ""
+
+
+def test_figure_composer_batch_source_selection_skips_incompatible_sources(
+    qtbot,
+) -> None:
+    first = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0, 2.0]},
+        name="first",
+    )
+    second = xr.DataArray(
+        np.arange(3.0),
+        dims=("y",),
+        coords={"y": [0.0, 1.0, 2.0]},
+        name="second",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"first": first, "second": second},
+        sources=(
+            FigureSourceState(name="first", label="first"),
+            FigureSourceState(name="second", label="second"),
+        ),
+        operations=(FigureOperationState.plot_array(label="array", source="first"),),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+
+    tool.source_list.clearSelection()
+    first_item = tool.source_list.topLevelItem(0)
+    second_item = tool.source_list.topLevelItem(1)
+    assert first_item is not None
+    assert second_item is not None
+    first_item.setSelected(True)
+    second_item.setSelected(True)
+
+    tool._update_selected_source_dimension("x", "isel", "1", "")
+
+    source_by_name = {source.name: source for source in tool.source_states()}
+    assert source_by_name["first"].isel == {"x": 1}
+    assert source_by_name["second"].isel == {}
+    xr.testing.assert_identical(tool.source_data()["first"], first.isel(x=1))
+    xr.testing.assert_identical(tool.source_data()["second"], second)
+    assert "second" in tool.source_status_label.text()
 
 
 def test_figure_composer_source_helpers_cover_selection_contract() -> None:
@@ -619,7 +935,7 @@ def test_figure_composer_source_helpers_cover_selection_contract() -> None:
     assert figurecomposer_plot_slices._source_names(
         FigureOperationState.plot_slices(
             label="mapped",
-            sources=(),
+            sources=("extra",),
             map_selections=(FigureDataSelectionState(source="extra"),),
         )
     ) == ("extra",)
@@ -735,7 +1051,7 @@ def test_figure_composer_raw_sources_use_public_nonuniform_dims(qtbot) -> None:
     assert "sample_temp_idx" not in shape.source_text
     shape_item = tool.source_list.topLevelItem(0)
     assert shape_item is not None
-    shape_label = tool.source_list.itemWidget(shape_item, 2)
+    shape_label = tool.source_list.itemWidget(shape_item, 1)
     assert isinstance(shape_label, QtWidgets.QLabel)
     assert "sample_temp_idx" not in shape_label.text()
 
@@ -782,23 +1098,23 @@ def test_figure_composer_source_inspector_is_sources_tab_compact(
     )
     qtbot.addWidget(tool)
 
-    assert tool.source_inspector.parentWidget() is tool.step_sources_page
+    assert tool.source_inspector.parentWidget() is tool.sources_page
+    assert tool.editor_tabs.indexOf(tool.sources_page) == 0
     assert not hasattr(tool, "step_detail_splitter")
     assert tool.source_inspector.source_name() == "map"
     assert tool.source_inspector.property("figureComposerSourceAlias") == "map"
     assert tool.source_inspector.property("figureComposerSourceDims") == ("eV", "kx")
     assert tool.source_inspector.property("figureComposerSourceDtype") == "float64"
-    assert tool.source_inspector.property("figureComposerSourceUsedByStep") is True
     assert not tool.source_inspector.details_button.isChecked()
     assert not tool.source_inspector.details_scroll.isVisibleTo(tool.source_inspector)
     assert tool.source_inspector.details_html() == "<p>formatted details</p>"
     assert format_calls[-1] == (
         ("eV", "kx"),
-        {"show_size": True, "show_summary": False, "load_values": False},
+        {"show_size": True, "show_summary": False},
     )
     assert (
         tool.source_list.selectionMode()
-        == QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        == QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
     )
     assert (
         tool.source_list.selectionBehavior()
@@ -808,7 +1124,7 @@ def test_figure_composer_source_inspector_is_sources_tab_compact(
     assert first_item is not None
     assert first_item.flags() & QtCore.Qt.ItemFlag.ItemIsSelectable
     assert tool.source_list.selectedItems() == [first_item]
-    shape_label = tool.source_list.itemWidget(first_item, 2)
+    shape_label = tool.source_list.itemWidget(first_item, 1)
     assert isinstance(shape_label, QtWidgets.QLabel)
     assert shape_label.testAttribute(
         QtCore.Qt.WidgetAttribute.WA_TransparentForMouseEvents
@@ -820,11 +1136,81 @@ def test_figure_composer_source_inspector_is_sources_tab_compact(
 
     second_item = tool.source_list.topLevelItem(1)
     assert second_item is not None
+    tool.source_list.clearSelection()
     tool.source_list.setCurrentItem(second_item)
     assert tool.source_list.selectedItems() == [second_item]
     assert tool.source_inspector.source_name() == "profile"
     assert tool.source_inspector.property("figureComposerSourceAlias") == "profile"
     assert tool.source_inspector.property("figureComposerSourceDims") == ("delay",)
+
+
+def test_figure_composer_source_inspector_details_show_coord_values(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(3.0),
+        dims=("x",),
+        coords={"x": [0.0, 1.0, 2.0], "temperature": 20.0},
+        name="profile",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"profile": data},
+        sources=(FigureSourceState(name="profile", label="Profile"),),
+        primary_source="profile",
+    )
+    qtbot.addWidget(tool)
+
+    html = tool.source_inspector.details_html()
+
+    assert "0 : 1 : 2" in html
+    assert ">20</td>" in html
+    assert "float64 [3]" not in html
+    assert "float64 scalar" not in html
+
+
+def test_figure_composer_source_inspector_details_fallback_is_metadata_only(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(
+        np.arange(3.0),
+        dims=("x",),
+        coords={"x": [0.0, 1.0, 2.0]},
+        name="profile",
+    )
+    format_calls: list[dict[str, typing.Any]] = []
+
+    def raise_load_coords(data: xr.DataArray) -> xr.DataArray:
+        raise RuntimeError("coordinate metadata unavailable")
+
+    def fake_format_darr_html(
+        data: xr.DataArray,
+        **kwargs: typing.Any,
+    ) -> str:
+        format_calls.append(kwargs)
+        return "<p>fallback details</p>"
+
+    monkeypatch.setattr(
+        figurecomposer_source_inspector,
+        "_source_data_with_loaded_coords",
+        raise_load_coords,
+    )
+    monkeypatch.setattr(
+        erlab.utils.formatting,
+        "format_darr_html",
+        fake_format_darr_html,
+    )
+
+    tool = FigureComposerTool.from_sources(
+        {"profile": data},
+        sources=(FigureSourceState(name="profile", label="Profile"),),
+        primary_source="profile",
+    )
+    qtbot.addWidget(tool)
+
+    assert tool.source_inspector.details_html() == "<p>fallback details</p>"
+    assert format_calls[-1] == {
+        "show_size": True,
+        "show_summary": False,
+        "load_values": False,
+    }
 
 
 def test_figure_composer_source_list_shape_cell_click_selects_row(qtbot) -> None:
@@ -844,6 +1230,7 @@ def test_figure_composer_source_list_shape_cell_click_selects_row(qtbot) -> None
         primary_source="map",
     )
     qtbot.addWidget(tool)
+    tool.editor_tabs.setCurrentWidget(tool.sources_page)
     with qtbot.waitExposed(tool):
         tool.show()
 
@@ -901,7 +1288,7 @@ def test_figure_composer_source_inspector_tracks_source_tab_selection(qtbot) -> 
         ),
         operations=(
             FigureOperationState.line(label="first line", source="first"),
-            FigureOperationState.line(label="second line", source="second"),
+            FigureOperationState.custom(label="custom", code="pass", trusted=True),
         ),
         primary_source="first",
     )
@@ -909,7 +1296,12 @@ def test_figure_composer_source_inspector_tracks_source_tab_selection(qtbot) -> 
 
     assert tool.source_inspector.source_name() == "first"
     tool.operation_list.setCurrentRow(1)
-    assert tool.source_inspector.source_name() == "second"
+    assert tool.source_inspector.source_name() == "first"
+    assert tool.source_status_label.text() == ""
+    assert tool.source_status_label.isHidden()
+    assert (
+        tool.step_source_status_label.text() == "This step does not read a data source."
+    )
     first_item = tool.source_list.topLevelItem(0)
     assert first_item is not None
     tool.source_list.setCurrentItem(first_item)
@@ -959,7 +1351,6 @@ def test_figure_composer_source_inspector_updates_without_render_or_history(
     assert render_calls == []
     assert write_calls == []
     assert tool.source_inspector.source_name() == "y"
-    assert tool.source_inspector.property("figureComposerSourceUsedByStep") is True
     assert tool.source_inspector.property("figureComposerSourceAlias") == "y"
 
 
@@ -976,7 +1367,7 @@ def test_figure_composer_source_inspector_helper_edges(qtbot) -> None:
     missing_metadata = figurecomposer_source_inspector.source_metadata_tooltip(
         source, "data", None
     )
-    assert "Alias: data" in missing_metadata
+    assert missing_metadata.startswith("data")
     assert "unavailable" in missing_metadata
 
     metadata = figurecomposer_source_inspector.source_metadata_tooltip(
@@ -1021,21 +1412,17 @@ def test_figure_composer_source_inspector_helper_edges(qtbot) -> None:
         source_name=None,
         source_state=None,
         data=None,
-        operation_source_names=(),
     )
     assert inspector.source_name() is None
     assert inspector.property("figureComposerSourceDims") == ()
-    assert inspector.property("figureComposerSourceUsedByStep") is False
     assert not inspector.details_button.isEnabled()
 
     inspector.set_context(
         source_name="data",
         source_state=source,
         data=None,
-        operation_source_names=("data",),
     )
     assert inspector.source_name() == "data"
-    assert inspector.property("figureComposerSourceUsedByStep") is True
     assert inspector.property("figureComposerSourceDims") == ()
     assert not inspector.details_button.isEnabled()
 
@@ -1185,9 +1572,7 @@ def test_figure_composer_provenance_includes_sources_and_build_step(
     spec = tool.current_provenance_spec()
     assert spec is not None
     assert spec.active_name == "fig"
-    assert tuple(script_input.name for script_input in spec.script_inputs) == (
-        "data_0",
-    )
+    assert tuple(script_input.name for script_input in spec.script_inputs) == ("map",)
     entries = spec.display_entries()
     assert len(entries) == 3
     assert entries[1].code is None
@@ -1199,6 +1584,228 @@ def test_figure_composer_provenance_includes_sources_and_build_step(
     assert code is not None
     namespace = _exec_generated_code(code, {})
     assert isinstance(namespace["fig"], Figure)
+
+
+def test_figure_composer_full_code_composes_selected_file_sources(
+    qtbot,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    first = xr.DataArray(
+        np.arange(8.0).reshape(2, 2, 2),
+        dims=("hv", "x", "y"),
+        coords={"hv": [39.274, 43.698], "x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="QV12 LH gap15",
+    )
+    second = (first + 10.0).rename("QV12 LH gap15 ALSU")
+    first_path = tmp_path / "first.nc"
+    second_path = tmp_path / "second.nc"
+    first.to_netcdf(first_path)
+    second.to_netcdf(second_path)
+    first_source = FigureSourceState(
+        name="data_3",
+        label="ImageTool 3: QV12 LH gap15",
+        provenance_spec=_file_load_provenance(first_path).model_dump(mode="json"),
+    )
+    second_source = FigureSourceState(
+        name="data_4",
+        label="ImageTool 4: QV12 LH gap15 ALSU",
+        provenance_spec=_file_load_provenance(second_path).model_dump(mode="json"),
+    )
+    first_selected = FigureSourceState(
+        name="data_3_selected",
+        label="QV12 LH gap15 selection",
+        selection_source="data_3",
+        qsel={"hv": 39.274},
+        provenance_spec=first_source.provenance_spec,
+    )
+    second_selected = FigureSourceState(
+        name="data_4_selected",
+        label="QV12 LH gap15 ALSU selection",
+        selection_source="data_4",
+        qsel={"hv": 43.698},
+        provenance_spec=second_source.provenance_spec,
+    )
+    tool = FigureComposerTool(
+        first,
+        recipe=FigureRecipeState(
+            sources=(first_source, first_selected, second_source, second_selected),
+            operations=(
+                FigureOperationState.plot_array(
+                    label="plot_array",
+                    source="data_3_selected",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ),
+                FigureOperationState.plot_array(
+                    label="plot_array",
+                    source="data_4_selected",
+                    axes=FigureAxesSelectionState(axes=((0, 1),)),
+                ),
+            ),
+            setup=FigureSubplotsState(nrows=1, ncols=2),
+            primary_source="data_3",
+        ),
+        source_data={
+            "data_3": first,
+            "data_3_selected": first.qsel(hv=39.274),
+            "data_4": second,
+            "data_4_selected": second.qsel(hv=43.698),
+        },
+    )
+    qtbot.addWidget(tool)
+
+    spec = tool.current_provenance_spec()
+    assert spec is not None
+    assert tuple(script_input.name for script_input in spec.script_inputs) == (
+        "qv12_lh_gap15",
+        "qv12_lh_gap15_alsu",
+    )
+    code = spec.display_code()
+    assert code is not None
+    lines = [line for line in code.splitlines() if line.strip()]
+    assert lines[:3] == [
+        "import xarray",
+        "import matplotlib.pyplot as plt",
+        "import erlab.plotting as eplt",
+    ]
+    assert "_itool_replay_" not in code
+    assert "data_3_selected =" not in code
+    assert "data_4_selected =" not in code
+    assert "qv12_lh_gap15 = xarray.load_dataarray" in code
+    assert "qv12_lh_gap15_alsu = xarray.load_dataarray" in code
+    assert code.count(".qsel(hv=") == 2
+    assert "eplt.plot_array(qv12_lh_gap15" in code
+    assert "eplt.plot_array(qv12_lh_gap15_alsu" in code
+
+    captured: list[xr.DataArray] = []
+    monkeypatch.setattr(
+        eplt,
+        "plot_array",
+        lambda arr, **_kwargs: captured.append(arr),
+    )
+    namespace = _exec_generated_code(code, {})
+    assert isinstance(namespace["fig"], Figure)
+    xr.testing.assert_identical(captured[0], first.qsel(hv=39.274))
+    xr.testing.assert_identical(captured[1], second.qsel(hv=43.698))
+
+
+def test_figure_composer_full_code_keeps_needed_base_and_selected_sources(
+    qtbot,
+    tmp_path: Path,
+) -> None:
+    data = xr.DataArray(
+        np.arange(8.0).reshape(2, 2, 2),
+        dims=("hv", "x", "y"),
+        coords={"hv": [39.274, 43.698], "x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="fig",
+    )
+    path = tmp_path / "source.nc"
+    data.to_netcdf(path)
+    source = FigureSourceState(
+        name="data_3",
+        label="ImageTool 3: fig",
+        provenance_spec=_file_load_provenance(path).model_dump(mode="json"),
+    )
+    selected = FigureSourceState(
+        name="data_3_selected",
+        label="fig selection",
+        selection_source="data_3",
+        qsel={"hv": 39.274},
+        provenance_spec=source.provenance_spec,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(source, selected),
+            operations=(
+                FigureOperationState.plot_array(
+                    label="raw",
+                    source="data_3",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ),
+                FigureOperationState.plot_array(
+                    label="selected",
+                    source="data_3_selected",
+                    axes=FigureAxesSelectionState(axes=((0, 1),)),
+                ),
+            ),
+            setup=FigureSubplotsState(nrows=1, ncols=2),
+            primary_source="data_3",
+        ),
+        source_data={"data_3": data, "data_3_selected": data.qsel(hv=39.274)},
+    )
+    qtbot.addWidget(tool)
+
+    spec = tool.current_provenance_spec()
+    assert spec is not None
+    assert tuple(script_input.name for script_input in spec.script_inputs) == (
+        "fig_2",
+        "fig_3",
+    )
+    code = spec.display_code()
+    assert code is not None
+    assert "fig =" not in code
+    assert "fig_2 = xarray.load_dataarray" in code
+    assert "fig_3 = fig_2.qsel(hv=39.274)" in code
+    assert "eplt.plot_array(fig_2" in code
+    assert "eplt.plot_array(fig_3" in code
+
+
+def test_figure_composer_full_code_falls_back_for_live_selected_source(
+    qtbot,
+    monkeypatch,
+) -> None:
+    data = xr.DataArray(
+        np.arange(8.0).reshape(2, 2, 2),
+        dims=("hv", "x", "y"),
+        coords={"hv": [39.274, 43.698], "x": [0.0, 1.0], "y": [0.0, 1.0]},
+        name="live",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(
+                FigureSourceState(name="data_3", label="live", node_uid="node"),
+                FigureSourceState(
+                    name="data_3_selected",
+                    label="live selection",
+                    selection_source="data_3",
+                    qsel={"hv": 39.274},
+                ),
+            ),
+            operations=(
+                FigureOperationState.plot_array(
+                    label="selected",
+                    source="data_3_selected",
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                ),
+            ),
+            primary_source="data_3",
+        ),
+        source_data={"data_3": data, "data_3_selected": data.qsel(hv=39.274)},
+    )
+    qtbot.addWidget(tool)
+
+    spec = tool.current_provenance_spec()
+    assert spec is not None
+    assert tuple(script_input.name for script_input in spec.script_inputs) == (
+        "data_3",
+    )
+    assert spec.display_code() is None
+
+    code = tool.generated_code()
+    assert "data_3_selected = data_3.qsel(hv=39.274)" in code
+    assert "eplt.plot_array(data_3_selected" in code
+
+    captured: list[xr.DataArray] = []
+    monkeypatch.setattr(
+        eplt,
+        "plot_array",
+        lambda arr, **_kwargs: captured.append(arr),
+    )
+    namespace = _exec_generated_code(code, {"data_3": data})
+    assert isinstance(namespace["fig"], Figure)
+    xr.testing.assert_identical(captured[0], data.qsel(hv=39.274))
 
 
 def test_figure_composer_copy_paste_steps_carries_same_process_source_data(
@@ -1306,7 +1913,7 @@ def test_figure_composer_cut_paste_steps_preserves_same_composer_sources(
     assert set(tool.source_data()) == {"data"}
     pasted_operation = tool.tool_status.operations[0]
     assert pasted_operation.sources == ("data",)
-    assert pasted_operation.map_selections[0].source == "data"
+    assert pasted_operation.map_selections == ()
     assert pasted_operation.operation_id != original_id
 
 
@@ -1375,7 +1982,7 @@ def test_figure_composer_cut_paste_steps_renames_cross_composer_sources(
     ]
     pasted_plot, pasted_line = destination.tool_status.operations
     assert pasted_plot.sources == ("data_copy",)
-    assert pasted_plot.map_selections[0].source == "data_copy"
+    assert pasted_plot.map_selections == ()
     assert pasted_line.line_source == "profile_copy"
     xr.testing.assert_identical(destination.source_data()["data"], existing_image)
     xr.testing.assert_identical(destination.source_data()["profile"], existing_profile)
@@ -1445,7 +2052,7 @@ def test_figure_composer_copy_paste_steps_renames_source_conflicts(qtbot) -> Non
     ]
     pasted_plot, pasted_line = destination.tool_status.operations
     assert pasted_plot.sources == ("data_copy",)
-    assert pasted_plot.map_selections[0].source == "data_copy"
+    assert pasted_plot.map_selections == ()
     assert pasted_line.line_source == "profile_copy"
     xr.testing.assert_identical(destination.source_data()["data"], existing_image)
     xr.testing.assert_identical(destination.source_data()["profile"], existing_profile)
@@ -1584,7 +2191,7 @@ def test_figure_composer_copy_paste_source_and_insert_fallbacks(
         sources=("data",),
         map_selections=(FigureDataSelectionState(source="extra"),),
     )
-    assert tool._operation_source_names(operation) == ("data", "extra")
+    assert tool._operation_source_names(operation) == ("data",)
 
     renamed_sources, _, _ = tool._renamed_pasted_sources(
         (
@@ -1708,7 +2315,8 @@ def test_figure_composer_toolbar_image_target_combo_elides_long_sources(qtbot) -
 
     tooltip = target_combo.itemData(0, QtCore.Qt.ItemDataRole.ToolTipRole)
     assert isinstance(tooltip, str)
-    assert all(label in tooltip for label in source_labels)
+    assert all(name in tooltip for name in source_names)
+    assert all(label not in tooltip for label in source_labels)
     assert target_combo.toolTip() == tooltip
     assert target_combo.view().textElideMode() == QtCore.Qt.TextElideMode.ElideMiddle
     assert (

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -53,6 +53,19 @@ def test_figure_composer_source_alias_candidate_rejects_unusable_names(
     )
 
 
+def test_figure_composer_source_state_normalizes_legacy_self_selection_parent() -> None:
+    source = FigureSourceState.model_validate(
+        {
+            "name": "selected",
+            "qsel": {"x": 1.0},
+            "selection_source": "selected",
+        }
+    )
+
+    assert source.selection_source is None
+    assert "selection_source" not in source.model_dump(mode="json")
+
+
 def test_figure_composer_plot_source_move_button_uses_disabled_icon_color(
     qtbot, monkeypatch
 ) -> None:
@@ -782,6 +795,35 @@ def test_figure_composer_source_alias_editor_renames_references(qtbot) -> None:
     assert tool._source_alias_error("data_1", current="renamed") is not None
 
 
+def test_figure_composer_source_alias_rename_keeps_own_selection_implicit(
+    qtbot,
+) -> None:
+    base = xr.DataArray(np.arange(4.0), dims=("x",), name="base")
+    selected = base.isel(x=slice(1, None))
+    tool = FigureComposerTool.from_sources(
+        {"selected": selected},
+        sources=(
+            FigureSourceState(
+                name="selected",
+                selection_source="selected",
+                isel={"x": slice(1, None)},
+            ),
+        ),
+        operations=(FigureOperationState.line(label="line", source="selected"),),
+        primary_source="selected",
+    )
+    qtbot.addWidget(tool)
+    tool._source_selection_base_data["selected"] = base
+
+    assert tool._rename_source_alias("selected", "renamed")
+
+    [source] = tool.source_states()
+    assert source.name == "renamed"
+    assert source.selection_source is None
+    xr.testing.assert_identical(tool.source_data()["renamed"], selected)
+    xr.testing.assert_identical(tool._source_selection_base_data["renamed"], base)
+
+
 def test_figure_composer_source_duplicate_and_reorder_controls(qtbot) -> None:
     first = _figure_composer_profile_source("first")
     second = _figure_composer_profile_source("second")
@@ -944,6 +986,7 @@ def test_figure_composer_duplicate_selected_source_generated_code_uses_raw_base(
     tool._source_selection_base_data["data"] = base
     tool._set_selected_source_names_silent({"data"}, "data")
     tool._duplicate_selected_sources()
+    assert tool._source_by_name()["data_copy"].selection_source is None
     tool._recipe = tool._recipe.model_copy(
         update={
             "operations": (
@@ -963,7 +1006,9 @@ def test_figure_composer_duplicate_selected_source_generated_code_uses_raw_base(
         "plot_array",
         lambda data, **_kwargs: captured.append(data),
     )
-    namespace = _exec_generated_code(tool.generated_code(), {"data": base})
+    namespace = _exec_generated_code(
+        tool.generated_code(), {"data": base, "data_copy": base}
+    )
 
     assert isinstance(namespace["fig"], Figure)
     assert len(captured) == 2
@@ -1823,7 +1868,7 @@ def test_figure_composer_source_refresh_applies_saved_selection(
     xr.testing.assert_identical(tool.source_data()["data"], replacement.qsel(eV=0.0))
     [source] = tool.source_states()
     assert source.qsel == {"eV": 0.0}
-    assert source.selection_source == "data"
+    assert source.selection_source is None
 
     stale = tool.source_data()["data"]
     incompatible = xr.DataArray(
@@ -2030,7 +2075,7 @@ def test_figure_composer_readding_linked_source_preserves_selection(qtbot) -> No
 
     [source] = tool.source_states()
     assert source.qsel == {"eV": 0.0}
-    assert source.selection_source == "data"
+    assert source.selection_source is None
     xr.testing.assert_identical(tool.source_data()["data"], refreshed.qsel(eV=0.0))
     xr.testing.assert_identical(tool._source_selection_base_data["data"], refreshed)
 
@@ -2079,6 +2124,7 @@ def test_figure_composer_readding_renamed_linked_source_updates_alias(qtbot) -> 
     assert tuple(source.name for source in tool.source_states()) == ("custom_alias",)
     assert tool.source_states()[0].label == "custom_alias"
     assert tool.source_states()[0].qsel == {"eV": 0.0}
+    assert tool.source_states()[0].selection_source is None
     xr.testing.assert_identical(
         tool.source_data()["custom_alias"], refreshed.qsel(eV=0.0)
     )
@@ -2121,7 +2167,7 @@ def test_figure_composer_replace_different_source_preserves_compatible_selection
     [source] = tool.source_states()
     assert source.node_uid == "new-node"
     assert source.qsel == {"eV": 0.0}
-    assert source.selection_source == "data"
+    assert source.selection_source is None
     xr.testing.assert_identical(tool.source_data()["data"], replacement.qsel(eV=0.0))
     xr.testing.assert_identical(tool._source_selection_base_data["data"], replacement)
 
@@ -2138,7 +2184,7 @@ def test_figure_composer_replace_different_source_preserves_compatible_selection
     )
     [source] = tool.source_states()
     assert source.qsel == {"eV": -1.0}
-    assert source.selection_source == "data"
+    assert source.selection_source is None
     xr.testing.assert_identical(
         tool.source_data()["data"], selected_replacement.qsel(eV=-1.0)
     )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -711,6 +711,49 @@ def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> 
     assert tool.source_list.findChildren(QtWidgets.QToolButton) == []
 
 
+def test_figure_composer_remove_selected_sources_coalesces_history(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    first_unused = data.copy(data=np.arange(3.0) + 10.0).rename("first_unused")
+    second_unused = data.copy(data=np.arange(3.0) + 20.0).rename("second_unused")
+    tool = FigureComposerTool.from_sources(
+        {
+            "data": data,
+            "first_unused": first_unused,
+            "second_unused": second_unused,
+        },
+        sources=(
+            FigureSourceState(name="data"),
+            FigureSourceState(name="first_unused"),
+            FigureSourceState(name="second_unused"),
+        ),
+        operations=(FigureOperationState.line(label="line", source="data"),),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    tool._reset_history_stack()
+    tool._set_selected_source_names_silent(
+        {"first_unused", "second_unused"}, "first_unused"
+    )
+
+    tool._remove_selected_sources()
+
+    assert tuple(tool.source_data()) == ("data",)
+    assert len(tool._prev_states) == 2
+    tool.undo()
+    assert tuple(tool.source_data()) == (
+        "data",
+        "first_unused",
+        "second_unused",
+    )
+    assert not tool.undoable
+    assert tool.redoable
+
+    tool.redo()
+    assert tuple(tool.source_data()) == ("data",)
+    assert tool.undoable
+    assert not tool.redoable
+
+
 def test_figure_composer_cannot_remove_source_used_by_selected_alias(qtbot) -> None:
     base = xr.DataArray(
         np.arange(6.0).reshape(2, 3),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -67,6 +67,29 @@ def test_figure_composer_source_state_normalizes_legacy_self_selection_parent() 
     assert source.selection_source is None
     assert "selection_source" not in source.model_dump(mode="json")
 
+    immutable_source = FigureSourceState.model_validate(
+        types.MappingProxyType(
+            {
+                "name": "immutable_selected",
+                "label": "immutable_selected",
+                "selection_source": "immutable_selected",
+            }
+        )
+    )
+    assert immutable_source.selection_source is None
+
+    with pytest.raises(ValueError):
+        FigureSourceState.model_validate("not a source mapping")
+
+    legacy_source = FigureSourceState(name="selected").model_copy(
+        update={"selection_source": "selected"}
+    )
+    selected_source = figurecomposer_sources._source_with_selection(
+        legacy_source,
+        FigureDataSelectionState(source="selected", isel={"x": 0}),
+    )
+    assert selected_source.selection_source is None
+
 
 def test_figure_composer_plot_source_move_button_uses_disabled_icon_color(
     qtbot, monkeypatch
@@ -1347,6 +1370,16 @@ def test_figure_composer_source_alias_editor_commit_paths(
     tool._refresh_source_selection_editor()
     alias_edit = tool.source_alias_edit
 
+    original_sources = tool.source_states()
+    monkeypatch.setattr(tool, "sender", lambda: None)
+    tool._commit_source_alias_edit()
+    assert tool.source_states() == original_sources
+
+    detached_edit = QtWidgets.QLineEdit()
+    monkeypatch.setattr(tool, "sender", lambda: detached_edit)
+    tool._commit_source_alias_edit()
+    assert tool.source_states() == original_sources
+
     monkeypatch.setattr(tool, "sender", lambda: alias_edit)
     alias_edit.setText("first")
     tool._commit_source_alias_edit()
@@ -1362,6 +1395,21 @@ def test_figure_composer_source_alias_editor_commit_paths(
     tool._commit_source_alias_edit()
     assert tuple(source.name for source in tool.source_states()) == ("first", "second")
     assert not tool.source_validation_label.isHidden()
+
+    with monkeypatch.context() as patch:
+        patch.setattr(tool, "_rename_source_alias", lambda *_args: False)
+        alias_edit.setText("third")
+        tool._commit_source_alias_edit()
+    assert alias_edit.text() == "first"
+
+    tool._set_selected_source_names_silent(set(), None)
+    tool._focus_source_alias_editor()
+    tool._set_selected_source_names_silent({"first"}, "first")
+    tool._refresh_source_detail_panel()
+    tool.source_alias_edit.setEnabled(False)
+    tool._focus_source_alias_editor()
+    assert not tool.source_alias_edit.isEnabled()
+    tool.source_alias_edit.setEnabled(True)
 
     alias_edit.setText("renamed")
     tool._commit_source_alias_edit()
@@ -3383,6 +3431,9 @@ def test_figure_composer_source_inspector_helper_edges(qtbot) -> None:
     assert inspector.property("figureComposerSourceDims") == ()
     assert not inspector.details_button.isEnabled()
 
+    inspector._ensure_details_html()
+    assert not inspector.details_label.text()
+
 
 def test_figure_composer_source_inspector_target_fallbacks(qtbot) -> None:
     data = xr.DataArray([1.0, 2.0], dims=("x",), name="data")
@@ -4591,3 +4642,486 @@ def test_figure_composer_restore_skips_missing_nonprimary_source_reference(
     assert any(source.name == "stale" for source in restored.tool_status.sources)
     assert restored.preview_pixmap is not None
     assert not restored.preview_pixmap_stale
+
+
+def test_figure_composer_source_structure_defensive_paths(qtbot) -> None:
+    first = xr.DataArray(np.arange(3.0), dims=("x",), name="first")
+    second = xr.DataArray(np.arange(3.0) + 10.0, dims=("x",), name="second")
+    tool = FigureComposerTool.from_sources(
+        {"first": first, "second": second},
+        sources=(FigureSourceState(name="first"), FigureSourceState(name="second")),
+        operations=(),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+
+    tool._update_source_list_item(QtWidgets.QTreeWidgetItem())
+    tool._set_selected_source_names_silent(set(), None)
+    assert tool._selected_source_names() == ()
+
+    refreshed: list[str] = []
+
+    def refresh_source(name: str) -> bool:
+        if name == "first":
+            tool._set_source_status_text("refresh rejected")
+            return False
+        refreshed.append(name)
+        return True
+
+    tool._set_source_refresh_callbacks(
+        can_refresh_source=lambda name: name in {"first", "second"},
+        refresh_source=refresh_source,
+    )
+    tool._refresh_source_names(("first", "second"))
+    assert refreshed == ["second"]
+    assert not tool.source_status_label.isHidden()
+
+    legacy_source = FigureSourceState(name="legacy").model_copy(
+        update={"selection_source": "legacy"}
+    )
+    renamed = FigureComposerTool._source_with_renamed_references(
+        legacy_source, {"legacy": "renamed"}
+    )
+    assert renamed.name == "renamed"
+    assert renamed.selection_source is None
+
+    tool._source_list_reordered(("second", "first"), (), "second")
+    assert tuple(source.name for source in tool.source_states()) == ("second", "first")
+    assert tool._selected_source_names() == ("second",)
+
+    first_source = tool._source_by_name()["first"].model_copy(
+        update={"selection_source": "second"}
+    )
+    second_source = tool._source_by_name()["second"].model_copy(
+        update={"selection_source": "first"}
+    )
+    tool._recipe = tool._recipe.model_copy(
+        update={"sources": (first_source, second_source)}
+    )
+    assert tool._source_dependency_names(("first",)) == ("second", "first")
+
+
+def test_figure_composer_legacy_source_selection_defensive_paths(qtbot) -> None:
+    base = xr.DataArray(np.arange(3.0), dims=("x",), name="base")
+    selected = FigureSourceState(
+        name="selected",
+        selection_source="base",
+        qsel={"missing": 0.0},
+    )
+    tool = FigureComposerTool.from_sources(
+        {"base": base},
+        sources=(FigureSourceState(name="base"), selected),
+        operations=(),
+        primary_source="base",
+    )
+    qtbot.addWidget(tool)
+
+    source_list = list(tool.source_states())
+    source_by_name = {source.name: source for source in source_list}
+    alias = tool._source_alias_for_legacy_selection(
+        FigureDataSelectionState(source="base", qsel={"missing": 0.0}),
+        source_list=source_list,
+        source_by_name=source_by_name,
+        reserved=set(source_by_name),
+    )
+    assert alias == "selected"
+    assert "selected" not in tool.source_data()
+    xr.testing.assert_identical(tool._source_selection_base_data["selected"], base)
+
+    assert FigureComposerTool._source_lineage_names(
+        "selected", {"selected": selected}
+    ) == ("selected",)
+    cycle_a = selected.model_copy(
+        update={"name": "cycle_a", "selection_source": "cycle_b"}
+    )
+    cycle_b = selected.model_copy(
+        update={"name": "cycle_b", "selection_source": "cycle_a"}
+    )
+    with pytest.raises(ValueError, match="cycle"):
+        FigureComposerTool._source_lineage_names(
+            "cycle_a", {"cycle_a": cycle_a, "cycle_b": cycle_b}
+        )
+    propagated = FigureComposerTool._source_states_with_propagated_link_metadata(
+        {"selected": selected}, ("missing",)
+    )
+    assert propagated["selected"] is selected
+
+    with pytest.raises(ValueError, match="unavailable"):
+        tool._source_data_with_recomputed_dependents(
+            {}, {}, ("base",), source_by_name=source_by_name
+        )
+
+    linked = FigureSourceState(name="linked", selection_source="base")
+    recomputed_data, recomputed_bases = tool._source_data_with_recomputed_dependents(
+        {"base": base},
+        {"linked": base},
+        ("base",),
+        source_by_name={"base": source_by_name["base"], "linked": linked},
+    )
+    xr.testing.assert_identical(recomputed_data["linked"], base)
+    assert "linked" not in recomputed_bases
+
+    empty_operation = FigureOperationState.plot_slices(label="empty", sources=())
+    converted_empty = tool._plot_slices_operation_with_shared_legacy_selection(
+        empty_operation
+    )
+    assert converted_empty is not None
+    assert converted_empty.map_selections == ()
+
+    invalid_operation = FigureOperationState.plot_slices(
+        label="invalid",
+        sources=("base",),
+        map_selections=(
+            FigureDataSelectionState(source="base", qsel={"missing": 0.0}),
+        ),
+    )
+    assert (
+        tool._plot_slices_operation_with_shared_legacy_selection(invalid_operation)
+        is None
+    )
+
+    no_slice_dimension = FigureOperationState.plot_slices(
+        label="legacy", sources=("base",)
+    ).model_copy(update={"slice_dim": None})
+    converted_slice = FigureComposerTool._plot_slices_operation_with_legacy_qsel(
+        no_slice_dimension,
+        {"x": 1.0, "x_width": 0.5},
+    )
+    assert converted_slice.slice_dim == "x"
+    assert converted_slice.slice_values == (1.0,)
+    assert converted_slice.slice_width == 0.5
+
+    no_selection_operation = FigureOperationState.plot_slices(
+        label="no selection",
+        sources=("base",),
+        map_selections=(FigureDataSelectionState(source="base"),),
+    )
+    converted_sources = tool._plot_slices_operation_with_legacy_source_aliases(
+        no_selection_operation,
+        source_list=[source_by_name["base"]],
+        source_by_name={"base": source_by_name["base"]},
+        reserved={"base"},
+    )
+    assert converted_sources.sources == ("base",)
+    assert converted_sources.map_selections == ()
+    assert (
+        FigureComposerTool._legacy_selection_fallback_source(
+            FigureOperationState.custom(label="custom", code="pass", trusted=True),
+            "base",
+        )
+        is None
+    )
+
+
+def test_figure_composer_add_and_replace_tolerate_broken_link_cycle(qtbot) -> None:
+    left_data = xr.DataArray(np.arange(3.0), dims=("x",), name="left")
+    right_data = left_data.rename("right")
+    left = FigureSourceState(name="left", node_uid="shared").model_copy(
+        update={"selection_source": "right"}
+    )
+    right = FigureSourceState(name="right", node_uid="shared").model_copy(
+        update={"selection_source": "left"}
+    )
+    tool = FigureComposerTool.from_sources(
+        {"left": left_data, "right": right_data},
+        sources=(left, right),
+        operations=(),
+        primary_source="left",
+    )
+    qtbot.addWidget(tool)
+
+    incoming = left_data + 10.0
+    result = tool.add_sources(
+        (FigureSourceState(name="incoming", node_uid="shared"),),
+        {"incoming": incoming},
+    )
+    assert result.added == (("incoming", "incoming"),)
+    xr.testing.assert_identical(tool.source_data()["incoming"], incoming)
+
+    replacement = left_data + 20.0
+    assert tool.replace_source(
+        "left",
+        FigureSourceState(name="replacement", node_uid="shared"),
+        replacement,
+    )
+    xr.testing.assert_identical(tool.source_data()["left"], replacement)
+
+    unavailable = tool.add_sources((FigureSourceState(name="missing"),), {})
+    assert not unavailable
+    assert unavailable.skipped[0][0] == "missing"
+    assert not tool.source_status_label.isHidden()
+
+
+def test_figure_composer_restore_persisted_selection_failure_paths(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="saved")
+
+    primary_tool = FigureComposerTool.from_sources(
+        {"primary": data},
+        sources=(FigureSourceState(name="primary"),),
+        operations=(),
+        primary_source="primary",
+    )
+    qtbot.addWidget(primary_tool)
+    invalid_primary = primary_tool.source_states()[0].model_copy(
+        update={"qsel": {"missing": 0.0}}
+    )
+    primary_tool._recipe = primary_tool._recipe.model_copy(
+        update={"sources": (invalid_primary,)}
+    )
+    primary_tool.set_source_data({})
+    primary_tool._restore_persistence_data_items(
+        {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: data},
+        xr.Dataset(attrs={"tool_data_name": "restored"}),
+    )
+    assert primary_tool.source_data()["primary"].name == "restored"
+    assert "primary" not in primary_tool._source_selection_base_data
+
+    invalid_child = FigureSourceState(
+        name="child",
+        selection_source="root",
+        qsel={"missing": 0.0},
+    )
+    descendant_tool = FigureComposerTool.from_sources(
+        {"root": data},
+        sources=(FigureSourceState(name="root"), invalid_child),
+        operations=(),
+        primary_source="root",
+    )
+    qtbot.addWidget(descendant_tool)
+    descendant_tool.set_source_data({})
+    descendant_tool._restore_persistence_data_items(
+        {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: data}, xr.Dataset()
+    )
+    assert "root" in descendant_tool.source_data()
+    assert "child" not in descendant_tool.source_data()
+
+    orphan = FigureSourceState(
+        name="orphan",
+        selection_source="missing",
+        qsel={"missing": 0.0},
+    )
+    pending_tool = FigureComposerTool.from_sources(
+        {"stable": data},
+        sources=(FigureSourceState(name="stable"), orphan),
+        operations=(),
+        primary_source="stable",
+    )
+    qtbot.addWidget(pending_tool)
+    pending_tool._restore_persistence_data_items({"orphan": data}, xr.Dataset())
+    assert "stable" in pending_tool.source_data()
+    assert "orphan" not in pending_tool.source_data()
+
+
+def test_figure_composer_selected_source_codegen_fallback_uses_base_input(
+    qtbot,
+) -> None:
+    base_data = xr.DataArray(np.arange(3.0), dims=("x",), name="base")
+    selected_data = base_data.isel(x=0)
+    base_source = FigureSourceState(name="base")
+    selected_source = FigureSourceState(
+        name="selected",
+        selection_source="base",
+        isel={"x": 0},
+    )
+    tool = FigureComposerTool.from_sources(
+        {"base": base_data, "selected": selected_data},
+        sources=(base_source, selected_source),
+        operations=(FigureOperationState.plot_array(label="plot", source="selected"),),
+        primary_source="base",
+    )
+    qtbot.addWidget(tool)
+
+    malformed_provenance = {"kind": "not-a-provenance-kind"}
+    tool._recipe = tool._recipe.model_copy(
+        update={
+            "sources": (
+                base_source.model_copy(
+                    update={"provenance_spec": malformed_provenance}
+                ),
+                selected_source.model_copy(
+                    update={"provenance_spec": malformed_provenance}
+                ),
+            )
+        }
+    )
+    script_inputs, skipped_names, source_name_map = tool._display_code_source_plan()
+    assert tuple(script_input.name for script_input in script_inputs) == ("base",)
+    assert skipped_names == frozenset()
+    assert source_name_map == {}
+
+    cleanup_tool = FigureComposerTool.from_sources(
+        {"base": base_data, "selected": selected_data},
+        sources=(base_source, selected_source),
+        operations=(),
+        primary_source="base",
+    )
+    qtbot.addWidget(cleanup_tool)
+    cleanup_tool._source_selection_base_data["selected"] = base_data
+    cleanup_tool.set_missing_sources({"selected"})
+    assert "selected" not in cleanup_tool.source_data()
+    assert "selected" not in cleanup_tool._source_selection_base_data
+
+
+def test_figure_composer_source_selection_control_guard_paths(qtbot) -> None:
+    plain = xr.DataArray(np.arange(2.0), dims=("x",), name="plain")
+    other = xr.DataArray(np.arange(2.0), dims=("y",), name="other")
+    empty = xr.DataArray(
+        np.empty(0), dims=("empty",), coords={"empty": np.empty(0)}, name="empty"
+    )
+    with_coordinates = xr.DataArray(
+        np.arange(2.0),
+        dims=("x",),
+        coords={"x": [0.0, 1.0]},
+        name="with_coordinates",
+    )
+    source_names = ("plain", "other", "empty", "with_coordinates", "unavailable")
+    tool = FigureComposerTool.from_sources(
+        {
+            "plain": plain,
+            "other": other,
+            "empty": empty,
+            "with_coordinates": with_coordinates,
+        },
+        sources=tuple(FigureSourceState(name=name) for name in source_names),
+        operations=(),
+        primary_source="plain",
+    )
+    qtbot.addWidget(tool)
+
+    assert tool._source_selection_dimension_tooltip("x", source_names)
+    assert tool._common_source_selection_dims(("unavailable", "plain", "other")) == ()
+    tool._set_selected_source_names_silent({"with_coordinates"}, "with_coordinates")
+    assert tool._default_source_inspector_target() == "with_coordinates"
+
+    mode_combo = tool._source_selection_mode_combo(
+        current="qsel", mixed=False, parent=tool
+    )
+    value_edit = QtWidgets.QLineEdit("1.0", tool)
+    width_edit = QtWidgets.QLineEdit("0.5", tool)
+    tool._connect_source_selection_dimension_controls(
+        "x", mode_combo, value_edit, width_edit
+    )
+    before = tool.source_states()
+    mode_combo.addItem("unsupported", object())
+    unsupported_index = mode_combo.count() - 1
+    mode_combo.setCurrentIndex(unsupported_index)
+    mode_combo.activated.emit(unsupported_index)
+    assert tool.source_states() == before
+
+    qsel_index = mode_combo.findData("qsel")
+    assert qsel_index >= 0
+    mode_combo.setCurrentIndex(qsel_index)
+    mode_combo.activated.emit(qsel_index)
+    FigureComposerTool._apply_mixed_line_edit(value_edit, True)
+    value_edit.editingFinished.emit()
+    assert tool.source_states() == before
+
+    FigureComposerTool._apply_mixed_line_edit(value_edit, False)
+    value_edit.setText("1.0")
+    FigureComposerTool._apply_mixed_line_edit(width_edit, True)
+    value_edit.editingFinished.emit()
+    assert tool.source_states() == before
+
+    FigureComposerTool._apply_mixed_line_edit(width_edit, False)
+    value_edit.setText("[")
+    width_edit.setText("0.5")
+    value_edit.editingFinished.emit()
+    assert not tool.source_validation_label.isHidden()
+
+    value_edit.setText("1.0")
+    width_edit.editingFinished.emit()
+    selected_source = tool._source_by_name()["with_coordinates"]
+    assert selected_source.qsel
+    assert "with_coordinates" in tool._source_selection_base_data
+
+    detached_selected = FigureSourceState(
+        name="selected", selection_source="missing_base"
+    )
+    detached_tool = FigureComposerTool.from_sources(
+        {"selected": with_coordinates},
+        sources=(FigureSourceState(name="missing_base"), detached_selected),
+        operations=(),
+        primary_source="selected",
+    )
+    qtbot.addWidget(detached_tool)
+    detached_tool._set_selected_source_names_silent({"selected"}, "selected")
+    detached_before = detached_tool.source_states()
+    detached_tool._update_selected_source_dimension("x", "qsel", "1.0", "")
+    assert detached_tool.source_states() == detached_before
+
+    tool._set_selected_source_names_silent({"unavailable"}, "unavailable")
+    tool._recipe = tool._recipe.model_copy(
+        update={
+            "sources": tuple(
+                source
+                for source in tool.source_states()
+                if source.name != "unavailable"
+            )
+        }
+    )
+    tool._refresh_source_detail_panel()
+    assert not tool.source_alias_edit.isEnabled()
+
+
+def test_figure_composer_restore_persisted_source_pending_paths(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="saved")
+    blocked_tool = FigureComposerTool.from_sources(
+        {"stable": data, "parent": data},
+        sources=(
+            FigureSourceState(name="stable"),
+            FigureSourceState(name="parent", selection_source="missing_parent"),
+            FigureSourceState(name="child", selection_source="parent"),
+        ),
+        operations=(),
+        primary_source="stable",
+    )
+    qtbot.addWidget(blocked_tool)
+    blocked_tool._restore_persistence_data_items({"child": data}, xr.Dataset())
+    assert "parent" in blocked_tool.source_data()
+    assert "child" not in blocked_tool.source_data()
+
+    fallback_tool = FigureComposerTool.from_sources(
+        {"stable": data},
+        sources=(
+            FigureSourceState(name="stable"),
+            FigureSourceState(name="orphan", selection_source="missing_parent"),
+        ),
+        operations=(),
+        primary_source="stable",
+    )
+    qtbot.addWidget(fallback_tool)
+    fallback_tool._restore_persistence_data_items({"orphan": data}, xr.Dataset())
+    xr.testing.assert_identical(fallback_tool.source_data()["orphan"], data)
+
+
+def test_figure_composer_selected_source_script_input_skips_nonreplayable_input(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(
+        np.arange(2.0), dims=("x",), coords={"x": [0.0, 1.0]}, name="base"
+    )
+    provenance_spec = provenance.public_data().model_dump(mode="json")
+    base = FigureSourceState(name="base", provenance_spec=provenance_spec)
+    selected = FigureSourceState(
+        name="selected",
+        selection_source="base",
+        qsel={"x": 1.0},
+        provenance_spec=provenance_spec,
+    )
+    tool = FigureComposerTool.from_sources(
+        {"base": data, "selected": data.qsel(x=1.0)},
+        sources=(base, selected),
+        operations=(FigureOperationState.line(label="line", source="selected"),),
+        primary_source="base",
+    )
+    qtbot.addWidget(tool)
+
+    monkeypatch.setattr(provenance, "to_replay_provenance_spec", lambda _spec: None)
+    assert (
+        tool._selected_source_script_input(
+            selected,
+            display_name="selected_display",
+            source_by_name={"base": base, "selected": selected},
+        )
+        is None
+    )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -2167,6 +2167,91 @@ def test_figure_composer_source_refresh_recomputes_transitive_selected_sources(
     assert tool.source_status_label.text() == ""
 
 
+def test_figure_composer_refreshing_selected_alias_updates_linked_root(qtbot) -> None:
+    tool, base, _selected_u, _selected_v = _transitive_selected_source_tool()
+    qtbot.addWidget(tool)
+    replacement = base + 100.0
+    provenance_spec = {"kind": "new-origin"}
+    snapshot_id = "new-snapshot"
+
+    assert tool.replace_source(
+        "selected_v",
+        FigureSourceState(
+            name="manager_default",
+            node_uid="base-node",
+            node_snapshot_token=snapshot_id,
+            provenance_spec=provenance_spec,
+        ),
+        replacement,
+    )
+
+    source_by_name = tool._source_by_name()
+    assert source_by_name["base"].selection_source is None
+    assert source_by_name["selected_u"].selection_source == "base"
+    assert source_by_name["selected_v"].selection_source == "selected_u"
+    assert {source.node_uid for source in source_by_name.values()} == {"base-node"}
+    assert {source.node_snapshot_token for source in source_by_name.values()} == {
+        snapshot_id
+    }
+    assert all(
+        source.provenance_spec == provenance_spec for source in source_by_name.values()
+    )
+    expected_u = replacement.qsel(u=1.0)
+    expected_v = expected_u.qsel(v=2.0)
+    xr.testing.assert_identical(tool.source_data()["base"], replacement)
+    xr.testing.assert_identical(tool.source_data()["selected_u"], expected_u)
+    xr.testing.assert_identical(tool.source_data()["selected_v"], expected_v)
+
+
+def test_figure_composer_readding_shared_link_updates_root_without_new_alias(
+    qtbot,
+) -> None:
+    tool, base, _selected_u, _selected_v = _transitive_selected_source_tool()
+    qtbot.addWidget(tool)
+    replacement = base + 100.0
+
+    result = tool.add_sources(
+        (FigureSourceState(name="manager_default", node_uid="base-node"),),
+        {"manager_default": replacement},
+    )
+
+    assert result.added == ()
+    assert result.updated == (("manager_default", "base"),)
+    assert result.skipped == ()
+    assert result.name_map == {"manager_default": "base"}
+    assert tuple(tool._source_by_name()) == ("base", "selected_u", "selected_v")
+    expected_u = replacement.qsel(u=1.0)
+    expected_v = expected_u.qsel(v=2.0)
+    xr.testing.assert_identical(tool.source_data()["base"], replacement)
+    xr.testing.assert_identical(tool.source_data()["selected_u"], expected_u)
+    xr.testing.assert_identical(tool.source_data()["selected_v"], expected_v)
+
+
+def test_figure_composer_add_sources_reports_partial_batch_outcome(qtbot) -> None:
+    tool, base, _selected_u, _selected_v = _transitive_selected_source_tool()
+    qtbot.addWidget(tool)
+    incompatible = base.isel(v=0, drop=True) + 100.0
+    extra = xr.DataArray(np.arange(3.0), dims=("x",), name="extra")
+
+    result = tool.add_sources(
+        (
+            FigureSourceState(name="incoming", node_uid="base-node"),
+            FigureSourceState(name="extra", node_uid="extra-node"),
+        ),
+        {"incoming": incompatible, "extra": extra},
+    )
+
+    assert result.added == (("extra", "extra"),)
+    assert result.updated == ()
+    assert result.skipped[0][0] == "incoming"
+    assert "base" in result.skipped[0][1]
+    assert result.name_map == {"extra": "extra"}
+    assert result
+    xr.testing.assert_identical(tool.source_data()["base"], base)
+    xr.testing.assert_identical(tool.source_data()["extra"], extra)
+    assert "Could not update source data for: base" in tool.source_status_label.text()
+
+
 @pytest.mark.parametrize("mutation", ("replace", "add", "refresh"))
 def test_figure_composer_source_refresh_is_atomic_when_dependent_selection_fails(
     qtbot,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -682,6 +682,367 @@ def test_figure_composer_source_list_keyboard_context_menu(qtbot) -> None:
     tool._source_context_menu.close()
 
 
+def test_figure_composer_source_list_edge_events(qtbot) -> None:
+    source_list = figurecomposer_tool_module._FigureComposerSourceList()
+    qtbot.addWidget(source_list)
+    emitted: list[tuple[object, object, object]] = []
+    source_list.rows_reordered.connect(
+        lambda names, selected, current: emitted.append((names, selected, current))
+    )
+
+    source_list.addTopLevelItem(QtWidgets.QTreeWidgetItem(["missing-role"]))
+    source_list._emit_rows_reordered()
+    source_list._model_rows_moved()
+    source_list.keyPressEvent(None)
+    source_list.dropEvent(None)
+
+    assert emitted == []
+
+
+def test_figure_composer_source_add_callbacks_handle_unavailable_paths(
+    qtbot,
+) -> None:
+    data = _figure_composer_profile_source("data")
+    tool = FigureComposerTool(data)
+    qtbot.addWidget(tool)
+    figure_window = figurecomposer_widgets._FigureComposerDisplayWindow(
+        FigureSubplotsState()
+    )
+    qtbot.addWidget(figure_window)
+    tool._figure_window = figure_window
+    mime = QtCore.QMimeData()
+    calls: list[str] = []
+
+    tool._set_source_add_callbacks(
+        add_sources=lambda: calls.append("add") or True,
+        can_drop_sources=lambda data: data is mime,
+        drop_sources=lambda data: calls.append("drop") or data is mime,
+    )
+    assert tool._source_add_available()
+    tool._request_add_sources_from_button()
+    assert calls == ["add"]
+    assert not tool._source_drop_available(None)
+    assert tool._source_drop_available(mime)
+    assert not tool._add_sources_from_mime(None)
+    assert tool._add_sources_from_mime(mime)
+    assert calls == ["add", "drop"]
+
+    def raise_value() -> bool:
+        raise ValueError("unavailable")
+
+    def raise_lookup(_mime: QtCore.QMimeData) -> bool:
+        raise LookupError("unavailable")
+
+    tool._set_source_add_callbacks(
+        add_sources=lambda: True,
+        can_add_sources=raise_value,
+        can_drop_sources=raise_lookup,
+        drop_sources=raise_lookup,
+    )
+    assert not tool._source_add_available()
+    tool._request_add_sources_from_button()
+    tool._figure_window = None
+    assert not tool._source_drop_available(mime)
+    assert not tool._add_sources_from_mime(mime)
+
+    tool._set_source_add_callbacks()
+    assert not tool._source_add_available()
+    tool._request_add_sources_from_button()
+
+
+def test_figure_composer_source_structure_edge_paths(qtbot) -> None:
+    data = {name: _figure_composer_profile_source(name) for name in ("first", "second")}
+    tool = FigureComposerTool.from_sources(
+        data,
+        sources=tuple(FigureSourceState(name=name) for name in data),
+        setup=FigureSubplotsState(),
+        primary_source="first",
+    )
+    qtbot.addWidget(tool)
+
+    def clear_source_current() -> None:
+        tool.source_list.clearSelection()
+        tool.source_list.setCurrentIndex(QtCore.QModelIndex())
+
+    clear_source_current()
+    tool._remove_selected_sources()
+    clear_source_current()
+    tool._duplicate_selected_sources()
+    clear_source_current()
+    tool._move_selected_sources(1)
+    assert not tool._source_move_possible(1)
+    assert tuple(source.name for source in tool.source_states()) == (
+        "first",
+        "second",
+    )
+
+    tool._set_selected_source_names_silent({"first"}, "first")
+    tool._move_selected_sources(-1)
+    assert tuple(source.name for source in tool.source_states()) == (
+        "first",
+        "second",
+    )
+    tool._rename_source_alias("missing", "renamed")
+    assert tuple(source.name for source in tool.source_states()) == (
+        "first",
+        "second",
+    )
+
+    assert tool._source_alias_error("") is not None
+    assert tool._source_alias_error("bad name") is not None
+    assert tool._source_alias_error(erlab.interactive.utils._SAVED_TOOL_DATA_NAME)
+    assert tool._source_alias_error("fig") is not None
+    assert tool._source_alias_error("second", current="first") is not None
+    reserved = {"first_copy"}
+    assert tool._source_unique_alias("first", reserved) == "first_copy_2"
+
+    tool._refresh_source_selection_editor()
+    alias_edit = tool.source_selection_controls.findChild(
+        QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
+    )
+    assert alias_edit is not None
+    tool._focus_source_alias_editor()
+    first_item = tool.source_list.topLevelItem(0)
+    assert first_item is not None
+    tool._source_list_item_double_clicked(first_item, 0)
+    tool._rename_source_alias("first", "renamed")
+    assert tuple(source.name for source in tool.source_states()) == (
+        "renamed",
+        "second",
+    )
+
+    tool._set_selected_source_names_silent({"renamed", "second"}, "renamed")
+    tool._focus_source_alias_editor()
+    tool._source_list_reordered("not-a-sequence", set(), None)
+    tool._source_list_reordered(("renamed", "renamed"), set(), None)
+    tool._source_list_reordered(("renamed", "second"), set(), None)
+    tool._source_list_reordered(("second", "renamed"), (), None)
+    assert tuple(source.name for source in tool.source_states()) == (
+        "second",
+        "renamed",
+    )
+
+
+def test_figure_composer_source_selection_editor_edge_paths(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [0.0, 1.0, 2.0]},
+        name="data",
+    )
+    other = data.rename("other")
+    scalar = xr.DataArray(1.0, name="scalar")
+    tool = FigureComposerTool.from_sources(
+        {"data": data, "other": other, "scalar": scalar},
+        sources=(
+            FigureSourceState(name="data", isel={"x": 0}),
+            FigureSourceState(name="other", qsel={"x": 1.0}),
+            FigureSourceState(name="scalar"),
+        ),
+        setup=FigureSubplotsState(),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+
+    def flush_deferred_editor_deletes() -> None:
+        QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+        QtWidgets.QApplication.processEvents()
+
+    tool.source_list.clearSelection()
+    tool.source_list.setCurrentIndex(QtCore.QModelIndex())
+    tool._refresh_source_selection_editor()
+    flush_deferred_editor_deletes()
+    item = tool.source_selection_controls_layout.itemAt(0)
+    assert item is not None
+    assert isinstance(item.widget(), QtWidgets.QLabel)
+
+    tool._set_selected_source_names_silent({"scalar"}, "scalar")
+    tool._refresh_source_selection_editor()
+    flush_deferred_editor_deletes()
+    item = tool.source_selection_controls_layout.itemAt(
+        tool.source_selection_controls_layout.rowCount() - 1,
+        QtWidgets.QFormLayout.ItemRole.FieldRole,
+    )
+    assert item is not None
+    assert isinstance(item.widget(), QtWidgets.QLabel)
+
+    tool.source_list.clearSelection()
+    first_item = tool.source_list.topLevelItem(0)
+    second_item = tool.source_list.topLevelItem(1)
+    assert first_item is not None
+    assert second_item is not None
+    tool.source_list.setCurrentItem(first_item)
+    first_item.setSelected(True)
+    second_item.setSelected(True)
+    tool._refresh_source_selection_editor()
+    flush_deferred_editor_deletes()
+    combo = None
+    for row in range(tool.source_selection_controls_layout.rowCount()):
+        item = tool.source_selection_controls_layout.itemAt(
+            row, QtWidgets.QFormLayout.ItemRole.FieldRole
+        )
+        widget = None if item is None else item.widget()
+        if widget is None or not widget.objectName().startswith(
+            "figureComposerSourceSelectionDimRow"
+        ):
+            continue
+        combo = widget.findChild(
+            QtWidgets.QComboBox, "figureComposerSourceSelectionModeCombo0"
+        )
+        if combo is not None:
+            break
+    assert combo is not None
+    assert combo.currentData() is _editor_controls.MIXED_VALUE
+
+    tool._source_data.clear()
+    tool._update_selected_source_dimension("x", "isel", "0", "")
+    assert tool._source_data == {}
+
+
+def test_figure_composer_source_selection_helper_edges(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "kx"),
+        coords={"eV": [0.0, 1.0], "kx": [0.0, 1.0, 2.0]},
+        name="data",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(
+            FigureSourceState(name="data"),
+            FigureSourceState(name="derived", selection_source="data"),
+        ),
+        setup=FigureSubplotsState(),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    assert (
+        tool._source_selection_input_data("derived", tool._source_by_name()["derived"])
+        is data
+    )
+
+    operation = FigureOperationState.plot_slices(
+        label="slice",
+        sources=("data",),
+        slice_dim="eV",
+    )
+    normalized = FigureComposerTool._plot_slices_operation_with_legacy_qsel(
+        operation,
+        {"eV": 1.0, "eV_width": 0.5},
+    )
+    assert normalized.slice_values == (1.0,)
+    assert normalized.slice_width == 0.5
+    assert normalized.slice_kwargs == {}
+
+    assert (
+        FigureComposerTool._legacy_selection_fallback_source(
+            FigureOperationState.line(label="line", source="data"),
+            "data",
+        )
+        is None
+    )
+    assert FigureComposerTool._operation_without_map_selections(
+        operation,
+        "data",
+    ).sources == ("data",)
+    assert (
+        FigureComposerTool._operation_without_map_selections(
+            FigureOperationState.custom(label="custom", code="pass", trusted=True),
+            None,
+        ).map_selections
+        == ()
+    )
+
+    tool.add_sources((FigureSourceState(name="missing"),), {})
+    assert tuple(source.name for source in tool.source_states()) == ("data", "derived")
+    tool.add_sources((FigureSourceState(name="data"),), {"data": data})
+    assert tuple(source.name for source in tool.source_states()) == (
+        "data",
+        "derived",
+        "data_copy",
+    )
+
+
+def test_figure_composer_legacy_source_selection_normalization_edges(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "kx"),
+        coords={"eV": [0.0, 1.0], "kx": [0.0, 1.0, 2.0]},
+        name="data",
+    )
+    selected = data.qsel(eV=1.0)
+    selected.name = data.name
+    reused = FigureSourceState(
+        name="data_selected",
+        selection_source="data",
+        qsel={"eV": 1.0},
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"), reused),
+            operations=(
+                FigureOperationState.plot_array(
+                    label="array",
+                    source="data",
+                    map_selections=(
+                        FigureDataSelectionState(source="data", qsel={"eV": 1.0}),
+                    ),
+                ),
+                FigureOperationState.plot_array(
+                    label="array_empty",
+                    source="data",
+                    map_selections=(FigureDataSelectionState(source="data"),),
+                ),
+                FigureOperationState.plot_array(
+                    label="array_multi",
+                    source="data",
+                    map_selections=(
+                        FigureDataSelectionState(source="data", qsel={"eV": 0.0}),
+                        FigureDataSelectionState(source="missing", qsel={"eV": 0.0}),
+                    ),
+                ),
+                FigureOperationState.plot_slices(
+                    label="slice",
+                    sources=("data",),
+                    map_selections=(
+                        FigureDataSelectionState(source="data", qsel={"eV": 1.0}),
+                    ),
+                    slice_dim="eV",
+                ),
+                FigureOperationState.plot_slices(
+                    label="slice_alias",
+                    sources=("data",),
+                    map_selections=(
+                        FigureDataSelectionState(source="data", isel={"kx": 1}),
+                    ),
+                    slice_dim="eV",
+                ),
+            ),
+            primary_source="data",
+        ),
+        source_data={"data": data},
+    )
+    qtbot.addWidget(tool)
+
+    sources = {source.name: source for source in tool.source_states()}
+    assert "data_selected" in sources
+    xr.testing.assert_identical(tool.source_data()["data_selected"], selected)
+    assert tool.tool_status.operations[0].sources == ("data_selected",)
+    assert tool.tool_status.operations[0].map_selections == ()
+    assert tool.tool_status.operations[1].sources == ("data",)
+    assert tool.tool_status.operations[1].map_selections == ()
+    assert tool.tool_status.operations[2].sources == ("data",)
+    assert tool.tool_status.operations[2].map_selections == ()
+    assert tool.tool_status.operations[3].slice_values == (1.0,)
+    assert tool.tool_status.operations[3].map_selections == ()
+    assert tool.tool_status.operations[4].sources == ("data_selected_2",)
+    assert tool.tool_status.operations[4].map_selections == ()
+    assert sources["data_selected_2"].isel == {"kx": 1}
+
+
 def test_figure_composer_source_display_helpers_use_alias_only() -> None:
     source = FigureSourceState(name="data_0", label="ImageTool 0: sample_map")
     assert figurecomposer_sources._source_display_label(source, "data_0") == "data_0"

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -122,6 +122,144 @@ def test_figure_composer_secondary_source_roundtrip_ignores_stale_backend_encodi
     assert secondary.coords["x"].encoding["compression"] == "unknown"
 
 
+@pytest.mark.parametrize("retain_base_data", (False, True))
+def test_figure_composer_selected_source_roundtrip_applies_selection_once(
+    qtbot, retain_base_data: bool
+) -> None:
+    base = xr.DataArray(
+        np.arange(10.0),
+        dims=("x",),
+        coords={"x": np.arange(10.0)},
+        name="profile",
+    )
+    selected = base.isel(x=slice(2, 8))
+    source = FigureSourceState(
+        name="profile",
+        isel={"x": slice(2, 8)},
+        selection_source="profile",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"profile": selected},
+        sources=(source,),
+        operations=(FigureOperationState.line(label="line", source="profile"),),
+        primary_source="profile",
+    )
+    qtbot.addWidget(tool)
+    if retain_base_data:
+        tool._source_selection_base_data["profile"] = base
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(tool.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, FigureComposerTool)
+    xr.testing.assert_identical(restored.source_data()["profile"], selected)
+    assert ("profile" in restored._source_selection_base_data) is retain_base_data
+
+    restored_again = erlab.interactive.utils.ToolWindow.from_dataset(
+        restored.to_dataset()
+    )
+    qtbot.addWidget(restored_again)
+    assert isinstance(restored_again, FigureComposerTool)
+    xr.testing.assert_identical(restored_again.source_data()["profile"], selected)
+
+
+def test_figure_composer_selected_source_reference_restores_from_base_data(
+    qtbot,
+) -> None:
+    base = xr.DataArray(
+        np.arange(10.0),
+        dims=("x",),
+        coords={"x": np.arange(10.0)},
+        name="profile",
+    )
+    selected = base.isel(x=slice(2, 8))
+    tool = FigureComposerTool.from_sources(
+        {"profile": selected},
+        sources=(
+            FigureSourceState(
+                name="profile",
+                isel={"x": slice(2, 8)},
+                selection_source="profile",
+                node_uid="profile-node",
+            ),
+        ),
+        operations=(FigureOperationState.line(label="line", source="profile"),),
+        primary_source="profile",
+    )
+    qtbot.addWidget(tool)
+
+    with tool._save_tool_data_reference_context({"profile-node"}):
+        saved = tool.to_dataset()
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _tool_data_reference_resolver=lambda _reference: base,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, FigureComposerTool)
+    xr.testing.assert_identical(restored.source_data()["profile"], selected)
+    xr.testing.assert_identical(restored._source_selection_base_data["profile"], base)
+
+
+def test_figure_composer_selected_alias_roundtrip_uses_source_alias_base(
+    qtbot,
+) -> None:
+    base = xr.DataArray(
+        np.arange(10.0),
+        dims=("x",),
+        coords={"x": np.arange(10.0)},
+        name="profile",
+    )
+    selected = base.isel(x=slice(2, 8))
+    tool = FigureComposerTool.from_sources(
+        {"base": base, "selected": selected},
+        sources=(
+            FigureSourceState(name="base"),
+            FigureSourceState(
+                name="selected",
+                isel={"x": slice(2, 8)},
+                selection_source="base",
+            ),
+        ),
+        operations=(FigureOperationState.line(label="line", source="selected"),),
+        primary_source="base",
+    )
+    qtbot.addWidget(tool)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(tool.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, FigureComposerTool)
+    xr.testing.assert_identical(restored.source_data()["selected"], selected)
+    xr.testing.assert_identical(restored._source_selection_base_data["selected"], base)
+
+
+def test_figure_composer_persistence_metadata_fallbacks(qtbot) -> None:
+    primary = xr.DataArray(np.arange(2.0), dims=("x",), name="primary")
+    fallback = xr.DataArray(np.arange(2.0) + 2.0, dims=("x",), name="fallback")
+    tool = FigureComposerTool.from_sources(
+        {"primary": primary, "fallback": fallback},
+        sources=(
+            FigureSourceState(name="primary"),
+            FigureSourceState(name="fallback"),
+            FigureSourceState(name="missing"),
+        ),
+        primary_source="primary",
+    )
+    qtbot.addWidget(tool)
+    del tool._source_data["primary"]
+
+    items = tool._persistence_data_items()
+    xr.testing.assert_identical(
+        items[erlab.interactive.utils._SAVED_TOOL_DATA_NAME], fallback
+    )
+    assert tool._embedded_selected_source_names(xr.Dataset()) == ()
+
+    attr = figurecomposer_tool_module._PERSISTED_SELECTED_SOURCE_DATA_ATTR
+    for payload in ("{", json.dumps({"selected": True})):
+        assert (
+            tool._persisted_selected_source_names(xr.Dataset(attrs={attr: payload}))
+            == frozenset()
+        )
+
+
 def test_figure_composer_source_ui_keeps_aliases_as_internal_keys(qtbot) -> None:
     first = _figure_composer_image_source("first")
     second = _figure_composer_image_source("second")
@@ -898,10 +1036,23 @@ def test_figure_composer_source_structure_edge_paths(qtbot) -> None:
     assert tool._source_unique_alias("first", reserved) == "first_2"
 
     tool._refresh_source_selection_editor()
-    alias_edit = tool.source_selection_controls.findChild(
-        QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
-    )
+    alias_edit = None
+    for row in range(tool.source_selection_controls_layout.rowCount()):
+        item = tool.source_selection_controls_layout.itemAt(
+            row, QtWidgets.QFormLayout.ItemRole.FieldRole
+        )
+        widget = None if item is None else item.widget()
+        if (
+            isinstance(widget, QtWidgets.QLineEdit)
+            and widget.objectName() == "figureComposerSourceAliasEdit"
+        ):
+            alias_edit = widget
+            break
     assert alias_edit is not None
+    alias_edit.setText("bvec")
+    alias_edit.editingFinished.emit()
+    assert alias_edit.text() == "first"
+    assert not tool.source_status_label.isHidden()
     tool._focus_source_alias_editor()
     first_item = tool.source_list.topLevelItem(0)
     assert first_item is not None
@@ -1339,6 +1490,110 @@ def test_figure_composer_source_refresh_applies_saved_selection(
     assert tool.source_status_label.text() == ""
 
 
+def test_figure_composer_readding_linked_source_preserves_selection(qtbot) -> None:
+    original = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "alpha"),
+        coords={"eV": [-1.0, 0.0], "alpha": [0.0, 1.0, 2.0]},
+        name="map",
+    )
+    selected = original.qsel(eV=0.0)
+    tool = FigureComposerTool.from_sources(
+        {"data": selected},
+        sources=(
+            FigureSourceState(
+                name="data",
+                qsel={"eV": 0.0},
+                selection_source="data",
+                node_uid="node",
+            ),
+        ),
+        operations=(FigureOperationState.plot_array(label="array", source="data"),),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+
+    refreshed = original + 10.0
+    tool.add_sources(
+        (FigureSourceState(name="data", node_uid="node"),),
+        {"data": refreshed},
+    )
+
+    [source] = tool.source_states()
+    assert source.qsel == {"eV": 0.0}
+    assert source.selection_source == "data"
+    xr.testing.assert_identical(tool.source_data()["data"], refreshed.qsel(eV=0.0))
+    xr.testing.assert_identical(tool._source_selection_base_data["data"], refreshed)
+
+    state_before = tool.tool_status
+    data_before = tool.source_data()["data"]
+    incompatible = xr.DataArray(np.arange(3.0), dims=("alpha",), name="map")
+    tool.add_sources(
+        (FigureSourceState(name="data", node_uid="node"),),
+        {"data": incompatible},
+    )
+    assert tool.tool_status == state_before
+    xr.testing.assert_identical(tool.source_data()["data"], data_before)
+    assert not tool.source_status_label.isHidden()
+
+
+def test_figure_composer_replace_different_source_preserves_compatible_selection(
+    qtbot,
+) -> None:
+    original = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("eV", "alpha"),
+        coords={"eV": [-1.0, 0.0], "alpha": [0.0, 1.0, 2.0]},
+        name="original",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": original.qsel(eV=0.0)},
+        sources=(
+            FigureSourceState(
+                name="data",
+                qsel={"eV": 0.0},
+                selection_source="original_base",
+                node_uid="old-node",
+            ),
+        ),
+        operations=(FigureOperationState.plot_array(label="array", source="data"),),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+
+    replacement = (original + 20.0).rename("replacement")
+    assert tool.replace_source(
+        "data",
+        FigureSourceState(name="replacement", node_uid="new-node"),
+        replacement,
+    )
+
+    [source] = tool.source_states()
+    assert source.node_uid == "new-node"
+    assert source.qsel == {"eV": 0.0}
+    assert source.selection_source == "data"
+    xr.testing.assert_identical(tool.source_data()["data"], replacement.qsel(eV=0.0))
+    xr.testing.assert_identical(tool._source_selection_base_data["data"], replacement)
+
+    selected_replacement = (original + 40.0).rename("selected_replacement")
+    assert tool.replace_source(
+        "data",
+        FigureSourceState(
+            name="selected_replacement",
+            qsel={"eV": -1.0},
+            selection_source="selected_replacement",
+            node_uid="newer-node",
+        ),
+        selected_replacement,
+    )
+    [source] = tool.source_states()
+    assert source.qsel == {"eV": -1.0}
+    assert source.selection_source == "data"
+    xr.testing.assert_identical(
+        tool.source_data()["data"], selected_replacement.qsel(eV=-1.0)
+    )
+
+
 def test_figure_composer_refresh_from_sources_covers_edge_paths(qtbot) -> None:
     first = xr.DataArray(
         np.arange(6.0).reshape(2, 3),
@@ -1486,6 +1741,43 @@ def test_figure_composer_source_provenance_helper_edges(qtbot) -> None:
     )
     assert "source_2" in used_names
 
+    gridspec_data = base_data.rename("gs0")
+    gridspec_tool = FigureComposerTool.from_sources(
+        {"source_data": gridspec_data},
+        sources=(FigureSourceState(name="source_data", provenance_spec=base_spec),),
+        operations=(
+            FigureOperationState.plot_array(label="array", source="source_data"),
+        ),
+        setup=FigureSubplotsState(
+            layout_mode="gridspec",
+            gridspec=FigureGridSpecLayoutState(
+                root=FigureGridSpecGridState(
+                    grid_id="root",
+                    nrows=1,
+                    ncols=1,
+                    axes=(
+                        FigureGridSpecAxesState(
+                            axes_id="main",
+                            span=FigureGridSpecSpanState(
+                                row_start=0,
+                                row_stop=1,
+                                col_start=0,
+                                col_stop=1,
+                            ),
+                        ),
+                    ),
+                )
+            ),
+        ),
+        primary_source="source_data",
+    )
+    qtbot.addWidget(gridspec_tool)
+    script_inputs, _skip_names, source_name_map = (
+        gridspec_tool._display_code_source_plan()
+    )
+    assert script_inputs[0].name == "gs0_source"
+    assert source_name_map["source_data"] == "gs0_source"
+
     script_input = provenance.ScriptInput(name="base", provenance_spec=base_spec)
     assert tool._script_input_with_name(script_input, "base") is script_input
     assert tool._script_input_with_name(script_input, "renamed").name == "renamed"
@@ -1542,6 +1834,14 @@ def test_figure_composer_source_helpers_cover_selection_contract() -> None:
     assert figurecomposer_sources._source_name(keyword_name) == "class_"
     assert figurecomposer_sources._source_name(leading_digit_name) == "_2_sample"
     assert figurecomposer_sources._source_name(mixed_name) == "sample_map"
+    reserved_name = xr.DataArray(np.arange(2.0), dims=("x",), name="profiles")
+    assert figurecomposer_sources._source_name(reserved_name) == "profiles_2"
+    bvec_name = xr.DataArray(np.arange(2.0), dims=("x",), name="bvec")
+    assert figurecomposer_sources._source_name(bvec_name) == "bvec_2"
+    assert figurecomposer_sources._source_alias_error("erlab") is not None
+    assert (
+        figurecomposer_sources._source_alias_error("line_color_values_norm") is not None
+    )
     reserved = {"sample_map"}
     assert figurecomposer_sources._source_unique_name("sample_map", reserved) == (
         "sample_map_2"
@@ -1549,6 +1849,12 @@ def test_figure_composer_source_helpers_cover_selection_contract() -> None:
     assert "sample_map_2" in reserved
     reserved = set()
     assert figurecomposer_sources._source_unique_name("fig", reserved) == "fig_2"
+    reserved = set()
+    assert (
+        figurecomposer_sources._source_unique_name("profiles", reserved) == "profiles_2"
+    )
+    reserved = set()
+    assert figurecomposer_sources._source_unique_name("gs0", reserved) == "gs0_source"
     assert figurecomposer_sources._source_display_tooltip(None, "data_0") == (
         "Alias: data_0"
     )
@@ -1569,6 +1875,28 @@ def test_figure_composer_source_helpers_cover_selection_contract() -> None:
             map_selections=(FigureDataSelectionState(source="extra"),),
         )
     ) == ("extra",)
+
+    method = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="set",
+        args=(slice(1, 5, 2),),
+        kwargs={
+            "indexer": slice(None, 3),
+            "metadata": {"kind": "slice", "start": 1, "stop": 2},
+        },
+    )
+    restored_method = FigureOperationState.model_validate_json(method.model_dump_json())
+    assert restored_method.method_args == (slice(1, 5, 2),)
+    assert restored_method.method_kwargs["indexer"] == slice(None, 3)
+    assert restored_method.method_kwargs["metadata"] == {
+        "kind": "slice",
+        "start": 1,
+        "stop": 2,
+    }
+    legacy_source = FigureSourceState.model_validate(
+        {"name": "legacy", "isel": {"x": {"kind": "slice", "start": 1}}}
+    )
+    assert legacy_source.isel == {"x": slice(1, None)}
 
     data = xr.DataArray(
         np.arange(6.0).reshape(2, 3),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -289,7 +289,7 @@ def test_figure_composer_source_ui_keeps_aliases_as_internal_keys(qtbot) -> None
     assert first_item is not None
     assert first_item.data(0, QtCore.Qt.ItemDataRole.UserRole) == "data_0"
     assert first_item.data(0, QtCore.Qt.ItemDataRole.UserRole + 1) is True
-    assert first_item.font(0).bold()
+    assert not first_item.font(0).bold()
     assert first_item.text(0) == "data_0"
     second_item = tool.source_list.topLevelItem(1)
     assert second_item is not None
@@ -330,7 +330,6 @@ def test_figure_composer_source_ui_uses_shared_shape_formatter(
     assert tool.source_list.toolTip() == ""
     assert first_item.toolTip(0)
     assert first_item.toolTip(1) == first_item.toolTip(0)
-    assert first_item.toolTip(2) == ""
     assert shape_widget.toolTip() == ""
     assert (tuple(str(dim) for dim in data.dims), False, None) in calls
     assert any(call[1] for call in calls)
@@ -360,35 +359,23 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
     )
     qtbot.addWidget(tool)
 
-    buttons = _source_refresh_buttons(tool)
-    assert set(buttons) == {"data_0", "profile"}
-    assert buttons["data_0"].property("figure_source_name") == "data_0"
-    assert buttons["data_0"].accessibleName() == "Refresh Source"
-    assert not buttons["data_0"].isEnabled()
-    assert (
-        buttons["data_0"].toolTip() == "This source is not linked to an open ImageTool"
-    )
-    assert tool.refresh_sources_button.accessibleName() == "Refresh Sources"
+    assert tool.source_list.columnCount() == 2
+    assert tool.source_list.findChildren(QtWidgets.QToolButton) == []
+    assert tool.refresh_sources_button.accessibleName() == "Refresh Selected Sources"
+    assert tool.refresh_sources_button.menu() is None
     assert not tool.refresh_sources_button.isEnabled()
-    assert tool.refresh_sources_button.toolTip() == (
-        "No sources are linked to open ImageTools"
-    )
     assert tool._source_refresh_label("data_0") is None
-    tool._refresh_source_from_button("data_0")
-    tool._refresh_sources_from_button()
+    tool._refresh_selected_sources_from_button()
+    assert not tool.source_status_label.isHidden()
 
-    refreshed: list[tuple[str, str | tuple[str, ...]]] = []
+    refreshed: list[str] = []
 
     def can_refresh_source(name: str) -> bool:
         return name == "data_0"
 
     def refresh_source(name: str) -> bool:
-        refreshed.append(("one", name))
+        refreshed.append(name)
         return True
-
-    def refresh_sources(names: Sequence[str]) -> int:
-        refreshed.append(("many", tuple(names)))
-        return len(names)
 
     def source_label(name: str) -> str | None:
         return "ImageTool 0: image" if name == "data_0" else None
@@ -396,64 +383,55 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
     tool._set_source_refresh_callbacks(
         can_refresh_source=can_refresh_source,
         refresh_source=refresh_source,
-        refresh_sources=refresh_sources,
         source_label=source_label,
     )
 
-    buttons = _source_refresh_buttons(tool)
-    assert buttons["data_0"].isEnabled()
-    assert buttons["data_0"].toolTip() == "Refresh “data_0” from ImageTool 0: image"
-    assert not buttons["profile"].isEnabled()
-    assert buttons["profile"].toolTip() == (
-        "This source is not linked to an open ImageTool"
-    )
+    first_item = tool.source_list.topLevelItem(0)
+    second_item = tool.source_list.topLevelItem(1)
+    assert first_item is not None
+    assert second_item is not None
+    assert first_item.icon(0).isNull()
+    assert second_item.icon(0).isNull()
+    assert first_item.data(0, QtCore.Qt.ItemDataRole.AccessibleDescriptionRole)
     assert tool.refresh_sources_button.isEnabled()
-    assert tool.refresh_sources_button.toolTip() == (
-        "Refresh all sources linked to open ImageTools"
-    )
-
-    status_before_refresh = (
-        tool.source_status_label.text(),
-        tool.source_status_label.isVisible(),
-    )
-    buttons["data_0"].click()
-    assert refreshed[-1] == ("one", "data_0")
-    assert (
-        tool.source_status_label.text(),
-        tool.source_status_label.isVisible(),
-    ) == status_before_refresh
 
     tool.refresh_sources_button.click()
-    assert refreshed[-1] == ("many", ("data_0",))
-    assert (
-        tool.source_status_label.text(),
-        tool.source_status_label.isVisible(),
-    ) == status_before_refresh
+    assert refreshed == ["data_0"]
+    assert not tool.source_status_label.isHidden()
 
-    def refresh_no_sources(names: Sequence[str]) -> int:
-        refreshed.append(("none", tuple(names)))
-        return 0
+    refreshed.clear()
+    tool._refresh_all_sources_from_button()
+    assert refreshed == ["data_0"]
+    assert not tool.source_status_label.isHidden()
 
+    tool._set_selected_source_names_silent({"data_0", "profile"}, "data_0")
+    tool._refresh_source_controls()
+    refreshed.clear()
+    tool.refresh_sources_button.click()
+    assert refreshed == ["data_0"]
+    assert "profile" in tool.source_status_label.text()
+
+    def raise_refresh(name: str) -> bool:
+        raise RuntimeError(f"{name} is incompatible")
+
+    tool._set_selected_source_names_silent({"data_0"}, "data_0")
     tool._set_source_refresh_callbacks(
         can_refresh_source=can_refresh_source,
-        refresh_source=refresh_source,
-        refresh_sources=refresh_no_sources,
+        refresh_source=raise_refresh,
         source_label=source_label,
     )
-    tool._set_source_status_text("diagnostic")
     tool.refresh_sources_button.click()
-    assert refreshed[-1] == ("none", ("data_0",))
-    assert tool.source_status_label.text() == "diagnostic"
+    assert "incompatible" in tool.source_status_label.text()
 
     tool._set_source_refresh_callbacks(
         can_refresh_source=lambda _name: False,
         refresh_source=refresh_source,
-        refresh_sources=refresh_sources,
         source_label=source_label,
     )
+    assert not tool.refresh_sources_button.isEnabled()
     refreshed.clear()
-    tool._refresh_source_from_button("data_0")
-    tool._refresh_sources_from_button()
+    tool._refresh_selected_sources_from_button()
+    tool._refresh_all_sources_from_button()
     assert refreshed == []
 
     def raise_lookup(name: str) -> bool:
@@ -465,7 +443,6 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
     tool._set_source_refresh_callbacks(
         can_refresh_source=raise_lookup,
         refresh_source=refresh_source,
-        refresh_sources=refresh_sources,
         source_label=raise_lookup_label,
     )
     assert not tool._source_refresh_available("data_0")
@@ -474,25 +451,9 @@ def test_figure_composer_source_refresh_controls_use_live_source_callbacks(
     tool._set_source_refresh_callbacks(
         can_refresh_source=can_refresh_source,
         refresh_source=refresh_source,
-        refresh_sources=refresh_sources,
         source_label=lambda _name: "",
     )
     assert tool._source_refresh_label("data_0") is None
-
-    direct_item = QtWidgets.QTreeWidgetItem(["direct", "", ""])
-    tool.source_list.addTopLevelItem(direct_item)
-    direct_button = QtWidgets.QToolButton(tool.source_list)
-    direct_button.setObjectName("figureComposerRefreshSourceButton")
-    tool.source_list.setItemWidget(direct_item, 2, direct_button)
-    assert (
-        tool._source_list_row_button(direct_item, "figureComposerRefreshSourceButton")
-        is direct_button
-    )
-    assert (
-        tool._source_list_row_button(direct_item, "figureComposerRemoveSourceButton")
-        is None
-    )
-    tool._refresh_source_controls()
 
 
 def test_figure_composer_source_remove_controls_disable_used_sources(qtbot) -> None:
@@ -532,34 +493,69 @@ def test_figure_composer_source_remove_controls_disable_used_sources(qtbot) -> N
         source_data={"data_0": image, "profile": profile, "unused": unused},
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
-
-    buttons = _source_remove_buttons(tool)
-    assert set(buttons) == {"data_0", "profile", "unused"}
-    assert buttons["unused"].property("figure_source_name") == "unused"
-    assert buttons["unused"].accessibleName() == "Remove Source"
-    assert not buttons["data_0"].isEnabled()
-    assert buttons["data_0"].toolTip() == "This source is used by one or more steps"
-    assert not buttons["profile"].isEnabled()
-    assert buttons["profile"].toolTip() == "This source is used by one or more steps"
-    assert buttons["unused"].isEnabled()
-    assert buttons["unused"].toolTip() == "Remove “unused” from this figure"
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
 
     before_status = tool.tool_status
     before_source_data = tool.source_data()
-    buttons["profile"].click()
-    assert tool.tool_status == before_status
-    assert set(tool.source_data()) == set(before_source_data)
-    tool._remove_source_from_button("profile")
+    tool._set_selected_source_names_silent({"profile"}, "profile")
+    tool._refresh_source_controls()
+    tool._refresh_source_detail_panel()
+    assert not tool.remove_selected_source_button.isEnabled()
+    assert tool.source_detail_content.property("figureComposerSourceUsageCount") == 1
+    tool._remove_selected_sources()
     assert tool.tool_status == before_status
     assert set(tool.source_data()) == set(before_source_data)
     assert not tool.remove_source("profile")
     assert not tool.remove_source("missing")
 
-    buttons["unused"].click()
+    tool._set_selected_source_names_silent({"unused"}, "unused")
+    tool._refresh_source_controls()
+    assert tool.remove_selected_source_button.isEnabled()
+    tool.remove_selected_source_button.click()
     assert "unused" not in tool.source_data()
     assert tool.source_status_label.text() == ""
     assert tool.source_status_label.isHidden()
+
+
+def test_figure_composer_source_list_has_plain_rows_and_balanced_columns(
+    qtbot,
+) -> None:
+    data = _figure_composer_profile_source("data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(
+                FigureSourceState(name="data", node_uid="node-data"),
+                FigureSourceState(name="missing", node_uid="node-missing"),
+            ),
+            primary_source="data",
+        ),
+        source_data={"data": data},
+    )
+    qtbot.addWidget(tool)
+    tool._set_source_refresh_callbacks(
+        can_refresh_source=lambda _name: True,
+        refresh_source=lambda _name: True,
+        source_label=lambda name: name,
+    )
+
+    data_item = tool.source_list.topLevelItem(0)
+    missing_item = tool.source_list.topLevelItem(1)
+    assert data_item is not None
+    assert missing_item is not None
+    assert data_item.icon(0).isNull()
+    assert missing_item.icon(0).isNull()
+    assert missing_item.data(0, QtCore.Qt.ItemDataRole.AccessibleDescriptionRole)
+
+    tool.resize(900, 650)
+    tool.show()
+    QtWidgets.QApplication.processEvents()
+    header = tool.source_list.header()
+    assert header is not None
+    assert header.sectionResizeMode(0) == QtWidgets.QHeaderView.ResizeMode.Stretch
+    assert header.sectionResizeMode(1) == QtWidgets.QHeaderView.ResizeMode.Interactive
+    assert header.sectionSize(0) >= 100
+    assert header.sectionSize(1) == 150
 
 
 def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> None:
@@ -606,10 +602,7 @@ def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> 
     assert tool.tool_status.operations == (operation,)
     assert tool.tool_status.primary_source == "data_0"
     assert tool.source_status_label.text() == ""
-    buttons = _source_remove_buttons(tool)
-    assert set(buttons) == {"data_0"}
-    assert not buttons["data_0"].isEnabled()
-    assert buttons["data_0"].toolTip() == "This source is used by one or more steps"
+    assert not tool.remove_selected_source_button.isEnabled()
 
     _render_figure_composer_rgba(tool)
     assert tool._operation_render_errors == {}
@@ -635,7 +628,7 @@ def test_figure_composer_remove_source_updates_state_history_and_code(qtbot) -> 
     assert set(tool.source_data()) == {"data_0"}
     assert tool.tool_status.primary_source == "data_0"
     tool._refresh_source_list()
-    assert set(_source_remove_buttons(tool)) == {"data_0"}
+    assert tool.source_list.findChildren(QtWidgets.QToolButton) == []
 
 
 def test_figure_composer_source_alias_editor_renames_references(qtbot) -> None:
@@ -669,12 +662,10 @@ def test_figure_composer_source_alias_editor_renames_references(qtbot) -> None:
     )
     qtbot.addWidget(tool)
     tool._set_selected_source_names_silent({"data_0"}, "data_0")
+    tool._refresh_source_detail_panel()
     tool._refresh_source_selection_editor()
 
-    alias_edit = tool.source_selection_controls.findChild(
-        QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
-    )
-    assert alias_edit is not None
+    alias_edit = tool.source_alias_edit
     assert alias_edit.text() == "data_0"
     tool._rename_source_alias("data_0", "renamed")
 
@@ -815,7 +806,20 @@ def test_figure_composer_source_list_internal_reorder_updates_recipe(qtbot) -> N
     tool.source_list.insertTopLevelItem(2, first_moved)
     tool.source_list.insertTopLevelItem(3, second_moved)
     tool._set_selected_source_names_silent({"b", "c"}, "b")
-    tool.source_list._emit_rows_reordered()
+    tool.source_list._queue_rows_reordered()
+
+    assert tuple(source.name for source in tool.source_states()) == (
+        "a",
+        "b",
+        "c",
+        "d",
+    )
+    qtbot.waitUntil(
+        lambda: (
+            tuple(source.name for source in tool.source_states())
+            == ("a", "d", "b", "c")
+        )
+    )
 
     assert tuple(source.name for source in tool.source_states()) == (
         "a",
@@ -837,6 +841,16 @@ def test_figure_composer_source_list_keyboard_context_menu(qtbot) -> None:
     )
     qtbot.addWidget(tool)
     tool._set_selected_source_names_silent({"b"}, "b")
+    refreshed: list[str] = []
+
+    def refresh_source(name: str) -> bool:
+        refreshed.append(name)
+        return True
+
+    tool._set_source_refresh_callbacks(
+        can_refresh_source=lambda _name: True,
+        refresh_source=refresh_source,
+    )
 
     event = QtGui.QKeyEvent(
         QtCore.QEvent.Type.KeyPress,
@@ -854,6 +868,14 @@ def test_figure_composer_source_list_keyboard_context_menu(qtbot) -> None:
     }
     assert "figureComposerContextMoveSourceUpAction" in action_names
     assert "figureComposerContextMoveSourceDownAction" in action_names
+    refresh_all_action = next(
+        action
+        for action in tool._source_context_menu.actions()
+        if action.objectName() == "figureComposerContextRefreshAllSourcesAction"
+    )
+    assert refresh_all_action.isEnabled()
+    refresh_all_action.trigger()
+    assert refreshed == ["a", "b"]
     tool._source_context_menu.close()
 
 
@@ -867,9 +889,10 @@ def test_figure_composer_source_list_edge_events(qtbot) -> None:
 
     source_list.addTopLevelItem(QtWidgets.QTreeWidgetItem(["missing-role"]))
     source_list._emit_rows_reordered()
-    source_list._model_rows_moved()
+    source_list._queue_rows_reordered()
     source_list.keyPressEvent(None)
     source_list.dropEvent(None)
+    qtbot.wait(1)
 
     assert emitted == []
 
@@ -893,11 +916,9 @@ def test_figure_composer_source_alias_editor_commit_paths(
     )
     qtbot.addWidget(tool)
     tool._set_selected_source_names_silent({"first"}, "first")
+    tool._refresh_source_detail_panel()
     tool._refresh_source_selection_editor()
-    alias_edit = tool.source_selection_controls.findChild(
-        QtWidgets.QLineEdit, "figureComposerSourceAliasEdit"
-    )
-    assert alias_edit is not None
+    alias_edit = tool.source_alias_edit
 
     monkeypatch.setattr(tool, "sender", lambda: alias_edit)
     alias_edit.setText("first")
@@ -906,8 +927,9 @@ def test_figure_composer_source_alias_editor_commit_paths(
 
     alias_edit.setText("second")
     tool._commit_source_alias_edit()
-    assert "already in use" in tool.source_status_label.text()
-    assert alias_edit.text() == "first"
+    assert not tool.source_validation_label.isHidden()
+    assert tool.source_status_label.isHidden()
+    assert alias_edit.text() == "second"
 
     alias_edit.setText("renamed")
     tool._commit_source_alias_edit()
@@ -1035,24 +1057,14 @@ def test_figure_composer_source_structure_edge_paths(qtbot) -> None:
     reserved = {"first"}
     assert tool._source_unique_alias("first", reserved) == "first_2"
 
+    tool._refresh_source_detail_panel()
     tool._refresh_source_selection_editor()
-    alias_edit = None
-    for row in range(tool.source_selection_controls_layout.rowCount()):
-        item = tool.source_selection_controls_layout.itemAt(
-            row, QtWidgets.QFormLayout.ItemRole.FieldRole
-        )
-        widget = None if item is None else item.widget()
-        if (
-            isinstance(widget, QtWidgets.QLineEdit)
-            and widget.objectName() == "figureComposerSourceAliasEdit"
-        ):
-            alias_edit = widget
-            break
-    assert alias_edit is not None
+    alias_edit = tool.source_alias_edit
     alias_edit.setText("bvec")
     alias_edit.editingFinished.emit()
-    assert alias_edit.text() == "first"
-    assert not tool.source_status_label.isHidden()
+    assert alias_edit.text() == "bvec"
+    assert not tool.source_validation_label.isHidden()
+    assert tool.source_status_label.isHidden()
     tool._focus_source_alias_editor()
     first_item = tool.source_list.topLevelItem(0)
     assert first_item is not None
@@ -1102,13 +1114,16 @@ def test_figure_composer_source_selection_editor_edge_paths(qtbot) -> None:
 
     tool.source_list.clearSelection()
     tool.source_list.setCurrentIndex(QtCore.QModelIndex())
+    tool._refresh_source_detail_panel()
     tool._refresh_source_selection_editor()
     flush_deferred_editor_deletes()
-    item = tool.source_selection_controls_layout.itemAt(0)
-    assert item is not None
-    assert isinstance(item.widget(), QtWidgets.QLabel)
+    assert tool.source_selection_controls_layout.count() == 0
+    assert (
+        tool.source_detail_content.property("figureComposerSourceEditorMode") == "empty"
+    )
 
     tool._set_selected_source_names_silent({"scalar"}, "scalar")
+    tool._refresh_source_detail_panel()
     tool._refresh_source_selection_editor()
     flush_deferred_editor_deletes()
     item = tool.source_selection_controls_layout.itemAt(
@@ -1126,6 +1141,7 @@ def test_figure_composer_source_selection_editor_edge_paths(qtbot) -> None:
     tool.source_list.setCurrentItem(first_item)
     first_item.setSelected(True)
     second_item.setSelected(True)
+    tool._refresh_source_detail_panel()
     tool._refresh_source_selection_editor()
     flush_deferred_editor_deletes()
     combo = None
@@ -1145,6 +1161,20 @@ def test_figure_composer_source_selection_editor_edge_paths(qtbot) -> None:
             break
     assert combo is not None
     assert combo.currentData() is _editor_controls.MIXED_VALUE
+    assert "Size:" in combo.toolTip()
+    for mode in ("isel", "qsel"):
+        index = combo.findData(mode)
+        assert index >= 0
+        assert combo.itemData(index, QtCore.Qt.ItemDataRole.ToolTipRole)
+    assert (
+        tool.source_detail_content.property("figureComposerSourceEditorMode")
+        == "multiple"
+    )
+    assert (
+        tool.source_detail_content.property("figureComposerSourceSelectionCount") == 2
+    )
+    assert not tool.source_alias_controls.isVisible()
+    assert tool.source_inspector.isHidden()
 
     tool._source_data.clear()
     tool._update_selected_source_dimension("x", "isel", "0", "")
@@ -1363,10 +1393,10 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
         source_data={"data_0": original},
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
 
-    assert "data_0" in tool.operation_list.item(0).text()
-    assert "data_0" in tool.operation_list.item(1).text()
+    assert "data_0" in tool.operation_list.topLevelItem(0).text(0)
+    assert "data_0" in tool.operation_list.topLevelItem(1).text(0)
     assert tool.step_section_buttons["sources"].text() == "Sources: data_0"
 
     replaced = tool.replace_source(
@@ -1390,10 +1420,10 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
     xr.testing.assert_identical(tool.source_data()["data_0"], replacement)
     assert tool.tool_status.operations[0].sources == ("data_0",)
     assert tool.tool_status.operations[1].line_source == "data_0"
-    assert "data_0" in tool.operation_list.item(0).text()
-    assert "ImageTool 1: replacement" not in tool.operation_list.item(0).text()
-    assert "data_0" in tool.operation_list.item(1).text()
-    assert "ImageTool 1: replacement" not in tool.operation_list.item(1).text()
+    assert "data_0" in tool.operation_list.topLevelItem(0).text(0)
+    assert "ImageTool 1: replacement" not in tool.operation_list.topLevelItem(0).text(0)
+    assert "data_0" in tool.operation_list.topLevelItem(1).text(0)
+    assert "ImageTool 1: replacement" not in tool.operation_list.topLevelItem(1).text(0)
     assert tool.step_section_buttons["sources"].text() == "Sources: data_0"
 
     _render_figure_composer_rgba(tool)
@@ -1682,7 +1712,8 @@ def test_figure_composer_batch_source_selection_skips_incompatible_sources(
     assert source_by_name["second"].isel == {}
     xr.testing.assert_identical(tool.source_data()["first"], first.isel(x=1))
     xr.testing.assert_identical(tool.source_data()["second"], second)
-    assert "second" in tool.source_status_label.text()
+    assert not tool.source_validation_label.isHidden()
+    assert "second" in tool.source_validation_label.text()
 
 
 def test_figure_composer_source_provenance_helper_edges(qtbot) -> None:
@@ -2022,7 +2053,7 @@ def test_figure_composer_source_inspector_is_sources_tab_compact(
         dims=("eV", "kx"),
         coords={"eV": [-0.1, 0.1], "kx": [0.0, 0.5, 1.0]},
         attrs={"sample": "TiSe2", "long": "x" * 200},
-        name="map",
+        name="original map",
     )
     second = xr.DataArray(
         np.arange(4.0),
@@ -2056,20 +2087,31 @@ def test_figure_composer_source_inspector_is_sources_tab_compact(
     )
     qtbot.addWidget(tool)
 
-    assert tool.source_inspector.parentWidget() is tool.sources_page
+    assert tool.source_splitter.orientation() == QtCore.Qt.Orientation.Horizontal
+    assert not tool.source_splitter.childrenCollapsible()
+    assert tool.source_inspector.parentWidget() is tool.source_detail_content
+    assert tool.source_detail_scroll.widget() is tool.source_detail_content
     assert tool.editor_tabs.indexOf(tool.sources_page) == 0
     assert not hasattr(tool, "step_detail_splitter")
     assert tool.source_inspector.source_name() == "map"
     assert tool.source_inspector.property("figureComposerSourceAlias") == "map"
     assert tool.source_inspector.property("figureComposerSourceDims") == ("eV", "kx")
     assert tool.source_inspector.property("figureComposerSourceDtype") == "float64"
+    summary_html = tool.source_inspector.subtitle_label.text()
+    assert summary_html.startswith("original map<br>")
+    assert "Original name:" not in summary_html
+    assert "<p>" not in summary_html
+    assert "<br><br>" not in summary_html
     assert not tool.source_inspector.details_button.isChecked()
-    assert not tool.source_inspector.details_scroll.isVisibleTo(tool.source_inspector)
-    assert tool.source_inspector.details_html() == "<p>formatted details</p>"
-    assert format_calls[-1] == (
-        ("eV", "kx"),
-        {"show_size": True, "show_summary": False},
+    assert not tool.source_inspector.details_label.isVisibleTo(tool.source_inspector)
+    assert tool.source_inspector.details_html() == ""
+    assert format_calls == []
+    assert (
+        tool.source_detail_content.property("figureComposerSourceEditorMode")
+        == "single"
     )
+    assert tool.source_detail_content.property("figureComposerSourceUsageCount") == 1
+    assert tool.source_alias_edit.text() == "map"
     assert (
         tool.source_list.selectionMode()
         == QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
@@ -2089,8 +2131,13 @@ def test_figure_composer_source_inspector_is_sources_tab_compact(
     )
 
     tool.source_inspector.details_button.setChecked(True)
-    assert tool.source_inspector.details_scroll.isVisibleTo(tool.source_inspector)
+    assert tool.source_inspector.details_label.isVisibleTo(tool.source_inspector)
     assert tool.source_inspector.property("figureComposerSourceDetailsExpanded") is True
+    assert tool.source_inspector.details_html() == "<p>formatted details</p>"
+    assert format_calls == [(("eV", "kx"), {"show_size": True, "show_summary": False})]
+    tool.source_inspector.details_button.setChecked(False)
+    tool.source_inspector.details_button.setChecked(True)
+    assert len(format_calls) == 1
 
     second_item = tool.source_list.topLevelItem(1)
     assert second_item is not None
@@ -2100,6 +2147,7 @@ def test_figure_composer_source_inspector_is_sources_tab_compact(
     assert tool.source_inspector.source_name() == "profile"
     assert tool.source_inspector.property("figureComposerSourceAlias") == "profile"
     assert tool.source_inspector.property("figureComposerSourceDims") == ("delay",)
+    assert len(format_calls) == 2
 
 
 def test_figure_composer_source_inspector_details_show_coord_values(qtbot) -> None:
@@ -2116,6 +2164,7 @@ def test_figure_composer_source_inspector_details_show_coord_values(qtbot) -> No
     )
     qtbot.addWidget(tool)
 
+    tool.source_inspector.details_button.setChecked(True)
     html = tool.source_inspector.details_html()
 
     assert "0 : 1 : 2" in html
@@ -2163,6 +2212,7 @@ def test_figure_composer_source_inspector_details_fallback_is_metadata_only(
     )
     qtbot.addWidget(tool)
 
+    tool.source_inspector.details_button.setChecked(True)
     assert tool.source_inspector.details_html() == "<p>fallback details</p>"
     assert format_calls[-1] == {
         "show_size": True,
@@ -2194,7 +2244,7 @@ def test_figure_composer_source_list_shape_cell_click_selects_row(qtbot) -> None
 
     second_item = tool.source_list.topLevelItem(1)
     assert second_item is not None
-    index = tool.source_list.indexFromItem(second_item, 2)
+    index = tool.source_list.indexFromItem(second_item, 1)
     rect = tool.source_list.visualRect(index)
     assert rect.isValid()
 
@@ -2231,6 +2281,7 @@ def test_figure_composer_source_inspector_uses_public_nonuniform_dims(qtbot) -> 
 
     dims = tool.source_inspector.property("figureComposerSourceDims")
     assert dims == ("alpha", "eV", "sample_temp")
+    tool.source_inspector.details_button.setChecked(True)
     assert "sample_temp_idx" not in tool.source_inspector.details_html()
     assert "sample_temp" in tool.source_inspector.details_html()
 
@@ -2253,18 +2304,16 @@ def test_figure_composer_source_inspector_tracks_source_tab_selection(qtbot) -> 
     qtbot.addWidget(tool)
 
     assert tool.source_inspector.source_name() == "first"
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     assert tool.source_inspector.source_name() == "first"
     assert tool.source_status_label.text() == ""
     assert tool.source_status_label.isHidden()
-    assert (
-        tool.step_source_status_label.text() == "This step does not read a data source."
-    )
+    assert tool.step_source_status_label.isHidden()
     first_item = tool.source_list.topLevelItem(0)
     assert first_item is not None
     tool.source_list.setCurrentItem(first_item)
     assert tool.source_inspector.source_name() == "first"
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     assert tool.source_inspector.source_name() == "first"
 
 
@@ -2368,7 +2417,6 @@ def test_figure_composer_source_inspector_helper_edges(qtbot) -> None:
     qtbot.addWidget(inspector)
     inspector.set_context(
         source_name=None,
-        source_state=None,
         data=None,
     )
     assert inspector.source_name() is None
@@ -2377,7 +2425,6 @@ def test_figure_composer_source_inspector_helper_edges(qtbot) -> None:
 
     inspector.set_context(
         source_name="data",
-        source_state=source,
         data=None,
     )
     assert inspector.source_name() == "data"
@@ -2400,8 +2447,11 @@ def test_figure_composer_source_inspector_target_fallbacks(qtbot) -> None:
     tool._source_data.clear()
     tool._select_source_list_row_silent(None)
     assert tool._default_source_inspector_target() == "saved"
-    tool._refresh_source_inspector()
-    assert tool.source_inspector.source_name() == "saved"
+    tool._refresh_source_detail_panel()
+    assert tool.source_inspector.source_name() is None
+    assert (
+        tool.source_detail_content.property("figureComposerSourceEditorMode") == "empty"
+    )
 
     tool._select_source_list_row_silent(None)
     assert tool.source_list.currentItem() is None
@@ -3166,7 +3216,7 @@ def test_figure_composer_copy_paste_source_and_insert_fallbacks(
             (_custom_order_step("b"),), ()
         )
     )
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     with monkeypatch.context() as patch:
         patch.setattr(tool, "_operation_id_for_item", lambda item: "missing")
         tool._paste_operations_from_clipboard()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -710,6 +710,7 @@ def test_figure_composer_source_alias_editor_renames_references(qtbot) -> None:
     assert tuple(tool.source_data()) == ("renamed", "data_1")
     assert tool.tool_status.operations[0].sources == ("renamed", "data_1")
     assert tool.tool_status.operations[1].line_source == "renamed"
+    assert tool._source_by_name()["renamed"].label == "Legacy first"
     assert tool.source_list.topLevelItem(0).text(0) == "renamed"
     assert "Legacy" not in tool.source_list.topLevelItem(0).text(0)
 
@@ -781,6 +782,7 @@ def test_figure_composer_source_duplicate_and_reorder_controls(qtbot) -> None:
         "third",
     )
     duplicate = tool._source_by_name()["second_copy"]
+    assert duplicate.label == "second_copy"
     assert duplicate.isel == {"x": 0}
     assert duplicate.selection_source == "first"
     xr.testing.assert_identical(tool.source_data()["second_copy"], second)
@@ -817,6 +819,31 @@ def test_figure_composer_source_duplicate_and_reorder_controls(qtbot) -> None:
         "second_copy",
     )
     assert tool.source_list.currentItem().text(0) == "second_copy"
+
+
+def test_figure_composer_duplicate_source_preserves_historical_label(qtbot) -> None:
+    source_data = {
+        name: xr.DataArray(np.arange(2.0), dims=("x",), name=name)
+        for name in ("automatic", "historical", "keeper")
+    }
+    tool = FigureComposerTool.from_sources(
+        source_data,
+        sources=(
+            FigureSourceState(name="automatic"),
+            FigureSourceState(name="historical", label="Historical display label"),
+            FigureSourceState(name="keeper"),
+        ),
+        operations=(),
+        primary_source="keeper",
+    )
+    qtbot.addWidget(tool)
+    tool._set_selected_source_names_silent({"automatic", "historical"}, "automatic")
+
+    tool._duplicate_selected_sources()
+
+    source_by_name = tool._source_by_name()
+    assert source_by_name["automatic_copy"].label == "automatic_copy"
+    assert source_by_name["historical_copy"].label == "Historical display label"
 
 
 def test_figure_composer_duplicate_selected_source_generated_code_uses_raw_base(
@@ -1035,6 +1062,7 @@ def test_figure_composer_source_alias_editor_commit_paths(
         "renamed",
         "second",
     )
+    assert tool._source_by_name()["renamed"].label == "renamed"
     assert "renamed" in tool._source_data
 
 
@@ -1420,6 +1448,7 @@ def test_figure_composer_legacy_source_selection_normalization_edges(
     assert tool.tool_status.operations[3].map_selections == ()
     assert tool.tool_status.operations[4].sources == ("data_selected_2",)
     assert tool.tool_status.operations[4].map_selections == ()
+    assert sources["data_selected_2"].label == "data_selected_2"
     assert sources["data_selected_2"].isel == {"kx": 1}
 
 
@@ -1512,6 +1541,7 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
     assert replaced is True
     [source] = tool.source_states()
     assert source.name == "data_0"
+    assert source.label == "ImageTool 1: replacement"
     assert source.node_uid == "new-node"
     assert source.node_snapshot_token == new_snapshot_id
     assert source.provenance_spec == {"source": "new"}
@@ -1550,14 +1580,22 @@ def test_figure_composer_replace_source_preserves_alias_and_generated_code(
     tool._source_data["orphan"] = original
     assert tool.replace_source(
         "orphan",
-        FigureSourceState(name="data_2", label="Orphan"),
+        FigureSourceState(name="data_2", label="Historical orphan"),
+        original,
+    )
+    tool._source_data["default_orphan"] = original
+    assert tool.replace_source(
+        "default_orphan",
+        FigureSourceState(name="data_3"),
         original,
     )
     assert tuple(source.name for source in tool.source_states()) == (
         "data_0",
         "orphan",
+        "default_orphan",
     )
-    assert not hasattr(tool.source_states()[-1], "label")
+    assert tool._source_by_name()["orphan"].label == "Historical orphan"
+    assert tool._source_by_name()["default_orphan"].label == "default_orphan"
 
 
 def test_figure_composer_source_refresh_applies_saved_selection(
@@ -1696,6 +1734,7 @@ def test_figure_composer_readding_renamed_linked_source_updates_alias(qtbot) -> 
     )
 
     assert tuple(source.name for source in tool.source_states()) == ("custom_alias",)
+    assert tool.source_states()[0].label == "custom_alias"
     assert tool.source_states()[0].qsel == {"eV": 0.0}
     xr.testing.assert_identical(
         tool.source_data()["custom_alias"], refreshed.qsel(eV=0.0)
@@ -1949,7 +1988,18 @@ def test_figure_composer_source_provenance_helper_edges(qtbot) -> None:
 
     script_input = provenance.ScriptInput(name="base", provenance_spec=base_spec)
     assert tool._script_input_with_name(script_input, "base") is script_input
-    assert tool._script_input_with_name(script_input, "renamed").name == "renamed"
+    renamed_script_input = tool._script_input_with_name(script_input, "renamed")
+    assert renamed_script_input.name == "renamed"
+    assert renamed_script_input.label == "renamed"
+    historical_input = script_input.model_copy(update={"label": "Historical input"})
+    renamed_historical_input = tool._script_input_with_name(historical_input, "renamed")
+    assert renamed_historical_input.name == "renamed"
+    assert renamed_historical_input.label == "Historical input"
+    historical_source = FigureSourceState.from_script_input(historical_input)
+    assert historical_source.label == "Historical input"
+    historical_roundtrip = historical_source.to_script_input()
+    assert historical_roundtrip is not None
+    assert historical_roundtrip.label == "Historical input"
 
     renamed_input = tool._selected_source_script_input(
         base_source,
@@ -2065,10 +2115,35 @@ def test_figure_composer_source_helpers_cover_selection_contract() -> None:
         "start": 1,
         "stop": 2,
     }
-    legacy_source = FigureSourceState.model_validate(
-        {"name": "legacy", "isel": {"x": {"kind": "slice", "start": 1}}}
+    ordinary_source = FigureSourceState(name="ordinary")
+    ordinary_payload = ordinary_source.model_dump(mode="json")
+    assert ordinary_payload["label"] == "ordinary"
+    assert "isel" not in ordinary_payload
+    assert "qsel" not in ordinary_payload
+    assert "mean_dims" not in ordinary_payload
+    assert "selection_source" not in ordinary_payload
+
+    current_saved_recipe = FigureRecipeState.model_validate(
+        {
+            "sources": (
+                {
+                    "name": "legacy",
+                    "isel": {"x": {"kind": "slice", "start": 1}},
+                    "selection_source": "base",
+                },
+            ),
+            "primary_source": "legacy",
+        }
     )
+    [legacy_source] = current_saved_recipe.sources
+    assert legacy_source.label == "legacy"
     assert legacy_source.isel == {"x": slice(1, None)}
+    [legacy_payload] = current_saved_recipe.model_dump(mode="json")["sources"]
+    assert legacy_payload["label"] == "legacy"
+    assert legacy_payload["isel"] == {
+        "x": {"__erlab_figure_composer_slice__": [1, None, None]}
+    }
+    assert legacy_payload["selection_source"] == "base"
 
     data = xr.DataArray(
         np.arange(6.0).reshape(2, 3),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -1,5 +1,7 @@
 # ruff: noqa: F403, F405
 
+import erlab.interactive._figurecomposer._codegen as figurecomposer_codegen
+
 from ._common import *
 
 
@@ -1014,6 +1016,89 @@ def test_figure_composer_duplicate_selected_source_generated_code_uses_raw_base(
     assert len(captured) == 2
     xr.testing.assert_identical(captured[0], selected)
     xr.testing.assert_identical(captured[1], selected)
+
+
+def test_figure_composer_generated_code_resolves_selected_source_dependencies(
+    qtbot, monkeypatch
+) -> None:
+    base = xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 2, 2),
+        dims=("u", "v", "x", "y"),
+        coords={
+            "u": [0.0, 1.0],
+            "v": [10.0, 20.0, 30.0],
+            "x": [0.0, 1.0],
+            "y": [0.0, 1.0],
+        },
+        name="base",
+    )
+    selected_u = base.qsel(u=1.0)
+    selected_v = selected_u.qsel(v=20.0)
+    tool = FigureComposerTool.from_sources(
+        {
+            "base": base,
+            "selected_u": selected_u,
+            "selected_v": selected_v,
+        },
+        sources=(
+            FigureSourceState(
+                name="selected_v",
+                selection_source="selected_u",
+                qsel={"v": 20.0},
+            ),
+            FigureSourceState(name="base"),
+            FigureSourceState(
+                name="selected_u",
+                selection_source="base",
+                qsel={"u": 1.0},
+            ),
+        ),
+        operations=(
+            FigureOperationState.plot_array(label="selected", source="selected_v"),
+        ),
+        primary_source="base",
+    )
+    qtbot.addWidget(tool)
+    captured: list[xr.DataArray] = []
+    monkeypatch.setattr(
+        eplt,
+        "plot_array",
+        lambda data, **_kwargs: captured.append(data),
+    )
+
+    code = tool.generated_code()
+
+    assert code.index("selected_u = base.qsel(u=1.0)") < code.index(
+        "selected_v = selected_u.qsel(v=20.0)"
+    )
+    _exec_generated_code(code, {"base": base})
+    xr.testing.assert_identical(captured[-1], selected_v)
+
+    code_with_materialized_parent = figurecomposer_codegen.generated_code(
+        tool,
+        skip_source_selection_names=frozenset({"selected_u"}),
+    )
+
+    assert "selected_u =" not in code_with_materialized_parent
+    assert "base.qsel" not in code_with_materialized_parent
+    _exec_generated_code(
+        code_with_materialized_parent,
+        {"selected_u": selected_u},
+    )
+    xr.testing.assert_identical(captured[-1], selected_v)
+
+    cyclic_sources = tuple(
+        source.model_copy(update={"selection_source": "selected_v"})
+        if source.name == "selected_u"
+        else source
+        for source in tool.source_states()
+    )
+    tool._recipe = tool._recipe.model_copy(update={"sources": cyclic_sources})
+    with pytest.raises(
+        figurecomposer_text.FigureComposerInputError,
+        match=r"dependency cycle: selected_v -> selected_u -> selected_v",
+    ):
+        tool.generated_code()
 
 
 def test_figure_composer_source_list_internal_reorder_updates_recipe(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -6600,16 +6600,16 @@ def test_figure_composer_toolbar_axes_dialog_updates_recipe(qtbot) -> None:
     tool._show_axes_customize_dialog()
     assert tool._axes_customize_dialog is dialog
     title_edit = dialog.findChild(
-        QtWidgets.QLineEdit, "figureComposerToolbarAxesTitleEdit"
+        QtWidgets.QPlainTextEdit, "figureComposerToolbarAxesTitleEdit"
     )
     xlim_edit = dialog.findChild(
         QtWidgets.QLineEdit, "figureComposerToolbarAxesXLimEdit"
     )
     xlabel_edit = dialog.findChild(
-        QtWidgets.QLineEdit, "figureComposerToolbarAxesXLabelEdit"
+        QtWidgets.QPlainTextEdit, "figureComposerToolbarAxesXLabelEdit"
     )
     ylabel_edit = dialog.findChild(
-        QtWidgets.QLineEdit, "figureComposerToolbarAxesYLabelEdit"
+        QtWidgets.QPlainTextEdit, "figureComposerToolbarAxesYLabelEdit"
     )
     aspect_edit = dialog.findChild(
         QtWidgets.QLineEdit, "figureComposerToolbarAxesAspectEdit"
@@ -6651,10 +6651,12 @@ def test_figure_composer_toolbar_axes_dialog_updates_recipe(qtbot) -> None:
     assert scales_row is not None
     assert grid_row is not None
     assert (
-        labels_row.findChild(QtWidgets.QLineEdit, xlabel_edit.objectName()) is not None
+        labels_row.findChild(QtWidgets.QPlainTextEdit, xlabel_edit.objectName())
+        is not None
     )
     assert (
-        labels_row.findChild(QtWidgets.QLineEdit, ylabel_edit.objectName()) is not None
+        labels_row.findChild(QtWidgets.QPlainTextEdit, ylabel_edit.objectName())
+        is not None
     )
     assert limits_row.findChild(QtWidgets.QLineEdit, xlim_edit.objectName()) is not None
     assert (
@@ -6681,24 +6683,17 @@ def test_figure_composer_toolbar_axes_dialog_updates_recipe(qtbot) -> None:
         is None
     )
 
-    title_edit.setText("Peak")
-    title_edit.setModified(True)
-    title_edit.editingFinished.emit()
-    title_edit.editingFinished.emit()
+    title_edit.setPlainText("Peak")
     title_ops = _method_operations(tool, FigureMethodFamily.AXES, "set_title")
     assert len(title_ops) == 1
     assert title_ops[0].axes.axes == ((0, 0),)
     assert title_ops[0].method_args == ("Peak",)
 
-    xlabel_edit.setText("Energy")
-    xlabel_edit.setModified(True)
-    xlabel_edit.editingFinished.emit()
-    ylabel_edit.setText("Intensity")
-    ylabel_edit.setModified(True)
-    ylabel_edit.editingFinished.emit()
+    xlabel_edit.setPlainText("Energy\n(eV)")
+    ylabel_edit.setPlainText("Intensity")
     assert _method_operations(tool, FigureMethodFamily.AXES, "set_xlabel")[
         0
-    ].method_args == ("Energy",)
+    ].method_args == ("Energy\n(eV)",)
     assert _method_operations(tool, FigureMethodFamily.AXES, "set_ylabel")[
         0
     ].method_args == ("Intensity",)
@@ -6810,7 +6805,7 @@ def test_figure_composer_toolbar_axes_dialog_shows_mixed_axis_selection(
     dialog = tool._axes_customize_dialog
     assert isinstance(dialog, QtWidgets.QDialog)
     title_edit = dialog.findChild(
-        QtWidgets.QLineEdit, "figureComposerToolbarAxesTitleEdit"
+        QtWidgets.QPlainTextEdit, "figureComposerToolbarAxesTitleEdit"
     )
     xlim_edit = dialog.findChild(
         QtWidgets.QLineEdit, "figureComposerToolbarAxesXLimEdit"
@@ -6825,7 +6820,7 @@ def test_figure_composer_toolbar_axes_dialog_shows_mixed_axis_selection(
     assert xlim_edit is not None
     assert xscale_combo is not None
     assert grid_check is not None
-    assert title_edit.text() == ""
+    assert title_edit.toPlainText() == ""
     assert title_edit.placeholderText() == _editor_controls.MIXED_VALUES_TEXT
     assert xlim_edit.text() == ""
     assert xlim_edit.placeholderText() == _editor_controls.MIXED_VALUES_TEXT
@@ -6847,9 +6842,7 @@ def test_figure_composer_toolbar_axes_dialog_shows_mixed_axis_selection(
     assert _method_operations(tool, FigureMethodFamily.AXES, "set_yscale") == ()
     assert _method_operations(tool, FigureMethodFamily.AXES, "grid") == ()
 
-    title_edit.setText("Shared")
-    title_edit.setModified(True)
-    title_edit.editingFinished.emit()
+    title_edit.setPlainText("Shared")
 
     title_ops = _method_operations(tool, FigureMethodFamily.AXES, "set_title")
     assert len(title_ops) == 1
@@ -6886,7 +6879,7 @@ def test_figure_composer_toolbar_axes_dialog_disables_unavailable_axes(
     dialog = tool._axes_customize_dialog
     assert isinstance(dialog, QtWidgets.QDialog)
     title_edit = dialog.findChild(
-        QtWidgets.QLineEdit, "figureComposerToolbarAxesTitleEdit"
+        QtWidgets.QPlainTextEdit, "figureComposerToolbarAxesTitleEdit"
     )
     xscale_combo = dialog.findChild(
         QtWidgets.QComboBox, "figureComposerToolbarAxesXScaleCombo"
@@ -7351,15 +7344,13 @@ def test_figure_composer_toolbar_axes_dialog_uses_gridspec_selector(qtbot) -> No
     assert isinstance(dialog, QtWidgets.QDialog)
     selector = dialog.findChild(figurecomposer_widgets._GridSpecViewWidget)
     title_edit = dialog.findChild(
-        QtWidgets.QLineEdit, "figureComposerToolbarAxesTitleEdit"
+        QtWidgets.QPlainTextEdit, "figureComposerToolbarAxesTitleEdit"
     )
     assert selector is not None
     assert selector.selected_axes_ids() == ("main",)
     assert title_edit is not None
 
-    title_edit.setText("GridSpec title")
-    title_edit.setModified(True)
-    title_edit.editingFinished.emit()
+    title_edit.setPlainText("GridSpec title")
 
     title_ops = _method_operations(tool, FigureMethodFamily.AXES, "set_title")
     assert len(title_ops) == 1

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -1163,6 +1163,38 @@ def test_figure_display_window_close_and_canvas_size_contracts(qtbot) -> None:
     QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
 
 
+def test_figure_display_window_event_filter_accepts_source_drag(qtbot) -> None:
+    window = figurecomposer_widgets._FigureComposerDisplayWindow(FigureSubplotsState())
+    qtbot.addWidget(window)
+    mime = QtCore.QMimeData()
+    window.set_source_drop_callbacks(can_drop=lambda data: data is mime)
+
+    class _NoMimeDragEnterEvent(QtGui.QDragEnterEvent):
+        def mimeData(self) -> None:
+            return None
+
+    no_mime_event = _NoMimeDragEnterEvent(
+        QtCore.QPoint(0, 0),
+        QtCore.Qt.DropAction.CopyAction,
+        mime,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    assert not window._handle_source_drag_event(no_mime_event)
+
+    event = QtGui.QDragEnterEvent(
+        QtCore.QPoint(0, 0),
+        QtCore.Qt.DropAction.MoveAction | QtCore.Qt.DropAction.CopyAction,
+        mime,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+
+    assert window.eventFilter(window.canvas, event)
+    assert event.isAccepted()
+    assert event.dropAction() == QtCore.Qt.DropAction.CopyAction
+
+
 def test_figure_display_window_show_for_setup_recalls_hidden_states(
     qtbot, monkeypatch
 ) -> None:
@@ -3420,6 +3452,115 @@ def test_figure_composer_operation_table_uses_text_for_single_axes(qtbot) -> Non
         "layout"
     )
 
+    thin_child = FigureGridSpecGridState(
+        grid_id="thin-child",
+        span=FigureGridSpecSpanState(
+            row_start=0,
+            row_stop=1,
+            col_start=1,
+            col_stop=2,
+        ),
+        axes=(
+            FigureGridSpecAxesState(
+                axes_id="thin-axis",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=0,
+                    col_stop=1,
+                ),
+            ),
+        ),
+    )
+    thin_root = FigureGridSpecGridState(
+        grid_id="thin-root",
+        ncols=400,
+        child_grids=(thin_child,),
+    )
+    thin_descriptor = figurecomposer_widgets._gridspec_target_preview_descriptor(
+        thin_root, ("thin-axis",)
+    )
+    assert [entry[0] for entry in thin_descriptor[2]].count("grid") == 1
+    assert all(entry[0] != "axis" for entry in thin_descriptor[2])
+
+
+def test_figure_composer_operation_row_target_and_source_drag_edges(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"), name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=2, ncols=2),
+            sources=(FigureSourceState(name="data"),),
+            operations=(
+                FigureOperationState.plot_array(
+                    label="image", source="data", axes=FigureAxesSelectionState()
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool._set_current_operation_row_silent(99, preserve_selection=False)
+    assert not tool.operation_list.currentIndex().isValid()
+
+    empty_expression = tool.tool_status.operations[0].model_copy(
+        update={"axes": FigureAxesSelectionState(expression="axs[:0, :0]")}
+    )
+    descriptor = tool._operation_target_preview_descriptor(empty_expression)
+    assert descriptor[-1] is True
+    assert not any(entry[-1] for entry in descriptor[2])
+
+    mime = QtCore.QMimeData()
+    monkeypatch.setattr(tool, "_source_drop_available", lambda data: data is mime)
+    monkeypatch.setattr(tool, "_add_sources_from_mime", lambda data: data is mime)
+
+    def drag_enter_event() -> QtGui.QDragEnterEvent:
+        return QtGui.QDragEnterEvent(
+            QtCore.QPoint(),
+            QtCore.Qt.DropAction.CopyAction,
+            mime,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+
+    def drag_move_event() -> QtGui.QDragMoveEvent:
+        return QtGui.QDragMoveEvent(
+            QtCore.QPoint(),
+            QtCore.Qt.DropAction.CopyAction,
+            mime,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+
+    def drop_event() -> QtGui.QDropEvent:
+        return QtGui.QDropEvent(
+            QtCore.QPointF(),
+            QtCore.Qt.DropAction.CopyAction,
+            mime,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+
+    filtered_event = drag_enter_event()
+    assert tool.eventFilter(tool, filtered_event)
+    assert filtered_event.isAccepted()
+
+    for handler, event in (
+        (tool.dragEnterEvent, drag_enter_event()),
+        (tool.dragMoveEvent, drag_move_event()),
+        (tool.dropEvent, drop_event()),
+    ):
+        handler(event)
+        assert event.isAccepted()
+
+    monkeypatch.setattr(tool, "_source_drop_available", lambda _data: False)
+    tool.dragEnterEvent(drag_enter_event())
+    tool.dragMoveEvent(drag_move_event())
+    tool.dropEvent(drop_event())
+
 
 def test_figure_composer_operation_target_preview_uses_axes_selector_palette(
     qtbot, monkeypatch
@@ -3469,6 +3610,90 @@ def test_figure_composer_operation_target_preview_uses_axes_selector_palette(
         painter.end()
 
     assert observed_sources == [tool.axes_selector]
+
+
+def test_figure_composer_operation_target_delegate_handles_empty_previews(
+    qtbot, monkeypatch
+) -> None:
+    view = QtWidgets.QTreeWidget()
+    view.setColumnCount(1)
+    qtbot.addWidget(view)
+    color_source = QtWidgets.QWidget()
+    qtbot.addWidget(color_source)
+    item = QtWidgets.QTreeWidgetItem(view)
+    descriptor_role = int(QtCore.Qt.ItemDataRole.UserRole) + 77
+    delegate = figurecomposer_widgets._AxesTargetItemDelegate(
+        descriptor_role, color_source, view
+    )
+    index = view.indexFromItem(item, 0)
+    option = QtWidgets.QStyleOptionViewItem()
+    option.initFrom(view)
+    option.widget = view
+    draw_calls: list[QtCore.QRectF] = []
+    draw_selector_rect = figurecomposer_widgets._draw_selector_rect
+
+    def record_selector_rect(
+        painter: QtGui.QPainter,
+        rect: QtCore.QRect | QtCore.QRectF,
+        **kwargs: typing.Any,
+    ) -> None:
+        draw_calls.append(QtCore.QRectF(rect))
+        draw_selector_rect(painter, rect, **kwargs)
+
+    monkeypatch.setattr(
+        figurecomposer_widgets, "_draw_selector_rect", record_selector_rect
+    )
+
+    def paint(descriptor: object, rect: QtCore.QRect) -> None:
+        item.setData(0, descriptor_role, descriptor)
+        option.rect = rect
+        pixmap = QtGui.QPixmap(max(1, rect.width()), max(1, rect.height()))
+        pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+        painter = QtGui.QPainter(pixmap)
+        try:
+            delegate.paint(painter, option, index)
+        finally:
+            painter.end()
+
+    paint(None, QtCore.QRect(0, 0, 80, 24))
+    assert draw_calls == []
+
+    descriptor = (
+        "layout",
+        1.0,
+        (("axis", 0.0, 0.0, 1.0, 1.0, False),),
+        False,
+    )
+    paint(descriptor, QtCore.QRect(0, 0, 7, 3))
+    assert draw_calls == []
+
+    paint(
+        (
+            "layout",
+            1.0,
+            (("axis", 0.0, 0.0, 0.0, 0.0, False),),
+            False,
+        ),
+        QtCore.QRect(0, 0, 80, 24),
+    )
+    assert len(draw_calls) == 1
+
+    observed_sources: list[QtWidgets.QWidget] = []
+    selector_colors = figurecomposer_widgets._selector_colors
+
+    def record_color_source(
+        widget: QtWidgets.QWidget,
+    ) -> figurecomposer_widgets._SelectorColors:
+        observed_sources.append(widget)
+        return selector_colors(widget)
+
+    monkeypatch.setattr(figurecomposer_widgets, "_selector_colors", record_color_source)
+    monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", lambda *_args: False)
+    draw_calls.clear()
+    paint(descriptor, QtCore.QRect(0, 0, 80, 24))
+
+    assert observed_sources == [view]
+    assert len(draw_calls) == 2
 
 
 def test_figure_composer_operation_table_presents_nested_gridspec_target(
@@ -4388,6 +4613,111 @@ def test_figure_composer_operation_list_keypress_defensive_paths(qtbot) -> None:
         QtCore.Qt.KeyboardModifier.NoModifier,
     )
     operation_list.keyPressEvent(fallback_event)
+
+
+def test_figure_composer_step_editor_and_reorder_defensive_paths(
+    qtbot, monkeypatch
+) -> None:
+    scroll = figurecomposer_tool_module._FigureComposerStepEditorScroll()
+    qtbot.addWidget(scroll)
+    empty_hint = scroll.minimumSizeHint()
+
+    class _HintWidget(QtWidgets.QWidget):
+        def minimumSizeHint(self) -> QtCore.QSize:
+            return QtCore.QSize(220, 20)
+
+    content = _HintWidget()
+    scroll.setWidget(content)
+    scroll.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+    assert scroll.minimumSizeHint().width() > empty_hint.width()
+
+    tabs = QtWidgets.QTabWidget()
+    qtbot.addWidget(tabs)
+    page = figurecomposer_tool_module._FigureComposerStepEditorPage(tabs, tabs)
+    page._background_color = QtGui.QColor(0, 0, 0, 0)
+    monkeypatch.setattr(tabs, "render", lambda *_args, **_kwargs: None)
+    page._refresh_background()
+    assert page._background_color.alpha() == 0
+    page.paintEvent(None)
+    page.changeEvent(None)
+
+    scheduled: list[tuple[QtCore.QObject, object]] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "single_shot",
+        lambda owner, _delay, callback, *_args: scheduled.append((owner, callback)),
+    )
+    page.changeEvent(QtCore.QEvent(QtCore.QEvent.Type.PaletteChange))
+    assert scheduled == [(page, page._refresh_background)]
+
+    rows = figurecomposer_tool_module._FigureComposerReorderList(0)
+    qtbot.addWidget(rows)
+    invalid_item = QtWidgets.QTreeWidgetItem(rows)
+    invalid_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, 1)
+    assert rows._row_ids() == ()
+    rows._emit_rows_reordered()
+
+    rows.clear()
+    for row_id in ("first", "second"):
+        item = QtWidgets.QTreeWidgetItem(rows)
+        item.setData(0, QtCore.Qt.ItemDataRole.UserRole, row_id)
+    emitted: list[tuple[tuple[str, ...], frozenset[str], str | None]] = []
+    rows.rows_reordered.connect(
+        lambda row_ids, selected_ids, current_id: emitted.append(
+            (row_ids, selected_ids, current_id)
+        )
+    )
+    rows.setCurrentIndex(QtCore.QModelIndex())
+    rows._emit_rows_reordered()
+    assert emitted[-1] == (("first", "second"), frozenset(), None)
+
+    with monkeypatch.context() as context:
+        context.setattr(rows, "currentItem", lambda: QtWidgets.QTreeWidgetItem())
+        rows._emit_rows_reordered()
+    assert emitted[-1][-1] is None
+
+    scheduled.clear()
+    rows._rows_reordered_pending = True
+    rows._queue_rows_reordered()
+    assert scheduled == []
+    rows._rows_reordered_pending = False
+    rows._queue_rows_reordered()
+    assert scheduled == [(rows, rows._emit_rows_reordered)]
+    rows._rows_reordered_pending = False
+
+    mime = QtCore.QMimeData()
+    external_drop = QtGui.QDropEvent(
+        QtCore.QPointF(),
+        QtCore.Qt.DropAction.MoveAction,
+        mime,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    rows.dropEvent(external_drop)
+    assert not external_drop.isAccepted()
+
+    class _InternalDropEvent(QtGui.QDropEvent):
+        def source(self) -> QtCore.QObject:
+            return rows
+
+    internal_drop = _InternalDropEvent(
+        QtCore.QPointF(),
+        QtCore.Qt.DropAction.MoveAction,
+        mime,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    queued: list[bool] = []
+    monkeypatch.setattr(rows, "_queue_rows_reordered", lambda: queued.append(True))
+    with monkeypatch.context() as context:
+        context.setattr(
+            QtWidgets.QTreeWidget,
+            "dropEvent",
+            lambda _tree, event: event.accept(),
+        )
+        rows.dropEvent(internal_drop)
+    assert internal_drop.isAccepted()
+    assert queued == [True]
 
 
 def test_figure_composer_copy_paste_defensive_paths(qtbot, monkeypatch) -> None:
@@ -7019,6 +7349,38 @@ def test_figure_composer_provenance_build_code_handles_invalid_recipes(
     operation = figurecomposer_provenance._figure_build_operation(fake_tool)
     assert operation.copyable
     assert operation.code == "fig = object()"
+
+
+def test_figure_composer_toolbar_axes_plain_text_handles_missing_document(
+    qtbot, monkeypatch
+) -> None:
+    class _DocumentlessPlainTextEdit(QtWidgets.QPlainTextEdit):
+        def document(self):
+            return None
+
+    edit = _DocumentlessPlainTextEdit()
+    qtbot.addWidget(edit)
+    figurecomposer_toolbar_dialogs._apply_axis_plain_text_edit_state(
+        edit,
+        figurecomposer_toolbar_dialogs._AxisValueState(value="Title", available=True),
+    )
+    assert edit.toPlainText() == "Title"
+
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+    tool.show_figure_window(activate=False)
+    tool._show_axes_customize_dialog()
+    dialog = tool._axes_customize_dialog
+    assert isinstance(dialog, QtWidgets.QDialog)
+    title_edit = dialog.findChild(
+        QtWidgets.QPlainTextEdit, "figureComposerToolbarAxesTitleEdit"
+    )
+    assert title_edit is not None
+    monkeypatch.setattr(title_edit, "document", lambda: None)
+
+    title_edit.textChanged.emit()
+
+    assert _method_operations(tool, FigureMethodFamily.AXES, "set_title") == ()
 
 
 def test_figure_composer_toolbar_axes_dialog_updates_recipe(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -3,6 +3,19 @@
 from ._common import *
 
 
+def _operation_context_action(
+    tool: FigureComposerTool, object_name: str
+) -> tuple[QtWidgets.QMenu, QtGui.QAction]:
+    tool._show_operation_context_menu(QtCore.QPoint(0, 0))
+    assert tool._operation_context_menu is not None
+    action = next(
+        action
+        for action in tool._operation_context_menu.actions()
+        if action.objectName() == object_name
+    )
+    return tool._operation_context_menu, action
+
+
 def test_figure_composer_color_widgets_parse_and_sync(qtbot, monkeypatch) -> None:
     opaque = QtGui.QColor(1, 2, 3)
     translucent = QtGui.QColor(1, 2, 3, 4)
@@ -2342,7 +2355,7 @@ def test_figure_composer_reports_and_clears_render_errors(qtbot) -> None:
     assert item is not None
     assert "(render error)" in item.text()
     assert "RuntimeError: boom" in item.toolTip()
-    assert "Render error: RuntimeError: boom" in tool.source_status_label.text()
+    assert "Render error: RuntimeError: boom" in tool.step_source_status_label.text()
 
     tool._replace_operation(
         0,
@@ -2353,7 +2366,7 @@ def test_figure_composer_reports_and_clears_render_errors(qtbot) -> None:
     assert item is not None
     assert "(render error)" not in item.text()
     assert "RuntimeError: boom" not in item.toolTip()
-    assert "Render error" not in tool.source_status_label.text()
+    assert "Render error" not in tool.step_source_status_label.text()
 
 
 def test_figure_composer_editor_input_errors_mark_and_clear_invalid_steps(
@@ -2384,7 +2397,7 @@ def test_figure_composer_editor_input_errors_mark_and_clear_invalid_steps(
     item = tool.operation_list.item(0)
     assert item is not None
     assert "Invalid input:" in item.toolTip()
-    assert "Invalid input:" in tool.source_status_label.text()
+    assert "Invalid input:" in tool.step_source_status_label.text()
     with pytest.raises(ValueError, match="invalid step inputs"):
         tool.generated_code()
 
@@ -2406,7 +2419,7 @@ def test_figure_composer_editor_input_errors_mark_and_clear_invalid_steps(
     item = tool.operation_list.item(0)
     assert item is not None
     assert "Invalid input:" not in item.toolTip()
-    assert "Invalid input:" not in tool.source_status_label.text()
+    assert "Invalid input:" not in tool.step_source_status_label.text()
 
 
 def test_figure_composer_editor_signal_allows_callback_to_delete_sender(qtbot) -> None:
@@ -3222,30 +3235,44 @@ def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    duplicate_button = tool.findChild(
-        QtWidgets.QToolButton, "figureComposerDuplicateStepButton"
-    )
-    move_up_button = tool.findChild(
-        QtWidgets.QToolButton, "figureComposerMoveStepUpButton"
-    )
-    move_down_button = tool.findChild(
-        QtWidgets.QToolButton, "figureComposerMoveStepDownButton"
-    )
     delete_button = tool.findChild(
         QtWidgets.QToolButton, "figureComposerDeleteStepButton"
     )
-    assert duplicate_button is tool.duplicate_operation_button
-    assert move_up_button is tool.move_operation_up_button
-    assert move_down_button is tool.move_operation_down_button
+    assert (
+        tool.findChild(QtWidgets.QToolButton, "figureComposerDuplicateStepButton")
+        is None
+    )
+    assert (
+        tool.findChild(QtWidgets.QToolButton, "figureComposerMoveStepUpButton") is None
+    )
+    assert (
+        tool.findChild(QtWidgets.QToolButton, "figureComposerMoveStepDownButton")
+        is None
+    )
     assert delete_button is tool.remove_operation_button
 
     tool.operation_list.setCurrentRow(0)
-    assert move_up_button.isEnabled() is False
-    assert move_down_button.isEnabled() is True
+    menu, move_up_action = _operation_context_action(
+        tool, "figureComposerContextMoveStepUpAction"
+    )
+    move_down_action = next(
+        action
+        for action in menu.actions()
+        if action.objectName() == "figureComposerContextMoveStepDownAction"
+    )
+    assert move_up_action.text() == "Move Up"
+    assert move_down_action.text() == "Move Down"
+    assert move_up_action.isEnabled() is False
+    assert move_down_action.isEnabled() is True
+    menu.close()
 
     _select_operation_rows(tool, (1,))
     second = tool.tool_status.operations[1]
-    duplicate_button.click()
+    menu, duplicate_action = _operation_context_action(
+        tool, "figureComposerContextDuplicateStepAction"
+    )
+    duplicate_action.trigger()
+    menu.close()
     duplicate = tool.tool_status.operations[2]
     assert tool.operation_list.currentRow() == 2
     assert len(tool.tool_status.operations) == 4
@@ -3255,16 +3282,33 @@ def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
     )
 
     duplicate_id = duplicate.operation_id
-    move_up_button.click()
+    menu, move_up_action = _operation_context_action(
+        tool, "figureComposerContextMoveStepUpAction"
+    )
+    move_up_action.trigger()
+    menu.close()
     assert tool.operation_list.currentRow() == 1
     assert tool.tool_status.operations[1].operation_id == duplicate_id
-    move_down_button.click()
+    menu, move_down_action = _operation_context_action(
+        tool, "figureComposerContextMoveStepDownAction"
+    )
+    move_down_action.trigger()
+    menu.close()
     assert tool.operation_list.currentRow() == 2
     assert tool.tool_status.operations[2].operation_id == duplicate_id
 
     tool.operation_list.setCurrentRow(3)
-    assert move_up_button.isEnabled() is True
-    assert move_down_button.isEnabled() is False
+    menu, move_up_action = _operation_context_action(
+        tool, "figureComposerContextMoveStepUpAction"
+    )
+    move_down_action = next(
+        action
+        for action in menu.actions()
+        if action.objectName() == "figureComposerContextMoveStepDownAction"
+    )
+    assert move_up_action.isEnabled() is True
+    assert move_down_action.isEnabled() is False
+    menu.close()
 
     namespace: dict[str, typing.Any] = {}
     exec(tool.generated_code(), namespace)  # noqa: S102
@@ -3307,7 +3351,11 @@ def test_figure_composer_batch_duplicates_reorders_and_removes_steps(qtbot) -> N
     selected_originals = [
         tool.tool_status.operations[index].operation_id for index in (1, 3)
     ]
-    tool.duplicate_operation_button.click()
+    menu, duplicate_action = _operation_context_action(
+        tool, "figureComposerContextDuplicateStepAction"
+    )
+    duplicate_action.trigger()
+    menu.close()
 
     assert [operation.label for operation in tool.tool_status.operations] == [
         "a",
@@ -3327,7 +3375,11 @@ def test_figure_composer_batch_duplicates_reorders_and_removes_steps(qtbot) -> N
     duplicate_ids = {
         tool.tool_status.operations[index].operation_id for index in (4, 5)
     }
-    tool.move_operation_up_button.click()
+    menu, move_up_action = _operation_context_action(
+        tool, "figureComposerContextMoveStepUpAction"
+    )
+    move_up_action.trigger()
+    menu.close()
     assert [operation.label for operation in tool.tool_status.operations] == [
         "a",
         "b",
@@ -3346,7 +3398,11 @@ def test_figure_composer_batch_duplicates_reorders_and_removes_steps(qtbot) -> N
     selected_ids = {
         tool.tool_status.operations[index].operation_id for index in (0, 2, 5)
     }
-    tool.move_operation_down_button.click()
+    menu, move_down_action = _operation_context_action(
+        tool, "figureComposerContextMoveStepDownAction"
+    )
+    move_down_action.trigger()
+    menu.close()
     assert [operation.label for operation in tool.tool_status.operations] == [
         "b",
         "a",
@@ -3432,6 +3488,38 @@ def test_figure_composer_drag_reorders_steps_and_history(qtbot) -> None:
         "b",
         "c",
     ]
+
+
+def test_figure_composer_operation_list_keyboard_context_menu(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=tuple(_custom_order_step(label) for label in "ab"),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_list.setCurrentRow(1)
+
+    event = QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_Menu,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    tool.operation_list.keyPressEvent(event)
+
+    assert event.isAccepted()
+    assert tool._operation_context_menu is not None
+    action_names = {
+        action.objectName()
+        for action in tool._operation_context_menu.actions()
+        if action.objectName()
+    }
+    assert "figureComposerContextMoveStepUpAction" in action_names
+    assert "figureComposerContextMoveStepDownAction" in action_names
+    tool._operation_context_menu.close()
 
 
 def test_figure_composer_copy_paste_steps_preserves_order_and_history(qtbot) -> None:
@@ -5313,9 +5401,6 @@ def test_figure_composer_step_section_buttons_are_tab_focusable(qtbot) -> None:
         tool.copy_operation_button,
         tool.cut_operation_button,
         tool.paste_operation_button,
-        tool.duplicate_operation_button,
-        tool.move_operation_up_button,
-        tool.move_operation_down_button,
         tool.remove_operation_button,
         tool.operation_list,
     )
@@ -6443,44 +6528,31 @@ def test_figure_composer_provenance_code_detection_edges() -> None:
     assert not figurecomposer_provenance._code_assigns_name("axs = make()", "fig")
 
 
-def test_figure_composer_provenance_build_code_handles_invalid_recipes() -> None:
-    class FakeTool:
-        def __init__(self, code: str | None = None, exc: Exception | None = None):
-            self._code = code
-            self._exc = exc
+def test_figure_composer_provenance_build_code_handles_invalid_recipes(
+    monkeypatch,
+) -> None:
+    code_or_exc: Exception | str = RuntimeError("invalid recipe")
 
-        def generated_code(self) -> str:
-            if self._exc is not None:
-                raise self._exc
-            if self._code is None:
-                raise RuntimeError
-            return self._code
+    def fake_generated_code(*_args, **_kwargs):
+        if isinstance(code_or_exc, Exception):
+            raise code_or_exc
+        return code_or_exc
 
-    assert (
-        figurecomposer_provenance._figure_build_code(
-            typing.cast(
-                "FigureComposerTool",
-                FakeTool(exc=RuntimeError("invalid recipe")),
-            )
-        )
-        is None
+    monkeypatch.setattr(
+        figurecomposer_provenance.erlab.interactive._figurecomposer._codegen,
+        "generated_code",
+        fake_generated_code,
     )
-    assert (
-        figurecomposer_provenance._figure_build_code(
-            typing.cast("FigureComposerTool", FakeTool("if"))
-        )
-        is None
-    )
-    assert (
-        figurecomposer_provenance._figure_build_code(
-            typing.cast("FigureComposerTool", FakeTool("axs = object()"))
-        )
-        is None
-    )
+    fake_tool = typing.cast("FigureComposerTool", object())
 
-    operation = figurecomposer_provenance._figure_build_operation(
-        typing.cast("FigureComposerTool", FakeTool("fig = object()"))
-    )
+    assert figurecomposer_provenance._figure_build_code(fake_tool) is None
+    code_or_exc = "if"
+    assert figurecomposer_provenance._figure_build_code(fake_tool) is None
+    code_or_exc = "axs = object()"
+    assert figurecomposer_provenance._figure_build_code(fake_tool) is None
+
+    code_or_exc = "fig = object()"
+    operation = figurecomposer_provenance._figure_build_operation(fake_tool)
     assert operation.copyable
     assert operation.code == "fig = object()"
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -532,28 +532,43 @@ def test_figure_composer_gridspec_view_widget_selection_and_editing(qtbot) -> No
     editor._update_hover_cursor(
         editor._handle_rects(axis_rect, hit=True)[0][1].center()
     )
-    assert editor.cursor().shape() == QtCore.Qt.CursorShape.SizeFDiagCursor
-    assert editor.cursor_shapes == [QtCore.Qt.CursorShape.SizeFDiagCursor]
+    native_hover_cursors = sys.platform != "darwin"
+    if native_hover_cursors:
+        assert editor.cursor().shape() == QtCore.Qt.CursorShape.SizeFDiagCursor
+        assert editor.cursor_shapes == [QtCore.Qt.CursorShape.SizeFDiagCursor]
+    else:
+        assert editor.cursor().shape() == QtCore.Qt.CursorShape.ArrowCursor
+        assert editor.cursor_shapes == []
     editor._update_hover_cursor(
         editor._handle_rects(axis_rect, hit=True)[0][1].center()
     )
-    assert editor.cursor_shapes == [QtCore.Qt.CursorShape.SizeFDiagCursor]
+    if native_hover_cursors:
+        assert editor.cursor_shapes == [QtCore.Qt.CursorShape.SizeFDiagCursor]
+    else:
+        assert editor.cursor_shapes == []
     editor._update_hover_cursor(
         editor._handle_rects(axis_rect, hit=True)[1][1].center()
     )
-    assert editor.cursor().shape() == QtCore.Qt.CursorShape.SizeBDiagCursor
-    assert editor.cursor_shapes == [
-        QtCore.Qt.CursorShape.SizeFDiagCursor,
-        QtCore.Qt.CursorShape.SizeBDiagCursor,
-    ]
+    if native_hover_cursors:
+        assert editor.cursor().shape() == QtCore.Qt.CursorShape.SizeBDiagCursor
+        assert editor.cursor_shapes == [
+            QtCore.Qt.CursorShape.SizeFDiagCursor,
+            QtCore.Qt.CursorShape.SizeBDiagCursor,
+        ]
+    else:
+        assert editor.cursor().shape() == QtCore.Qt.CursorShape.ArrowCursor
+        assert editor.cursor_shapes == []
     editor._set_region_handles_visible(False)
     editor._update_hover_cursor(axis_rect.center())
-    assert editor.cursor().shape() == QtCore.Qt.CursorShape.SizeAllCursor
+    if native_hover_cursors:
+        assert editor.cursor().shape() == QtCore.Qt.CursorShape.SizeAllCursor
+    else:
+        assert editor.cursor().shape() == QtCore.Qt.CursorShape.ArrowCursor
     editor._update_hover_cursor(QtCore.QPoint(-100, -100))
     assert editor.cursor().shape() == QtCore.Qt.CursorShape.ArrowCursor
-    assert editor.unset_count == 1
+    assert editor.unset_count == int(native_hover_cursors)
     editor._update_hover_cursor(QtCore.QPoint(-100, -100))
-    assert editor.unset_count == 1
+    assert editor.unset_count == int(native_hover_cursors)
     assert editor._active_preview_span() is None
     editor._drag_mode = "create"
     editor._drag_origin_cell = (0, 0)

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -3421,6 +3421,56 @@ def test_figure_composer_operation_table_uses_text_for_single_axes(qtbot) -> Non
     )
 
 
+def test_figure_composer_operation_target_preview_uses_axes_selector_palette(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(ncols=2),
+            sources=(FigureSourceState(name="data"),),
+            operations=(
+                FigureOperationState.plot_array(
+                    label="image",
+                    source="data",
+                    axes=FigureAxesSelectionState(axes=((0, 1),)),
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    item = tool.operation_list.topLevelItem(0)
+    assert item is not None
+    index = tool.operation_list.indexFromItem(
+        item, figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN
+    )
+    observed_sources: list[QtWidgets.QWidget] = []
+    selector_colors = figurecomposer_widgets._selector_colors
+
+    def record_color_source(
+        widget: QtWidgets.QWidget,
+    ) -> figurecomposer_widgets._SelectorColors:
+        observed_sources.append(widget)
+        return selector_colors(widget)
+
+    monkeypatch.setattr(figurecomposer_widgets, "_selector_colors", record_color_source)
+    option = QtWidgets.QStyleOptionViewItem()
+    option.initFrom(tool.operation_list)
+    option.widget = tool.operation_list
+    option.rect = QtCore.QRect(0, 0, 80, 24)
+    pixmap = QtGui.QPixmap(option.rect.size())
+    pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+    painter = QtGui.QPainter(pixmap)
+    try:
+        tool.operation_target_delegate.paint(painter, option, index)
+    finally:
+        painter.end()
+
+    assert observed_sources == [tool.axes_selector]
+
+
 def test_figure_composer_operation_table_presents_nested_gridspec_target(
     qtbot,
 ) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -424,7 +424,11 @@ def test_figure_composer_gridspec_view_widget_selection_and_editing(qtbot) -> No
     assert not selector.axis_rect("main-axis").isNull()
     assert selector.axis_rect("missing").isNull()
     assert selector._range_axes_ids("missing", "child-axis") == ("child-axis",)
-    assert selector._axis_edges(0, 100, 2, ()) == (0.0, 50.0, 100.0)
+    assert figurecomposer_widgets._ratio_edges(0, 100, 2, ()) == (
+        0.0,
+        50.0,
+        100.0,
+    )
 
     selected: list[tuple[str, ...]] = []
     selector.sigSelectionChanged.connect(selected.append)
@@ -511,8 +515,8 @@ def test_figure_composer_gridspec_view_widget_selection_and_editing(qtbot) -> No
     assert editor._cell_at(QtCore.QPoint(-100, -100), clamp_to_grid=True) is not None
     assert editor._cell_at(QtCore.QPoint(-100, -100), clamp_to_grid=False) is None
     assert editor._occupied_grid_cells(root) >= {(0, 0), (0, 1), (1, 1)}
-    assert editor._axis_edges(0, 100, 0, ()) == (0.0,)
-    assert editor._axis_edges(0, 100, 2, (2.0, 1.0)) == (
+    assert figurecomposer_widgets._ratio_edges(0, 100, 0, ()) == (0.0,)
+    assert figurecomposer_widgets._ratio_edges(0, 100, 2, (2.0, 1.0)) == (
         0.0,
         200.0 / 3.0,
         100.0,
@@ -1650,12 +1654,12 @@ def test_figure_composer_tool_edge_state_contracts(qtbot, monkeypatch) -> None:
     tool._target_current_operation_all_axes()
     tool._target_current_operation_valid_axes()
     assert tool.tool_status.operations[0].axes.axes == ()
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    item.setCheckState(QtCore.Qt.CheckState.Unchecked)
+    item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
     assert not tool.tool_status.operations[0].enabled
     tool.operation_list.clearSelection()
-    tool.operation_list.setCurrentRow(-1)
+    tool.operation_list.setCurrentIndex(QtCore.QModelIndex())
     tool._update_step_action_buttons()
     assert not tool.remove_operation_button.isEnabled()
 
@@ -1870,7 +1874,7 @@ def test_figure_composer_axes_selection_guards_recipe_updates(
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     render_calls: list[tuple[object, ...]] = []
     monkeypatch.setattr(
         figurecomposer_tool_module,
@@ -1904,7 +1908,7 @@ def test_figure_composer_axes_selection_guards_recipe_updates(
     tool.add_operation(
         FigureOperationState.custom(label="code", code="pass", trusted=True)
     )
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool._axes_selection_changed(((0, 0),))
     assert tool.tool_status.operations[1].axes.axes == ()
     tool.axes_expression_edit.setText("axs")
@@ -1959,7 +1963,7 @@ def test_figure_composer_gridspec_axes_selection_guards_recipe_updates(
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     render_calls: list[tuple[object, ...]] = []
     monkeypatch.setattr(
         figurecomposer_tool_module,
@@ -1984,7 +1988,7 @@ def test_figure_composer_gridspec_axes_selection_guards_recipe_updates(
     tool.add_operation(
         FigureOperationState.custom(label="code", code="pass", trusted=True)
     )
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
     tool.gridspec_axes_selector.set_selected_axes_ids(("left",), emit=False)
     tool._gridspec_axes_selection_changed()
     assert tool.tool_status.operations[1].axes.axes_ids == ()
@@ -2366,22 +2370,28 @@ def test_figure_composer_reports_and_clears_render_errors(qtbot) -> None:
     qtbot.addWidget(tool)
     tool.show_figure_window(activate=False)
 
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    assert "(render error)" in item.text()
-    assert "RuntimeError: boom" in item.toolTip()
-    assert "Render error: RuntimeError: boom" in tool.step_source_status_label.text()
+    assert _operation_status_codes(tool, 0) == ("render_error",)
+    assert "RuntimeError: boom" in item.toolTip(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN
+    )
+    assert tool.step_source_status_label.text() == ""
+    assert tool.step_source_status_label.isHidden()
 
     tool._replace_operation(
         0,
         operation.model_copy(update={"code": "ax.set_title('ok')"}),
     )
 
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    assert "(render error)" not in item.text()
-    assert "RuntimeError: boom" not in item.toolTip()
-    assert "Render error" not in tool.step_source_status_label.text()
+    assert _operation_status_codes(tool, 0) == ()
+    assert "RuntimeError: boom" not in item.toolTip(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN
+    )
+    assert tool.step_source_status_label.text() == ""
+    assert tool.step_source_status_label.isHidden()
 
 
 def test_figure_composer_editor_input_errors_mark_and_clear_invalid_steps(
@@ -2409,9 +2419,12 @@ def test_figure_composer_editor_input_errors_mark_and_clear_invalid_steps(
     edit.editingFinished.emit()
 
     assert tool._operation_has_invalid_input(operation)
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    assert "Invalid input:" in item.toolTip()
+    assert _operation_status_codes(tool, 0) == ("invalid_input",)
+    assert "Invalid input:" in item.toolTip(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN
+    )
     assert "Invalid input:" in tool.step_source_status_label.text()
     with pytest.raises(ValueError, match="invalid step inputs"):
         tool.generated_code()
@@ -2431,9 +2444,12 @@ def test_figure_composer_editor_input_errors_mark_and_clear_invalid_steps(
 
     assert not tool._operation_has_invalid_input(operation)
     assert tool.tool_status.operations[0].extra_kwargs == {"alpha": 0.5}
-    item = tool.operation_list.item(0)
+    item = tool.operation_list.topLevelItem(0)
     assert item is not None
-    assert "Invalid input:" not in item.toolTip()
+    assert _operation_status_codes(tool, 0) == ()
+    assert "Invalid input:" not in item.toolTip(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN
+    )
     assert "Invalid input:" not in tool.step_source_status_label.text()
 
 
@@ -2538,7 +2554,7 @@ def test_figure_composer_disabled_step_edits_do_not_render_or_queue(
     )
     tool = FigureComposerTool(data)
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
 
     render_calls: list[tuple[object, ...]] = []
     info_changed: list[None] = []
@@ -2549,9 +2565,9 @@ def test_figure_composer_disabled_step_edits_do_not_render_or_queue(
         lambda *args, **_kwargs: render_calls.append(args),
     )
 
-    operation_item = tool.operation_list.item(0)
+    operation_item = tool.operation_list.topLevelItem(0)
     assert operation_item is not None
-    operation_item.setCheckState(QtCore.Qt.CheckState.Unchecked)
+    operation_item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
     assert tool.tool_status.operations[0].enabled is False
     assert render_calls == [(tool,)]
     assert info_changed == [None]
@@ -2578,9 +2594,9 @@ def test_figure_composer_disabled_step_edits_do_not_render_or_queue(
     assert not tool._preview_render_update_pending
     assert info_changed == [None, None]
 
-    operation_item = tool.operation_list.item(0)
+    operation_item = tool.operation_list.topLevelItem(0)
     assert operation_item is not None
-    operation_item.setCheckState(QtCore.Qt.CheckState.Checked)
+    operation_item.setCheckState(0, QtCore.Qt.CheckState.Checked)
     assert tool.tool_status.operations[0].enabled is True
     assert render_calls == [(tool,)]
     assert info_changed == [None, None, None]
@@ -3208,6 +3224,363 @@ def test_figure_composer_preview_suppresses_collapsed_layout_warning(
     )
 
 
+def test_figure_composer_operation_table_presents_targets_and_selects_rows(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        name="data",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=2, ncols=2),
+            sources=(FigureSourceState(name="data"),),
+            operations=(
+                FigureOperationState.set_palette(),
+                FigureOperationState.plot_array(
+                    label="image",
+                    source="data",
+                    axes=FigureAxesSelectionState(axes=((0, 1),)),
+                ),
+                FigureOperationState.plot_slices(
+                    label="slices",
+                    sources=("data",),
+                    axes=FigureAxesSelectionState(expression="axs[:, 0]"),
+                ),
+                FigureOperationState.custom(label="custom", code="pass", trusted=True),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    operation_list = tool.operation_list
+    assert isinstance(operation_list, QtWidgets.QTreeWidget)
+    assert operation_list.columnCount() == 3
+    assert (
+        operation_list.selectionBehavior()
+        == QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+    )
+    assert isinstance(
+        operation_list.itemDelegateForColumn(
+            figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN
+        ),
+        figurecomposer_widgets._AxesTargetItemDelegate,
+    )
+    header = operation_list.header()
+    assert (
+        header.sectionSize(figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN)
+        <= 80
+    )
+    assert (
+        header.sectionSize(figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN)
+        <= 96
+    )
+
+    palette_item = operation_list.topLevelItem(0)
+    image_item = operation_list.topLevelItem(1)
+    expression_item = operation_list.topLevelItem(2)
+    custom_item = operation_list.topLevelItem(3)
+    assert all(
+        item is not None
+        for item in (palette_item, image_item, expression_item, custom_item)
+    )
+    palette_descriptor = palette_item.data(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+    )
+    custom_descriptor = custom_item.data(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+    )
+    assert palette_descriptor[0] == custom_descriptor[0] == "text"
+    assert palette_descriptor != custom_descriptor
+
+    image_descriptor = image_item.data(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+    )
+    expression_descriptor = expression_item.data(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+    )
+    assert image_descriptor[0] == expression_descriptor[0] == "layout"
+    assert [entry[-1] for entry in image_descriptor[2]] == [False, True, False, False]
+    assert [entry[-1] for entry in expression_descriptor[2]] == [
+        True,
+        False,
+        True,
+        False,
+    ]
+    unresolved_descriptor = tool._operation_target_preview_descriptor(
+        tool.tool_status.operations[2].model_copy(
+            update={
+                "axes": FigureAxesSelectionState(expression="axs + axs"),
+            }
+        )
+    )
+    assert unresolved_descriptor[-1] is True
+    expression_item.setData(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+        unresolved_descriptor,
+    )
+    assert (
+        expression_item.data(
+            figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+            QtCore.Qt.ItemDataRole.AccessibleDescriptionRole,
+        )
+        == "axs[:, 0]"
+    )
+    for row in range(operation_list.topLevelItemCount()):
+        item = operation_list.topLevelItem(row)
+        assert item is not None
+        assert item.sizeHint(0).height() <= 24
+        for column in range(operation_list.columnCount()):
+            assert operation_list.itemWidget(item, column) is None
+
+    tool.editor_tabs.setCurrentWidget(tool.recipe_page)
+    tool.show()
+    operation_list.scrollToItem(expression_item)
+    initial_list_height = operation_list.height()
+    for row in range(operation_list.topLevelItemCount()):
+        operation_list.setCurrentItem(operation_list.topLevelItem(row))
+        QtWidgets.QApplication.processEvents()
+        assert operation_list.height() == initial_list_height
+        assert (
+            tool.step_editor_scroll.minimumSizeHint().width()
+            >= tool.step_editor_stack.minimumSizeHint().width()
+        )
+    operation_list.setCurrentItem(palette_item)
+    QtWidgets.QApplication.processEvents()
+    target_index = operation_list.indexFromItem(
+        expression_item,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+    )
+    target_rect = operation_list.visualRect(target_index)
+    assert not target_rect.isEmpty()
+    editor_generation = tool._operation_editor_generation
+    qtbot.mouseClick(
+        operation_list.viewport(),
+        QtCore.Qt.MouseButton.LeftButton,
+        pos=target_rect.center(),
+    )
+    assert operation_list.indexOfTopLevelItem(operation_list.currentItem()) == 2
+    assert expression_item.isSelected()
+    assert tool._operation_editor_generation == editor_generation
+    qtbot.waitUntil(
+        lambda: tool._operation_editor_generation == editor_generation + 1,
+        timeout=1000,
+    )
+    assert operation_list.height() == initial_list_height
+
+
+def test_figure_composer_operation_table_uses_text_for_single_axes(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(FigureOperationState.plot_array(label="image", source="data"),),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    item = tool.operation_list.topLevelItem(0)
+    assert item is not None
+    assert item.data(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+    ) == ("single_axes",)
+    tool.editor_tabs.setCurrentWidget(tool.recipe_page)
+    tool.show()
+    qtbot.wait(1)
+
+    root = FigureGridSpecGridState(
+        grid_id="root",
+        axes=(
+            FigureGridSpecAxesState(
+                axes_id="only-axis",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=0,
+                    col_stop=1,
+                ),
+            ),
+        ),
+    )
+    assert figurecomposer_widgets._gridspec_target_preview_descriptor(
+        root, ("only-axis",)
+    ) == ("single_axes",)
+    assert figurecomposer_widgets._gridspec_target_preview_descriptor(root, ())[0] == (
+        "layout"
+    )
+
+
+def test_figure_composer_operation_table_presents_nested_gridspec_target(
+    qtbot,
+) -> None:
+    child_axis = FigureGridSpecAxesState(
+        axes_id="child-axis",
+        span=FigureGridSpecSpanState(
+            row_start=1,
+            row_stop=2,
+            col_start=0,
+            col_stop=1,
+        ),
+    )
+    root = FigureGridSpecGridState(
+        grid_id="root",
+        nrows=1,
+        ncols=2,
+        axes=(
+            FigureGridSpecAxesState(
+                axes_id="root-axis",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=0,
+                    col_stop=1,
+                ),
+            ),
+        ),
+        child_grids=(
+            FigureGridSpecGridState(
+                grid_id="child",
+                nrows=2,
+                ncols=1,
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=1,
+                    col_stop=2,
+                ),
+                axes=(child_axis,),
+            ),
+            FigureGridSpecGridState(
+                grid_id="outside-root",
+                nrows=1,
+                ncols=1,
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=2,
+                    col_stop=3,
+                ),
+            ),
+        ),
+    )
+    data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(
+                layout_mode="gridspec",
+                gridspec=FigureGridSpecLayoutState(root=root),
+            ),
+            sources=(FigureSourceState(name="data"),),
+            operations=(
+                FigureOperationState.plot_slices(
+                    label="slices",
+                    sources=("data",),
+                    axes=FigureAxesSelectionState(axes_ids=("child-axis",)),
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    item = tool.operation_list.topLevelItem(0)
+    assert item is not None
+    descriptor = item.data(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+    )
+    assert descriptor[0] == "layout"
+    assert any(entry[0] == "grid" for entry in descriptor[2])
+    assert sum(entry[0] == "axis" and entry[-1] for entry in descriptor[2]) == 1
+    tool.editor_tabs.setCurrentWidget(tool.recipe_page)
+    tool.show()
+    qtbot.wait(10)
+
+
+def test_figure_composer_operation_table_centralizes_status_and_layout_refresh(
+    qtbot,
+) -> None:
+    data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    operation = FigureOperationState.plot_array(
+        label="image",
+        source="missing",
+        axes=FigureAxesSelectionState(axes=((0, 1),)),
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=1),
+            sources=(
+                FigureSourceState(name="data"),
+                FigureSourceState(name="missing"),
+            ),
+            operations=(operation,),
+            primary_source="data",
+        ),
+        source_data={"data": data},
+    )
+    qtbot.addWidget(tool)
+
+    assert _operation_status_codes(tool, 0) == (
+        "invalid_target",
+        "missing_source",
+    )
+    item = tool.operation_list.topLevelItem(0)
+    assert item is not None
+    assert item.text(
+        figurecomposer_tool_module._OPERATION_LIST_STEP_COLUMN
+    ) == tool._operation_display_text(tool.tool_status.operations[0])
+
+    tool._set_operation_input_errors(
+        {operation.operation_id: {"test": "invalid value"}}
+    )
+    tool._set_operation_render_errors({operation.operation_id: "render failed"})
+    assert _operation_status_codes(tool, 0) == (
+        "invalid_target",
+        "missing_source",
+        "invalid_input",
+        "render_error",
+    )
+    item = tool.operation_list.topLevelItem(0)
+    assert item is not None
+    status_description = item.data(
+        figurecomposer_tool_module._OPERATION_LIST_STATUS_COLUMN,
+        QtCore.Qt.ItemDataRole.AccessibleDescriptionRole,
+    )
+    assert "invalid value" in status_description
+    assert "render failed" in status_description
+
+    tool._set_operation_input_errors({})
+    tool._set_operation_render_errors({})
+    tool.ncols_spin.setValue(2)
+    assert _operation_status_codes(tool, 0) == ("missing_source",)
+    descriptor = tool.operation_list.topLevelItem(0).data(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+    )
+    assert [entry[-1] for entry in descriptor[2]] == [False, True]
+
+    tool.undo()
+    assert "invalid_target" in _operation_status_codes(tool, 0)
+    descriptor = tool.operation_list.topLevelItem(0).data(
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_COLUMN,
+        figurecomposer_tool_module._OPERATION_LIST_TARGET_ROLE,
+    )
+    assert [entry[-1] for entry in descriptor[2]] == [False]
+
+
 def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0),
@@ -3266,7 +3639,7 @@ def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
     )
     assert delete_button is tool.remove_operation_button
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     menu, move_up_action = _operation_context_action(
         tool, "figureComposerContextMoveStepUpAction"
     )
@@ -3289,7 +3662,7 @@ def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
     duplicate_action.trigger()
     menu.close()
     duplicate = tool.tool_status.operations[2]
-    assert tool.operation_list.currentRow() == 2
+    assert tool._current_operation_index() == 2
     assert len(tool.tool_status.operations) == 4
     assert duplicate.operation_id != second.operation_id
     assert duplicate.model_dump(exclude={"operation_id"}) == second.model_dump(
@@ -3302,17 +3675,17 @@ def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
     )
     move_up_action.trigger()
     menu.close()
-    assert tool.operation_list.currentRow() == 1
+    assert tool._current_operation_index() == 1
     assert tool.tool_status.operations[1].operation_id == duplicate_id
     menu, move_down_action = _operation_context_action(
         tool, "figureComposerContextMoveStepDownAction"
     )
     move_down_action.trigger()
     menu.close()
-    assert tool.operation_list.currentRow() == 2
+    assert tool._current_operation_index() == 2
     assert tool.tool_status.operations[2].operation_id == duplicate_id
 
-    tool.operation_list.setCurrentRow(3)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(3))
     menu, move_up_action = _operation_context_action(
         tool, "figureComposerContextMoveStepUpAction"
     )
@@ -3382,7 +3755,7 @@ def test_figure_composer_batch_duplicates_reorders_and_removes_steps(qtbot) -> N
         "e",
     ]
     assert _selected_operation_rows(tool) == (4, 5)
-    assert tool.operation_list.currentRow() == 4
+    assert tool._current_operation_index() == 4
     assert [
         tool.tool_status.operations[index].operation_id for index in (4, 5)
     ] != selected_originals
@@ -3440,7 +3813,7 @@ def test_figure_composer_batch_duplicates_reorders_and_removes_steps(qtbot) -> N
         "e",
     ]
     assert _selected_operation_rows(tool) == (1,)
-    assert tool.operation_list.currentRow() == 1
+    assert tool._current_operation_index() == 1
 
 
 def test_figure_composer_drag_reorders_steps_and_history(qtbot) -> None:
@@ -3467,13 +3840,31 @@ def test_figure_composer_drag_reorders_steps_and_history(qtbot) -> None:
     assert tool.operation_list.defaultDropAction() == QtCore.Qt.DropAction.MoveAction
     assert tool.operation_list.showDropIndicator()
 
+    tool.editor_tabs.setCurrentWidget(tool.recipe_page)
+    tool.show()
+    qtbot.waitUntil(tool.isVisible)
+
     _select_operation_rows(tool, (1, 2))
-    assert tool.operation_list.model().moveRows(
-        QtCore.QModelIndex(),
-        1,
-        2,
-        QtCore.QModelIndex(),
-        4,
+    first_moved = tool.operation_list.takeTopLevelItem(1)
+    second_moved = tool.operation_list.takeTopLevelItem(1)
+    assert first_moved is not None
+    assert second_moved is not None
+    tool.operation_list.insertTopLevelItem(2, first_moved)
+    tool.operation_list.insertTopLevelItem(3, second_moved)
+    tool.operation_list.setCurrentItem(first_moved)
+    first_moved.setSelected(True)
+    second_moved.setSelected(True)
+    tool.operation_list._queue_rows_reordered()
+
+    assert tool.operation_list.topLevelItemCount() == 4
+    assert [operation.label for operation in tool.tool_status.operations] == list(
+        "abcd"
+    )
+    qtbot.waitUntil(
+        lambda: (
+            [operation.label for operation in tool.tool_status.operations]
+            == ["a", "d", "b", "c"]
+        )
     )
 
     assert [operation.label for operation in tool.tool_status.operations] == [
@@ -3482,8 +3873,12 @@ def test_figure_composer_drag_reorders_steps_and_history(qtbot) -> None:
         "b",
         "c",
     ]
+    assert all(
+        tool.operation_list.topLevelItem(row).childCount() == 0
+        for row in range(tool.operation_list.topLevelItemCount())
+    )
     assert _selected_operation_rows(tool) == (2, 3)
-    assert tool.operation_list.currentRow() == 2
+    assert tool._current_operation_index() == 2
 
     namespace: dict[str, typing.Any] = {}
     exec(tool.generated_code(), namespace)  # noqa: S102
@@ -3516,7 +3911,7 @@ def test_figure_composer_operation_list_keyboard_context_menu(qtbot) -> None:
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(1)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(1))
 
     event = QtGui.QKeyEvent(
         QtCore.QEvent.Type.KeyPress,
@@ -3570,7 +3965,7 @@ def test_figure_composer_copy_paste_steps_preserves_order_and_history(qtbot) -> 
         "d",
     ]
     assert _selected_operation_rows(tool) == (1, 2)
-    assert tool.operation_list.currentRow() == 1
+    assert tool._current_operation_index() == 1
     pasted_ids = {tool.tool_status.operations[index].operation_id for index in (1, 2)}
     assert pasted_ids.isdisjoint(copied_ids)
 
@@ -3619,7 +4014,7 @@ def test_figure_composer_cut_paste_steps_preserves_order_and_history(qtbot) -> N
         "c",
     ]
     assert _selected_operation_rows(tool) == (1,)
-    assert tool.operation_list.currentRow() == 1
+    assert tool._current_operation_index() == 1
     mime = clipboard.mimeData()
     payload_text = bytes(
         mime.data(figurecomposer_tool_module._STEPS_CLIPBOARD_MIME).data()
@@ -3643,7 +4038,7 @@ def test_figure_composer_cut_paste_steps_preserves_order_and_history(qtbot) -> N
         "d",
     ]
     assert _selected_operation_rows(tool) == (2, 3)
-    assert tool.operation_list.currentRow() == 2
+    assert tool._current_operation_index() == 2
     pasted_ids = {tool.tool_status.operations[index].operation_id for index in (2, 3)}
     assert pasted_ids.isdisjoint(cut_ids)
 
@@ -3917,6 +4312,8 @@ def test_figure_composer_operation_list_keypress_defensive_paths(qtbot) -> None:
     operation_list.paste_requested.connect(lambda: pasted.append(True))
 
     operation_list.keyPressEvent(None)
+    operation_list.dropEvent(None)
+    operation_list._emit_rows_reordered()
 
     paste_event = QtGui.QKeyEvent(
         QtCore.QEvent.Type.KeyPress,
@@ -3972,7 +4369,7 @@ def test_figure_composer_copy_paste_defensive_paths(qtbot, monkeypatch) -> None:
     qtbot.addWidget(tool)
 
     assert tool._clipboard() is not None
-    tool.operation_list.setCurrentRow(-1)
+    tool.operation_list.setCurrentIndex(QtCore.QModelIndex())
     tool.operation_list.clearSelection()
     tool._copy_selected_operations()
 
@@ -4457,7 +4854,7 @@ def test_figure_composer_axes_status_uses_compact_labels(qtbot) -> None:
     )
     qtbot.addWidget(tool)
 
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("axes")
     assert tool.target_axes_status_label.text() == "Targets: axs[0, :]"
     assert (
@@ -5119,6 +5516,7 @@ def test_figure_composer_gridspec_widget_hides_handles_after_outside_click(
     tool._setup_controls_changed()
     tool.show()
     qtbot.wait_until(lambda: tool.isVisible(), timeout=5000)
+    qtbot.wait(1)
 
     axis = tool.tool_status.setup.gridspec.root.axes[0]
     widget = tool.gridspec_layout_widget
@@ -5876,7 +6274,7 @@ def test_figure_composer_subplots_adjust_pairs_stay_valid(qtbot) -> None:
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("method")
     method_page = tool.step_editor_stack.currentWidget()
     left_spin = method_page.findChild(
@@ -7428,7 +7826,7 @@ def test_figure_composer_editor_widget_rebuilds_are_deferred(
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("selection")
     values_edit = tool.step_editor_stack.currentWidget().findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesValuesEdit"
@@ -7530,7 +7928,7 @@ def test_figure_composer_retired_editor_widgets_drain_after_popup(
         ),
     )
     qtbot.addWidget(tool)
-    tool.operation_list.setCurrentRow(0)
+    tool.operation_list.setCurrentItem(tool.operation_list.topLevelItem(0))
     tool._select_step_section("selection")
     old_page = tool.step_editor_stack.currentWidget()
     active_popup: list[QtWidgets.QWidget | None] = [None]
@@ -7572,14 +7970,16 @@ def test_figure_composer_operation_list_event_filter_is_removed_on_close(
     assert erlab.interactive.utils.qt_is_valid(viewport)
 
     tool._operation_multi_select_event = True
+    tool._operation_selection_input_event = True
     erlab.interactive.utils.single_shot(
-        tool, 0, tool._clear_operation_multi_select_event
+        tool, 0, tool._clear_operation_selection_input_state
     )
     tool.close()
     qtbot.wait(10)
 
     assert tool._operation_list_viewport is None
     assert tool._operation_multi_select_event is False
+    assert tool._operation_selection_input_event is False
     assert erlab.interactive.utils.qt_is_valid(viewport)
 
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -4297,12 +4297,13 @@ def test_figure_composer_step_payload_rejects_malformed_clipboard_data() -> None
     mime = QtCore.QMimeData()
     mime.setText(payload_with())
     mime.figure_composer_source_data = object()
-    operations, sources, source_data = (
+    operations, sources, source_data, selection_base_data = (
         figurecomposer_tool_module._step_clipboard_payload(mime)
     )
     assert [operation.label for operation in operations] == ["a"]
     assert sources == ()
     assert source_data == {}
+    assert selection_base_data == {}
 
 
 def test_figure_composer_operation_list_keypress_defensive_paths(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -897,6 +897,10 @@ def test_manager_console_bare_expression_opens_provenance_root(
             "data_0",
             "data_1",
         ]
+        assert [source.label for source in provenance.script_inputs] == [
+            "ImageTool 0: left",
+            "ImageTool 1: right",
+        ]
         assert [source.node_uid for source in provenance.script_inputs] == [
             manager._tool_graph.root_wrappers[0].uid,
             manager._tool_graph.root_wrappers[1].uid,
@@ -931,6 +935,10 @@ def test_manager_console_bare_expression_opens_provenance_root(
         assert [source.name for source in loaded[0].script_inputs] == [
             "data_0",
             "data_1",
+        ]
+        assert [source.label for source in loaded[0].script_inputs] == [
+            "ImageTool 0: left",
+            "ImageTool 1: right",
         ]
         derived_uid = manager._tool_graph.root_wrappers[2].uid
         assert manager.dependency_status_for_uid(derived_uid) == "current"
@@ -3590,7 +3598,9 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         assert manager.dependency_status_label_for_uid(derived_uid) is not None
         manager.dependency_status_badge_for_uid(derived_uid)
         assert manager.dependency_status_tooltip_for_uid(derived_uid) is not None
-        assert manager.dependency_input_summary_for_uid(derived_uid) is not None
+        dependency_summary = manager.dependency_input_summary_for_uid(derived_uid)
+        assert dependency_summary is not None
+        assert "data_0: ImageTool 0" in dependency_summary
         assert manager.dependency_status_label_for_uid("missing") is None
         assert manager.dependency_status_badge_for_uid("missing") is None
         assert manager.dependency_status_tooltip_for_uid("missing") is None
@@ -3807,6 +3817,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         )
         ref = provenance.ScriptInputDependencyRef(
             name="file_input",
+            label="File input",
             node_uid="missing-file-node",
             node_snapshot_token=file_marker,
         )
@@ -3828,6 +3839,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         )
         script_input = manager._script_input_for_node(fake_child)
         assert script_input.name.startswith("data__1_child")
+        assert script_input.label == "Child node"
         assert script_input.parsed_provenance_spec() == file_spec
 
         monkeypatch.setattr(manager_mainwindow.QtWidgets, "QMessageBox", FakeMessageBox)

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -3620,6 +3620,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         assert not manager._script_input_can_reload(full_data_input)
         assert manager._script_input_unavailable_reason(full_data_input) is not None
         file_without_source_input = types.SimpleNamespace(
+            name="file_without_source",
             node_uid=None,
             label="File without source",
             parsed_provenance_spec=lambda: file_spec.model_copy(
@@ -3653,6 +3654,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         replay_call = load_source.replay_call
         assert replay_call is not None
         no_replay_call_input = types.SimpleNamespace(
+            name="no_replay_call",
             node_uid=None,
             label="No replay call",
             parsed_provenance_spec=lambda: file_spec.model_copy(
@@ -3805,7 +3807,6 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         )
         ref = provenance.ScriptInputDependencyRef(
             name="file_input",
-            label="File input",
             node_uid="missing-file-node",
             node_snapshot_token=file_marker,
         )

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -21,7 +21,18 @@ import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace_io as manager_workspace_io
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.utils
-from erlab.interactive._figurecomposer import FigureComposerTool
+from erlab.interactive._figurecomposer import (
+    FigureAxesSelectionState,
+    FigureComposerTool,
+    FigureOperationState,
+    FigureRecipeState,
+    FigureSourceState,
+    FigureSubplotsState,
+)
+from erlab.interactive._figurecomposer._exceptions import (
+    FigureComposerPlotSlicesSelectionError,
+)
+from erlab.interactive._figurecomposer._tool import FigureSourceAddResult
 from erlab.interactive._widgets import _CenteredIconToolButton
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool
@@ -612,6 +623,29 @@ def test_details_panel_update_info_uses_default_child_preview_aspect_ratio() -> 
     assert metadata_nodes == [node]
     assert preview_widget.pixmap_calls == [(pixmap, {})]
     assert preview_widget.visible is True
+
+
+def test_details_panel_script_input_labels_omit_redundant_history() -> None:
+    manager = types.SimpleNamespace(
+        _tool_graph=types.SimpleNamespace(nodes={}),
+    )
+    controller = _DetailsPanelController(
+        typing.cast("manager_mainwindow.ImageToolManager", manager)
+    )
+
+    assert (
+        controller._script_input_row_label(
+            provenance.ScriptInput(name="source"), include_history=False
+        )
+        == "Use source"
+    )
+    assert (
+        controller._script_input_row_label(
+            provenance.ScriptInput(name="source", node_uid="missing"),
+            include_history=True,
+        )
+        == "Missing source for source"
+    )
 
 
 def test_single_image_preview_does_not_show_null_pixmap(qtbot) -> None:
@@ -3047,6 +3081,162 @@ def test_shutdown_remove_all_tools_skips_teardown_ui_refresh(
         assert root_index not in manager._tool_graph.root_wrappers
         assert figure_uid not in manager._tool_graph.nodes
         assert calls == []
+
+
+def test_manager_append_reports_post_alias_plot_slices_error(
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("source")
+    existing = _batch_data("existing")
+    with manager_context() as manager:
+        source_tool = itool(source, manager=False, execute=False)
+        manager.add_imagetool(source_tool, show=False)
+        figure_tool = FigureComposerTool(
+            existing,
+            recipe=FigureRecipeState(
+                setup=FigureSubplotsState(),
+                sources=(FigureSourceState(name="existing"),),
+                operations=(),
+                primary_source="existing",
+            ),
+        )
+        figure_uid = manager.add_figuretool(figure_tool, show=False)
+        calls: list[tuple[str, ...]] = []
+
+        def image_operations(
+            _targets: tuple[int | str, ...], source_names: tuple[str, ...]
+        ) -> tuple[FigureOperationState, ...]:
+            calls.append(source_names)
+            if len(calls) == 2:
+                raise FigureComposerPlotSlicesSelectionError("source")
+            return (
+                FigureOperationState.plot_array(label="source", source=source_names[0]),
+            )
+
+        errors: list[FigureComposerPlotSlicesSelectionError] = []
+        monkeypatch.setattr(
+            manager, "_figure_operations_from_image_targets", image_operations
+        )
+        monkeypatch.setattr(
+            manager, "_show_figure_plot_slices_selection_error", errors.append
+        )
+
+        assert not manager.append_figure_from_targets(
+            (0,),
+            figure_uid=figure_uid,
+            axes_selection=FigureAxesSelectionState(axes=((0, 0),)),
+            show=False,
+        )
+        assert len(calls) == 2
+        assert len(errors) == 1
+        assert figure_tool.tool_status.operations == ()
+
+
+def test_manager_append_partial_source_result_shows_figure_without_new_step(
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = xr.DataArray(np.arange(4.0), dims=("x",), name="source")
+    existing = xr.DataArray(np.arange(4.0), dims=("x",), name="existing")
+    with manager_context() as manager:
+        source_tool = itool(source, manager=False, execute=False)
+        manager.add_imagetool(source_tool, show=False)
+        figure_tool = FigureComposerTool(
+            existing,
+            recipe=FigureRecipeState(
+                setup=FigureSubplotsState(),
+                sources=(FigureSourceState(name="existing"),),
+                operations=(),
+                primary_source="existing",
+            ),
+        )
+        figure_uid = manager.add_figuretool(figure_tool, show=False)
+        node = manager._child_node(figure_uid)
+        source_name = manager._script_input_name_for_node(manager._node_for_target(0))
+        shown: list[str] = []
+        monkeypatch.setattr(
+            figure_tool,
+            "add_sources",
+            lambda _sources, _source_data: FigureSourceAddResult(
+                added=((source_name, source_name),),
+                skipped=(("rejected", "rejected"),),
+            ),
+        )
+        monkeypatch.setattr(node, "show", lambda: shown.append(figure_uid))
+
+        assert manager.append_figure_from_targets(
+            (0,),
+            figure_uid=figure_uid,
+            axes_selection=FigureAxesSelectionState(axes=((0, 0),)),
+            operation=FigureOperationState.line(label="line", source=source_name),
+            show=True,
+        )
+        assert shown == [figure_uid]
+        assert figure_tool.tool_status.operations == ()
+
+
+def test_manager_append_reuses_short_axes_id_selection_for_all_operations() -> None:
+    operations = (
+        FigureOperationState.plot_array(label="first", source="first"),
+        FigureOperationState.plot_array(label="second", source="second"),
+    )
+    selection = FigureAxesSelectionState(axes_ids=("only",))
+
+    mapped = manager_mainwindow.ImageToolManager._figure_operations_with_append_axes(
+        operations, selection
+    )
+
+    assert [operation.axes for operation in mapped] == [selection, selection]
+
+
+def test_manager_figure_source_picker_skips_stale_rows_and_deduplicates_targets(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = xr.DataArray(np.arange(4.0), dims=("x",), name="source")
+    with manager_context() as manager:
+        source_tool = itool(source, manager=False, execute=False)
+        manager.add_imagetool(source_tool, show=False)
+        root = manager._tool_graph.root_wrappers[0]
+        figure_uid = manager.add_figuretool(FigureComposerTool(source), show=False)
+        original_children = list(root._childtool_indices)
+        root._childtool_indices.extend(("missing-child", figure_uid))
+        try:
+            with monkeypatch.context() as context:
+                context.setattr(
+                    manager._tool_graph,
+                    "root_indices_for_workspace",
+                    lambda: (999, 0),
+                )
+                dialog = manager_mainwindow._FigureSourcePickerDialog(manager)
+                qtbot.addWidget(dialog)
+                assert dialog.tree.topLevelItemCount() == 1
+                root_item = dialog.tree.topLevelItem(0)
+                assert root_item is not None
+                assert root_item.childCount() == 0
+        finally:
+            root._childtool_indices[:] = original_children
+
+        assert manager._figure_source_uid_for_target("missing") is None
+        assert manager._figure_imagetool_targets(
+            (0, root.uid, "missing", figure_uid)
+        ) == (0,)
+
+        with monkeypatch.context() as context:
+            context.setattr(
+                manager,
+                "_selected_imagetool_targets",
+                lambda: (0, root.uid, "missing", figure_uid),
+            )
+            assert manager._selected_figure_source_uids() == (root.uid,)
 
 
 def test_remove_child_imagetool_remove_action(

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -290,6 +290,9 @@ def test_drop_mimedata(
 
         # Test single selection, top-level drops
         mime_single = model.mimeData([model.index(0, 0)])
+        assert manager.tree_view.figure_source_uids_from_mime(mime_single) == (
+            model.index(0, 0).internalPointer().uid,
+        )
         assert model.canDropMimeData(
             mime_single, QtCore.Qt.DropAction.MoveAction, 0, 0, QtCore.QModelIndex()
         )
@@ -328,6 +331,12 @@ def test_drop_mimedata(
         old_order = list(parent_wrapper._childtool_indices)
         parent_index: QtCore.QModelIndex = model._row_index(0)
         child_index: QtCore.QModelIndex = model._row_index(child_uid)
+        assert (
+            manager.tree_view.figure_source_uids_from_mime(
+                model.mimeData([child_index])
+            )
+            == ()
+        )
 
         # Drop to different parent
         logger.info("Testing drop to different parent")

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -28,10 +28,12 @@ from erlab.interactive.imagetool.manager._modelview import (
     _FIGURE_SOURCE_MIME,
     _MIME,
     _ImageToolWrapperItemDelegate,
+    _ImageToolWrapperItemModel,
     _RowBadge,
 )
 from erlab.interactive.imagetool.manager._tool_graph import _ManagerToolGraph
 from erlab.interactive.imagetool.manager._workspace_io import _WorkspaceIOController
+from erlab.interactive.imagetool.manager._wrapper import _ImageToolWrapper
 
 from .helpers import (
     assert_nonempty_tooltip,
@@ -40,11 +42,6 @@ from .helpers import (
     select_child_tool,
     select_tools,
 )
-
-if typing.TYPE_CHECKING:
-    from erlab.interactive.imagetool.manager._modelview import (
-        _ImageToolWrapperItemModel,
-    )
 
 logger = logging.getLogger(__name__)
 
@@ -420,10 +417,61 @@ def test_drop_mimedata(
             QtCore.QByteArray(json.dumps({"uids": "not a list"}).encode("utf-8")),
         )
         assert model.decode_figure_source_mime(invalid_source_mime) == ()
-
         missing_child_index = model.createIndex(0, 0, "missing-child")
         missing_child_mime = model.mimeData([missing_child_index])
         assert _MIME not in missing_child_mime.formats()
+
+
+def test_figure_source_mime_filters_duplicates_and_malformed_rows(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _FakeManager(QtWidgets.QWidget):
+        pass
+
+    manager = _FakeManager()
+    qtbot.addWidget(manager)
+    wrapper = _ImageToolWrapper(
+        typing.cast("ImageToolManager", manager),
+        index=0,
+        uid="root-source",
+        tool=None,
+    )
+    manager._tool_graph = types.SimpleNamespace(
+        displayed_indices=[0],
+        root_wrappers={0: wrapper},
+        nodes={"root-source": wrapper},
+    )
+    model = _ImageToolWrapperItemModel(
+        typing.cast("ImageToolManager", manager), manager
+    )
+    root_index = model.index(0, 0)
+    root_uid = root_index.internalPointer().uid
+
+    duplicate_source_mime = model.mimeData([root_index, root_index])
+    assert model.decode_figure_source_mime(duplicate_source_mime) == (root_uid,)
+
+    mixed_source_mime = QtCore.QMimeData()
+    mixed_source_mime.setData(
+        _FIGURE_SOURCE_MIME,
+        QtCore.QByteArray(
+            json.dumps({"uids": ["first", 1, "first", None, "second"]}).encode("utf-8")
+        ),
+    )
+    assert model.decode_figure_source_mime(mixed_source_mime) == (
+        "first",
+        "second",
+    )
+
+    missing_child_index = model.createIndex(0, 0, "missing-child")
+    malformed_parent = model.createIndex(0, 0, object())
+    with monkeypatch.context() as context:
+        context.setattr(
+            type(model),
+            "parent",
+            lambda _self, _index: malformed_parent,
+        )
+        malformed_child_mime = model.mimeData([missing_child_index])
+    assert malformed_child_mime.formats() == []
 
 
 def test_treeview(qtbot, accept_dialog, test_data) -> None:

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -25,6 +25,7 @@ from erlab.interactive.imagetool.manager._actions import _ActionsController
 from erlab.interactive.imagetool.manager._dependency import _ManagerDependencyTracker
 from erlab.interactive.imagetool.manager._dialogs import _NameFilterDialog
 from erlab.interactive.imagetool.manager._modelview import (
+    _FIGURE_SOURCE_MIME,
     _MIME,
     _ImageToolWrapperItemDelegate,
     _RowBadge,
@@ -248,6 +249,10 @@ def test_drop_mimedata(
 
         # Check mimedata
         model = typing.cast("_ImageToolWrapperItemModel", manager.tree_view.model())
+        assert (
+            model.supportedDragActions()
+            == QtCore.Qt.DropAction.MoveAction | QtCore.Qt.DropAction.CopyAction
+        )
 
         # Drop None
         assert not model.canDropMimeData(None, 0, 0, 0, QtCore.QModelIndex())
@@ -399,6 +404,26 @@ def test_drop_mimedata(
             QtCore.QByteArray(json.dumps("not a dict").encode("utf-8")),
         )
         assert model._decode_mime(invalid_mime) is None
+
+        logger.info("Testing invalid Figure Composer source mimedata decoding")
+        assert model.decode_figure_source_mime(None) == ()
+        invalid_source_mime = QtCore.QMimeData()
+        invalid_source_mime.setData(_FIGURE_SOURCE_MIME, QtCore.QByteArray(b"not json"))
+        assert model.decode_figure_source_mime(invalid_source_mime) == ()
+        invalid_source_mime.setData(
+            _FIGURE_SOURCE_MIME,
+            QtCore.QByteArray(json.dumps("not a dict").encode("utf-8")),
+        )
+        assert model.decode_figure_source_mime(invalid_source_mime) == ()
+        invalid_source_mime.setData(
+            _FIGURE_SOURCE_MIME,
+            QtCore.QByteArray(json.dumps({"uids": "not a list"}).encode("utf-8")),
+        )
+        assert model.decode_figure_source_mime(invalid_source_mime) == ()
+
+        missing_child_index = model.createIndex(0, 0, "missing-child")
+        missing_child_mime = model.mimeData([missing_child_index])
+        assert _MIME not in missing_child_mime.formats()
 
 
 def test_treeview(qtbot, accept_dialog, test_data) -> None:

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1932,8 +1932,8 @@ def test_manager_provenance_collects_nested_file_load_targets(
         tmp_path / "b.h5",
     ]
     assert [target.display_text for target in targets] == [
-        "Derived: data_0",
-        "Derived: data_1: nested",
+        "Derived: First",
+        "Derived: Second: Nested",
     ]
 
 
@@ -10914,8 +10914,7 @@ def test_manager_metadata_missing_script_input_uses_neutral_label(qtbot) -> None
     assert input_item is not None
     assert input_item.text() == "Missing source for data_10"
     assert "ImageTool 10" not in input_item.text()
-    assert "Missing source for data_10" in details
-    assert "ImageTool 10" not in details
+    assert "Missing source for data_10 (recorded as ImageTool 10: stale)" in details
 
 
 def test_manager_copy_selected_derivation_code_fallbacks(

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -13553,3 +13553,23 @@ def test_manager_workspace_roundtrip_watched_1d_root_preserves_copy_code_cleanup
 
         assert copied
         _assert_modelfit_code_replays_source(copied[-1], "my_1d", data)
+
+
+def test_manager_dependency_summary_coalesces_matching_input_name_and_label() -> None:
+    """Avoid repeating an input's name when its label is identical."""
+    ref = types.SimpleNamespace(
+        name="data",
+        label="data",
+        node_uid="closed-parent",
+        node_snapshot_token=None,
+    )
+    manager = types.SimpleNamespace(
+        _dependency_refs_for_uid=lambda _uid: (ref,),
+        _tool_graph=types.SimpleNamespace(nodes={}),
+        _dependency_ref_has_recorded_file=lambda _spec, _ref: False,
+    )
+    controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
+
+    assert controller.dependency_input_summary_for_uid("derived") == (
+        "data (parent no longer open)"
+    )

--- a/tests/interactive/imagetool/manager/test_provenance.py
+++ b/tests/interactive/imagetool/manager/test_provenance.py
@@ -1932,8 +1932,8 @@ def test_manager_provenance_collects_nested_file_load_targets(
         tmp_path / "b.h5",
     ]
     assert [target.display_text for target in targets] == [
-        "Derived: First",
-        "Derived: Second: Nested",
+        "Derived: data_0",
+        "Derived: data_1: nested",
     ]
 
 
@@ -10914,7 +10914,8 @@ def test_manager_metadata_missing_script_input_uses_neutral_label(qtbot) -> None
     assert input_item is not None
     assert input_item.text() == "Missing source for data_10"
     assert "ImageTool 10" not in input_item.text()
-    assert "Missing source for data_10 (recorded as ImageTool 10: stale)" in details
+    assert "Missing source for data_10" in details
+    assert "ImageTool 10" not in details
 
 
 def test_manager_copy_selected_derivation_code_fallbacks(

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -15449,6 +15449,109 @@ def test_pending_workspace_lazy_source_data_uses_saved_slicer_dimension_order(
         loaded_ds.close()
 
 
+def test_pending_workspace_saved_dim_order_handles_invalid_state(monkeypatch) -> None:
+    controller_cls = manager_workspace_io._WorkspaceIOController
+    data = xr.DataArray(
+        np.arange(6, dtype=np.float64).reshape((2, 3)),
+        dims=("x", "y"),
+    )
+    valid_state = {"slice": {"dims": ["y", "x"]}}
+
+    reordered = controller_cls._pending_workspace_data_with_saved_dim_order(
+        data, {"itool_state": json.dumps(valid_state).encode()}
+    )
+    assert reordered.dims == ("y", "x")
+    np.testing.assert_array_equal(reordered.values, data.transpose("y", "x").values)
+
+    assert (
+        controller_cls._pending_workspace_data_with_saved_dim_order(
+            data, {"itool_state": b"\xff"}
+        )
+        is data
+    )
+    assert (
+        controller_cls._pending_workspace_data_with_saved_dim_order(
+            data, {"itool_state": "{"}
+        )
+        is data
+    )
+    assert (
+        controller_cls._pending_workspace_data_with_saved_dim_order(
+            data, {"itool_state": "[]"}
+        )
+        is data
+    )
+    assert (
+        controller_cls._pending_workspace_data_with_saved_dim_order(
+            data, {"itool_state": json.dumps({"slice": []})}
+        )
+        is data
+    )
+    assert (
+        controller_cls._pending_workspace_data_with_saved_dim_order(
+            data, {"itool_state": json.dumps({"slice": {"dims": "xy"}})}
+        )
+        is data
+    )
+
+    def _raise_transpose(self: xr.DataArray, *_args, **_kwargs) -> xr.DataArray:
+        raise ValueError("bad dim order")
+
+    monkeypatch.setattr(xr.DataArray, "transpose", _raise_transpose)
+    assert (
+        controller_cls._pending_workspace_data_with_saved_dim_order(
+            data, {"itool_state": json.dumps(valid_state)}
+        )
+        is data
+    )
+
+
+def test_pending_workspace_filter_validation(monkeypatch) -> None:
+    controller_cls = manager_workspace_io._WorkspaceIOController
+    data = xr.DataArray(
+        np.arange(6, dtype=np.float64).reshape((2, 3)),
+        dims=("x", "y"),
+    )
+
+    assert controller_cls._apply_pending_workspace_filter(data, None) is data
+    with pytest.raises(TypeError, match="Invalid pending filter operation"):
+        controller_cls._apply_pending_workspace_filter(data, object())
+
+    class _FakeOperation:
+        def __init__(self, result: xr.DataArray) -> None:
+            self._result = result
+
+        def apply(
+            self, _data: xr.DataArray, *, parent_data: xr.DataArray
+        ) -> xr.DataArray:
+            assert parent_data is data
+            return self._result
+
+    def _set_filter_result(result: xr.DataArray) -> None:
+        monkeypatch.setattr(
+            manager_workspace_io.provenance,
+            "parse_tool_provenance_operation",
+            lambda _payload: _FakeOperation(result),
+        )
+
+    _set_filter_result(data.mean("x"))
+    with pytest.raises(ValueError, match="changed data dimensions"):
+        controller_cls._apply_pending_workspace_filter(data, {})
+
+    _set_filter_result(
+        xr.DataArray(
+            np.arange(8, dtype=np.float64).reshape((2, 4)),
+            dims=("x", "y"),
+        )
+    )
+    with pytest.raises(ValueError, match="changed data shape"):
+        controller_cls._apply_pending_workspace_filter(data, {})
+
+    _set_filter_result(data.transpose("y", "x"))
+    filtered = controller_cls._apply_pending_workspace_filter(data, {})
+    xr.testing.assert_identical(filtered, data)
+
+
 def test_pending_workspace_metadata_coord_load_failure_falls_back(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -15449,6 +15449,72 @@ def test_pending_workspace_lazy_source_data_uses_saved_slicer_dimension_order(
         loaded_ds.close()
 
 
+def test_pending_workspace_lazy_source_data_restores_nonuniform_dimension_order(
+    qtbot, tmp_path
+) -> None:
+    data = xr.DataArray(
+        np.arange(4 * 5 * 3, dtype=np.float64).reshape((4, 5, 3)),
+        dims=("alpha", "eV", "sample_temp"),
+        coords={
+            "alpha": np.linspace(-2.0, 2.0, 4),
+            "eV": np.linspace(-0.5, 0.5, 5),
+            "sample_temp": np.array([249.4, 251.2, 253.8]),
+        },
+        name="pending_nonuniform_order",
+    )
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+    saved = tool.to_dataset()
+    state = json.loads(saved.attrs["itool_state"])
+    assert tuple(state["slice"]["dims"]) == (
+        "alpha",
+        "eV",
+        "sample_temp_idx",
+    )
+
+    stored = xr.Dataset(
+        {
+            manager_workspace_io._ITOOL_DATA_NAME: saved[
+                manager_workspace_io._ITOOL_DATA_NAME
+            ].transpose("sample_temp", "eV", "alpha")
+        },
+        attrs=dict(saved.attrs),
+    )
+    fname = tmp_path / "pending-nonuniform-saved-dim-order.itws"
+    assert manager_workspace._write_workspace_dataset_group_h5py(
+        fname, "0/imagetool", stored
+    )
+    node = types.SimpleNamespace(
+        pending_workspace_memory_payload=(fname, "0/imagetool"),
+        pending_workspace_payload_attrs=None,
+        name=data.name,
+        added_time_display="Today",
+    )
+    controller = manager_workspace_io._WorkspaceIOController(
+        typing.cast("ImageToolManager", None)
+    )
+    reference_datasets = {}
+    try:
+        pending = controller._pending_workspace_lazy_source_data(
+            node,
+            reference_datasets=reference_datasets,
+        )
+        assert pending.dims == tool.slicer_area.data.dims
+        assert pending.chunks is not None
+        xr.testing.assert_identical(
+            erlab.interactive.imagetool.slicer.restore_nonuniform_dims(
+                pending.compute()
+            ),
+            data,
+        )
+        info = controller._pending_workspace_imagetool_info_text(node)
+        assert info is not None
+        assert "sample_temp_idx" not in info
+    finally:
+        controller._close_workspace_reference_datasets(reference_datasets)
+    assert node.pending_workspace_memory_payload == (fname, "0/imagetool")
+
+
 def test_pending_workspace_saved_dim_order_handles_invalid_state(monkeypatch) -> None:
     controller_cls = manager_workspace_io._WorkspaceIOController
     data = xr.DataArray(

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -15384,6 +15384,71 @@ def test_pending_workspace_metadata_loads_only_coords() -> None:
     assert float(loaded.coords["temperature"].values) == 12.0
 
 
+def test_pending_workspace_lazy_source_data_uses_saved_slicer_dimension_order(
+    qtbot, tmp_path
+) -> None:
+    data = xr.DataArray(
+        np.arange(2 * 3 * 4, dtype=np.float64).reshape((2, 3, 4)),
+        dims=("x", "hv", "y"),
+        coords={
+            "x": np.array([0.0, 1.0]),
+            "hv": np.array([10.0, 20.0, 30.0]),
+            "y": np.array([-1.0, 0.0, 1.0, 2.0]),
+        },
+        name="pending_order",
+    )
+    tool = erlab.interactive.imagetool.ImageTool(data)
+    qtbot.addWidget(tool)
+    saved = tool.to_dataset()
+    state = json.loads(saved.attrs["itool_state"])
+    assert tuple(state["slice"]["dims"]) == data.dims
+
+    stored = xr.Dataset(
+        {
+            manager_workspace_io._ITOOL_DATA_NAME: saved[
+                manager_workspace_io._ITOOL_DATA_NAME
+            ].transpose("hv", "y", "x")
+        },
+        attrs=dict(saved.attrs),
+    )
+    fname = tmp_path / "pending-saved-dim-order.itws"
+    assert manager_workspace._write_workspace_dataset_group_h5py(
+        fname, "0/imagetool", stored
+    )
+    node = types.SimpleNamespace(
+        pending_workspace_memory_payload=(fname, "0/imagetool"),
+        pending_workspace_payload_attrs=None,
+        name="pending_order",
+        added_time_display="Today",
+    )
+    controller = manager_workspace_io._WorkspaceIOController(
+        typing.cast("ImageToolManager", None)
+    )
+    reference_datasets = {}
+    try:
+        pending = controller._pending_workspace_lazy_source_data(
+            node,
+            reference_datasets=reference_datasets,
+        )
+        assert pending.dims == data.dims
+        assert pending.chunks is not None
+        np.testing.assert_array_equal(pending.values, data.values)
+    finally:
+        controller._close_workspace_reference_datasets(reference_datasets)
+    assert node.pending_workspace_memory_payload == (fname, "0/imagetool")
+
+    controller_cls = manager_workspace_io._WorkspaceIOController
+    loaded_ds = controller_cls._read_workspace_imagetool_payload_dataset(
+        fname, "0/imagetool", load_data=True
+    )
+    restored = erlab.interactive.imagetool.ImageTool.from_dataset(loaded_ds)
+    qtbot.addWidget(restored)
+    try:
+        assert restored.slicer_area.data.dims == pending.dims
+    finally:
+        loaded_ds.close()
+
+
 def test_pending_workspace_metadata_coord_load_failure_falls_back(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/interactive/imagetool/manager/test_workspace.py
+++ b/tests/interactive/imagetool/manager/test_workspace.py
@@ -15552,6 +15552,38 @@ def test_pending_workspace_filter_validation(monkeypatch) -> None:
     xr.testing.assert_identical(filtered, data)
 
 
+def test_pending_workspace_source_data_decodes_saved_state_attrs(monkeypatch) -> None:
+    controller = manager_workspace_io._WorkspaceIOController.__new__(
+        manager_workspace_io._WorkspaceIOController
+    )
+    data_name = manager_workspace_io._ITOOL_DATA_NAME
+    payload = xr.Dataset(
+        {data_name: xr.DataArray(np.arange(3.0), dims=("x",), name=data_name)}
+    )
+
+    monkeypatch.setattr(
+        controller,
+        "_workspace_imagetool_reference_dataset",
+        lambda *_args, **_kwargs: payload,
+    )
+
+    node = types.SimpleNamespace(
+        name="restored",
+        pending_workspace_payload_attrs={
+            "itool_state": json.dumps({"filter_operation": None}).encode()
+        },
+    )
+    loaded = controller._pending_workspace_lazy_source_data(node)
+    assert loaded.name == "restored"
+    np.testing.assert_array_equal(loaded.values, np.arange(3.0))
+
+    node.pending_workspace_payload_attrs = {"itool_state": "{"}
+    assert controller._pending_workspace_lazy_source_data(node).name == "restored"
+
+    node.pending_workspace_payload_attrs = {"itool_state": "[]"}
+    assert controller._pending_workspace_lazy_source_data(node).name == "restored"
+
+
 def test_pending_workspace_metadata_coord_load_failure_falls_back(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -4261,8 +4261,8 @@ def test_script_provenance_supports_named_console_inputs() -> None:
     assert reparsed == spec
     assert [entry.label for entry in spec.display_entries()] == [
         "Run ImageTool manager console code",
-        "Use data_0",
-        "Use data_1",
+        "Use data_0 from ImageTool 0",
+        "Use data_1 from ImageTool 1",
         "Subtract console inputs",
     ]
     rows = spec.display_rows()
@@ -4460,6 +4460,7 @@ def test_script_input_dependency_refs_recurse_and_rebase() -> None:
             provenance.ScriptInput(
                 name="diff",
                 label="console variable 'diff'",
+                node_uid="",
                 provenance_spec=nested,
             ),
             provenance.ScriptInput(
@@ -4472,10 +4473,12 @@ def test_script_input_dependency_refs_recurse_and_rebase() -> None:
     )
 
     refs = provenance.script_input_dependency_refs(spec)
-    assert [(ref.name, ref.node_uid, ref.node_snapshot_token) for ref in refs] == [
-        ("data_0", "old-left", left_snapshot_id),
-        ("data_1", "old-right", right_snapshot_id),
-        ("data_2", "old-extra", extra_snapshot_id),
+    assert [
+        (ref.name, ref.label, ref.node_uid, ref.node_snapshot_token) for ref in refs
+    ] == [
+        ("data_0", "ImageTool 0", "old-left", left_snapshot_id),
+        ("data_1", "ImageTool 1", "old-right", right_snapshot_id),
+        ("data_2", "ImageTool 2", "old-extra", extra_snapshot_id),
     ]
 
     rebased = provenance.rebase_script_input_node_uids(
@@ -4493,12 +4496,12 @@ def test_script_input_dependency_refs_recurse_and_rebase() -> None:
         "derived = diff + data_2"
     )
     assert [
-        (ref.name, ref.node_uid, ref.node_snapshot_token)
+        (ref.name, ref.label, ref.node_uid, ref.node_snapshot_token)
         for ref in provenance.script_input_dependency_refs(rebased)
     ] == [
-        ("data_0", "new-left", left_snapshot_id),
-        ("data_1", "new-right", right_snapshot_id),
-        ("data_2", "new-extra", extra_snapshot_id),
+        ("data_0", "ImageTool 0", "new-left", left_snapshot_id),
+        ("data_1", "ImageTool 1", "new-right", right_snapshot_id),
+        ("data_2", "ImageTool 2", "new-extra", extra_snapshot_id),
     ]
     assert provenance.script_input_dependency_refs(None) == ()
     assert provenance.rebase_script_input_node_uids(spec, {}) is spec
@@ -4688,7 +4691,7 @@ derived = data
             provenance._validate_script_replay_code(code_snippet)
 
 
-def test_script_input_legacy_label_is_ignored() -> None:
+def test_script_input_label_is_preserved_and_defaults_to_name() -> None:
 
     script_input = provenance.ScriptInput(
         name="data_0",
@@ -4696,9 +4699,28 @@ def test_script_input_legacy_label_is_ignored() -> None:
     )
 
     assert script_input.name == "data_0"
-    assert "label" not in script_input.model_dump()
-    assert not hasattr(script_input, "label")
-    assert provenance.ScriptInput(name="data_0", label="\n  \t").name == "data_0"
+    assert script_input.label == "ImageTool 0: processed data"
+    assert script_input.model_dump()["label"] == "ImageTool 0: processed data"
+    assert provenance.ScriptInput(name="data_0").label == "data_0"
+    assert provenance.ScriptInput(name="data_0", label=None).label == "data_0"
+
+    node_marker = "snapshot"
+    assert provenance.ScriptInputDependencyRef(
+        "data_0", "ImageTool 0", "node", node_marker
+    ) == provenance.ScriptInputDependencyRef(
+        name="data_0",
+        label="ImageTool 0",
+        node_uid="node",
+        node_snapshot_token=node_marker,
+    )
+    legacy_dependency = provenance.ScriptInputDependencyRef("data_0", "", "")
+    assert legacy_dependency.label == ""
+    assert legacy_dependency.node_uid == ""
+
+    with pytest.raises(TypeError, match="script input label"):
+        provenance.ScriptInput(name="data_0", label=1)
+    with pytest.raises(ValidationError):
+        provenance.ScriptInput(name="data_0", label="\n  \t")
 
 
 def test_replay_script_provenance_uses_resolved_inputs_without_mutating() -> None:

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -4261,8 +4261,8 @@ def test_script_provenance_supports_named_console_inputs() -> None:
     assert reparsed == spec
     assert [entry.label for entry in spec.display_entries()] == [
         "Run ImageTool manager console code",
-        "Use data_0 from ImageTool 0",
-        "Use data_1 from ImageTool 1",
+        "Use data_0",
+        "Use data_1",
         "Subtract console inputs",
     ]
     rows = spec.display_rows()
@@ -4489,7 +4489,6 @@ def test_script_input_dependency_refs_recurse_and_rebase() -> None:
 
     assert [source.name for source in rebased.script_inputs] == ["diff", "data_2"]
     assert rebased.script_inputs[1].node_uid == "new-extra"
-    assert rebased.script_inputs[1].label == "ImageTool 2"
     assert typing.cast("str", rebased.operations[-1].derivation_entry().code) == (
         "derived = diff + data_2"
     )
@@ -4633,10 +4632,6 @@ derived = data
 
     with pytest.raises(ValidationError):
         provenance.ScriptInput(name=None, label="Input")
-    with pytest.raises(TypeError, match="script input label"):
-        provenance.ScriptInput(name="data_0", label=1)
-    with pytest.raises(ValidationError):
-        provenance.ScriptInput(name="data_0", label="   ")
     with pytest.raises(ValidationError):
         provenance.ScriptInput(name="data_0", label="Input", node_snapshot_token="")
     with pytest.raises(TypeError, match="script input provenance"):
@@ -4693,16 +4688,17 @@ derived = data
             provenance._validate_script_replay_code(code_snippet)
 
 
-def test_script_input_label_is_single_line_display_text() -> None:
+def test_script_input_legacy_label_is_ignored() -> None:
 
     script_input = provenance.ScriptInput(
         name="data_0",
         label="  ImageTool 0:\n\n  processed data  ",
     )
 
-    assert script_input.label == "ImageTool 0: processed data"
-    with pytest.raises(ValidationError):
-        provenance.ScriptInput(name="data_0", label="\n  \t")
+    assert script_input.name == "data_0"
+    assert "label" not in script_input.model_dump()
+    assert not hasattr(script_input, "label")
+    assert provenance.ScriptInput(name="data_0", label="\n  \t").name == "data_0"
 
 
 def test_replay_script_provenance_uses_resolved_inputs_without_mutating() -> None:

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -1569,7 +1569,11 @@ def test_replay_graph_emit_reports_script_rewrite_syntax_errors(monkeypatch) -> 
     source_key = graph.add_node(
         "source",
         "file_load",
-        payload={"active_name": "loaded", "load_code": "loaded = data"},
+        payload={
+            "active_name": "loaded",
+            "load_code": "loaded = data",
+            "load_source": _file_replay_source("source.nc"),
+        },
     )
     graph.output_key = graph.add_node(
         "script",
@@ -2210,6 +2214,29 @@ def test_replay_graph_script_nodes_are_not_deduplicated() -> None:
         namespace["derived"],
         xr.DataArray([11.0, 22.0], dims=["x"]),
     )
+
+
+def test_replay_graph_does_not_hoist_imports_from_user_script_code() -> None:
+    spec = provenance.script(
+        provenance.ScriptCodeOperation(
+            label="User code",
+            code=(
+                "events.append('before')\n"
+                "import statistics\n"
+                "events.append('after')\n"
+                "fig = statistics.fmean([1.0, 2.0])"
+            ),
+        ),
+        start_label="Build result",
+        seed_code="events = []",
+        active_name="fig",
+    )
+
+    code = typing.cast("str", spec.display_code())
+    assert code.index("events.append") < code.index("import statistics")
+    namespace = _exec_generated_code(code)
+    assert namespace["events"] == ["before", "after"]
+    assert namespace["fig"] == 1.5
 
 
 def test_replay_graph_allows_for_loop_script_code() -> None:

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -1,6 +1,7 @@
 import ast
 import pathlib
 import re
+import textwrap
 import types
 import typing
 from collections.abc import Mapping
@@ -2304,6 +2305,178 @@ def test_group_framework_imports_places_future_imports_first() -> None:
     assert code.startswith("from __future__ import annotations\n")
     namespace = _exec_generated_code(code)
     assert namespace["__annotations__"] == {"second": "MissingType | None"}
+
+
+def test_replay_import_helpers_preserve_nonhoistable_imports() -> None:
+    source = (
+        "import numpy as np\n"
+        "from xarray import DataArray as Array\n"
+        "result = Array(np.asarray([1.0]))"
+    )
+    imports, body = _replay_graph._leading_top_level_imports(source)
+
+    assert imports == [
+        ("import numpy as np", "import numpy as np"),
+        (
+            "from xarray import DataArray as Array",
+            "from xarray import DataArray as Array",
+        ),
+    ]
+    assert body == "result = Array(np.asarray([1.0]))"
+    assert _replay_graph._leading_top_level_imports("if True:\n") == (
+        [],
+        "if True:\n",
+    )
+    assert _replay_graph._leading_top_level_imports("value = 1") == ([], "value = 1")
+    commented_import = "import numpy as np  # preserve this comment\nvalue = np"
+    assert _replay_graph._leading_top_level_imports(commented_import) == (
+        [],
+        commented_import,
+    )
+
+    assert _replay_graph._import_binding_targets("import numpy.linalg") == {
+        "numpy": "module:numpy"
+    }
+    assert _replay_graph._import_binding_targets(
+        "import numpy.linalg as linalg, xarray as xr"
+    ) == {"linalg": "module:numpy.linalg", "xr": "module:xarray"}
+    assert _replay_graph._import_binding_targets(
+        "from ..package import item as alias"
+    ) == {"alias": "from:..package:item"}
+    assert (
+        _replay_graph._import_binding_targets("from __future__ import annotations")
+        == {}
+    )
+    assert _replay_graph._import_binding_targets("from package import *") is None
+    assert (
+        _replay_graph._import_binding_targets(
+            "from package import first as item, second as item"
+        )
+        is None
+    )
+    assert (
+        _replay_graph._import_binding_targets(
+            "import numpy as module, xarray as module"
+        )
+        is None
+    )
+    assert _replay_graph._is_future_import("from __future__ import annotations")
+    assert not _replay_graph._is_future_import("import numpy as np")
+
+
+def test_replay_import_helpers_preserve_imports_without_ast_locations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import_node = ast.Import(names=[ast.alias(name="numpy")])
+    import_node.lineno = 1
+    import_node.col_offset = 0
+    import_node.end_lineno = None
+    import_node.end_col_offset = None
+    module = ast.Module(body=[import_node], type_ignores=[])
+    monkeypatch.setattr(_replay_graph.ast, "parse", lambda *_args, **_kwargs: module)
+
+    assert _replay_graph._leading_top_level_imports("import numpy") == (
+        [],
+        "import numpy",
+    )
+
+
+def test_replay_import_helpers_track_names_bound_by_python_constructs() -> None:
+    accessed, rebound = _replay_graph._code_name_accesses(
+        textwrap.dedent(
+            """\
+            import numpy as np
+            from package import *
+            def helper():
+                pass
+            class Result:
+                pass
+            value = np
+            del value
+            try:
+                raise error_type
+            except error_type as caught:
+                handled = caught
+            try:
+                raise error_type
+            except:
+                handled_without_name = True
+            match subject:
+                case [head, *tail] as whole:
+                    matched = whole
+                case {"key": item, **remaining}:
+                    mapped = remaining
+            """
+        )
+    )
+
+    assert {
+        "*",
+        "Result",
+        "caught",
+        "head",
+        "helper",
+        "remaining",
+        "tail",
+        "value",
+        "whole",
+    } <= accessed
+    assert {
+        "*",
+        "Result",
+        "caught",
+        "head",
+        "helper",
+        "remaining",
+        "tail",
+        "value",
+        "whole",
+    } <= rebound
+    assert _replay_graph._code_name_accesses("if value:\n") == ({"*"}, {"*"})
+
+
+def test_group_framework_imports_keeps_unsafe_and_rebound_imports_local() -> None:
+    code = _replay_graph._group_framework_imports(
+        (
+            (
+                "from __future__ import annotations\nfrom package import *\nfirst = 1",
+                True,
+            ),
+            (
+                "from __future__ import annotations\nsecond: MissingType | None = None",
+                True,
+            ),
+            ("import numpy as np\nthird = np.asarray([3.0])", True),
+        )
+    )
+
+    assert code.count("from __future__ import annotations") == 1
+    assert code.index("from package import *") < code.index("first = 1")
+    assert code.index("first = 1") < code.index("import numpy as np")
+    assert code.index("import numpy as np") < code.index("third =")
+
+    rebound_code = _replay_graph._group_framework_imports(
+        (
+            ("import numpy as np\nfirst = np.asarray([1.0])", True),
+            ("np = 'changed'", False),
+            ("import numpy as np\nsecond = np.asarray([2.0])", True),
+        )
+    )
+    assert rebound_code.count("import numpy as np") == 2
+    assert rebound_code.index("first =") < rebound_code.index("np = 'changed'")
+    assert rebound_code.index("np = 'changed'") < rebound_code.rindex(
+        "import numpy as np"
+    )
+
+    non_framework_code = "import numpy as np\nvalue = np.asarray([1.0])"
+    assert (
+        _replay_graph._group_framework_imports(((non_framework_code, False),))
+        == non_framework_code
+    )
+    assert (
+        _replay_graph._group_framework_imports((("import numpy as np", True),))
+        == "import numpy as np"
+    )
 
 
 def test_replay_graph_allows_for_loop_script_code() -> None:

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -2239,6 +2239,73 @@ def test_replay_graph_does_not_hoist_imports_from_user_script_code() -> None:
     assert namespace["fig"] == 1.5
 
 
+def test_group_framework_imports_preserves_conflicting_alias_bindings() -> None:
+    code = _replay_graph._group_framework_imports(
+        (
+            (
+                "import xarray as array_module\n"
+                "first = array_module.DataArray([1.0], dims=['x'])",
+                True,
+            ),
+            (
+                "import numpy as array_module\nsecond = array_module.asarray([2.0])",
+                True,
+            ),
+        )
+    )
+
+    assert code.index("import xarray") < code.index("first =")
+    assert code.index("first =") < code.index("import numpy")
+    assert code.index("import numpy") < code.index("second =")
+    namespace = _exec_generated_code(code)
+    xr.testing.assert_identical(namespace["first"], xr.DataArray([1.0], dims=["x"]))
+    np.testing.assert_array_equal(namespace["second"], np.asarray([2.0]))
+
+
+def test_group_framework_imports_deduplicates_canonical_aliases() -> None:
+    code = _replay_graph._group_framework_imports(
+        (
+            ("import numpy as np\nfirst = np.asarray([1.0])", True),
+            ("import numpy as np\nsecond = np.asarray([2.0])", True),
+        )
+    )
+
+    assert code.count("import numpy as np") == 1
+    namespace = _exec_generated_code(code)
+    np.testing.assert_array_equal(namespace["first"], np.asarray([1.0]))
+    np.testing.assert_array_equal(namespace["second"], np.asarray([2.0]))
+
+
+def test_group_framework_imports_preserves_rebinding_before_import() -> None:
+    code = _replay_graph._group_framework_imports(
+        (
+            ("np = 'sentinel'\nfirst = np", True),
+            ("import numpy as np\nsecond = np.asarray([2.0])", True),
+        )
+    )
+
+    assert code.index("first =") < code.index("import numpy as np")
+    namespace = _exec_generated_code(code)
+    assert namespace["first"] == "sentinel"
+    np.testing.assert_array_equal(namespace["second"], np.asarray([2.0]))
+
+
+def test_group_framework_imports_places_future_imports_first() -> None:
+    code = _replay_graph._group_framework_imports(
+        (
+            ("import numpy as np\nfirst = np.asarray([1.0])", True),
+            (
+                "from __future__ import annotations\nsecond: MissingType | None = None",
+                True,
+            ),
+        )
+    )
+
+    assert code.startswith("from __future__ import annotations\n")
+    namespace = _exec_generated_code(code)
+    assert namespace["__annotations__"] == {"second": "MissingType | None"}
+
+
 def test_replay_graph_allows_for_loop_script_code() -> None:
     spec = provenance.script(
         provenance.ScriptCodeOperation(

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -516,6 +516,17 @@ def test_goldtool_handles_missing_cpu_count(qtbot, gold, monkeypatch) -> None:
     assert cpu_widget.maximum() == 1
 
 
+def test_goldtool_cancel_background_work_stops_pending_update(qtbot, gold) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    win._pending_update_timer.start(1000)
+
+    assert win._pending_update_timer.isActive()
+    assert win._cancel_background_work(timeout_ms=0)
+    assert not win._pending_update_timer.isActive()
+
+
 def test_goldtool_duplicate_roundtrip(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
     qtbot.addWidget(win)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -19,6 +19,7 @@ from qtpy import PYQT6, QtCore, QtGui, QtTest, QtWidgets
 import erlab.interactive.utils
 from erlab.interactive.imagetool import provenance
 from erlab.interactive.imagetool.manager._modelview import (
+    _FIGURE_SOURCE_MIME,
     _MIME,
     _NODE_UID_ROLE,
     _TOOL_TYPE_ROLE,
@@ -3728,7 +3729,7 @@ def test_imagetool_wrapper_item_model_child_edge_branches(qtbot, monkeypatch) ->
     assert model.parent(child_index).internalPointer() is parent_node
     assert model.rowCount(nonzero_column_index) == 0
     assert not model.hasChildren(nonzero_column_index)
-    assert model.mimeTypes() == [_MIME]
+    assert model.mimeTypes() == [_MIME, _FIGURE_SOURCE_MIME]
     with pytest.raises(KeyError):
         model._childtool_uid(0, "missing-parent")
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -915,6 +915,60 @@ def test_wait_dialog_constructor_failure_does_not_suppress_later_dialogs(
         assert isinstance(dialog, erlab.interactive.utils._WaitDialog)
 
 
+def test_set_widget_cursor_skips_native_cursor_updates_on_macos(
+    qtbot, monkeypatch
+) -> None:
+    class CursorWidget(QtWidgets.QWidget):
+        def setCursor(self, cursor: object) -> None:
+            del cursor
+            raise AssertionError("setCursor should not be called on macOS")
+
+        def unsetCursor(self) -> None:
+            raise AssertionError("unsetCursor should not be called on macOS")
+
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", "darwin")
+    widget = CursorWidget()
+    qtbot.addWidget(widget)
+
+    erlab.interactive.utils.set_widget_cursor(
+        widget, QtCore.Qt.CursorShape.SizeAllCursor
+    )
+    erlab.interactive.utils.set_widget_cursor(
+        widget, QtCore.Qt.CursorShape.SizeAllCursor
+    )
+    erlab.interactive.utils.set_widget_cursor(widget, None)
+
+    assert not widget.testAttribute(QtCore.Qt.WidgetAttribute.WA_SetCursor)
+
+
+def test_set_widget_cursor_keeps_idempotent_native_updates(qtbot, monkeypatch) -> None:
+    calls: list[object | None] = []
+
+    class CursorWidget(QtWidgets.QWidget):
+        def setCursor(self, cursor: object) -> None:
+            calls.append(cursor)
+            self.setAttribute(QtCore.Qt.WidgetAttribute.WA_SetCursor, True)
+
+        def unsetCursor(self) -> None:
+            calls.append(None)
+            self.setAttribute(QtCore.Qt.WidgetAttribute.WA_SetCursor, False)
+
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", "linux")
+    widget = CursorWidget()
+    qtbot.addWidget(widget)
+
+    erlab.interactive.utils.set_widget_cursor(
+        widget, QtCore.Qt.CursorShape.SizeAllCursor
+    )
+    erlab.interactive.utils.set_widget_cursor(
+        widget, QtCore.Qt.CursorShape.SizeAllCursor
+    )
+    erlab.interactive.utils.set_widget_cursor(widget, None)
+    erlab.interactive.utils.set_widget_cursor(widget, None)
+
+    assert calls == [QtCore.Qt.CursorShape.SizeAllCursor, None]
+
+
 def test_single_shot_ignores_pyside_deleted_wrapper_error(qtbot) -> None:
     widget = QtWidgets.QWidget()
     qtbot.addWidget(widget)


### PR DESCRIPTION
## Summary
- Treat Figure Composer sources as named data variables with editable source-level selections.
- Add manager-backed source insertion and drag/drop source addition from ImageTool rows.
- Clean up generated replay code and modernize source/recipe row actions with drag reorder plus context-menu commands.

## Notes
- This is stacked on `imagetool-workspace-save-optimizations` so the diff stays focused on Figure Composer behavior.
- The branch includes manager integration needed for ImageTool-backed source capture and refresh paths.

## Validation
- `QT_API=pyside6 uv run pytest tests/interactive/imagetool/manager/figurecomposer/test_sources.py tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py tests/interactive/imagetool/manager/figurecomposer/test_manager.py -q`
- `QT_API=pyside6 uv run pytest tests/interactive/imagetool/manager/test_modelview.py -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`
