### PR TITLE
feat(manager): add acquisition context and metadata editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,6 @@ jobs:
           if [[ "${{ matrix.use-xdist }}" == "true" ]]; then
             pytest_args+=(-n auto --dist=loadgroup)
           fi
-          if [[ "${{ matrix.group }}" == "cov-qt-manager-provenance-console" ]]; then
-            pytest_args+=(-vv)
-          fi
           uv run pytest "${pytest_args[@]}" "${targets[@]}"
 
       - name: Package shard artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,9 @@ jobs:
           if [[ "${{ matrix.use-xdist }}" == "true" ]]; then
             pytest_args+=(-n auto --dist=loadgroup)
           fi
+          if [[ "${{ matrix.group }}" == "cov-qt-manager-provenance-console" ]]; then
+            pytest_args+=(-vv)
+          fi
           uv run pytest "${pytest_args[@]}" "${targets[@]}"
 
       - name: Package shard artifacts

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -107,6 +107,9 @@ Once the manager is running, you can open ImageTools in several ways:
 - Use the manager’s {menuselection}`File --> Add Data Files…` action to load data in a new
   ImageTool.
 
+  To add or replace coordinates and attributes while loading files, see
+  {ref}`imagetool-manager-acquisition-context`.
+
 - Drag and drop supported ARPES data into the manager window.
 
   In the dialog that appears, you can choose the plugin to use for loading the data. For
@@ -283,6 +286,43 @@ rows opened from another row can show the state badges described in
 {ref}`imagetool-manager-refresh`, and results that depend on several ImageTools can show
 the {guilabel}`Changed` or {guilabel}`Missing` badges described in
 {ref}`imagetool-manager-derived-data`.
+
+(imagetool-manager-acquisition-context)=
+
+## Setting coordinates and attributes while loading files
+
+```{versionadded} 3.25.0
+```
+
+Use Acquisition Context when files do not contain every coordinate or attribute you want
+to keep with the data, or when a value in the files needs to be replaced. This is
+particularly useful when conducting experiments at some endstations that provide partial
+or incorrect metadata in the data files.
+
+Open {menuselection}`File --> Acquisition Context…` and enter the current values. You
+can enter fields directly or use {guilabel}`Add from Selected ImageTool…` to copy them
+from a selected ImageTool.
+
+When you want the current context applied as you load new files, turn on
+{guilabel}`Apply automatically when loading data from files` and save. Update the
+context whenever acquisition conditions change. To change coordinates or attributes in
+ImageTools that are already open, use the
+{ref}`Metadata Editor <imagetool-manager-metadata-editor>`.
+
+(imagetool-manager-metadata-editor)=
+
+## Batch editing metadata
+
+```{versionadded} 3.25.0
+```
+
+Select one or more ImageTools and choose {menuselection}`Edit --> Metadata Editor…`.
+Each row represents one ImageTool. Use {guilabel}`Fields` to choose which coordinates
+and attributes appear as columns, then edit or paste values as you would in a logbook.
+
+A marker in the upper-right corner shows that a value was assigned in ImageTool after
+loading either from an acquisition context or manual assignment, rather than from the
+file metadata. Use {guilabel}`Revert Assignment` to restore its earlier value.
 
 (imagetool-manager-figure-composer)=
 

--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -64,6 +64,7 @@ description: Use when answering questions or working on ERLabPy ARPES analysis w
   `Reconnect Watched Variables`, `.itws`, `standalone application`,
   `recent documents`, `Jump List`, `Dock menu`, `Result Placement`, `stale`,
   `automatic updates`, `Auto`, `Changed`, `Missing`, `Reload Data`,
+  `Acquisition Context`, `Metadata Editor`, `missing acquisition metadata`,
   `Concatenate`, `tools[0] - tools[1]`, `tools[0].children`,
   `tools.selected`, `tools[0].qsel`, `era.transform.rotate(tools[0])`,
   `xr.concat([tools[0], tools[1]])`, `my_func(tools[0])`,

--- a/src/erlab/interactive/_figurecomposer/_operations/_set_palette.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_set_palette.py
@@ -105,7 +105,7 @@ _SEABORN_SPECIAL_PALETTES = (
 _HIDDEN_PALETTE_OPTIONS = frozenset({"jet", "jet_r"})
 _DESAT_AUTO_VALUE = -0.01
 _PALETTE_COUNT_MAX = 256
-_PALETTE_ICON_SIZE = QtCore.QSize(72, 14)
+_PALETTE_ICON_SIZE = (72, 14)
 _PALETTE_ICON_COLORS = 8
 _PALETTE_MODE_LABELS = {
     "named": "Named palette",
@@ -493,8 +493,8 @@ def _palette_icon(
 @functools.lru_cache(maxsize=512)
 def _palette_pixmap(
     hex_colors: tuple[str, ...],
-    width: int = _PALETTE_ICON_SIZE.width(),
-    height: int = _PALETTE_ICON_SIZE.height(),
+    width: int = _PALETTE_ICON_SIZE[0],
+    height: int = _PALETTE_ICON_SIZE[1],
 ) -> QtGui.QPixmap:
     pixmap = QtGui.QPixmap(width, height)
     pixmap.fill(QtCore.Qt.GlobalColor.transparent)
@@ -519,7 +519,7 @@ def _apply_palette_combo_icons(
     combo: QtWidgets.QComboBox,
     sns: typing.Any | None,
 ) -> None:
-    combo.setIconSize(_PALETTE_ICON_SIZE)
+    combo.setIconSize(QtCore.QSize(*_PALETTE_ICON_SIZE))
     for index in range(combo.count()):
         icon = _palette_icon(sns, combo.itemText(index))
         if not icon.isNull():

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -193,7 +193,7 @@ _PREVIEW_PIXMAP_UPDATE_DELAY_MS = 250
 _PERSISTED_PREVIEW_CACHE_ATTR = "figure_composer_preview_cache_png"
 _PERSISTED_PREVIEW_CACHE_STALE_ATTR = "figure_composer_preview_cache_stale"
 _PERSISTED_SELECTED_SOURCE_DATA_ATTR = "figure_composer_selected_source_data"
-_PERSISTED_PREVIEW_CACHE_SIZE = QtCore.QSize(512, 384)
+_PERSISTED_PREVIEW_CACHE_SIZE = (512, 384)
 _PERSISTED_PREVIEW_CACHE_MAX_BYTES = 384_000
 _RESTORE_OPERATION_EDITOR_KEY = "figure_composer_operation_editor"
 _RESTORE_REDRAW_KEY = "figure_composer_restored_redraw"
@@ -4476,11 +4476,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if preview is None or preview.isNull():
             return None
         if (
-            preview.width() > _PERSISTED_PREVIEW_CACHE_SIZE.width()
-            or preview.height() > _PERSISTED_PREVIEW_CACHE_SIZE.height()
+            preview.width() > _PERSISTED_PREVIEW_CACHE_SIZE[0]
+            or preview.height() > _PERSISTED_PREVIEW_CACHE_SIZE[1]
         ):
             return preview.scaled(
-                _PERSISTED_PREVIEW_CACHE_SIZE,
+                QtCore.QSize(*_PERSISTED_PREVIEW_CACHE_SIZE),
                 QtCore.Qt.AspectRatioMode.KeepAspectRatio,
                 QtCore.Qt.TransformationMode.SmoothTransformation,
             )

--- a/src/erlab/interactive/_figurecomposer/_ui/_axes_widgets.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_axes_widgets.py
@@ -59,7 +59,7 @@ class _GridSpecOutsideClickFilter(QtCore.QObject):
 _SELECTOR_CORNER_RADIUS = 6.0
 _SELECTOR_BORDER_WIDTH = 1.0
 _SELECTOR_SELECTED_BORDER_WIDTH = 1.6
-_SELECTOR_MUTED_STATUS_COLOR = QtGui.QColor("#59636e")
+_SELECTOR_MUTED_STATUS_COLOR = "#59636e"
 
 
 def _blend_qcolors(
@@ -100,7 +100,7 @@ def _selector_colors(widget: QtWidgets.QWidget) -> _SelectorColors:
     selection_face = _blend_qcolors(face, selection, 0.18)
     muted_text = _blend_qcolors(
         text,
-        _SELECTOR_MUTED_STATUS_COLOR,
+        QtGui.QColor(_SELECTOR_MUTED_STATUS_COLOR),
         0.55 if text.lightness() > panel.lightness() else 0.72,
     )
     return _SelectorColors(

--- a/src/erlab/interactive/imagetool/manager/_acquisition_context.py
+++ b/src/erlab/interactive/imagetool/manager/_acquisition_context.py
@@ -12,6 +12,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive._figurecomposer._ui._panel_controls import _step_toolbar_button
+from erlab.interactive._figurecomposer._ui._reorder_list import ReorderList
 from erlab.interactive.imagetool._provenance._model import (
     ToolProvenanceOperation,
     decode_provenance_value,
@@ -394,19 +395,30 @@ class AcquisitionContextDialog(QtWidgets.QDialog):
         self.enabled_check.setChecked(state.enabled)
         layout.addWidget(self.enabled_check)
 
-        self.table = QtWidgets.QTableWidget(self)
+        self.table = ReorderList(0, self)
         self.table.setObjectName("manager_acquisition_context_table")
         self.table.setColumnCount(5)
-        self.table.setHorizontalHeaderLabels(
-            ["Kind", "Name", "Type", "Value", "If Present"]
-        )
+        self.table.setHeaderLabels(["Kind", "Name", "Type", "Value", "If Present"])
+        self.table.setRootIsDecorated(False)
+        self.table.setItemsExpandable(False)
+        self.table.setIndentation(0)
+        self.table.setUniformRowHeights(True)
+        self.table.setAlternatingRowColors(True)
         self.table.setSelectionBehavior(
             QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
         )
         self.table.setSelectionMode(
             QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
         )
-        self.table.doubleClicked.connect(self._edit_field)
+        self.table.itemDoubleClicked.connect(self._edit_field)
+        self.table.rows_reordered.connect(self._rows_reordered)
+
+        header = typing.cast("QtWidgets.QHeaderView", self.table.header())
+        for column in (0, 1, 2, 4):
+            header.setSectionResizeMode(
+                column, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+            )
+        header.setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeMode.Stretch)
 
         field_buttons = QtWidgets.QHBoxLayout()
         field_buttons.setSpacing(4)
@@ -492,9 +504,24 @@ class AcquisitionContextDialog(QtWidgets.QDialog):
             enabled=self.enabled_check.isChecked(), fields=tuple(self._fields)
         )
 
+    @staticmethod
+    def _field_row_id(field: AcquisitionContextField) -> str:
+        return json.dumps(field.key, ensure_ascii=False, separators=(",", ":"))
+
+    def _current_row(self) -> int:
+        item = self.table.currentItem()
+        return -1 if item is None else self.table.indexOfTopLevelItem(item)
+
+    def _select_row(self, row: int) -> None:
+        item = self.table.topLevelItem(row)
+        if item is None:
+            self.table.setCurrentIndex(QtCore.QModelIndex())
+        else:
+            self.table.setCurrentItem(item)
+
     def _populate_table(self) -> None:
-        self.table.setRowCount(len(self._fields))
-        for row, field in enumerate(self._fields):
+        self.table.clear()
+        for field in self._fields:
             values = (
                 "Coordinate" if field.kind == "coordinate" else "Attribute",
                 field.name,
@@ -502,26 +529,22 @@ class AcquisitionContextDialog(QtWidgets.QDialog):
                 field.display_value(),
                 "Replace" if field.replace_existing else "Keep",
             )
-            for column, value in enumerate(values):
-                item = QtWidgets.QTableWidgetItem(value)
-                item.setFlags(
-                    QtCore.Qt.ItemFlag.ItemIsEnabled
-                    | QtCore.Qt.ItemFlag.ItemIsSelectable
-                )
-                if column == 0:
-                    item.setData(QtCore.Qt.ItemDataRole.UserRole, field)
-                self.table.setItem(row, column, item)
-        header = self.table.horizontalHeader()
-        if header is not None:
-            for column in (0, 1, 2, 4):
-                header.setSectionResizeMode(
-                    column, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
-                )
-            header.setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeMode.Stretch)
+            item = QtWidgets.QTreeWidgetItem(values)
+            item.setFlags(
+                QtCore.Qt.ItemFlag.ItemIsEnabled
+                | QtCore.Qt.ItemFlag.ItemIsSelectable
+                | QtCore.Qt.ItemFlag.ItemIsDragEnabled
+            )
+            item.setData(
+                0,
+                QtCore.Qt.ItemDataRole.UserRole,
+                self._field_row_id(field),
+            )
+            self.table.addTopLevelItem(item)
 
     @QtCore.Slot()
     def _sync_buttons(self) -> None:
-        has_row = self.table.currentRow() >= 0
+        has_row = self._current_row() >= 0
         self.edit_button.setEnabled(has_row)
         self.remove_button.setEnabled(has_row)
         targets = self._manager._selected_imagetool_targets()
@@ -538,6 +561,24 @@ class AcquisitionContextDialog(QtWidgets.QDialog):
                 self._fields.append(field)
         self._populate_table()
         self._sync_buttons()
+
+    @QtCore.Slot(object, object, object)
+    def _rows_reordered(
+        self,
+        row_ids: object,
+        _selected_ids: object,
+        _current_id: object,
+    ) -> None:
+        if not isinstance(row_ids, tuple) or not all(
+            isinstance(row_id, str) for row_id in row_ids
+        ):
+            return
+        fields_by_id = {self._field_row_id(field): field for field in self._fields}
+        if len(row_ids) != len(fields_by_id) or set(row_ids) != set(fields_by_id):
+            self._populate_table()
+            self._sync_buttons()
+            return
+        self._fields = [fields_by_id[row_id] for row_id in row_ids]
 
     @QtCore.Slot()
     def _show_add_menu(self) -> None:
@@ -561,9 +602,13 @@ class AcquisitionContextDialog(QtWidgets.QDialog):
             self._merge_fields((dialog.field,))
 
     @QtCore.Slot()
-    @QtCore.Slot(QtCore.QModelIndex)
-    def _edit_field(self, _index: QtCore.QModelIndex | None = None) -> None:
-        row = self.table.currentRow()
+    @QtCore.Slot(QtWidgets.QTreeWidgetItem, int)
+    def _edit_field(
+        self,
+        _item: QtWidgets.QTreeWidgetItem | None = None,
+        _column: int = 0,
+    ) -> None:
+        row = self._current_row()
         if row < 0:
             return
         dialog = _ContextFieldDialog(self, field=self._fields[row])
@@ -586,11 +631,11 @@ class AcquisitionContextDialog(QtWidgets.QDialog):
             return
         self._fields[row] = dialog.field
         self._populate_table()
-        self.table.selectRow(row)
+        self._select_row(row)
 
     @QtCore.Slot()
     def _remove_field(self) -> None:
-        row = self.table.currentRow()
+        row = self._current_row()
         if row < 0:
             return
         del self._fields[row]
@@ -735,6 +780,9 @@ class _AcquisitionContextController(QtCore.QObject):
                 if field.kind == "attribute":
                     attrs[field.name] = desired
                 else:
+                    if attrs:
+                        operations.append(AssignAttrsOperation(attrs=attrs))
+                        attrs = {}
                     operations.append(operation)
                 statuses.append("replace" if present else "add")
             except Exception as exc:

--- a/src/erlab/interactive/imagetool/manager/_acquisition_context.py
+++ b/src/erlab/interactive/imagetool/manager/_acquisition_context.py
@@ -1,0 +1,766 @@
+"""Workspace-scoped coordinate and attribute enrichment for ImageTool Manager."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import json
+import typing
+
+import pydantic
+from qtpy import QtCore, QtGui, QtWidgets
+
+import erlab
+from erlab.interactive._figurecomposer._ui._panel_controls import _step_toolbar_button
+from erlab.interactive.imagetool._provenance._model import (
+    ToolProvenanceOperation,
+    decode_provenance_value,
+    encode_provenance_value,
+    full_data,
+)
+from erlab.interactive.imagetool._provenance._operations import (
+    AssignAttrsOperation,
+    AssignScalarCoordOperation,
+)
+from erlab.interactive.imagetool.manager._metadata_editor import (
+    _parse_typed_value,
+    _value_text,
+    _value_type_name,
+    _values_equal,
+)
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Hashable, Iterable, Sequence
+
+    import xarray as xr
+
+    from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
+
+
+_ContextFieldKind = typing.Literal["coordinate", "attribute"]
+_ContextStatus = typing.Literal["add", "replace", "identical", "keep"]
+
+
+class AcquisitionContextField(pydantic.BaseModel):
+    """One reusable coordinate or attribute assignment."""
+
+    kind: _ContextFieldKind
+    name: str
+    value: typing.Any
+    replace_existing: bool = False
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="forbid")
+
+    @pydantic.field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("Field names cannot be empty.")
+        return value
+
+    @pydantic.model_validator(mode="after")
+    def _validate_value(self) -> typing.Self:
+        decoded = self.decoded_value
+        if (
+            self.kind == "coordinate"
+            and getattr(decoded, "ndim", None) != 0
+            and not isinstance(decoded, str | bytes)
+        ):
+            try:
+                iter(decoded)
+            except TypeError:
+                pass
+            else:
+                raise ValueError("Coordinates require a scalar value.")
+        try:
+            json.dumps(self.value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Field values must have a stable serializable representation."
+            ) from exc
+        return self
+
+    @classmethod
+    def from_value(
+        cls,
+        *,
+        kind: _ContextFieldKind,
+        name: str,
+        value: typing.Any,
+        replace_existing: bool = False,
+    ) -> typing.Self:
+        return cls(
+            kind=kind,
+            name=name,
+            value=encode_provenance_value(value),
+            replace_existing=replace_existing,
+        )
+
+    @property
+    def decoded_value(self) -> typing.Any:
+        return decode_provenance_value(self.value)
+
+    @property
+    def key(self) -> tuple[_ContextFieldKind, str]:
+        return self.kind, self.name
+
+    def with_value(self, value: typing.Any) -> typing.Self:
+        return type(self).from_value(
+            kind=self.kind,
+            name=self.name,
+            value=value,
+            replace_existing=self.replace_existing,
+        )
+
+    def operation(self) -> ToolProvenanceOperation:
+        value = self.decoded_value
+        if self.kind == "attribute":
+            return AssignAttrsOperation(attrs={self.name: value})
+        return AssignScalarCoordOperation(coord_name=self.name, value=value)
+
+    def display_type(self) -> str:
+        if self.kind == "attribute":
+            return _value_type_name(self.decoded_value)
+        return f"Scalar {_value_type_name(self.decoded_value)}"
+
+    def display_value(self) -> str:
+        return _value_text(self.decoded_value)
+
+
+class AcquisitionContextState(pydantic.BaseModel):
+    """Serializable state for one Manager workspace."""
+
+    schema_version: int = 1
+    enabled: bool = False
+    fields: tuple[AcquisitionContextField, ...] = ()
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="ignore")
+
+    @pydantic.model_validator(mode="after")
+    def _validate_fields(self) -> typing.Self:
+        keys = [field.key for field in self.fields]
+        if len(keys) != len(set(keys)):
+            raise ValueError("Acquisition context field names must be unique by kind.")
+        if self.enabled and not self.fields:
+            return self.model_copy(update={"enabled": False})
+        return self
+
+
+@dataclasses.dataclass(frozen=True)
+class ContextResolution:
+    operations: tuple[ToolProvenanceOperation, ...]
+    statuses: tuple[_ContextStatus, ...]
+    errors: tuple[str, ...] = ()
+
+    @property
+    def added(self) -> int:
+        return self.statuses.count("add")
+
+    @property
+    def replaced(self) -> int:
+        return self.statuses.count("replace")
+
+    @property
+    def identical(self) -> int:
+        return self.statuses.count("identical")
+
+    @property
+    def kept(self) -> int:
+        return self.statuses.count("keep")
+
+
+@dataclasses.dataclass
+class ContextIngressSummary:
+    added: int = 0
+    replaced: int = 0
+    identical: int = 0
+    kept: int = 0
+    failed: int = 0
+
+    def add_resolution(self, resolution: ContextResolution) -> None:
+        self.identical += resolution.identical
+        self.kept += resolution.kept
+        if resolution.errors:
+            self.failed += 1
+            return
+        self.added += resolution.added
+        self.replaced += resolution.replaced
+
+
+class _ContextFieldDialog(QtWidgets.QDialog):
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget,
+        *,
+        field: AcquisitionContextField | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Acquisition Context Field")
+        self._field: AcquisitionContextField | None = None
+
+        layout = QtWidgets.QFormLayout(self)
+        self.kind_combo = QtWidgets.QComboBox(self)
+        self.kind_combo.addItem("Coordinate", userData="coordinate")
+        self.kind_combo.addItem("Attribute", userData="attribute")
+        layout.addRow("Kind", self.kind_combo)
+
+        self.name_edit = QtWidgets.QLineEdit(self)
+        layout.addRow("Name", self.name_edit)
+
+        self.type_combo = QtWidgets.QComboBox(self)
+        self.type_combo.addItems(["String", "Int", "Float", "Bool", "Python literal"])
+        layout.addRow("Value Type", self.type_combo)
+
+        self.value_edit = erlab.interactive.utils.SingleLinePlainTextEdit(self)
+        self.value_edit.setFont(
+            QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
+        )
+        layout.addRow("Value", self.value_edit)
+
+        self.existing_combo = QtWidgets.QComboBox(self)
+        self.existing_combo.addItem("Keep Existing", userData=False)
+        self.existing_combo.addItem("Replace Existing", userData=True)
+        layout.addRow("If Present", self.existing_combo)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+        if field is not None:
+            self._restore_field(field)
+        else:
+            self.type_combo.setCurrentText("Float")
+            self.value_edit.setText("0.0")
+
+    @property
+    def field(self) -> AcquisitionContextField:
+        if self._field is None:
+            raise RuntimeError("The context field dialog was not accepted.")
+        return self._field
+
+    def _restore_field(self, field: AcquisitionContextField) -> None:
+        self.kind_combo.setCurrentIndex(
+            self.kind_combo.findData(field.kind, QtCore.Qt.ItemDataRole.UserRole)
+        )
+        self.name_edit.setText(field.name)
+        value = field.decoded_value
+        self.type_combo.setCurrentText(_value_type_name(value))
+        self.value_edit.setText(_value_text(value))
+        self.existing_combo.setCurrentIndex(
+            self.existing_combo.findData(
+                field.replace_existing, QtCore.Qt.ItemDataRole.UserRole
+            )
+        )
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        try:
+            kind = typing.cast("_ContextFieldKind", self.kind_combo.currentData())
+            value = _parse_typed_value(
+                self.type_combo.currentText(), self.value_edit.text()
+            )
+            self._field = AcquisitionContextField.from_value(
+                kind=kind,
+                name=self.name_edit.text(),
+                value=value,
+                replace_existing=bool(self.existing_combo.currentData()),
+            )
+        except Exception as exc:
+            erlab.interactive.utils.MessageDialog.critical(
+                self,
+                "Invalid Field",
+                "The acquisition context field is not valid.",
+                str(exc),
+            )
+            return
+        super().accept()
+
+
+class _ContextSourcePickerDialog(QtWidgets.QDialog):
+    def __init__(self, parent: QtWidgets.QWidget, data: xr.DataArray) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Add Fields from ImageTool")
+        self._selected_fields: tuple[AcquisitionContextField, ...] = ()
+
+        layout = QtWidgets.QVBoxLayout(self)
+        self.tree = QtWidgets.QTreeWidget(self)
+        self.tree.setHeaderLabels(["Field", "Value"])
+        self.tree.setRootIsDecorated(True)
+        layout.addWidget(self.tree)
+
+        coords_root = QtWidgets.QTreeWidgetItem(["Coordinates"])
+        attrs_root = QtWidgets.QTreeWidgetItem(["Attributes"])
+        self.tree.addTopLevelItems([coords_root, attrs_root])
+        for name, coord in data.coords.items():
+            if not isinstance(name, str) or coord.ndim != 0:
+                continue
+            field: AcquisitionContextField | None = None
+            with contextlib.suppress(Exception):
+                field = AcquisitionContextField.from_value(
+                    kind="coordinate", name=name, value=coord.item()
+                )
+            if field is None:
+                continue
+            self._add_picker_item(coords_root, field)
+        for name, value in data.attrs.items():
+            if not isinstance(name, str):
+                continue
+            field = None
+            with contextlib.suppress(Exception):
+                field = AcquisitionContextField.from_value(
+                    kind="attribute", name=name, value=value
+                )
+            if field is None:
+                continue
+            self._add_picker_item(attrs_root, field)
+        self.tree.expandAll()
+        self.tree.resizeColumnToContents(0)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _add_picker_item(
+        self, parent: QtWidgets.QTreeWidgetItem, field: AcquisitionContextField
+    ) -> None:
+        item = QtWidgets.QTreeWidgetItem([field.name, field.display_value()])
+        item.setFlags(
+            item.flags()
+            | QtCore.Qt.ItemFlag.ItemIsUserCheckable
+            | QtCore.Qt.ItemFlag.ItemIsEnabled
+        )
+        item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
+        item.setData(0, QtCore.Qt.ItemDataRole.UserRole, field)
+        parent.addChild(item)
+
+    @property
+    def selected_fields(self) -> tuple[AcquisitionContextField, ...]:
+        return self._selected_fields
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        fields: list[AcquisitionContextField] = []
+        root = self.tree.invisibleRootItem()
+        if root is None:
+            return
+        for group_index in range(root.childCount()):
+            group = root.child(group_index)
+            if group is None:
+                continue
+            for row in range(group.childCount()):
+                item = group.child(row)
+                if item is None:
+                    continue
+                if item.checkState(0) != QtCore.Qt.CheckState.Checked:
+                    continue
+                field = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+                if isinstance(field, AcquisitionContextField):
+                    fields.append(field)
+        if not fields:
+            QtWidgets.QMessageBox.warning(
+                self, "No Fields Selected", "Select at least one field to add."
+            )
+            return
+        self._selected_fields = tuple(fields)
+        super().accept()
+
+
+class AcquisitionContextDialog(QtWidgets.QDialog):
+    def __init__(
+        self, parent: QtWidgets.QWidget, controller: _AcquisitionContextController
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Acquisition Context")
+        self._controller = controller
+        self._manager = controller.manager
+        state = controller.state
+        self._fields = list(state.fields)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        self.enabled_check = QtWidgets.QCheckBox(
+            "Apply automatically when loading data from files", self
+        )
+        self.enabled_check.setChecked(state.enabled)
+        layout.addWidget(self.enabled_check)
+
+        self.table = QtWidgets.QTableWidget(self)
+        self.table.setObjectName("manager_acquisition_context_table")
+        self.table.setColumnCount(5)
+        self.table.setHorizontalHeaderLabels(
+            ["Kind", "Name", "Type", "Value", "If Present"]
+        )
+        self.table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.table.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        )
+        self.table.doubleClicked.connect(self._edit_field)
+
+        field_buttons = QtWidgets.QHBoxLayout()
+        field_buttons.setSpacing(4)
+        self.add_button = _step_toolbar_button(
+            self,
+            "manager_acquisition_context_add_button",
+            "Add ▾",
+            "Add an acquisition context field.",
+        )
+        self.add_button.setAccessibleName("Add acquisition context field")
+        self.add_button.setProperty("uses_inline_menu_arrow", True)
+        self.add_menu = QtWidgets.QMenu(self.add_button)
+        self.add_menu.setObjectName("manager_acquisition_context_add_menu")
+        self.add_field_action = QtGui.QAction("Add Field…", self.add_menu)
+        self.add_field_action.setObjectName(
+            "manager_acquisition_context_add_field_action"
+        )
+        self.add_field_action.triggered.connect(self._add_field)
+        self.add_menu.addAction(self.add_field_action)
+        self.from_selected_action = QtGui.QAction(
+            "Add from Selected ImageTool…", self.add_menu
+        )
+        self.from_selected_action.setObjectName(
+            "manager_acquisition_context_from_selected_action"
+        )
+        self.from_selected_action.triggered.connect(self._from_selected)
+        self.add_menu.addAction(self.from_selected_action)
+        self.add_button.clicked.connect(self._show_add_menu)
+        field_buttons.addWidget(self.add_button)
+
+        self.edit_button = _step_toolbar_button(
+            self,
+            "manager_acquisition_context_edit_button",
+            "Edit…",
+            "Edit the selected acquisition context field.",
+        )
+        self.edit_button.setAccessibleName("Edit acquisition context field")
+        self.edit_button.clicked.connect(self._edit_field)
+        field_buttons.addWidget(self.edit_button)
+
+        self.remove_button = _step_toolbar_button(
+            self,
+            "manager_acquisition_context_remove_button",
+            "Remove",
+            "Remove the selected acquisition context field.",
+        )
+        self.remove_button.setAccessibleName("Remove acquisition context field")
+        self.remove_button.clicked.connect(self._remove_field)
+        field_buttons.addWidget(self.remove_button)
+        field_buttons.addStretch()
+        layout.addLayout(field_buttons)
+        layout.addWidget(self.table)
+
+        footer = QtWidgets.QHBoxLayout()
+        self.clear_button = QtWidgets.QPushButton("Clear Context…", self)
+        self.clear_button.clicked.connect(self._clear)
+        footer.addWidget(self.clear_button)
+        footer.addStretch()
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Save
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        self.button_box.accepted.connect(self._save)
+        self.button_box.rejected.connect(self.reject)
+        footer.addWidget(self.button_box)
+        layout.addLayout(footer)
+
+        self.table.itemSelectionChanged.connect(self._sync_buttons)
+        self._populate_table()
+        self._sync_buttons()
+        self.resize(720, 420)
+
+    def _selected_data(self) -> xr.DataArray | None:
+        targets = self._manager._selected_imagetool_targets()
+        if len(targets) != 1:
+            return None
+        return self._manager._metadata_editor.metadata_data(targets[0])
+
+    def _state(self) -> AcquisitionContextState:
+        return AcquisitionContextState(
+            enabled=self.enabled_check.isChecked(), fields=tuple(self._fields)
+        )
+
+    def _populate_table(self) -> None:
+        self.table.setRowCount(len(self._fields))
+        for row, field in enumerate(self._fields):
+            values = (
+                "Coordinate" if field.kind == "coordinate" else "Attribute",
+                field.name,
+                field.display_type(),
+                field.display_value(),
+                "Replace" if field.replace_existing else "Keep",
+            )
+            for column, value in enumerate(values):
+                item = QtWidgets.QTableWidgetItem(value)
+                item.setFlags(
+                    QtCore.Qt.ItemFlag.ItemIsEnabled
+                    | QtCore.Qt.ItemFlag.ItemIsSelectable
+                )
+                if column == 0:
+                    item.setData(QtCore.Qt.ItemDataRole.UserRole, field)
+                self.table.setItem(row, column, item)
+        header = self.table.horizontalHeader()
+        if header is not None:
+            for column in (0, 1, 2, 4):
+                header.setSectionResizeMode(
+                    column, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+                )
+            header.setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeMode.Stretch)
+
+    @QtCore.Slot()
+    def _sync_buttons(self) -> None:
+        has_row = self.table.currentRow() >= 0
+        self.edit_button.setEnabled(has_row)
+        self.remove_button.setEnabled(has_row)
+        targets = self._manager._selected_imagetool_targets()
+        self.from_selected_action.setEnabled(len(targets) == 1)
+        self.clear_button.setEnabled(bool(self._fields))
+
+    def _merge_fields(self, fields: Iterable[AcquisitionContextField]) -> None:
+        positions = {field.key: index for index, field in enumerate(self._fields)}
+        for field in fields:
+            if field.key in positions:
+                self._fields[positions[field.key]] = field
+            else:
+                positions[field.key] = len(self._fields)
+                self._fields.append(field)
+        self._populate_table()
+        self._sync_buttons()
+
+    @QtCore.Slot()
+    def _show_add_menu(self) -> None:
+        self.add_menu.popup(
+            self.add_button.mapToGlobal(QtCore.QPoint(0, self.add_button.height()))
+        )
+
+    @QtCore.Slot()
+    def _from_selected(self) -> None:
+        data = self._selected_data()
+        if data is None:
+            return
+        dialog = _ContextSourcePickerDialog(self, data)
+        if dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
+            self._merge_fields(dialog.selected_fields)
+
+    @QtCore.Slot()
+    def _add_field(self) -> None:
+        dialog = _ContextFieldDialog(self)
+        if dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
+            self._merge_fields((dialog.field,))
+
+    @QtCore.Slot()
+    @QtCore.Slot(QtCore.QModelIndex)
+    def _edit_field(self, _index: QtCore.QModelIndex | None = None) -> None:
+        row = self.table.currentRow()
+        if row < 0:
+            return
+        dialog = _ContextFieldDialog(self, field=self._fields[row])
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+        duplicate = next(
+            (
+                index
+                for index, field in enumerate(self._fields)
+                if index != row and field.key == dialog.field.key
+            ),
+            None,
+        )
+        if duplicate is not None:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Duplicate Field",
+                "Coordinate and attribute names must be unique within each kind.",
+            )
+            return
+        self._fields[row] = dialog.field
+        self._populate_table()
+        self.table.selectRow(row)
+
+    @QtCore.Slot()
+    def _remove_field(self) -> None:
+        row = self.table.currentRow()
+        if row < 0:
+            return
+        del self._fields[row]
+        self._populate_table()
+        self._sync_buttons()
+
+    @QtCore.Slot()
+    def _save(self) -> None:
+        try:
+            self._controller.set_state(self._state())
+        except Exception as exc:
+            erlab.interactive.utils.MessageDialog.critical(
+                self,
+                "Invalid Context",
+                "The acquisition context is not valid.",
+                str(exc),
+            )
+            return
+        self.accept()
+
+    @QtCore.Slot()
+    def _clear(self) -> None:
+        answer = QtWidgets.QMessageBox.question(
+            self,
+            "Clear Acquisition Context",
+            "Remove every field and turn off automatic application?",
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+            QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        if answer != QtWidgets.QMessageBox.StandardButton.Yes:
+            return
+        self._controller.set_state(AcquisitionContextState())
+        self.accept()
+
+
+class _AcquisitionContextController(QtCore.QObject):
+    """Coordinate acquisition-context state, UI, and file ingress."""
+
+    def __init__(self, manager: ImageToolManager) -> None:
+        super().__init__(manager)
+        self.manager = manager
+        self._status_button: QtWidgets.QToolButton | None = None
+        if not isinstance(manager._workspace_state.acquisition_context, dict):
+            manager._workspace_state.acquisition_context = {}
+
+    @property
+    def state(self) -> AcquisitionContextState:
+        try:
+            return AcquisitionContextState.model_validate(
+                self.manager._workspace_state.acquisition_context
+            )
+        except Exception:
+            return AcquisitionContextState()
+
+    def state_payload(self) -> dict[str, typing.Any]:
+        return self.state.model_dump(mode="json")
+
+    def set_state(
+        self, state: AcquisitionContextState, *, mark_dirty: bool = True
+    ) -> None:
+        state = AcquisitionContextState.model_validate(state)
+        payload = state.model_dump(mode="json")
+        if state == self.state:
+            self.manager._workspace_state.acquisition_context = payload
+            self.refresh_ui()
+            return
+        self.manager._workspace_state.acquisition_context = payload
+        self.refresh_ui()
+        if mark_dirty:
+            self.manager._workspace_controller._mark_workspace_context_dirty()
+
+    def restore_state_payload(self, payload: typing.Any) -> None:
+        try:
+            state = AcquisitionContextState.model_validate(payload or {})
+        except Exception:
+            erlab.utils.misc.emit_user_level_warning(
+                "Ignoring invalid saved acquisition context state."
+            )
+            state = AcquisitionContextState()
+        self.set_state(state, mark_dirty=False)
+
+    def bind_status_button(self, button: QtWidgets.QToolButton) -> None:
+        self._status_button = button
+        button.clicked.connect(self.show_editor)
+        self.refresh_ui()
+
+    def refresh_ui(self) -> None:
+        button = self._status_button
+        if button is None:
+            return
+        state = self.state
+        active = state.enabled and bool(state.fields)
+        button.setVisible(active)
+        if not active:
+            return
+        button.setText(f"Context · {len(state.fields)} fields")
+        button.setToolTip(
+            "Applied automatically when loading data from files\n"
+            + "\n".join(
+                f"{field.name}: {field.display_value()}" for field in state.fields
+            )
+        )
+
+    @QtCore.Slot()
+    def show_editor(self) -> None:
+        dialog = AcquisitionContextDialog(self.manager, self)
+        dialog.exec()
+
+    def resolve(
+        self,
+        data: xr.DataArray,
+        fields: Sequence[AcquisitionContextField] | None = None,
+    ) -> ContextResolution:
+        if fields is None:
+            fields = self.state.fields
+        operations: list[ToolProvenanceOperation] = []
+        attrs: dict[Hashable, typing.Any] = {}
+        statuses: list[_ContextStatus] = []
+        errors: list[str] = []
+        for field in fields:
+            try:
+                desired = field.decoded_value
+                if field.kind == "coordinate":
+                    present = field.name in data.coords
+                    if present:
+                        coord = data.coords[field.name]
+                        current = coord.values[()] if coord.ndim == 0 else coord.values
+                    else:
+                        current = None
+                else:
+                    present = field.name in data.attrs
+                    current = data.attrs.get(field.name)
+                if present and _values_equal(current, desired):
+                    statuses.append("identical")
+                    continue
+                if present and not field.replace_existing:
+                    statuses.append("keep")
+                    continue
+                operation = field.operation()
+                operation.apply(data, parent_data=data)
+                if field.kind == "attribute":
+                    attrs[field.name] = desired
+                else:
+                    operations.append(operation)
+                statuses.append("replace" if present else "add")
+            except Exception as exc:
+                errors.append(f"{field.name}: {exc}")
+        if errors:
+            return ContextResolution((), tuple(statuses), tuple(errors))
+        if attrs:
+            operations.append(AssignAttrsOperation(attrs=attrs))
+        if operations:
+            try:
+                processed = full_data(*operations).apply(data)
+                erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(
+                    processed
+                )
+            except Exception as exc:
+                return ContextResolution((), tuple(statuses), (str(exc),))
+        return ContextResolution(tuple(operations), tuple(statuses))
+
+    def apply_to_file_data(
+        self, data: xr.DataArray
+    ) -> tuple[xr.DataArray, tuple[ToolProvenanceOperation, ...], ContextResolution]:
+        state = self.state
+        if not state.enabled or not state.fields:
+            return data, (), ContextResolution((), ())
+        resolution = self.resolve(data, state.fields)
+        if resolution.errors or not resolution.operations:
+            return data, (), resolution
+        processed = full_data(*resolution.operations).apply(data).rename(data.name)
+        return processed, resolution.operations, resolution

--- a/src/erlab/interactive/imagetool/manager/_acquisition_context.py
+++ b/src/erlab/interactive/imagetool/manager/_acquisition_context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc
 import contextlib
 import dataclasses
 import json
@@ -138,13 +139,22 @@ class AcquisitionContextState(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(frozen=True, extra="ignore")
 
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _disable_empty_context(cls, value: typing.Any) -> typing.Any:
+        if (
+            isinstance(value, collections.abc.Mapping)
+            and value.get("enabled")
+            and not value.get("fields")
+        ):
+            value = {**value, "enabled": False}
+        return value
+
     @pydantic.model_validator(mode="after")
     def _validate_fields(self) -> typing.Self:
         keys = [field.key for field in self.fields]
         if len(keys) != len(set(keys)):
             raise ValueError("Acquisition context field names must be unique by kind.")
-        if self.enabled and not self.fields:
-            return self.model_copy(update={"enabled": False})
         return self
 
 

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -505,9 +505,8 @@ class _ActionsController:
         ) in preflight_plan:
             try:
                 processed = source_spec.apply(slicer_area.data).rename(input_name)
-                erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
-                    processed,
-                    copy_values=False,
+                erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(
+                    processed
                 )
 
                 parent_provenance = node.displayed_provenance_spec
@@ -934,16 +933,45 @@ class _ActionsController:
         )
         if prepared_data is None:
             return
+
+        plans: list[
+            tuple[
+                bool,
+                int | str,
+                xr.DataArray,
+                tuple[xr.DataArray, ToolProvenanceSpec | None] | None,
+            ]
+        ] = []
+        planned_next_idx = self._manager.next_idx
         for prepared, idx in zip(prepared_data, indices, strict=True):
             darr = prepared.data
             if isinstance(idx, int) and idx < 0:
                 # Negative index counts from the end
                 idx = sorted(self._manager._tool_graph.root_wrappers.keys())[idx]
-            elif isinstance(idx, int) and idx == self._manager.next_idx:
-                # If not yet created, add new tool
-                self._manager._data_ingress.receive_data([darr], {})
+            add_new = isinstance(idx, int) and idx == planned_next_idx
+            if add_new:
+                erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(darr)
+                plans.append((True, idx, darr, None))
+                planned_next_idx += 1
                 continue
-            self._manager.get_imagetool(idx).slicer_area.replace_source_data(darr)
+            replacement = self._manager._metadata_editor.prepare_replacement(
+                idx, darr, source_input_dtype=prepared.source_dtype
+            )
+            if replacement is None:
+                erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(darr)
+            plans.append((False, idx, darr, replacement))
+
+        for add_new, idx, darr, replacement in plans:
+            if add_new:
+                # If not yet created, add new tool.
+                self._manager._data_ingress.receive_data([darr], {})
+            elif replacement is None:
+                self._manager.get_imagetool(idx).slicer_area.replace_source_data(darr)
+            else:
+                processed, provenance = replacement
+                self._manager._metadata_editor.commit_replacement(
+                    idx, darr, processed, provenance
+                )
         self._manager._sigDataReplaced.emit()
 
     def _find_watched_idx(self, uid: str) -> int | None:
@@ -1066,11 +1094,36 @@ class _ActionsController:
             if prepared_data is None:  # pragma: no cover - no dialog is shown here
                 return
             prepared = prepared_data[0]
+            try:
+                replacement = self._manager._metadata_editor.prepare_replacement(
+                    idx,
+                    prepared.data,
+                    source_input_dtype=prepared.source_dtype,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "Could not preserve metadata assignments on watched variable "
+                    "update",
+                    extra={"suppress_ui_alert": True},
+                )
+                erlab.interactive.utils.MessageDialog.critical(
+                    self._manager,
+                    "Watched Data Update Failed",
+                    f"Could not update watched variable {varname!r} in ImageTool.",
+                    str(exc),
+                )
+                return
             wrapper.set_source_input_ndim(prepared.source_ndim)
             wrapper.set_source_input_dtype(prepared.source_dtype)
-            self._manager.get_imagetool(idx).slicer_area.replace_source_data(
-                prepared.data
-            )
+            if replacement is None:
+                self._manager.get_imagetool(idx).slicer_area.replace_source_data(
+                    prepared.data
+                )
+            else:
+                processed, provenance = replacement
+                self._manager._metadata_editor.commit_replacement(
+                    idx, prepared.data, processed, provenance
+                )
 
     def _data_unwatch(self, uid: str) -> None:
         idx = self._manager._find_watched_idx(uid)

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -961,10 +961,14 @@ class _ActionsController:
                 erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(darr)
             plans.append((False, idx, darr, replacement))
 
+        data_changed = False
         for add_new, idx, darr, replacement in plans:
             if add_new:
                 # If not yet created, add new tool.
-                self._manager._data_ingress.receive_data([darr], {})
+                if idx != self._manager.next_idx:
+                    break
+                if self._manager._data_ingress.receive_data([darr], {}) != [True]:
+                    break
             elif replacement is None:
                 self._manager.get_imagetool(idx).slicer_area.replace_source_data(darr)
             else:
@@ -972,7 +976,9 @@ class _ActionsController:
                 self._manager._metadata_editor.commit_replacement(
                     idx, darr, processed, provenance
                 )
-        self._manager._sigDataReplaced.emit()
+            data_changed = True
+        if data_changed:
+            self._manager._sigDataReplaced.emit()
 
     def _find_watched_idx(self, uid: str) -> int | None:
         """Find the index of the watched ImageTool corresponding to the given UID."""

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -1001,7 +1001,7 @@ class _ActionsController:
             )
         )
         idx = all_source_keys.index(source_key)
-        return _WATCHED_VAR_COLORS[idx % len(_WATCHED_VAR_COLORS)]
+        return QtGui.QColor(*_WATCHED_VAR_COLORS[idx % len(_WATCHED_VAR_COLORS)])
 
     def _remove_watched(self, uid: str) -> None:
         """Remove the ImageTool corresponding to the given watched variable UID."""

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -25,6 +25,9 @@ if typing.TYPE_CHECKING:
     from erlab.interactive._options.schema import AppOptions
     from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
     from erlab.interactive.imagetool._mainwindow import ImageTool
+    from erlab.interactive.imagetool.manager._acquisition_context import (
+        _AcquisitionContextController,
+    )
     from erlab.interactive.imagetool.manager._actions import _ActionsController
     from erlab.interactive.imagetool.manager._console import (
         _ImageToolManagerJupyterConsole,
@@ -49,6 +52,9 @@ if typing.TYPE_CHECKING:
     from erlab.interactive.imagetool.manager._lineage import _LineageController
     from erlab.interactive.imagetool.manager._linking import _ManagerLinkRegistry
     from erlab.interactive.imagetool.manager._metadata import _ManagerToolMetadataQueue
+    from erlab.interactive.imagetool.manager._metadata_editor import (
+        _MetadataEditorController,
+    )
     from erlab.interactive.imagetool.manager._modelview import _ImageToolWrapperTreeView
     from erlab.interactive.imagetool.manager._provenance_edit import (
         _ProvenanceEditController,
@@ -108,6 +114,9 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
 
     # Actions and widgets installed by ImageToolManager.__init__.
     console: _ImageToolManagerJupyterConsole
+    acquisition_context_action: QtGui.QAction
+    acquisition_context_status_button: QtWidgets.QToolButton
+    metadata_editor_action: QtGui.QAction
     concat_action: QtGui.QAction
     compact_workspace_action: QtGui.QAction
     create_figure_action: QtGui.QAction
@@ -160,6 +169,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     _alert_dialogs: list[erlab.interactive.utils.MessageDialog]
     _application_quit_filter: QtCore.QObject | None
     _actions_controller: _ActionsController
+    _acquisition_context: _AcquisitionContextController
     _bulk_remove_depth: int
     _dask_menu: DaskMenu
     _dependency_tracker: _ManagerDependencyTracker
@@ -182,6 +192,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     _metadata_detail_labels: dict[str, QtWidgets.QLabel]
     _metadata_full_code_available: bool
     _metadata_monospace_font: QtGui.QFont
+    _metadata_editor: _MetadataEditorController
     _metadata_node_uid: str | None
     _notes_node_uid: str | None
     _note_commit_timer: QtCore.QTimer

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -1376,6 +1376,7 @@ class _DetailsPanelController:
             multiple_selected and len(selection_children) == 0
         )
         self._manager.batch_action.setEnabled(self._manager.batch_target_count() >= 2)
+        self._manager.metadata_editor_action.setEnabled(bool(imagetool_targets))
         self._manager.create_figure_action.setEnabled(
             bool(self._manager._selected_figure_source_targets())
         )

--- a/src/erlab/interactive/imagetool/manager/_heartbeat.py
+++ b/src/erlab/interactive/imagetool/manager/_heartbeat.py
@@ -167,12 +167,10 @@ class _RegistryHeartbeatController(QtCore.QObject):
                 return False
             app = QtCore.QCoreApplication.instance()
             if app is not None:
+                # The worker completion is a queued metacall. Processing every event
+                # here can re-enter unrelated UI teardown while the controller stops.
                 QtCore.QCoreApplication.sendPostedEvents(
                     None, int(QtCore.QEvent.Type.MetaCall.value)
-                )
-                app.processEvents(
-                    QtCore.QEventLoop.ProcessEventsFlag.AllEvents,
-                    min(10, remaining_ms),
                 )
             QtCore.QThread.msleep(min(10, remaining_ms))
         return True

--- a/src/erlab/interactive/imagetool/manager/_io.py
+++ b/src/erlab/interactive/imagetool/manager/_io.py
@@ -235,7 +235,6 @@ class _DataIngressController:
                 context_data, context_operations, context_resolution = (
                     self._manager._acquisition_context.apply_to_file_data(source_data)
                 )
-                context_summary.add_resolution(context_resolution)
             preparation_operations = (
                 *preparation_operations,
                 *context_operations,
@@ -268,6 +267,8 @@ class _DataIngressController:
                     source_input_dtype=source_input_dtype,
                 )
                 indices.append(new_index)
+                if context_resolution is not None:
+                    context_summary.add_resolution(context_resolution)
                 if watched_var is not None:
                     node = self._manager._node_for_target(indices[-1])
                     if node.imagetool is not None:

--- a/src/erlab/interactive/imagetool/manager/_io.py
+++ b/src/erlab/interactive/imagetool/manager/_io.py
@@ -20,6 +20,9 @@ from qtpy import QtCore, QtWidgets
 import erlab
 from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool._provenance._model import FileDataSelection
+from erlab.interactive.imagetool.manager._acquisition_context import (
+    ContextIngressSummary,
+)
 from erlab.interactive.imagetool.manager._dialogs import _is_loader_func
 
 logger = logging.getLogger(__name__)
@@ -89,9 +92,12 @@ class _DataIngressController:
         watched_var: tuple[str, str] | None = None,
         watched_metadata: Mapping[str, typing.Any] | None = None,
         show: bool | None = None,
+        _context_summary: ContextIngressSummary | None = None,
     ) -> list[bool]:
         """Construct manager-owned ImageTools from received arrays or datasets."""
         flags: list[bool] = []
+        report_context_status = _context_summary is None
+        context_summary = _context_summary or ContextIngressSummary()
         if erlab.utils.misc.is_sequence_of(data, xr.Dataset):
             for ds in data:
                 try:
@@ -221,35 +227,47 @@ class _DataIngressController:
                 if source_input_dtypes is not None
                 else prepared.source_dtype
             )
-            try:
-                indices.append(
-                    self._manager.add_imagetool(
-                        ImageTool(
-                            prepared.data,
-                            **kwargs,
-                            load_func=this_load_func,
-                            preparation_operations=preparation_operations,
-                        ),
-                        show=show,
-                        activate=show,
-                        watched_var=watched_var,
-                        watched_workspace_link_id=typing.cast(
-                            "str | None",
-                            watched_metadata.get("workspace_link_id"),
-                        ),
-                        watched_source_label=typing.cast(
-                            "str | None", watched_metadata.get("source_label")
-                        ),
-                        watched_source_uid=typing.cast(
-                            "str | None", watched_metadata.get("source_uid")
-                        ),
-                        watched_connected=bool(
-                            watched_metadata.get("connected", watched_var is not None)
-                        ),
-                        source_input_ndim=source_input_ndim,
-                        source_input_dtype=source_input_dtype,
-                    )
+            source_data = prepared.data
+            context_data = source_data
+            context_operations: tuple[ToolProvenanceOperation, ...] = ()
+            context_resolution = None
+            if this_load_func is not None:
+                context_data, context_operations, context_resolution = (
+                    self._manager._acquisition_context.apply_to_file_data(source_data)
                 )
+                context_summary.add_resolution(context_resolution)
+            preparation_operations = (
+                *preparation_operations,
+                *context_operations,
+            )
+            try:
+                new_index = self._manager.add_imagetool(
+                    ImageTool(
+                        context_data,
+                        **kwargs,
+                        load_func=this_load_func,
+                        preparation_operations=preparation_operations,
+                    ),
+                    show=show,
+                    activate=show,
+                    watched_var=watched_var,
+                    watched_workspace_link_id=typing.cast(
+                        "str | None",
+                        watched_metadata.get("workspace_link_id"),
+                    ),
+                    watched_source_label=typing.cast(
+                        "str | None", watched_metadata.get("source_label")
+                    ),
+                    watched_source_uid=typing.cast(
+                        "str | None", watched_metadata.get("source_uid")
+                    ),
+                    watched_connected=bool(
+                        watched_metadata.get("connected", watched_var is not None)
+                    ),
+                    source_input_ndim=source_input_ndim,
+                    source_input_dtype=source_input_dtype,
+                )
+                indices.append(new_index)
                 if watched_var is not None:
                     node = self._manager._node_for_target(indices[-1])
                     if node.imagetool is not None:
@@ -267,7 +285,29 @@ class _DataIngressController:
         if link:
             self._manager.link_imagetools(*indices, link_colors=link_colors)
 
+        if report_context_status:
+            context_status = self._context_status(context_summary)
+            if context_status:
+                self._manager._status_bar.showMessage(
+                    f"Loaded data · {context_status}", 5000
+                )
+
         return flags
+
+    @staticmethod
+    def _context_status(summary: ContextIngressSummary) -> str:
+        parts: list[str] = []
+        if summary.added:
+            parts.append(f"context added {summary.added} values")
+        if summary.replaced:
+            parts.append(f"replaced {summary.replaced} values")
+        if summary.kept:
+            parts.append(f"kept {summary.kept} existing values")
+        if summary.identical:
+            parts.append(f"{summary.identical} values already matched")
+        if summary.failed:
+            parts.append(f"skipped {summary.failed} incompatible targets")
+        return " · ".join(parts)
 
     def _show_loaded_info(
         self,
@@ -275,6 +315,7 @@ class _DataIngressController:
         canceled: list[pathlib.Path],
         failed: list[pathlib.Path],
         retry_callback: Callable[[list[pathlib.Path]], typing.Any],
+        context_summary: ContextIngressSummary,
     ) -> None:
         """Report aggregate file-loading results and offer to retry failures."""
         loaded, canceled, failed = (
@@ -283,9 +324,10 @@ class _DataIngressController:
             list(dict.fromkeys(failed)),
         )
         n_done, n_fail = len(loaded), len(failed)
-        self._manager._status_bar.showMessage(
-            f"Loaded {n_done} {'file' if n_done == 1 else 'files'}", 5000
-        )
+        status = f"Loaded {n_done} {'file' if n_done == 1 else 'files'}"
+        if context_status := self._context_status(context_summary):
+            status += f" · {context_status}"
+        self._manager._status_bar.showMessage(status, 5000)
         if n_fail == 0:
             return
 
@@ -421,6 +463,7 @@ class _DataIngressController:
                 aborted,
                 failed + failed_new,
                 retry_callback=retry_callback,
+                context_summary=handler.context_summary,
             )
             self._manager._file_handlers.remove(handler)
 
@@ -528,6 +571,7 @@ class _MultiFileHandler(QtCore.QObject):
         self.loaded: list[pathlib.Path] = []
         self.canceled: list[pathlib.Path] = []
         self.failed: list[pathlib.Path] = []
+        self.context_summary = ContextIngressSummary()
 
         self._abort: bool = False
 
@@ -626,6 +670,7 @@ class _MultiFileHandler(QtCore.QObject):
                 ),
             },
             show=(self.n_total == 1),
+            _context_summary=self.context_summary,
         )
         erlab.interactive.utils.single_shot(self, 0, self._load_next)
 

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -14,6 +14,9 @@ import erlab.interactive.imagetool.slicer
 from erlab.interactive._dask import DaskMenu
 from erlab.interactive.imagetool.manager import _desktop
 from erlab.interactive.imagetool.manager import _server as _manager_server
+from erlab.interactive.imagetool.manager._acquisition_context import (
+    _AcquisitionContextController,
+)
 from erlab.interactive.imagetool.manager._actions import _ActionsController
 from erlab.interactive.imagetool.manager._base import _ImageToolManagerBase
 from erlab.interactive.imagetool.manager._dependency import _ManagerDependencyTracker
@@ -33,6 +36,9 @@ from erlab.interactive.imagetool.manager._io import (
 from erlab.interactive.imagetool.manager._lineage import _LineageController
 from erlab.interactive.imagetool.manager._linking import _ManagerLinkRegistry
 from erlab.interactive.imagetool.manager._metadata import _ManagerToolMetadataQueue
+from erlab.interactive.imagetool.manager._metadata_editor import (
+    _MetadataEditorController,
+)
 from erlab.interactive.imagetool.manager._modelview import _ImageToolWrapperTreeView
 from erlab.interactive.imagetool.manager._provenance_edit import (
     _ProvenanceEditController,
@@ -284,6 +290,8 @@ class ImageToolManager(_ImageToolManagerBase):
         self._interaction_gate = _ManagerInteractionGate(self)
         self._interaction_gate.register_window(self)
         self._workspace_controller = _WorkspaceController(self)
+        self._acquisition_context = _AcquisitionContextController(self)
+        self._metadata_editor = _MetadataEditorController(self)
         self._tool_metadata_queue = _ManagerToolMetadataQueue(
             self,
             self._flush_pending_tool_metadata_updates,
@@ -517,6 +525,26 @@ class ImageToolManager(_ImageToolManagerBase):
         self.batch_action.triggered.connect(self.show_batch_operations)
         self.batch_action.setToolTip("Apply an operation to multiple ImageTools")
 
+        self.acquisition_context_action = QtWidgets.QAction(
+            "Acquisition Context…", self
+        )
+        self.acquisition_context_action.setObjectName(
+            "manager_acquisition_context_action"
+        )
+        self.acquisition_context_action.setToolTip(
+            "Configure coordinates and attributes applied while loading data files"
+        )
+        self.acquisition_context_action.triggered.connect(
+            self._acquisition_context.show_editor
+        )
+
+        self.metadata_editor_action = QtWidgets.QAction("Metadata Editor…", self)
+        self.metadata_editor_action.setObjectName("manager_metadata_editor_action")
+        self.metadata_editor_action.setToolTip(
+            "Edit scalar coordinates and attributes across selected ImageTools"
+        )
+        self.metadata_editor_action.triggered.connect(self._metadata_editor.show_editor)
+
         self.create_figure_action = QtWidgets.QAction("Add to Figure…", self)
         self.create_figure_action.setObjectName("manager_figure_action")
         self.create_figure_action.triggered.connect(self.create_figure_from_selection)
@@ -610,6 +638,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self.file_menu.addAction(self.open_action)
         self.file_menu.addAction(self.import_workspace_action)
         self.file_menu.addAction(self.explorer_action)
+        self.file_menu.addAction(self.acquisition_context_action)
         self.file_menu.addSeparator()
         self.file_menu.addAction(self.new_manager_action)
         self.file_menu.addSeparator()
@@ -634,6 +663,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self.edit_menu.addAction(self.reindex_action)
         self.edit_menu.addSeparator()
         self.edit_menu.addAction(self.concat_action)
+        self.edit_menu.addAction(self.metadata_editor_action)
         self.edit_menu.addAction(self.batch_action)
         self.edit_menu.addAction(self.create_figure_action)
         self.edit_menu.addAction(self.duplicate_action)
@@ -1009,6 +1039,16 @@ class ImageToolManager(_ImageToolManagerBase):
         self._file_handlers: set[_MultiFileHandler] = set()
 
         # Initialize status bar
+        self.acquisition_context_status_button = QtWidgets.QToolButton(self)
+        self.acquisition_context_status_button.setObjectName(
+            "manager_acquisition_context_status_button"
+        )
+        self.acquisition_context_status_button.setAutoRaise(True)
+        self.acquisition_context_status_button.setVisible(False)
+        self._status_bar.addPermanentWidget(self.acquisition_context_status_button)
+        self._acquisition_context.bind_status_button(
+            self.acquisition_context_status_button
+        )
         self._status_bar.showMessage("")
         self._manager_layout_tracking_enabled = True
 
@@ -1889,6 +1929,12 @@ class ImageToolManager(_ImageToolManagerBase):
     ) -> tuple[np.ndarray, np.ndarray] | None:
         loader = self._workspace_controller.loading
         return loader.pending._pending_workspace_imagetool_preview_curve(node)
+
+    def _pending_workspace_imagetool_metadata_data(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> xr.DataArray:
+        pending = self._workspace_controller.loading.pending
+        return pending._pending_workspace_imagetool_metadata_data(node)
 
     def _pending_workspace_tool_preview_image(
         self, node: _ImageToolWrapper | _ManagedWindowNode

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1539,7 +1539,7 @@ class ImageToolManager(_ImageToolManagerBase):
             if node is not None and node.workspace_link_key is not None:
                 return self.color_for_workspace_link_key(node.workspace_link_key)
         idx = self._link_registry.index(linker)
-        return _LINKER_COLORS[idx % len(_LINKER_COLORS)]
+        return QtGui.QColor(*_LINKER_COLORS[idx % len(_LINKER_COLORS)])
 
     def _invalidate_workspace_link_color_cache(self) -> None:
         self._workspace_link_color_cache_dirty = True
@@ -1590,7 +1590,7 @@ class ImageToolManager(_ImageToolManagerBase):
         if self._workspace_link_color_cache_dirty:
             color_indices = self._reconcile_workspace_link_color_cache()
         idx = color_indices.get(link_key, 0)
-        return _LINKER_COLORS[idx % len(_LINKER_COLORS)]
+        return QtGui.QColor(*_LINKER_COLORS[idx % len(_LINKER_COLORS)])
 
     def _clear_singleton_workspace_link_groups(
         self, link_keys: Iterable[str]

--- a/src/erlab/interactive/imagetool/manager/_metadata_editor.py
+++ b/src/erlab/interactive/imagetool/manager/_metadata_editor.py
@@ -44,7 +44,9 @@ if typing.TYPE_CHECKING:
 
 MetadataFieldKind = typing.Literal["coordinate", "attribute"]
 MetadataOrigin = typing.Literal["source", "assigned", "missing"]
+MetadataValueType = typing.Literal["String", "Int", "Float", "Bool", "Python literal"]
 _MISSING = object()
+_UNKNOWN_REFERENCE = object()
 
 
 def _values_equal(left: typing.Any, right: typing.Any) -> bool:
@@ -76,7 +78,7 @@ def _values_equal(left: typing.Any, right: typing.Any) -> bool:
         return bool(np.array_equal(left_array, right_array))
 
 
-def _value_type_name(value: typing.Any) -> str:
+def _value_type_name(value: typing.Any) -> MetadataValueType:
     if isinstance(value, bool):
         return "Bool"
     if isinstance(value, int | np.integer):
@@ -118,6 +120,11 @@ def _parse_typed_value(type_name: str, text: str) -> typing.Any:
 
 def _parse_editor_value(reference: typing.Any, text: str) -> typing.Any:
     """Parse table input while allowing deliberate metadata type changes."""
+    if reference is _UNKNOWN_REFERENCE:
+        try:
+            return ast.literal_eval(text.strip())
+        except (SyntaxError, ValueError):
+            return text
     try:
         return _parse_typed_value(_value_type_name(reference), text)
     except (SyntaxError, TypeError, ValueError) as typed_error:
@@ -158,14 +165,24 @@ class MetadataFieldWidth(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(frozen=True, extra="forbid")
 
 
+class MetadataFieldType(pydantic.BaseModel):
+    """Saved parse type for a metadata field that may be absent later."""
+
+    field: MetadataField
+    value_type: MetadataValueType
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="forbid")
+
+
 class MetadataEditorLayout(pydantic.BaseModel):
     """Workspace-scoped logbook column layout."""
 
-    schema_version: int = 2
+    schema_version: int = 3
     initialized: bool = False
     fields: tuple[MetadataField, ...] = ()
     data_column_width: int | None = pydantic.Field(default=None, ge=1, le=10_000)
     field_widths: tuple[MetadataFieldWidth, ...] = ()
+    field_types: tuple[MetadataFieldType, ...] = ()
 
     model_config = pydantic.ConfigDict(frozen=True, extra="ignore")
 
@@ -345,14 +362,21 @@ class _MetadataTableModel(QtCore.QAbstractTableModel):
                 value = _field_value(data, field)
                 match = matches.get(field)
                 present = value is not _MISSING
-                reference = value if present else self.field_defaults.get(field, "")
+                reference = (
+                    value
+                    if present
+                    else self.field_defaults.get(field, _UNKNOWN_REFERENCE)
+                )
                 self.cells[row, field] = MetadataCell(
                     field=field,
                     present=present,
                     value=None if not present else value,
                     assignment_ref=None if match is None else match[0],
                     assignment=None if match is None else match[1],
-                    editable=_stable_edit_value(field, reference),
+                    editable=(
+                        reference is _UNKNOWN_REFERENCE
+                        or _stable_edit_value(field, reference)
+                    ),
                 )
 
     def rowCount(self, parent: QtCore.QModelIndex | None = None) -> int:
@@ -498,7 +522,11 @@ class _MetadataTableModel(QtCore.QAbstractTableModel):
             raise ValueError("This value type cannot be edited reliably in the table.")
         reference = self.edited_values.get(
             key,
-            cell.value if cell.present else self.field_defaults.get(field, ""),
+            (
+                cell.value
+                if cell.present
+                else self.field_defaults.get(field, _UNKNOWN_REFERENCE)
+            ),
         )
         try:
             parsed = _parse_editor_value(reference, str(value))
@@ -1420,7 +1448,7 @@ class MetadataEditorDialog(QtWidgets.QDialog):
             self.model.set_fields(fields, self.model.field_defaults)
             self._resize_and_restore_columns()
         self.fields_widget.set_field_visible(field, visible)
-        self.controller.set_layout_fields(fields)
+        self.controller.set_layout_fields(fields, self.model.field_defaults)
 
     @QtCore.Slot(object)
     def _set_visible_fields(self, fields: object) -> None:
@@ -1434,7 +1462,7 @@ class MetadataEditorDialog(QtWidgets.QDialog):
             self._resize_and_restore_columns()
         for field in self.available_fields:
             self.fields_widget.set_field_visible(field, field in visible)
-        self.controller.set_layout_fields(visible)
+        self.controller.set_layout_fields(visible, self.model.field_defaults)
 
     @QtCore.Slot(object, object)
     def _add_field(self, field: object, value: object) -> None:
@@ -1447,7 +1475,7 @@ class MetadataEditorDialog(QtWidgets.QDialog):
             self.model.add_field(field, value)
             self._resize_and_restore_columns()
         self.fields_widget.add_field(field)
-        self.controller.set_layout_fields(self.model.fields)
+        self.controller.set_layout_fields(self.model.fields, self.model.field_defaults)
         self.fields_menu.close()
 
     @QtCore.Slot(QtCore.QPoint)
@@ -1467,7 +1495,7 @@ class MetadataEditorDialog(QtWidgets.QDialog):
     def _column_moved(self, _logical: int, _old: int, _new: int) -> None:
         ordered = self._visual_fields()
         if len(ordered) == len(self.model.fields):
-            self.controller.set_layout_fields(ordered)
+            self.controller.set_layout_fields(ordered, self.model.field_defaults)
 
     def _visual_fields(self) -> list[MetadataField]:
         header = typing.cast("QtWidgets.QHeaderView", self.table.horizontalHeader())
@@ -1615,15 +1643,40 @@ class _MetadataEditorController(QtCore.QObject):
             mode="json"
         )
 
-    def set_layout_fields(self, fields: Sequence[MetadataField]) -> None:
-        state = self.layout_state.model_copy(
+    def set_layout_fields(
+        self,
+        fields: Sequence[MetadataField],
+        field_defaults: Mapping[MetadataField, typing.Any] | None = None,
+    ) -> None:
+        state = self.layout_state
+        field_types = {saved.field: saved.value_type for saved in state.field_types}
+        if field_defaults is not None:
+            for field in fields:
+                value = field_defaults.get(field, _UNKNOWN_REFERENCE)
+                if value is not _UNKNOWN_REFERENCE:
+                    field_types[field] = _value_type_name(value)
+        state = state.model_copy(
             update={
-                "schema_version": 2,
+                "schema_version": 3,
                 "initialized": True,
                 "fields": tuple(fields),
+                "field_types": tuple(
+                    MetadataFieldType(field=field, value_type=value_type)
+                    for field, value_type in field_types.items()
+                ),
             }
         )
         self._set_layout_state(state)
+
+    def saved_field_type(self, field: MetadataField) -> MetadataValueType | None:
+        return next(
+            (
+                saved.value_type
+                for saved in reversed(self.layout_state.field_types)
+                if saved.field == field
+            ),
+            None,
+        )
 
     def saved_column_width(self, field: MetadataField | None) -> int | None:
         state = self.layout_state
@@ -1644,7 +1697,7 @@ class _MetadataEditorController(QtCore.QObject):
             if state.data_column_width == width:
                 return
             state = state.model_copy(
-                update={"schema_version": 2, "data_column_width": width}
+                update={"schema_version": 3, "data_column_width": width}
             )
         else:
             widths = {saved.field: saved.width for saved in state.field_widths}
@@ -1653,7 +1706,7 @@ class _MetadataEditorController(QtCore.QObject):
             widths[field] = width
             state = state.model_copy(
                 update={
-                    "schema_version": 2,
+                    "schema_version": 3,
                     "field_widths": tuple(
                         MetadataFieldWidth(field=saved_field, width=saved_width)
                         for saved_field, saved_width in widths.items()
@@ -1742,7 +1795,22 @@ class _MetadataEditorController(QtCore.QObject):
             if saved_field not in seen:
                 ordered.append(saved_field)
                 seen.add(saved_field)
-            defaults.setdefault(saved_field, "")
+            saved_type = self.saved_field_type(saved_field)
+            default_by_type: dict[MetadataValueType, typing.Any] = {
+                "String": "",
+                "Int": 0,
+                "Float": 0.0,
+                "Bool": False,
+                "Python literal": None,
+            }
+            defaults.setdefault(
+                saved_field,
+                (
+                    _UNKNOWN_REFERENCE
+                    if saved_type is None
+                    else default_by_type[saved_type]
+                ),
+            )
             coverage.setdefault(saved_field, 0)
         ordered.sort(
             key=lambda field: (

--- a/src/erlab/interactive/imagetool/manager/_metadata_editor.py
+++ b/src/erlab/interactive/imagetool/manager/_metadata_editor.py
@@ -31,7 +31,7 @@ from erlab.interactive.imagetool._provenance._operations import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable, Iterable, Mapping, Sequence
+    from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
 
     import xarray as xr
 
@@ -149,12 +149,23 @@ class MetadataField(pydantic.BaseModel):
         return AssignScalarCoordOperation(coord_name=self.name, value=value)
 
 
+class MetadataFieldWidth(pydantic.BaseModel):
+    """Saved width for a metadata column with a stable field identity."""
+
+    field: MetadataField
+    width: int = pydantic.Field(ge=1, le=10_000)
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="forbid")
+
+
 class MetadataEditorLayout(pydantic.BaseModel):
     """Workspace-scoped logbook column layout."""
 
-    schema_version: int = 1
+    schema_version: int = 2
     initialized: bool = False
     fields: tuple[MetadataField, ...] = ()
+    data_column_width: int | None = pydantic.Field(default=None, ge=1, le=10_000)
+    field_widths: tuple[MetadataFieldWidth, ...] = ()
 
     model_config = pydantic.ConfigDict(frozen=True, extra="ignore")
 
@@ -721,7 +732,7 @@ class _MetadataTableView(QtWidgets.QTableView):
         )
         frozen_vertical_header.hide()
         frozen_horizontal_header.setSectionResizeMode(
-            QtWidgets.QHeaderView.ResizeMode.Fixed
+            QtWidgets.QHeaderView.ResizeMode.Interactive
         )
         self.frozen_view.setHorizontalScrollBarPolicy(
             QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
@@ -749,6 +760,7 @@ class _MetadataTableView(QtWidgets.QTableView):
             "QtWidgets.QScrollBar", self.frozen_view.verticalScrollBar()
         )
         horizontal_header.sectionResized.connect(self._sync_frozen_width)
+        frozen_horizontal_header.sectionResized.connect(self._sync_main_width)
         horizontal_header.geometriesChanged.connect(self._update_frozen_geometry)
         vertical_header.sectionResized.connect(self._sync_frozen_row_height)
         vertical_header.geometriesChanged.connect(self._update_frozen_geometry)
@@ -804,6 +816,11 @@ class _MetadataTableView(QtWidgets.QTableView):
         if logical == 0:
             self.frozen_view.setColumnWidth(0, new)
             self._update_frozen_geometry()
+
+    @QtCore.Slot(int, int, int)
+    def _sync_main_width(self, logical: int, _old: int, new: int) -> None:
+        if logical == 0 and self.columnWidth(0) != new:
+            self.setColumnWidth(0, new)
 
     @QtCore.Slot(int, int, int)
     def _sync_frozen_row_height(self, logical: int, _old: int, new: int) -> None:
@@ -1200,6 +1217,7 @@ class MetadataEditorDialog(QtWidgets.QDialog):
         self.setObjectName("manager_metadata_editor_dialog")
         self.controller = controller
         self.targets = tuple(targets)
+        self._column_width_tracking_enabled = False
         metadata_by_target = controller.metadata_for_targets(targets)
         self.available_fields, coverage, defaults = controller.discover_fields(
             targets, metadata_by_target=metadata_by_target
@@ -1286,7 +1304,9 @@ class MetadataEditorDialog(QtWidgets.QDialog):
         header.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         header.customContextMenuRequested.connect(self._show_header_menu)
         header.sectionMoved.connect(self._column_moved)
-        self.table.resize_columns_to_contents()
+        self._resize_and_restore_columns()
+        header.sectionResized.connect(self._column_resized)
+        self._column_width_tracking_enabled = True
         layout.addWidget(self.table)
 
         self.summary_label = QtWidgets.QLabel(self)
@@ -1355,6 +1375,38 @@ class MetadataEditorDialog(QtWidgets.QDialog):
             )
         )
 
+    @contextlib.contextmanager
+    def _suspend_column_width_tracking(self) -> Iterator[None]:
+        enabled = self._column_width_tracking_enabled
+        self._column_width_tracking_enabled = False
+        try:
+            yield
+        finally:
+            self._column_width_tracking_enabled = enabled
+
+    def _resize_and_restore_columns(self) -> None:
+        with self._suspend_column_width_tracking():
+            self.table.resize_columns_to_contents()
+            data_width = self.controller.saved_column_width(None)
+            if data_width is not None:
+                self.table.setColumnWidth(0, data_width)
+            for column in range(1, self.model.columnCount()):
+                field = self.model.field_at(column)
+                if field is None:
+                    continue
+                width = self.controller.saved_column_width(field)
+                if width is not None:
+                    self.table.setColumnWidth(column, width)
+
+    @QtCore.Slot(int, int, int)
+    def _column_resized(self, logical: int, _old: int, new: int) -> None:
+        if not self._column_width_tracking_enabled:
+            return
+        field = self.model.field_at(logical)
+        if logical != 0 and field is None:
+            return
+        self.controller.set_column_width(field, new)
+
     @QtCore.Slot(object, bool)
     def _set_field_visible(self, field: object, visible: bool) -> None:
         if not isinstance(field, MetadataField):
@@ -1364,8 +1416,9 @@ class MetadataEditorDialog(QtWidgets.QDialog):
             fields.append(field)
         elif not visible and field in fields:
             fields.remove(field)
-        self.model.set_fields(fields, self.model.field_defaults)
-        self.table.resize_columns_to_contents()
+        with self._suspend_column_width_tracking():
+            self.model.set_fields(fields, self.model.field_defaults)
+            self._resize_and_restore_columns()
         self.fields_widget.set_field_visible(field, visible)
         self.controller.set_layout_fields(fields)
 
@@ -1376,8 +1429,9 @@ class MetadataEditorDialog(QtWidgets.QDialog):
         ):
             return
         visible = typing.cast("tuple[MetadataField, ...]", fields)
-        self.model.set_fields(visible, self.model.field_defaults)
-        self.table.resize_columns_to_contents()
+        with self._suspend_column_width_tracking():
+            self.model.set_fields(visible, self.model.field_defaults)
+            self._resize_and_restore_columns()
         for field in self.available_fields:
             self.fields_widget.set_field_visible(field, field in visible)
         self.controller.set_layout_fields(visible)
@@ -1388,9 +1442,10 @@ class MetadataEditorDialog(QtWidgets.QDialog):
             return
         if field not in self.available_fields:
             self.available_fields = (*self.available_fields, field)
-        self.model.set_fields(self._visual_fields(), self.model.field_defaults)
-        self.model.add_field(field, value)
-        self.table.resize_columns_to_contents()
+        with self._suspend_column_width_tracking():
+            self.model.set_fields(self._visual_fields(), self.model.field_defaults)
+            self.model.add_field(field, value)
+            self._resize_and_restore_columns()
         self.fields_widget.add_field(field)
         self.controller.set_layout_fields(self.model.fields)
         self.fields_menu.close()
@@ -1561,7 +1616,53 @@ class _MetadataEditorController(QtCore.QObject):
         )
 
     def set_layout_fields(self, fields: Sequence[MetadataField]) -> None:
-        state = MetadataEditorLayout(initialized=True, fields=tuple(fields))
+        state = self.layout_state.model_copy(
+            update={
+                "schema_version": 2,
+                "initialized": True,
+                "fields": tuple(fields),
+            }
+        )
+        self._set_layout_state(state)
+
+    def saved_column_width(self, field: MetadataField | None) -> int | None:
+        state = self.layout_state
+        if field is None:
+            return state.data_column_width
+        return next(
+            (
+                saved.width
+                for saved in reversed(state.field_widths)
+                if saved.field == field
+            ),
+            None,
+        )
+
+    def set_column_width(self, field: MetadataField | None, width: int) -> None:
+        state = self.layout_state
+        if field is None:
+            if state.data_column_width == width:
+                return
+            state = state.model_copy(
+                update={"schema_version": 2, "data_column_width": width}
+            )
+        else:
+            widths = {saved.field: saved.width for saved in state.field_widths}
+            if widths.get(field) == width:
+                return
+            widths[field] = width
+            state = state.model_copy(
+                update={
+                    "schema_version": 2,
+                    "field_widths": tuple(
+                        MetadataFieldWidth(field=saved_field, width=saved_width)
+                        for saved_field, saved_width in widths.items()
+                    ),
+                }
+            )
+        self._set_layout_state(state)
+
+    def _set_layout_state(self, state: MetadataEditorLayout) -> None:
         payload = state.model_dump(mode="json")
         if payload == self.manager._workspace_state.metadata_editor_layout:
             return

--- a/src/erlab/interactive/imagetool/manager/_metadata_editor.py
+++ b/src/erlab/interactive/imagetool/manager/_metadata_editor.py
@@ -45,7 +45,6 @@ if typing.TYPE_CHECKING:
 MetadataFieldKind = typing.Literal["coordinate", "attribute"]
 MetadataOrigin = typing.Literal["source", "assigned", "missing"]
 _MISSING = object()
-_INVALID_INDEX = QtCore.QModelIndex()
 
 
 def _values_equal(left: typing.Any, right: typing.Any) -> bool:
@@ -345,11 +344,11 @@ class _MetadataTableModel(QtCore.QAbstractTableModel):
                     editable=_stable_edit_value(field, reference),
                 )
 
-    def rowCount(self, parent: QtCore.QModelIndex = _INVALID_INDEX) -> int:
-        return 0 if parent.isValid() else len(self.targets)
+    def rowCount(self, parent: QtCore.QModelIndex | None = None) -> int:
+        return 0 if parent is not None and parent.isValid() else len(self.targets)
 
-    def columnCount(self, parent: QtCore.QModelIndex = _INVALID_INDEX) -> int:
-        return 0 if parent.isValid() else 1 + len(self.fields)
+    def columnCount(self, parent: QtCore.QModelIndex | None = None) -> int:
+        return 0 if parent is not None and parent.isValid() else 1 + len(self.fields)
 
     def field_at(self, column: int) -> MetadataField | None:
         if column <= 0 or column > len(self.fields):

--- a/src/erlab/interactive/imagetool/manager/_metadata_editor.py
+++ b/src/erlab/interactive/imagetool/manager/_metadata_editor.py
@@ -1,0 +1,2022 @@
+"""Logbook-style scalar metadata editing for ImageTool Manager."""
+
+from __future__ import annotations
+
+import ast
+import collections.abc
+import contextlib
+import csv
+import dataclasses
+import io
+import typing
+
+import numpy as np
+import pydantic
+from qtpy import QtCore, QtGui, QtWidgets
+
+import erlab
+from erlab.interactive._figurecomposer._ui._panel_controls import _step_toolbar_button
+from erlab.interactive.imagetool._provenance._model import (
+    ToolProvenanceOperation,
+    ToolProvenanceSpec,
+    _ProvenanceStepRef,
+    compose_full_provenance,
+    full_data,
+    iter_operation_refs,
+    require_live_source_spec,
+)
+from erlab.interactive.imagetool._provenance._operations import (
+    AssignAttrsOperation,
+    AssignScalarCoordOperation,
+)
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Hashable, Iterable, Mapping, Sequence
+
+    import xarray as xr
+
+    from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
+    from erlab.interactive.imagetool.manager._provenance_edit._controller import (
+        _ValidatedProvenanceEdit,
+    )
+    from erlab.interactive.imagetool.manager._wrapper import _ManagedWindowNode
+
+
+MetadataFieldKind = typing.Literal["coordinate", "attribute"]
+MetadataOrigin = typing.Literal["source", "assigned", "missing"]
+_MISSING = object()
+_INVALID_INDEX = QtCore.QModelIndex()
+
+
+def _values_equal(left: typing.Any, right: typing.Any) -> bool:
+    left = erlab.utils.misc._convert_to_native(left)
+    right = erlab.utils.misc._convert_to_native(right)
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, list | tuple):
+        return len(left) == len(right) and all(
+            _values_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right, strict=True)
+        )
+    if isinstance(left, collections.abc.Mapping):
+        if left.keys() != right.keys():
+            return False
+        return all(_values_equal(left[key], right[key]) for key in left)
+    try:
+        left_array = np.asarray(left)
+        right_array = np.asarray(right)
+    except Exception:
+        return False
+    if left_array.shape != right_array.shape:
+        return False
+    if left_array.dtype.kind != right_array.dtype.kind:
+        return False
+    try:
+        return bool(np.array_equal(left_array, right_array, equal_nan=True))
+    except TypeError:
+        return bool(np.array_equal(left_array, right_array))
+
+
+def _value_type_name(value: typing.Any) -> str:
+    if isinstance(value, bool):
+        return "Bool"
+    if isinstance(value, int | np.integer):
+        return "Int"
+    if isinstance(value, float | np.floating):
+        return "Float"
+    if isinstance(value, str):
+        return "String"
+    return "Python literal"
+
+
+def _value_text(value: typing.Any) -> str:
+    if isinstance(value, str):
+        return value
+    return erlab.interactive.utils._parse_single_arg(value)
+
+
+def _parse_typed_value(type_name: str, text: str) -> typing.Any:
+    stripped = text.strip()
+    match type_name:
+        case "String":
+            return text
+        case "Int":
+            return int(stripped)
+        case "Float":
+            return float(stripped)
+        case "Bool":
+            lowered = stripped.casefold()
+            if lowered in {"true", "1", "yes"}:
+                return True
+            if lowered in {"false", "0", "no"}:
+                return False
+            raise ValueError("Boolean values must be True or False.")
+        case "Python literal":
+            return ast.literal_eval(stripped)
+        case _:
+            raise ValueError(f"Unknown value type {type_name!r}.")
+
+
+def _parse_editor_value(reference: typing.Any, text: str) -> typing.Any:
+    """Parse table input while allowing deliberate metadata type changes."""
+    try:
+        return _parse_typed_value(_value_type_name(reference), text)
+    except (SyntaxError, TypeError, ValueError) as typed_error:
+        try:
+            return ast.literal_eval(text.strip())
+        except (SyntaxError, ValueError):
+            raise typed_error from None
+
+
+class MetadataField(pydantic.BaseModel):
+    """Stable identity for one scalar coordinate or attribute column."""
+
+    kind: MetadataFieldKind
+    name: str
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="forbid")
+
+    @pydantic.field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("Metadata field names cannot be empty.")
+        return value
+
+    def operation(self, value: typing.Any) -> ToolProvenanceOperation:
+        if self.kind == "attribute":
+            return AssignAttrsOperation(attrs={self.name: value})
+        return AssignScalarCoordOperation(coord_name=self.name, value=value)
+
+
+class MetadataEditorLayout(pydantic.BaseModel):
+    """Workspace-scoped logbook column layout."""
+
+    schema_version: int = 1
+    initialized: bool = False
+    fields: tuple[MetadataField, ...] = ()
+
+    model_config = pydantic.ConfigDict(frozen=True, extra="ignore")
+
+
+@dataclasses.dataclass(frozen=True)
+class MetadataCell:
+    field: MetadataField
+    present: bool
+    value: typing.Any = None
+    assignment_ref: _ProvenanceStepRef | None = None
+    assignment: ToolProvenanceOperation | None = None
+    editable: bool = True
+
+    @property
+    def origin(self) -> MetadataOrigin:
+        if not self.present:
+            return "missing"
+        if self.assignment_ref is not None:
+            return "assigned"
+        return "source"
+
+
+@dataclasses.dataclass(frozen=True)
+class MetadataCellEdit:
+    field: MetadataField
+    value: typing.Any = None
+    revert: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class _MetadataTargetEdit:
+    target: int | str
+    node: _ManagedWindowNode
+    scope: typing.Literal["display", "source"]
+    kind: typing.Literal["none", "direct", "validated"]
+    data: xr.DataArray | None = None
+    spec: ToolProvenanceSpec | None = None
+    live_parent_data: xr.DataArray | None = None
+    validated: _ValidatedProvenanceEdit | None = None
+
+
+def _field_value(data: xr.DataArray, field: MetadataField) -> typing.Any:
+    if field.kind == "coordinate":
+        if field.name not in data.coords or data.coords[field.name].ndim != 0:
+            return _MISSING
+        return data.coords[field.name].values[()]
+    return data.attrs.get(field.name, _MISSING)
+
+
+def _operation_value(
+    operation: ToolProvenanceOperation, field: MetadataField
+) -> typing.Any:
+    if (
+        field.kind == "coordinate"
+        and isinstance(operation, AssignScalarCoordOperation)
+        and operation.coord_name == field.name
+    ):
+        return operation.decoded_value
+    if (
+        field.kind == "attribute"
+        and isinstance(operation, AssignAttrsOperation)
+        and field.name in operation.attrs
+    ):
+        return operation.attrs[field.name]
+    return _MISSING
+
+
+def _stable_edit_value(field: MetadataField, value: typing.Any) -> bool:
+    """Return whether a value survives provenance serialization unchanged."""
+    try:
+        parsed = _parse_editor_value(value, _value_text(value))
+        operation = field.operation(parsed)
+        restored_operation = type(operation).model_validate_json(
+            operation.model_dump_json()
+        )
+        restored = _operation_value(restored_operation, field)
+    except Exception:
+        return False
+    return (
+        restored is not _MISSING
+        and type(parsed) is type(restored)
+        and _values_equal(parsed, restored)
+    )
+
+
+def _editable_attribute(value: typing.Any) -> bool:
+    try:
+        parsed = _parse_typed_value(_value_type_name(value), _value_text(value))
+        operation = AssignAttrsOperation(attrs={"value": parsed})
+        restored = AssignAttrsOperation.model_validate_json(
+            operation.model_dump_json()
+        ).attrs["value"]
+    except Exception:
+        return False
+    return type(parsed) is type(restored) and _values_equal(parsed, restored)
+
+
+def _primitive_value(value: typing.Any) -> bool:
+    return value is None or isinstance(
+        value, bool | int | float | str | np.integer | np.floating
+    )
+
+
+class _MetadataEditCommand(QtGui.QUndoCommand):
+    def __init__(
+        self,
+        model: _MetadataTableModel,
+        before_values: Mapping[tuple[int, MetadataField], typing.Any],
+        before_reverted: Iterable[tuple[int, MetadataField]],
+        after_values: Mapping[tuple[int, MetadataField], typing.Any],
+        after_reverted: Iterable[tuple[int, MetadataField]],
+        text: str,
+    ) -> None:
+        super().__init__(text)
+        self._model = model
+        self._before_values = dict(before_values)
+        self._before_reverted = frozenset(before_reverted)
+        self._after_values = dict(after_values)
+        self._after_reverted = frozenset(after_reverted)
+
+    def undo(self) -> None:
+        self._model._restore_pending_state(self._before_values, self._before_reverted)
+
+    def redo(self) -> None:
+        self._model._restore_pending_state(self._after_values, self._after_reverted)
+
+
+class _MetadataTableModel(QtCore.QAbstractTableModel):
+    pendingChangesChanged = QtCore.Signal()
+    editRejected = QtCore.Signal(str)
+
+    OriginRole = QtCore.Qt.ItemDataRole.UserRole + 1
+    FieldRole = QtCore.Qt.ItemDataRole.UserRole + 2
+    TargetRole = QtCore.Qt.ItemDataRole.UserRole + 3
+    DirtyRole = QtCore.Qt.ItemDataRole.UserRole + 4
+    RevertRole = QtCore.Qt.ItemDataRole.UserRole + 5
+
+    def __init__(
+        self,
+        controller: _MetadataEditorController,
+        targets: Sequence[int | str],
+        fields: Sequence[MetadataField],
+        field_defaults: Mapping[MetadataField, typing.Any],
+        parent: QtCore.QObject | None = None,
+        *,
+        metadata_by_target: Mapping[int | str, xr.DataArray] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.controller = controller
+        self.targets = tuple(targets)
+        self.fields = list(fields)
+        self.field_defaults = dict(field_defaults)
+        self.metadata_by_target = (
+            None if metadata_by_target is None else dict(metadata_by_target)
+        )
+        self.cells: dict[tuple[int, MetadataField], MetadataCell] = {}
+        self.edited_values: dict[tuple[int, MetadataField], typing.Any] = {}
+        self.reverted: set[tuple[int, MetadataField]] = set()
+        self.undo_stack = QtGui.QUndoStack(self)
+        self._populate_cells()
+
+    def _populate_cells(self) -> None:
+        for row, target in enumerate(self.targets):
+            data = (
+                self.controller.metadata_data(target)
+                if self.metadata_by_target is None
+                else self.metadata_by_target[target]
+            )
+            matches = self.controller.matching_assignments(
+                self.controller.spec_and_scope(
+                    self.controller.manager._node_for_target(target)
+                )[0],
+                data,
+                self.fields,
+            )
+            for field in self.fields:
+                value = _field_value(data, field)
+                match = matches.get(field)
+                present = value is not _MISSING
+                reference = value if present else self.field_defaults.get(field, "")
+                self.cells[row, field] = MetadataCell(
+                    field=field,
+                    present=present,
+                    value=None if not present else value,
+                    assignment_ref=None if match is None else match[0],
+                    assignment=None if match is None else match[1],
+                    editable=_stable_edit_value(field, reference),
+                )
+
+    def rowCount(self, parent: QtCore.QModelIndex = _INVALID_INDEX) -> int:
+        return 0 if parent.isValid() else len(self.targets)
+
+    def columnCount(self, parent: QtCore.QModelIndex = _INVALID_INDEX) -> int:
+        return 0 if parent.isValid() else 1 + len(self.fields)
+
+    def field_at(self, column: int) -> MetadataField | None:
+        if column <= 0 or column > len(self.fields):
+            return None
+        return self.fields[column - 1]
+
+    def _owns_index(self, index: QtCore.QModelIndex) -> bool:
+        return (
+            index.isValid()
+            and index.model() is self
+            and 0 <= index.row() < len(self.targets)
+            and 0 <= index.column() <= len(self.fields)
+        )
+
+    def cell_at(self, index: QtCore.QModelIndex) -> MetadataCell | None:
+        if not self._owns_index(index):
+            return None
+        field = self.field_at(index.column())
+        return None if field is None else self.cells.get((index.row(), field))
+
+    def data(
+        self,
+        index: QtCore.QModelIndex,
+        role: int = QtCore.Qt.ItemDataRole.DisplayRole,
+    ) -> typing.Any:
+        if not self._owns_index(index):
+            return None
+        target = self.targets[index.row()]
+        if index.column() == 0:
+            node = self.controller.manager._node_for_target(target)
+            if role == QtCore.Qt.ItemDataRole.DisplayRole:
+                return node.display_text
+            if role == QtCore.Qt.ItemDataRole.ToolTipRole:
+                paths = node._file_label_paths()
+                return "\n".join(str(path) for path in paths)
+            if role == self.TargetRole:
+                return target
+            return None
+
+        field = self.field_at(index.column())
+        if field is None:
+            return None
+        key = (index.row(), field)
+        cell = self.cells[key]
+        value = self.edited_values.get(key, cell.value)
+        if role in {
+            QtCore.Qt.ItemDataRole.DisplayRole,
+            QtCore.Qt.ItemDataRole.EditRole,
+        }:
+            if key in self.reverted:
+                return _value_text(cell.value)
+            if key not in self.edited_values and not cell.present:
+                return "" if role == QtCore.Qt.ItemDataRole.EditRole else "—"
+            return _value_text(value)
+        if role == QtCore.Qt.ItemDataRole.ToolTipRole:
+            if not cell.editable:
+                return "This value type cannot be edited reliably in the table."
+            if key in self.reverted:
+                return "The explicit assignment will be reverted when changes apply."
+            if cell.origin == "assigned":
+                operation = cell.assignment
+                method = (
+                    "assign_coords"
+                    if isinstance(operation, AssignScalarCoordOperation)
+                    else "assign_attrs"
+                )
+                return f"Assigned by {method}."
+            if cell.origin == "missing":
+                return "This field is missing from the data."
+            return "Loaded or produced without a matching assignment operation."
+        if role == self.OriginRole:
+            return cell.origin
+        if role == self.FieldRole:
+            return field
+        if role == self.TargetRole:
+            return target
+        if role == self.DirtyRole:
+            return key in self.edited_values or key in self.reverted
+        if role == self.RevertRole:
+            return key in self.reverted
+        if role == QtCore.Qt.ItemDataRole.TextAlignmentRole:
+            return int(
+                QtCore.Qt.AlignmentFlag.AlignVCenter
+                | (
+                    QtCore.Qt.AlignmentFlag.AlignLeft
+                    if isinstance(value, str)
+                    else QtCore.Qt.AlignmentFlag.AlignRight
+                )
+            )
+        return None
+
+    def headerData(
+        self,
+        section: int,
+        orientation: QtCore.Qt.Orientation,
+        role: int = QtCore.Qt.ItemDataRole.DisplayRole,
+    ) -> typing.Any:
+        if section < 0:
+            return None
+        if orientation == QtCore.Qt.Orientation.Vertical:
+            if section >= len(self.targets):
+                return None
+            return section + 1 if role == QtCore.Qt.ItemDataRole.DisplayRole else None
+        if section == 0:
+            return "Data" if role == QtCore.Qt.ItemDataRole.DisplayRole else None
+        if section > len(self.fields):
+            return None
+        field = self.fields[section - 1]
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
+            kind = "coord" if field.kind == "coordinate" else "attr"
+            return f"{field.name} ({kind})"
+        if role == self.FieldRole:
+            return field
+        return None
+
+    def flags(self, index: QtCore.QModelIndex) -> QtCore.Qt.ItemFlag:
+        if not self._owns_index(index):
+            return QtCore.Qt.ItemFlag.NoItemFlags
+        flags = super().flags(index)
+        cell = self.cell_at(index)
+        if cell is not None and cell.editable:
+            flags |= QtCore.Qt.ItemFlag.ItemIsEditable
+        return flags
+
+    def _parsed_edit(
+        self, index: QtCore.QModelIndex, value: typing.Any
+    ) -> tuple[tuple[int, MetadataField], typing.Any]:
+        if not self._owns_index(index) or index.column() == 0:
+            raise ValueError("Only metadata cells can be edited.")
+        field = self.field_at(index.column())
+        if field is None:
+            raise ValueError("The metadata field is unavailable.")
+        key = (index.row(), field)
+        cell = self.cells[key]
+        if not cell.editable:
+            raise ValueError("This value type cannot be edited reliably in the table.")
+        reference = self.edited_values.get(
+            key,
+            cell.value if cell.present else self.field_defaults.get(field, ""),
+        )
+        try:
+            parsed = _parse_editor_value(reference, str(value))
+        except Exception as exc:
+            raise ValueError(
+                f"Row {index.row() + 1}, {field.kind} {field.name!r}: {exc}"
+            ) from exc
+        if not _stable_edit_value(field, parsed):
+            raise ValueError(
+                f"Row {index.row() + 1}, {field.kind} {field.name!r}: "
+                "the value cannot be stored without changing its type."
+            )
+        return key, parsed
+
+    def _restore_pending_state(
+        self,
+        values: Mapping[tuple[int, MetadataField], typing.Any],
+        reverted: Iterable[tuple[int, MetadataField]],
+    ) -> None:
+        self.edited_values = dict(values)
+        self.reverted = set(reverted)
+        if self.rowCount() and self.columnCount() > 1:
+            self.dataChanged.emit(
+                self.index(0, 1),
+                self.index(self.rowCount() - 1, self.columnCount() - 1),
+                [
+                    QtCore.Qt.ItemDataRole.DisplayRole,
+                    self.DirtyRole,
+                    self.RevertRole,
+                ],
+            )
+        self.pendingChangesChanged.emit()
+
+    def _push_pending_state(
+        self,
+        values: Mapping[tuple[int, MetadataField], typing.Any],
+        reverted: Iterable[tuple[int, MetadataField]],
+        command_text: str,
+    ) -> None:
+        reverted_set = set(reverted)
+        if self.edited_values == values and self.reverted == reverted_set:
+            return
+        self.undo_stack.push(
+            _MetadataEditCommand(
+                self,
+                self.edited_values,
+                self.reverted,
+                values,
+                reverted_set,
+                command_text,
+            )
+        )
+
+    def set_values(
+        self,
+        values: Sequence[tuple[QtCore.QModelIndex, typing.Any]],
+        *,
+        command_text: str = "Edit Metadata",
+    ) -> None:
+        """Validate and stage several cell values as one model transaction."""
+        prepared: dict[tuple[int, MetadataField], typing.Any] = {}
+        for index, value in values:
+            key, parsed = self._parsed_edit(index, value)
+            prepared[key] = parsed
+        edited_values = dict(self.edited_values)
+        reverted = set(self.reverted)
+        for key, parsed in prepared.items():
+            cell = self.cells[key]
+            reverted.discard(key)
+            if cell.present and _values_equal(parsed, cell.value):
+                edited_values.pop(key, None)
+            else:
+                edited_values[key] = parsed
+        self._push_pending_state(edited_values, reverted, command_text)
+
+    def setData(
+        self,
+        index: QtCore.QModelIndex,
+        value: typing.Any,
+        role: int = QtCore.Qt.ItemDataRole.EditRole,
+    ) -> bool:
+        if (
+            role != QtCore.Qt.ItemDataRole.EditRole
+            or not self._owns_index(index)
+            or index.column() == 0
+        ):
+            return False
+        try:
+            self.set_values(((index, value),))
+        except ValueError as exc:
+            self.editRejected.emit(str(exc))
+            return False
+        return True
+
+    def set_fields(
+        self,
+        fields: Sequence[MetadataField],
+        field_defaults: Mapping[MetadataField, typing.Any],
+    ) -> None:
+        self.beginResetModel()
+        self.fields = list(fields)
+        self.field_defaults.update(field_defaults)
+        self.cells.clear()
+        self._populate_cells()
+        self.endResetModel()
+
+    def add_field(self, field: MetadataField, value: typing.Any) -> None:
+        fields = [*self.fields, field] if field not in self.fields else self.fields
+        self.field_defaults[field] = value
+        self.set_fields(fields, self.field_defaults)
+        column = self.fields.index(field) + 1
+        self.set_values(
+            tuple(
+                (self.index(row, column), _value_text(value))
+                for row in range(self.rowCount())
+            ),
+            command_text="Add Metadata Field",
+        )
+
+    def revert_indexes(
+        self,
+        indexes: Iterable[QtCore.QModelIndex],
+        *,
+        command_text: str = "Revert Metadata Assignment",
+    ) -> None:
+        edited_values = dict(self.edited_values)
+        reverted = set(self.reverted)
+        for index in indexes:
+            cell = self.cell_at(index)
+            if cell is None or cell.assignment_ref is None:
+                continue
+            key = (index.row(), cell.field)
+            edited_values.pop(key, None)
+            reverted.add(key)
+        self._push_pending_state(edited_values, reverted, command_text)
+
+    def edits_by_target(
+        self,
+    ) -> dict[int | str, tuple[MetadataCellEdit, ...]]:
+        edits: dict[int | str, list[MetadataCellEdit]] = {}
+        for (row, field), value in self.edited_values.items():
+            edits.setdefault(self.targets[row], []).append(
+                MetadataCellEdit(field, value=value)
+            )
+        for row, field in self.reverted:
+            edits.setdefault(self.targets[row], []).append(
+                MetadataCellEdit(field, revert=True)
+            )
+        return {target: tuple(values) for target, values in edits.items()}
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.edited_values or self.reverted)
+
+
+class _MetadataCellDelegate(QtWidgets.QStyledItemDelegate):
+    """Paint unobtrusive per-cell assignment and pending-revert markers."""
+
+    def paint(
+        self,
+        painter: QtGui.QPainter | None,
+        option: QtWidgets.QStyleOptionViewItem,
+        index: QtCore.QModelIndex,
+    ) -> None:
+        super().paint(painter, option, index)
+        if painter is None or index.column() == 0:
+            return
+        assigned = index.data(_MetadataTableModel.OriginRole) == "assigned"
+        reverting = bool(index.data(_MetadataTableModel.RevertRole))
+        if not assigned and not reverting:
+            return
+        size = min(8, max(4, option.rect.height() // 3))
+        corner = option.rect.topRight()
+        polygon = QtGui.QPolygon(
+            [
+                corner,
+                corner + QtCore.QPoint(-size, 0),
+                corner + QtCore.QPoint(0, size),
+            ]
+        )
+        painter.save()
+        color = option.palette.color(
+            QtGui.QPalette.ColorRole.Link
+            if not reverting
+            else QtGui.QPalette.ColorRole.Highlight
+        )
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
+        painter.setBrush(color)
+        painter.drawPolygon(polygon)
+        painter.restore()
+
+
+def _set_bulk_values(
+    parent: QtWidgets.QWidget,
+    model: _MetadataTableModel,
+    values: Sequence[tuple[QtCore.QModelIndex, typing.Any]],
+    *,
+    command_text: str,
+    title: str,
+    informative_text: str,
+) -> bool:
+    try:
+        model.set_values(values, command_text=command_text)
+    except ValueError as exc:
+        erlab.interactive.utils.MessageDialog.critical(
+            parent,
+            title,
+            informative_text,
+            str(exc),
+        )
+        return False
+    return True
+
+
+class _MetadataTableView(QtWidgets.QTableView):
+    _MIN_DATA_COLUMN_WIDTH = 160
+    _MAX_DATA_COLUMN_WIDTH = 320
+    _MIN_METADATA_COLUMN_WIDTH = 72
+    _MAX_METADATA_COLUMN_WIDTH = 220
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.frozen_view = QtWidgets.QTableView(self)
+        self.frozen_view.setObjectName("manager_metadata_editor_frozen_data_column")
+        self.frozen_view.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        frozen_vertical_header = typing.cast(
+            "QtWidgets.QHeaderView", self.frozen_view.verticalHeader()
+        )
+        frozen_horizontal_header = typing.cast(
+            "QtWidgets.QHeaderView", self.frozen_view.horizontalHeader()
+        )
+        frozen_vertical_header.hide()
+        frozen_horizontal_header.setSectionResizeMode(
+            QtWidgets.QHeaderView.ResizeMode.Fixed
+        )
+        self.frozen_view.setHorizontalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self.frozen_view.setVerticalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self.frozen_view.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self.frozen_view.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectItems
+        )
+        self.frozen_view.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.setAlternatingRowColors(True)
+        self.frozen_view.setAlternatingRowColors(True)
+        horizontal_header = typing.cast(
+            "QtWidgets.QHeaderView", self.horizontalHeader()
+        )
+        vertical_header = typing.cast("QtWidgets.QHeaderView", self.verticalHeader())
+        vertical_scrollbar = typing.cast(
+            "QtWidgets.QScrollBar", self.verticalScrollBar()
+        )
+        frozen_scrollbar = typing.cast(
+            "QtWidgets.QScrollBar", self.frozen_view.verticalScrollBar()
+        )
+        horizontal_header.sectionResized.connect(self._sync_frozen_width)
+        horizontal_header.geometriesChanged.connect(self._update_frozen_geometry)
+        vertical_header.sectionResized.connect(self._sync_frozen_row_height)
+        vertical_header.geometriesChanged.connect(self._update_frozen_geometry)
+        vertical_scrollbar.valueChanged.connect(frozen_scrollbar.setValue)
+        frozen_scrollbar.valueChanged.connect(vertical_scrollbar.setValue)
+
+    def setModel(self, model: QtCore.QAbstractItemModel | None) -> None:
+        super().setModel(model)
+        self.frozen_view.setModel(model)
+        selection_model = self.selectionModel()
+        if selection_model is not None:
+            self.frozen_view.setSelectionModel(selection_model)
+        if model is not None:
+            model.modelReset.connect(self._sync_frozen_columns)
+            model.columnsInserted.connect(self._sync_frozen_columns)
+            model.columnsRemoved.connect(self._sync_frozen_columns)
+        self._sync_frozen_columns()
+
+    @QtCore.Slot()
+    @QtCore.Slot(QtCore.QModelIndex, int, int)
+    def _sync_frozen_columns(self, *_args: object) -> None:
+        model = self.model()
+        if model is None:
+            return
+        for column in range(model.columnCount()):
+            self.frozen_view.setColumnHidden(column, column != 0)
+        self.frozen_view.setColumnWidth(0, self.columnWidth(0))
+        for row in range(model.rowCount()):
+            self.frozen_view.setRowHeight(row, self.rowHeight(row))
+        self._update_frozen_geometry()
+
+    def resize_columns_to_contents(self) -> None:
+        model = self.model()
+        if model is None:
+            return
+        for column in range(model.columnCount()):
+            self.resizeColumnToContents(column)
+            minimum, maximum = (
+                (self._MIN_DATA_COLUMN_WIDTH, self._MAX_DATA_COLUMN_WIDTH)
+                if column == 0
+                else (
+                    self._MIN_METADATA_COLUMN_WIDTH,
+                    self._MAX_METADATA_COLUMN_WIDTH,
+                )
+            )
+            self.setColumnWidth(
+                column, max(minimum, min(self.columnWidth(column), maximum))
+            )
+        self._update_frozen_geometry()
+
+    @QtCore.Slot(int, int, int)
+    def _sync_frozen_width(self, logical: int, _old: int, new: int) -> None:
+        if logical == 0:
+            self.frozen_view.setColumnWidth(0, new)
+            self._update_frozen_geometry()
+
+    @QtCore.Slot(int, int, int)
+    def _sync_frozen_row_height(self, logical: int, _old: int, new: int) -> None:
+        self.frozen_view.setRowHeight(logical, new)
+
+    def _update_frozen_geometry(self) -> None:
+        width = self.columnWidth(0)
+        vertical_header = typing.cast("QtWidgets.QHeaderView", self.verticalHeader())
+        horizontal_header = typing.cast(
+            "QtWidgets.QHeaderView", self.horizontalHeader()
+        )
+        frozen_header = typing.cast(
+            "QtWidgets.QHeaderView", self.frozen_view.horizontalHeader()
+        )
+        viewport = typing.cast("QtWidgets.QWidget", self.viewport())
+        frozen_header.setFixedHeight(horizontal_header.height())
+        self.frozen_view.setGeometry(
+            vertical_header.width() + self.frameWidth(),
+            self.frameWidth(),
+            width,
+            viewport.height() + horizontal_header.height(),
+        )
+
+    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
+        super().resizeEvent(event)
+        self._update_frozen_geometry()
+
+    def moveCursor(
+        self,
+        cursor_action: QtWidgets.QAbstractItemView.CursorAction,
+        modifiers: QtCore.Qt.KeyboardModifier,
+    ) -> QtCore.QModelIndex:
+        current = super().moveCursor(cursor_action, modifiers)
+        if current.column() > 0:
+            visual = self.visualRect(current)
+            frozen_width = self.frozen_view.columnWidth(0)
+            if visual.left() < frozen_width:
+                scrollbar = typing.cast(
+                    "QtWidgets.QScrollBar", self.horizontalScrollBar()
+                )
+                scrollbar.setValue(scrollbar.value() + visual.left() - frozen_width)
+        return current
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent | None) -> None:
+        if event is not None:
+            if event.matches(QtGui.QKeySequence.StandardKey.Copy):
+                self._copy_selection()
+                event.accept()
+                return
+            if event.matches(QtGui.QKeySequence.StandardKey.Paste):
+                self._paste_clipboard()
+                event.accept()
+                return
+        super().keyPressEvent(event)
+
+    def _copy_selection(self) -> None:
+        app = QtWidgets.QApplication.instance()
+        if not isinstance(app, QtWidgets.QApplication):
+            return
+        clipboard = app.clipboard()
+        model = self.model()
+        indexes = self.selectedIndexes()
+        if clipboard is None or model is None or not indexes:
+            return
+
+        selected = {(index.row(), index.column()) for index in indexes}
+        first_row = min(row for row, _column in selected)
+        last_row = max(row for row, _column in selected)
+        header = typing.cast("QtWidgets.QHeaderView", self.horizontalHeader())
+        selected_visual_columns = {
+            header.visualIndex(column) for _row, column in selected
+        }
+        first_visual = min(selected_visual_columns)
+        last_visual = max(selected_visual_columns)
+        logical_columns = tuple(
+            logical
+            for visual in range(first_visual, last_visual + 1)
+            if (logical := header.logicalIndex(visual)) >= 0
+            and not self.isColumnHidden(logical)
+        )
+
+        output = io.StringIO()
+        writer = csv.writer(output, delimiter="\t", lineterminator="\n")
+        for row in range(first_row, last_row + 1):
+            values: list[str] = []
+            for column in logical_columns:
+                if (row, column) not in selected:
+                    values.append("")
+                    continue
+                index = model.index(row, column)
+                role = (
+                    QtCore.Qt.ItemDataRole.DisplayRole
+                    if column == 0
+                    else QtCore.Qt.ItemDataRole.EditRole
+                )
+                value = index.data(role)
+                values.append("" if value is None else str(value))
+            writer.writerow(values)
+        clipboard.setText(output.getvalue().removesuffix("\n"))
+
+    def _paste_clipboard(self) -> None:
+        app = QtWidgets.QApplication.instance()
+        if not isinstance(app, QtWidgets.QApplication):
+            return
+        start = self.currentIndex()
+        clipboard = app.clipboard()
+        if not start.isValid() or clipboard is None:
+            return
+        model = self.model()
+        if model is None:
+            return
+        edits: list[tuple[QtCore.QModelIndex, str]] = []
+        rows = csv.reader(io.StringIO(clipboard.text()), delimiter="\t")
+        header = typing.cast("QtWidgets.QHeaderView", self.horizontalHeader())
+        start_visual = header.visualIndex(start.column())
+        for row_offset, values in enumerate(rows):
+            for column_offset, value in enumerate(values):
+                row = start.row() + row_offset
+                visual_column = start_visual + column_offset
+                column = header.logicalIndex(visual_column)
+                if row >= model.rowCount() or column < 0 or self.isColumnHidden(column):
+                    continue
+                index = model.index(row, column)
+                if column > 0:
+                    edits.append((index, value))
+        if isinstance(model, _MetadataTableModel):
+            _set_bulk_values(
+                self,
+                model,
+                edits,
+                command_text="Paste Metadata",
+                title="Paste Failed",
+                informative_text="No metadata values were pasted.",
+            )
+
+
+class _MetadataFieldChooser(QtWidgets.QWidget):
+    visibility_changed = QtCore.Signal(object, bool)
+    visible_fields_changed = QtCore.Signal(object)
+    field_added = QtCore.Signal(object, object)
+
+    def __init__(
+        self,
+        fields: Sequence[MetadataField],
+        visible: Sequence[MetadataField],
+        coverage: Mapping[MetadataField, int],
+        target_count: int,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._fields = tuple(fields)
+        self._visible = set(visible)
+        self._coverage = dict(coverage)
+        self._target_count = target_count
+        self._updating = False
+        self._items: dict[MetadataField, QtWidgets.QTreeWidgetItem] = {}
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        self.search_edit = QtWidgets.QLineEdit(self)
+        self.search_edit.setPlaceholderText("Search fields…")
+        self.search_edit.textChanged.connect(self._filter)
+        layout.addWidget(self.search_edit)
+
+        self.tree = QtWidgets.QTreeWidget(self)
+        self.tree.setObjectName("manager_metadata_field_chooser_tree")
+        self.tree.setHeaderLabels(["Field", "Present"])
+        self.tree.setRootIsDecorated(True)
+        self.tree.itemChanged.connect(self._item_changed)
+        layout.addWidget(self.tree)
+
+        presets = QtWidgets.QHBoxLayout()
+        for text, mode in (
+            ("All", "all"),
+            ("Common", "common"),
+            ("Incomplete", "incomplete"),
+            ("Clear", "clear"),
+        ):
+            button = QtWidgets.QToolButton(self)
+            button.setObjectName(f"manager_metadata_editor_fields_{mode}_button")
+            button.setText(text)
+            button.setAutoRaise(True)
+            button.clicked.connect(lambda _checked=False, mode=mode: self._preset(mode))
+            presets.addWidget(button)
+        presets.addStretch()
+        layout.addLayout(presets)
+
+        self.add_toggle = QtWidgets.QToolButton(self)
+        self.add_toggle.setText("Add Field")
+        self.add_toggle.setAutoRaise(True)
+        self.add_toggle.setCheckable(True)
+        layout.addWidget(self.add_toggle)
+
+        self.add_widget = QtWidgets.QWidget(self)
+        add_layout = QtWidgets.QFormLayout(self.add_widget)
+        add_layout.setContentsMargins(0, 4, 0, 0)
+        self.kind_combo = QtWidgets.QComboBox(self.add_widget)
+        self.kind_combo.addItem("Coordinate", userData="coordinate")
+        self.kind_combo.addItem("Attribute", userData="attribute")
+        add_layout.addRow("Kind", self.kind_combo)
+        self.name_edit = QtWidgets.QLineEdit(self.add_widget)
+        add_layout.addRow("Name", self.name_edit)
+        self.type_combo = QtWidgets.QComboBox(self.add_widget)
+        self.type_combo.addItems(["String", "Int", "Float", "Bool", "Python literal"])
+        self.type_combo.setCurrentText("Float")
+        add_layout.addRow("Type", self.type_combo)
+        self.value_edit = QtWidgets.QLineEdit("0.0", self.add_widget)
+        add_layout.addRow("Initial value", self.value_edit)
+        add_buttons = QtWidgets.QHBoxLayout()
+        add_buttons.addStretch()
+        self.cancel_add_button = QtWidgets.QToolButton(self.add_widget)
+        self.cancel_add_button.setText("Cancel")
+        add_buttons.addWidget(self.cancel_add_button)
+        self.confirm_add_button = QtWidgets.QToolButton(self.add_widget)
+        self.confirm_add_button.setText("Add")
+        add_buttons.addWidget(self.confirm_add_button)
+        add_layout.addRow(add_buttons)
+        self.add_widget.setVisible(False)
+        layout.addWidget(self.add_widget)
+        self.add_toggle.toggled.connect(self.add_widget.setVisible)
+        self.cancel_add_button.clicked.connect(
+            lambda: self.add_toggle.setChecked(False)
+        )
+        self.confirm_add_button.clicked.connect(self._add_field)
+
+        self._populate()
+        self.setMinimumSize(380, 360)
+
+    def _populate(self) -> None:
+        self._updating = True
+        try:
+            self.tree.clear()
+            self._items.clear()
+            groups = {
+                "coordinate": QtWidgets.QTreeWidgetItem(["Coordinates"]),
+                "attribute": QtWidgets.QTreeWidgetItem(["Attributes"]),
+            }
+            self.tree.addTopLevelItems(list(groups.values()))
+            for field in self._fields:
+                item = QtWidgets.QTreeWidgetItem(
+                    [
+                        field.name,
+                        f"{self._coverage.get(field, 0)} / {self._target_count}",
+                    ]
+                )
+                item.setFlags(item.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+                item.setCheckState(
+                    0,
+                    QtCore.Qt.CheckState.Checked
+                    if field in self._visible
+                    else QtCore.Qt.CheckState.Unchecked,
+                )
+                item.setData(0, QtCore.Qt.ItemDataRole.UserRole, field)
+                groups[field.kind].addChild(item)
+                self._items[field] = item
+            self.tree.expandAll()
+            self.tree.resizeColumnToContents(0)
+        finally:
+            self._updating = False
+
+    def add_field(self, field: MetadataField) -> None:
+        if field not in self._fields:
+            self._fields = (*self._fields, field)
+        self._visible.add(field)
+        self._coverage.setdefault(field, 0)
+        self._populate()
+
+    def set_field_visible(self, field: MetadataField, visible: bool) -> None:
+        if visible:
+            self._visible.add(field)
+        else:
+            self._visible.discard(field)
+        item = self._items.get(field)
+        if item is None:
+            return
+        self._updating = True
+        try:
+            item.setCheckState(
+                0,
+                QtCore.Qt.CheckState.Checked
+                if visible
+                else QtCore.Qt.CheckState.Unchecked,
+            )
+        finally:
+            self._updating = False
+
+    @QtCore.Slot(str)
+    def _filter(self, text: str) -> None:
+        needle = text.casefold().strip()
+        root = self.tree.invisibleRootItem()
+        if root is None:
+            return
+        for group_index in range(root.childCount()):
+            group = root.child(group_index)
+            if group is None:
+                continue
+            visible_children = 0
+            for row in range(group.childCount()):
+                item = group.child(row)
+                if item is None:
+                    continue
+                hidden = bool(needle and needle not in item.text(0).casefold())
+                item.setHidden(hidden)
+                visible_children += not hidden
+            group.setHidden(visible_children == 0)
+
+    @QtCore.Slot(QtWidgets.QTreeWidgetItem, int)
+    def _item_changed(self, item: QtWidgets.QTreeWidgetItem, column: int) -> None:
+        if self._updating or column != 0:
+            return
+        field = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        if isinstance(field, MetadataField):
+            visible = item.checkState(0) == QtCore.Qt.CheckState.Checked
+            if visible:
+                self._visible.add(field)
+            else:
+                self._visible.discard(field)
+            self.visibility_changed.emit(
+                field,
+                visible,
+            )
+
+    def _preset(self, mode: str) -> None:
+        visible: set[MetadataField] = set()
+        self._updating = True
+        try:
+            root = self.tree.invisibleRootItem()
+            if root is None:
+                return
+            for group_index in range(root.childCount()):
+                group = root.child(group_index)
+                if group is None:
+                    continue
+                for row in range(group.childCount()):
+                    item = group.child(row)
+                    if item is None:
+                        continue
+                    field = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+                    if not isinstance(field, MetadataField):
+                        continue
+                    count = self._coverage.get(field, 0)
+                    checked = (
+                        mode == "all"
+                        or (mode == "common" and count == self._target_count)
+                        or (mode == "incomplete" and count < self._target_count)
+                    )
+                    item.setCheckState(
+                        0,
+                        QtCore.Qt.CheckState.Checked
+                        if checked
+                        else QtCore.Qt.CheckState.Unchecked,
+                    )
+                    if checked:
+                        visible.add(field)
+        finally:
+            self._updating = False
+        self._visible = visible
+        self.visible_fields_changed.emit(
+            tuple(field for field in self._fields if field in visible)
+        )
+
+    @QtCore.Slot()
+    def _add_field(self) -> None:
+        try:
+            field = MetadataField(
+                kind=typing.cast("MetadataFieldKind", self.kind_combo.currentData()),
+                name=self.name_edit.text(),
+            )
+            value = _parse_typed_value(
+                self.type_combo.currentText(), self.value_edit.text()
+            )
+            field.operation(value)
+        except Exception as exc:
+            erlab.interactive.utils.MessageDialog.critical(
+                self,
+                "Invalid Field",
+                "The metadata field is not valid.",
+                str(exc),
+            )
+            return
+        self.field_added.emit(field, value)
+        self.add_toggle.setChecked(False)
+
+
+class MetadataEditorDialog(QtWidgets.QDialog):
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget,
+        controller: _MetadataEditorController,
+        targets: Sequence[int | str],
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Metadata Editor")
+        self.setObjectName("manager_metadata_editor_dialog")
+        self.controller = controller
+        self.targets = tuple(targets)
+        metadata_by_target = controller.metadata_for_targets(targets)
+        self.available_fields, coverage, defaults = controller.discover_fields(
+            targets, metadata_by_target=metadata_by_target
+        )
+        visible = controller.visible_fields(self.available_fields, defaults)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        toolbar = QtWidgets.QHBoxLayout()
+        toolbar.setSpacing(4)
+        self.fields_button = _step_toolbar_button(
+            self,
+            "manager_metadata_editor_fields_button",
+            "Fields ▾",
+            "Choose the metadata fields shown in the logbook.",
+        )
+        self.fields_button.setProperty("uses_inline_menu_arrow", True)
+        toolbar.addWidget(self.fields_button)
+        self.fill_down_button = _step_toolbar_button(
+            self,
+            "manager_metadata_editor_fill_down_button",
+            "Fill Down",
+            "Copy the current cell through the selected rows.",
+        )
+        toolbar.addWidget(self.fill_down_button)
+        self.fill_series_button = _step_toolbar_button(
+            self,
+            "manager_metadata_editor_fill_series_button",
+            "Fill Series…",
+            "Fill selected rows with a numeric series.",
+        )
+        toolbar.addWidget(self.fill_series_button)
+        self.revert_button = _step_toolbar_button(
+            self,
+            "manager_metadata_editor_revert_button",
+            "Revert Assignment",
+            "Remove the explicit assignment from the selected cells.",
+        )
+        toolbar.addWidget(self.revert_button)
+        toolbar.addStretch()
+        layout.addLayout(toolbar)
+
+        self.model = _MetadataTableModel(
+            controller,
+            targets,
+            visible,
+            defaults,
+            parent=self,
+            metadata_by_target=metadata_by_target,
+        )
+        self.model.editRejected.connect(self._show_cell_edit_error)
+        self.undo_action = typing.cast(
+            "QtGui.QAction", self.model.undo_stack.createUndoAction(self, "Undo")
+        )
+        self.undo_action.setObjectName("manager_metadata_editor_undo_action")
+        self.undo_action.setShortcuts(
+            QtGui.QKeySequence.keyBindings(QtGui.QKeySequence.StandardKey.Undo)
+        )
+        self.undo_action.setShortcutContext(QtCore.Qt.ShortcutContext.WidgetShortcut)
+        self.redo_action = typing.cast(
+            "QtGui.QAction", self.model.undo_stack.createRedoAction(self, "Redo")
+        )
+        self.redo_action.setObjectName("manager_metadata_editor_redo_action")
+        self.redo_action.setShortcuts(
+            QtGui.QKeySequence.keyBindings(QtGui.QKeySequence.StandardKey.Redo)
+        )
+        self.redo_action.setShortcutContext(QtCore.Qt.ShortcutContext.WidgetShortcut)
+        self.table = _MetadataTableView(self)
+        self.table.setObjectName("manager_metadata_editor_table")
+        self.table.addActions((self.undo_action, self.redo_action))
+        self.table.setModel(self.model)
+        self.table.setItemDelegate(_MetadataCellDelegate(self.table))
+        self.table.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectItems
+        )
+        self.table.setHorizontalScrollMode(
+            QtWidgets.QAbstractItemView.ScrollMode.ScrollPerPixel
+        )
+        header = typing.cast("QtWidgets.QHeaderView", self.table.horizontalHeader())
+        header.setSectionsMovable(True)
+        header.setFirstSectionMovable(False)
+        header.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+        header.customContextMenuRequested.connect(self._show_header_menu)
+        header.sectionMoved.connect(self._column_moved)
+        self.table.resize_columns_to_contents()
+        layout.addWidget(self.table)
+
+        self.summary_label = QtWidgets.QLabel(self)
+        self.summary_label.setObjectName("manager_metadata_editor_summary")
+        layout.addWidget(self.summary_label)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Apply
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        apply_button = self.button_box.button(
+            QtWidgets.QDialogButtonBox.StandardButton.Apply
+        )
+        if apply_button is not None:
+            apply_button.setObjectName("manager_metadata_editor_apply_button")
+            apply_button.clicked.connect(self._apply)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+        self.fields_menu = QtWidgets.QMenu(self.fields_button)
+        self.fields_menu.setObjectName("manager_metadata_editor_fields_menu")
+        self.fields_widget = _MetadataFieldChooser(
+            self.available_fields,
+            visible,
+            coverage,
+            len(targets),
+            self.fields_menu,
+        )
+        self.fields_widget.visibility_changed.connect(self._set_field_visible)
+        self.fields_widget.visible_fields_changed.connect(self._set_visible_fields)
+        self.fields_widget.field_added.connect(self._add_field)
+        self.fields_action = QtWidgets.QWidgetAction(self.fields_menu)
+        self.fields_action.setDefaultWidget(self.fields_widget)
+        self.fields_menu.addAction(self.fields_action)
+        self.fields_button.clicked.connect(self._show_fields_menu)
+
+        self.fill_down_button.clicked.connect(self._fill_down)
+        self.fill_series_button.clicked.connect(self._fill_series)
+        self.revert_button.clicked.connect(self._revert_assignment)
+        self.model.dataChanged.connect(self._refresh_summary)
+        self.model.modelReset.connect(self._refresh_summary)
+        self.model.pendingChangesChanged.connect(self._refresh_summary)
+        selection_model = typing.cast(
+            "QtCore.QItemSelectionModel", self.table.selectionModel()
+        )
+        selection_model.selectionChanged.connect(self._refresh_summary)
+        selection_model.currentChanged.connect(self._refresh_summary)
+        self._refresh_summary()
+        self.resize(980, min(720, 280 + 34 * len(targets)))
+
+    @QtCore.Slot(str)
+    def _show_cell_edit_error(self, details: str) -> None:
+        erlab.interactive.utils.MessageDialog.critical(
+            self,
+            "Metadata Edit Failed",
+            "The metadata value could not be changed.",
+            details,
+        )
+
+    @QtCore.Slot()
+    def _show_fields_menu(self) -> None:
+        self.fields_menu.popup(
+            self.fields_button.mapToGlobal(
+                QtCore.QPoint(0, self.fields_button.height())
+            )
+        )
+
+    @QtCore.Slot(object, bool)
+    def _set_field_visible(self, field: object, visible: bool) -> None:
+        if not isinstance(field, MetadataField):
+            return
+        fields = self._visual_fields()
+        if visible and field not in fields:
+            fields.append(field)
+        elif not visible and field in fields:
+            fields.remove(field)
+        self.model.set_fields(fields, self.model.field_defaults)
+        self.table.resize_columns_to_contents()
+        self.fields_widget.set_field_visible(field, visible)
+        self.controller.set_layout_fields(fields)
+
+    @QtCore.Slot(object)
+    def _set_visible_fields(self, fields: object) -> None:
+        if not isinstance(fields, tuple) or not all(
+            isinstance(field, MetadataField) for field in fields
+        ):
+            return
+        visible = typing.cast("tuple[MetadataField, ...]", fields)
+        self.model.set_fields(visible, self.model.field_defaults)
+        self.table.resize_columns_to_contents()
+        for field in self.available_fields:
+            self.fields_widget.set_field_visible(field, field in visible)
+        self.controller.set_layout_fields(visible)
+
+    @QtCore.Slot(object, object)
+    def _add_field(self, field: object, value: object) -> None:
+        if not isinstance(field, MetadataField):
+            return
+        if field not in self.available_fields:
+            self.available_fields = (*self.available_fields, field)
+        self.model.set_fields(self._visual_fields(), self.model.field_defaults)
+        self.model.add_field(field, value)
+        self.table.resize_columns_to_contents()
+        self.fields_widget.add_field(field)
+        self.controller.set_layout_fields(self.model.fields)
+        self.fields_menu.close()
+
+    @QtCore.Slot(QtCore.QPoint)
+    def _show_header_menu(self, position: QtCore.QPoint) -> None:
+        header = typing.cast("QtWidgets.QHeaderView", self.table.horizontalHeader())
+        logical = header.logicalIndexAt(position)
+        field = self.model.field_at(logical)
+        if field is None:
+            return
+        menu = QtWidgets.QMenu(self.table)
+        hide_action = menu.addAction("Hide Field")
+        chosen = menu.exec(header.mapToGlobal(position))
+        if chosen is hide_action:
+            self._set_field_visible(field, False)
+
+    @QtCore.Slot(int, int, int)
+    def _column_moved(self, _logical: int, _old: int, _new: int) -> None:
+        ordered = self._visual_fields()
+        if len(ordered) == len(self.model.fields):
+            self.controller.set_layout_fields(ordered)
+
+    def _visual_fields(self) -> list[MetadataField]:
+        header = typing.cast("QtWidgets.QHeaderView", self.table.horizontalHeader())
+        ordered: list[MetadataField] = []
+        for visual in range(header.count()):
+            logical = header.logicalIndex(visual)
+            field = self.model.field_at(logical)
+            if field is not None:
+                ordered.append(field)
+        return ordered
+
+    @QtCore.Slot()
+    @QtCore.Slot(QtCore.QModelIndex, QtCore.QModelIndex)
+    @QtCore.Slot(QtCore.QModelIndex, QtCore.QModelIndex, list)
+    def _refresh_summary(self, *_args: object) -> None:
+        changes = sum(len(values) for values in self.model.edits_by_target().values())
+        assigned = sum(
+            index.data(_MetadataTableModel.OriginRole) == "assigned"
+            for index in self.table.selectedIndexes()
+        )
+        self.summary_label.setText(
+            f"{len(self.targets)} data rows · {changes} pending changes"
+        )
+        self.revert_button.setEnabled(assigned > 0)
+        current = self.table.currentIndex()
+        cell = self.model.cell_at(current)
+        value = (
+            None
+            if cell is None
+            else self.model.edited_values.get((current.row(), cell.field), cell.value)
+        )
+        self.fill_down_button.setEnabled(cell is not None)
+        self.fill_series_button.setEnabled(
+            isinstance(value, int | float | np.integer | np.floating)
+            and not isinstance(value, bool | np.bool_)
+        )
+        apply_button = self.button_box.button(
+            QtWidgets.QDialogButtonBox.StandardButton.Apply
+        )
+        if apply_button is not None:
+            apply_button.setEnabled(self.model.has_changes)
+
+    @QtCore.Slot()
+    def _fill_down(self) -> None:
+        current = self.table.currentIndex()
+        if self.model.cell_at(current) is None:
+            return
+        value = current.data(QtCore.Qt.ItemDataRole.EditRole)
+        rows = sorted({index.row() for index in self.table.selectedIndexes()})
+        if len(rows) < 2:
+            rows = list(range(current.row(), self.model.rowCount()))
+        _set_bulk_values(
+            self,
+            self.model,
+            [(self.model.index(row, current.column()), value) for row in rows],
+            command_text="Fill Metadata Down",
+            title="Fill Down Failed",
+            informative_text="No metadata values were filled.",
+        )
+
+    @QtCore.Slot()
+    def _fill_series(self) -> None:
+        current = self.table.currentIndex()
+        cell = self.model.cell_at(current)
+        if cell is None:
+            return
+        value = self.model.edited_values.get((current.row(), cell.field), cell.value)
+        if not isinstance(value, int | float | np.integer | np.floating) or isinstance(
+            value, bool | np.bool_
+        ):
+            return
+        start, ok = QtWidgets.QInputDialog.getDouble(
+            self, "Fill Series", "Start", float(value), decimals=12
+        )
+        if not ok:
+            return
+        step, ok = QtWidgets.QInputDialog.getDouble(
+            self, "Fill Series", "Step", 1.0, decimals=12
+        )
+        if not ok:
+            return
+        rows = sorted({index.row() for index in self.table.selectedIndexes()})
+        if not rows:
+            rows = list(range(self.model.rowCount()))
+        edits: list[tuple[QtCore.QModelIndex, str]] = []
+        for offset, row in enumerate(rows):
+            result = start + step * offset
+            text = (
+                str(int(result))
+                if isinstance(value, int | np.integer)
+                else repr(result)
+            )
+            edits.append((self.model.index(row, current.column()), text))
+        _set_bulk_values(
+            self,
+            self.model,
+            edits,
+            command_text="Fill Metadata Series",
+            title="Fill Series Failed",
+            informative_text="No metadata values were filled.",
+        )
+
+    @QtCore.Slot()
+    def _revert_assignment(self) -> None:
+        self.model.revert_indexes(self.table.selectedIndexes())
+        self._refresh_summary()
+
+    @QtCore.Slot()
+    def _apply(self) -> None:
+        edits = self.model.edits_by_target()
+        if edits and self.controller.apply_edits(edits):
+            self.accept()
+
+
+class _MetadataEditorController(QtCore.QObject):
+    """Coordinate the logbook UI and canonical metadata operations."""
+
+    def __init__(self, manager: ImageToolManager) -> None:
+        super().__init__(manager)
+        self.manager = manager
+        if not isinstance(manager._workspace_state.metadata_editor_layout, dict):
+            manager._workspace_state.metadata_editor_layout = {}
+
+    @property
+    def layout_state(self) -> MetadataEditorLayout:
+        try:
+            return MetadataEditorLayout.model_validate(
+                self.manager._workspace_state.metadata_editor_layout
+            )
+        except Exception:
+            return MetadataEditorLayout()
+
+    def layout_payload(self) -> dict[str, typing.Any]:
+        return self.layout_state.model_dump(mode="json")
+
+    def restore_layout_payload(self, payload: typing.Any) -> None:
+        try:
+            state = MetadataEditorLayout.model_validate(payload or {})
+        except Exception:
+            erlab.utils.misc.emit_user_level_warning(
+                "Ignoring invalid saved metadata editor layout."
+            )
+            state = MetadataEditorLayout()
+        self.manager._workspace_state.metadata_editor_layout = state.model_dump(
+            mode="json"
+        )
+
+    def set_layout_fields(self, fields: Sequence[MetadataField]) -> None:
+        state = MetadataEditorLayout(initialized=True, fields=tuple(fields))
+        payload = state.model_dump(mode="json")
+        if payload == self.manager._workspace_state.metadata_editor_layout:
+            return
+        self.manager._workspace_state.metadata_editor_layout = payload
+        self.manager._workspace_controller._mark_workspace_layout_dirty()
+
+    def metadata_data(self, target: int | str) -> xr.DataArray:
+        node = self.manager._node_for_target(target)
+        if node.imagetool is not None:
+            return node.current_public_data()
+        if node.pending_workspace_memory_payload is not None:
+            return self.manager._pending_workspace_imagetool_metadata_data(node)
+        raise ValueError("ImageTool metadata is unavailable.")
+
+    def metadata_for_targets(
+        self, targets: Sequence[int | str]
+    ) -> dict[int | str, xr.DataArray]:
+        return {target: self.metadata_data(target) for target in targets}
+
+    def discover_fields(
+        self,
+        targets: Sequence[int | str],
+        *,
+        metadata_by_target: Mapping[int | str, xr.DataArray] | None = None,
+    ) -> tuple[
+        tuple[MetadataField, ...],
+        dict[MetadataField, int],
+        dict[MetadataField, typing.Any],
+    ]:
+        ordered: list[MetadataField] = []
+        coverage: dict[MetadataField, int] = {}
+        defaults: dict[MetadataField, typing.Any] = {}
+        seen: set[MetadataField] = set()
+        for target in targets:
+            data = (
+                self.metadata_data(target)
+                if metadata_by_target is None
+                else metadata_by_target[target]
+            )
+            present: set[MetadataField] = set()
+            for name, coord in data.coords.items():
+                if not isinstance(name, str) or coord.ndim != 0:
+                    continue
+                field = MetadataField(kind="coordinate", name=name)
+                if field not in seen:
+                    seen.add(field)
+                    ordered.append(field)
+                    defaults[field] = _field_value(data, field)
+                present.add(field)
+            for name, value in data.attrs.items():
+                if not isinstance(name, str) or not _editable_attribute(value):
+                    continue
+                field = MetadataField(kind="attribute", name=name)
+                if field not in seen:
+                    seen.add(field)
+                    ordered.append(field)
+                    defaults[field] = value
+                present.add(field)
+            for field in present:
+                coverage[field] = coverage.get(field, 0) + 1
+
+        context_fields = tuple(
+            MetadataField(kind=field.kind, name=field.name)
+            for field in self.manager._acquisition_context.state.fields
+        )
+        for context_field, source_field in zip(
+            context_fields,
+            self.manager._acquisition_context.state.fields,
+            strict=True,
+        ):
+            if context_field not in seen:
+                ordered.insert(0, context_field)
+                seen.add(context_field)
+            defaults.setdefault(context_field, source_field.decoded_value)
+            coverage.setdefault(context_field, 0)
+        for saved_field in self.layout_state.fields:
+            if saved_field not in seen:
+                ordered.append(saved_field)
+                seen.add(saved_field)
+            defaults.setdefault(saved_field, "")
+            coverage.setdefault(saved_field, 0)
+        ordered.sort(
+            key=lambda field: (
+                0 if field in context_fields else 1,
+                0 if field.kind == "coordinate" else 1,
+                field.name.casefold(),
+            )
+        )
+        return tuple(ordered), coverage, defaults
+
+    def visible_fields(
+        self,
+        available: Sequence[MetadataField],
+        defaults: Mapping[MetadataField, typing.Any],
+    ) -> tuple[MetadataField, ...]:
+        state = self.layout_state
+        if state.initialized:
+            return state.fields
+        context_keys = {
+            MetadataField(kind=field.kind, name=field.name)
+            for field in self.manager._acquisition_context.state.fields
+        }
+        return tuple(
+            field
+            for field in available
+            if field.kind == "coordinate"
+            or field in context_keys
+            or _primitive_value(defaults.get(field))
+        )
+
+    @QtCore.Slot()
+    def show_editor(self) -> None:
+        targets = self.manager._selected_imagetool_targets()
+        if not targets:
+            return
+        dialog = MetadataEditorDialog(self.manager, self, targets)
+        dialog.exec()
+
+    @staticmethod
+    def spec_and_scope(
+        node: _ManagedWindowNode,
+    ) -> tuple[ToolProvenanceSpec | None, typing.Literal["display", "source"]]:
+        source_spec = node.displayed_source_spec
+        if source_spec is not None:
+            return source_spec, "source"
+        return node.displayed_provenance_spec, "display"
+
+    @staticmethod
+    def matching_assignments(
+        spec: ToolProvenanceSpec | None,
+        data: xr.DataArray,
+        fields: Sequence[MetadataField],
+    ) -> dict[MetadataField, tuple[_ProvenanceStepRef, ToolProvenanceOperation]]:
+        if spec is None:
+            return {}
+        unmatched = set(fields)
+        matches: dict[
+            MetadataField, tuple[_ProvenanceStepRef, ToolProvenanceOperation]
+        ] = {}
+        for ref, operation in reversed(tuple(iter_operation_refs(spec))):
+            for field in tuple(unmatched):
+                operation_value = _operation_value(operation, field)
+                if operation_value is _MISSING:
+                    continue
+                current_value = _field_value(data, field)
+                if current_value is _MISSING or not _values_equal(
+                    operation_value, current_value
+                ):
+                    continue
+                matches[field] = (ref, operation)
+                unmatched.remove(field)
+        return matches
+
+    @staticmethod
+    def _append_operations(
+        spec: ToolProvenanceSpec | None,
+        operations: Sequence[ToolProvenanceOperation],
+    ) -> ToolProvenanceSpec:
+        appended = full_data(*operations)
+        if spec is None:
+            return appended
+        with contextlib.suppress(TypeError):
+            live_spec = require_live_source_spec(spec)
+            if live_spec is not None:
+                return live_spec.append_replacement_operations(*operations)
+        composed = compose_full_provenance(spec, appended)
+        if composed is None:
+            raise RuntimeError("Could not compose metadata provenance.")
+        return composed
+
+    @staticmethod
+    def _clean_empty_replay_stages(spec: ToolProvenanceSpec) -> ToolProvenanceSpec:
+        if spec.kind not in {"file", "script"}:
+            return spec
+        stages = tuple(stage for stage in spec.replay_stages if stage.operations)
+        if stages == spec.replay_stages:
+            return spec
+        return spec.model_copy(update={"replay_stages": stages})
+
+    def _plan_target_edit(
+        self,
+        target: int | str,
+        edits: Sequence[MetadataCellEdit],
+    ) -> _MetadataTargetEdit:
+        node = self.manager._node_for_target(target)
+        current = node.current_public_data()
+        spec, scope = self.spec_and_scope(node)
+        matches = self.matching_assignments(
+            spec, current, tuple(edit.field for edit in edits)
+        )
+        replacements: dict[_ProvenanceStepRef, ToolProvenanceOperation | None] = {}
+        changed_refs: set[_ProvenanceStepRef] = set()
+        patch_operations: list[ToolProvenanceOperation] = []
+        added_coords: list[ToolProvenanceOperation] = []
+        added_attrs: dict[Hashable, typing.Any] = {}
+        removed_assignment = False
+
+        for edit in edits:
+            match = matches.get(edit.field)
+            if edit.revert:
+                if match is None:
+                    continue
+                ref, original = match
+                replacement = replacements.get(ref, original)
+                if replacement is None:
+                    raise RuntimeError("Overlapping metadata assignments are invalid.")
+                if isinstance(replacement, AssignAttrsOperation):
+                    attrs = dict(replacement.attrs)
+                    attrs.pop(edit.field.name, None)
+                    replacement = (
+                        AssignAttrsOperation(attrs=attrs, group=replacement.group)
+                        if attrs
+                        else None
+                    )
+                else:
+                    replacement = None
+                replacements[ref] = replacement
+                changed_refs.add(ref)
+                removed_assignment = True
+                continue
+
+            operation = edit.field.operation(edit.value)
+            operation.apply(current, parent_data=current)
+            if match is not None:
+                ref, original = match
+                replacement = replacements.get(ref, original)
+                if replacement is None:
+                    raise RuntimeError("Overlapping metadata assignments are invalid.")
+                if isinstance(replacement, AssignAttrsOperation):
+                    attrs = dict(replacement.attrs)
+                    attrs[edit.field.name] = edit.value
+                    replacement = AssignAttrsOperation(
+                        attrs=attrs, group=replacement.group
+                    )
+                else:
+                    replacement = operation.model_copy(
+                        update={"group": replacement.group}
+                    )
+                replacements[ref] = replacement
+                changed_refs.add(ref)
+                patch_operations.append(operation)
+            elif edit.field.kind == "attribute":
+                added_attrs[edit.field.name] = edit.value
+            else:
+                added_coords.append(operation)
+
+        candidate = spec
+        if replacements:
+            if candidate is None:
+                raise RuntimeError("Matching metadata assignments are unavailable.")
+            for ref in sorted(
+                replacements,
+                key=lambda item: (
+                    -1 if item.stage_index is None else item.stage_index,
+                    typing.cast("int", item.operation_index),
+                ),
+                reverse=True,
+            ):
+                replacement = replacements[ref]
+                candidate = candidate._replace_operation_ref(
+                    ref, () if replacement is None else (replacement,)
+                )
+            candidate = self._clean_empty_replay_stages(candidate)
+
+        added_operations = [*added_coords]
+        if added_attrs:
+            added_operations.append(AssignAttrsOperation(attrs=added_attrs))
+        if added_operations:
+            candidate = self._append_operations(candidate, added_operations)
+
+        if candidate == spec:
+            return _MetadataTargetEdit(target, node, scope, "none")
+        if candidate is None:
+            raise RuntimeError("The edited metadata has no provenance.")
+
+        operation_refs = tuple(iter_operation_refs(spec)) if spec is not None else ()
+        positions = {ref: i for i, (ref, _operation) in enumerate(operation_refs)}
+        terminal_edit = not removed_assignment
+        if changed_refs:
+            first_changed = min(positions[ref] for ref in changed_refs)
+            terminal_edit = terminal_edit and all(
+                isinstance(operation, AssignScalarCoordOperation | AssignAttrsOperation)
+                for _ref, operation in operation_refs[first_changed:]
+            )
+        slicer_area = self.manager.get_imagetool(target).slicer_area
+        terminal_edit = terminal_edit and not slicer_area.has_active_filter
+
+        if terminal_edit:
+            processed = full_data(*patch_operations, *added_operations).apply(current)
+            processed = processed.rename(current.name)
+            erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(processed)
+            live_parent_data = None
+            if candidate.kind in {"full_data", "public_data", "selection"}:
+                live_parent_data = (
+                    node.detached_live_parent_data
+                    if node.detached_live_parent_data is not None
+                    else current
+                )
+            return _MetadataTargetEdit(
+                target,
+                node,
+                scope,
+                "direct",
+                data=processed,
+                spec=candidate,
+                live_parent_data=live_parent_data,
+            )
+
+        validated = self.manager._provenance_edit_controller._validated_edit(
+            node,
+            scope,
+            candidate,
+            where="validating the edited metadata",
+        )
+        return _MetadataTargetEdit(
+            target, node, scope, "validated", validated=validated
+        )
+
+    def apply_edits(
+        self,
+        edits_by_target: Mapping[int | str, Sequence[MetadataCellEdit]],
+    ) -> bool:
+        plans: list[_MetadataTargetEdit] = []
+        for target, edits in edits_by_target.items():
+            try:
+                plans.append(self._plan_target_edit(target, edits))
+            except Exception as exc:
+                erlab.interactive.utils.MessageDialog.critical(
+                    self.manager,
+                    "Metadata Edit Failed",
+                    "The metadata changes could not be applied.",
+                    str(exc),
+                )
+                return False
+
+        data_changed = False
+        try:
+            for plan in plans:
+                if plan.kind == "direct":
+                    data = typing.cast("xr.DataArray", plan.data)
+                    spec = typing.cast("ToolProvenanceSpec", plan.spec)
+                    if plan.scope == "source":
+                        self.manager._provenance_edit_controller._replace_node_data(
+                            plan.node, plan.scope, data, spec, None
+                        )
+                    else:
+                        plan.node.replace_with_detached_data(
+                            data, spec, live_parent_data=plan.live_parent_data
+                        )
+                    self.manager._update_info(uid=plan.node.uid)
+                    data_changed = True
+                elif plan.kind == "validated":
+                    validated = typing.cast("_ValidatedProvenanceEdit", plan.validated)
+                    self.manager._provenance_edit_controller._apply_validated_edit(
+                        validated
+                    )
+                    data_changed = True
+        except Exception as exc:
+            erlab.interactive.utils.MessageDialog.critical(
+                self.manager,
+                "Metadata Edit Failed",
+                "An error occurred while applying the metadata changes.",
+                str(exc),
+            )
+            return False
+        if data_changed:
+            self.manager._sigDataReplaced.emit()
+        return True
+
+    def _preserved_assignments(
+        self, target: int | str
+    ) -> tuple[ToolProvenanceOperation, ...]:
+        node = self.manager._node_for_target(target)
+        current = node.current_public_data()
+        spec, _scope = self.spec_and_scope(node)
+        if spec is None:
+            return ()
+        fields: list[MetadataField] = []
+        for _ref, operation in iter_operation_refs(spec):
+            if isinstance(operation, AssignScalarCoordOperation) and isinstance(
+                operation.coord_name, str
+            ):
+                field = MetadataField(kind="coordinate", name=operation.coord_name)
+                if field not in fields:
+                    fields.append(field)
+            elif isinstance(operation, AssignAttrsOperation):
+                for name in operation.attrs:
+                    if isinstance(name, str):
+                        field = MetadataField(kind="attribute", name=name)
+                        if field not in fields:
+                            fields.append(field)
+        matches = self.matching_assignments(spec, current, fields)
+        by_ref: dict[_ProvenanceStepRef, list[MetadataField]] = {}
+        for field, (ref, _operation) in matches.items():
+            by_ref.setdefault(ref, []).append(field)
+        operations: list[ToolProvenanceOperation] = []
+        for ref, operation in iter_operation_refs(spec):
+            matched = by_ref.get(ref)
+            if not matched:
+                continue
+            if isinstance(operation, AssignAttrsOperation):
+                attrs: dict[Hashable, typing.Any] = {
+                    field.name: operation.attrs[field.name] for field in matched
+                }
+                operations.append(
+                    AssignAttrsOperation(attrs=attrs, group=operation.group)
+                )
+            else:
+                operations.append(operation)
+        return tuple(operations)
+
+    def prepare_replacement(
+        self,
+        target: int | str,
+        source_data: xr.DataArray,
+        *,
+        source_input_dtype: np.dtype[typing.Any] | str | None = None,
+    ) -> tuple[xr.DataArray, ToolProvenanceSpec | None] | None:
+        operations = self._preserved_assignments(target)
+        if not operations:
+            return None
+        local_spec = full_data(*operations)
+        processed = local_spec.apply(source_data).rename(source_data.name)
+        erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(processed)
+        node = self.manager._node_for_target(target)
+        watched_input = getattr(node, "_watched_input_provenance_spec", None)
+        base_spec = (
+            watched_input(source_input_dtype=source_input_dtype)
+            if callable(watched_input)
+            else None
+        )
+        provenance = (
+            compose_full_provenance(base_spec, local_spec)
+            if base_spec is not None
+            else local_spec
+        )
+        return processed, provenance
+
+    def commit_replacement(
+        self,
+        target: int | str,
+        source_data: xr.DataArray,
+        processed: xr.DataArray,
+        provenance: ToolProvenanceSpec | None,
+        *,
+        emit_edited: bool = False,
+    ) -> None:
+        node = self.manager._node_for_target(target)
+        if node.has_source_binding:
+            self.manager.get_imagetool(target).slicer_area.replace_source_data(
+                processed, emit_edited=emit_edited
+            )
+            return
+        node.set_detached_provenance(provenance, live_parent_data=source_data)
+        self.manager.get_imagetool(target).slicer_area.replace_source_data(
+            processed, emit_edited=emit_edited
+        )

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -1788,6 +1788,7 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
         self._menu.addAction(manager.reindex_action)
         self._menu.addSeparator()
         self._menu.addAction(manager.concat_action)
+        self._menu.addAction(manager.metadata_editor_action)
         self._menu.addAction(manager.batch_action)
         self._menu.addAction(manager.create_figure_action)
         self._menu.addAction(manager.duplicate_action)

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
@@ -201,10 +201,7 @@ class _ProvenanceEditController:
                     "source",
                     candidate,
                 )
-                data = erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
-                    data,
-                    copy_values=False,
-                )
+                erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(data)
             except Exception as exc:
                 raise _ProvenanceReplayFailure(
                     "validating the pasted provenance steps: "
@@ -229,7 +226,7 @@ class _ProvenanceEditController:
         *,
         where: str,
     ) -> None:
-        current_data = node.current_source_data()
+        current_data = node.current_public_data()
         try:
             if local.kind == "script":
                 trusted_user_code = script_provenance_requires_trust(local)
@@ -248,10 +245,7 @@ class _ProvenanceEditController:
                 )
             else:
                 data = local.apply(current_data)
-            data = erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
-                data,
-                copy_values=False,
-            )
+            erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(data)
         except _TrustedScriptReplayCancelled:
             raise
         except Exception as exc:

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -1051,26 +1051,26 @@ _ICON_PATH = os.path.join(
 """Path to the icon file for the manager window."""
 
 
-_LINKER_COLORS: tuple[QtGui.QColor, ...] = (
-    QtGui.QColor(76, 114, 176),
-    QtGui.QColor(221, 132, 82),
-    QtGui.QColor(85, 168, 104),
-    QtGui.QColor(196, 78, 82),
-    QtGui.QColor(129, 114, 179),
-    QtGui.QColor(147, 120, 96),
-    QtGui.QColor(218, 139, 195),
-    QtGui.QColor(140, 140, 140),
-    QtGui.QColor(204, 185, 116),
-    QtGui.QColor(100, 181, 205),
+_LINKER_COLORS: tuple[tuple[int, int, int], ...] = (
+    (76, 114, 176),
+    (221, 132, 82),
+    (85, 168, 104),
+    (196, 78, 82),
+    (129, 114, 179),
+    (147, 120, 96),
+    (218, 139, 195),
+    (140, 140, 140),
+    (204, 185, 116),
+    (100, 181, 205),
 )
 """Colors for different linkers."""
 
-_WATCHED_VAR_COLORS: tuple[QtGui.QColor, ...] = (
-    QtGui.QColor(72, 120, 208),
-    QtGui.QColor(238, 133, 74),
-    QtGui.QColor(106, 204, 100),
-    QtGui.QColor(214, 95, 95),
-    QtGui.QColor(149, 108, 180),
+_WATCHED_VAR_COLORS: tuple[tuple[int, int, int], ...] = (
+    (72, 120, 208),
+    (238, 133, 74),
+    (106, 204, 100),
+    (214, 95, 95),
+    (149, 108, 180),
 )
 """Colors for watched variables from different kernels."""
 

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -864,6 +864,12 @@ class _WorkspaceController:
                 if self._manager._workspace_state.options_modified
                 else (),
             ),
+            (
+                "Acquisition context modified",
+                ("Acquisition context",)
+                if self._manager._workspace_state.context_modified
+                else (),
+            ),
         )
         blocks: list[str] = []
         for label, items in sections:
@@ -1019,6 +1025,16 @@ class _WorkspaceController:
         ):
             return
         if self._manager._workspace_state.mark_options_dirty():
+            self._update_workspace_window_title(force=False)
+
+    def _mark_workspace_context_dirty(self) -> None:
+        if (
+            self._manager._workspace_state.loading_depth > 0
+            or self._manager._workspace_state.saving_depth > 0
+            or self._manager._workspace_state.closing_document
+        ):
+            return
+        if self._manager._workspace_state.mark_context_dirty():
             self._update_workspace_window_title(force=False)
 
     def _mark_workspace_clean(self) -> None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_format.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_format.py
@@ -275,6 +275,7 @@ def _workspace_root_attrs_payload(
     loader_state: Mapping[str, typing.Any] | None = None,
     standalone_apps: Mapping[str, typing.Any] | None = None,
     option_overrides: Mapping[str, typing.Any] | None = None,
+    acquisition_context: Mapping[str, typing.Any] | None = None,
     estimated_obsolete_bytes: int = 0,
     replacement_delta_count: int = 0,
     repack_estimate_known: bool = True,
@@ -302,6 +303,9 @@ def _workspace_root_attrs_payload(
     if option_overrides is not None:
         # Sparse interactive settings overrides portable with this workspace.
         manifest["interactive_option_overrides"] = dict(option_overrides)
+    if acquisition_context is not None:
+        # Context defaults are workspace-scoped and independent of loader choices.
+        manifest["acquisition_context"] = dict(acquisition_context)
     if delta_save_count > 0:
         # Marks files written through the recoverable in-place delta-save protocol.
         manifest["transaction_protocol"] = _WORKSPACE_TRANSACTION_PROTOCOL

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -693,6 +693,7 @@ class _WorkspaceLoader:
     ) -> None:
         self._manager._tool_graph.restore_uid_counter(snapshot["node_uid_counter"])
         dirty_uids = self._manager._workspace_state.restore(snapshot)
+        self._manager._acquisition_context.refresh_ui()
         if self._manager._workspace_state.path is not None:
             self._manager._recent_directory = str(
                 self._manager._workspace_state.path.parent
@@ -1578,6 +1579,7 @@ class _WorkspaceLoader:
                         self._restore_workspace_layout(manifest)
                         self._restore_workspace_option_overrides(manifest)
                         self._restore_workspace_loader_state(manifest)
+                        self._restore_acquisition_context(manifest)
                         self._restore_standalone_apps_state(manifest)
                 if not mark_dirty:
                     with profiler.stage("ui catch-up"):
@@ -1766,6 +1768,7 @@ class _WorkspaceLoader:
                             self._restore_workspace_layout(manifest)
                             self._restore_workspace_option_overrides(manifest)
                             self._restore_workspace_loader_state(manifest)
+                            self._restore_acquisition_context(manifest)
                             self._restore_standalone_apps_state(manifest)
                     if not mark_dirty:
                         with profiler.stage("ui catch-up"):
@@ -1839,9 +1842,10 @@ class _WorkspaceLoader:
     def _restore_workspace_layout(
         self, manifest: Mapping[str, typing.Any] | None
     ) -> None:
-        if manifest is None:
-            return
-        layout = manifest.get("manager_layout")
+        layout = None if manifest is None else manifest.get("manager_layout")
+        self._manager._metadata_editor.restore_layout_payload(
+            layout.get("metadata_editor") if isinstance(layout, dict) else None
+        )
         if not isinstance(layout, dict):
             return
 
@@ -1895,6 +1899,12 @@ class _WorkspaceLoader:
                 for name, extensions in loader_extensions.items()
             },
         )
+
+    def _restore_acquisition_context(
+        self, manifest: Mapping[str, typing.Any] | None
+    ) -> None:
+        payload = None if manifest is None else manifest.get("acquisition_context")
+        self._manager._acquisition_context.restore_state_payload(payload)
 
     def _restore_workspace_loader_state(
         self,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -207,6 +207,20 @@ class _PendingWorkspacePayloads:
         }
         return data.copy(deep=False).assign_coords(loaded_coords)
 
+    def _pending_workspace_imagetool_metadata_data(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> xr.DataArray:
+        """Return pending ImageTool metadata without materializing its data window."""
+        data = self._pending_workspace_lazy_source_data(
+            node, data_role="source", owner_node=node
+        )
+        scalar_coords = {
+            key: coord.copy(deep=False).load()
+            for key, coord in data.coords.items()
+            if isinstance(key, str) and coord.ndim == 0
+        }
+        return data.copy(deep=False).assign_coords(scalar_coords)
+
     def _pending_workspace_imagetool_info_text(
         self, node: _ImageToolWrapper | _ManagedWindowNode
     ) -> str | None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -421,6 +421,7 @@ class _WorkspaceSaver:
             loader_state=self._workspace_loader_state_snapshot(),
             standalone_apps=self._workspace_standalone_apps_snapshot(),
             option_overrides=self._workspace_option_overrides_snapshot(),
+            acquisition_context=(self._manager._acquisition_context.state_payload()),
             estimated_obsolete_bytes=estimated_obsolete_bytes,
             replacement_delta_count=replacement_delta_count,
             repack_estimate_known=repack_estimate_known,
@@ -439,6 +440,7 @@ class _WorkspaceSaver:
             "right_splitter": erlab.interactive.utils._qt_bytearray_to_base64(
                 self._manager.right_splitter.saveState()
             ),
+            "metadata_editor": self._manager._metadata_editor.layout_payload(),
         }
 
     def _workspace_option_overrides_snapshot(self) -> dict[str, typing.Any]:
@@ -1122,6 +1124,7 @@ class _WorkspaceSaver:
         return (
             self._manager._workspace_state.layout_modified
             or self._manager._workspace_state.options_modified
+            or self._manager._workspace_state.context_modified
         ) and not self._workspace_has_non_layout_modifications()
 
     def _workspace_rewrite_group_snapshot(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_state.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_state.py
@@ -9,6 +9,7 @@ __all__ = [
 ]
 
 import contextlib
+import copy
 import typing
 import uuid
 from dataclasses import dataclass
@@ -50,6 +51,9 @@ class _WorkspaceStateSnapshot(typing.TypedDict):
     layout_modified: bool
     options_modified: bool
     option_overrides: dict[str, typing.Any]
+    context_modified: bool
+    acquisition_context: dict[str, typing.Any]
+    metadata_editor_layout: dict[str, typing.Any]
     dirty_generation: int
     dirty_events: tuple[_WorkspaceDirtyEvent, ...]
     delta_save_count: int
@@ -77,6 +81,9 @@ class _ManagerWorkspaceState:
         self.layout_modified: bool = False
         self.options_modified: bool = False
         self.option_overrides: dict[str, typing.Any] = {}
+        self.context_modified: bool = False
+        self.acquisition_context: dict[str, typing.Any] = {}
+        self.metadata_editor_layout: dict[str, typing.Any] = {}
         self.needs_full_save: bool = False
         self.dirty_generation: int = 0
         self.dirty_events: list[_WorkspaceDirtyEvent] = []
@@ -90,7 +97,7 @@ class _ManagerWorkspaceState:
         self.closing_document: bool = False
 
     def is_modified(self, *, has_nodes: bool) -> bool:
-        if self.path is None and not has_nodes:
+        if self.path is None and not has_nodes and not self.context_modified:
             return False
         return (
             self.structure_modified
@@ -100,6 +107,7 @@ class _ManagerWorkspaceState:
             or bool(self.dirty_state)
             or bool(self.dirty_removed)
             or self.options_modified
+            or self.context_modified
         )
 
     def apply_dirty_event(self, event: _WorkspaceDirtyEvent) -> bool:
@@ -162,10 +170,21 @@ class _ManagerWorkspaceState:
         self.dirty_generation += 1
         return True
 
+    def mark_context_dirty(self) -> bool:
+        if self.context_modified:
+            if self.save_in_progress:
+                self.dirty_generation += 1
+                return True
+            return False
+        self.context_modified = True
+        self.dirty_generation += 1
+        return True
+
     def mark_clean(self) -> None:
         self.structure_modified = False
         self.layout_modified = False
         self.options_modified = False
+        self.context_modified = False
         self.dirty_added.clear()
         self.dirty_data.clear()
         self.dirty_state.clear()
@@ -216,6 +235,9 @@ class _ManagerWorkspaceState:
             "layout_modified": self.layout_modified,
             "options_modified": self.options_modified,
             "option_overrides": dict(self.option_overrides),
+            "context_modified": self.context_modified,
+            "acquisition_context": copy.deepcopy(self.acquisition_context),
+            "metadata_editor_layout": copy.deepcopy(self.metadata_editor_layout),
             "dirty_generation": self.dirty_generation,
             "dirty_events": tuple(self.dirty_events),
             "delta_save_count": self.delta_save_count,
@@ -239,6 +261,9 @@ class _ManagerWorkspaceState:
         self.layout_modified = snapshot["layout_modified"]
         self.options_modified = snapshot["options_modified"]
         self.option_overrides = dict(snapshot["option_overrides"])
+        self.context_modified = snapshot["context_modified"]
+        self.acquisition_context = copy.deepcopy(snapshot["acquisition_context"])
+        self.metadata_editor_layout = copy.deepcopy(snapshot["metadata_editor_layout"])
         self.dirty_generation = snapshot["dirty_generation"]
         self.dirty_events = list(snapshot["dirty_events"])
         self.delta_save_count = snapshot["delta_save_count"]

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -1920,6 +1920,25 @@ class _ManagedWindowNode(QtCore.QObject):
             return self.tool_window.tool_data.copy(deep=False)
         raise ValueError("Managed node is not available")
 
+    def current_public_data(self) -> xr.DataArray:
+        """Return current public data in canonical source dimension order."""
+        if (
+            self.pending_workspace_payload is not None
+            and not self.materialize_pending_workspace_payload()
+        ):
+            raise ValueError(
+                "Could not read this node's saved data from the workspace file."
+            )
+        if self.imagetool is not None:
+            data = self.slicer_area.displayed_data
+            source_dims = tuple(self.slicer_area._data.dims)
+            if data.dims != source_dims:
+                data = data.transpose(*source_dims, transpose_coords=True)
+            return data.copy(deep=False)
+        if self.tool_window is not None:
+            return self.tool_window.tool_data.copy(deep=False)
+        raise ValueError("Managed node is not available")
+
     def parent_source_data(self) -> xr.DataArray:
         return self.manager._parent_source_data_for_uid(self.uid)
 
@@ -2364,21 +2383,26 @@ class _ImageToolWrapper(_ManagedWindowNode):
     def _load_source_input_dtype(self) -> np.dtype[typing.Any] | None:
         return self._source_input_dtype
 
-    def _watched_root_provenance_spec(
+    def _watched_input_provenance_spec(
         self,
+        *,
+        source_input_dtype: np.dtype[typing.Any] | str | None = None,
     ) -> ToolProvenanceSpec | None:
         varname = self._watched_varname
         if (
             not self.watched
-            or self._provenance_spec is not None
-            or self._source_spec is not None
             or varname is None
             or not varname.isidentifier()
             or keyword.iskeyword(varname)
         ):
             return None
         seed_source = varname
-        if self._source_input_dtype not in (
+        input_dtype = (
+            self._source_input_dtype
+            if source_input_dtype is None
+            else np.dtype(source_input_dtype)
+        )
+        if input_dtype not in (
             None,
             np.dtype(np.float32),
             np.dtype(np.float64),
@@ -2389,6 +2413,11 @@ class _ImageToolWrapper(_ManagedWindowNode):
             seed_code=f"derived = {seed_source}",
             active_name="derived",
         )
+
+    def _watched_root_provenance_spec(self) -> ToolProvenanceSpec | None:
+        if self._provenance_spec is not None or self._source_spec is not None:
+            return None
+        return self._watched_input_provenance_spec()
 
     @property
     def provenance_spec(

--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -852,6 +852,11 @@ class ArraySlicer(QtCore.QObject):
 
         return erlab.utils.array._make_dims_uniform(data)
 
+    @classmethod
+    def preflight_array(cls, data: xr.DataArray) -> None:
+        """Check display compatibility without exposing renderer normalization."""
+        cls.validate_array(data, copy_values=False)
+
     def _reset_property_cache(self, propname: str) -> None:
         self.__dict__.pop(propname, None)
 

--- a/src/erlab/interactive/ptable/_inspector.py
+++ b/src/erlab/interactive/ptable/_inspector.py
@@ -44,7 +44,7 @@ class _LevelsTableRow:
 
 
 class CompactElementChip(QtWidgets.QFrame):
-    _COMPACT_SIZE = QtCore.QSize(92, 58)
+    _COMPACT_SIZE = (92, 58)
     _DETAILED_HEIGHT = 90
     _COMPACT_CONTENT_MARGINS = (6, 4, 6, 4)
     _DETAILED_CONTENT_MARGINS = (6, 4, 6, 7)
@@ -132,7 +132,7 @@ class CompactElementChip(QtWidgets.QFrame):
 
         self.mass_label.setVisible(self._detailed)
         self.config_label.setVisible(self._detailed)
-        self.set_chip_width(self._COMPACT_SIZE.width())
+        self.set_chip_width(self._COMPACT_SIZE[0])
         self.set_record(record)
         self.apply_theme(self._theme)
 
@@ -354,9 +354,7 @@ class CompactElementChip(QtWidgets.QFrame):
         )
 
     def set_chip_width(self, width: int) -> None:
-        height = (
-            self._DETAILED_HEIGHT if self._detailed else self._COMPACT_SIZE.height()
-        )
+        height = self._DETAILED_HEIGHT if self._detailed else self._COMPACT_SIZE[1]
         self.setFixedSize(width, height)
         self._update_text_fonts()
 
@@ -967,7 +965,7 @@ class ElementInspector(QtWidgets.QWidget):
             card_height = CompactElementChip._DETAILED_HEIGHT
         else:
             visible_rows = self._SUMMARY_COMPACT_VISIBLE_ROWS
-            card_height = CompactElementChip._COMPACT_SIZE.height()
+            card_height = CompactElementChip._COMPACT_SIZE[1]
         row_spacing = self.summary_cards_grid.verticalSpacing()
         rows_height = (visible_rows * card_height) + (
             row_spacing * max(visible_rows - 1, 0)

--- a/src/erlab/interactive/ptable/_window.py
+++ b/src/erlab/interactive/ptable/_window.py
@@ -425,7 +425,7 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
     sigStateChanged = QtCore.Signal()
 
     _MAX_HARMONIC = 10
-    _LEGACY_MINIMUM_WINDOW_SIZE = QtCore.QSize(1180, 760)
+    _LEGACY_MINIMUM_WINDOW_SIZE = (1180, 760)
     _LEGACY_TOP_SPLITTER_RATIO = 560 / (560 + 340)
 
     def __init__(
@@ -1131,11 +1131,11 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
 
         margins = root_layout.contentsMargins()
         available_width = max(
-            self._LEGACY_MINIMUM_WINDOW_SIZE.width() - margins.left() - margins.right(),
+            self._LEGACY_MINIMUM_WINDOW_SIZE[0] - margins.left() - margins.right(),
             0,
         )
         available_height = max(
-            self._LEGACY_MINIMUM_WINDOW_SIZE.height()
+            self._LEGACY_MINIMUM_WINDOW_SIZE[1]
             - margins.top()
             - margins.bottom()
             - self.header.sizeHint().height()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -1070,16 +1070,15 @@ def test_figure_composer_redraw_and_preview_cache_edges(qtbot, monkeypatch) -> N
 
     assert tool._persisted_preview_cache_pixmap() is None
     preview = QtGui.QPixmap(
-        figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE.width() + 20,
-        figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE.height() + 20,
+        figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE[0] + 20,
+        figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE[1] + 20,
     )
     preview.fill(QtGui.QColor("red"))
     tool._preview_pixmap_cache = preview
     persisted = tool._persisted_preview_cache_pixmap()
     assert persisted is not None
     assert (
-        persisted.width()
-        <= figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE.width()
+        persisted.width() <= figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE[0]
     )
     saved = tool._append_persistence_payload(xr.Dataset())
     assert figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_ATTR in saved.attrs

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -496,11 +496,11 @@ def test_figure_composer_persists_compact_preview_cache_without_rendering(
     xr.testing.assert_identical(restored.source_data()["second"], second)
     assert (
         restored_preview.width()
-        <= figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE.width()
+        <= figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE[0]
     )
     assert (
         restored_preview.height()
-        <= figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE.height()
+        <= figurecomposer_tool_module._PERSISTED_PREVIEW_CACHE_SIZE[1]
     )
     thumbnail = restored._preview_thumbnail_pixmap(QtCore.QSize(64, 64))
     assert thumbnail is not None

--- a/tests/interactive/imagetool/manager/provenance/test_clipboard.py
+++ b/tests/interactive/imagetool/manager/provenance/test_clipboard.py
@@ -22,6 +22,7 @@ from erlab.interactive.imagetool._provenance._execution import (
 from erlab.interactive.imagetool._provenance._model import (
     DerivationEntry,
     ScriptInput,
+    ToolProvenanceOperation,
     ToolProvenanceSpec,
     _ProvenanceDisplayRow,
     _ProvenanceStepRef,
@@ -35,12 +36,16 @@ from erlab.interactive.imagetool._provenance._operations import (
     AffineCoordOperation,
     AssignAttrsOperation,
     AverageOperation,
+    DivideByCoordOperation,
     GaussianFilterOperation,
     IselOperation,
     KspaceConvertOperation,
     KspaceSetNormalOperation,
     KspaceWorkFunctionOperation,
     ScriptCodeOperation,
+    SortByOperation,
+    SwapDimsOperation,
+    TransposeOperation,
 )
 from erlab.interactive.imagetool.manager import replace_data
 from erlab.interactive.imagetool.manager._provenance_edit import (
@@ -634,7 +639,7 @@ def test_manager_paste_detached_steps_uses_replay_spec_fallback(
     node = types.SimpleNamespace(
         uid="node",
         displayed_provenance_spec=full_data(),
-        current_source_data=lambda: data,
+        current_public_data=lambda: data,
         replace_with_detached_data=lambda data, spec, preserve_filter: replaced.append(
             (data, spec, preserve_filter)
         ),
@@ -1101,6 +1106,144 @@ def test_manager_paste_structured_provenance_steps_into_selected_imagetools(
         xr.testing.assert_identical(tool_b.slicer_area._data, expected_b)
         assert manager._tool_graph.root_wrappers[index_a].displayed_provenance_spec
         assert manager._tool_graph.root_wrappers[index_b].displayed_provenance_spec
+
+
+@pytest.mark.parametrize("target_kind", ["root", "source_child"])
+def test_manager_paste_steps_preserves_nonuniform_public_dimension(
+    target_kind: str,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(12, dtype=float).reshape(3, 4) + 1.0,
+        dims=("Track Shift", "eV"),
+        coords={
+            "Track Shift": [0.0, 1.0, 2.0],
+            "eV": [-0.2, -0.1, 0.0, 0.1],
+            "sample_temp": ("Track Shift", [20.0, 22.0, 25.0]),
+            "mesh_current": ("Track Shift", [1.0, 2.0, 4.0]),
+        },
+        name="scan",
+    )
+    operations = (
+        SwapDimsOperation(mapping={"Track Shift": "sample_temp"}),
+        DivideByCoordOperation(coord_name="mesh_current"),
+    )
+    expected = full_data(*operations).apply(data)
+
+    with manager_context() as manager:
+        if target_kind == "root":
+            tool = itool(data.copy(deep=True), manager=False, execute=False)
+            assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+            index = manager.add_imagetool(
+                tool,
+                show=False,
+                provenance_spec=full_data(),
+            )
+            node = manager._tool_graph.root_wrappers[index]
+            select_tools(manager, [index])
+        else:
+            parent_tool = itool(data, manager=False, execute=False)
+            assert isinstance(parent_tool, erlab.interactive.imagetool.ImageTool)
+            parent_index = manager.add_imagetool(parent_tool, show=False)
+            tool = itool(data.copy(deep=True), manager=False, execute=False)
+            assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+            child_uid = manager.add_imagetool_child(
+                tool,
+                parent_index,
+                show=False,
+                source_spec=full_data(),
+                source_auto_update=True,
+            )
+            node = manager._child_node(child_uid)
+            select_child_tool(manager, child_uid)
+
+        _set_provenance_steps_clipboard(operations)
+        manager._paste_provenance_steps_from_clipboard()
+
+        xr.testing.assert_identical(tool.slicer_area._data, expected)
+        assert tuple(tool.slicer_area.data.dims) == ("sample_temp_idx", "eV")
+        xr.testing.assert_identical(tool.slicer_area.displayed_data, expected)
+        assert isinstance(node.info_text, str)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "nonuniform_attr",
+        "nonuniform_transpose",
+        "nonuniform_sort",
+        "nonuniform_script",
+        "promoted_1d",
+        "squeezed_5d",
+    ],
+)
+def test_manager_paste_steps_starts_from_public_target_data(
+    case: str,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(12, dtype=float).reshape(3, 4) + 1.0,
+        dims=("sample_temp", "eV"),
+        coords={
+            "sample_temp": [20.0, 22.0, 25.0],
+            "eV": [-0.2, -0.1, 0.0, 0.1],
+        },
+        name="scan",
+    )
+    operations: tuple[ToolProvenanceOperation, ...]
+    contains_script = False
+    displayed_expected: xr.DataArray
+    if case == "nonuniform_attr":
+        operations = (AssignAttrsOperation(attrs={"sample": "reference"}),)
+        expected = operations[0].apply(data, parent_data=data)
+    elif case == "nonuniform_transpose":
+        operations = (TransposeOperation(dims=("eV", "sample_temp")),)
+        expected = operations[0].apply(data, parent_data=data)
+    elif case == "nonuniform_sort":
+        data = data.assign_coords(sample_temp=[25.0, 20.0, 22.0])
+        operations = (SortByOperation(variables=("sample_temp",)),)
+        expected = operations[0].apply(data, parent_data=data)
+    elif case == "nonuniform_script":
+        operations = (
+            ScriptCodeOperation(label="Offset data", code="derived = derived + 1.0"),
+        )
+        contains_script = True
+        expected = data + 1.0
+    elif case == "promoted_1d":
+        data = data.isel(eV=0, drop=True)
+        operations = (AssignAttrsOperation(attrs={"sample": "reference"}),)
+        expected = operations[0].apply(data, parent_data=data)
+    else:
+        data = data.expand_dims(a=[1.0], b=[2.0], c=[3.0])
+        operations = (AssignAttrsOperation(attrs={"sample": "reference"}),)
+        expected = operations[0].apply(data, parent_data=data)
+    displayed_expected = expected.transpose(*data.dims, transpose_coords=True)
+
+    with manager_context() as manager:
+        tool = itool(data.copy(deep=True), manager=False, execute=False)
+        assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+        index = manager.add_imagetool(
+            tool,
+            show=False,
+            provenance_spec=full_data(),
+        )
+        node = manager._tool_graph.root_wrappers[index]
+
+        manager._provenance_edit_controller._paste_steps_into_node(
+            node,
+            operations,
+            active_name="derived",
+            contains_script=contains_script,
+        )
+
+        xr.testing.assert_identical(tool.slicer_area._data, expected)
+        xr.testing.assert_identical(tool.slicer_area.displayed_data, displayed_expected)
+        xr.testing.assert_identical(node.current_public_data(), expected)
+        assert isinstance(node.info_text, str)
 
 
 def test_manager_paste_structured_provenance_steps_into_pending_memory_imagetool(
@@ -1653,13 +1796,14 @@ def test_manager_paste_script_steps_replays_from_current_output_name(
         manager._paste_provenance_steps_from_clipboard()
 
         expected = dest_data + 2.0
-        displayed_expected = (
+        renderer_expected = (
             erlab.interactive.imagetool.slicer.ArraySlicer.validate_array(
                 expected,
                 copy_values=False,
             )
         )
-        xr.testing.assert_identical(dest_tool.slicer_area._data, displayed_expected)
+        xr.testing.assert_identical(dest_tool.slicer_area._data, expected)
+        xr.testing.assert_identical(dest_tool.slicer_area.data, renderer_expected)
         dest_node = manager._tool_graph.root_wrappers[dest_index]
         assert dest_node.displayed_provenance_spec is not None
         assert [

--- a/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
+++ b/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
@@ -299,15 +299,15 @@ def test_manager_watched_badge_color_groups_by_source_uid(
         other = manager._tool_graph.root_wrappers[2]
 
         assert (
-            manager.color_for_watched_var_source(left)
+            manager.color_for_watched_var_source(left).getRgb()[:3]
             == manager_widgets._WATCHED_VAR_COLORS[0]
         )
         assert (
-            manager.color_for_watched_var_source(right)
+            manager.color_for_watched_var_source(right).getRgb()[:3]
             == manager_widgets._WATCHED_VAR_COLORS[0]
         )
         assert (
-            manager.color_for_watched_var_source(other)
+            manager.color_for_watched_var_source(other).getRgb()[:3]
             == manager_widgets._WATCHED_VAR_COLORS[1]
         )
 

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -730,6 +730,13 @@ def test_acquisition_context_dialog_commands_are_atomic(
         )
         dialog._from_selected()
         assert dialog._fields == [changed_sample, run]
+        monkeypatch.setattr(
+            _AcceptedSourcePicker,
+            "exec",
+            lambda _self: QtWidgets.QDialog.DialogCode.Rejected,
+        )
+        dialog._from_selected()
+        assert dialog._fields == [changed_sample, run]
 
         temperature = AcquisitionContextField.from_value(
             kind="coordinate", name="temperature", value=20.0
@@ -750,6 +757,13 @@ def test_acquisition_context_dialog_commands_are_atomic(
         )
         dialog._add_field()
         assert dialog._fields[-1] == temperature
+        _AcceptedFieldDialog.result = QtWidgets.QDialog.DialogCode.Rejected
+        dialog._add_field()
+        assert dialog._fields[-1] == temperature
+        dialog._select_row(0)
+        dialog._edit_field()
+        assert dialog._fields[0] == changed_sample
+        _AcceptedFieldDialog.result = QtWidgets.QDialog.DialogCode.Accepted
 
         warnings: list[tuple[object, ...]] = []
         monkeypatch.setattr(
@@ -857,6 +871,13 @@ def test_acquisition_context_controller_recovers_from_invalid_state(
         controller.restore_state_payload({"fields": [{"kind": "invalid"}]})
         assert warnings
         assert controller.state == AcquisitionContextState()
+
+        manager._workspace_state.acquisition_context = {"fields": [{"kind": "invalid"}]}
+        assert controller.state == AcquisitionContextState()
+        manager._workspace_state.acquisition_context = "invalid"  # type: ignore[assignment]
+        replacement_controller = type(controller)(manager)
+        assert manager._workspace_state.acquisition_context == {}
+        replacement_controller.deleteLater()
 
         button = controller._status_button
         controller._status_button = None
@@ -2175,7 +2196,6 @@ def test_metadata_editor_field_chooser_and_frozen_data_column(
     with manager_context() as manager:
         _add_batch_tools(qtbot, manager, data0, data1)
         dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0, 1))
-        qtbot.addWidget(dialog)
         dialog.show()
         qtbot.mouseClick(dialog.fields_button, QtCore.Qt.MouseButton.LeftButton)
         qtbot.wait_until(dialog.fields_menu.isVisible)
@@ -2263,6 +2283,23 @@ def test_metadata_editor_field_chooser_and_frozen_data_column(
         assert added[-1] == (run, 4)
         assert run in dialog.model.fields
         chooser.add_field(run)
+        chooser.set_field_visible(
+            MetadataField(kind="attribute", name="not-listed"), True
+        )
+        sample_item = chooser._items[sample]
+        chooser._item_changed(sample_item, 1)
+        sample_item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
+        assert sample not in dialog.model.fields
+        sample_item.setCheckState(0, QtCore.Qt.CheckState.Checked)
+        assert sample in dialog.model.fields
+
+        dialog._set_field_visible(object(), True)
+        dialog._set_visible_fields([coord])
+        dialog._add_field(object(), 0)
+
+        messages.clear()
+        dialog._show_cell_edit_error("invalid value")
+        assert messages
 
         dialog._set_field_visible(coord, False)
         assert coord not in dialog.model.fields
@@ -2279,8 +2316,36 @@ def test_metadata_editor_field_chooser_and_frozen_data_column(
         dialog.table.setRowHeight(0, 38)
         assert dialog.table.frozen_view.columnWidth(0) == 210
         assert dialog.table.frozen_view.rowHeight(0) == 38
+        manager._metadata_editor.set_column_width(None, 210)
 
-        dialog._show_header_menu(QtCore.QPoint(1, 1))
+        selection_model = typing.cast(
+            "QtCore.QItemSelectionModel", dialog.table.selectionModel()
+        )
+        selection_model.clearSelection()
+        dialog.table.setCurrentIndex(index)
+        dialog._fill_down()
+        dialog._revert_assignment()
+
+        header = typing.cast("QtWidgets.QHeaderView", dialog.table.horizontalHeader())
+        sample_column = dialog.model.fields.index(sample) + 1
+        sample_position = QtCore.QPoint(
+            header.sectionViewportPosition(sample_column) + 1, 1
+        )
+
+        def _choose_hide_field() -> None:
+            menu = QtWidgets.QApplication.activePopupWidget()
+            if not isinstance(menu, QtWidgets.QMenu):
+                pytest.fail("The metadata header menu did not open.")
+            action = menu.actions()[0]
+            qtbot.mouseClick(
+                menu,
+                QtCore.Qt.MouseButton.LeftButton,
+                pos=menu.actionGeometry(action).center(),
+            )
+
+        QtCore.QTimer.singleShot(0, _choose_hide_field)
+        dialog._show_header_menu(sample_position)
+        assert sample not in dialog.model.fields
         dialog._set_field_visible(run, False)
         assert run not in dialog.model.fields
 

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -1909,6 +1909,15 @@ def test_metadata_editor_layout_discovery_and_action_dispatch(
         assert dirty_calls == 0
         controller.set_layout_fields((sample,))
         assert dirty_calls == 1
+        controller.set_column_width(None, 237)
+        controller.set_column_width(sample, 119)
+        assert dirty_calls == 3
+        controller.set_column_width(sample, 119)
+        assert dirty_calls == 3
+        controller.set_layout_fields((saved_field,))
+        assert dirty_calls == 4
+        assert controller.saved_column_width(None) == 237
+        assert controller.saved_column_width(sample) == 119
 
         with pytest.warns(UserWarning, match="metadata editor layout"):
             controller.restore_layout_payload({"fields": [{"kind": "invalid"}]})
@@ -6122,17 +6131,51 @@ def test_metadata_editor_layout_persists_with_workspace(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    field = MetadataField(kind="attribute", name="sample")
+    sample = MetadataField(kind="attribute", name="sample")
+    operator = MetadataField(kind="attribute", name="operator")
     transient = MetadataField(kind="coordinate", name="temperature")
 
     with manager_context() as manager:
-        _add_batch_tools(qtbot, manager, _batch_data("scan"))
-        manager._metadata_editor.set_layout_fields((field,))
+        _add_batch_tools(
+            qtbot,
+            manager,
+            _batch_data("scan").assign_attrs(sample="reference", operator="user"),
+        )
+        manager._metadata_editor.set_layout_fields((sample, operator))
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0,))
+        qtbot.addWidget(dialog)
+        dialog.show()
+        dialog.table.frozen_view.setColumnWidth(0, 237)
+        assert dialog.table.columnWidth(0) == 237
+        dialog.table.setColumnWidth(dialog.model.fields.index(sample) + 1, 119)
+        dialog.table.setColumnWidth(dialog.model.fields.index(operator) + 1, 173)
+        assert manager._metadata_editor.saved_column_width(None) == 237
+        assert manager._metadata_editor.saved_column_width(sample) == 119
+        assert manager._metadata_editor.saved_column_width(operator) == 173
+
+        dialog._set_visible_fields((operator, sample))
+        assert dialog.table.columnWidth(dialog.model.fields.index(sample) + 1) == 119
+        assert dialog.table.columnWidth(dialog.model.fields.index(operator) + 1) == 173
+        dialog.reject()
+
+        reopened = MetadataEditorDialog(manager, manager._metadata_editor, (0,))
+        qtbot.addWidget(reopened)
+        assert reopened.table.columnWidth(0) == 237
+        assert (
+            reopened.table.columnWidth(reopened.model.fields.index(sample) + 1) == 119
+        )
+        assert (
+            reopened.table.columnWidth(reopened.model.fields.index(operator) + 1) == 173
+        )
+        reopened.reject()
+
         workspace_path = tmp_path / "metadata-layout.itws"
         manager._workspace_controller.saving._save_workspace_document(
             workspace_path, force_full=True
         )
         manager._metadata_editor.set_layout_fields((transient,))
+        manager._metadata_editor.set_column_width(None, 301)
+        manager._metadata_editor.set_column_width(transient, 181)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,
@@ -6140,7 +6183,21 @@ def test_metadata_editor_layout_persists_with_workspace(
             mark_dirty=False,
             select=False,
         )
-        assert manager._metadata_editor.layout_state.fields == (field,)
+        assert manager._metadata_editor.layout_state.fields == (operator, sample)
+        assert manager._metadata_editor.saved_column_width(None) == 237
+        assert manager._metadata_editor.saved_column_width(sample) == 119
+        assert manager._metadata_editor.saved_column_width(operator) == 173
+        assert manager._metadata_editor.saved_column_width(transient) is None
+
+        restored = MetadataEditorDialog(manager, manager._metadata_editor, (0,))
+        qtbot.addWidget(restored)
+        assert restored.table.columnWidth(0) == 237
+        assert (
+            restored.table.columnWidth(restored.model.fields.index(sample) + 1) == 119
+        )
+        assert (
+            restored.table.columnWidth(restored.model.fields.index(operator) + 1) == 173
+        )
 
 
 def test_metadata_editor_reads_deferred_workspace_metadata_without_materializing(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -16,6 +16,7 @@ import erlab
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
+import erlab.interactive.imagetool.manager._io as manager_io
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._metadata_editor as metadata_editor
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
@@ -872,6 +873,58 @@ def test_acquisition_context_is_hidden_until_active_and_enriches_file_data(
         replaced = manager.get_imagetool(0).slicer_area.data
         assert replaced.coords["photon_energy"].item() == 21.2
         assert replaced.attrs["sample"] == "reference"
+
+
+def test_failed_file_ingress_does_not_report_acquisition_context(
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("scan")
+    field = AcquisitionContextField.from_value(
+        kind="attribute", name="sample", value="reference"
+    )
+    load_options = {
+        "load_func": (
+            xr.load_dataarray,
+            {},
+            FileDataSelection(kind="dataarray"),
+        )
+    }
+    creation_errors: list[None] = []
+
+    def fail_registration(*_args: object, **_kwargs: object) -> typing.NoReturn:
+        raise RuntimeError("registration failed")
+
+    with manager_context() as manager:
+        manager._acquisition_context.set_state(
+            AcquisitionContextState(enabled=True, fields=(field,)),
+            mark_dirty=False,
+        )
+        monkeypatch.setattr(manager_io, "ImageTool", lambda *_args, **_kwargs: object())
+        monkeypatch.setattr(manager, "add_imagetool", fail_registration)
+        monkeypatch.setattr(
+            manager._data_ingress,
+            "_error_creating_imagetool",
+            lambda: creation_errors.append(None),
+        )
+
+        manager._status_bar.showMessage("unchanged")
+        assert manager._data_ingress.receive_data(
+            [source], load_options.copy(), show=False
+        ) == [False]
+        assert manager._status_bar.currentMessage() == "unchanged"
+
+        summary = ContextIngressSummary()
+        assert manager._data_ingress.receive_data(
+            [source],
+            load_options.copy(),
+            show=False,
+            _context_summary=summary,
+        ) == [False]
+        assert summary == ContextIngressSummary()
+        assert len(creation_errors) == 2
 
 
 def test_acquisition_context_collision_policy_and_incompatible_input_are_atomic(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -680,9 +680,93 @@ def test_acquisition_context_field_actions_use_toolbar_and_add_menu(
         qtbot.wait_until(dialog.add_menu.isVisible)
         dialog.add_menu.hide()
 
-        dialog.table.selectRow(0)
+        dialog.table.setCurrentItem(dialog.table.topLevelItem(0))
         assert dialog.edit_button.isEnabled()
         assert dialog.remove_button.isEnabled()
+
+
+def test_acquisition_context_drag_order_controls_provenance_order(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    sample = AcquisitionContextField.from_value(
+        kind="attribute", name="sample", value="reference"
+    )
+    photon_energy = AcquisitionContextField.from_value(
+        kind="coordinate", name="photon_energy", value=21.2
+    )
+    run = AcquisitionContextField.from_value(kind="attribute", name="run", value=4)
+    initial_state = AcquisitionContextState(
+        enabled=True,
+        fields=(sample, photon_energy, run),
+    )
+    source = _batch_data("scan")
+
+    with manager_context() as manager:
+        manager._acquisition_context.set_state(initial_state, mark_dirty=False)
+        initial = manager._acquisition_context.resolve(source)
+        assert [type(operation) for operation in initial.operations] == [
+            AssignAttrsOperation,
+            AssignScalarCoordOperation,
+            AssignAttrsOperation,
+        ]
+
+        dialog = AcquisitionContextDialog(manager, manager._acquisition_context)
+        qtbot.addWidget(dialog)
+        assert (
+            dialog.table.dragDropMode()
+            == QtWidgets.QAbstractItemView.DragDropMode.InternalMove
+        )
+        assert dialog.table.defaultDropAction() == QtCore.Qt.DropAction.MoveAction
+        assert dialog.table.showDropIndicator()
+        assert not dialog.table.dragDropOverwriteMode()
+        assert all(
+            bool(
+                typing.cast(
+                    "QtWidgets.QTreeWidgetItem", dialog.table.topLevelItem(row)
+                ).flags()
+                & QtCore.Qt.ItemFlag.ItemIsDragEnabled
+            )
+            and not bool(
+                typing.cast(
+                    "QtWidgets.QTreeWidgetItem", dialog.table.topLevelItem(row)
+                ).flags()
+                & QtCore.Qt.ItemFlag.ItemIsDropEnabled
+            )
+            for row in range(dialog.table.topLevelItemCount())
+        )
+
+        moved = dialog.table.takeTopLevelItem(1)
+        assert moved is not None
+        dialog.table.insertTopLevelItem(0, moved)
+        dialog.table.setCurrentItem(moved)
+        dialog.table._queue_rows_reordered()
+        qtbot.waitUntil(
+            lambda: dialog._fields == [photon_energy, sample, run],
+        )
+
+        dialog._save()
+
+        assert manager._acquisition_context.state.fields == (
+            photon_energy,
+            sample,
+            run,
+        )
+        assert manager._workspace_state.context_modified
+        processed, operations, resolution = (
+            manager._acquisition_context.apply_to_file_data(source)
+        )
+        assert not resolution.errors
+        assert [type(operation) for operation in operations] == [
+            AssignScalarCoordOperation,
+            AssignAttrsOperation,
+        ]
+        attrs_operation = typing.cast("AssignAttrsOperation", operations[1])
+        assert tuple(attrs_operation.attrs) == ("sample", "run")
+        assert processed.coords["photon_energy"].item() == 21.2
+        assert processed.attrs == {"sample": "reference", "run": 4}
 
 
 def test_saving_unchanged_default_acquisition_context_keeps_workspace_clean(
@@ -6033,6 +6117,10 @@ def test_acquisition_context_persists_on_open_but_not_workspace_import(
             AcquisitionContextField.from_value(
                 kind="attribute", name="operator", value="current user"
             ),
+            AcquisitionContextField.from_value(
+                kind="coordinate", name="photon_energy", value=21.2
+            ),
+            AcquisitionContextField.from_value(kind="attribute", name="run", value=4),
         ),
     )
     transient_state = AcquisitionContextState(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -166,7 +166,9 @@ def test_color_for_linker_falls_back_without_structural_link_key() -> None:
     )
 
     assert (
-        manager_mainwindow.ImageToolManager.color_for_linker(manager, linker)
+        manager_mainwindow.ImageToolManager.color_for_linker(manager, linker).getRgb()[
+            :3
+        ]
         == manager_mainwindow._LINKER_COLORS[1]
     )
 
@@ -1292,6 +1294,8 @@ def test_metadata_editor_table_model_tracks_origin_and_pending_state(
             },
         )
 
+        assert model.rowCount() == 1
+        assert model.columnCount() == 6
         assert model.rowCount(model.index(0, 0)) == 0
         assert model.columnCount(model.index(0, 0)) == 0
         assert model.cell_at(model.index(0, 0)) is None

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -17,6 +17,7 @@ import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
+import erlab.interactive.imagetool.manager._metadata_editor as metadata_editor
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.utils
@@ -38,17 +39,20 @@ from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import _kspace_conversion, itool
 from erlab.interactive.imagetool._load_source import _LoadSourceDetails
+from erlab.interactive.imagetool._provenance._execution import replay_file_provenance
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     ScriptInput,
     ToolProvenanceOperation,
     ToolProvenanceSpec,
     full_data,
+    iter_operation_refs,
     public_data,
     selection,
 )
 from erlab.interactive.imagetool._provenance._operations import (
     AssignAttrsOperation,
+    AssignScalarCoordOperation,
     ImageDerivativeOperation,
     ImageToolSelectionSourceBinding,
     IselOperation,
@@ -59,6 +63,13 @@ from erlab.interactive.imagetool._provenance._operations import (
     TransposeOperation,
 )
 from erlab.interactive.imagetool.manager import fetch, replace_data
+from erlab.interactive.imagetool.manager._acquisition_context import (
+    AcquisitionContextDialog,
+    AcquisitionContextField,
+    AcquisitionContextState,
+    ContextIngressSummary,
+    _ContextSourcePickerDialog,
+)
 from erlab.interactive.imagetool.manager._details_panel import _DetailsPanelController
 from erlab.interactive.imagetool.manager._dialogs import (
     _batch_operation_dialog_classes,
@@ -67,6 +78,12 @@ from erlab.interactive.imagetool.manager._dialogs import (
     _RenameDialog,
 )
 from erlab.interactive.imagetool.manager._figurecomposer import _dialogs
+from erlab.interactive.imagetool.manager._metadata_editor import (
+    MetadataCellEdit,
+    MetadataEditorDialog,
+    MetadataField,
+    _MetadataTableModel,
+)
 from erlab.interactive.imagetool.manager._modelview import (
     _TOOL_TYPE_ROLE,
     _ImageToolWrapperItemDelegate,
@@ -571,6 +588,1556 @@ class _BatchFilterStub:
 
     def filter_operation(self) -> ToolProvenanceOperation | None:
         return self._operation
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [1.0, 2.0],
+        (1.0, 2.0),
+        {"start": 1.0},
+        {1.0, 2.0},
+        frozenset({1.0, 2.0}),
+        np.array([1.0, 2.0]),
+    ],
+)
+def test_acquisition_context_coordinates_are_scalar_only(value) -> None:
+    with pytest.raises(ValueError, match="Coordinates require a scalar value"):
+        AcquisitionContextField.from_value(kind="coordinate", name="angle", value=value)
+    scalar_field = AcquisitionContextField.from_value(
+        kind="coordinate", name="angle", value=1.0
+    )
+    with pytest.raises(ValueError, match="Coordinates require a scalar value"):
+        scalar_field.with_value(value)
+
+
+def test_acquisition_context_values_are_serialization_stable() -> None:
+    with pytest.raises(ValueError, match="stable serializable representation"):
+        AcquisitionContextField.from_value(
+            kind="attribute", name="labels", value={"sample", "reference"}
+        )
+    field = AcquisitionContextField.from_value(
+        kind="attribute", name="range", value=(1.0, 2.0)
+    )
+    payload = AcquisitionContextState(fields=(field,)).model_dump(mode="json")
+    restored = AcquisitionContextState.model_validate(payload)
+    assert restored.fields[0].decoded_value == (1.0, 2.0)
+
+
+def test_acquisition_context_field_actions_use_toolbar_and_add_menu(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    field = AcquisitionContextField.from_value(
+        kind="attribute", name="sample", value="reference"
+    )
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, _batch_data("scan"))
+        select_tools(manager, [0])
+        manager._acquisition_context.set_state(
+            AcquisitionContextState(fields=(field,)), mark_dirty=False
+        )
+        dialog = AcquisitionContextDialog(manager, manager._acquisition_context)
+        qtbot.addWidget(dialog)
+
+        assert isinstance(dialog.add_button, QtWidgets.QToolButton)
+        assert isinstance(dialog.edit_button, QtWidgets.QToolButton)
+        assert isinstance(dialog.remove_button, QtWidgets.QToolButton)
+        for button in (
+            dialog.add_button,
+            dialog.edit_button,
+            dialog.remove_button,
+        ):
+            assert button.toolButtonStyle() == (
+                QtCore.Qt.ToolButtonStyle.ToolButtonTextOnly
+            )
+            assert button.icon().isNull()
+        assert dialog.add_button.property("uses_inline_menu_arrow") is True
+        assert dialog.add_menu.actions() == [
+            dialog.add_field_action,
+            dialog.from_selected_action,
+        ]
+        assert dialog.from_selected_action.isEnabled()
+        assert not dialog.edit_button.isEnabled()
+        assert not dialog.remove_button.isEnabled()
+
+        root_layout = dialog.layout()
+        assert root_layout is not None
+        assert root_layout.indexOf(dialog.table) == 2
+        toolbar_layout = root_layout.itemAt(1).layout()
+        assert toolbar_layout is not None
+        assert toolbar_layout.indexOf(dialog.add_button) == 0
+        assert toolbar_layout.indexOf(dialog.edit_button) == 1
+        assert toolbar_layout.indexOf(dialog.remove_button) == 2
+
+        dialog.show()
+        qtbot.mouseClick(dialog.add_button, QtCore.Qt.MouseButton.LeftButton)
+        qtbot.wait_until(dialog.add_menu.isVisible)
+        dialog.add_menu.hide()
+
+        dialog.table.selectRow(0)
+        assert dialog.edit_button.isEnabled()
+        assert dialog.remove_button.isEnabled()
+
+
+def test_saving_unchanged_default_acquisition_context_keeps_workspace_clean(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager._workspace_controller._mark_workspace_clean()
+        generation = manager._workspace_state.dirty_generation
+        dialog = AcquisitionContextDialog(manager, manager._acquisition_context)
+        qtbot.addWidget(dialog)
+
+        dialog._save()
+
+        assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+        assert not manager._workspace_state.context_modified
+        assert manager._workspace_state.dirty_generation == generation
+        assert not manager._workspace_state.is_modified(has_nodes=False)
+
+
+def test_acquisition_context_is_hidden_until_active_and_enriches_file_data(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("scan").assign_coords(temperature=12.0)
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+    fields = (
+        AcquisitionContextField.from_value(
+            kind="coordinate", name="temperature", value=20.0
+        ),
+        AcquisitionContextField.from_value(
+            kind="coordinate",
+            name="photon_energy",
+            value=21.2,
+        ),
+        AcquisitionContextField.from_value(
+            kind="attribute", name="sample", value="reference"
+        ),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        assert manager.acquisition_context_status_button.isHidden()
+        file_actions = manager.file_menu.actions()
+        assert manager.acquisition_context_action in file_actions
+        assert manager.acquisition_context_action not in manager.edit_menu.actions()
+        assert manager.metadata_editor_action in manager.edit_menu.actions()
+        assert manager.metadata_editor_action not in file_actions
+        assert not manager.metadata_editor_action.isEnabled()
+        assert file_actions.index(manager.acquisition_context_action) == (
+            file_actions.index(manager.explorer_action) + 1
+        )
+
+        manager._workspace_controller._mark_workspace_clean()
+        manager._acquisition_context.set_state(
+            AcquisitionContextState(enabled=True, fields=fields)
+        )
+        assert manager._workspace_state.context_modified
+        qtbot.wait_until(manager.acquisition_context_status_button.isVisible)
+
+        assert manager._data_ingress.receive_data(
+            [source],
+            {
+                "file_path": file_path,
+                "load_func": (
+                    xr.load_dataarray,
+                    {"engine": "h5netcdf"},
+                    FileDataSelection(kind="dataarray"),
+                ),
+            },
+            show=False,
+        ) == [True]
+        actual = manager.get_imagetool(0).slicer_area._data
+        assert actual.coords["temperature"].item() == 12.0
+        assert actual.coords["photon_energy"].item() == 21.2
+        assert actual.attrs["sample"] == "reference"
+        assert "photon_energy" not in source.coords
+        assert "sample" not in source.attrs
+        select_tools(manager, [0])
+        assert manager.metadata_editor_action.isEnabled()
+
+        provenance = manager._tool_graph.root_wrappers[0].displayed_provenance_spec
+        assert provenance is not None
+        xr.testing.assert_identical(replay_file_provenance(provenance), actual)
+        code = provenance.display_code()
+        assert code is not None
+        namespace = _exec_generated_code(code, {"data": source.copy(deep=True)})
+        xr.testing.assert_identical(namespace["derived"], actual)
+
+        manager._acquisition_context.set_state(AcquisitionContextState())
+        assert manager.acquisition_context_status_button.isHidden()
+
+        replacement = _batch_data("replacement", offset=100.0)
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            replace_data(0, replacement)
+        replaced = manager.get_imagetool(0).slicer_area.data
+        assert replaced.coords["photon_energy"].item() == 21.2
+        assert replaced.attrs["sample"] == "reference"
+
+
+def test_acquisition_context_collision_policy_and_incompatible_input_are_atomic(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("scan").assign_coords(temperature=12.0)
+    keep = AcquisitionContextField.from_value(
+        kind="coordinate", name="temperature", value=20.0
+    )
+    replace = keep.model_copy(update={"replace_existing": True})
+    identical = keep.with_value(12.0)
+    incompatible_fields = (
+        AcquisitionContextField.from_value(
+            kind="attribute", name="sample", value="reference"
+        ),
+        AcquisitionContextField.from_value(
+            kind="coordinate",
+            name="x",
+            value=1.0,
+            replace_existing=True,
+        ),
+    )
+
+    with manager_context() as manager:
+        identical_resolution = manager._acquisition_context.resolve(
+            source, (identical,)
+        )
+        assert identical_resolution.identical == 1
+        assert identical_resolution.operations == ()
+
+        keep_resolution = manager._acquisition_context.resolve(source, (keep,))
+        assert keep_resolution.kept == 1
+        assert keep_resolution.operations == ()
+
+        replace_resolution = manager._acquisition_context.resolve(source, (replace,))
+        assert replace_resolution.replaced == 1
+        replaced = full_data(*replace_resolution.operations).apply(source)
+        assert replaced.coords["temperature"].item() == 20.0
+
+        manager._acquisition_context.set_state(
+            AcquisitionContextState(enabled=True, fields=incompatible_fields),
+            mark_dirty=False,
+        )
+        processed, operations, resolution = (
+            manager._acquisition_context.apply_to_file_data(source)
+        )
+        assert operations == ()
+        assert resolution.errors
+        assert resolution.added == 1
+        summary = ContextIngressSummary()
+        summary.add_resolution(resolution)
+        assert summary.added == 0
+        assert summary.replaced == 0
+        assert summary.failed == 1
+        xr.testing.assert_identical(processed, source)
+        assert "sample" not in processed.attrs
+
+
+def test_metadata_assignments_survive_live_replacement_and_update_provenance(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("scan").assign_coords(temperature=12.0)
+    edits = (
+        MetadataCellEdit(
+            MetadataField(kind="coordinate", name="temperature"), value=20.0
+        ),
+        MetadataCellEdit(MetadataField(kind="coordinate", name="angle"), value=1.5),
+        MetadataCellEdit(
+            MetadataField(kind="attribute", name="sample"), value="reference"
+        ),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        assert manager._data_ingress.receive_data([source], {}, show=False) == [True]
+        assert manager._metadata_editor.apply_edits({0: edits})
+
+        replacement = _batch_data("replacement", offset=100.0)
+        replacement_payloads: list[xr.DataArray] = []
+        manager.get_imagetool(0).slicer_area.sigSourceDataReplaced.connect(
+            replacement_payloads.append
+        )
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            replace_data(0, replacement)
+
+        actual = manager.get_imagetool(0).slicer_area.data
+        expected = replacement.assign_coords(temperature=20.0, angle=1.5)
+        expected = expected.assign_attrs(sample="reference")
+        xr.testing.assert_identical(actual, expected)
+        assert replacement_payloads
+        xr.testing.assert_identical(replacement_payloads[-1], expected)
+
+        node = manager._tool_graph.root_wrappers[0]
+        assert node.detached_live_parent_data is not None
+        xr.testing.assert_identical(node.detached_live_parent_data, replacement)
+        provenance = node.displayed_provenance_spec
+        assert provenance is not None
+        xr.testing.assert_identical(
+            provenance.apply(node.detached_live_parent_data), actual
+        )
+
+        incompatible = xr.DataArray(
+            np.arange(16.0).reshape(4, 4),
+            dims=("angle", "y"),
+            name="incompatible",
+        )
+        before = actual.copy(deep=True)
+        with pytest.raises(ValueError, match="angle"):
+            replace_data(0, incompatible)
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, before)
+        xr.testing.assert_identical(node.detached_live_parent_data, replacement)
+
+
+def test_metadata_edits_and_replacement_preserve_nonuniform_public_data(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data(
+        "scan",
+        dims=("sample_temp", "eV"),
+        first_coord=[20.0, 22.0, 25.0],
+    )
+    field = MetadataField(kind="attribute", name="sample")
+
+    with manager_context() as manager:
+        tool = itool(source.copy(deep=True), manager=False, execute=False)
+        assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+        index = manager.add_imagetool(
+            tool,
+            show=False,
+            provenance_spec=full_data(),
+        )
+        assert manager._metadata_editor.apply_edits(
+            {index: (MetadataCellEdit(field, value="reference"),)}
+        )
+
+        expected = source.assign_attrs(sample="reference")
+        xr.testing.assert_identical(tool.slicer_area._data, expected)
+        assert tuple(tool.slicer_area.data.dims) == ("sample_temp_idx", "eV")
+        xr.testing.assert_identical(tool.slicer_area.displayed_data, expected)
+
+        replacement = _batch_data(
+            "replacement",
+            dims=("sample_temp", "eV"),
+            offset=100.0,
+            first_coord=[30.0, 32.0, 35.0],
+        )
+        replace_data(index, replacement)
+
+        replaced_expected = replacement.assign_attrs(sample="reference")
+        xr.testing.assert_identical(tool.slicer_area._data, replaced_expected)
+        assert tuple(tool.slicer_area.data.dims) == ("sample_temp_idx", "eV")
+        xr.testing.assert_identical(tool.slicer_area.displayed_data, replaced_expected)
+        node = manager._tool_graph.root_wrappers[index]
+        assert node.detached_live_parent_data is not None
+        xr.testing.assert_identical(node.detached_live_parent_data, replacement)
+        assert node.displayed_provenance_spec is not None
+        xr.testing.assert_identical(
+            node.displayed_provenance_spec.apply(node.detached_live_parent_data),
+            replaced_expected,
+        )
+
+
+def test_multi_target_replacement_preflights_preserved_metadata_atomically(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source0 = _batch_data("scan0")
+    source1 = _batch_data("scan1", offset=100.0)
+    angle = MetadataField(kind="coordinate", name="angle")
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, source0, source1)
+        assert manager._metadata_editor.apply_edits(
+            {1: (MetadataCellEdit(angle, value=1.5),)}
+        )
+        before0 = manager.get_imagetool(0).slicer_area._data.copy(deep=True)
+        before1 = manager.get_imagetool(1).slicer_area._data.copy(deep=True)
+        replacements = [
+            _batch_data("replacement0", offset=200.0),
+            _batch_data(
+                "replacement1",
+                dims=("angle", "y"),
+                offset=300.0,
+            ),
+        ]
+        replacement_signals: list[None] = []
+        manager._sigDataReplaced.connect(lambda: replacement_signals.append(None))
+
+        with pytest.raises(ValueError, match="angle"):
+            manager._data_replace(replacements, [0, 1])
+
+        assert not replacement_signals
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area._data, before0)
+        xr.testing.assert_identical(manager.get_imagetool(1).slicer_area._data, before1)
+
+        valid_replacements = [
+            replacements[0],
+            _batch_data("replacement1", offset=300.0),
+        ]
+        manager._data_replace(valid_replacements, [0, 1])
+
+        assert replacement_signals == [None]
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area._data,
+            valid_replacements[0],
+        )
+        xr.testing.assert_identical(
+            manager.get_imagetool(1).slicer_area._data,
+            valid_replacements[1].assign_coords(angle=1.5),
+        )
+
+
+def test_multi_target_replacement_adds_consecutive_new_indices(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    replacements = [
+        _batch_data("replacement0"),
+        _batch_data("replacement1", offset=100.0),
+    ]
+
+    with manager_context() as manager:
+        first_new_idx = manager.next_idx
+        replacement_signals: list[None] = []
+        manager._sigDataReplaced.connect(lambda: replacement_signals.append(None))
+
+        manager._data_replace(
+            replacements,
+            [first_new_idx, first_new_idx + 1],
+        )
+
+        assert replacement_signals == [None]
+        assert manager.next_idx == first_new_idx + 2
+        for offset, replacement in enumerate(replacements):
+            xr.testing.assert_identical(
+                manager.get_imagetool(first_new_idx + offset).slicer_area._data,
+                replacement,
+            )
+
+
+def test_metadata_assignments_survive_watched_variable_updates(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("scan")
+    edits = (
+        MetadataCellEdit(
+            MetadataField(kind="attribute", name="sample"), value="reference"
+        ),
+        MetadataCellEdit(MetadataField(kind="coordinate", name="angle"), value=1.5),
+    )
+    messages = _block_message_dialog(monkeypatch)
+
+    with manager_context() as manager:
+        manager._data_watched_update("scan", "watched-uid", source)
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, source)
+        assert manager._metadata_editor.apply_edits({0: edits})
+
+        replacement = _batch_data("scan", offset=100.0)
+        manager._data_watched_update("scan", "watched-uid", replacement)
+
+        actual = manager.get_imagetool(0).slicer_area.data
+        expected = replacement.assign_coords(angle=1.5)
+        expected = expected.assign_attrs(sample="reference")
+        xr.testing.assert_identical(actual, expected)
+        node = manager._tool_graph.root_wrappers[0]
+        provenance = node.displayed_provenance_spec
+        assert provenance is not None
+        code = provenance.display_code()
+        assert code is not None
+        namespace = _exec_generated_code(code, {"scan": replacement})
+        xr.testing.assert_identical(namespace["derived"], actual)
+
+        incompatible = xr.DataArray(
+            np.arange(16.0).reshape(4, 4), dims=("angle", "y"), name="scan"
+        )
+        manager._data_watched_update("scan", "watched-uid", incompatible)
+        assert messages
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+
+
+def test_acquisition_context_does_not_apply_when_child_is_promoted(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    field = AcquisitionContextField.from_value(
+        kind="attribute", name="sample", value="reference"
+    )
+    child_data = _batch_data("child", offset=100.0)
+
+    with manager_context() as manager:
+        manager._acquisition_context.set_state(
+            AcquisitionContextState(enabled=True, fields=(field,)), mark_dirty=False
+        )
+        _add_batch_tools(qtbot, manager, _batch_data("root"))
+        child_tool = itool(child_data, manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(child_tool, 0, show=False)
+
+        promoted_index = manager.promote_child_imagetool(child_uid)
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(promoted_index).slicer_area.data, child_data
+        )
+
+
+def test_live_replacement_preserves_explicit_assignment_when_source_matches(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    field = MetadataField(kind="coordinate", name="temperature")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        assert manager._data_ingress.receive_data(
+            [_batch_data("scan")], {}, show=False
+        ) == [True]
+        assert manager._metadata_editor.apply_edits(
+            {0: (MetadataCellEdit(field, value=20.0),)}
+        )
+
+        replacement = _batch_data("replacement", offset=100.0).assign_coords(
+            temperature=12.0
+        )
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            replace_data(0, replacement)
+
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data,
+            replacement.assign_coords(temperature=20.0),
+        )
+        node = manager._tool_graph.root_wrappers[0]
+        assert node.displayed_provenance_spec is not None
+        assert node.detached_live_parent_data is not None
+
+
+def test_acquisition_context_can_copy_selected_coordinates_and_attributes(
+    qtbot,
+) -> None:
+    data = _batch_data("scan").assign_coords(temperature=20.0)
+    data = data.assign_coords(grid=(("x", "y"), np.zeros(data.shape)))
+    data.attrs.update({"sample": "reference", "run": 4})
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    dialog = _ContextSourcePickerDialog(parent, data)
+
+    selected_keys = {("coordinate", "temperature"), ("attribute", "sample")}
+    root = dialog.tree.invisibleRootItem()
+    assert root is not None
+    available: dict[tuple[str, str], QtWidgets.QTreeWidgetItem] = {}
+    for group_index in range(root.childCount()):
+        group = root.child(group_index)
+        assert group is not None
+        for row in range(group.childCount()):
+            item = group.child(row)
+            assert item is not None
+            field = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+            assert isinstance(field, AcquisitionContextField)
+            available[field.key] = item
+    assert (
+        not {("coordinate", "x"), ("coordinate", "y"), ("coordinate", "grid")}
+        & available.keys()
+    )
+    for key in selected_keys:
+        available[key].setCheckState(0, QtCore.Qt.CheckState.Checked)
+
+    dialog.accept()
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+    assert {field.key for field in dialog.selected_fields} == selected_keys
+
+
+def test_metadata_editor_scalar_value_and_operation_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BadArray:
+        def __array__(self, *_args, **_kwargs):
+            raise RuntimeError("not array-like")
+
+    assert metadata_editor._values_equal(np.nan, np.nan)
+    assert metadata_editor._values_equal(np.int64(1), 1)
+    assert metadata_editor._values_equal(np.float64(1.0), 1.0)
+    assert not metadata_editor._values_equal(1, 1.0)
+    assert not metadata_editor._values_equal(1, True)
+    assert not metadata_editor._values_equal([1], [1.0])
+    assert not metadata_editor._values_equal({"value": 1}, {"value": True})
+    assert not metadata_editor._values_equal([1, 2], [1])
+    assert not metadata_editor._values_equal(_BadArray(), 1)
+
+    original_array_equal = np.array_equal
+    calls = 0
+
+    def _array_equal(left, right, *, equal_nan=False):
+        nonlocal calls
+        calls += 1
+        if equal_nan:
+            raise TypeError
+        return original_array_equal(left, right)
+
+    monkeypatch.setattr(metadata_editor.np, "array_equal", _array_equal)
+    assert metadata_editor._values_equal(1, 1)
+    assert calls == 2
+
+    for value, expected in (
+        (True, "Bool"),
+        (np.int64(1), "Int"),
+        (np.float64(1.0), "Float"),
+        ("value", "String"),
+        ([1, 2], "Python literal"),
+    ):
+        assert metadata_editor._value_type_name(value) == expected
+    assert metadata_editor._parse_typed_value("String", " value ") == " value "
+    assert metadata_editor._parse_typed_value("Int", " 4 ") == 4
+    assert metadata_editor._parse_typed_value("Float", " 4.5 ") == 4.5
+    assert metadata_editor._parse_typed_value("Bool", "yes") is True
+    assert metadata_editor._parse_typed_value("Bool", "0") is False
+    assert metadata_editor._parse_typed_value("Python literal", "[1, 2]") == [1, 2]
+    assert metadata_editor._parse_editor_value(20, "20.5") == 20.5
+    assert metadata_editor._parse_editor_value(20.0, "20") == 20.0
+    assert metadata_editor._parse_editor_value(False, "0") is False
+    assert metadata_editor._parse_editor_value(True, "1") is True
+    assert metadata_editor._parse_editor_value("20", "20") == "20"
+    assert metadata_editor._parse_editor_value("20", "21") == "21"
+    assert metadata_editor._parse_editor_value("sample", "reference") == "reference"
+    with pytest.raises(ValueError, match="Boolean"):
+        metadata_editor._parse_typed_value("Bool", "sometimes")
+    with pytest.raises(ValueError, match="Unknown value type"):
+        metadata_editor._parse_typed_value("unknown", "1")
+    with pytest.raises(ValueError, match="Metadata field names cannot be empty"):
+        MetadataField(kind="attribute", name=" ")
+
+    coord = MetadataField(kind="coordinate", name="temperature")
+    attr = MetadataField(kind="attribute", name="sample")
+    assert isinstance(coord.operation(20), AssignScalarCoordOperation)
+    assert isinstance(attr.operation("reference"), AssignAttrsOperation)
+    data = _batch_data("scan").assign_coords(temperature=np.int64(20))
+    assert metadata_editor._field_value(data, coord) == 20
+    assert metadata_editor._field_value(data, attr) is metadata_editor._MISSING
+    assert metadata_editor._operation_value(coord.operation(20), coord) == 20
+    assert (
+        metadata_editor._operation_value(attr.operation("reference"), coord)
+        is metadata_editor._MISSING
+    )
+    assert metadata_editor._editable_attribute([1, 2])
+    assert metadata_editor._editable_attribute({"range": (1, 2)})
+    assert not metadata_editor._editable_attribute({1, 2})
+    assert not metadata_editor._editable_attribute(frozenset({1, 2}))
+    assert not metadata_editor._editable_attribute(np.array([1, 2]))
+    assert not metadata_editor._editable_attribute(object())
+    assert metadata_editor._primitive_value(np.float64(1.0))
+    assert not metadata_editor._primitive_value([1.0])
+
+
+def test_metadata_editor_table_model_tracks_origin_and_pending_state(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    temperature = MetadataField(kind="coordinate", name="temperature")
+    angle = MetadataField(kind="coordinate", name="angle")
+    sample = MetadataField(kind="attribute", name="sample")
+    enabled = MetadataField(kind="attribute", name="enabled")
+    acquired = MetadataField(kind="coordinate", name="acquired")
+    source = _batch_data("scan").assign_coords(
+        temperature=np.int64(20), acquired=np.datetime64("2024-01-01")
+    )
+    source.attrs["sample"] = "source"
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, source)
+        assert manager._metadata_editor.apply_edits(
+            {0: (MetadataCellEdit(angle, value=1.5),)}
+        )
+        model = _MetadataTableModel(
+            manager._metadata_editor,
+            (0,),
+            (temperature, angle, sample, enabled, acquired),
+            {
+                temperature: 0,
+                angle: 0.0,
+                sample: "",
+                enabled: False,
+                acquired: np.datetime64("2024-01-01"),
+            },
+        )
+
+        assert model.rowCount(model.index(0, 0)) == 0
+        assert model.columnCount(model.index(0, 0)) == 0
+        assert model.cell_at(model.index(0, 0)) is None
+        assert model.field_at(-1) is None
+        assert model.field_at(model.columnCount()) is None
+        assert model.data(QtCore.QModelIndex()) is None
+        foreign_model = QtGui.QStandardItemModel(1, 1)
+        foreign_index = foreign_model.index(0, 0)
+        assert model.cell_at(foreign_index) is None
+        assert model.data(foreign_index) is None
+        assert model.flags(foreign_index) == QtCore.Qt.ItemFlag.NoItemFlags
+        assert not model.setData(foreign_index, "ignored")
+        assert (
+            model.headerData(
+                -1,
+                QtCore.Qt.Orientation.Horizontal,
+                QtCore.Qt.ItemDataRole.DisplayRole,
+            )
+            is None
+        )
+        assert (
+            model.headerData(
+                model.columnCount(),
+                QtCore.Qt.Orientation.Horizontal,
+                QtCore.Qt.ItemDataRole.DisplayRole,
+            )
+            is None
+        )
+        assert isinstance(model.index(0, 0).data(), str)
+        assert model.index(0, 0).data(_MetadataTableModel.TargetRole) == 0
+        assert model.index(0, 1).data(_MetadataTableModel.OriginRole) == "source"
+        assert model.index(0, 2).data(_MetadataTableModel.OriginRole) == "assigned"
+        assert model.index(0, 3).data(_MetadataTableModel.OriginRole) == "source"
+        assert model.index(0, 4).data(_MetadataTableModel.OriginRole) == "missing"
+        assert model.index(0, 1).data(_MetadataTableModel.FieldRole) == temperature
+        assert model.index(0, 1).data(_MetadataTableModel.TargetRole) == 0
+        assert not model.index(0, 1).data(_MetadataTableModel.DirtyRole)
+        assert not model.index(0, 1).data(_MetadataTableModel.RevertRole)
+        assert isinstance(
+            model.index(0, 2).data(QtCore.Qt.ItemDataRole.ToolTipRole), str
+        )
+        assert isinstance(
+            model.index(0, 4).data(QtCore.Qt.ItemDataRole.ToolTipRole), str
+        )
+        assert isinstance(
+            model.index(0, 1).data(QtCore.Qt.ItemDataRole.TextAlignmentRole), int
+        )
+        assert (
+            model.headerData(
+                1, QtCore.Qt.Orientation.Horizontal, _MetadataTableModel.FieldRole
+            )
+            == temperature
+        )
+        assert not (model.flags(model.index(0, 0)) & QtCore.Qt.ItemFlag.ItemIsEditable)
+        assert model.flags(model.index(0, 1)) & QtCore.Qt.ItemFlag.ItemIsEditable
+        assert not model.setData(model.index(0, 0), "ignored")
+        assert not model.setData(
+            model.index(0, 1), "21", QtCore.Qt.ItemDataRole.DisplayRole
+        )
+        assert not model.setData(model.index(0, 1), "not-an-int")
+        assert model.setData(model.index(0, 1), "20")
+        assert not model.has_changes
+        assert model.setData(model.index(0, 1), "20.0")
+        assert model.edited_values[(0, temperature)] == 20.0
+        assert isinstance(model.edited_values[(0, temperature)], float)
+        model.undo_stack.undo()
+        assert not model.has_changes
+        assert model.setData(model.index(0, 1), "20.5")
+        assert model.edited_values[(0, temperature)] == 20.5
+        assert isinstance(model.edited_values[(0, temperature)], float)
+        model.undo_stack.undo()
+        assert not model.has_changes
+        assert model.setData(model.index(0, 1), "21")
+        assert model.has_changes
+
+        acquired_index = model.index(0, 5)
+        rejected: list[str] = []
+        model.editRejected.connect(rejected.append)
+        assert not (model.flags(acquired_index) & QtCore.Qt.ItemFlag.ItemIsEditable)
+        assert not model.setData(acquired_index, "2024-01-02")
+        assert rejected
+
+        model.revert_indexes((model.index(0, 0), model.index(0, 3)))
+        assert not model.index(0, 3).data(_MetadataTableModel.RevertRole)
+        model.revert_indexes((model.index(0, 2),))
+        assert model.index(0, 2).data(_MetadataTableModel.RevertRole)
+        assert model.index(0, 2).data(_MetadataTableModel.DirtyRole)
+        assert isinstance(
+            model.index(0, 2).data(QtCore.Qt.ItemDataRole.ToolTipRole), str
+        )
+        model.undo_stack.undo()
+        assert not model.index(0, 2).data(_MetadataTableModel.RevertRole)
+        assert model.index(0, 1).data(_MetadataTableModel.DirtyRole)
+        model.undo_stack.redo()
+        assert model.index(0, 2).data(_MetadataTableModel.RevertRole)
+
+        model.add_field(enabled, False)
+        enabled_index = model.index(0, model.fields.index(enabled) + 1)
+        assert model.setData(enabled_index, "yes")
+        edits = model.edits_by_target()[0]
+        assert {edit.field for edit in edits} == {temperature, angle, enabled}
+
+        delegate = metadata_editor._MetadataCellDelegate(manager)
+        pixmap = QtGui.QPixmap(180, 36)
+        pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+        option = QtWidgets.QStyleOptionViewItem()
+        option.rect = QtCore.QRect(0, 0, 180, 36)
+        painter = QtGui.QPainter(pixmap)
+        delegate.paint(painter, option, model.index(0, 0))
+        delegate.paint(painter, option, model.index(0, 1))
+        delegate.paint(painter, option, model.index(0, 2))
+        painter.end()
+
+        model.set_fields((sample,), model.field_defaults)
+        assert model.has_changes
+        assert {edit.field for edit in model.edits_by_target()[0]} == {
+            temperature,
+            angle,
+            enabled,
+        }
+
+
+def test_metadata_editor_supports_paste_and_per_row_values(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = _batch_data("scan0")
+    data1 = _batch_data("scan1", offset=100.0)
+    temperature = MetadataField(kind="coordinate", name="temperature")
+    sample = MetadataField(kind="attribute", name="sample")
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, data0, data1)
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0, 1))
+        qtbot.addWidget(dialog)
+        dialog.model.add_field(temperature, 20.0)
+        dialog.model.add_field(sample, "unknown")
+        dialog.table.setCurrentIndex(dialog.model.index(0, 1))
+        clipboard = QtWidgets.QApplication.clipboard()
+        clipboard.setText("15.0\tA\n25.0\tB")
+        dialog.table._paste_clipboard()
+
+        temperature_column = dialog.model.fields.index(temperature) + 1
+        temperature_selection = QtCore.QItemSelection(
+            dialog.model.index(0, temperature_column),
+            dialog.model.index(1, temperature_column),
+        )
+        dialog.table.setCurrentIndex(dialog.model.index(0, temperature_column))
+        selection_model = typing.cast(
+            "QtCore.QItemSelectionModel", dialog.table.selectionModel()
+        )
+        selection_model.select(
+            temperature_selection,
+            QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect,
+        )
+        series_values = iter(((30.0, True), (5.0, True)))
+        monkeypatch.setattr(
+            QtWidgets.QInputDialog,
+            "getDouble",
+            staticmethod(lambda *_args, **_kwargs: next(series_values)),
+        )
+        dialog._fill_series()
+
+        sample_column = dialog.model.fields.index(sample) + 1
+        sample_selection = QtCore.QItemSelection(
+            dialog.model.index(0, sample_column),
+            dialog.model.index(1, sample_column),
+        )
+        dialog.table.setCurrentIndex(dialog.model.index(0, sample_column))
+        selection_model.select(
+            sample_selection,
+            QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect,
+        )
+        dialog._fill_down()
+
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            dialog._apply()
+        assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+
+        for index, temperature, sample, source in (
+            (0, 30.0, "A", data0),
+            (1, 35.0, "A", data1),
+        ):
+            actual = manager.get_imagetool(index).slicer_area._data
+            assert actual.coords["temperature"].item() == temperature
+            assert actual.attrs["sample"] == sample
+            provenance = manager._tool_graph.root_wrappers[
+                index
+            ].displayed_provenance_spec
+            assert provenance is not None
+            xr.testing.assert_identical(provenance.apply(source), actual)
+
+
+def test_metadata_editor_fill_series_rejects_boolean_columns(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    enabled = MetadataField(kind="attribute", name="enabled")
+    sources = tuple(
+        _batch_data(f"scan{index}", offset=100.0 * index).assign_attrs(
+            enabled=bool(index % 2)
+        )
+        for index in range(3)
+    )
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, *sources)
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0, 1, 2))
+        qtbot.addWidget(dialog)
+        column = dialog.model.fields.index(enabled) + 1
+        selection = QtCore.QItemSelection(
+            dialog.model.index(0, column), dialog.model.index(2, column)
+        )
+        dialog.table.setCurrentIndex(dialog.model.index(0, column))
+        selection_model = typing.cast(
+            "QtCore.QItemSelectionModel", dialog.table.selectionModel()
+        )
+        selection_model.select(
+            selection, QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect
+        )
+        dialog._refresh_summary()
+        assert not dialog.fill_series_button.isEnabled()
+        monkeypatch.setattr(
+            QtWidgets.QInputDialog,
+            "getDouble",
+            staticmethod(
+                lambda *_args, **_kwargs: pytest.fail(
+                    "Boolean columns must not open the numeric series dialog"
+                )
+            ),
+        )
+
+        dialog._fill_series()
+
+        assert not dialog.model.has_changes
+
+
+def test_metadata_editor_copies_selection_and_undoes_bulk_edits(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    temperature = MetadataField(kind="coordinate", name="temperature")
+    sample = MetadataField(kind="attribute", name="sample")
+    sources = (
+        _batch_data("scan0").assign_coords(temperature=10.0).assign_attrs(sample="A"),
+        _batch_data("scan1", offset=100.0)
+        .assign_coords(temperature=20.0)
+        .assign_attrs(sample="B"),
+    )
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, *sources)
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0, 1))
+        qtbot.addWidget(dialog)
+        temperature_column = dialog.model.fields.index(temperature) + 1
+        sample_column = dialog.model.fields.index(sample) + 1
+        header = dialog.table.horizontalHeader()
+        header.moveSection(header.visualIndex(sample_column), 1)
+
+        selection = QtCore.QItemSelection(
+            dialog.model.index(0, temperature_column),
+            dialog.model.index(1, sample_column),
+        )
+        selection_model = typing.cast(
+            "QtCore.QItemSelectionModel", dialog.table.selectionModel()
+        )
+        selection_model.select(
+            selection, QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect
+        )
+        dialog.table._copy_selection()
+        clipboard = QtWidgets.QApplication.clipboard()
+        assert clipboard.text() == "A\t10.0\nB\t20.0"
+
+        undo_shortcuts = {
+            shortcut.toString(QtGui.QKeySequence.SequenceFormat.PortableText)
+            for shortcut in dialog.undo_action.shortcuts()
+        }
+        redo_shortcuts = {
+            shortcut.toString(QtGui.QKeySequence.SequenceFormat.PortableText)
+            for shortcut in dialog.redo_action.shortcuts()
+        }
+        assert undo_shortcuts == {
+            shortcut.toString(QtGui.QKeySequence.SequenceFormat.PortableText)
+            for shortcut in QtGui.QKeySequence.keyBindings(
+                QtGui.QKeySequence.StandardKey.Undo
+            )
+        }
+        assert redo_shortcuts == {
+            shortcut.toString(QtGui.QKeySequence.SequenceFormat.PortableText)
+            for shortcut in QtGui.QKeySequence.keyBindings(
+                QtGui.QKeySequence.StandardKey.Redo
+            )
+        }
+
+        dialog.table.setCurrentIndex(dialog.model.index(0, sample_column))
+        clipboard.setText("C\t30\nD\t40")
+        dialog.table._paste_clipboard()
+        assert dialog.model.has_changes
+        assert dialog.model.cell_at(dialog.model.index(0, sample_column)).value == "A"
+        assert dialog.model.index(0, sample_column).data() == "C"
+        assert dialog.model.index(1, temperature_column).data() == "40.0"
+
+        dialog.undo_action.trigger()
+        assert not dialog.model.has_changes
+        assert dialog.model.index(0, sample_column).data() == "A"
+        assert dialog.model.index(1, temperature_column).data() == "20.0"
+
+        dialog.redo_action.trigger()
+        assert dialog.model.has_changes
+        assert dialog.model.index(0, sample_column).data() == "C"
+        assert dialog.model.index(1, temperature_column).data() == "40.0"
+
+
+def test_metadata_editor_bulk_edits_are_atomic_for_mixed_cell_types(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    mixed = MetadataField(kind="attribute", name="mixed")
+    sources = (
+        _batch_data("scan0").assign_attrs(mixed=2),
+        _batch_data("scan1", offset=100.0).assign_attrs(mixed=1.0 + 2.0j),
+    )
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, *sources)
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0, 1))
+        qtbot.addWidget(dialog)
+        column = dialog.model.fields.index(mixed) + 1
+        current = dialog.model.index(0, column)
+        selection = QtCore.QItemSelection(current, dialog.model.index(1, column))
+        dialog.table.setCurrentIndex(current)
+        selection_model = typing.cast(
+            "QtCore.QItemSelectionModel", dialog.table.selectionModel()
+        )
+        selection_model.select(
+            selection, QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect
+        )
+        messages = _block_message_dialog(monkeypatch)
+
+        dialog._fill_down()
+        assert messages
+        assert not dialog.model.has_changes
+
+        messages.clear()
+        series_values = iter(((2.0, True), (1.0, True)))
+        monkeypatch.setattr(
+            QtWidgets.QInputDialog,
+            "getDouble",
+            staticmethod(lambda *_args, **_kwargs: next(series_values)),
+        )
+        dialog._fill_series()
+        assert messages
+        assert not dialog.model.has_changes
+
+        messages.clear()
+        clipboard = QtWidgets.QApplication.clipboard()
+        clipboard.setText("3\n2")
+        dialog.table._paste_clipboard()
+        assert messages
+        assert not dialog.model.has_changes
+
+
+def test_metadata_editor_field_chooser_and_frozen_data_column(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = _batch_data("scan0").assign_coords(temperature=20.0)
+    data0.attrs.update({"sample": "A", "temperature": "measured"})
+    data1 = _batch_data("scan1", offset=100.0).assign_attrs(sample="B")
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, data0, data1)
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0, 1))
+        qtbot.addWidget(dialog)
+        dialog.show()
+        qtbot.mouseClick(dialog.fields_button, QtCore.Qt.MouseButton.LeftButton)
+        qtbot.wait_until(dialog.fields_menu.isVisible)
+        dialog.fields_menu.hide()
+
+        coord = MetadataField(kind="coordinate", name="temperature")
+        attr = MetadataField(kind="attribute", name="temperature")
+        sample = MetadataField(kind="attribute", name="sample")
+        assert {coord, attr, sample} <= set(dialog.available_fields)
+        assert dialog.fields_widget._coverage[coord] == 1
+        assert dialog.fields_widget._coverage[attr] == 1
+        assert dialog.fields_widget._coverage[sample] == 2
+        assert dialog.table.frozen_view.model() is dialog.model
+        assert not dialog.table.frozen_view.isColumnHidden(0)
+        assert all(
+            dialog.table.frozen_view.isColumnHidden(column)
+            for column in range(1, dialog.model.columnCount())
+        )
+        assert dialog.table.alternatingRowColors()
+        assert dialog.table.frozen_view.alternatingRowColors()
+        qtbot.wait_until(
+            lambda: (
+                dialog.table.horizontalHeader().height()
+                == dialog.table.frozen_view.horizontalHeader().height()
+            )
+        )
+        assert (
+            dialog.table.viewport().mapToGlobal(QtCore.QPoint()).y()
+            == dialog.table.frozen_view.viewport().mapToGlobal(QtCore.QPoint()).y()
+        )
+        metadata_widths = {
+            dialog.table.columnWidth(column)
+            for column in range(1, dialog.model.columnCount())
+        }
+        assert len(metadata_widths) > 1
+
+        chooser = dialog.fields_widget
+        chooser.search_edit.setText("sample")
+        root = chooser.tree.invisibleRootItem()
+        assert root is not None
+        chooser_items: dict[MetadataField, QtWidgets.QTreeWidgetItem] = {}
+        for group_index in range(root.childCount()):
+            group = root.child(group_index)
+            assert group is not None
+            for row in range(group.childCount()):
+                item = group.child(row)
+                assert item is not None
+                field = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+                if isinstance(field, MetadataField):
+                    chooser_items[field] = item
+        assert not chooser_items[sample].isHidden()
+        assert chooser_items[coord].isHidden()
+        chooser.search_edit.clear()
+
+        visible_field_sets: list[tuple[MetadataField, ...]] = []
+        chooser.visible_fields_changed.connect(visible_field_sets.append)
+        chooser._preset("common")
+        assert visible_field_sets[-1] == (sample,)
+        assert dialog.model.fields == [sample]
+        chooser._preset("incomplete")
+        assert set(visible_field_sets[-1]) == {coord, attr}
+        assert set(dialog.model.fields) == {coord, attr}
+        clear_button = chooser.findChild(
+            QtWidgets.QToolButton, "manager_metadata_editor_fields_clear_button"
+        )
+        assert clear_button is not None
+        chooser._preset("clear")
+        assert visible_field_sets[-1] == ()
+        assert dialog.model.columnCount() == 1
+        chooser._preset("all")
+        assert set(dialog.model.fields) == {coord, attr, sample}
+
+        messages = _block_message_dialog(monkeypatch)
+        chooser.name_edit.clear()
+        chooser._add_field()
+        assert messages
+        added: list[tuple[MetadataField, object]] = []
+        chooser.field_added.connect(lambda field, value: added.append((field, value)))
+        chooser.kind_combo.setCurrentIndex(1)
+        chooser.name_edit.setText("run")
+        chooser.type_combo.setCurrentText("Int")
+        chooser.value_edit.setText("4")
+        chooser._add_field()
+        run = MetadataField(kind="attribute", name="run")
+        assert added[-1] == (run, 4)
+        assert run in dialog.model.fields
+        chooser.add_field(run)
+
+        dialog._set_field_visible(coord, False)
+        assert coord not in dialog.model.fields
+        assert coord not in manager._metadata_editor.layout_state.fields
+        dialog._set_field_visible(coord, True)
+        assert coord in dialog.model.fields
+        assert manager._metadata_editor.layout_state.fields[-1] == coord
+        dialog._set_field_visible(sample, True)
+
+        index = dialog.model.index(0, dialog.model.fields.index(sample) + 1)
+        assert dialog.model.setData(index, "changed")
+
+        dialog.table.setColumnWidth(0, 210)
+        dialog.table.setRowHeight(0, 38)
+        assert dialog.table.frozen_view.columnWidth(0) == 210
+        assert dialog.table.frozen_view.rowHeight(0) == 38
+
+        dialog._show_header_menu(QtCore.QPoint(1, 1))
+        dialog._set_field_visible(run, False)
+        assert run not in dialog.model.fields
+
+        dialog.table.setCurrentIndex(QtCore.QModelIndex())
+        dialog._refresh_summary()
+        assert not dialog.fill_down_button.isEnabled()
+        assert not dialog.fill_series_button.isEnabled()
+        dialog._fill_down()
+        dialog._fill_series()
+        dialog.table._paste_clipboard()
+        dialog.reject()
+        assert manager.get_imagetool(0).slicer_area.data.attrs["sample"] == "A"
+
+
+def test_metadata_editor_shows_file_source_and_cell_origin(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("scan")
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+    first_field = MetadataField(kind="attribute", name="sample")
+    next_field = MetadataField(kind="coordinate", name="temperature")
+
+    with manager_context() as manager:
+        assert manager._data_ingress.receive_data(
+            [source],
+            {
+                "file_path": file_path,
+                "load_func": (
+                    xr.load_dataarray,
+                    {"engine": "h5netcdf"},
+                    FileDataSelection(kind="dataarray"),
+                ),
+            },
+            show=False,
+        ) == [True]
+        assert manager._metadata_editor.apply_edits(
+            {0: (MetadataCellEdit(first_field, value="reference"),)}
+        )
+        assert manager.get_imagetool(0).slicer_area._file_path is None
+
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0,))
+        qtbot.addWidget(dialog)
+        dialog.model.set_fields(
+            (first_field, next_field),
+            {first_field: "reference", next_field: 20.0},
+        )
+        assert dialog.model.index(0, 0).data(QtCore.Qt.ItemDataRole.ToolTipRole) == str(
+            file_path
+        )
+        assert dialog.model.index(0, 1).data(_MetadataTableModel.OriginRole) == (
+            "assigned"
+        )
+        assert dialog.model.index(0, 2).data(_MetadataTableModel.OriginRole) == (
+            "missing"
+        )
+
+
+def test_metadata_editor_layout_discovery_and_action_dispatch(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    context_field = AcquisitionContextField.from_value(
+        kind="coordinate", name="photon_energy", value=21.2
+    )
+    saved_field = MetadataField(kind="attribute", name="operator")
+    complex_field = MetadataField(kind="attribute", name="history")
+    invalid_field = MetadataField(kind="attribute", name="unserializable")
+    source = _batch_data("scan").assign_coords(temperature=20.0)
+    source.attrs.update(
+        {
+            "sample": "reference",
+            complex_field.name: [1, 2],
+            invalid_field.name: object(),
+        }
+    )
+
+    with manager_context() as manager:
+        controller = manager._metadata_editor
+        controller.restore_layout_payload(None)
+        manager._acquisition_context.set_state(
+            AcquisitionContextState(fields=(context_field,)), mark_dirty=False
+        )
+        controller.set_layout_fields((saved_field,))
+
+        _add_batch_tools(qtbot, manager, source)
+        fields, coverage, defaults = controller.discover_fields((0,))
+        context_key = MetadataField(kind="coordinate", name="photon_energy")
+        sample = MetadataField(kind="attribute", name="sample")
+        temperature = MetadataField(kind="coordinate", name="temperature")
+        assert {context_key, saved_field, complex_field, sample, temperature} <= set(
+            fields
+        )
+        assert invalid_field not in fields
+        assert coverage[context_key] == 0
+        assert defaults[context_key] == 21.2
+        assert controller.visible_fields(fields, defaults) == (saved_field,)
+        assert controller.layout_payload()["initialized"] is True
+
+        dirty_calls = 0
+
+        def _mark_dirty() -> None:
+            nonlocal dirty_calls
+            dirty_calls += 1
+
+        monkeypatch.setattr(
+            manager._workspace_controller, "_mark_workspace_layout_dirty", _mark_dirty
+        )
+        controller.set_layout_fields((saved_field,))
+        assert dirty_calls == 0
+        controller.set_layout_fields((sample,))
+        assert dirty_calls == 1
+
+        with pytest.warns(UserWarning, match="metadata editor layout"):
+            controller.restore_layout_payload({"fields": [{"kind": "invalid"}]})
+        assert not controller.layout_state.initialized
+        manager._workspace_state.metadata_editor_layout = "invalid"  # type: ignore[assignment]
+        assert not controller.layout_state.initialized
+        controller.restore_layout_payload(None)
+
+        calls: list[tuple[int | str, ...]] = []
+        monkeypatch.setattr(
+            metadata_editor.MetadataEditorDialog,
+            "exec",
+            lambda dialog: (
+                calls.append(dialog.targets)
+                or int(QtWidgets.QDialog.DialogCode.Rejected)
+            ),
+        )
+        manager.tree_view.clearSelection()
+        controller.show_editor()
+        assert not calls
+        select_tools(manager, [0])
+        controller.show_editor()
+        assert calls == [(0,)]
+
+
+def test_metadata_editor_updates_child_source_assignments(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    parent = _batch_data("parent")
+    child = parent.assign_attrs(seed=1)
+    field = MetadataField(kind="attribute", name="sample")
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, parent)
+        child_tool = itool(child, manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=full_data(AssignAttrsOperation(attrs={"seed": 1})),
+        )
+        child_node = manager._node_for_target(child_uid)
+        assert child_node.displayed_source_spec is not None
+
+        assert manager._metadata_editor.apply_edits(
+            {child_uid: (MetadataCellEdit(field, value="reference"),)}
+        )
+
+        assert manager.get_imagetool(child_uid).slicer_area.data.attrs["sample"] == (
+            "reference"
+        )
+        assert "sample" not in manager.get_imagetool(0).slicer_area.data.attrs
+
+
+def test_metadata_preserving_replacement_keeps_child_source_binding(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    parent = _batch_data("parent")
+    source_spec = full_data(
+        AssignAttrsOperation(attrs={"sample": "reference", "seed": 1})
+    )
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, parent)
+        child_tool = itool(source_spec.apply(parent), manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool,
+            0,
+            show=False,
+            source_spec=source_spec,
+            source_auto_update=True,
+        )
+        child_node = manager._child_node(child_uid)
+
+        manual = _batch_data("manual", offset=100.0)
+        replace_data(child_uid, manual)
+
+        assert child_node.has_source_binding
+        assert child_node.source_auto_update
+        assert child_node.source_spec == source_spec
+        xr.testing.assert_identical(
+            child_tool.slicer_area._data,
+            manual.assign_attrs(sample="reference", seed=1),
+        )
+
+        updated_parent = _batch_data("updated", offset=200.0)
+        replace_data(0, updated_parent)
+        qtbot.wait_until(
+            lambda: (
+                child_tool.slicer_area._data.attrs.get("sample") == "reference"
+                and np.array_equal(
+                    child_tool.slicer_area._data.values,
+                    updated_parent.values,
+                )
+            )
+        )
+        xr.testing.assert_identical(
+            child_tool.slicer_area._data,
+            updated_parent.assign_attrs(sample="reference", seed=1),
+        )
+
+
+def test_metadata_editor_replaces_assignments_in_place_and_reverts(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("scan")
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+    context_fields = (
+        AcquisitionContextField.from_value(
+            kind="coordinate", name="temperature", value=20.0
+        ),
+        AcquisitionContextField.from_value(
+            kind="attribute", name="sample", value="reference"
+        ),
+        AcquisitionContextField.from_value(kind="attribute", name="run", value=1),
+    )
+    fields = (
+        MetadataField(kind="coordinate", name="temperature"),
+        MetadataField(kind="attribute", name="sample"),
+        MetadataField(kind="attribute", name="run"),
+    )
+    edits = tuple(
+        MetadataCellEdit(field, value=value)
+        for field, value in zip(fields, (25.0, "edited", 2), strict=True)
+    )
+
+    with manager_context() as manager:
+        manager._acquisition_context.set_state(
+            AcquisitionContextState(enabled=True, fields=context_fields),
+            mark_dirty=False,
+        )
+        assert manager._data_ingress.receive_data(
+            [source],
+            {
+                "file_path": file_path,
+                "load_func": (
+                    xr.load_dataarray,
+                    {"engine": "h5netcdf"},
+                    FileDataSelection(kind="dataarray"),
+                ),
+            },
+            show=False,
+        ) == [True]
+        node = manager._tool_graph.root_wrappers[0]
+        before_spec = node.displayed_provenance_spec
+        assert before_spec is not None
+        before_assignments = tuple(
+            operation
+            for _ref, operation in iter_operation_refs(before_spec)
+            if isinstance(operation, AssignScalarCoordOperation | AssignAttrsOperation)
+        )
+        assert len(before_assignments) == 2
+
+        file_path.unlink()
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            assert manager._metadata_editor.apply_edits({0: edits})
+
+        actual = manager.get_imagetool(0).slicer_area.data
+        assert actual.coords["temperature"].item() == 25.0
+        assert actual.attrs["sample"] == "edited"
+        assert actual.attrs["run"] == 2
+        edited_spec = node.displayed_provenance_spec
+        assert edited_spec is not None
+        edited_assignments = tuple(
+            operation
+            for _ref, operation in iter_operation_refs(edited_spec)
+            if isinstance(operation, AssignScalarCoordOperation | AssignAttrsOperation)
+        )
+        assert len(edited_assignments) == len(before_assignments)
+        scalar_operation = next(
+            operation
+            for operation in edited_assignments
+            if isinstance(operation, AssignScalarCoordOperation)
+        )
+        attrs_operation = next(
+            operation
+            for operation in edited_assignments
+            if isinstance(operation, AssignAttrsOperation)
+        )
+        assert scalar_operation.decoded_value == 25.0
+        assert attrs_operation.attrs == {"sample": "edited", "run": 2}
+
+        source.to_netcdf(file_path, engine="h5netcdf")
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            assert manager._metadata_editor.apply_edits(
+                {0: tuple(MetadataCellEdit(field, revert=True) for field in fields)}
+            )
+        xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, source)
+        deactivated_spec = node.displayed_provenance_spec
+        assert deactivated_spec is not None
+        assert not any(
+            isinstance(operation, AssignScalarCoordOperation | AssignAttrsOperation)
+            for _ref, operation in iter_operation_refs(deactivated_spec)
+        )
+
+
+def test_metadata_editor_preflights_every_target(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    messages = _block_message_dialog(monkeypatch)
+    compatible = _batch_data("compatible")
+    incompatible = _batch_data("incompatible", dims=("angle", "y"))
+    field = MetadataField(kind="coordinate", name="angle")
+    edit = MetadataCellEdit(field, value=1.5)
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, compatible, incompatible)
+        assert not manager._metadata_editor.apply_edits({0: (edit,), 1: (edit,)})
+        assert messages
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data, compatible
+        )
+        xr.testing.assert_identical(
+            manager.get_imagetool(1).slicer_area.data, incompatible
+        )
 
 
 def test_batch_operation_metadata_matches_launcher() -> None:
@@ -4088,6 +5655,62 @@ def test_managed_child_imagetool_file_menu_reload_refreshes_file_parent(
         xr.testing.assert_identical(fetch(child_uid), updated)
 
 
+def test_acquisition_context_is_replayed_when_file_data_reloads(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("scan")
+    file_path = tmp_path / "scan.h5"
+    source.to_netcdf(file_path, engine="h5netcdf")
+    state = AcquisitionContextState(
+        enabled=True,
+        fields=(
+            AcquisitionContextField.from_value(
+                kind="coordinate", name="temperature", value=20.0
+            ),
+            AcquisitionContextField.from_value(
+                kind="attribute", name="sample", value="reference"
+            ),
+        ),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager._acquisition_context.set_state(state, mark_dirty=False)
+        assert manager._data_ingress.receive_data(
+            [source],
+            {
+                "file_path": file_path,
+                "load_func": (
+                    xr.load_dataarray,
+                    {"engine": "h5netcdf"},
+                    FileDataSelection(kind="dataarray"),
+                ),
+            },
+            show=False,
+        ) == [True]
+        select_tools(manager, [0])
+
+        updated = (source + 100.0).rename("updated")
+        updated.to_netcdf(file_path, engine="h5netcdf")
+        with qtbot.wait_signal(
+            manager.get_imagetool(0).slicer_area.sigDataChanged, timeout=5000
+        ):
+            manager.reload_selected()
+
+        actual = manager.get_imagetool(0).slicer_area.data
+        assert actual.coords["temperature"].item() == 20.0
+        assert actual.attrs["sample"] == "reference"
+        xr.testing.assert_identical(
+            actual,
+            updated.assign_coords(temperature=20.0).assign_attrs(sample="reference"),
+        )
+
+
 def test_imagetool_source_chain_reload_target_falls_back_without_managed_source(
     qtbot,
     test_data,
@@ -4373,6 +5996,233 @@ def test_manager_notes_persist_workspace_roundtrip(
         assert manager._child_node(figure_uid).note == "figure note"
 
 
+def test_acquisition_context_persists_on_open_but_not_workspace_import(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    saved_state = AcquisitionContextState(
+        enabled=True,
+        fields=(
+            AcquisitionContextField.from_value(
+                kind="coordinate", name="temperature", value=20.0
+            ),
+            AcquisitionContextField.from_value(
+                kind="attribute", name="sample", value="reference"
+            ),
+        ),
+    )
+    delta_saved_state = AcquisitionContextState(
+        enabled=True,
+        fields=(
+            AcquisitionContextField.from_value(
+                kind="attribute", name="operator", value="current user"
+            ),
+        ),
+    )
+    transient_state = AcquisitionContextState(
+        enabled=True,
+        fields=(
+            AcquisitionContextField.from_value(kind="attribute", name="run", value=4),
+        ),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, _batch_data("scan"))
+        manager._acquisition_context.set_state(saved_state, mark_dirty=False)
+        workspace_path = tmp_path / "acquisition-context.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+
+        manager._acquisition_context.set_state(delta_saved_state)
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=False
+        )
+        assert manager._workspace_state.delta_save_count == 1
+
+        manager._acquisition_context.set_state(transient_state, mark_dirty=False)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=False,
+            associate=False,
+            mark_dirty=True,
+            select=False,
+        )
+        assert manager._acquisition_context.state == transient_state
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        assert manager._acquisition_context.state == delta_saved_state
+        assert manager.acquisition_context_status_button.isVisible()
+
+
+def test_metadata_assignment_provenance_persists_for_live_replacement(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    field = MetadataField(kind="attribute", name="sample")
+    source = _batch_data("scan")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        assert manager._data_ingress.receive_data([source], {}, show=False) == [True]
+        assert manager._metadata_editor.apply_edits(
+            {0: (MetadataCellEdit(field, value="reference"),)}
+        )
+
+        workspace_path = tmp_path / "metadata-assignment.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        assert manager._acquisition_context.state == AcquisitionContextState()
+        spec = manager._tool_graph.root_wrappers[0].displayed_provenance_spec
+        assert spec is not None
+        assert any(
+            isinstance(operation, AssignAttrsOperation)
+            for _ref, operation in iter_operation_refs(spec)
+        )
+
+        replacement = _batch_data("replacement", offset=100.0)
+        with qtbot.wait_signal(manager._sigDataReplaced, timeout=5000):
+            replace_data(0, replacement)
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data,
+            replacement.assign_attrs(sample="reference"),
+        )
+
+
+def test_metadata_editor_layout_persists_with_workspace(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    field = MetadataField(kind="attribute", name="sample")
+    transient = MetadataField(kind="coordinate", name="temperature")
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, _batch_data("scan"))
+        manager._metadata_editor.set_layout_fields((field,))
+        workspace_path = tmp_path / "metadata-layout.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+        manager._metadata_editor.set_layout_fields((transient,))
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        assert manager._metadata_editor.layout_state.fields == (field,)
+
+
+def test_metadata_editor_reads_deferred_workspace_metadata_without_materializing(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    temperature = MetadataField(kind="coordinate", name="temperature")
+    sample = MetadataField(kind="attribute", name="sample")
+
+    with manager_context() as manager:
+        manager.show()
+        for index in range(2):
+            data = _batch_data(f"deferred{index}").assign_coords(
+                temperature=20.0 + index
+            )
+            data.attrs["sample"] = f"sample-{index}"
+            tool = typing.cast(
+                "erlab.interactive.imagetool.ImageTool",
+                itool(data, manager=False, execute=False),
+            )
+            manager.add_imagetool(tool, show=False)
+            tool.hide()
+
+        workspace_path = tmp_path / "deferred-metadata-editor.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        wrappers = tuple(manager._tool_graph.root_wrappers.values())
+        assert all(
+            wrapper.pending_workspace_memory_payload is not None for wrapper in wrappers
+        )
+
+        def _fail_materialize_pending_payload(_node) -> bool:
+            pytest.fail("opening the metadata editor materialized deferred data")
+
+        monkeypatch.setattr(
+            manager,
+            "_materialize_pending_workspace_payload",
+            _fail_materialize_pending_payload,
+        )
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0, 1))
+        qtbot.addWidget(dialog)
+
+        temperature_column = dialog.model.fields.index(temperature) + 1
+        sample_column = dialog.model.fields.index(sample) + 1
+        assert (
+            dialog.model.cell_at(dialog.model.index(0, temperature_column)).value
+            == 20.0
+        )
+        assert (
+            dialog.model.cell_at(dialog.model.index(1, temperature_column)).value
+            == 21.0
+        )
+        assert dialog.model.cell_at(dialog.model.index(0, sample_column)).value == (
+            "sample-0"
+        )
+        assert dialog.model.cell_at(dialog.model.index(1, sample_column)).value == (
+            "sample-1"
+        )
+        assert all(
+            wrapper.pending_workspace_memory_payload is not None for wrapper in wrappers
+        )
+
+        select_tools(manager, [0])
+        context_dialog = AcquisitionContextDialog(manager, manager._acquisition_context)
+        qtbot.addWidget(context_dialog)
+        selected_data = context_dialog._selected_data()
+        assert selected_data is not None
+        assert selected_data.coords["temperature"].item() == 20.0
+        assert selected_data.attrs["sample"] == "sample-0"
+        assert all(
+            wrapper.pending_workspace_memory_payload is not None for wrapper in wrappers
+        )
+
+
 def test_manager_notes_preserved_by_duplicate_and_promote(
     qtbot,
     monkeypatch,
@@ -4398,7 +6248,6 @@ def test_manager_notes_preserved_by_duplicate_and_promote(
             source_spec=full_data(),
             note="child note",
         )
-
         select_tools(manager, [0])
         manager.edit_note_action.trigger()
         manager.notes_editor.setPlainText("pending duplicate root note")
@@ -4425,7 +6274,6 @@ def test_manager_notes_preserved_by_duplicate_and_promote(
         assert (
             manager._tool_graph.nodes[child_uid].note == "pending promoted child note"
         )
-
         figure_uid = manager.add_figuretool(
             FigureComposerTool(test_data),
             show=False,

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -14,6 +14,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
+import erlab.interactive.imagetool.manager._acquisition_context as acquisition_context
 import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
 import erlab.interactive.imagetool.manager._io as manager_io
@@ -69,6 +70,7 @@ from erlab.interactive.imagetool.manager._acquisition_context import (
     AcquisitionContextField,
     AcquisitionContextState,
     ContextIngressSummary,
+    _ContextFieldDialog,
     _ContextSourcePickerDialog,
 )
 from erlab.interactive.imagetool.manager._details_panel import _DetailsPanelController
@@ -625,6 +627,269 @@ def test_acquisition_context_values_are_serialization_stable() -> None:
     payload = AcquisitionContextState(fields=(field,)).model_dump(mode="json")
     restored = AcquisitionContextState.model_validate(payload)
     assert restored.fields[0].decoded_value == (1.0, 2.0)
+    assert not AcquisitionContextState(enabled=True).enabled
+    with pytest.raises(ValueError, match="unique by kind"):
+        AcquisitionContextState(fields=(field, field))
+
+
+def test_acquisition_context_field_dialog_validates_and_restores(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    dialog = _ContextFieldDialog(parent)
+
+    with pytest.raises(RuntimeError, match="was not accepted"):
+        _ = dialog.field
+
+    messages = _block_message_dialog(monkeypatch)
+    dialog.accept()
+    assert messages
+    assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
+
+    dialog.kind_combo.setCurrentIndex(
+        dialog.kind_combo.findData("attribute", QtCore.Qt.ItemDataRole.UserRole)
+    )
+    dialog.name_edit.setText("run")
+    dialog.type_combo.setCurrentText("Int")
+    dialog.value_edit.setText("4")
+    dialog.existing_combo.setCurrentIndex(
+        dialog.existing_combo.findData(True, QtCore.Qt.ItemDataRole.UserRole)
+    )
+    dialog.accept()
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+    assert dialog.field == AcquisitionContextField.from_value(
+        kind="attribute", name="run", value=4, replace_existing=True
+    )
+
+    restored = _ContextFieldDialog(parent, field=dialog.field)
+    assert restored.kind_combo.currentData() == "attribute"
+    assert restored.name_edit.text() == "run"
+    assert restored.type_combo.currentText() == "Int"
+    assert restored.value_edit.text() == "4"
+    assert restored.existing_combo.currentData() is True
+
+
+def test_acquisition_context_dialog_commands_are_atomic(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    sample = AcquisitionContextField.from_value(
+        kind="attribute", name="sample", value="A"
+    )
+    run = AcquisitionContextField.from_value(kind="attribute", name="run", value=1)
+    changed_sample = sample.with_value("B")
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, _batch_data("scan"))
+        manager._acquisition_context.set_state(
+            AcquisitionContextState(fields=(sample, run)), mark_dirty=False
+        )
+        dialog = AcquisitionContextDialog(manager, manager._acquisition_context)
+
+        select_tools(manager, [])
+        assert dialog._selected_data() is None
+        dialog._select_row(-1)
+        assert dialog._current_row() == -1
+        dialog._remove_field()
+        dialog._edit_field()
+
+        dialog._merge_fields((changed_sample,))
+        assert dialog._fields == [changed_sample, run]
+        dialog._rows_reordered(["invalid"], None, None)
+        assert dialog._fields == [changed_sample, run]
+        dialog._rows_reordered((dialog._field_row_id(run),), None, None)
+        assert dialog.table.topLevelItemCount() == 2
+        dialog._rows_reordered(
+            (dialog._field_row_id(run), dialog._field_row_id(changed_sample)),
+            None,
+            None,
+        )
+        assert dialog._fields == [run, changed_sample]
+
+        dialog._select_row(0)
+        dialog._remove_field()
+        assert dialog._fields == [changed_sample]
+
+        select_tools(manager, [0])
+
+        class _AcceptedSourcePicker:
+            selected_fields = (run,)
+
+            def __init__(self, *_args, **_kwargs) -> None:
+                pass
+
+            def exec(self) -> QtWidgets.QDialog.DialogCode:
+                return QtWidgets.QDialog.DialogCode.Accepted
+
+        monkeypatch.setattr(
+            acquisition_context, "_ContextSourcePickerDialog", _AcceptedSourcePicker
+        )
+        dialog._from_selected()
+        assert dialog._fields == [changed_sample, run]
+
+        temperature = AcquisitionContextField.from_value(
+            kind="coordinate", name="temperature", value=20.0
+        )
+
+        class _AcceptedFieldDialog:
+            next_field = temperature
+            result = QtWidgets.QDialog.DialogCode.Accepted
+
+            def __init__(self, *_args, **_kwargs) -> None:
+                self.field = self.next_field
+
+            def exec(self) -> QtWidgets.QDialog.DialogCode:
+                return self.result
+
+        monkeypatch.setattr(
+            acquisition_context, "_ContextFieldDialog", _AcceptedFieldDialog
+        )
+        dialog._add_field()
+        assert dialog._fields[-1] == temperature
+
+        warnings: list[tuple[object, ...]] = []
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "warning",
+            staticmethod(lambda *args, **_kwargs: warnings.append(args)),
+        )
+        dialog._select_row(0)
+        _AcceptedFieldDialog.next_field = run
+        dialog._edit_field()
+        assert warnings
+        assert dialog._fields[0] == changed_sample
+
+        replacement = changed_sample.with_value("C")
+        _AcceptedFieldDialog.next_field = replacement
+        dialog._edit_field()
+        assert dialog._fields[0] == replacement
+
+        messages = _block_message_dialog(monkeypatch)
+
+        def _fail_set_state(*_args, **_kwargs):
+            raise ValueError("invalid state")
+
+        monkeypatch.setattr(dialog._controller, "set_state", _fail_set_state)
+        dialog._save()
+        assert messages
+        assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
+
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            staticmethod(
+                lambda *_args, **_kwargs: QtWidgets.QMessageBox.StandardButton.Cancel
+            ),
+        )
+        dialog._clear()
+        assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
+
+        saved: list[AcquisitionContextState] = []
+        monkeypatch.setattr(
+            dialog._controller,
+            "set_state",
+            lambda state, **_kwargs: saved.append(state),
+        )
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            staticmethod(
+                lambda *_args, **_kwargs: QtWidgets.QMessageBox.StandardButton.Yes
+            ),
+        )
+        dialog._clear()
+        assert saved == [AcquisitionContextState()]
+        assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+
+
+def test_acquisition_context_source_picker_rejects_empty_selection(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = _batch_data("scan").assign_coords(
+        temperature=20.0,
+        unsupported=xr.Variable((), object()),
+    )
+    data.attrs["unsupported"] = {1, 2}
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    dialog = _ContextSourcePickerDialog(parent, data)
+    warnings: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        staticmethod(lambda *args, **_kwargs: warnings.append(args)),
+    )
+
+    dialog.accept()
+
+    assert warnings
+    assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
+    root = dialog.tree.invisibleRootItem()
+    assert root is not None
+    assert all(
+        child.text(0) != "unsupported"
+        for group_index in range(root.childCount())
+        if (group := root.child(group_index)) is not None
+        for row in range(group.childCount())
+        if (child := group.child(row)) is not None
+    )
+
+
+def test_acquisition_context_controller_recovers_from_invalid_state(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        controller = manager._acquisition_context
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            erlab.utils.misc,
+            "emit_user_level_warning",
+            lambda message, *_args, **_kwargs: warnings.append(message),
+        )
+        controller.restore_state_payload({"fields": [{"kind": "invalid"}]})
+        assert warnings
+        assert controller.state == AcquisitionContextState()
+
+        button = controller._status_button
+        controller._status_button = None
+        controller.refresh_ui()
+        controller._status_button = button
+
+        shown: list[object] = []
+
+        class _Editor:
+            def __init__(self, *_args, **_kwargs) -> None:
+                pass
+
+            def exec(self) -> None:
+                shown.append(self)
+
+        monkeypatch.setattr(acquisition_context, "AcquisitionContextDialog", _Editor)
+        controller.show_editor()
+        assert shown
+
+        class _InvalidField:
+            name = "invalid"
+            kind = "attribute"
+            replace_existing = False
+            decoded_value = "value"
+
+            def operation(self):
+                raise RuntimeError("cannot create operation")
+
+        resolution = controller.resolve(
+            _batch_data("scan"), typing.cast("typing.Any", (_InvalidField(),))
+        )
+        assert resolution.operations == ()
+        assert resolution.errors == ("invalid: cannot create operation",)
 
 
 def test_acquisition_context_field_actions_use_toolbar_and_add_menu(
@@ -1369,8 +1634,11 @@ def test_metadata_editor_scalar_value_and_operation_helpers(
     assert not metadata_editor._values_equal(1, 1.0)
     assert not metadata_editor._values_equal(1, True)
     assert not metadata_editor._values_equal([1], [1.0])
+    assert not metadata_editor._values_equal({"value": 1}, {"other": 1})
     assert not metadata_editor._values_equal({"value": 1}, {"value": True})
     assert not metadata_editor._values_equal([1, 2], [1])
+    assert not metadata_editor._values_equal(np.ones((1, 2)), np.ones((2, 1)))
+    assert not metadata_editor._values_equal(np.array([1]), np.array(["1"]))
     assert not metadata_editor._values_equal(_BadArray(), 1)
 
     original_array_equal = np.array_equal
@@ -1408,6 +1676,15 @@ def test_metadata_editor_scalar_value_and_operation_helpers(
     assert metadata_editor._parse_editor_value("20", "20") == "20"
     assert metadata_editor._parse_editor_value("20", "21") == "21"
     assert metadata_editor._parse_editor_value("sample", "reference") == "reference"
+    assert metadata_editor._parse_editor_value(
+        metadata_editor._UNKNOWN_REFERENCE, "[1, 2]"
+    ) == [1, 2]
+    assert (
+        metadata_editor._parse_editor_value(
+            metadata_editor._UNKNOWN_REFERENCE, "unquoted text"
+        )
+        == "unquoted text"
+    )
     with pytest.raises(ValueError, match="Boolean"):
         metadata_editor._parse_typed_value("Bool", "sometimes")
     with pytest.raises(ValueError, match="Unknown value type"):
@@ -1755,6 +2032,34 @@ def test_metadata_editor_copies_selection_and_undoes_bulk_edits(
         clipboard = QtWidgets.QApplication.clipboard()
         assert clipboard.text() == "A\t10.0\nB\t20.0"
 
+        selection_model.clearSelection()
+        for index in (
+            dialog.model.index(0, sample_column),
+            dialog.model.index(1, temperature_column),
+        ):
+            selection_model.select(
+                index, QtCore.QItemSelectionModel.SelectionFlag.Select
+            )
+        dialog.table._copy_selection()
+        assert clipboard.text() == "A\t\n\t20.0"
+
+        copy_combination = QtGui.QKeySequence.keyBindings(
+            QtGui.QKeySequence.StandardKey.Copy
+        )[0][0]
+        copy_event = QtGui.QKeyEvent(
+            QtCore.QEvent.Type.KeyPress,
+            copy_combination.key(),
+            copy_combination.keyboardModifiers(),
+        )
+        dialog.table.keyPressEvent(copy_event)
+        assert copy_event.isAccepted()
+
+        dialog.table.setCurrentIndex(dialog.model.index(0, sample_column))
+        dialog.table.moveCursor(
+            QtWidgets.QAbstractItemView.CursorAction.MoveRight,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+
         undo_shortcuts = {
             shortcut.toString(QtGui.QKeySequence.SequenceFormat.PortableText)
             for shortcut in dialog.undo_action.shortcuts()
@@ -1778,7 +2083,16 @@ def test_metadata_editor_copies_selection_and_undoes_bulk_edits(
 
         dialog.table.setCurrentIndex(dialog.model.index(0, sample_column))
         clipboard.setText("C\t30\nD\t40")
-        dialog.table._paste_clipboard()
+        paste_combination = QtGui.QKeySequence.keyBindings(
+            QtGui.QKeySequence.StandardKey.Paste
+        )[0][0]
+        paste_event = QtGui.QKeyEvent(
+            QtCore.QEvent.Type.KeyPress,
+            paste_combination.key(),
+            paste_combination.keyboardModifiers(),
+        )
+        dialog.table.keyPressEvent(paste_event)
+        assert paste_event.isAccepted()
         assert dialog.model.has_changes
         assert dialog.model.cell_at(dialog.model.index(0, sample_column)).value == "A"
         assert dialog.model.index(0, sample_column).data() == "C"

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -1177,6 +1177,46 @@ def test_multi_target_replacement_adds_consecutive_new_indices(
             )
 
 
+@pytest.mark.parametrize(("fail_on", "expected_tools"), [(1, 0), (2, 1)])
+def test_multi_target_replacement_stops_when_new_tool_creation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    fail_on: int,
+    expected_tools: int,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    replacements = [
+        _batch_data(f"replacement{index}", offset=100.0 * index) for index in range(3)
+    ]
+
+    with manager_context() as manager:
+        original_receive_data = manager._data_ingress.receive_data
+        receive_calls = 0
+
+        def receive_data(data, kwargs):
+            nonlocal receive_calls
+            receive_calls += 1
+            if receive_calls == fail_on:
+                return [False]
+            return original_receive_data(data, kwargs, show=False)
+
+        monkeypatch.setattr(manager._data_ingress, "receive_data", receive_data)
+        replacement_signals: list[None] = []
+        manager._sigDataReplaced.connect(lambda: replacement_signals.append(None))
+
+        manager._data_replace(replacements, [0, 1, 2])
+
+        assert receive_calls == fail_on
+        assert manager.ntools == expected_tools
+        assert manager.next_idx == expected_tools
+        assert replacement_signals == ([None] if expected_tools else [])
+        if expected_tools:
+            xr.testing.assert_identical(
+                manager.get_imagetool(0).slicer_area._data, replacements[0]
+            )
+
+
 def test_metadata_assignments_survive_watched_variable_updates(
     qtbot,
     monkeypatch,
@@ -2078,6 +2118,38 @@ def test_metadata_editor_layout_discovery_and_action_dispatch(
         select_tools(manager, [0])
         controller.show_editor()
         assert calls == [(0,)]
+
+
+@pytest.mark.parametrize("remember_type", [False, True])
+def test_metadata_editor_parses_remembered_missing_numeric_fields(
+    qtbot,
+    remember_type: bool,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    field = MetadataField(kind="coordinate", name="temperature")
+    payload: dict[str, object] = {
+        "schema_version": 3 if remember_type else 2,
+        "initialized": True,
+        "fields": [field.model_dump(mode="json")],
+    }
+    if remember_type:
+        payload["field_types"] = [
+            {"field": field.model_dump(mode="json"), "value_type": "Float"}
+        ]
+
+    with manager_context() as manager:
+        _add_batch_tools(qtbot, manager, _batch_data("scan"))
+        manager._metadata_editor.restore_layout_payload(payload)
+        dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0,))
+        qtbot.addWidget(dialog)
+        column = dialog.model.fields.index(field) + 1
+
+        assert dialog.model.setData(dialog.model.index(0, column), "20.5")
+        value = dialog.model.edited_values[(0, field)]
+        assert value == 20.5
+        assert isinstance(value, float)
 
 
 def test_metadata_editor_updates_child_source_assignments(
@@ -6282,7 +6354,11 @@ def test_metadata_editor_layout_persists_with_workspace(
             manager,
             _batch_data("scan").assign_attrs(sample="reference", operator="user"),
         )
-        manager._metadata_editor.set_layout_fields((sample, operator))
+        manager._metadata_editor.set_layout_fields(
+            (sample, operator), {sample: "reference", operator: "user"}
+        )
+        assert manager._metadata_editor.saved_field_type(sample) == "String"
+        assert manager._metadata_editor.saved_field_type(operator) == "String"
         dialog = MetadataEditorDialog(manager, manager._metadata_editor, (0,))
         qtbot.addWidget(dialog)
         dialog.show()
@@ -6329,6 +6405,8 @@ def test_metadata_editor_layout_persists_with_workspace(
         assert manager._metadata_editor.saved_column_width(sample) == 119
         assert manager._metadata_editor.saved_column_width(operator) == 173
         assert manager._metadata_editor.saved_column_width(transient) is None
+        assert manager._metadata_editor.saved_field_type(sample) == "String"
+        assert manager._metadata_editor.saved_field_type(operator) == "String"
 
         restored = MetadataEditorDialog(manager, manager._metadata_editor, (0,))
         qtbot.addWidget(restored)

--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -869,6 +869,36 @@ def test_manager_registry_heartbeat_controller_edge_paths(
         controller.stop()
 
 
+def test_manager_registry_heartbeat_idle_wait_does_not_dispatch_unrelated_events(
+    qapp,
+) -> None:
+    class _EventReceiver(QtCore.QObject):
+        def __init__(self) -> None:
+            super().__init__()
+            self.received = False
+
+        def event(self, event: QtCore.QEvent) -> bool:
+            if event.type() == QtCore.QEvent.Type.User:
+                self.received = True
+                return True
+            return super().event(event)
+
+    controller = manager_heartbeat._RegistryHeartbeatController("manager-id")
+    receiver = _EventReceiver()
+    QtCore.QCoreApplication.postEvent(
+        receiver,
+        QtCore.QEvent(QtCore.QEvent.Type.User),
+    )
+    try:
+        controller._in_flight_generation = 1
+        assert not controller._wait_until_idle(20)
+        assert not receiver.received
+    finally:
+        QtCore.QCoreApplication.removePostedEvents(receiver)
+        controller._in_flight_generation = None
+        controller.stop()
+
+
 def test_manager_registry_heartbeat_retains_orphan_until_thread_finishes(
     qtbot,
 ) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -1673,7 +1673,7 @@ def test_pending_workspace_actions_and_color_branches(
         linked_color = manager.color_for_linker(manager._link_registry.linkers[0])
         assert manager.color_for_workspace_link_key(link_key) == linked_color
         assert (
-            manager.color_for_workspace_link_key("unknown-link-key")
+            manager.color_for_workspace_link_key("unknown-link-key").getRgb()[:3]
             == (manager_mainwindow._LINKER_COLORS[0])
         )
 

--- a/tests/interactive/imagetool/test_module_split.py
+++ b/tests/interactive/imagetool/test_module_split.py
@@ -1,3 +1,4 @@
+import ast
 import importlib
 import multiprocessing
 import pathlib
@@ -11,6 +12,54 @@ import warnings
 import erlab
 import erlab.interactive.imagetool.plot_items
 import erlab.interactive.imagetool.viewer
+
+
+def test_interactive_modules_do_not_construct_global_qt_values() -> None:
+    interactive_root = pathlib.Path(erlab.__file__).resolve().parent / "interactive"
+    offenders: list[str] = []
+
+    def qt_constructors(node: ast.AST | None) -> list[ast.Call]:
+        if node is None:
+            return []
+        return [
+            child
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr.startswith("Q")
+            and isinstance(child.func.value, ast.Name)
+            and child.func.value.id in {"QtCore", "QtGui", "QtWidgets"}
+        ]
+
+    def inspect_definition_body(path: pathlib.Path, body: list[ast.stmt]) -> None:
+        for node in body:
+            values: list[ast.AST | None] = []
+            if isinstance(node, ast.Assign | ast.AnnAssign):
+                values.append(node.value)
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                values.extend(node.args.defaults)
+                values.extend(
+                    default for default in node.args.kw_defaults if default is not None
+                )
+            elif isinstance(node, ast.ClassDef):
+                inspect_definition_body(path, node.body)
+                continue
+            for value in values:
+                for call in qt_constructors(value):
+                    function = call.func
+                    if not isinstance(function, ast.Attribute) or not isinstance(
+                        function.value, ast.Name
+                    ):
+                        raise TypeError("Invalid Qt constructor expression")
+                    relative = path.relative_to(interactive_root)
+                    offenders.append(
+                        f"{relative}:{call.lineno} {function.value.id}.{function.attr}"
+                    )
+
+    for path in interactive_root.rglob("*.py"):
+        inspect_definition_body(path, ast.parse(path.read_text()).body)
+
+    assert offenders == []
 
 
 def test_core_shim_export_identity_and_deprecation_warning() -> None:

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -3145,7 +3145,7 @@ def test_ptable_multi_select_summary_and_plot_picker(
     assert (
         2 * CompactElementChip._DETAILED_HEIGHT
         + win.inspector.summary_cards_grid.verticalSpacing()
-        == 3 * CompactElementChip._COMPACT_SIZE.height()
+        == 3 * CompactElementChip._COMPACT_SIZE[1]
         + 2 * win.inspector.summary_cards_grid.verticalSpacing()
     )
 


### PR DESCRIPTION
## Summary

- add Acquisition Context under the File menu for applying reusable scalar coordinates and attributes as data files are loaded
- add a spreadsheet-style Metadata Editor for editing selected ImageTools, including field selection, origin indicators, fill operations, multi-cell clipboard support, and local undo/redo
- preserve metadata assignment provenance, source bindings, and automatic child updates when metadata is changed or source data is replaced
- persist acquisition context in manager workspaces and read metadata from deferred workspace data without materializing full arrays
- make provenance replacement and pasted dimension-changing operations validate against the resulting public data layout
- document when to use Acquisition Context versus the Metadata Editor

## Why

Some acquisition files omit coordinates or attributes, or contain values that need to be replaced as conditions change. Re-entering those values for every file is cumbersome, while existing batch editing did not provide a compact logbook-like view across multiple ImageTools.

This adds an explicit context for future file loads and a separate editor for data that is already open. The context only runs while new data is loaded from files; it does not retroactively change existing ImageTools.

## Impact

Users can maintain changing acquisition values once, see when they are applied during file loading, and edit existing scalar metadata across many ImageTools without losing provenance or forcing deferred workspace arrays to load. Metadata edits remain replayable and continue to follow source-bound child data when parents update.

## Validation

- `uv run pytest -q tests/interactive/imagetool/manager`
- focused Acquisition Context and Metadata Editor tests with PyQt6 and PySide6
- `uv run mypy src`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check HEAD`
