### PR TITLE
feat(interactive): reveal managed windows in manager

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -40,7 +40,8 @@ Use {guilabel}`Add…` to select ImageTool rows from the manager. You can also d
 ImageTool rows from the manager into the composer controls or figure window.
 
 Select one or more sources and use {guilabel}`Refresh` to update them from their
-ImageTools.
+ImageTools. Use {guilabel}`Reveal in Manager` to select their ImageTool rows and bring
+ImageTool Manager to the front.
 
 When you choose {guilabel}`Add to Figure…` from ImageTool Manager, the corresponding
 ImageTool rows are added to the figure sources. In that dialog, different choices for

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -667,6 +667,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._source_refresh_available_callback: Callable[[str], bool] | None = None
         self._source_refresh_callback: Callable[[str], bool] | None = None
         self._source_refresh_label_callback: Callable[[str], str | None] | None = None
+        self._source_reveal_available_callback: Callable[[str], bool] | None = None
+        self._source_reveal_callback: Callable[[Sequence[str]], bool] | None = None
         self._source_add_available_callback: Callable[[], bool] | None = None
         self._source_add_callback: Callable[[], bool] | None = None
         self._source_drop_available_callback: (
@@ -1607,6 +1609,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._remove_selected_sources
         )
         source_actions_layout.addWidget(self.remove_selected_source_button)
+        self.reveal_sources_button = _step_toolbar_button(
+            self.source_actions,
+            "figureComposerRevealSourcesButton",
+            "Reveal in Manager",
+            "Reveal selected sources in ImageTool Manager",
+        )
+        self.reveal_sources_button.setAccessibleName(
+            "Reveal Selected Sources in ImageTool Manager"
+        )
+        self.reveal_sources_button.clicked.connect(self._reveal_selected_sources)
+        source_actions_layout.addWidget(self.reveal_sources_button)
         source_actions_layout.addStretch(1)
         self.refresh_sources_button = QtWidgets.QToolButton(self.source_actions)
         self.refresh_sources_button.setObjectName("figureComposerRefreshSourcesButton")
@@ -2264,6 +2277,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._source_refresh_label_callback = source_label
         self.refresh_source_controls()
 
+    def _set_source_reveal_callbacks(
+        self,
+        *,
+        can_reveal_source: Callable[[str], bool] | None = None,
+        reveal_sources: Callable[[Sequence[str]], bool] | None = None,
+    ) -> None:
+        self._source_reveal_available_callback = can_reveal_source
+        self._source_reveal_callback = reveal_sources
+        self.refresh_source_controls()
+
     def _set_source_add_callbacks(
         self,
         *,
@@ -2587,6 +2610,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             return bool(self._source_refresh_available_callback(name))
         return False
 
+    def _source_reveal_available(self, name: str) -> bool:
+        if (
+            self._source_reveal_available_callback is None
+            or self._source_reveal_callback is None
+        ):
+            return False
+        with contextlib.suppress(LookupError, RuntimeError, ValueError):
+            return bool(self._source_reveal_available_callback(name))
+        return False
+
     def _source_refresh_label(self, name: str) -> str | None:
         if self._source_refresh_label_callback is None:
             return None
@@ -2624,6 +2657,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.refresh_sources_button.setEnabled(bool(selected_refreshable))
         self.refresh_sources_button.setToolTip(selected_tip)
         self.refresh_sources_button.setStatusTip(self.refresh_sources_button.toolTip())
+        selected_revealable = tuple(
+            name for name in selected_names if self._source_reveal_available(name)
+        )
+        reveal_tip = (
+            "Reveal selected sources in ImageTool Manager"
+            if selected_revealable
+            else "No selected sources are associated with an ImageTool Manager row"
+        )
+        self.reveal_sources_button.setEnabled(bool(selected_revealable))
+        self.reveal_sources_button.setToolTip(reveal_tip)
+        self.reveal_sources_button.setStatusTip(reveal_tip)
 
         removable_selected = [
             name for name in selected_names if self._source_removable(name)
@@ -2661,6 +2705,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     @QtCore.Slot()
     def _refresh_selected_sources_from_button(self) -> None:
         self._refresh_source_names(self._selected_source_names())
+
+    @QtCore.Slot()
+    def _reveal_selected_sources(self) -> None:
+        callback = self._source_reveal_callback
+        source_names = tuple(
+            name
+            for name in self._selected_source_names()
+            if self._source_reveal_available(name)
+        )
+        if callback is None or not source_names:
+            self._refresh_source_controls()
+            return
+        callback(source_names)
+        self._refresh_source_controls()
 
     @QtCore.Slot()
     def _refresh_all_sources_from_button(self) -> None:
@@ -3167,9 +3225,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         menu.addAction(move_down_action)
 
         menu.addSeparator()
+        reveal_action = QtGui.QAction("Reveal in Manager", menu)
+        reveal_action.setObjectName("figureComposerContextRevealSourceAction")
+        selected_names = self._selected_source_names()
+        reveal_action.setEnabled(
+            any(self._source_reveal_available(name) for name in selected_names)
+        )
+        reveal_action.triggered.connect(self._reveal_selected_sources)
+        menu.addAction(reveal_action)
+
         refresh_action = QtGui.QAction("Refresh Selected", menu)
         refresh_action.setObjectName("figureComposerContextRefreshSourceAction")
-        selected_names = self._selected_source_names()
         refresh_action.setEnabled(
             any(self._source_refresh_available(name) for name in selected_names)
         )

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -408,6 +408,7 @@ class ImageTool(BaseImageTool):
         super().__init__(data, **kwargs)
         self.__recent_name_filter: str | None = None
         self.__recent_directory: str | None = None
+        self._managed_reveal_callback: Callable[[], bool] | None = None
 
         self._dask_menu = erlab.interactive._dask.DaskMenu(self, "Dask")
         self._history_menu = erlab.interactive.imagetool._history.HistoryMenu(
@@ -469,6 +470,14 @@ class ImageTool(BaseImageTool):
         self.remove_act.triggered.connect(self.slicer_area.remove_from_manager)
         self.remove_act.setVisible(self.slicer_area._in_manager)
 
+        self.reveal_in_manager_act = QtWidgets.QAction(
+            "Reveal in ImageTool Manager", self
+        )
+        self.reveal_in_manager_act.setObjectName("itool_reveal_in_manager_action")
+        self.reveal_in_manager_act.setIcon(QtGui.QIcon.fromTheme("go-jump"))
+        self.reveal_in_manager_act.setVisible(False)
+        self.reveal_in_manager_act.triggered.connect(self._reveal_in_manager)
+
         self.toggle_controls_act = QtWidgets.QAction("Show Controls", self)
         self.toggle_controls_act.setCheckable(True)
         self.toggle_controls_act.setChecked(self.controls_visible)
@@ -485,6 +494,33 @@ class ImageTool(BaseImageTool):
             self.hide()
         else:
             self.close()
+
+    def _set_managed_reveal_callback(self, callback: Callable[[], bool] | None) -> None:
+        """Set the manager-owned callback that reveals this window's row."""
+        self._managed_reveal_callback = callback
+        if not erlab.interactive.utils.qt_is_valid(self):  # pragma: no cover
+            # Deleted Qt wrappers are binding-dependent during manager teardown.
+            return
+        available = callback is not None
+        if erlab.interactive.utils.qt_is_valid(
+            self.reveal_in_manager_act
+        ):  # pragma: no branch
+            self.reveal_in_manager_act.setVisible(available)
+        menu = getattr(self.menuBar(), "menu_dict", {}).get("windowMenu")
+        if isinstance(menu, QtWidgets.QMenu) and erlab.interactive.utils.qt_is_valid(
+            menu
+        ):  # pragma: no branch
+            menu_action = menu.menuAction()
+            if menu_action is not None and erlab.interactive.utils.qt_is_valid(
+                menu_action
+            ):  # pragma: no branch
+                menu_action.setVisible(available)
+
+    @QtCore.Slot()
+    def _reveal_in_manager(self) -> None:
+        callback = self._managed_reveal_callback
+        if callback is not None:
+            callback()
 
     @property
     def mnb(self) -> ItoolMenuBar:
@@ -797,6 +833,12 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
                     },
                 },
             },
+            "windowMenu": {
+                "title": "&Window",
+                "actions": {
+                    "revealInManagerAct": self.image_tool.reveal_in_manager_act,
+                },
+            },
             "daskMenu": {"menu": self.image_tool._dask_menu},
             "helpMenu": {
                 "title": "&Help",
@@ -873,6 +915,9 @@ class ItoolMenuBar(erlab.interactive.utils.DictMenuBar):
     def createMenus(self) -> None:
         menu_kwargs = self._generate_menu_kwargs()
         self.add_items(**menu_kwargs)
+        typing.cast(
+            "QtGui.QAction", self.menu_dict["windowMenu"].menuAction()
+        ).setVisible(False)
 
         # Disable/Enable menus based on context
         self.menu_dict["fileMenu"].aboutToShow.connect(self._file_menu_visibility)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -3028,6 +3028,14 @@ class ImageToolManager(_ImageToolManagerBase):
                 figure_uid, source_name
             ),
         )
+        tool._set_source_reveal_callbacks(
+            can_reveal_source=lambda source_name: self._can_reveal_figure_source(
+                figure_uid, source_name
+            ),
+            reveal_sources=lambda source_names: self._reveal_figure_sources(
+                figure_uid, source_names
+            ),
+        )
         tool._set_source_add_callbacks(
             can_add_sources=functools.partial(
                 self._can_request_add_sources_to_figure, figure_uid
@@ -3109,6 +3117,26 @@ class ImageToolManager(_ImageToolManagerBase):
             # Invalid Qt wrappers are binding- and lifetime-dependent.
             return None  # pragma: no cover
         return node
+
+    def _can_reveal_figure_source(self, figure_uid: str, source_name: str) -> bool:
+        node = self._figure_source_node(figure_uid, source_name)
+        return node is not None and node.is_imagetool
+
+    def _reveal_figure_sources(
+        self, figure_uid: str, source_names: Sequence[str]
+    ) -> bool:
+        if not self._is_figure_uid(figure_uid):
+            return False
+        uids = tuple(
+            dict.fromkeys(
+                node.uid
+                for source_name in source_names
+                if (node := self._figure_source_node(figure_uid, source_name))
+                is not None
+                and node.is_imagetool
+            )
+        )
+        return self.reveal_nodes(uids)
 
     def _can_refresh_figure_source(self, figure_uid: str, source_name: str) -> bool:
         return self._figure_source_live_node(figure_uid, source_name) is not None
@@ -4883,6 +4911,77 @@ class ImageToolManager(_ImageToolManagerBase):
         self, uid: str, parent_data: xr.DataArray | None = None
     ) -> None:
         self._lineage_controller._propagate_source_change_from_uid(uid, parent_data)
+
+    def reveal_nodes(self, uids: Iterable[str]) -> bool:
+        """Reveal manager nodes in their corresponding manager collection."""
+        nodes: list[_ImageToolWrapper | _ManagedWindowNode] = []
+        seen: set[str] = set()
+        for uid in uids:
+            node = self._tool_graph.nodes.get(uid)
+            if node is None or uid in seen:
+                continue
+            nodes.append(node)
+            seen.add(uid)
+        if not nodes:
+            return False
+
+        first_is_figure = self._is_figure_node(nodes[0])
+        nodes = [
+            node for node in nodes if self._is_figure_node(node) == first_is_figure
+        ]
+        focus_widget: QtWidgets.QWidget
+        if first_is_figure:
+            self._sync_figures_ui()
+            self.tree_view.deselect_all()
+            self.figure_list.clearSelection()
+            items = [
+                typing.cast(
+                    "QtWidgets.QListWidgetItem",
+                    self._figure_list_item_for_uid(node.uid),
+                )
+                for node in nodes
+            ]
+            self.figure_list.setCurrentItem(items[0])
+            for item in items:
+                item.setSelected(True)
+            self.left_tabs.setCurrentWidget(self.figure_tab)
+            self.figure_list.scrollToItem(items[0])
+            focus_widget = self.figure_list
+            self._update_actions()
+            self._update_info()
+        else:
+            indexes = [self.tree_view._model._row_index(node.uid) for node in nodes]
+            for index in indexes:
+                parent = index.parent()
+                while parent.isValid():
+                    self.tree_view.expand(parent)
+                    parent = parent.parent()
+            selection = QtCore.QItemSelection()
+            for index in indexes:
+                selection.select(index, index)
+            selection_model = self.tree_view.selectionModel()
+            if selection_model is None:  # pragma: no cover
+                return False
+            selection_model.select(
+                selection,
+                QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect
+                | QtCore.QItemSelectionModel.SelectionFlag.Rows,
+            )
+            selection_model.setCurrentIndex(
+                indexes[0], QtCore.QItemSelectionModel.SelectionFlag.NoUpdate
+            )
+            self.left_tabs.setCurrentWidget(self.tree_view)
+            self.tree_view.scrollTo(indexes[0])
+            focus_widget = self.tree_view
+
+        if self.isMinimized():
+            self.showNormal()
+        elif not self.isVisible():
+            self.show()
+        self.raise_()
+        self.activateWindow()
+        focus_widget.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+        return True
 
     def show_selected(self) -> None:
         self._lineage_controller.show_selected()

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -518,6 +518,7 @@ class _ManagedWindowNode(QtCore.QObject):
             old._set_managed_source_update_dialog(None)
             old._set_managed_source_reload(None)
             old._set_managed_secondary_window_callback(None)
+            old._set_managed_reveal_callback(None)
             old.set_source_parent_fetcher(None)
             old.set_input_provenance_parent_fetcher(None)
             old.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
@@ -550,6 +551,7 @@ class _ManagedWindowNode(QtCore.QObject):
             )
             value.slicer_area._in_manager = True
             value.remove_act.setVisible(True)
+            value._set_managed_reveal_callback(self.reveal_in_manager)
             for plot in value.slicer_area._materialized_axes():
                 plot.ensure_manager_figure_actions()
             return
@@ -574,6 +576,7 @@ class _ManagedWindowNode(QtCore.QObject):
         tool._set_managed_secondary_window_callback(
             self._configure_tool_secondary_window
         )
+        tool._set_managed_reveal_callback(self.reveal_in_manager)
         for secondary_window, _title in tool._managed_secondary_windows():
             self._configure_tool_secondary_window(secondary_window)
 
@@ -645,6 +648,15 @@ class _ManagedWindowNode(QtCore.QObject):
                 ),
             )
 
+    def reveal_in_manager(self) -> bool:
+        """Reveal this node in its manager window."""
+        manager = self._manager()
+        if manager is None or not erlab.interactive.utils.qt_is_valid(manager):
+            return False
+        if manager._tool_graph.nodes.get(self.uid) is not self:
+            return False
+        return manager.reveal_nodes((self.uid,))
+
     def _handle_tool_window_destroyed(self, _obj: QtCore.QObject | None = None) -> None:
         manager = self._manager()
         if manager is None or not erlab.interactive.utils.qt_is_valid(manager):
@@ -680,6 +692,7 @@ class _ManagedWindowNode(QtCore.QObject):
             old.slicer_area.sigSourceDataReplaced.disconnect(
                 self._handle_source_data_replaced
             )
+        old._set_managed_reveal_callback(None)
         if close:
             old.close()
         self._imagetool = None

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3349,6 +3349,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._managed_secondary_window_callback: (
             Callable[[QtWidgets.QWidget], None] | None
         ) = None
+        self._managed_reveal_callback: Callable[[], bool] | None = None
         self._output_imagetool_targets: dict[str, str | QtWidgets.QWidget] = {}
         self._save_tool_data_references = False
         self._save_tool_data_reference_node_uids: frozenset[str] | None = None
@@ -3407,6 +3408,21 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self.redo_action.triggered.connect(self.redo)
         self._tool_edit_menu.addAction(self.redo_action)
         self._update_history_actions()
+
+        self._tool_window_menu = typing.cast(
+            "QtWidgets.QMenu", menu_bar.addMenu("&Window")
+        )
+        self._tool_window_menu.setObjectName("tool_window_menu")
+        self.reveal_in_manager_action = QtWidgets.QAction(
+            "Reveal in ImageTool Manager", self
+        )
+        self.reveal_in_manager_action.setObjectName("tool_reveal_in_manager_action")
+        self.reveal_in_manager_action.setIcon(QtGui.QIcon.fromTheme("go-jump"))
+        self.reveal_in_manager_action.triggered.connect(self._reveal_in_manager)
+        self._tool_window_menu.addAction(self.reveal_in_manager_action)
+        typing.cast("QtGui.QAction", self._tool_window_menu.menuAction()).setVisible(
+            False
+        )
 
         # Enable closing with keyboard shortcut
         self.__close_shortcut = QtWidgets.QShortcut("Ctrl+W", self, self._hide_or_close)
@@ -4625,6 +4641,28 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     ) -> None:
         """Set the manager-owned callback for secondary tool windows."""
         self._managed_secondary_window_callback = callback
+
+    def _set_managed_reveal_callback(self, callback: Callable[[], bool] | None) -> None:
+        """Set the manager-owned callback that reveals this window's row."""
+        self._managed_reveal_callback = callback
+        if not qt_is_valid(self):  # pragma: no cover
+            # Deleted Qt wrappers are binding-dependent during manager teardown.
+            return
+        available = callback is not None
+        if qt_is_valid(self.reveal_in_manager_action):  # pragma: no branch
+            self.reveal_in_manager_action.setVisible(available)
+        if qt_is_valid(self._tool_window_menu):  # pragma: no branch
+            menu_action = self._tool_window_menu.menuAction()
+            if menu_action is not None and qt_is_valid(
+                menu_action
+            ):  # pragma: no branch
+                menu_action.setVisible(available)
+
+    @QtCore.Slot()
+    def _reveal_in_manager(self) -> None:
+        callback = self._managed_reveal_callback
+        if callback is not None:
+            callback()
 
     def _configure_managed_secondary_window(self, window: QtWidgets.QWidget) -> None:
         """Apply manager-owned behavior to a secondary tool window."""

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager.py
@@ -3276,6 +3276,74 @@ def test_manager_figure_action_replace_source_keeps_recipe_steps(
         assert "second" not in figure_tool.source_data()
 
 
+def test_manager_figure_sources_reveal_associated_imagetool_rows(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        first = xr.DataArray(
+            np.arange(4.0).reshape(2, 2), dims=("x", "y"), name="first"
+        )
+        second = xr.DataArray(
+            np.arange(4.0, 8.0).reshape(2, 2), dims=("x", "y"), name="second"
+        )
+        itool(first, manager=True)
+        itool(second, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0, 1), show=False)
+        assert figure_uid is not None
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        assert not manager._reveal_figure_sources("missing", ("first",))
+
+        def raise_reveal_error(_source_name: str) -> bool:
+            raise RuntimeError("source is unavailable")
+
+        original_reveal_available = figure_tool._source_reveal_available_callback
+        figure_tool._source_reveal_available_callback = raise_reveal_error
+        assert not figure_tool._source_reveal_available("first")
+        figure_tool._source_reveal_available_callback = original_reveal_available
+
+        figure_tool._set_selected_source_names_silent({"first"}, "first")
+        figure_tool._duplicate_selected_sources()
+        source_names = {source.name for source in figure_tool.source_states()}
+        figure_tool._set_selected_source_names_silent(source_names, "first")
+        figure_tool._refresh_source_controls()
+        assert figure_tool.reveal_sources_button.isEnabled()
+        assert not figure_tool.reveal_sources_button.autoRaise()
+        assert (
+            figure_tool.reveal_sources_button.toolButtonStyle()
+            == QtCore.Qt.ToolButtonStyle.ToolButtonTextOnly
+        )
+
+        figure_tool.reveal_sources_button.click()
+
+        assert manager.tree_view.selected_imagetool_indices == [0, 1]
+        assert manager.left_tabs.currentWidget() is manager.tree_view
+
+        manager.tree_view.clearSelection()
+        figure_tool._show_source_context_menu(QtCore.QPoint(0, 0))
+        assert figure_tool._source_context_menu is not None
+        reveal_action = next(
+            action
+            for action in figure_tool._source_context_menu.actions()
+            if action.objectName() == "figureComposerContextRevealSourceAction"
+        )
+        assert reveal_action.isEnabled()
+        reveal_action.trigger()
+        assert manager.tree_view.selected_imagetool_indices == [0, 1]
+        figure_tool._source_context_menu.close()
+
+        manager.remove_imagetool(1)
+        figure_tool._set_selected_source_names_silent({"second"}, "second")
+        figure_tool._refresh_source_controls()
+        assert not figure_tool.reveal_sources_button.isEnabled()
+        figure_tool._reveal_selected_sources()
+
+
 def test_manager_figure_source_row_refresh_updates_only_selected_source(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -153,6 +153,117 @@ def _selection_shortcut_sequences(
     }
 
 
+def test_managed_window_actions_reveal_tree_and_figure_rows(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    standalone_imagetool = typing.cast(
+        "erlab.interactive.imagetool.ImageTool",
+        itool(test_data, manager=False, execute=False),
+    )
+    qtbot.addWidget(standalone_imagetool)
+    standalone_imagetool_menu = typing.cast(
+        "erlab.interactive.imagetool._mainwindow.ItoolMenuBar",
+        standalone_imagetool.menuBar(),
+    )
+    assert (
+        not standalone_imagetool_menu.menu_dict["windowMenu"].menuAction().isVisible()
+    )
+    standalone_imagetool._reveal_in_manager()
+
+    standalone_tool = erlab.interactive.utils.ToolWindow()
+    qtbot.addWidget(standalone_tool)
+    assert not standalone_tool._tool_window_menu.menuAction().isVisible()
+    standalone_tool._reveal_in_manager()
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, test_data, test_data + 1)
+        root_tool = manager.get_imagetool(0)
+        second_uid = manager._tool_graph.root_wrappers[1].uid
+
+        child_tool = erlab.interactive.utils.ToolWindow()
+        child_uid = manager.add_childtool(child_tool, 0, show=False)
+        figure_tool = FigureComposerTool(test_data)
+        figure_uid = manager.add_figuretool(figure_tool, show=False)
+
+        root_menu = typing.cast(
+            "erlab.interactive.imagetool._mainwindow.ItoolMenuBar",
+            root_tool.menuBar(),
+        ).menu_dict["windowMenu"]
+        assert root_menu.menuAction().isVisible()
+        assert root_tool.reveal_in_manager_act in root_menu.actions()
+        assert child_tool._tool_window_menu.menuAction().isVisible()
+        assert figure_tool._tool_window_menu.menuAction().isVisible()
+
+        manager.tree_view.clearSelection()
+        root_tool.reveal_in_manager_act.trigger()
+        assert manager.tree_view.selected_imagetool_indices == [0]
+        assert manager.left_tabs.currentWidget() is manager.tree_view
+
+        child_index = manager.tree_view._model._row_index(child_uid)
+        manager.tree_view.collapse(child_index.parent())
+        child_tool.reveal_in_manager_action.trigger()
+        assert manager.tree_view.selected_childtool_uids == [child_uid]
+        assert manager.tree_view.isExpanded(child_index.parent())
+
+        assert manager.reveal_nodes((child_uid, second_uid, child_uid, "missing"))
+        assert manager.tree_view.selected_imagetool_indices == [1]
+        assert manager.tree_view.selected_childtool_uids == [child_uid]
+        assert not manager.reveal_nodes(("missing",))
+
+        figure_tool.reveal_in_manager_action.trigger()
+        assert manager.left_tabs.currentWidget() is manager.figure_tab
+        selected_figure_uids = {
+            manager._figure_uid_from_item(item)
+            for item in manager.figure_list.selectedItems()
+        }
+        assert selected_figure_uids == {figure_uid}
+        assert not manager.tree_view.selectedIndexes()
+
+        child_node = manager._child_node(child_uid)
+        manager_ref = child_node._manager
+        child_node._manager = lambda: None
+        assert not child_node.reveal_in_manager()
+        child_node._manager = manager_ref
+        manager._remove_childtool(child_uid)
+        assert not child_node.reveal_in_manager()
+        assert not child_tool.reveal_in_manager_action.isVisible()
+
+
+def test_reveal_nodes_restores_minimized_manager(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, test_data)
+        calls: list[str] = []
+        monkeypatch.setattr(manager, "isMinimized", lambda: True)
+        monkeypatch.setattr(manager, "showNormal", lambda: calls.append("normal"))
+        monkeypatch.setattr(manager, "raise_", lambda: calls.append("raise"))
+        monkeypatch.setattr(manager, "activateWindow", lambda: calls.append("activate"))
+
+        assert manager.reveal_nodes((manager._tool_graph.root_wrappers[0].uid,))
+
+        assert calls == ["normal", "raise", "activate"]
+
+        calls.clear()
+        monkeypatch.setattr(manager, "isMinimized", lambda: False)
+        monkeypatch.setattr(manager, "isVisible", lambda: False)
+        monkeypatch.setattr(manager, "show", lambda: calls.append("show"))
+
+        assert manager.reveal_nodes((manager._tool_graph.root_wrappers[0].uid,))
+
+        assert calls == ["show", "raise", "activate"]
+
+
 def test_manager_open_settings_reuses_live_dialog(
     qtbot,
     manager_context: Callable[


### PR DESCRIPTION
## Summary

- add a Window menu command that reveals managed ImageTool, analysis tool, and Figure Composer windows in ImageTool Manager
- select and scroll to nested Data/Tools rows or the corresponding Figures entry, then restore and focus the manager
- add an outlined Reveal in Manager action to Figure Composer sources, including multi-source selection and deduplication

## Why

When many managed windows are open, it can be difficult to find the row or figure associated with the active window or a Figure Composer source. This adds an explicit, user-initiated navigation path back to the manager.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `QT_API=pyqt6 uv run --group pyqt6 mypy src`
- affected ImageTool Manager and Figure Composer tests under PyQt6: 178 passed
- targeted feature tests under PySide6
- changed-line and branch coverage for the feature
- `uv run --directory docs make html`