### PR TITLE
fix(manager): support deferred tool duplication and linking

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -51,6 +51,10 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _DuplicateMaterializationError(RuntimeError):
+    """A workspace payload already reported its materialization failure."""
+
+
 class _ActionsController:
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager = manager
@@ -129,6 +133,8 @@ class _ActionsController:
                     QtCore.QItemSelection(qmodelindex, qmodelindex),
                     QtCore.QItemSelectionModel.SelectionFlag.Select,
                 )
+        except _DuplicateMaterializationError:
+            return
         except Exception:
             self._manager._show_operation_error(
                 "Error while duplicating selected windows",
@@ -713,70 +719,123 @@ class _ActionsController:
         """Rename the ImageTool window corresponding to the given index."""
         self._manager._tool_graph.root_wrappers[index].name = str(new_name)
 
+    def _materialize_duplicate_subtree(self, target: int | str) -> None:
+        node = self._manager._node_for_target(target)
+        if not node.materialize_pending_workspace_payload():
+            raise _DuplicateMaterializationError(
+                f"Could not materialize {node.display_text!r} for duplication"
+            )
+        for child_uid in tuple(node._childtool_indices):
+            self._materialize_duplicate_subtree(child_uid)
+
+    def _discard_duplicated_subtree(self, target: int | str) -> None:
+        if isinstance(target, int):
+            self._manager.remove_imagetool(target)
+        else:
+            self._manager._remove_childtool(target)
+
+    def _finish_duplicated_subtree(self, target: int | str) -> None:
+        node = self._manager._node_for_target(target)
+        duplicated_uids = self._manager._tool_graph.subtree_uids(node.uid)
+        if self._manager._is_figure_node(node):
+            self._manager._figure_collection.select_uid(node.uid)
+        for uid in duplicated_uids:
+            self._manager._tool_graph.nodes[uid].show()
+        for uid in duplicated_uids:
+            self._manager._mark_node_added(uid)
+
+    def _duplicate_target(self, target: int | str) -> int | str:
+        self._materialize_duplicate_subtree(target)
+        workspace_state_snapshot = self._manager._workspace_state.snapshot(
+            node_uid_counter=self._manager._tool_graph.uid_counter
+        )
+        duplicated: int | str | None = None
+        try:
+            with self._manager._workspace_load_context():
+                duplicated = self._manager._duplicate_subtree(target)
+            self._finish_duplicated_subtree(duplicated)
+        except Exception:
+            try:
+                if duplicated is not None:
+                    with self._manager._workspace_load_context():
+                        self._discard_duplicated_subtree(duplicated)
+            finally:
+                self._manager._workspace_state.restore(workspace_state_snapshot)
+                self._manager._update_workspace_window_title()
+            raise
+        return duplicated
+
     def _duplicate_subtree(
         self, target: int | str, *, parent_override: int | str | None = None
     ) -> int | str:
         node = self._manager._node_for_target(target)
-        if node.is_imagetool:
-            persistence = node.persistence_view()
-            duplicated_window = self._manager.get_imagetool(target).duplicate(
-                _in_manager=True
-            )
-            if isinstance(node, _ImageToolWrapper):
-                new_target: int | str = self._manager.add_imagetool(
-                    duplicated_window,
-                    activate=True,
-                    source_input_ndim=node.source_input_ndim,
-                    provenance_spec=persistence.provenance_spec,
-                    source_spec=persistence.source_spec,
-                    source_binding=persistence.source_binding,
-                    source_auto_update=persistence.source_auto_update,
-                    source_state=persistence.source_state,
-                    note=node.note,
+        new_target: int | str | None = None
+        try:
+            if node.is_imagetool:
+                persistence = node.persistence_view()
+                duplicated_window = self._manager.get_imagetool(target).duplicate(
+                    _in_manager=True
                 )
-            else:
-                parent_target = (
-                    parent_override
-                    if parent_override is not None
-                    else (self._manager._parent_node(node).uid)
-                )
-                new_target = self._manager.add_imagetool_child(
-                    duplicated_window,
-                    parent_target,
-                    activate=True,
-                    provenance_spec=persistence.provenance_spec,
-                    source_spec=persistence.source_spec,
-                    source_binding=persistence.source_binding,
-                    source_auto_update=persistence.source_auto_update,
-                    source_state=persistence.source_state,
-                    output_id=persistence.output_id,
-                    note=node.note,
-                )
-        else:
-            tool = typing.cast("erlab.interactive.utils.ToolWindow", node.tool_window)
-            if node.parent_uid is None and self._manager._is_figure_node(node):
-                duplicated_tool = tool.duplicate()
-                duplicated_tool._tool_display_name = (
-                    self._manager._figure_collection.duplicated_display_name(
-                        node.display_text
+                if isinstance(node, _ImageToolWrapper):
+                    new_target = self._manager.add_imagetool(
+                        duplicated_window,
+                        show=False,
+                        source_input_ndim=node.source_input_ndim,
+                        provenance_spec=persistence.provenance_spec,
+                        source_spec=persistence.source_spec,
+                        source_binding=persistence.source_binding,
+                        source_auto_update=persistence.source_auto_update,
+                        source_state=persistence.source_state,
+                        note=node.note,
                     )
-                )
-                new_target = self._manager.add_figuretool(
-                    duplicated_tool, note=node.note
-                )
+                else:
+                    parent_target = (
+                        parent_override
+                        if parent_override is not None
+                        else (self._manager._parent_node(node).uid)
+                    )
+                    new_target = self._manager.add_imagetool_child(
+                        duplicated_window,
+                        parent_target,
+                        show=False,
+                        provenance_spec=persistence.provenance_spec,
+                        source_spec=persistence.source_spec,
+                        source_binding=persistence.source_binding,
+                        source_auto_update=persistence.source_auto_update,
+                        source_state=persistence.source_state,
+                        output_id=persistence.output_id,
+                        note=node.note,
+                    )
             else:
-                parent_target = (
-                    parent_override
-                    if parent_override is not None
-                    else self._manager._parent_node(node).uid
-                )
-                new_target = self._manager.add_childtool(
-                    tool.duplicate(), parent_target, note=node.note
-                )
+                tool = self._manager.get_childtool(node.uid)
+                if node.parent_uid is None and self._manager._is_figure_node(node):
+                    duplicated_tool = tool.duplicate()
+                    duplicated_tool._tool_display_name = (
+                        self._manager._figure_collection.duplicated_display_name(
+                            node.display_text
+                        )
+                    )
+                    new_target = self._manager.add_figuretool(
+                        duplicated_tool, show=False, note=node.note
+                    )
+                else:
+                    parent_target = (
+                        parent_override
+                        if parent_override is not None
+                        else self._manager._parent_node(node).uid
+                    )
+                    new_target = self._manager.add_childtool(
+                        tool.duplicate(), parent_target, show=False, note=node.note
+                    )
 
-        for child_uid in node._childtool_indices:
-            self._manager._duplicate_subtree(child_uid, parent_override=new_target)
-        return new_target
+            for child_uid in tuple(node._childtool_indices):
+                self._manager._duplicate_subtree(child_uid, parent_override=new_target)
+        except Exception:
+            if new_target is not None:
+                self._discard_duplicated_subtree(new_target)
+            raise
+        else:
+            return new_target
 
     def duplicate_imagetool(self, index: int | str) -> int | str:
         """Duplicate the ImageTool window corresponding to the given index.
@@ -792,7 +851,7 @@ class _ActionsController:
             Index of the newly created ImageTool window.
         """
         self._manager._commit_note_editor()
-        return self._manager._duplicate_subtree(index)
+        return self._duplicate_target(index)
 
     def duplicate_childtool(self, uid: str) -> str:
         """Duplicate the child tool corresponding to the given UID.
@@ -808,7 +867,7 @@ class _ActionsController:
             UID of the newly created child tool.
         """
         self._manager._commit_note_editor()
-        duplicated = self._manager._duplicate_subtree(uid)
+        duplicated = self._duplicate_target(uid)
         if isinstance(duplicated, str):
             return duplicated
         raise TypeError("Expected duplicated child target to remain nested")

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -236,6 +236,8 @@ class ImageToolManager(_ImageToolManagerBase):
         self._manager_record = reserve_manager_record(host=_manager_server.HOST_IP)
         self.manager_index = self._manager_record.index
         self._tool_graph = _ManagerToolGraph()
+        self._workspace_link_color_indices: dict[str, int] = {}
+        self._workspace_link_color_cache_dirty = True
         self._dependency_tracker = _ManagerDependencyTracker(self._tool_graph)
         self._trusted_script_replay_keys: set[str] = set()
         self._lineage_controller = _LineageController(self)
@@ -1164,14 +1166,20 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def _register_root_wrapper(self, wrapper: _ImageToolWrapper) -> None:
         self._tool_graph.register_root(wrapper)
+        if wrapper.workspace_link_key is not None:
+            self._invalidate_workspace_link_color_cache()
 
     def _register_child_node(self, node: _ManagedWindowNode) -> None:
         self._tool_graph.register_child(node)
+        if node.workspace_link_key is not None:
+            self._invalidate_workspace_link_color_cache()
         if node.tool_window is not None:
             node.tool_window._refresh_reload_data_action()
 
     def _register_figure_node(self, node: _ManagedWindowNode) -> None:
         self._tool_graph.register_figure(node)
+        if node.workspace_link_key is not None:
+            self._invalidate_workspace_link_color_cache()
         if node.tool_window is not None:
             node.tool_window._refresh_reload_data_action()
 
@@ -1179,6 +1187,8 @@ class ImageToolManager(_ImageToolManagerBase):
         node = self._tool_graph.unregister_node(uid)
         if node is None:
             return
+        if node.workspace_link_key is not None:
+            self._invalidate_workspace_link_color_cache()
         self._dependency_tracker.clear_uid(uid)
         if not self._workspace_state.closing_document:
             self._refresh_dependency_dependents(uid)
@@ -1382,6 +1392,8 @@ class ImageToolManager(_ImageToolManagerBase):
             self._remove_uid_target(uid)
 
         self._tool_graph.unregister_root(index)
+        if wrapper.workspace_link_key is not None:
+            self._invalidate_workspace_link_color_cache()
         if not self._workspace_state.closing_document:
             self._mark_singleton_workspace_link_groups_dirty(removed_link_keys)
             self._refresh_dependency_dependents(wrapper.uid)
@@ -1482,26 +1494,62 @@ class ImageToolManager(_ImageToolManagerBase):
         self, linker: erlab.interactive.imagetool.viewer_linking.SlicerLinkProxy
     ) -> QtGui.QColor:
         """Get the color that should represent the given linker."""
+        for slicer_area in linker.children:
+            node = self.node_from_slicer_area(slicer_area)
+            if node is not None and node.workspace_link_key is not None:
+                return self.color_for_workspace_link_key(node.workspace_link_key)
         idx = self._link_registry.index(linker)
         return _LINKER_COLORS[idx % len(_LINKER_COLORS)]
 
-    def color_for_workspace_link_key(self, link_key: str) -> QtGui.QColor:
-        """Get the color that should represent a restored structural link group."""
-        for linker in self._link_registry.linkers:
-            for slicer_area in linker.children:
-                node = self.node_from_slicer_area(slicer_area)
-                if node is not None and node.workspace_link_key == link_key:
-                    return self.color_for_linker(linker)
+    def _invalidate_workspace_link_color_cache(self) -> None:
+        self._workspace_link_color_cache_dirty = True
 
-        link_keys: list[str] = []
+    def _reconcile_workspace_link_color_cache(self) -> dict[str, int]:
+        """Preserve surviving colors and allocate free slots to active link groups."""
+        active_keys: list[str] = []
+        active_key_set: set[str] = set()
         for node in self._tool_graph.nodes.values():
-            node_link_key = node.workspace_link_key
-            if node_link_key is not None and node_link_key not in link_keys:
-                link_keys.append(node_link_key)
-        try:
-            idx = link_keys.index(link_key)
-        except ValueError:
-            idx = 0
+            link_key = node.workspace_link_key
+            if link_key is not None and link_key not in active_key_set:
+                active_keys.append(link_key)
+                active_key_set.add(link_key)
+
+        color_indices: dict[str, int] = {}
+        color_counts = [0] * len(_LINKER_COLORS)
+        unassigned_keys: list[str] = []
+        for link_key, color_index in self._workspace_link_color_indices.items():
+            if link_key not in active_key_set:
+                continue
+            color_index %= len(_LINKER_COLORS)
+            if color_counts[color_index] == 0:
+                color_indices[link_key] = color_index
+                color_counts[color_index] = 1
+            else:
+                unassigned_keys.append(link_key)
+
+        unassigned_keys.extend(
+            link_key
+            for link_key in active_keys
+            if link_key not in self._workspace_link_color_indices
+        )
+        for link_key in unassigned_keys:
+            color_index = min(
+                range(len(_LINKER_COLORS)),
+                key=lambda index: (color_counts[index], index),
+            )
+            color_indices[link_key] = color_index
+            color_counts[color_index] += 1
+
+        self._workspace_link_color_indices = color_indices
+        self._workspace_link_color_cache_dirty = False
+        return color_indices
+
+    def color_for_workspace_link_key(self, link_key: str) -> QtGui.QColor:
+        """Get the color that should represent a managed link group."""
+        color_indices = self._workspace_link_color_indices
+        if self._workspace_link_color_cache_dirty:
+            color_indices = self._reconcile_workspace_link_color_cache()
+        idx = color_indices.get(link_key, 0)
         return _LINKER_COLORS[idx % len(_LINKER_COLORS)]
 
     def _clear_singleton_workspace_link_groups(

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -442,7 +442,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 link_color = self.manager.color_for_workspace_link_key(
                     tool_wrapper.workspace_link_key
                 )
-            elif tool_wrapper.imagetool is not None:
+            else:
                 proxy = tool_wrapper.slicer_area._linking_proxy
                 if proxy is not None:
                     link_color = self.manager.color_for_linker(proxy)

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -438,17 +438,14 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
 
         if link_rect:
             link_color: QtGui.QColor | None = None
-            proxy = (
-                None
-                if tool_wrapper.imagetool is None
-                else tool_wrapper.slicer_area._linking_proxy
-            )
-            if proxy is not None:
-                link_color = self.manager.color_for_linker(proxy)
-            elif tool_wrapper.workspace_link_key is not None:
+            if tool_wrapper.workspace_link_key is not None:
                 link_color = self.manager.color_for_workspace_link_key(
                     tool_wrapper.workspace_link_key
                 )
+            elif tool_wrapper.imagetool is not None:
+                proxy = tool_wrapper.slicer_area._linking_proxy
+                if proxy is not None:
+                    link_color = self.manager.color_for_linker(proxy)
             if link_color is not None:
                 link_icon = qta.icon("mdi6.link-variant", color=link_color)
                 self._paint_icon(painter, option, link_rect, link_icon)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -1208,60 +1208,88 @@ class _PendingWorkspacePayloads:
         if pending is None:
             return False
         workspace_path, payload_path = pending
-        array_slicer: erlab.interactive.imagetool.slicer.ArraySlicer | None = None
         try:
-            ds = self._loader._read_workspace_imagetool_payload_dataset(
-                workspace_path, payload_path, load_data=False
+            cache = node._pending_workspace_link_slicer_cache
+            if (
+                cache is not None
+                and cache[0] == pending
+                and erlab.interactive.utils.qt_is_valid(cache[2])
+            ):
+                _, cached_state, array_slicer = cache
+                if cached_state != raw_state:
+                    array_slicer.state = copy.deepcopy(state["slice"])
+                    node._pending_workspace_link_slicer_cache = (
+                        pending,
+                        raw_state,
+                        array_slicer,
+                    )
+            else:
+                node._clear_pending_workspace_link_slicer_cache()
+                ds = self._loader._read_workspace_imagetool_payload_dataset(
+                    workspace_path, payload_path, load_data=False
+                )
+                try:
+                    ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
+                    if _ITOOL_DATA_NAME not in ds:
+                        return False
+                    target_data = ds[_ITOOL_DATA_NAME]
+                    target_data = self._pending_workspace_data_with_saved_dim_order(
+                        target_data, attrs
+                    )
+                    array_slicer = erlab.interactive.imagetool.slicer.ArraySlicer(
+                        target_data,
+                        node,
+                        display_value_abs_limit=(
+                            source.array_slicer.display_value_abs_limit
+                        ),
+                    )
+                    node._pending_workspace_link_slicer_cache = (
+                        pending,
+                        raw_state,
+                        array_slicer,
+                    )
+                    array_slicer.state = copy.deepcopy(state["slice"])
+                finally:
+                    ds.close()
+
+            target = _PendingWorkspaceLinkTarget(array_slicer)
+            converter = erlab.interactive.imagetool.viewer_linking.SlicerLinkProxy()
+            converted_args = converter.convert_args(
+                source,
+                typing.cast("typing.Any", target),
+                dict(arguments),
+                source_dims,
+                indices,
+                steps,
+                transaction_id,
+                keep_pending,
             )
-            try:
-                ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
-                if _ITOOL_DATA_NAME not in ds:
-                    return False
-                target_data = ds[_ITOOL_DATA_NAME]
-                target_data = self._pending_workspace_data_with_saved_dim_order(
-                    target_data, attrs
-                )
-                array_slicer = erlab.interactive.imagetool.slicer.ArraySlicer(
-                    target_data,
-                    self._manager,
-                    display_value_abs_limit=source.array_slicer.display_value_abs_limit,
-                )
-                array_slicer.state = copy.deepcopy(state["slice"])
-                target = _PendingWorkspaceLinkTarget(array_slicer)
-                converter = erlab.interactive.imagetool.viewer_linking.SlicerLinkProxy()
-                converted_args = converter.convert_args(
-                    source,
-                    typing.cast("typing.Any", target),
-                    dict(arguments),
-                    source_dims,
-                    indices,
-                    steps,
-                    transaction_id,
-                    keep_pending,
-                )
-                if converted_args is None:
-                    return False
-                for key in (
-                    "__slicer_skip_sync",
-                    "__slicer_transaction_id",
-                    "__slicer_keep_pending",
-                ):
-                    converted_args.pop(key, None)
-                original_state_json = json.dumps(state)
-                if not self._update_pending_link_state_for_operation(
-                    state, array_slicer, source, funcname, converted_args
-                ):
-                    return False
-                state_json = json.dumps(state)
-                if state_json == original_state_json:
-                    return False
-                updated_attrs = dict(attrs)
-                updated_attrs["itool_state"] = state_json
-                node.update_pending_workspace_payload_attrs(updated_attrs)
-                return True
-            finally:
-                ds.close()
+            if converted_args is None:
+                return False
+            for key in (
+                "__slicer_skip_sync",
+                "__slicer_transaction_id",
+                "__slicer_keep_pending",
+            ):
+                converted_args.pop(key, None)
+            original_state_json = json.dumps(state)
+            if not self._update_pending_link_state_for_operation(
+                state, array_slicer, source, funcname, converted_args
+            ):
+                return False
+            state_json = json.dumps(state)
+            if state_json == original_state_json:
+                return False
+            updated_attrs = dict(attrs)
+            updated_attrs["itool_state"] = state_json
+            node.update_pending_workspace_payload_attrs(updated_attrs)
+            node._pending_workspace_link_slicer_cache = (
+                pending,
+                state_json,
+                array_slicer,
+            )
         except Exception:
+            node._clear_pending_workspace_link_slicer_cache()
             logger.debug(
                 "Could not apply linked operation %s to pending workspace payload %s "
                 "from %s",
@@ -1271,9 +1299,8 @@ class _PendingWorkspacePayloads:
                 exc_info=True,
             )
             return False
-        finally:
-            if array_slicer is not None:
-                array_slicer.deleteLater()
+        else:
+            return True
 
     def _update_pending_link_state_for_operation(
         self,
@@ -1415,11 +1442,13 @@ class _PendingWorkspacePayloads:
         if funcname == "toggle_snap":
             slice_state = dict(state["slice"])
             value = arguments.get("value")
-            slice_state["snap_to_data"] = (
+            snap_to_data = (
                 not bool(slice_state.get("snap_to_data", False))
                 if value is None
                 else bool(value)
             )
+            array_slicer.snap_to_data = snap_to_data
+            slice_state["snap_to_data"] = snap_to_data
             state["slice"] = slice_state
             return True
         return False

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -59,6 +59,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Mapping, Sequence
 
     from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
+    from erlab.interactive.imagetool.slicer import ArraySlicer
     from erlab.interactive.imagetool.viewer import ImageSlicerArea
     from erlab.interactive.imagetool.viewer_state import ImageSlicerState
 
@@ -469,6 +470,9 @@ class _ManagedWindowNode(QtCore.QObject):
             ]
             | None
         ) = None
+        self._pending_workspace_link_slicer_cache: (
+            tuple[tuple[pathlib.Path, str], str, ArraySlicer] | None
+        ) = None
         self._workspace_link_key: str | None = None
         self._workspace_link_colors: bool = True
         self._snapshot_token = (
@@ -806,6 +810,7 @@ class _ManagedWindowNode(QtCore.QObject):
         payload_path: str,
         payload_attrs: Mapping[str, typing.Any] | None = None,
     ) -> None:
+        self._clear_pending_workspace_link_slicer_cache()
         self._pending_workspace_payload_kind = kind
         self._pending_workspace_payload = (
             pathlib.Path(workspace_path),
@@ -831,7 +836,14 @@ class _ManagedWindowNode(QtCore.QObject):
             payload_attrs=payload_attrs,
         )
 
+    def _clear_pending_workspace_link_slicer_cache(self) -> None:
+        cache = self._pending_workspace_link_slicer_cache
+        self._pending_workspace_link_slicer_cache = None
+        if cache is not None and erlab.interactive.utils.qt_is_valid(cache[2]):
+            cache[2].deleteLater()
+
     def clear_pending_workspace_payload(self) -> None:
+        self._clear_pending_workspace_link_slicer_cache()
         self._pending_workspace_payload = None
         self._pending_workspace_payload_kind = None
         self._pending_workspace_payload_attrs = None
@@ -923,10 +935,14 @@ class _ManagedWindowNode(QtCore.QObject):
         return self._workspace_link_key is not None
 
     def set_workspace_link_state(self, key: str, *, link_colors: bool) -> None:
+        if self._workspace_link_key != key:
+            self.manager._invalidate_workspace_link_color_cache()
         self._workspace_link_key = key
         self._workspace_link_colors = bool(link_colors)
 
     def clear_workspace_link_state(self) -> None:
+        if self._workspace_link_key is not None:
+            self.manager._invalidate_workspace_link_color_cache()
         self._workspace_link_key = None
         self._workspace_link_colors = True
 
@@ -1990,6 +2006,7 @@ class _ManagedWindowNode(QtCore.QObject):
 
     @QtCore.Slot()
     def dispose(self) -> None:
+        self._clear_pending_workspace_link_slicer_cache()
         self.window = None
 
     @QtCore.Slot()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
@@ -460,6 +460,70 @@ def test_manager_duplicate_figure_assigns_unique_display_name_and_keeps_state(
         assert manager._selected_figure_uids() == [second_custom_copy_uid]
 
 
+def test_manager_duplicate_deferred_figure_materializes_saved_payload(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        data = xr.DataArray(
+            np.arange(4.0).reshape(2, 2),
+            dims=("x", "y"),
+            coords={"x": [0.0, 1.0], "y": [0.0, 1.0]},
+            name="map",
+        )
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_node = manager._child_node(figure_uid)
+        figure_node.name = "Band map"
+        figure_tool = figure_node.tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        manager.get_imagetool(0).hide()
+
+        workspace_path = tmp_path / "deferred-figure-duplicate.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+
+        source_node = manager._tool_graph.root_wrappers[0]
+        loaded_node = manager._child_node(figure_uid)
+        assert source_node.pending_workspace_memory_payload is not None
+        assert loaded_node.pending_workspace_tool_payload is not None
+        assert loaded_node.tool_window is None
+
+        manager._figure_collection.select_uid(figure_uid)
+        manager.duplicate_selected()
+
+        assert source_node.pending_workspace_memory_payload is not None
+        assert loaded_node.pending_workspace_tool_payload is None
+        loaded_tool = loaded_node.tool_window
+        assert isinstance(loaded_tool, FigureComposerTool)
+        duplicate_uid = next(
+            uid for uid in manager._tool_graph.figure_uids if uid != figure_uid
+        )
+        duplicate_node = manager._child_node(duplicate_uid)
+        duplicate_tool = duplicate_node.tool_window
+        assert isinstance(duplicate_tool, FigureComposerTool)
+        assert duplicate_node.display_text == "Band map copy"
+        assert duplicate_tool.tool_status == loaded_tool.tool_status
+        xr.testing.assert_identical(duplicate_tool.tool_data, loaded_tool.tool_data)
+        assert manager._selected_figure_uids() == [duplicate_uid]
+        assert duplicate_uid in manager._workspace_state.dirty_added
+        assert figure_uid not in manager._workspace_state.dirty_added
+
+
 def test_manager_create_figure_uses_first_selected_main_image_state(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -101,6 +101,59 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def test_register_linked_nodes_invalidates_workspace_link_color_cache() -> None:
+    registered: list[tuple[str, object]] = []
+    graph = types.SimpleNamespace(
+        register_root=lambda node: registered.append(("root", node)),
+        register_child=lambda node: registered.append(("child", node)),
+        register_figure=lambda node: registered.append(("figure", node)),
+    )
+    manager = types.SimpleNamespace(
+        _tool_graph=graph,
+        _workspace_link_color_cache_dirty=False,
+    )
+    manager._invalidate_workspace_link_color_cache = types.MethodType(
+        manager_mainwindow.ImageToolManager._invalidate_workspace_link_color_cache,
+        manager,
+    )
+    nodes = {
+        "root": types.SimpleNamespace(workspace_link_key="root-link"),
+        "child": types.SimpleNamespace(
+            workspace_link_key="child-link", tool_window=None
+        ),
+        "figure": types.SimpleNamespace(
+            workspace_link_key="figure-link", tool_window=None
+        ),
+    }
+
+    for kind, method_name in (
+        ("root", "_register_root_wrapper"),
+        ("child", "_register_child_node"),
+        ("figure", "_register_figure_node"),
+    ):
+        manager._workspace_link_color_cache_dirty = False
+        getattr(manager_mainwindow.ImageToolManager, method_name)(manager, nodes[kind])
+        assert manager._workspace_link_color_cache_dirty
+
+    assert registered == [(kind, nodes[kind]) for kind in nodes]
+
+
+def test_color_for_linker_falls_back_without_structural_link_key() -> None:
+    child = object()
+    linker = types.SimpleNamespace(children=(child,))
+    manager = types.SimpleNamespace(
+        node_from_slicer_area=lambda slicer_area: types.SimpleNamespace(
+            workspace_link_key=None
+        ),
+        _link_registry=types.SimpleNamespace(index=lambda candidate: 1),
+    )
+
+    assert (
+        manager_mainwindow.ImageToolManager.color_for_linker(manager, linker)
+        == manager_mainwindow._LINKER_COLORS[1]
+    )
+
+
 def _record_reload_unavailable_dialog(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     reasons: list[str] = []
     monkeypatch.setattr(

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -951,6 +951,7 @@ def test_remove_imagetool_removes_childtools() -> None:
         def __init__(self):
             self.uid = "root-uid-0"
             self._childtool_indices = [uid]
+            self.workspace_link_key = None
             self.disposed = False
             self.deleted = False
 

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -210,6 +210,76 @@ def test_childtool_hover_preview_hides_missing_imageitem_pixmap(
     assert not delegate.preview_popup.isVisible()
 
 
+def test_link_badge_falls_back_to_live_linker(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for offset in (0.0, 10.0):
+            tool = itool(
+                xr.DataArray(
+                    np.arange(offset, offset + 16).reshape(4, 4),
+                    dims=("x", "y"),
+                ),
+                manager=False,
+                execute=False,
+            )
+            assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(tool, show=False)
+        manager.link_imagetools(0, 1, link_colors=False)
+
+        wrapper = manager._tool_graph.root_wrappers[0]
+        proxy = wrapper.slicer_area._linking_proxy
+        assert proxy is not None
+        link_key = wrapper.workspace_link_key
+        assert link_key is not None
+        linker_calls: list[object] = []
+        original_color_for_linker = manager.color_for_linker
+
+        def _record_linker(candidate):
+            linker_calls.append(candidate)
+            return original_color_for_linker(candidate)
+
+        monkeypatch.setattr(manager, "color_for_linker", _record_linker)
+        monkeypatch.setattr(
+            _ImageToolWrapper,
+            "workspace_linked",
+            property(lambda _wrapper: True),
+        )
+        index = manager.tree_view._model.index(0, 0)
+
+        def _paint() -> None:
+            option = manager.tree_view._delegate._option_for_index(
+                manager.tree_view, index
+            )
+            canvas = QtGui.QPixmap(200, 32)
+            canvas.fill(QtGui.QColor("white"))
+            painter = QtGui.QPainter(canvas)
+            try:
+                manager.tree_view._delegate.paint(painter, option, index)
+            finally:
+                painter.end()
+
+        wrapper._workspace_link_key = None
+        try:
+            _paint()
+            assert linker_calls == [proxy]
+
+            wrapper.slicer_area._linking_proxy = None
+            try:
+                _paint()
+            finally:
+                wrapper.slicer_area._linking_proxy = proxy
+        finally:
+            wrapper._workspace_link_key = link_key
+
+        assert linker_calls == [proxy]
+
+
 def test_drop_mimedata(
     qtbot,
     accept_dialog,

--- a/tests/interactive/imagetool/manager/test_warnings.py
+++ b/tests/interactive/imagetool/manager/test_warnings.py
@@ -20,6 +20,7 @@ from erlab.interactive.imagetool.manager import ImageToolManager
 from erlab.interactive.imagetool.manager._workspace import (
     _controller as workspace_controller,
 )
+from tests.interactive.imagetool.manager.workspace._support import _AddedTimeChildTool
 
 from .helpers import _UnserializableChildTool, select_child_tool
 
@@ -190,6 +191,172 @@ def test_manager_duplicate_unserializable_child_shows_error(
             "An error occurred while duplicating the selected window."
         )
         assert "data_corr" in critical_calls[0][1]["detailed_text"]
+
+
+def test_manager_duplicate_failure_rolls_back_partial_subtree(
+    qtbot,
+    gold,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root = itool(gold, link=False, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        serializable_uid = manager.add_childtool(
+            _AddedTimeChildTool(gold.rename("serializable child")),
+            0,
+            show=False,
+        )
+        manager.add_childtool(
+            _UnserializableChildTool(gold.copy(deep=True)),
+            serializable_uid,
+            show=False,
+        )
+        original_uids = set(manager._tool_graph.nodes)
+        original_dirty_events = tuple(manager._workspace_state.dirty_events)
+
+        with pytest.raises(
+            ValueError,
+            match="unsupported when `data_corr` is provided separately",
+        ):
+            manager.duplicate_imagetool(0)
+
+        assert manager.ntools == 1
+        assert set(manager._tool_graph.nodes) == original_uids
+        assert tuple(manager._workspace_state.dirty_events) == original_dirty_events
+
+
+def test_manager_duplicate_finish_failure_rolls_back_subtree(
+    qtbot,
+    gold,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root = itool(gold, link=False, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        original_uids = set(manager._tool_graph.nodes)
+        original_dirty_events = tuple(manager._workspace_state.dirty_events)
+
+        def _fail_finish(_target: int | str) -> None:
+            raise RuntimeError("finish failed")
+
+        monkeypatch.setattr(
+            manager._actions_controller,
+            "_finish_duplicated_subtree",
+            _fail_finish,
+        )
+
+        with pytest.raises(RuntimeError, match="finish failed"):
+            manager.duplicate_imagetool(0)
+
+        assert manager.ntools == 1
+        assert set(manager._tool_graph.nodes) == original_uids
+        assert tuple(manager._workspace_state.dirty_events) == original_dirty_events
+
+
+def test_manager_duplicate_mark_failure_restores_workspace_state(
+    qtbot,
+    gold,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root = itool(gold, link=False, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        manager.add_childtool(
+            _AddedTimeChildTool(gold.rename("child")),
+            0,
+            show=False,
+        )
+        original_uids = set(manager._tool_graph.nodes)
+        original_workspace_state = manager._workspace_state.snapshot(
+            node_uid_counter=manager._tool_graph.uid_counter
+        )
+        original_mark_node_added = manager._mark_node_added
+        mark_calls = 0
+
+        def _fail_after_mark(uid: str) -> bool:
+            nonlocal mark_calls
+            marked = original_mark_node_added(uid)
+            mark_calls += 1
+            if mark_calls == 2:
+                raise RuntimeError("mark failed")
+            return marked
+
+        monkeypatch.setattr(manager, "_mark_node_added", _fail_after_mark)
+
+        with pytest.raises(RuntimeError, match="mark failed"):
+            manager.duplicate_imagetool(0)
+
+        current_workspace_state = manager._workspace_state.snapshot(
+            node_uid_counter=manager._tool_graph.uid_counter
+        )
+        current_workspace_state["node_uid_counter"] = original_workspace_state[
+            "node_uid_counter"
+        ]
+        assert mark_calls == 2
+        assert manager.ntools == 1
+        assert set(manager._tool_graph.nodes) == original_uids
+        assert current_workspace_state == original_workspace_state
+
+
+def test_manager_duplicate_materialization_failure_is_not_reported_twice(
+    qtbot,
+    gold,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root = itool(gold, link=False, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        child_uid = manager.add_childtool(
+            _UnserializableChildTool(gold.copy(deep=True)),
+            0,
+            show=False,
+        )
+        original_uids = set(manager._tool_graph.nodes)
+        reported_errors: list[str] = []
+
+        def _fail_materialization() -> bool:
+            reported_errors.append("saved payload")
+            return False
+
+        monkeypatch.setattr(
+            manager._child_node(child_uid),
+            "materialize_pending_workspace_payload",
+            _fail_materialization,
+        )
+        monkeypatch.setattr(
+            manager,
+            "_show_operation_error",
+            lambda *_args, **_kwargs: reported_errors.append("duplicate"),
+        )
+
+        select_child_tool(manager, child_uid)
+        manager.duplicate_selected()
+
+        assert reported_errors == ["saved payload"]
+        assert set(manager._tool_graph.nodes) == original_uids
 
 
 def test_manager_save_unserializable_child_shows_error(

--- a/tests/interactive/imagetool/manager/test_wrapper.py
+++ b/tests/interactive/imagetool/manager/test_wrapper.py
@@ -24,9 +24,27 @@ from erlab.interactive.imagetool.manager._wrapper import (
     _coerce_note,
     _format_added_time,
     _format_chunk_summary,
+    _ManagedWindowNode,
     _preview_from_imagetool,
     _preview_image_for_node,
 )
+
+
+def test_reapplying_workspace_link_state_keeps_color_cache_valid() -> None:
+    invalidated: list[None] = []
+    node = types.SimpleNamespace(
+        _workspace_link_key="link-group",
+        _workspace_link_colors=True,
+        manager=types.SimpleNamespace(
+            _invalidate_workspace_link_color_cache=lambda: invalidated.append(None)
+        ),
+    )
+
+    _ManagedWindowNode.set_workspace_link_state(node, "link-group", link_colors=False)
+
+    assert invalidated == []
+    assert node._workspace_link_key == "link-group"
+    assert node._workspace_link_colors is False
 
 
 def test_wrapper_preview_fallback_branches(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -1362,7 +1362,89 @@ def test_pending_workspace_link_payload_helper_fallbacks(
             )
             updated_state = json.loads(node.attrs["itool_state"])
             assert updated_state["slice"]["indices"][0][0] == 1
+
+            cached_slicer = node._pending_workspace_link_slicer_cache[2]
+            updated_state["slice"]["indices"][0][0] = 4
+            updated_state["slice"]["values"][0][0] = 4.0
+            resynced_state_json = json.dumps(updated_state)
+            node.attrs = {"itool_state": resynced_state_json}
+            assert not loader.pending._apply_pending_workspace_link_operation(
+                source,
+                node,
+                "unknown_operation",
+                {},
+                tuple(data.dims),
+                True,
+                False,
+                None,
+                False,
+            )
+            cache = node._pending_workspace_link_slicer_cache
+            assert cache == (
+                node.pending_workspace_memory_payload,
+                resynced_state_json,
+                cached_slicer,
+            )
+            assert cached_slicer.get_index(0, 0) == 4
+
+            node._clear_pending_workspace_link_slicer_cache()
+            with monkeypatch.context() as patch:
+                patch.setattr(
+                    controller.loading,
+                    "_read_workspace_imagetool_payload_dataset",
+                    lambda *_args, **_kwargs: xr.Dataset({"other": data}),
+                )
+                assert not loader.pending._apply_pending_workspace_link_operation(
+                    source,
+                    node,
+                    "set_index",
+                    {"axis": 0, "value": 1},
+                    tuple(data.dims),
+                    True,
+                    False,
+                    None,
+                    False,
+                )
+            assert node._pending_workspace_link_slicer_cache is None
+
+            with monkeypatch.context() as patch:
+                patch.setattr(
+                    erlab.interactive.imagetool.viewer_linking.SlicerLinkProxy,
+                    "convert_args",
+                    lambda _self, *_args, **_kwargs: None,
+                )
+                assert not loader.pending._apply_pending_workspace_link_operation(
+                    source,
+                    node,
+                    "set_index",
+                    {"axis": 0, "value": 1},
+                    tuple(data.dims),
+                    True,
+                    False,
+                    None,
+                    False,
+                )
+
+            node._clear_pending_workspace_link_slicer_cache()
+            with monkeypatch.context() as patch:
+                patch.setattr(
+                    loader.pending,
+                    "_update_pending_link_state_for_operation",
+                    lambda *_args, **_kwargs: True,
+                )
+                assert not loader.pending._apply_pending_workspace_link_operation(
+                    source,
+                    node,
+                    "set_index",
+                    {"axis": 0, "value": 1},
+                    tuple(data.dims),
+                    True,
+                    False,
+                    None,
+                    False,
+                )
         finally:
+            node._clear_pending_workspace_link_slicer_cache()
             target_slicer.deleteLater()
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -11,7 +11,7 @@ import h5py
 import numpy as np
 import pytest
 import xarray as xr
-from qtpy import QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool._serialization as imagetool_serialization
@@ -216,6 +216,227 @@ def test_manager_workspace_mixed_pending_link_badge_uses_group_color(
         assert icon_colors
         assert icon_colors[-1] == manager.color_for_workspace_link_key(link_key)
         assert icon_colors[-1] != option.palette.color(QtGui.QPalette.ColorRole.Mid)
+
+
+def test_manager_workspace_link_badge_colors_do_not_depend_on_materialization(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        for offset in (0, 100, 200, 300):
+            data = xr.DataArray(
+                np.arange(offset, offset + 25, dtype=np.float64).reshape((5, 5)),
+                dims=["x", "y"],
+            )
+            root = itool(data, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+            root.hide()
+        manager.link_imagetools(0, 1, link_colors=False)
+        manager.link_imagetools(2, 3, link_colors=False)
+
+        fname = tmp_path / "pending-link-badge-colors.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        wrappers = [manager._tool_graph.root_wrappers[index] for index in range(4)]
+        first_key = wrappers[0].workspace_link_key
+        second_key = wrappers[2].workspace_link_key
+        assert first_key is not None
+        assert second_key is not None
+        assert first_key != second_key
+        first_color = manager.color_for_workspace_link_key(first_key)
+        second_color = manager.color_for_workspace_link_key(second_key)
+        color_cache = manager._workspace_link_color_indices
+        assert first_color != second_color
+        assert color_cache is not None
+
+        manager.get_imagetool(2)
+        manager.get_imagetool(3)
+
+        assert wrappers[0].pending_workspace_memory_payload is not None
+        assert wrappers[1].pending_workspace_memory_payload is not None
+        second_proxy = wrappers[2].slicer_area._linking_proxy
+        assert second_proxy is not None
+        assert manager.color_for_workspace_link_key(first_key) == first_color
+        assert manager.color_for_workspace_link_key(second_key) == second_color
+        assert manager.color_for_linker(second_proxy) == second_color
+        assert manager._workspace_link_color_indices is color_cache
+
+
+def test_manager_workspace_link_badge_color_cache_reuses_and_invalidates(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        for offset in (0, 100, 200, 300):
+            data = xr.DataArray(
+                np.arange(offset, offset + 25, dtype=np.float64).reshape((5, 5)),
+                dims=["x", "y"],
+            )
+            root = itool(data, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+        manager.link_imagetools(0, 1, link_colors=False)
+        manager.link_imagetools(2, 3, link_colors=False)
+
+        wrappers = [manager._tool_graph.root_wrappers[index] for index in range(4)]
+        first_key = wrappers[0].workspace_link_key
+        second_key = wrappers[2].workspace_link_key
+        assert first_key is not None
+        assert second_key is not None
+
+        reconcile_calls = 0
+        original_reconcile = manager._reconcile_workspace_link_color_cache
+
+        def _count_reconcile() -> dict[str, int]:
+            nonlocal reconcile_calls
+            reconcile_calls += 1
+            return original_reconcile()
+
+        monkeypatch.setattr(
+            manager,
+            "_reconcile_workspace_link_color_cache",
+            _count_reconcile,
+        )
+        manager._invalidate_workspace_link_color_cache()
+
+        first_color = manager.color_for_workspace_link_key(first_key)
+        second_color = manager.color_for_workspace_link_key(second_key)
+        color_cache = manager._workspace_link_color_indices
+        assert first_color != second_color
+        assert reconcile_calls == 1
+        assert color_cache is not None
+        for _ in range(3):
+            assert manager.color_for_workspace_link_key(first_key) == first_color
+            assert manager.color_for_workspace_link_key(second_key) == second_color
+        assert manager._workspace_link_color_indices is color_cache
+        assert reconcile_calls == 1
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager,
+                "color_for_linker",
+                lambda _proxy: pytest.fail(
+                    "managed badge painting should use its structural link key"
+                ),
+            )
+            index = manager.tree_view._model.index(2, 0)
+            option = manager.tree_view._delegate._option_for_index(
+                manager.tree_view, index
+            )
+            canvas = QtGui.QPixmap(200, 32)
+            canvas.fill(QtGui.QColor("white"))
+            painter = QtGui.QPainter(canvas)
+            try:
+                manager.tree_view._delegate.paint(painter, option, index)
+            finally:
+                painter.end()
+        assert manager._workspace_link_color_indices is color_cache
+        assert reconcile_calls == 1
+
+        manager._actions_controller.unlink_imagetool_nodes(wrappers[:2])
+        assert manager._workspace_link_color_cache_dirty
+        assert manager.color_for_workspace_link_key(second_key) == second_color
+        assert reconcile_calls == 2
+
+        manager.link_imagetools(0, 1, link_colors=False)
+        first_key = wrappers[0].workspace_link_key
+        assert first_key is not None
+        assert manager._workspace_link_color_cache_dirty
+        assert manager.color_for_workspace_link_key(
+            first_key
+        ) != manager.color_for_workspace_link_key(second_key)
+        assert reconcile_calls == 3
+
+
+def test_manager_workspace_link_badge_colors_survive_member_removal(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        for offset in range(5):
+            data = xr.DataArray(
+                np.arange(offset, offset + 25, dtype=np.float64).reshape((5, 5)),
+                dims=["x", "y"],
+            )
+            root = itool(data, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+        manager.link_imagetools(0, 2, 4, link_colors=False)
+        manager.link_imagetools(1, 3, link_colors=False)
+
+        first_key = manager._tool_graph.root_wrappers[0].workspace_link_key
+        second_key = manager._tool_graph.root_wrappers[1].workspace_link_key
+        assert first_key is not None
+        assert second_key is not None
+        first_color = manager.color_for_workspace_link_key(first_key)
+        second_color = manager.color_for_workspace_link_key(second_key)
+        assert first_color != second_color
+
+        manager.remove_imagetool(0)
+
+        assert manager._tool_graph.root_wrappers[2].workspace_link_key == first_key
+        assert manager._tool_graph.root_wrappers[4].workspace_link_key == first_key
+        assert manager._workspace_link_color_cache_dirty
+        assert manager.color_for_workspace_link_key(first_key) == first_color
+        assert manager.color_for_workspace_link_key(second_key) == second_color
+        assert not manager._workspace_link_color_cache_dirty
+
+
+def test_manager_workspace_link_badge_palette_exhaustion_recovers_free_color() -> None:
+    palette_size = len(manager_mainwindow._LINKER_COLORS)
+    assert palette_size > 1
+    link_keys = [f"group-{index}" for index in range(palette_size + 1)]
+    nodes = {
+        f"node-{index}": types.SimpleNamespace(workspace_link_key=link_key)
+        for index, link_key in enumerate(link_keys)
+    }
+    manager = types.SimpleNamespace(
+        _tool_graph=types.SimpleNamespace(nodes=nodes),
+        _workspace_link_color_indices={},
+        _workspace_link_color_cache_dirty=True,
+    )
+
+    initial_indices = (
+        manager_mainwindow.ImageToolManager._reconcile_workspace_link_color_cache(
+            manager
+        )
+    )
+
+    assert len(set(initial_indices.values())) == palette_size
+    assert initial_indices[link_keys[0]] == initial_indices[link_keys[-1]]
+
+    nodes.pop("node-1")
+    recovered_indices = (
+        manager_mainwindow.ImageToolManager._reconcile_workspace_link_color_cache(
+            manager
+        )
+    )
+
+    assert len(set(recovered_indices.values())) == palette_size
+    assert recovered_indices[link_keys[-1]] == initial_indices[link_keys[1]]
+    assert recovered_indices[link_keys[0]] == initial_indices[link_keys[0]]
+    for link_key in link_keys[2:-1]:
+        assert recovered_indices[link_key] == initial_indices[link_key]
 
 
 def test_manager_update_actions_for_pending_memory_link_state_does_not_materialize(
@@ -867,6 +1088,20 @@ def test_manager_remove_pending_linked_child_prunes_partner_without_materializin
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
 
+        removed_node = manager._child_node(child_uids[0])
+        pending = removed_node.pending_workspace_memory_payload
+        attrs = removed_node.pending_workspace_payload_attrs
+        assert pending is not None
+        assert attrs is not None
+        cached_slicer = erlab.interactive.imagetool.slicer.ArraySlicer(
+            root_data, removed_node
+        )
+        removed_node._pending_workspace_link_slicer_cache = (
+            pending,
+            str(attrs["itool_state"]),
+            cached_slicer,
+        )
+
         def _fail_materialize_pending_payload(_node) -> bool:
             pytest.fail(
                 "removing linked children should not materialize hidden memory data"
@@ -881,6 +1116,11 @@ def test_manager_remove_pending_linked_child_prunes_partner_without_materializin
         manager._remove_childtool(child_uids[0])
         survivor = manager._child_node(child_uids[1])
         assert child_uids[0] not in manager._tool_graph.nodes
+        assert removed_node._pending_workspace_link_slicer_cache is None
+        qtbot.wait_until(
+            lambda: not erlab.interactive.utils.qt_is_valid(cached_slicer),
+            timeout=5000,
+        )
         assert survivor.pending_workspace_memory_payload is not None
         assert not survivor.workspace_linked
         assert survivor.workspace_link_key is None
@@ -954,16 +1194,18 @@ def test_pending_workspace_link_payload_helper_fallbacks(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    class PendingNode:
+    class PendingNode(QtCore.QObject):
         uid = "pending"
         is_imagetool = True
 
-        def __init__(self) -> None:
+        def __init__(self, parent: QtCore.QObject) -> None:
+            super().__init__(parent)
             self.attrs: dict[str, typing.Any] | None = None
             self.pending_workspace_memory_payload: tuple[pathlib.Path, str] | None = (
                 tmp_path / "source.itws",
                 "0/imagetool",
             )
+            self._pending_workspace_link_slicer_cache = None
 
         @property
         def pending_workspace_payload_attrs(self) -> dict[str, typing.Any] | None:
@@ -973,6 +1215,12 @@ def test_pending_workspace_link_payload_helper_fallbacks(
             self, attrs: Mapping[str, typing.Any]
         ) -> None:
             self.attrs = dict(attrs)
+
+        def _clear_pending_workspace_link_slicer_cache(self) -> None:
+            cache = self._pending_workspace_link_slicer_cache
+            self._pending_workspace_link_slicer_cache = None
+            if cache is not None and erlab.interactive.utils.qt_is_valid(cache[2]):
+                cache[2].deleteLater()
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -989,7 +1237,7 @@ def test_pending_workspace_link_payload_helper_fallbacks(
         source = root.slicer_area
         source.array_slicer.set_index(0, 0, 2, update=False)
 
-        node = PendingNode()
+        node = PendingNode(manager)
         assert not loader.pending._update_pending_workspace_manual_limits(
             node, {"x": [0.0, 1.0]}
         )

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -102,14 +102,33 @@ def test_manager_save_updates_pending_linked_partner_state(
         )
 
         loaded = manager.get_imagetool(0).slicer_area
-        loaded.set_index(0, 3)
+        loader = manager._workspace_controller.loading
+        read_calls = 0
+        original_read = loader._read_workspace_imagetool_payload_dataset
+
+        def _count_read(*args, **kwargs):
+            nonlocal read_calls
+            read_calls += 1
+            return original_read(*args, **kwargs)
+
+        monkeypatch.setattr(
+            loader,
+            "_read_workspace_imagetool_payload_dataset",
+            _count_read,
+        )
+        for value in (-0.5, 0.0, 0.5):
+            loaded.set_value(0, value, update=False, uniform=True)
         qtbot.wait_until(
             lambda: wrappers[1].uid in manager._workspace_state.dirty_state,
             timeout=5000,
         )
 
         assert materialized_calls == 1
+        assert read_calls == 1
         assert wrappers[1].pending_workspace_memory_payload is not None
+        cache = wrappers[1]._pending_workspace_link_slicer_cache
+        assert cache is not None
+        cached_slicer = cache[2]
         assert _request_workspace_save_and_wait(qtbot, manager)
         assert materialized_calls == 1
         assert wrappers[1].pending_workspace_memory_payload is not None
@@ -117,6 +136,13 @@ def test_manager_save_updates_pending_linked_partner_state(
         with h5py.File(fname, "r") as h5_file:
             saved_state = json.loads(h5_file["1/imagetool"].attrs["itool_state"])
         assert saved_state["slice"]["indices"][0][0] == 3
+
+        manager.get_imagetool(1)
+        assert wrappers[1]._pending_workspace_link_slicer_cache is None
+        qtbot.wait_until(
+            lambda: not erlab.interactive.utils.qt_is_valid(cached_slicer),
+            timeout=5000,
+        )
 
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
@@ -247,10 +273,12 @@ def test_pending_link_state_operation_variants_update_saved_state(
                 state, array_slicer, source, "toggle_snap", {}
             )
             assert state["slice"]["snap_to_data"] is True
+            assert array_slicer.snap_to_data is True
             assert loader.pending._update_pending_link_state_for_operation(
                 state, array_slicer, source, "toggle_snap", {"value": False}
             )
             assert state["slice"]["snap_to_data"] is False
+            assert array_slicer.snap_to_data is False
             assert not loader.pending._update_pending_link_state_for_operation(
                 state, array_slicer, source, "unknown_operation", {}
             )
@@ -1055,6 +1083,153 @@ def test_manager_duplicate_pending_memory_uses_saved_payload(
         duplicated = manager.get_imagetool(duplicate_index).slicer_area
         assert workspace_arrays.dataarray_is_numpy_backed(duplicated._data)
         np.testing.assert_array_equal(duplicated._data.values, data.values)
+
+
+def test_manager_duplicate_pending_child_tool_uses_saved_payload(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25, dtype=np.float64).reshape((5, 5)),
+            dims=("x", "y"),
+            name="source",
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root.hide()
+
+        child_data = (data + 10.0).rename("child")
+        child = _AddedTimeChildTool(child_data)
+        child.tool_status = child.StateModel(value=7)
+        child_uid = manager.add_childtool(
+            child, 0, show=False, note="pending child note"
+        )
+        child.hide()
+
+        fname = tmp_path / "duplicate-hidden-child-tool.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        root_node = manager._tool_graph.root_wrappers[0]
+        child_node = manager._child_node(child_uid)
+        assert root_node.pending_workspace_memory_payload is not None
+        assert child_node.pending_workspace_tool_payload is not None
+        assert child_node.tool_window is None
+
+        duplicate_uid = manager.duplicate_childtool(child_uid)
+
+        assert root_node.pending_workspace_memory_payload is not None
+        assert child_node.pending_workspace_tool_payload is None
+        loaded_child = child_node.tool_window
+        assert isinstance(loaded_child, _AddedTimeChildTool)
+        duplicate_node = manager._child_node(duplicate_uid)
+        duplicate = duplicate_node.tool_window
+        assert isinstance(duplicate, _AddedTimeChildTool)
+        xr.testing.assert_identical(duplicate.tool_data, loaded_child.tool_data)
+        assert duplicate.tool_status == loaded_child.tool_status
+        assert duplicate_node.parent_uid == root_node.uid
+        assert duplicate_node.note == "pending child note"
+        assert duplicate_uid in manager._workspace_state.dirty_added
+        assert child_uid not in manager._workspace_state.dirty_added
+
+
+def test_manager_duplicate_pending_mixed_subtree_is_complete(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25, dtype=np.float64).reshape((5, 5)),
+            dims=("x", "y"),
+            name="root",
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        image_data = (data + 10.0).rename("image child")
+        image_child = itool(image_data, manager=False, execute=False)
+        assert isinstance(image_child, erlab.interactive.imagetool.ImageTool)
+        image_uid = manager.add_imagetool_child(image_child, 0, show=False)
+
+        tool_data = (data + 20.0).rename("tool child")
+        tool_child = _AddedTimeChildTool(tool_data)
+        tool_child.tool_status = tool_child.StateModel(value=9)
+        tool_uid = manager.add_childtool(tool_child, 0, show=False)
+
+        for window in (root, image_child, tool_child):
+            window.hide()
+        fname = tmp_path / "duplicate-pending-mixed-subtree.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        original_root = manager._tool_graph.root_wrappers[0]
+        original_image = manager._child_node(image_uid)
+        original_tool = manager._child_node(tool_uid)
+        assert original_root.pending_workspace_memory_payload is not None
+        assert original_image.pending_workspace_memory_payload is not None
+        assert original_tool.pending_workspace_tool_payload is not None
+
+        duplicate_index = manager.duplicate_imagetool(0)
+
+        assert isinstance(duplicate_index, int)
+        assert manager.ntools == 2
+        assert len(manager._tool_graph.nodes) == 6
+        assert original_root.pending_workspace_memory_payload is None
+        assert original_image.pending_workspace_memory_payload is None
+        assert original_tool.pending_workspace_tool_payload is None
+
+        duplicate_root = manager._tool_graph.root_wrappers[duplicate_index]
+        assert len(duplicate_root._childtool_indices) == 2
+        duplicate_children = [
+            manager._child_node(uid) for uid in duplicate_root._childtool_indices
+        ]
+        duplicate_image = next(node for node in duplicate_children if node.is_imagetool)
+        duplicate_tool_node = next(
+            node for node in duplicate_children if not node.is_imagetool
+        )
+        original_root_tool = manager.get_imagetool(0)
+        original_image_tool = manager.get_imagetool(original_image.uid)
+        xr.testing.assert_identical(
+            manager.get_imagetool(duplicate_index).slicer_area.data,
+            original_root_tool.slicer_area.data,
+        )
+        xr.testing.assert_identical(
+            manager.get_imagetool(duplicate_image.uid).slicer_area.data,
+            original_image_tool.slicer_area.data,
+        )
+        loaded_tool = original_tool.tool_window
+        assert isinstance(loaded_tool, _AddedTimeChildTool)
+        duplicate_tool = duplicate_tool_node.tool_window
+        assert isinstance(duplicate_tool, _AddedTimeChildTool)
+        xr.testing.assert_identical(duplicate_tool.tool_data, loaded_tool.tool_data)
+        assert duplicate_tool.tool_status == loaded_tool.tool_status
+        assert set(manager._tool_graph.subtree_uids(duplicate_root.uid)) <= (
+            manager._workspace_state.dirty_added
+        )
+        assert {
+            original_root.uid,
+            original_image.uid,
+            original_tool.uid,
+        }.isdisjoint(manager._workspace_state.dirty_added)
 
 
 def test_manager_promote_pending_child_memory_uses_saved_payload(


### PR DESCRIPTION
## Summary

- materialize complete managed subtrees before duplication and roll back both nodes and workspace state when duplication fails
- reuse deferred ImageTool slicers during linked interactions so repeated Ctrl-drag events do not reread workspace metadata
- assign link badge colors from stable structural groups with cached O(1) paint lookups and collision recovery

## Root cause

Deferred tools existed structurally before their Qt windows and payloads were materialized. Duplication assumed live windows, while each linked cursor event rebuilt a temporary slicer from the workspace. Badge colors also followed transient linker registration order, so materialization could reassign colors or collide with pending groups.

## User impact

Deferred figures, ImageTools, and child tools can now be duplicated reliably. Linked interactions remain responsive after the first pending-node setup, and badge colors stay consistent as tools materialize or group membership changes.

## Validation

- `uv run pytest -q` — 4,984 passed, 1 skipped
- 173 directly affected manager tests passed
- `uv run mypy src`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `git diff --check`
