### PR TITLE
feat(manager): drag tool references into console

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -512,6 +512,12 @@ many of the same operations and keep track of the manager history. For example:
   tools[0].data = tools[0].assign_coords(time=tools[1].time)
   ```
 
+:::{tip}
+Drag one row from the {guilabel}`Data/Tools` tree into the console to insert its
+`tools[...]` expression where you drop it. Nested rows insert their full
+`.children[...]` path automatically.
+:::
+
 Run standard Python, `%magic` commands, or inspect objects with `?` exactly as you would
 in a notebook.
 

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -1806,21 +1806,8 @@ class ToolsNamespace:
     def _node_path(
         self, node: _ImageToolWrapper | _ManagedWindowNode
     ) -> list[int] | None:
-        path: list[int] = []
-        current = node
-        while current.parent_uid is not None:
-            parent = self._manager._tool_graph.nodes.get(current.parent_uid)
-            if parent is None:
-                return None
-            if current.uid not in parent._childtool_indices:
-                return None
-            child_index = parent._childtool_indices.index(current.uid)
-            path.append(child_index)
-            current = parent
-        for root_index, wrapper in self._manager._tool_graph.root_wrappers.items():
-            if wrapper.uid == current.uid:
-                return [root_index, *reversed(path)]
-        return None
+        path = self._manager._tool_graph.node_path(node)
+        return None if path is None else list(path)
 
     def _child_nodes(
         self, node: _ImageToolWrapper | _ManagedWindowNode
@@ -2192,7 +2179,9 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
             return out
 
         info_str = (
-            _command_ansi(
+            "\033[1mTip:\033[0m Drag a row here to insert its tools[...] "
+            "expression.\n\n"
+            + _command_ansi(
                 "Access raw data",
                 [
                     "tools[<index>].data",

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -1412,11 +1412,12 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
         return False
 
     def mimeTypes(self) -> list[str]:
-        return [_MIME, _FIGURE_SOURCE_MIME]
+        return [_MIME, _FIGURE_SOURCE_MIME, "text/plain"]
 
     def mimeData(self, indexes: Iterable[QtCore.QModelIndex]) -> QtCore.QMimeData:
         # Collect unique sibling rows from a single parent.
         rows: list[int] = []
+        dragged_uids: list[str] = []
         source_uids: list[str] = []
         internal_move_valid = True
         parent_pointer: str | None = None
@@ -1426,16 +1427,16 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
                 continue
             node = idx.internalPointer()
             if isinstance(node, _ImageToolWrapper):
+                dragged_uid = node.uid
                 if node.uid not in source_uids:
                     source_uids.append(node.uid)
                 current_parent_pointer = None
             else:
                 child_node = self._node_from_uid(typing.cast("str", node))
-                if (
-                    child_node is not None
-                    and child_node.is_imagetool
-                    and child_node.uid not in source_uids
-                ):
+                if child_node is None:
+                    internal_move_valid = False
+                    continue
+                if child_node.is_imagetool and child_node.uid not in source_uids:
                     source_uids.append(child_node.uid)
                 parent_index = self.parent(idx)
                 if not parent_index.isValid():
@@ -1449,6 +1450,10 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
                 else:
                     internal_move_valid = False
                     continue
+                dragged_uid = child_node.uid
+
+            if dragged_uid not in dragged_uids:
+                dragged_uids.append(dragged_uid)
 
             if parent_pointer is None and current_parent_pointer is None:
                 parent_pointer = None
@@ -1483,6 +1488,16 @@ class _ImageToolWrapperItemModel(QtCore.QAbstractItemModel):
                     json.dumps({"uids": tuple(source_uids)}).encode("utf-8")
                 ),
             )
+        if len(dragged_uids) == 1:
+            dragged_node = self.manager._tool_graph.nodes.get(dragged_uids[0])
+            if dragged_node is not None:
+                path = self.manager._tool_graph.node_path(dragged_node)
+                if path:
+                    expression = f"tools[{path[0]}]"
+                    expression += "".join(
+                        f".children[{child_row}]" for child_row in path[1:]
+                    )
+                    mime_data.setText(expression)
         return mime_data
 
     @staticmethod

--- a/src/erlab/interactive/imagetool/manager/_tool_graph.py
+++ b/src/erlab/interactive/imagetool/manager/_tool_graph.py
@@ -81,6 +81,24 @@ class _ManagerToolGraph:
             node = self.parent(node)
         return node
 
+    def node_path(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> tuple[int, ...] | None:
+        """Return the root index and child rows that currently address a node."""
+        child_rows: list[int] = []
+        current = node
+        while current.parent_uid is not None:
+            parent = self.nodes.get(current.parent_uid)
+            if parent is None or current.uid not in parent._childtool_indices:
+                return None
+            child_rows.append(parent._childtool_indices.index(current.uid))
+            current = parent
+
+        for root_index, wrapper in self.root_wrappers.items():
+            if wrapper is current:
+                return (root_index, *reversed(child_rows))
+        return None
+
     def uid_from_window(self, widget: object) -> str | None:
         for uid, node in self.nodes.items():
             if node.window is widget:

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from IPython.core.interactiveshell import InteractiveShell
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager._console as manager_console
@@ -63,6 +63,7 @@ from .helpers import (
 if typing.TYPE_CHECKING:
     from erlab.interactive.imagetool.manager._modelview import (
         _ImageToolWrapperItemDelegate,
+        _ImageToolWrapperItemModel,
     )
 
 
@@ -1432,7 +1433,7 @@ def test_manager_console_tree_namespace_helper_branches() -> None:
 
     class FakeManager:
         def __init__(self) -> None:
-            self._tool_graph = types.SimpleNamespace(root_wrappers={}, nodes={})
+            self._tool_graph = _ManagerToolGraph()
 
         def get_imagetool(self, uid: str) -> object:
             return self._tool_graph.nodes[uid].imagetool
@@ -1847,6 +1848,51 @@ def test_manager_console_child_imagetool_access_tracks_provenance(
         )
 
         shell = manager.console._console_widget.kernel_manager.kernel.shell
+        console_widget = manager.console._console_widget
+        tree_model = typing.cast(
+            "_ImageToolWrapperItemModel", manager.tree_view.model()
+        )
+        child_mime = tree_model.mimeData([tree_model._row_index(child_uid)])
+        assert child_mime.text() == "tools[0].children[0].children[0]"
+
+        qtbot.wait_until(
+            lambda: (
+                not console_widget._executing
+                and not console_widget._reading
+                and not console_widget._control.isReadOnly()
+                and console_widget._prompt_pos > 0
+                and console_widget._prompt_pos == console_widget._get_end_pos()
+            ),
+            timeout=5000,
+        )
+        console_widget.input_buffer = "dropped =  + 1"
+        qtbot.wait_until(
+            lambda: console_widget.input_buffer == "dropped =  + 1", timeout=5000
+        )
+        cursor = console_widget._control.textCursor()
+        cursor.setPosition(console_widget._prompt_pos + len("dropped = "))
+        console_widget._control.setTextCursor(cursor)
+        child_order_before_drop = list(intermediate_node._childtool_indices)
+        drop_event = QtGui.QDropEvent(
+            QtCore.QPointF(console_widget._control.cursorRect(cursor).center()),
+            QtCore.Qt.DropAction.CopyAction,
+            child_mime,
+            QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+        )
+
+        console_widget.dropEvent(drop_event)
+
+        assert (
+            console_widget.input_buffer
+            == "dropped = tools[0].children[0].children[0] + 1"
+        )
+        assert "dropped" not in shell.user_ns
+        assert intermediate_node._childtool_indices == child_order_before_drop
+        console_widget.input_buffer = ""
+        console_widget.execute(f"dropped = {child_mime.text()}")
+        assert shell.user_ns["dropped"].uid == child_uid
+        console_widget.execute("del dropped", hidden=True)
 
         manager.console._console_widget.execute("child_handles = tools[0].children")
         child_handles = shell.user_ns["child_handles"]

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -321,6 +321,7 @@ def test_drop_mimedata(
 
         # Check mimedata
         model = typing.cast("_ImageToolWrapperItemModel", manager.tree_view.model())
+        assert model.mimeTypes() == [_MIME, _FIGURE_SOURCE_MIME, "text/plain"]
         assert (
             model.supportedDragActions()
             == QtCore.Qt.DropAction.MoveAction | QtCore.Qt.DropAction.CopyAction
@@ -367,6 +368,7 @@ def test_drop_mimedata(
 
         # Test single selection, top-level drops
         mime_single = model.mimeData([model.index(0, 0)])
+        assert mime_single.text() == "tools[0]"
         assert manager.tree_view.figure_source_uids_from_mime(mime_single) == (
             model.index(0, 0).internalPointer().uid,
         )
@@ -389,6 +391,7 @@ def test_drop_mimedata(
 
         # Check new order
         assert manager._tool_graph.displayed_indices == [1, 2, 0]
+        assert model.mimeData([model.index(0, 0)]).text() == "tools[1]"
 
         # No-op drop (drop on itself)
         assert not model.dropMimeData(
@@ -408,6 +411,7 @@ def test_drop_mimedata(
         old_order = list(parent_wrapper._childtool_indices)
         parent_index: QtCore.QModelIndex = model._row_index(0)
         child_index: QtCore.QModelIndex = model._row_index(child_uid)
+        assert model.mimeData([child_index]).text() == "tools[0].children[0]"
         assert (
             manager.tree_view.figure_source_uids_from_mime(
                 model.mimeData([child_index])
@@ -440,10 +444,15 @@ def test_drop_mimedata(
             old_order[0],
             old_order[2],
         ]
+        assert (
+            model.mimeData([model._row_index(child_uid)]).text()
+            == "tools[0].children[1]"
+        )
 
         # Test multiple selection
         logger.info("Testing multiple selection drop")
-        mime_multiple = model.mimeData([model.index(0, 0), model.index(0, 1)])
+        mime_multiple = model.mimeData([model.index(0, 0), model.index(1, 0)])
+        assert not mime_multiple.hasText()
         assert model.canDropMimeData(
             mime_multiple, QtCore.Qt.DropAction.MoveAction, 0, 0, QtCore.QModelIndex()
         )
@@ -456,6 +465,7 @@ def test_drop_mimedata(
         parent_wrapper = model.manager._tool_graph.root_wrappers[0]
         child_uid: str = parent_wrapper._childtool_indices[0]
         mime_mixed = model.mimeData([model._row_index(0), model._row_index(child_uid)])
+        assert not mime_mixed.hasText()
         assert not model.dropMimeData(
             mime_mixed, QtCore.Qt.DropAction.MoveAction, 0, 0, QtCore.QModelIndex()
         )
@@ -495,6 +505,7 @@ def test_drop_mimedata(
         missing_child_index = model.createIndex(0, 0, "missing-child")
         missing_child_mime = model.mimeData([missing_child_index])
         assert _MIME not in missing_child_mime.formats()
+        assert not missing_child_mime.hasText()
 
 
 def test_figure_source_mime_filters_duplicates_and_malformed_rows(
@@ -511,11 +522,10 @@ def test_figure_source_mime_filters_duplicates_and_malformed_rows(
         uid="root-source",
         tool=None,
     )
-    manager._tool_graph = types.SimpleNamespace(
-        displayed_indices=[0],
-        root_wrappers={0: wrapper},
-        nodes={"root-source": wrapper},
-    )
+    manager._tool_graph = _ManagerToolGraph()
+    manager._tool_graph.displayed_indices = [0]
+    manager._tool_graph.root_wrappers[0] = wrapper
+    manager._tool_graph.nodes["root-source"] = wrapper
     model = _ImageToolWrapperItemModel(
         typing.cast("ImageToolManager", manager), manager
     )
@@ -524,6 +534,7 @@ def test_figure_source_mime_filters_duplicates_and_malformed_rows(
 
     duplicate_source_mime = model.mimeData([root_index, root_index])
     assert model.decode_figure_source_mime(duplicate_source_mime) == (root_uid,)
+    assert duplicate_source_mime.text() == "tools[0]"
 
     mixed_source_mime = QtCore.QMimeData()
     mixed_source_mime.setData(

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -3870,7 +3870,7 @@ def test_imagetool_wrapper_item_model_child_edge_branches(qtbot, monkeypatch) ->
     assert model.parent(child_index).internalPointer() is parent_node
     assert model.rowCount(nonzero_column_index) == 0
     assert not model.hasChildren(nonzero_column_index)
-    assert model.mimeTypes() == [_MIME, _FIGURE_SOURCE_MIME]
+    assert model.mimeTypes() == [_MIME, _FIGURE_SOURCE_MIME, "text/plain"]
     with pytest.raises(KeyError):
         model._childtool_uid(0, "missing-parent")
 


### PR DESCRIPTION
## Summary

- expose a plain-text `tools[...]` expression when one ImageTool or child-tool row is dragged from the manager tree
- insert the expression at the console drop position while preserving manager reordering and Figure Composer drag data
- centralize manager-tree path resolution so console handles and drag expressions stay consistent
- advertise the shortcut in the console banner and manager guide

## User impact

Deeply nested child tools can now be referenced without manually typing chains such as `tools[0].children[1].children[0]`. Dragging a single row into the embedded console inserts its complete current expression without executing it or changing the tree order.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- affected manager test modules under PyQt6: 110 passed
- affected manager test modules under PySide6: 110 passed
- real `QDropEvent` console integration under both Qt bindings
- `uv run --directory docs make html SPHINXOPTS='-W --keep-going'`
