### PR TITLE
Support readonly arrays in fast binning and DA30 slice extraction

### DIFF
--- a/src/erlab/interactive/imagetool/fastbinning.py
+++ b/src/erlab/interactive/imagetool/fastbinning.py
@@ -28,42 +28,27 @@ if importlib.util.find_spec("numbagg"):
 
 # _SIG_M_N is the list of signatures that reduces from M to N dimensions.
 
-_SIG_2_1 = [
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float32, 2, "C")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float32, 2, "A")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float64, 2, "C")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float64, 2, "A")),
-]
-_SIG_3_1 = [
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float32, 3, "C")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float32, 3, "A")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float64, 3, "C")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float64, 3, "A")),
-]
-_SIG_3_2 = [
-    numba.types.Array(numba.float64, 2, "C")(numba.types.Array(numba.float32, 3, "C")),
-    numba.types.Array(numba.float64, 2, "C")(numba.types.Array(numba.float32, 3, "A")),
-    numba.types.Array(numba.float64, 2, "C")(numba.types.Array(numba.float64, 3, "C")),
-    numba.types.Array(numba.float64, 2, "C")(numba.types.Array(numba.float64, 3, "A")),
-]
-_SIG_4_1 = [
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float32, 4, "C")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float32, 4, "A")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float64, 4, "C")),
-    numba.types.Array(numba.float64, 1, "C")(numba.types.Array(numba.float64, 4, "A")),
-]
-_SIG_4_2 = [
-    numba.types.Array(numba.float64, 2, "C")(numba.types.Array(numba.float32, 4, "C")),
-    numba.types.Array(numba.float64, 2, "C")(numba.types.Array(numba.float32, 4, "A")),
-    numba.types.Array(numba.float64, 2, "C")(numba.types.Array(numba.float64, 4, "C")),
-    numba.types.Array(numba.float64, 2, "C")(numba.types.Array(numba.float64, 4, "A")),
-]
-_SIG_4_3 = [
-    numba.types.Array(numba.float64, 3, "C")(numba.types.Array(numba.float32, 4, "C")),
-    numba.types.Array(numba.float64, 3, "C")(numba.types.Array(numba.float32, 4, "A")),
-    numba.types.Array(numba.float64, 3, "C")(numba.types.Array(numba.float64, 4, "C")),
-    numba.types.Array(numba.float64, 3, "C")(numba.types.Array(numba.float64, 4, "A")),
-]
+
+def _nanmean_signatures(input_ndim: int, output_ndim: int) -> list[typing.Any]:
+    output_type = numba.types.Array(numba.float64, output_ndim, "C")
+    return [
+        output_type(input_type)
+        for dtype in (numba.float32, numba.float64)
+        for input_type in (
+            numba.types.Array(dtype, input_ndim, "C"),
+            # A readonly signature accepts both writable and readonly arrays. Keep the
+            # C signature writable to avoid ambiguous overloads for writable C arrays.
+            numba.types.Array(dtype, input_ndim, "A", readonly=True),
+        )
+    ]
+
+
+_SIG_2_1 = _nanmean_signatures(2, 1)
+_SIG_3_1 = _nanmean_signatures(3, 1)
+_SIG_3_2 = _nanmean_signatures(3, 2)
+_SIG_4_1 = _nanmean_signatures(4, 1)
+_SIG_4_2 = _nanmean_signatures(4, 2)
+_SIG_4_3 = _nanmean_signatures(4, 3)
 
 
 @numba.njit(cache=True)

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -1,3 +1,5 @@
+import zipfile
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -12,6 +14,7 @@ from erlab.interactive.imagetool.slicer import (
     qsel_args_from_indexers,
     restore_nonuniform_dims,
 )
+from erlab.io.plugins.da30 import load_zip
 
 
 def test_nonuniform_axes_ignores_user_idx_dim(qtbot) -> None:
@@ -338,6 +341,48 @@ def test_bin_along_multiaxis_point_value_single_binned_axis_reduces_1d(qtbot) ->
     result = slicer._bin_along_multiaxis(0, (0, 1, 2))
 
     assert result == np.nanmean(values[1, 1:4, 3])
+
+
+def test_da30_zip_readonly_array_binning(qtbot, tmp_path) -> None:
+    values = np.arange(3 * 5 * 7, dtype=np.float32).reshape(3, 5, 7)
+    zip_path = tmp_path / "data.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr(
+            "Spectrum_R1.ini",
+            """[spectrum]
+depth = 3
+depthoffset = 0
+depthdelta = 1
+depthlabel = a
+height = 5
+heightoffset = 0
+heightdelta = 1
+heightlabel = b
+width = 7
+widthoffset = 0
+widthdelta = 1
+widthlabel = c
+name = data
+""",
+        )
+        zf.writestr("R1.ini", "[attrs]\n")
+        zf.writestr("Spectrum_R1.bin", values.tobytes())
+
+    data = load_zip(zip_path)
+    assert isinstance(data, xr.DataArray)
+    assert not data.values.flags.writeable
+    slicer = ArraySlicer(data, parent=QtCore.QObject())
+    assert not slicer._obj.values.flags.writeable
+    assert np.shares_memory(data.values, slicer._obj.values)
+    selected = slicer._obj.values[:, 1:4, :]
+    assert not selected.flags.c_contiguous
+    assert not selected.flags.f_contiguous
+    slicer.set_indices(0, [1, 2, 3], update=False)
+    slicer.set_bin(0, 1, 3, update=False)
+
+    result = slicer.extract_avg_slice(0, (1,))
+
+    np.testing.assert_allclose(result, np.nanmean(values[:, 1:4, :], axis=1))
 
 
 def test_get_binned_cache_tracks_bin_updates_and_axis_swaps(qtbot) -> None:

--- a/tests/interactive/test_fastbinning.py
+++ b/tests/interactive/test_fastbinning.py
@@ -31,6 +31,37 @@ def test_fast_nanmean_signature() -> None:
                 )
 
 
+@pytest.mark.parametrize("dtype", [np.float32, np.float64], ids=["float32", "float64"])
+@pytest.mark.parametrize("layout", ["C", "A"], ids=["contiguous", "strided"])
+@pytest.mark.parametrize(
+    ("shape", "axis"),
+    [
+        ((4, 5), 0),
+        ((4, 5, 6), 1),
+        ((4, 5, 6), (0, 2)),
+        ((4, 5, 6, 7), 2),
+        ((4, 5, 6, 7), (0, 2)),
+        ((4, 5, 6, 7), (0, 2, 3)),
+    ],
+    ids=["2d-1-axis", "3d-1-axis", "3d-2-axis", "4d-1-axis", "4d-2-axis", "4d-3-axis"],
+)
+def test_fast_nanmean_readonly(dtype, layout, shape, axis) -> None:
+    base_shape = (*shape[:-1], shape[-1] * (2 if layout == "A" else 1))
+    values = np.random.RandomState(42).randn(*base_shape).astype(dtype)
+    if layout == "A":
+        values = values[..., ::2]
+        assert not values.flags.c_contiguous
+        assert not values.flags.f_contiguous
+    values[(0,) * values.ndim] = np.nan
+    values.setflags(write=False)
+
+    result = fast_nanmean(values, axis=axis)
+    expected = np.nanmean(values.astype(np.float64), axis=axis).astype(dtype)
+
+    assert not values.flags.writeable
+    np.testing.assert_allclose(result, expected, rtol=1e-7, atol=0)
+
+
 def test_fast_nanmean_5d() -> None:
     x = np.random.RandomState(42).randn(3, 4, 5, 6, 7).astype(np.float64)
     # Test with different axes


### PR DESCRIPTION
## Summary
- Replaced hard-coded nanmean signature lists with a generator that includes readonly array overloads for 2D-4D inputs.
- Added coverage for readonly `fast_nanmean` across float32/float64, contiguous and strided layouts, and multiple reduction axes.
- Added a regression test for DA30 ZIP-loaded readonly arrays to verify binning and averaging still work without writeable backing storage.

## Testing
- Added targeted unit tests for readonly binning and fast nanmean signature coverage.
- Not run (not requested).