### PR TITLE
fix(io): resolve inherited file dialog filters

### DIFF
--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -1316,6 +1316,13 @@ def file_loaders(
         Dictionary of file loaders. The keys are name filters(argument to
         :meth:`QtWidgets.QFileDialog.setNameFilter`), and the values are tuples of the
         loader function and additional keyword arguments.
+
+    Notes
+    -----
+    When a loader and its subclasses provide the same name filter through inheritance,
+    the base loader owns the filter. Subclasses should provide a filter with a different
+    name to avoid conflicts. Duplicate filters from separate loader hierarchies raise a
+    ValueError.
     """
     valid_loaders: dict[str, tuple[Callable, dict]] = {
         "xarray HDF5 Files (*.h5)": (xr.load_dataarray, {"engine": "h5netcdf"}),
@@ -1336,11 +1343,34 @@ def file_loaders(
             {"engine": "zarr", "chunks": "auto"},
         )
 
+    candidates: dict[
+        str,
+        list[tuple[str, object, tuple[Callable, dict]]],
+    ] = collections.defaultdict(list)
+    for loader_name in erlab.io.loaders:
+        loader = erlab.io.loaders[loader_name]
+        for name_filter, method in loader.file_dialog_methods.items():
+            candidates[name_filter].append((loader_name, loader, method))
+
     additional_loaders: dict[str, tuple[Callable, dict]] = {}
-    for k in erlab.io.loaders:
-        additional_loaders = (
-            additional_loaders | erlab.io.loaders[k].file_dialog_methods
-        )
+    for name_filter, filter_candidates in candidates.items():
+        most_general = [
+            candidate
+            for candidate in filter_candidates
+            if all(
+                isinstance(other_loader, type(candidate[1]))
+                for _, other_loader, _ in filter_candidates
+            )
+        ]
+        if not most_general:
+            loader_names = ", ".join(
+                sorted(loader_name for loader_name, _, _ in filter_candidates)
+            )
+            raise ValueError(
+                f"Conflicting file dialog filter {name_filter!r} implemented by "
+                f"loader plugins: {loader_names}"
+            )
+        additional_loaders[name_filter] = most_general[0][2]
 
     valid_loaders = valid_loaders | dict(sorted(additional_loaders.items()))
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -57,6 +57,83 @@ def _exec_generated_code(
     return locals_ns
 
 
+@pytest.mark.parametrize(
+    "order",
+    [(0, 1, 2), (1, 2, 0), (2, 0, 1)],
+)
+def test_file_loaders_prefers_most_general(
+    monkeypatch,
+    order: tuple[int, int, int],
+) -> None:
+    name_filter = "Test files (*.test)"
+
+    class BaseLoader:
+        @property
+        def file_dialog_methods(self):
+            return {name_filter: (self.load, {})}
+
+        def load(self) -> None:
+            pass
+
+    class FirstLoader(BaseLoader):
+        pass
+
+    class SecondLoader(BaseLoader):
+        pass
+
+    loaders = [
+        ("base", BaseLoader()),
+        ("first", FirstLoader()),
+        ("second", SecondLoader()),
+    ]
+    registry = dict(loaders[index] for index in order)
+    monkeypatch.setattr(erlab.io, "loaders", registry)
+
+    func, kwargs = erlab.interactive.utils.file_loaders()[name_filter]
+
+    assert func.__self__ is registry["base"]
+    assert kwargs == {}
+
+
+def test_file_loaders_rejects_ambiguous_filter(monkeypatch) -> None:
+    name_filter = "Test files (*.test)"
+
+    class BaseLoader:
+        @property
+        def file_dialog_methods(self):
+            return {name_filter: (self.load, {})}
+
+        def load(self) -> None:
+            pass
+
+    class FirstLoader(BaseLoader):
+        pass
+
+    class SecondLoader(BaseLoader):
+        pass
+
+    monkeypatch.setattr(
+        erlab.io,
+        "loaders",
+        {"first": FirstLoader(), "second": SecondLoader()},
+    )
+
+    with pytest.raises(ValueError, match="Conflicting file dialog filter"):
+        erlab.interactive.utils.file_loaders()
+
+
+def test_file_loaders_resolve_da30_filter_to_da30() -> None:
+    da30_loader = erlab.io.loaders["da30"]
+    name_filter = next(iter(da30_loader.file_dialog_methods))
+
+    for loader_name in ("esm", "kriss"):
+        assert name_filter in erlab.io.loaders[loader_name].file_dialog_methods
+
+    func, _ = erlab.interactive.utils.file_loaders()[name_filter]
+
+    assert func.__self__ is da30_loader
+
+
 class _PersistentToolState(pydantic.BaseModel):
     value: int = 0
 


### PR DESCRIPTION
## Summary

- resolve shared file-dialog filters through the base loader when subclasses inherit the same filter
- reject conflicting filter names implemented by loaders from separate class hierarchies
- add order-independent regression coverage, including the DA30/ESM/KRISS case

## Why

`DA30Loader`, `ESMLoader`, and `KRISSLoader` all exposed the inherited `DA30 Raw Data` filter. The previous alphabetical dictionary merge left the filter bound to `KRISSLoader`, so data selected as DA30 was tagged with `data_loader_name="kriss"` and received KRISS-specific processing.

The new resolution is based on loader inheritance rather than registry order, keeping the dialog entry bound to `DA30Loader`.

## Validation

- `uv run pytest tests/interactive/test_utils.py` — 163 passed
- `uv run ruff format --check src/erlab/interactive/utils.py tests/interactive/test_utils.py`
- `uv run ruff check src/erlab/interactive/utils.py tests/interactive/test_utils.py`
- `uv run mypy src`
