### PR TITLE
fix(interactive): keep colormap thumbnails visible

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices.py
@@ -3339,8 +3339,8 @@ def _build_plot_slices_editor(
         cmap_combo.setObjectName("figureComposerCmapCombo")
         cmap_combo.setToolTip("Colormap passed to plot_slices.")
         cmap_combo.default_cmap = None if cmap_mixed else cmap_base
+        cmap_combo.ensure_populated()
         with QtCore.QSignalBlocker(cmap_combo):
-            cmap_combo.ensure_populated()
             if cmap_mixed:
                 tool._set_combo_mixed_placeholder(cmap_combo)
             else:

--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -110,7 +110,9 @@ class ColorMapComboBox(QtWidgets.QComboBox):
 
     @QtCore.Slot()
     def _populate(self) -> None:
-        if not erlab.interactive.utils.qt_is_valid(self):  # pragma: no cover
+        if self._populated or not erlab.interactive.utils.qt_is_valid(
+            self
+        ):  # pragma: no cover
             return
         self._populated = True
         with QtCore.QSignalBlocker(self):
@@ -118,7 +120,7 @@ class ColorMapComboBox(QtWidgets.QComboBox):
                 self._add_colormap_item(name)
             if self.default_cmap is not None:
                 self.setCurrentText(self.default_cmap)
-                self.load_thumbnail(self.currentIndex())
+            self.load_thumbnail(self.currentIndex())
         self.blockSignals(False)
 
     def ensure_populated(self) -> None:
@@ -129,13 +131,14 @@ class ColorMapComboBox(QtWidgets.QComboBox):
     def clear(self) -> None:
         with QtCore.QSignalBlocker(self):
             super().clear()
+        self.thumbnails_loaded = False
 
     def showEvent(self, event: QtGui.QShowEvent | None) -> None:
         super().showEvent(event)
         if not self._populated:
             erlab.interactive.utils.single_shot(self, 0, self._populate)
 
-    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:  # pragma: no cover
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         self.blockSignals(True)
         super().closeEvent(event)
 
@@ -145,12 +148,13 @@ class ColorMapComboBox(QtWidgets.QComboBox):
             self._menu.popup(self.mapToGlobal(position))
 
     def load_thumbnail(self, index: int) -> None:
-        if not self.thumbnails_loaded and 0 <= index < self.count():
+        if 0 <= index < self.count() and self.itemIcon(index).isNull():
             text = self.itemText(index)
             with contextlib.suppress(RuntimeError):
                 self.setItemIcon(index, QtGui.QIcon(pg_colormap_to_QPixmap(text)))
 
     def load_all(self) -> None:
+        self.ensure_populated()
         current_data = self.currentData()
         current_colormap = (
             current_data if isinstance(current_data, str) else self.currentText()
@@ -162,7 +166,6 @@ class ColorMapComboBox(QtWidgets.QComboBox):
             self.clear()
             for name in pg_colormap_names("all", exclude_local=True):
                 self._add_colormap_item(name)
-            self.thumbnails_loaded = False
             if current_colormap:
                 restored_current = self._set_current_text_if_available(current_colormap)
             if not restored_current:
@@ -173,6 +176,7 @@ class ColorMapComboBox(QtWidgets.QComboBox):
     def _add_colormap_item(self, name: str, icon: QtGui.QIcon | None = None) -> None:
         matplotlib_name = matplotlib_colormap_name(name)
         if icon is None:
+            self.thumbnails_loaded = False
             self.addItem(name, matplotlib_name)
         else:
             self.addItem(icon, name, matplotlib_name)
@@ -197,6 +201,7 @@ class ColorMapComboBox(QtWidgets.QComboBox):
 
     # https://forum.qt.io/topic/105012/qcombobox-specify-width-less-than-content/11
     def showPopup(self) -> None:
+        self.ensure_populated()
         maxWidth = self.maximumWidth()
         if maxWidth and maxWidth < 16777215:  # default maxwidth of QWidgets
             self.setPopupMinimumWidthForItems()
@@ -264,6 +269,11 @@ class ColorMapComboBox(QtWidgets.QComboBox):
             return
         if self.count():
             self.setCurrentIndex(0)
+
+    def setCurrentIndex(self, index: int) -> None:
+        """Set the current index and ensure its thumbnail is available."""
+        super().setCurrentIndex(index)
+        self.load_thumbnail(self.currentIndex())
 
     def current_matplotlib_name(self) -> str:
         """Return the selected colormap name as registered by Matplotlib."""

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -575,7 +575,7 @@ def test_colormap_thumbnail_pixmap_normalizes_colorcet_cache_key(qtbot) -> None:
     assert cache_info.misses == 1
 
 
-def test_colormap_combobox_load_all_defers_thumbnail_rendering(
+def test_colormap_combobox_load_all_only_renders_current_thumbnail(
     qtbot, monkeypatch
 ) -> None:
     rendered: list[str] = []
@@ -589,15 +589,78 @@ def test_colormap_combobox_load_all_defers_thumbnail_rendering(
     )
     combo = ColorMapComboBox()
     qtbot.addWidget(combo)
+    combo.setDefaultCmap("viridis")
+    combo.ensure_populated()
+    rendered.clear()
 
     combo.load_all()
 
     assert combo.count() == len(pg_colormap_names("all", exclude_local=True))
-    assert rendered == []
+    assert combo.currentText() == "viridis"
+    assert not combo.itemIcon(combo.currentIndex()).isNull()
+    assert rendered == ["viridis"]
 
-    combo.load_thumbnail(0)
+    other_index = next(i for i in range(combo.count()) if i != combo.currentIndex())
+    combo.load_thumbnail(other_index)
 
-    assert rendered == [combo.itemText(0)]
+    assert rendered == ["viridis", combo.itemText(other_index)]
+
+
+def test_colormap_combobox_blocked_updates_keep_thumbnail_and_signal_state(
+    qtbot,
+) -> None:
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+    combo.setDefaultCmap("viridis")
+
+    assert combo.signalsBlocked()
+    combo.ensure_populated()
+    assert not combo.signalsBlocked()
+    assert combo.currentText() == "viridis"
+    assert not combo.itemIcon(combo.currentIndex()).isNull()
+
+    with QtCore.QSignalBlocker(combo):
+        combo.setCurrentText("magma")
+    assert not combo.signalsBlocked()
+    assert combo.currentText() == "magma"
+    assert not combo.itemIcon(combo.currentIndex()).isNull()
+
+
+def test_colormap_combobox_close_blocks_teardown_signals(qtbot) -> None:
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+    combo.show()
+
+    assert combo.close()
+    assert combo.signalsBlocked()
+
+
+def test_colormap_combobox_popup_populates_once_before_loading_thumbnails(
+    qtbot, monkeypatch
+) -> None:
+    rendered: list[str] = []
+
+    def record_thumbnail(name, *args, **kwargs):
+        rendered.append(name)
+        return QtGui.QPixmap(64, 16)
+
+    monkeypatch.setattr(
+        erlab.interactive.colors, "pg_colormap_to_QPixmap", record_thumbnail
+    )
+    monkeypatch.setattr(QtWidgets.QComboBox, "showPopup", lambda self: None)
+    combo = ColorMapComboBox()
+    qtbot.addWidget(combo)
+
+    combo.showPopup()
+    count = combo.count()
+
+    assert count == len(pg_colormap_names("matplotlib", exclude_local=True))
+    assert rendered == [combo.itemText(i) for i in range(count)]
+    assert all(not combo.itemIcon(i).isNull() for i in range(count))
+
+    combo._populate()
+
+    assert combo.count() == count
 
 
 def test_colormap_combobox_load_all_keeps_current_selection(qtbot) -> None:


### PR DESCRIPTION
## Summary

- keep the selected colormap thumbnail visible after signal-blocked state updates and loading additional colormaps
- make lazy colormap population idempotent and populate before opening the popup
- preserve signal blocking for hidden/closing ImageTools while avoiding a permanently blocked Figure Composer selector
- add regressions for thumbnail restoration, blocked updates, teardown signaling, and popup population

## Root cause

`ColorMapComboBox` created items without icons and relied on `currentIndexChanged` to generate the selected thumbnail. Selection restoration and several Figure Composer synchronization paths deliberately block signals, so the visible item could retain a null icon. The initial signal block could also be restored by an outer `QSignalBlocker`, leaving that selector permanently blocked.

## Validation

- `uv run pytest -q -n auto --dist=loadgroup ...`: 4,723 passed, 1 skipped (excluding two pre-existing macOS cursor assertions reproduced on pristine `HEAD`)
- PyQt6 `cov-qt-ux` shape with coverage and xdist: 361 passed
- complete Figure Composer suite under PyQt6: 583 passed
- compatibility targets under PySide6: 709 passed
- complete Figure Composer suite under PySide6 with coverage: 583 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run python -m scripts.ci_test_groups --check-partition`
