### PR TITLE
fix(manager): support mixed file drops

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -1260,13 +1260,6 @@ class _ActionsController:
             extensions: set[str] = {
                 file_path.suffix.lower() for file_path in file_paths
             }
-            if len(extensions) != 1:
-                QtWidgets.QMessageBox.critical(
-                    self._manager,
-                    "Error",
-                    "Multiple file types cannot be opened at the same time.",
-                )
-                return
             self._manager._data_ingress.open_multiple_files(
                 file_paths,
                 try_workspace=extensions == {".itws"},

--- a/src/erlab/interactive/imagetool/manager/_io.py
+++ b/src/erlab/interactive/imagetool/manager/_io.py
@@ -375,7 +375,6 @@ class _DataIngressController:
             )
             return
 
-        n_files = len(paths)
         loaded: list[pathlib.Path] = []
         failed: list[pathlib.Path] = []
         if try_workspace:
@@ -407,13 +406,15 @@ class _DataIngressController:
                     explorer.add_tab(root_path=path)
                 return
 
-            singular = n_files == 1
+            extensions = sorted({path.suffix.lower() for path in paths})
+            file_types = ", ".join(
+                repr(extension) if extension else "no extension"
+                for extension in extensions
+            )
             QtWidgets.QMessageBox.critical(
                 self._manager,
                 "Error",
-                f"The selected {'file' if singular else 'files'} "
-                f"with extension '{paths[0].suffix}' {'is' if singular else 'are'} "
-                "not supported by any available plugin.",
+                f"No available loader supports all selected file types: {file_types}.",
             )
             return
 

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -1257,10 +1257,12 @@ def file_loaders(
 
     valid_keys: list[str] = []
     for name_filter in valid_loaders:
-        for pattern in _filter_to_patterns(name_filter):
-            if all(fnmatch.fnmatch(p.name, pattern) for p in file_paths):
-                valid_keys.append(name_filter)
-                break
+        patterns = _filter_to_patterns(name_filter)
+        if all(
+            any(fnmatch.fnmatch(path.name, pattern) for pattern in patterns)
+            for path in file_paths
+        ):
+            valid_keys.append(name_filter)
 
     return {k: valid_loaders[k] for k in valid_keys}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,10 +192,24 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(pytest.mark.compat)
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     for settings_path in _TEST_INTERACTIVE_OPTIONS_PATHS:
         with contextlib.suppress(OSError):
             settings_path.unlink()
+
+    qapp = QtWidgets.QApplication.instance()
+    if qapp is None:
+        return
+
+    # pytest-qt closes registered widgets with deleteLater(), but processEvents()
+    # does not guarantee that DeferredDelete events run before interpreter shutdown.
+    for _ in range(2):
+        QtWidgets.QApplication.sendPostedEvents(
+            None, int(QtCore.QEvent.Type.DeferredDelete.value)
+        )
+        QtWidgets.QApplication.sendPostedEvents(None, 0)
+        qapp.processEvents()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/interactive/imagetool/manager/test_warnings.py
+++ b/tests/interactive/imagetool/manager/test_warnings.py
@@ -646,6 +646,52 @@ def test_handle_dropped_files_treats_itws_suffix_case_insensitively(
     assert calls == [([fname], True)]
 
 
+def test_handle_dropped_files_allows_mixed_extensions(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    calls: list[tuple[list[pathlib.Path], bool]] = []
+    paths = [tmp_path / "first.pxt", tmp_path / "second.zip"]
+
+    def _record_open(paths, try_workspace: bool = False) -> None:
+        calls.append((paths, try_workspace))
+
+    with manager_context() as manager:
+        monkeypatch.setattr(manager._data_ingress, "open_multiple_files", _record_open)
+        manager._handle_dropped_files(paths)
+
+    assert calls == [(paths, False)]
+
+
+def test_open_multiple_files_reports_incompatible_mixed_extensions(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    critical_calls: list[tuple[typing.Any, ...]] = []
+    paths = [tmp_path / "first.pxt", tmp_path / "second.txt"]
+
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "critical",
+        lambda *args: critical_calls.append(args),
+    )
+
+    with manager_context() as manager:
+        manager._data_ingress.open_multiple_files(paths)
+
+    assert len(critical_calls) == 1
+    message = critical_calls[0][2]
+    assert "all selected file types" in message
+    assert "'.pxt'" in message
+    assert "'.txt'" in message
+
+
 def test_open_multiple_files_dropped_itws_error_does_not_fall_through_to_loaders(
     monkeypatch,
     tmp_path,

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -144,6 +144,17 @@ def test_file_loaders_resolve_da30_filter_to_da30() -> None:
     assert func.__self__ is da30_loader
 
 
+def test_file_loaders_match_mixed_extensions() -> None:
+    da30_filter = next(iter(erlab.io.loaders["da30"].file_dialog_methods))
+
+    valid_loaders = erlab.interactive.utils.file_loaders(
+        ["first_scan.pxt", "second_scan.zip"]
+    )
+
+    assert da30_filter in valid_loaders
+    assert (xr.load_dataarray, {"engine": "erlab-igor"}) not in valid_loaders.values()
+
+
 class _PersistentToolState(pydantic.BaseModel):
     value: int = 0
 


### PR DESCRIPTION
## Summary

- allow mixed file selections from the system file manager when one loader filter covers every selected extension
- show only loader filters that can handle the complete selection
- report all selected file types when no common loader is available
- drain deferred Qt deletions before test-session shutdown to prevent intermittent post-summary segfaults

## Root cause

The manager rejected any drop containing more than one suffix before loader discovery ran. The shared filter matcher also required one glob pattern to match every file, so a filter such as `*.ibw *.pxt *.zip` could not match a `.pxt` and `.zip` selection together.

Separately, pytest-qt closes registered widgets with `deleteLater()`, while its normal event processing does not guarantee delivery of `DeferredDelete` events before interpreter shutdown. The options smoke tests alone left 1,183 top-level Qt objects pending; finalizing that native object graph intermittently produced exit code 139 after pytest reported every test passed.

## User impact

Users can now drop compatible mixed selections, including `.pxt` and `.zip` DA30 data, and choose from the applicable loader filters. Incompatible selections produce one error identifying all selected file types.

The compatibility smoke suite now clears queued Qt objects while the application is still valid instead of relying on interpreter-finalization order.

## Validation

- `uv run pytest tests/interactive/test_utils.py tests/interactive/imagetool/manager/test_warnings.py` (194 passed)
- Python 3.14 + PyQt6 compatibility smoke set (716 passed)
- Python 3.14 + PySide6 compatibility smoke set (716 passed)
- `tests/interactive/test_options.py` under both bindings (57 passed; zero post-session widgets)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
