### PR TITLE
feat(imagetool): improve window layout and narrow controls

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -229,6 +229,10 @@ and right-click context menus:
   Rename multiple selections at once or activate in-place editing for a single tool.
   {guilabel}`Duplicate` clones the currently selected windows, including their state.
 
+- {guilabel}`Arrange Selected Windows…`
+
+  Arranges two or more selected windows into a grid.
+
 - {guilabel}`Reset Index`
 
   Renumbers all windows from zero.

--- a/src/erlab/interactive/_figurecomposer/_ui/_layout_panel.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_layout_panel.py
@@ -41,6 +41,7 @@ from erlab.interactive._figurecomposer._ui._axes_widgets import (
     _GridSpecViewWidget,
 )
 from erlab.interactive._figurecomposer._ui._panel_controls import _step_toolbar_button
+from erlab.interactive._widgets import _Separator
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -350,12 +351,12 @@ class FigureLayoutPanel(QtWidgets.QWidget):
         container_layout = QtWidgets.QVBoxLayout(self.gridspec_editor_container)
         container_layout.setContentsMargins(0, 2, 0, 2)
         container_layout.setSpacing(4)
-        self.gridspec_editor_top_line = QtWidgets.QFrame(self.gridspec_editor_container)
+        self.gridspec_editor_top_line = _Separator(
+            parent=self.gridspec_editor_container
+        )
         self.gridspec_editor_top_line.setObjectName(
             "figureComposerGridSpecEditorTopLine"
         )
-        self.gridspec_editor_top_line.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-        self.gridspec_editor_top_line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
         container_layout.addWidget(self.gridspec_editor_top_line)
 
         self.gridspec_editor_widget = QtWidgets.QWidget(self.gridspec_editor_container)
@@ -457,14 +458,12 @@ class FigureLayoutPanel(QtWidgets.QWidget):
         editor_layout.addWidget(self.gridspec_status_label)
 
         container_layout.addWidget(self.gridspec_editor_widget)
-        self.gridspec_editor_bottom_line = QtWidgets.QFrame(
-            self.gridspec_editor_container
+        self.gridspec_editor_bottom_line = _Separator(
+            parent=self.gridspec_editor_container
         )
         self.gridspec_editor_bottom_line.setObjectName(
             "figureComposerGridSpecEditorBottomLine"
         )
-        self.gridspec_editor_bottom_line.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-        self.gridspec_editor_bottom_line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
         container_layout.addWidget(self.gridspec_editor_bottom_line)
         layout.addWidget(self.gridspec_editor_container, 2, 0, 1, 5)
 

--- a/src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
@@ -21,6 +21,7 @@ from erlab.interactive._figurecomposer._ui._editor_controls import (
     PlainTextControlAdapter,
     SignalValueControlAdapter,
 )
+from erlab.interactive._widgets import _Separator
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -1084,9 +1085,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
         label_font = label.font()
         label_font.setBold(True)
         label.setFont(label_font)
-        line = QtWidgets.QFrame(section)
-        line.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-        line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+        line = _Separator(parent=section)
         if object_name:
             line.setObjectName(f"{object_name}Line")
 

--- a/src/erlab/interactive/_figurecomposer/_ui/_source_panel.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_source_panel.py
@@ -21,6 +21,7 @@ from erlab.interactive._figurecomposer._ui._reorder_list import (
 from erlab.interactive._figurecomposer._ui._source_inspector import (
     SourceInspectorWidget,
 )
+from erlab.interactive._widgets import _Separator
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Collection, Mapping, Sequence
@@ -332,10 +333,8 @@ class FigureSourcePanel(QtWidgets.QWidget):
         font = label.font()
         font.setBold(True)
         label.setFont(font)
-        line = QtWidgets.QFrame(section)
+        line = _Separator(parent=section)
         line.setObjectName("figureComposerSourceSelectionSectionLine")
-        line.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-        line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
         layout.addWidget(label)
         layout.addWidget(line, 1)
         return section

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -23,6 +23,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab.interactive.utils
+from erlab.interactive._widgets import _Separator
 
 if typing.TYPE_CHECKING:
     from collections.abc import Hashable, Mapping
@@ -1449,9 +1450,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_tab_layout.addStretch()
         self._right_layout.addStretch(1)
 
-        separator = QtWidgets.QFrame()
-        separator.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-        separator.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+        separator = _Separator()
         self._right_layout.addWidget(separator)
         self._right_layout.addLayout(self.fit_buttons)
         self._right_layout.addWidget(stats_group)

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -22,6 +22,7 @@ from erlab.interactive._options.parameters import (
     StylesheetListWidget,
 )
 from erlab.interactive._options.schema import AppOptions
+from erlab.interactive._widgets import _Separator
 
 _Scope = typing.Literal["user", "workspace"]
 _CATEGORY_ORDER = ("colors", "io", "ktool", "figure")
@@ -583,9 +584,7 @@ class OptionDialog(QtWidgets.QDialog):
                 )
             layout.addWidget(row)
             if path != paths[-1]:
-                line = QtWidgets.QFrame(page)
-                line.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-                line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+                line = _Separator(parent=page)
                 layout.addWidget(line)
         layout.addStretch(1)
         scroll.setWidget(page)

--- a/src/erlab/interactive/_widgets.py
+++ b/src/erlab/interactive/_widgets.py
@@ -1,6 +1,78 @@
 from qtpy import QtCore, QtGui, QtWidgets
 
 
+class _Separator(QtWidgets.QWidget):
+    """Draw a subtle, palette-aware one-pixel separator."""
+
+    def __init__(
+        self,
+        orientation: QtCore.Qt.Orientation = QtCore.Qt.Orientation.Horizontal,
+        parent: QtWidgets.QWidget | None = None,
+        *,
+        inset: int = 0,
+    ) -> None:
+        super().__init__(parent)
+        if inset < 0:
+            raise ValueError("Separator inset cannot be negative")
+        self._orientation = orientation
+        self._inset = inset
+        if orientation == QtCore.Qt.Orientation.Horizontal:
+            self.setSizePolicy(
+                QtWidgets.QSizePolicy.Policy.Expanding,
+                QtWidgets.QSizePolicy.Policy.Fixed,
+            )
+        else:
+            self.setSizePolicy(
+                QtWidgets.QSizePolicy.Policy.Fixed,
+                QtWidgets.QSizePolicy.Policy.Expanding,
+            )
+
+    @property
+    def orientation(self) -> QtCore.Qt.Orientation:
+        """Return the direction in which the separator extends."""
+        return self._orientation
+
+    @property
+    def inset(self) -> int:
+        """Return the space left at both ends of the separator."""
+        return self._inset
+
+    def sizeHint(self) -> QtCore.QSize:
+        length = 2 * self._inset + 1
+        if self._orientation == QtCore.Qt.Orientation.Horizontal:
+            return QtCore.QSize(length, 1)
+        return QtCore.QSize(1, length)
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        return self.sizeHint()
+
+    def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
+        del event
+        if self._orientation == QtCore.Qt.Orientation.Horizontal:
+            if self.width() <= 2 * self._inset:
+                return
+            center = self.height() / 2
+            start = QtCore.QPointF(self._inset, center)
+            end = QtCore.QPointF(self.width() - self._inset, center)
+        else:
+            if self.height() <= 2 * self._inset:
+                return
+            center = self.width() / 2
+            start = QtCore.QPointF(center, self._inset)
+            end = QtCore.QPointF(center, self.height() - self._inset)
+
+        color = self.palette().color(QtGui.QPalette.ColorRole.WindowText)
+        background = self.palette().color(QtGui.QPalette.ColorRole.Window)
+        color.setAlphaF(0.18 if background.lightnessF() < 0.5 else 0.14)
+
+        painter = QtGui.QPainter(self)
+        pen = QtGui.QPen(color)
+        pen.setWidthF(1.0)
+        painter.setPen(pen)
+        painter.drawLine(start, end)
+        painter.end()
+
+
 class _CenteredIconToolButton(QtWidgets.QToolButton):
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -27,6 +27,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive import _qt_state
+from erlab.interactive._widgets import _Separator
 from erlab.interactive.imagetool import _serialization
 from erlab.interactive.imagetool._load_source import _load_provenance_from_file_details
 from erlab.interactive.imagetool.viewer_state import _select_input_dataarrays
@@ -60,7 +61,7 @@ class _ControlsBar(QtWidgets.QScrollArea):
         self._contents.setObjectName("itoolControlsContents")
         self._contents.installEventFilter(self)
         self._layout = QtWidgets.QHBoxLayout(self._contents)
-        self._layout.setContentsMargins(6, 3, 6, 3)
+        self._layout.setContentsMargins(6, 6, 6, 6)
         self._layout.setSpacing(6)
         self._layout.setSizeConstraint(QtWidgets.QLayout.SizeConstraint.SetFixedSize)
         self.setWidget(self._contents)
@@ -105,14 +106,8 @@ class _ControlsBar(QtWidgets.QScrollArea):
     def add_group(self, widget: QtWidgets.QWidget, accessible_name: str) -> None:
         """Append a control group, separated from preceding groups by a line."""
         if self._layout.count():
-            separator = QtWidgets.QFrame(self._contents)
+            separator = _Separator(QtCore.Qt.Orientation.Vertical, self._contents)
             separator.setObjectName("itoolControlsSeparator")
-            separator.setFrameShape(QtWidgets.QFrame.Shape.VLine)
-            separator.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
-            separator.setSizePolicy(
-                QtWidgets.QSizePolicy.Policy.Fixed,
-                QtWidgets.QSizePolicy.Policy.Expanding,
-            )
             self._layout.addWidget(separator)
 
         widget.setAccessibleName(accessible_name)

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -40,6 +40,207 @@ _ITOOL_DATA_NAME: str = _serialization.ITOOL_DATA_NAME
 #: Name to use for the data variable in cached datasets
 
 
+class _ControlsBar(QtWidgets.QScrollArea):
+    """Horizontally scrollable strip of ImageTool control groups."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("itoolControlsBar")
+        self.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setWidgetResizable(False)
+        self.setMinimumWidth(0)
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+
+        self._contents = QtWidgets.QWidget()
+        self._contents.setObjectName("itoolControlsContents")
+        self._contents.installEventFilter(self)
+        self._layout = QtWidgets.QHBoxLayout(self._contents)
+        self._layout.setContentsMargins(6, 3, 6, 3)
+        self._layout.setSpacing(6)
+        self._layout.setSizeConstraint(QtWidgets.QLayout.SizeConstraint.SetFixedSize)
+        self.setWidget(self._contents)
+
+        self._previous_button = self._create_scroll_button(
+            "itoolControlsPreviousButton",
+            QtCore.Qt.ArrowType.LeftArrow,
+            "Show previous controls",
+            -1,
+        )
+        self._next_button = self._create_scroll_button(
+            "itoolControlsNextButton",
+            QtCore.Qt.ArrowType.RightArrow,
+            "Show more controls",
+            1,
+        )
+
+        scroll_bar = typing.cast("QtWidgets.QScrollBar", self.horizontalScrollBar())
+        scroll_bar.rangeChanged.connect(self._update_navigation)
+        scroll_bar.valueChanged.connect(self._update_navigation)
+        self._update_navigation()
+
+    def _create_scroll_button(
+        self,
+        object_name: str,
+        arrow_type: QtCore.Qt.ArrowType,
+        description: str,
+        direction: int,
+    ) -> QtWidgets.QToolButton:
+        button = QtWidgets.QToolButton(self.viewport())
+        button.setObjectName(object_name)
+        button.setArrowType(arrow_type)
+        button.setToolTip(description)
+        button.setAccessibleName(description)
+        button.setAutoRepeat(True)
+        button.setAutoRepeatDelay(300)
+        button.setAutoRepeatInterval(80)
+        button.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        button.clicked.connect(lambda: self._scroll_page(direction))
+        return button
+
+    def add_group(self, widget: QtWidgets.QWidget, accessible_name: str) -> None:
+        """Append a control group, separated from preceding groups by a line."""
+        if self._layout.count():
+            separator = QtWidgets.QFrame(self._contents)
+            separator.setObjectName("itoolControlsSeparator")
+            separator.setFrameShape(QtWidgets.QFrame.Shape.VLine)
+            separator.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+            separator.setSizePolicy(
+                QtWidgets.QSizePolicy.Policy.Fixed,
+                QtWidgets.QSizePolicy.Policy.Expanding,
+            )
+            self._layout.addWidget(separator)
+
+        widget.setAccessibleName(accessible_name)
+        widget.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Maximum,
+            QtWidgets.QSizePolicy.Policy.Preferred,
+        )
+        self._layout.addWidget(widget)
+        self._watch_focus(widget)
+
+    def viewportSizeHint(self) -> QtCore.QSize:
+        return self._contents.sizeHint()
+
+    def sizeHint(self) -> QtCore.QSize:
+        return self.viewportSizeHint()
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        hint = self.sizeHint()
+        hint.setWidth(0)
+        return hint
+
+    def eventFilter(
+        self, obj: QtCore.QObject | None, event: QtCore.QEvent | None
+    ) -> bool:
+        if (
+            obj is self._contents
+            and event is not None
+            and event.type() == QtCore.QEvent.Type.LayoutRequest
+        ):
+            self.updateGeometry()
+            erlab.interactive.utils.single_shot(
+                self, 0, self._update_navigation, self._contents
+            )
+        elif (
+            isinstance(obj, QtWidgets.QWidget)
+            and event is not None
+            and event.type() == QtCore.QEvent.Type.FocusIn
+            and self._contents.isAncestorOf(obj)
+        ):
+            erlab.interactive.utils.single_shot(
+                self,
+                0,
+                lambda: self.ensureWidgetVisible(obj, self._next_button.width() + 3, 3),
+                obj,
+            )
+        elif (
+            isinstance(obj, QtWidgets.QWidget)
+            and event is not None
+            and event.type() == QtCore.QEvent.Type.ChildAdded
+            and self._contents.isAncestorOf(obj)
+        ):
+            erlab.interactive.utils.single_shot(
+                self, 0, lambda: self._watch_focus(obj), obj
+            )
+        return super().eventFilter(obj, event)
+
+    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
+        super().resizeEvent(event)
+        self._position_navigation()
+        self._update_navigation()
+
+    def showEvent(self, event: QtGui.QShowEvent | None) -> None:
+        super().showEvent(event)
+        self._position_navigation()
+        self._update_navigation()
+
+    def wheelEvent(self, event: QtGui.QWheelEvent | None) -> None:
+        scroll_bar = typing.cast("QtWidgets.QScrollBar", self.horizontalScrollBar())
+        if event is None or scroll_bar.maximum() == scroll_bar.minimum():
+            super().wheelEvent(event)
+            return
+
+        pixel_delta = event.pixelDelta()
+        delta = pixel_delta.x()
+        if delta == 0:
+            delta = pixel_delta.y()
+        if delta == 0:
+            angle_delta = event.angleDelta()
+            delta = angle_delta.x()
+            if delta == 0:
+                delta = angle_delta.y()
+            delta = round(delta / 120 * scroll_bar.singleStep())
+        if delta:
+            scroll_bar.setValue(scroll_bar.value() - delta)
+            event.accept()
+            return
+        super().wheelEvent(event)
+
+    def _scroll_page(self, direction: int) -> None:
+        scroll_bar = typing.cast("QtWidgets.QScrollBar", self.horizontalScrollBar())
+        viewport = typing.cast("QtWidgets.QWidget", self.viewport())
+        step = max(1, viewport.width() - self._next_button.width())
+        scroll_bar.setValue(scroll_bar.value() + direction * step)
+
+    def _watch_focus(self, widget: QtWidgets.QWidget) -> None:
+        widget.installEventFilter(self)
+        for child in widget.findChildren(QtWidgets.QWidget):
+            child.installEventFilter(self)
+
+    def _position_navigation(self) -> None:
+        viewport = typing.cast("QtWidgets.QWidget", self.viewport())
+        style = self.style() or QtWidgets.QApplication.style()
+        if style is None:  # pragma: no cover
+            return
+        width = style.pixelMetric(
+            QtWidgets.QStyle.PixelMetric.PM_ScrollBarExtent, None, self
+        )
+        width = max(16, width)
+        height = viewport.height()
+        self._previous_button.setGeometry(0, 0, width, height)
+        self._next_button.setGeometry(
+            max(0, viewport.width() - width), 0, width, height
+        )
+        self._previous_button.raise_()
+        self._next_button.raise_()
+
+    def _update_navigation(self, *args: int) -> None:
+        del args
+        scroll_bar = typing.cast("QtWidgets.QScrollBar", self.horizontalScrollBar())
+        has_overflow = scroll_bar.maximum() > scroll_bar.minimum()
+        self._previous_button.setVisible(
+            has_overflow and scroll_bar.value() > scroll_bar.minimum()
+        )
+        self._next_button.setVisible(
+            has_overflow and scroll_bar.value() < scroll_bar.maximum()
+        )
+
+
 class BaseImageTool(QtWidgets.QMainWindow):
     """Base class for an ImageTool window.
 
@@ -73,38 +274,30 @@ class BaseImageTool(QtWidgets.QMainWindow):
         self._slicer_area = erlab.interactive.imagetool.viewer.ImageSlicerArea(
             self, data, **kwargs
         )
-        self.setCentralWidget(self.slicer_area)
-
-        self.docks: tuple[QtWidgets.QDockWidget, ...] = tuple(
-            QtWidgets.QDockWidget(name, self) for name in ("Cursor", "Color", "Binning")
-        )
-        for d in self.docks:
-            d.setFeatures(QtWidgets.QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
-
-        self.docks[0].setWidget(
-            self.widget_box(
-                erlab.interactive.imagetool.controls.ItoolCrosshairControls(
-                    self.slicer_area, orientation=QtCore.Qt.Orientation.Vertical
-                )
+        self.cursor_controls = (
+            erlab.interactive.imagetool.controls.ItoolCrosshairControls(
+                self.slicer_area, orientation=QtCore.Qt.Orientation.Vertical
             )
         )
-        self.docks[1].setWidget(
-            self.widget_box(
-                erlab.interactive.imagetool.controls.ItoolColormapControls(
-                    self.slicer_area
-                )
-            )
+        self.colormap_controls = (
+            erlab.interactive.imagetool.controls.ItoolColormapControls(self.slicer_area)
         )
-        self.docks[2].setWidget(
-            self.widget_box(
-                erlab.interactive.imagetool.controls.ItoolBinningControls(
-                    self.slicer_area
-                )
-            )
+        self.binning_controls = (
+            erlab.interactive.imagetool.controls.ItoolBinningControls(self.slicer_area)
         )
 
-        for d in self.docks:
-            self.addDockWidget(QtCore.Qt.DockWidgetArea.TopDockWidgetArea, d)
+        self.controls_bar = _ControlsBar(self)
+        self.controls_bar.add_group(self.cursor_controls, "Cursor controls")
+        self.controls_bar.add_group(self.colormap_controls, "Color controls")
+        self.controls_bar.add_group(self.binning_controls, "Binning controls")
+
+        central_widget = QtWidgets.QWidget(self)
+        central_layout = QtWidgets.QVBoxLayout(central_widget)
+        central_layout.setContentsMargins(0, 0, 0, 0)
+        central_layout.setSpacing(0)
+        central_layout.addWidget(self.controls_bar)
+        central_layout.addWidget(self.slicer_area, 1)
+        self.setCentralWidget(central_widget)
         self.resize(720, 720)
 
         try:
@@ -137,8 +330,8 @@ class BaseImageTool(QtWidgets.QMainWindow):
 
     @property
     def controls_visible(self) -> bool:
-        """Whether the ImageTool control docks are shown."""
-        return all(not dock.isHidden() for dock in self.docks)
+        """Whether the ImageTool controls are shown."""
+        return not self.controls_bar.isHidden()
 
     @controls_visible.setter
     def controls_visible(self, visible: bool) -> None:
@@ -146,8 +339,7 @@ class BaseImageTool(QtWidgets.QMainWindow):
 
     def _set_controls_visible(self, visible: bool) -> None:
         visible = bool(visible)
-        for dock in self.docks:
-            dock.setVisible(visible)
+        self.controls_bar.setVisible(visible)
 
         menu_bar = self.menuBar()
         action = getattr(menu_bar, "action_dict", {}).get("toggleControlsAct")
@@ -366,33 +558,6 @@ class BaseImageTool(QtWidgets.QMainWindow):
 
         show_in_manager(self.to_dataset())
         self.close()
-
-    # TODO: this is ugly and temporary, fix it
-    def widget_box(self, widget: QtWidgets.QWidget, **kwargs) -> QtWidgets.QGroupBox:
-        """Create a box that surrounds the given widget.
-
-        Parameters
-        ----------
-        widget
-            The widget to be added to the box.
-        **kwargs
-            Additional keyword arguments passed to :class:`QtWidgets.QGroupBox`
-
-        Returns
-        -------
-        group
-            The created widget box.
-
-        """
-        group = QtWidgets.QGroupBox(**kwargs)
-        group.setSizePolicy(
-            QtWidgets.QSizePolicy.Policy.Maximum, QtWidgets.QSizePolicy.Policy.Preferred
-        )
-        group_layout = QtWidgets.QVBoxLayout(group)
-        group_layout.setContentsMargins(3, 3, 3, 3)
-        group_layout.setSpacing(3)
-        group_layout.addWidget(widget)
-        return group
 
     def eventFilter(
         self, obj: QtCore.QObject | None = None, event: QtCore.QEvent | None = None

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -76,6 +76,71 @@ def clear_layout(layout: QtWidgets.QLayout | None) -> None:
                     child_layout.deleteLater()
 
 
+class _ElidedLabel(QtWidgets.QLabel):
+    """Single-line label whose full text does not determine its minimum width."""
+
+    _MAXIMUM_HINT_EMS = 12
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._full_text = ""
+        self.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        self.setTextInteractionFlags(
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        self.setMinimumWidth(0)
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Preferred,
+        )
+
+    @property
+    def full_text(self) -> str:
+        return self._full_text
+
+    def setText(self, text: str | None) -> None:
+        self._full_text = "" if text is None else text
+        super().setText(self._full_text)
+        self.setToolTip(self._full_text)
+        self.setAccessibleName(self._full_text)
+        self.update()
+
+    def sizeHint(self) -> QtCore.QSize:
+        hint = super().sizeHint()
+        maximum_width = self.fontMetrics().horizontalAdvance(
+            "m" * self._MAXIMUM_HINT_EMS
+        )
+        hint.setWidth(min(hint.width(), maximum_width))
+        return hint
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        hint = super().minimumSizeHint()
+        hint.setWidth(0)
+        return hint
+
+    def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
+        del event
+        painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.TextAntialiasing)
+        rect = self.contentsRect()
+        text = self.fontMetrics().elidedText(
+            self._full_text,
+            QtCore.Qt.TextElideMode.ElideRight,
+            max(rect.width(), 0),
+        )
+        style = self.style() or QtWidgets.QApplication.style()
+        if style is not None:  # pragma: no branch
+            style.drawItemText(
+                painter,
+                rect,
+                int(self.alignment()) | int(QtCore.Qt.TextFlag.TextSingleLine.value),
+                self.palette(),
+                self.isEnabled(),
+                text,
+                self.foregroundRole(),
+            )
+
+
 class ItoolControlsBase(QtWidgets.QWidget):
     """Base class for ImageTool controls."""
 
@@ -334,11 +399,8 @@ class ItoolCrosshairControls(ItoolControlsBase):
         typing.cast("QtWidgets.QLayout", self.layout()).addWidget(self.values_groups[0])
 
         # info widgets
-        self.label_dim = tuple(QtWidgets.QLabel(grp) for grp in self.values_groups[1:])
+        self.label_dim = tuple(_ElidedLabel(grp) for grp in self.values_groups[1:])
         for lab in self.label_dim:
-            lab.setTextInteractionFlags(
-                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
-            )
             lab.setAlignment(
                 QtCore.Qt.AlignmentFlag.AlignHCenter
                 | QtCore.Qt.AlignmentFlag.AlignVCenter
@@ -856,7 +918,7 @@ class ItoolBinningControls(ItoolControlsBase):
         layout.addLayout(self.gridlayout)
         layout.addLayout(self.buttonslayout)
 
-        self.labels = tuple(QtWidgets.QLabel() for _ in range(self.data.ndim))
+        self.labels = tuple(_ElidedLabel() for _ in range(self.data.ndim))
         self.val_labels = tuple(QtWidgets.QLabel() for _ in range(self.data.ndim))
         self.spins = tuple(
             erlab.interactive.utils.BetterSpinBox(

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -406,7 +406,8 @@ class ItoolCrosshairControls(ItoolControlsBase):
         self.label_dim = tuple(_ElidedLabel(grp) for grp in self.values_groups[1:])
         for lab in self.label_dim:
             lab.setAlignment(
-                QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter
+                QtCore.Qt.AlignmentFlag.AlignHCenter
+                | QtCore.Qt.AlignmentFlag.AlignVCenter
             )
 
         self.spin_idx = tuple(

--- a/src/erlab/interactive/imagetool/controls.py
+++ b/src/erlab/interactive/imagetool/controls.py
@@ -315,8 +315,12 @@ class ItoolCrosshairControls(ItoolControlsBase):
         )
         for s in self.values_layouts:
             s.setContentsMargins(0, 0, 0, 0)
-
             s.setSpacing(3)
+            if self.orientation == QtCore.Qt.Orientation.Vertical:
+                s.setVerticalSpacing(0)
+                for row in (1, 3):
+                    s.setRowMinimumHeight(row, 3)
+                    s.setRowStretch(row, 1)
         # buttons for multicursor control
         self.btn_add = erlab.interactive.utils.IconButton(
             _ICON_ALIASES["plus"], toolTip="Add cursor"
@@ -388,8 +392,8 @@ class ItoolCrosshairControls(ItoolControlsBase):
             self.values_layouts[0].addWidget(self.btn_add, 0, 1, 1, 1)
             self.values_layouts[0].addWidget(self.btn_rem, 0, 2, 1, 1)
             self.values_layouts[0].addWidget(self.btn_snap, 0, 0, 1, 1)
-            self.values_layouts[0].addWidget(self.cb_cursors, 1, 0, 1, 3)
-            self.values_layouts[0].addWidget(self.spin_dat, 2, 0, 1, 3)
+            self.values_layouts[0].addWidget(self.cb_cursors, 2, 0, 1, 3)
+            self.values_layouts[0].addWidget(self.spin_dat, 4, 0, 1, 3)
         else:
             self.values_layouts[0].addWidget(self.btn_add, 0, 1, 1, 1)
             self.values_layouts[0].addWidget(self.btn_rem, 0, 2, 1, 1)
@@ -402,8 +406,7 @@ class ItoolCrosshairControls(ItoolControlsBase):
         self.label_dim = tuple(_ElidedLabel(grp) for grp in self.values_groups[1:])
         for lab in self.label_dim:
             lab.setAlignment(
-                QtCore.Qt.AlignmentFlag.AlignHCenter
-                | QtCore.Qt.AlignmentFlag.AlignVCenter
+                QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter
             )
 
         self.spin_idx = tuple(
@@ -451,8 +454,8 @@ class ItoolCrosshairControls(ItoolControlsBase):
             if self.orientation == QtCore.Qt.Orientation.Vertical:
                 self.values_layouts[i + 1].addWidget(self.label_dim[i], 0, 0, 1, 1)
                 self.values_layouts[i + 1].addWidget(self.btn_transpose[i], 0, 1, 1, 1)
-                self.values_layouts[i + 1].addWidget(self.spin_idx[i], 1, 0, 1, 2)
-                self.values_layouts[i + 1].addWidget(self.spin_val[i], 2, 0, 1, 2)
+                self.values_layouts[i + 1].addWidget(self.spin_idx[i], 2, 0, 1, 2)
+                self.values_layouts[i + 1].addWidget(self.spin_val[i], 4, 0, 1, 2)
             else:
                 self.values_layouts[i + 1].addWidget(self.label_dim[i], 0, 0, 1, 1)
                 self.values_layouts[i + 1].addWidget(self.btn_transpose[i], 0, 1, 1, 1)
@@ -908,7 +911,11 @@ class ItoolBinningControls(ItoolControlsBase):
         super().initialize_widgets()
         self.gridlayout = QtWidgets.QGridLayout()
         self.gridlayout.setContentsMargins(0, 0, 0, 0)
-        self.gridlayout.setSpacing(3)
+        self.gridlayout.setHorizontalSpacing(3)
+        self.gridlayout.setVerticalSpacing(0)
+        for row in (1, 3):
+            self.gridlayout.setRowMinimumHeight(row, 3)
+            self.gridlayout.setRowStretch(row, 1)
 
         self.buttonslayout = QtWidgets.QVBoxLayout()
         self.buttonslayout.setContentsMargins(0, 0, 0, 0)
@@ -948,11 +955,18 @@ class ItoolBinningControls(ItoolControlsBase):
         )
 
         height = QtGui.QFontMetrics(self.labels[0].font()).height() + 3
+        alignment = (
+            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter
+        )
+        self.gridlayout.setRowMinimumHeight(0, self.reset_btn.sizeHint().height())
+        self.gridlayout.setRowMinimumHeight(4, self.spins[0].minimumHeight())
 
         for i in range(self.data.ndim):
             self.gridlayout.addWidget(self.labels[i], 0, i, 1, 1)
-            self.gridlayout.addWidget(self.spins[i], 1, i, 1, 1)
-            self.gridlayout.addWidget(self.val_labels[i], 2, i, 1, 1)
+            self.gridlayout.addWidget(self.spins[i], 2, i, 1, 1)
+            self.gridlayout.addWidget(self.val_labels[i], 4, i, 1, 1)
+            self.labels[i].setAlignment(alignment)
+            self.val_labels[i].setAlignment(alignment)
             self.val_labels[i].setMaximumHeight(height)
             self.spins[i].setToolTip("Number of bins")
             self.val_labels[i].setToolTip("Value corresponding to number of bins")

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -836,9 +836,9 @@ class DataTransformDialog(_DataManipulationDialog):
         self,
         provenance_spec: ToolProvenanceSpec | None,
     ) -> None:
-        parent = self.slicer_area.parent()
-        if parent is not None and hasattr(parent, "set_provenance_spec"):
-            typing.cast("typing.Any", parent).set_provenance_spec(provenance_spec)
+        window = self.slicer_area.window()
+        if hasattr(window, "set_provenance_spec"):
+            typing.cast("typing.Any", window).set_provenance_spec(provenance_spec)
 
     def _apply_source_transform(self, data: xr.DataArray) -> xr.DataArray:
         operation = self.source_transform_operation()

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -174,10 +174,27 @@ class _ActionsController:
                 str(error),
             )
             return
-        snapshots = [
-            (window, window.isVisible(), window.windowState(), window.geometry())
-            for window in windows
-        ]
+        snapshots: list[
+            tuple[
+                QtWidgets.QWidget,
+                bool,
+                QtCore.Qt.WindowState,
+                QtCore.QRect,
+            ]
+        ] = []
+        for window in windows:
+            state = window.windowState()
+            geometry = window.normalGeometry()
+            if not (
+                state
+                & (
+                    QtCore.Qt.WindowState.WindowMaximized
+                    | QtCore.Qt.WindowState.WindowFullScreen
+                )
+                and geometry.isValid()
+            ):
+                geometry = window.geometry()
+            snapshots.append((window, window.isVisible(), state, geometry))
         try:
             with self._manager._workspace_load_context():
                 for window in windows:
@@ -202,7 +219,10 @@ class _ActionsController:
         except (RuntimeError, TypeError, ValueError):
             with self._manager._workspace_load_context():
                 self._restore_window_layout_snapshots(snapshots)
-            logger.exception("Error while arranging selected windows")
+            logger.exception(
+                "Error while arranging selected windows",
+                extra={"suppress_ui_alert": True},
+            )
             erlab.interactive.utils.MessageDialog.critical(
                 self._manager,
                 "Error",

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -33,6 +33,12 @@ from erlab.interactive.imagetool.manager._dialogs import (
     _StoreDialog,
 )
 from erlab.interactive.imagetool.manager._widgets import _WATCHED_VAR_COLORS
+from erlab.interactive.imagetool.manager._window_layout import (
+    _WindowLayoutDialog,
+    frame_margins,
+    frame_rects_fit_windows,
+    window_layout_rects,
+)
 from erlab.interactive.imagetool.manager._wrapper import (
     _ImageToolWrapper,
     _ManagedWindowNode,
@@ -60,6 +66,8 @@ class _ActionsController:
         self.__rename_dialog: _RenameDialog | None = None
         self.__concat_dialog: _ConcatDialog | None = None
         self.__batch_dialog: _BatchOperationDialog | None = None
+        self.__window_layout_dialog: _WindowLayoutDialog | None = None
+        self._window_layout_target_uids: tuple[str, ...] = ()
 
     @property
     def _rename_dialog(self) -> _RenameDialog:
@@ -98,6 +106,111 @@ class _ActionsController:
             [self._manager._tool_graph.root_wrappers[i].name for i in root_selected],
         )
         dlg.open()
+
+    @property
+    def _window_layout_dialog(self) -> _WindowLayoutDialog:
+        if self.__window_layout_dialog is None:
+            self.__window_layout_dialog = _WindowLayoutDialog(self._manager)
+            self.__window_layout_dialog.accepted.connect(self._apply_window_layout)
+        return self.__window_layout_dialog
+
+    def arrange_selected_windows(self) -> None:
+        """Open layout controls for the selected managed windows."""
+        target_uids = tuple(self._manager._selected_layout_uids())
+        if len(target_uids) < 2:
+            return
+        self._window_layout_target_uids = target_uids
+        dialog = self._window_layout_dialog
+        dialog.set_window_count(len(target_uids))
+        dialog.open()
+
+    @staticmethod
+    def _restore_window_layout_snapshots(
+        snapshots: list[
+            tuple[
+                QtWidgets.QWidget,
+                bool,
+                QtCore.Qt.WindowState,
+                QtCore.QRect,
+            ]
+        ],
+    ) -> None:
+        for window, visible, state, geometry in snapshots:
+            window.showNormal()
+            window.setGeometry(geometry)
+            window.setWindowState(state)
+            window.setVisible(visible)
+
+    def _apply_window_layout(self) -> None:
+        dialog = self.__window_layout_dialog
+        if dialog is None:
+            return
+        windows: list[QtWidgets.QWidget] = []
+        for uid in self._window_layout_target_uids:
+            node = self._manager._tool_graph.nodes.get(uid)
+            if node is None or not node.materialize_pending_workspace_payload():
+                return
+            window = node.window
+            if window is None or not erlab.interactive.utils.qt_is_valid(window):
+                return
+            windows.append(window)
+
+        screen = self._manager.screen() or QtGui.QGuiApplication.primaryScreen()
+        if screen is None:  # pragma: no cover
+            return
+        try:
+            frame_rects = window_layout_rects(
+                screen.availableGeometry(),
+                len(windows),
+                dialog.layout_mode,
+                dialog.primary_count,
+                dialog.spacing,
+                dialog.reverse_order,
+            )
+        except ValueError as error:
+            QtWidgets.QMessageBox.warning(
+                self._manager,
+                "Unable to Arrange Windows",
+                str(error),
+            )
+            return
+        snapshots = [
+            (window, window.isVisible(), window.windowState(), window.geometry())
+            for window in windows
+        ]
+        try:
+            with self._manager._workspace_load_context():
+                for window in windows:
+                    window.showNormal()
+                    window.ensurePolished()
+                layout_fits = frame_rects_fit_windows(windows, frame_rects)
+                if not layout_fits:
+                    self._restore_window_layout_snapshots(snapshots)
+            if not layout_fits:
+                QtWidgets.QMessageBox.warning(
+                    self._manager,
+                    "Unable to Arrange Windows",
+                    "The selected layout does not leave enough room for the "
+                    "minimum size of every window. Reduce the spacing or use fewer "
+                    "rows or columns.",
+                )
+                return
+            for window, frame_rect in zip(windows, frame_rects, strict=True):
+                window.setGeometry(frame_rect.marginsRemoved(frame_margins(window)))
+                window.show()
+                window.raise_()
+        except (RuntimeError, TypeError, ValueError):
+            with self._manager._workspace_load_context():
+                self._restore_window_layout_snapshots(snapshots)
+            logger.exception("Error while arranging selected windows")
+            erlab.interactive.utils.MessageDialog.critical(
+                self._manager,
+                "Error",
+                "An error occurred while arranging the selected windows.",
+                detailed_text=erlab.interactive.utils._format_traceback(
+                    traceback.format_exc()
+                ),
+            )
 
     def duplicate_selected(self) -> None:
         """Duplicate selected windows."""

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -124,6 +124,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     edit_note_action: QtGui.QAction
     copy_note_action: QtGui.QAction
     clear_note_action: QtGui.QAction
+    arrange_windows_action: QtGui.QAction
     hide_action: QtGui.QAction
     left_tabs: QtWidgets.QTabWidget
     link_action: QtGui.QAction
@@ -357,6 +358,32 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         ]
         selected.extend(self._selected_figure_uids())
         return selected
+
+    def _selected_layout_uids(self) -> list[str]:
+        figure_uids = self._selected_figure_uids()
+        if figure_uids:
+            return figure_uids
+
+        def _index_path(index: QtCore.QModelIndex) -> tuple[int, ...]:
+            rows: list[int] = []
+            while index.isValid():
+                rows.append(index.row())
+                index = index.parent()
+            return tuple(reversed(rows))
+
+        output: list[str] = []
+        seen: set[str] = set()
+        for index in sorted(self.tree_view.selectedIndexes(), key=_index_path):
+            pointer = index.internalPointer()
+            uid = (
+                pointer
+                if isinstance(pointer, str)
+                else typing.cast("typing.Any", pointer).uid
+            )
+            if isinstance(uid, str) and uid not in seen:
+                output.append(uid)
+                seen.add(uid)
+        return output
 
     def _selected_figure_source_targets(self) -> list[int | str]:
         return list(self._selected_imagetool_targets())

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -1366,6 +1366,7 @@ class _DetailsPanelController:
 
         self._manager.show_action.setEnabled(something_selected)
         self._manager.hide_action.setEnabled(something_selected)
+        self._manager.arrange_windows_action.setEnabled(total_selected >= 2)
         self._manager.remove_action.setEnabled(something_selected)
         self._manager.rename_action.setEnabled(
             single_selected or multiple_root_imagetools_selected

--- a/src/erlab/interactive/imagetool/manager/_figurecomposer/_collection.py
+++ b/src/erlab/interactive/imagetool/manager/_figurecomposer/_collection.py
@@ -236,7 +236,10 @@ class _FigureCollectionController(QtCore.QObject):
         if pane is None:
             return []
         output: list[str] = []
-        for item in pane.list_widget.selectedItems():
+        for row in range(pane.list_widget.count()):
+            item = pane.list_widget.item(row)
+            if item is None or not item.isSelected():
+                continue
             uid = self.uid_from_item(item)
             if uid is not None and self._host._is_figure_uid(uid):
                 output.append(uid)
@@ -477,6 +480,7 @@ class _FigureCollectionController(QtCore.QObject):
         menu.aboutToHide.connect(lambda *, popup=menu: self._release_menu(popup))
         menu.addAction(self._host.show_action)
         menu.addAction(self._host.hide_action)
+        menu.addAction(self._host.arrange_windows_action)
         menu.addSeparator()
         menu.addAction(self._host.duplicate_action)
         menu.addAction(self._host.remove_action)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -367,6 +367,18 @@ class ImageToolManager(_ImageToolManagerBase):
         self.hide_action.setShortcut("Ctrl+W")
         self.hide_action.setToolTip("Hide selected windows")
 
+        self.arrange_windows_action = QtWidgets.QAction(
+            "Arrange Selected Windows…", self
+        )
+        self.arrange_windows_action.setObjectName(
+            "manager_arrange_selected_windows_action"
+        )
+        self.arrange_windows_action.setToolTip(
+            "Arrange and resize selected windows on this screen"
+        )
+        self.arrange_windows_action.setIcon(QtGui.QIcon.fromTheme("view-grid"))
+        self.arrange_windows_action.triggered.connect(self.arrange_selected_windows)
+
         self.gc_action = QtWidgets.QAction("Run Garbage Collection", self)
         self.gc_action.triggered.connect(self.garbage_collect)
         self.gc_action.setToolTip("Run garbage collection to free up memory")
@@ -686,6 +698,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self.view_menu.addSeparator()
         self.view_menu.addAction(self.preview_action)
         self.view_menu.addSeparator()
+        self.view_menu.addAction(self.arrange_windows_action)
 
         self.apps_menu: QtWidgets.QMenu = typing.cast(
             "QtWidgets.QMenu", self.menu_bar.addMenu("&Apps")
@@ -2437,6 +2450,9 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def hide_selected(self) -> None:
         self._lineage_controller.hide_selected()
+
+    def arrange_selected_windows(self) -> None:
+        self._actions_controller.arrange_selected_windows()
 
     def hide_all(self) -> None:
         self._lineage_controller.hide_all()

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -1796,6 +1796,7 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
         self._menu.addSeparator()
         self._menu.addAction(manager.show_action)
         self._menu.addAction(manager.hide_action)
+        self._menu.addAction(manager.arrange_windows_action)
         self._menu.addSeparator()
         self._menu.addAction(manager.remove_action)
         self._menu.addAction(manager.unwatch_action)

--- a/src/erlab/interactive/imagetool/manager/_window_layout.py
+++ b/src/erlab/interactive/imagetool/manager/_window_layout.py
@@ -1,0 +1,433 @@
+"""Visual controls and geometry helpers for arranging managed windows."""
+
+from __future__ import annotations
+
+import math
+import typing
+
+from qtpy import QtCore, QtGui, QtWidgets
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+_LayoutMode = typing.Literal["grid_row", "grid_column", "row", "column"]
+
+_LAYOUT_LABELS: dict[_LayoutMode, str] = {
+    "grid_row": "Grid by Row",
+    "grid_column": "Grid by Column",
+    "row": "Arrange by Row",
+    "column": "Arrange by Column",
+}
+
+
+def _partition_axis(
+    origin: int, extent: int, count: int, spacing: int
+) -> list[tuple[int, int]]:
+    available = extent - spacing * (count - 1)
+    if available <= 0:
+        raise ValueError("Spacing leaves no room for windows")
+    base, remainder = divmod(available, count)
+    output: list[tuple[int, int]] = []
+    position = origin
+    for index in range(count):
+        size = base + (index < remainder)
+        output.append((position, size))
+        position += size + spacing
+    return output
+
+
+def window_layout_rects(
+    bounds: QtCore.QRect,
+    count: int,
+    mode: _LayoutMode,
+    primary_count: int,
+    spacing: int,
+    reverse: bool,
+) -> list[QtCore.QRect]:
+    """Return equal-cell outer-frame rectangles in traversal order."""
+    if count < 1:
+        raise ValueError("Window count must be positive")
+    if primary_count < 1:
+        raise ValueError("Primary layout count must be positive")
+    if spacing < 0:
+        raise ValueError("Window spacing cannot be negative")
+    if mode == "grid_row":
+        columns = min(count, primary_count)
+        rows = math.ceil(count / columns)
+    elif mode == "grid_column":
+        rows = min(count, primary_count)
+        columns = math.ceil(count / rows)
+    elif mode == "row":
+        rows, columns = 1, count
+    else:
+        rows, columns = count, 1
+
+    x_parts = _partition_axis(bounds.x(), bounds.width(), columns, spacing)
+    y_parts = _partition_axis(bounds.y(), bounds.height(), rows, spacing)
+    output: list[QtCore.QRect] = []
+    for index in range(count):
+        if mode in {"grid_row", "row"}:
+            row, column = divmod(index, columns)
+        else:
+            column, row = divmod(index, rows)
+        if reverse:
+            column = columns - 1 - column
+        x, width = x_parts[column]
+        y, height = y_parts[row]
+        output.append(QtCore.QRect(x, y, width, height))
+    return output
+
+
+def _layout_icon(
+    widget: QtWidgets.QWidget,
+    mode: _LayoutMode,
+    *,
+    reverse: bool = False,
+) -> QtGui.QIcon:
+    logical_size = QtCore.QSize(32, 28)
+    ratio = max(1.0, widget.devicePixelRatioF())
+    pixmap = QtGui.QPixmap(
+        round(logical_size.width() * ratio), round(logical_size.height() * ratio)
+    )
+    pixmap.setDevicePixelRatio(ratio)
+    pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+    painter = QtGui.QPainter(pixmap)
+    try:
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+        if reverse and mode != "column":
+            painter.translate(logical_size.width(), 0)
+            painter.scale(-1, 1)
+        color = widget.palette().color(QtGui.QPalette.ColorRole.ButtonText)
+        painter.setBrush(color)
+        if mode == "grid_row":
+            painter.translate(3.5, 1)
+        elif mode == "grid_column":
+            painter.translate(3, 1)
+        elif mode == "row":
+            painter.translate(3, 0)
+        else:
+            painter.translate(0, 2)
+        painter.setPen(
+            QtGui.QPen(
+                color,
+                2.0,
+                QtCore.Qt.PenStyle.SolidLine,
+                QtCore.Qt.PenCapStyle.FlatCap,
+                QtCore.Qt.PenJoinStyle.MiterJoin,
+            )
+        )
+        if mode == "grid_row":
+            painter.drawPolyline(
+                QtGui.QPolygonF(
+                    [
+                        QtCore.QPointF(5.5, 5.5),
+                        QtCore.QPointF(20.5, 5.5),
+                        QtCore.QPointF(5.5, 20.5),
+                        QtCore.QPointF(16, 20.5),
+                    ]
+                )
+            )
+        elif mode == "grid_column":
+            painter.drawPolyline(
+                QtGui.QPolygonF(
+                    [
+                        QtCore.QPointF(5.5, 5.5),
+                        QtCore.QPointF(5.5, 20.5),
+                        QtCore.QPointF(20.5, 5.5),
+                        QtCore.QPointF(20.5, 18),
+                    ]
+                )
+            )
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
+
+        if mode == "grid_row":
+            for rectangle in (
+                QtCore.QRectF(2, 2, 7, 7),
+                QtCore.QRectF(17, 2, 7, 7),
+                QtCore.QRectF(2, 17, 7, 7),
+            ):
+                painter.drawRoundedRect(rectangle, 1, 1)
+            painter.drawPolygon(
+                QtGui.QPolygonF(
+                    [
+                        QtCore.QPointF(24, 20.5),
+                        QtCore.QPointF(16, 14.5),
+                        QtCore.QPointF(16, 26.5),
+                    ]
+                )
+            )
+        elif mode == "grid_column":
+            for rectangle in (
+                QtCore.QRectF(2, 2, 7, 7),
+                QtCore.QRectF(2, 17, 7, 7),
+                QtCore.QRectF(17, 2, 7, 7),
+            ):
+                painter.drawRoundedRect(rectangle, 1, 1)
+            painter.drawPolygon(
+                QtGui.QPolygonF(
+                    [
+                        QtCore.QPointF(20.5, 25),
+                        QtCore.QPointF(14, 18),
+                        QtCore.QPointF(27, 18),
+                    ]
+                )
+            )
+        elif mode == "row":
+            painter.drawRect(QtCore.QRectF(6, 13, 13, 2))
+            painter.drawPolygon(
+                QtGui.QPolygonF(
+                    [
+                        QtCore.QPointF(27, 14),
+                        QtCore.QPointF(19, 8),
+                        QtCore.QPointF(19, 20),
+                    ]
+                )
+            )
+            painter.drawRoundedRect(QtCore.QRectF(2, 10, 8, 8), 1, 1)
+        else:
+            painter.drawRect(QtCore.QRectF(15, 5, 2, 12.5))
+            painter.drawPolygon(
+                QtGui.QPolygonF(
+                    [
+                        QtCore.QPointF(16, 26),
+                        QtCore.QPointF(10, 17.5),
+                        QtCore.QPointF(22, 17.5),
+                    ]
+                )
+            )
+            painter.drawRoundedRect(QtCore.QRectF(12, 1, 8, 8), 1, 1)
+    finally:
+        painter.end()
+    return QtGui.QIcon(pixmap)
+
+
+def _direction_icon(widget: QtWidgets.QWidget, *, reverse: bool) -> QtGui.QIcon:
+    size = QtCore.QSize(18, 18)
+    ratio = max(1.0, widget.devicePixelRatioF())
+    pixmap = QtGui.QPixmap(round(size.width() * ratio), round(size.height() * ratio))
+    pixmap.setDevicePixelRatio(ratio)
+    pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+    painter = QtGui.QPainter(pixmap)
+    try:
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+        color = widget.palette().color(QtGui.QPalette.ColorRole.ButtonText)
+        painter.translate(0.75 if reverse else -0.75, 0)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
+        painter.setBrush(color)
+        if reverse:
+            painter.drawRect(QtCore.QRectF(6, 7.5, 9, 3))
+            painter.drawPolygon(
+                QtGui.QPolygonF(
+                    [
+                        QtCore.QPointF(2, 9),
+                        QtCore.QPointF(7, 4.5),
+                        QtCore.QPointF(7, 13.5),
+                    ]
+                )
+            )
+        else:
+            painter.drawRect(QtCore.QRectF(3, 7.5, 9, 3))
+            painter.drawPolygon(
+                QtGui.QPolygonF(
+                    [
+                        QtCore.QPointF(16, 9),
+                        QtCore.QPointF(11, 4.5),
+                        QtCore.QPointF(11, 13.5),
+                    ]
+                )
+            )
+    finally:
+        painter.end()
+    return QtGui.QIcon(pixmap)
+
+
+class _WindowLayoutDialog(QtWidgets.QDialog):
+    """Illustrator-inspired controls for arranging selected windows."""
+
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Arrange Selected Windows")
+        self.setModal(True)
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, False)
+        self._count_initialized = False
+
+        main_layout = QtWidgets.QVBoxLayout(self)
+        options = QtWidgets.QFormLayout()
+        options.setLabelAlignment(
+            QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
+        )
+        layout_widget = QtWidgets.QWidget(self)
+        layout_row = QtWidgets.QHBoxLayout(layout_widget)
+        layout_row.setContentsMargins(0, 0, 0, 0)
+        layout_row.setSpacing(4)
+        self.layout_group = QtWidgets.QButtonGroup(self)
+        self.layout_group.setExclusive(True)
+        self.layout_buttons: dict[_LayoutMode, QtWidgets.QToolButton] = {}
+        for mode, label in _LAYOUT_LABELS.items():
+            button = QtWidgets.QToolButton(layout_widget)
+            button.setObjectName(f"manager_window_layout_{mode}_button")
+            button.setProperty("layoutMode", mode)
+            button.setCheckable(True)
+            button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly)
+            button.setIconSize(QtCore.QSize(24, 22))
+            button.setFixedSize(32, 32)
+            button.setAccessibleName(label)
+            button.setToolTip(f"Arrange selected windows using {label.lower()}.")
+            self.layout_group.addButton(button)
+            self.layout_buttons[mode] = button
+            layout_row.addWidget(button)
+        layout_row.addStretch()
+        options.addRow("Layout", layout_widget)
+        self.layout_buttons["grid_row"].setChecked(True)
+        self.layout_group.buttonToggled.connect(self._layout_changed)
+
+        direction_widget = QtWidgets.QWidget(self)
+        direction_layout = QtWidgets.QHBoxLayout(direction_widget)
+        direction_layout.setContentsMargins(0, 0, 0, 0)
+        direction_layout.setSpacing(4)
+        self.direction_group = QtWidgets.QButtonGroup(self)
+        self.direction_group.setExclusive(True)
+        self.direction_buttons: dict[bool, QtWidgets.QToolButton] = {}
+        for reverse in (False, True):
+            label = "Right to Left" if reverse else "Left to Right"
+            button = QtWidgets.QToolButton(direction_widget)
+            button.setObjectName(
+                "manager_window_layout_reverse_button"
+                if reverse
+                else "manager_window_layout_forward_button"
+            )
+            button.setProperty("layoutReverse", reverse)
+            button.setCheckable(True)
+            button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly)
+            button.setIconSize(QtCore.QSize(18, 18))
+            button.setFixedSize(32, 32)
+            button.setAccessibleName(label)
+            button.setToolTip(f"Arrange selected windows {label.lower()}.")
+            button.setIcon(_direction_icon(self, reverse=reverse))
+            self.direction_group.addButton(button)
+            self.direction_buttons[reverse] = button
+            direction_layout.addWidget(button)
+        direction_layout.addStretch()
+        self.direction_buttons[False].setChecked(True)
+        self.direction_group.buttonToggled.connect(self._order_changed)
+        options.addRow("Layout order", direction_widget)
+
+        self.primary_count_spin = QtWidgets.QSpinBox(self)
+        self.primary_count_spin.setObjectName("manager_window_layout_primary_count")
+        self.primary_count_spin.setRange(1, 2)
+        self.primary_count_spin.setValue(2)
+        self.primary_count_spin.setMaximumWidth(100)
+        self.primary_count_label = QtWidgets.QLabel("Columns", self)
+        options.addRow(self.primary_count_label, self.primary_count_spin)
+
+        self.spacing_spin = QtWidgets.QSpinBox(self)
+        self.spacing_spin.setObjectName("manager_window_layout_spacing")
+        self.spacing_spin.setRange(0, 256)
+        self.spacing_spin.setValue(0)
+        self.spacing_spin.setSuffix(" px")
+        self.spacing_spin.setMaximumWidth(100)
+        options.addRow("Spacing", self.spacing_spin)
+        main_layout.addLayout(options)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            parent=self,
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        main_layout.addWidget(self.button_box)
+        self._refresh_layout_icons()
+        self._layout_changed()
+
+    @property
+    def layout_mode(self) -> _LayoutMode:
+        button = self.layout_group.checkedButton()
+        if button is None:  # pragma: no cover
+            return "grid_row"
+        return typing.cast("_LayoutMode", button.property("layoutMode"))
+
+    @property
+    def reverse_order(self) -> bool:
+        button = self.direction_group.checkedButton()
+        return bool(button is not None and button.property("layoutReverse"))
+
+    @property
+    def primary_count(self) -> int:
+        return self.primary_count_spin.value()
+
+    @property
+    def spacing(self) -> int:
+        return self.spacing_spin.value()
+
+    def set_window_count(self, count: int) -> None:
+        count = max(2, count)
+        self.primary_count_spin.setMaximum(count)
+        if not self._count_initialized:
+            self.primary_count_spin.setValue(math.ceil(math.sqrt(count)))
+            self._count_initialized = True
+        elif self.primary_count_spin.value() > count:
+            self.primary_count_spin.setValue(count)
+
+    @QtCore.Slot()
+    @QtCore.Slot(QtWidgets.QAbstractButton, bool)
+    def _layout_changed(
+        self,
+        _button: QtWidgets.QAbstractButton | None = None,
+        checked: bool = True,
+    ) -> None:
+        if not checked:
+            return
+        mode = self.layout_mode
+        single_axis = mode in {"row", "column"}
+        self.primary_count_label.setText("Rows" if mode == "grid_column" else "Columns")
+        self.primary_count_label.setEnabled(not single_axis)
+        self.primary_count_spin.setEnabled(not single_axis)
+
+    @QtCore.Slot(QtWidgets.QAbstractButton, bool)
+    def _order_changed(self, _button: QtWidgets.QAbstractButton, checked: bool) -> None:
+        if checked:
+            self._refresh_layout_icons()
+
+    def _refresh_layout_icons(self) -> None:
+        for mode, button in self.layout_buttons.items():
+            button.setIcon(_layout_icon(self, mode, reverse=self.reverse_order))
+
+    def changeEvent(self, event: QtCore.QEvent | None) -> None:
+        super().changeEvent(event)
+        if event is not None and event.type() in {
+            QtCore.QEvent.Type.PaletteChange,
+            QtCore.QEvent.Type.StyleChange,
+        }:
+            self._refresh_layout_icons()
+            for reverse, button in self.direction_buttons.items():
+                button.setIcon(_direction_icon(self, reverse=reverse))
+
+
+def frame_margins(window: QtWidgets.QWidget) -> QtCore.QMargins:
+    """Return the current native frame margins around a top-level widget."""
+    frame = window.frameGeometry()
+    client = window.geometry()
+    return QtCore.QMargins(
+        client.left() - frame.left(),
+        client.top() - frame.top(),
+        frame.right() - client.right(),
+        frame.bottom() - client.bottom(),
+    )
+
+
+def frame_rects_fit_windows(
+    windows: Sequence[QtWidgets.QWidget], frame_rects: Sequence[QtCore.QRect]
+) -> bool:
+    """Return whether each frame cell can contain its window's minimum size."""
+    for window, rectangle in zip(windows, frame_rects, strict=True):
+        minimum = window.minimumSize()
+        margins = frame_margins(window)
+        if (
+            rectangle.width() < minimum.width() + margins.left() + margins.right()
+            or rectangle.height() < minimum.height() + margins.top() + margins.bottom()
+        ):
+            return False
+    return True

--- a/src/erlab/interactive/imagetool/manager/_window_layout.py
+++ b/src/erlab/interactive/imagetool/manager/_window_layout.py
@@ -290,7 +290,7 @@ class _WindowLayoutDialog(QtWidgets.QDialog):
         self.direction_group = QtWidgets.QButtonGroup(self)
         self.direction_group.setExclusive(True)
         self.direction_buttons: dict[bool, QtWidgets.QToolButton] = {}
-        for reverse in (False, True):
+        for reverse in (True, False):
             label = "Right to Left" if reverse else "Left to Right"
             button = QtWidgets.QToolButton(direction_widget)
             button.setObjectName(

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -181,7 +181,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """Canonical replay provenance for the current ImageTool data."""
         return typing.cast(
             "ToolProvenanceSpec | None",
-            getattr(self.parent(), "provenance_spec", None),
+            getattr(self.window(), "provenance_spec", None),
         )
 
     @property
@@ -681,9 +681,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     @property
     def parent_title(self) -> str:
-        parent = self.parent()
-        if isinstance(parent, QtWidgets.QWidget):  # pragma: no branch
-            return parent.windowTitle()
+        window = self.window()
+        if isinstance(window, QtWidgets.QWidget):  # pragma: no branch
+            return window.windowTitle()
         return ""
 
     @property
@@ -727,9 +727,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     @property
     def controls_visible(self) -> bool:
-        parent = self.parent()
-        if hasattr(parent, "controls_visible"):
-            return bool(typing.cast("typing.Any", parent).controls_visible)
+        window = self.window()
+        if hasattr(window, "controls_visible"):
+            return bool(typing.cast("typing.Any", window).controls_visible)
         return True
 
     @property
@@ -783,9 +783,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
     ) -> None:
         logger.debug("Restoring state...")
         with self._workspace_load_stage("imagetool state restore: layout"):
-            parent = self.parent()
-            if hasattr(parent, "_set_controls_visible"):
-                typing.cast("typing.Any", parent)._set_controls_visible(
+            window = self.window()
+            if hasattr(window, "_set_controls_visible"):
+                typing.cast("typing.Any", window)._set_controls_visible(
                     bool(state.get("controls_visible", True))
                 )
 
@@ -2307,13 +2307,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.levels = cached_levels
 
         self.flush_history()
-        parent = self.parent()
+        window = self.window()
         if (
             self._file_path is not None
-            and hasattr(parent, "_sync_file_load_provenance")
-            and hasattr(parent, "_slicer_area")
+            and hasattr(window, "_sync_file_load_provenance")
+            and hasattr(window, "_slicer_area")
         ):
-            typing.cast("typing.Any", parent)._sync_file_load_provenance()
+            typing.cast("typing.Any", window)._sync_file_load_provenance()
         if source_replaced:
             self.sigSourceDataChanged.emit()
             self.sigSourceDataReplaced.emit(self._tool_source_parent_data())

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -43,6 +43,7 @@ from qtpy import PYQT6, PYSIDE6, QtCore, QtGui, QtWidgets, uic
 
 import erlab
 from erlab.interactive import _qt_state
+from erlab.interactive._widgets import _Separator
 from erlab.utils._code import (
     _parse_single_arg,
     format_1d_numeric_array_code,
@@ -797,9 +798,7 @@ class MessageDialog(QtWidgets.QDialog):
         self._details = QtWidgets.QPlainTextEdit()
         self._details.setReadOnly(True)
 
-        _hline = QtWidgets.QFrame()
-        _hline.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-        _hline.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+        _hline = _Separator()
 
         self._details_container = QtWidgets.QWidget()
 

--- a/tests/interactive/imagetool/manager/figurecomposer/_common.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/_common.py
@@ -35,6 +35,7 @@ from erlab.interactive._figurecomposer._ui import (
 )
 from erlab.interactive._options import options
 from erlab.interactive._options.schema import FigureOptions
+from erlab.interactive._widgets import _Separator
 from erlab.interactive.imagetool._provenance._graph import (
     ReplayGraphError,
     compile_replay_graph,
@@ -395,10 +396,9 @@ def _assert_step_editor_section(
     assert label is not None
     assert label.font().bold()
 
-    line = section.findChild(QtWidgets.QFrame, f"{object_name}Line")
+    line = section.findChild(_Separator, f"{object_name}Line")
     assert line is not None
-    assert line.frameShape() == QtWidgets.QFrame.Shape.HLine
-    assert line.frameShadow() == QtWidgets.QFrame.Shadow.Sunken
+    assert line.orientation == QtCore.Qt.Orientation.Horizontal
     return section
 
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -65,6 +65,7 @@ from erlab.interactive._figurecomposer._ui import (
     _toolbar_dialogs as figurecomposer_toolbar_dialogs,
 )
 from erlab.interactive._options import options
+from erlab.interactive._widgets import _Separator
 from erlab.interactive.imagetool._provenance._code import (
     _SCRIPT_REPLAY_ALLOWED_BUILTINS,
 )
@@ -2094,8 +2095,8 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         QtWidgets.QWidget, "figureComposerGridSpecEditorContainer"
     )
     assert gridspec_container is tool.layout_panel.gridspec_editor_container
-    assert tool.findChild(QtWidgets.QFrame, "figureComposerGridSpecEditorTopLine")
-    assert tool.findChild(QtWidgets.QFrame, "figureComposerGridSpecEditorBottomLine")
+    assert tool.findChild(_Separator, "figureComposerGridSpecEditorTopLine")
+    assert tool.findChild(_Separator, "figureComposerGridSpecEditorBottomLine")
     assert layout_grid.getItemPosition(layout_grid.indexOf(gridspec_container)) == (
         2,
         0,

--- a/tests/interactive/imagetool/manager/test_dialogs.py
+++ b/tests/interactive/imagetool/manager/test_dialogs.py
@@ -172,6 +172,9 @@ def test_window_layout_dialog_uses_semantic_icon_controls(qtbot) -> None:
             *dialog.direction_buttons.values(),
         )
     } == {4}
+    direction_layout = dialog.direction_buttons[True].parentWidget().layout()
+    assert direction_layout.indexOf(dialog.direction_buttons[True]) == 0
+    assert direction_layout.indexOf(dialog.direction_buttons[False]) == 1
     assert dialog.layout().itemAt(0).layout().labelAlignment() == (
         QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
     )

--- a/tests/interactive/imagetool/manager/test_dialogs.py
+++ b/tests/interactive/imagetool/manager/test_dialogs.py
@@ -4,10 +4,11 @@ import typing
 
 import pytest
 import xarray as xr
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
+import erlab.interactive.imagetool.manager._window_layout as window_layout
 from erlab.interactive.imagetool._load_source import (
     _load_code_from_file_details,
     _resolve_identified_path,
@@ -21,6 +22,218 @@ from erlab.interactive.imagetool.manager._dialogs import (
     _NameMapEditorDialog,
     _text_to_loader_extension_value,
 )
+
+
+@pytest.mark.parametrize(
+    ("mode", "primary_count", "reverse", "expected_positions"),
+    [
+        (
+            "grid_row",
+            3,
+            False,
+            [(-100, 20), (-66, 20), (-32, 20), (-100, 51), (-66, 51)],
+        ),
+        (
+            "grid_row",
+            3,
+            True,
+            [(-32, 20), (-66, 20), (-100, 20), (-32, 51), (-66, 51)],
+        ),
+        (
+            "grid_column",
+            2,
+            False,
+            [(-100, 20), (-100, 51), (-66, 20), (-66, 51), (-32, 20)],
+        ),
+        (
+            "grid_column",
+            2,
+            True,
+            [(-32, 20), (-32, 51), (-66, 20), (-66, 51), (-100, 20)],
+        ),
+        (
+            "row",
+            2,
+            False,
+            [(-100, 20), (-79, 20), (-58, 20), (-38, 20), (-18, 20)],
+        ),
+        (
+            "column",
+            2,
+            True,
+            [(-100, 20), (-100, 33), (-100, 46), (-100, 58), (-100, 70)],
+        ),
+    ],
+)
+def test_window_layout_rects_follow_visual_order(
+    mode,
+    primary_count: int,
+    reverse: bool,
+    expected_positions: list[tuple[int, int]],
+) -> None:
+    rects = window_layout.window_layout_rects(
+        QtCore.QRect(-100, 20, 101, 61),
+        5,
+        mode,
+        primary_count,
+        1,
+        reverse,
+    )
+
+    assert [(rect.x(), rect.y()) for rect in rects] == expected_positions
+    assert all(rect.width() > 0 and rect.height() > 0 for rect in rects)
+
+
+def test_window_layout_rects_reject_impossible_spacing() -> None:
+    with pytest.raises(ValueError, match="Spacing"):
+        window_layout.window_layout_rects(
+            QtCore.QRect(0, 0, 10, 10), 3, "row", 1, 5, False
+        )
+    with pytest.raises(ValueError, match="positive"):
+        window_layout.window_layout_rects(
+            QtCore.QRect(0, 0, 10, 10), 0, "row", 1, 0, False
+        )
+    with pytest.raises(ValueError, match="positive"):
+        window_layout.window_layout_rects(
+            QtCore.QRect(0, 0, 10, 10), 2, "row", 0, 0, False
+        )
+    with pytest.raises(ValueError, match="negative"):
+        window_layout.window_layout_rects(
+            QtCore.QRect(0, 0, 10, 10), 2, "row", 1, -1, False
+        )
+
+
+def test_window_layout_minimum_size_validation(qtbot) -> None:
+    window = QtWidgets.QWidget()
+    qtbot.addWidget(window)
+    window.setMinimumSize(100, 80)
+
+    assert not window_layout.frame_rects_fit_windows(
+        [window], [QtCore.QRect(0, 0, 99, 80)]
+    )
+    assert window_layout.frame_rects_fit_windows(
+        [window], [QtCore.QRect(0, 0, 100, 80)]
+    )
+
+
+def test_window_layout_dialog_uses_semantic_icon_controls(qtbot) -> None:
+    def icon_image(button: QtWidgets.QToolButton) -> QtGui.QImage:
+        return (
+            button.icon()
+            .pixmap(button.iconSize())
+            .toImage()
+            .convertToFormat(QtGui.QImage.Format.Format_RGBA8888)
+        )
+
+    def alpha_centroid(button: QtWidgets.QToolButton) -> tuple[float, float]:
+        image = icon_image(button)
+        total_alpha = weighted_x = weighted_y = 0
+        for y in range(image.height()):
+            for x in range(image.width()):
+                alpha = image.pixelColor(x, y).alpha()
+                total_alpha += alpha
+                weighted_x += x * alpha
+                weighted_y += y * alpha
+        return weighted_x / total_alpha, weighted_y / total_alpha
+
+    def max_channel_delta(first: QtGui.QImage, second: QtGui.QImage) -> int:
+        return max(
+            abs(
+                first.pixelColor(x, y).getRgb()[channel]
+                - second.pixelColor(x, y).getRgb()[channel]
+            )
+            for y in range(first.height())
+            for x in range(first.width())
+            for channel in range(4)
+        )
+
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    dialog = window_layout._WindowLayoutDialog(parent)
+    qtbot.addWidget(dialog)
+    dialog.set_window_count(7)
+
+    assert dialog.primary_count == 3
+    assert dialog.spacing == 0
+    assert all(not button.icon().isNull() for button in dialog.layout_buttons.values())
+    assert all(button.accessibleName() for button in dialog.layout_buttons.values())
+    assert all(
+        button.toolButtonStyle() == QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly
+        and button.size() == QtCore.QSize(32, 32)
+        for button in (
+            *dialog.layout_buttons.values(),
+            *dialog.direction_buttons.values(),
+        )
+    )
+    assert {
+        button.parentWidget().layout().spacing()
+        for button in (
+            *dialog.layout_buttons.values(),
+            *dialog.direction_buttons.values(),
+        )
+    } == {4}
+    assert dialog.layout().itemAt(0).layout().labelAlignment() == (
+        QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
+    )
+    assert all(
+        button.property("layoutMode") == mode
+        for mode, button in dialog.layout_buttons.items()
+    )
+    for button in dialog.layout_buttons.values():
+        image = icon_image(button)
+        centroid = alpha_centroid(button)
+        assert centroid[0] == pytest.approx((image.width() - 1) / 2, abs=0.2)
+        assert centroid[1] == pytest.approx((image.height() - 1) / 2, abs=0.2)
+
+    dialog.layout_buttons["grid_column"].click()
+    assert dialog.layout_mode == "grid_column"
+    assert dialog.primary_count_spin.isEnabled()
+    assert all(
+        not button.icon().isNull() for button in dialog.direction_buttons.values()
+    )
+    assert all(button.accessibleName() for button in dialog.direction_buttons.values())
+    for button in dialog.direction_buttons.values():
+        image = icon_image(button)
+        centroid = alpha_centroid(button)
+        assert centroid[0] == pytest.approx((image.width() - 1) / 2, abs=0.2)
+        assert centroid[1] == pytest.approx((image.height() - 1) / 2, abs=0.2)
+
+    forward_icons = {
+        mode: icon_image(button) for mode, button in dialog.layout_buttons.items()
+    }
+    dialog.direction_buttons[True].click()
+    for mode, button in dialog.layout_buttons.items():
+        expected = (
+            forward_icons[mode]
+            if mode == "column"
+            else forward_icons[mode].flipped(QtCore.Qt.Orientation.Horizontal)
+        )
+        assert max_channel_delta(icon_image(button), expected) <= 2
+        image = icon_image(button)
+        centroid = alpha_centroid(button)
+        assert centroid[0] == pytest.approx((image.width() - 1) / 2, abs=0.2)
+        assert centroid[1] == pytest.approx((image.height() - 1) / 2, abs=0.2)
+    dialog.direction_buttons[False].click()
+
+    dialog.layout_buttons["column"].click()
+    assert dialog.layout_mode == "column"
+    assert not dialog.primary_count_spin.isEnabled()
+    dialog.direction_buttons[True].click()
+    assert dialog.reverse_order
+    dialog.primary_count_spin.setValue(7)
+    dialog.set_window_count(4)
+    assert dialog.primary_count == 4
+
+    old_keys = {
+        mode: button.icon().cacheKey() for mode, button in dialog.layout_buttons.items()
+    }
+    palette = dialog.palette()
+    palette.setColor(QtGui.QPalette.ColorRole.Highlight, QtGui.QColor("#ff00aa"))
+    dialog.setPalette(palette)
+    assert any(
+        button.icon().cacheKey() != old_keys[mode]
+        for mode, button in dialog.layout_buttons.items()
+    )
 
 
 def test_load_code_from_file_details_uses_erlab_io_loader_syntax(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -457,6 +457,7 @@ def test_arrange_selected_windows_preserves_geometry_when_layout_does_not_fit(
 def test_arrange_selected_windows_rolls_back_geometry_on_error(
     qtbot,
     monkeypatch,
+    caplog: pytest.LogCaptureFixture,
     test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -490,20 +491,36 @@ def test_arrange_selected_windows_rolls_back_geometry_on_error(
         uids = [manager.add_childtool(window, 0) for window in windows]
         for uid in uids:
             select_child_tool(manager, uid)
-        windows[0].hide()
+        windows[0].setGeometry(80, 90, 320, 240)
+        windows[0].showMaximized()
+        windows[1].hide()
+        qtbot.wait_until(
+            lambda: windows[0].isMaximized() and not windows[1].isVisible()
+        )
+        normal_geometry = windows[0].normalGeometry()
+        assert normal_geometry.isValid()
         original = [
             (window.isVisible(), window.windowState(), window.geometry())
             for window in windows
         ]
 
+        caplog.clear()
         manager.arrange_selected_windows()
         manager._actions_controller._window_layout_dialog.accept()
 
         assert errors
+        error_record = next(
+            record
+            for record in caplog.records
+            if record.getMessage() == "Error while arranging selected windows"
+        )
+        assert error_record.suppress_ui_alert
         assert [
             (window.isVisible(), window.windowState(), window.geometry())
             for window in windows
         ] == original
+        windows[0].showNormal()
+        qtbot.wait_until(lambda: windows[0].geometry() == normal_geometry)
 
 
 def test_reveal_nodes_restores_minimized_manager(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -15,12 +15,14 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._acquisition_context as acquisition_context
+import erlab.interactive.imagetool.manager._actions as manager_actions
 import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
 import erlab.interactive.imagetool.manager._io as manager_io
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._metadata_editor as metadata_editor
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
+import erlab.interactive.imagetool.manager._window_layout as window_layout
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.utils
 from erlab.interactive._figurecomposer import (
@@ -285,6 +287,9 @@ def test_managed_window_actions_reveal_tree_and_figure_rows(
         child_uid = manager.add_childtool(child_tool, 0, show=False)
         figure_tool = FigureComposerTool(test_data)
         figure_uid = manager.add_figuretool(figure_tool, show=False)
+        second_figure_uid = manager.add_figuretool(
+            FigureComposerTool(test_data + 1), show=False
+        )
 
         root_menu = typing.cast(
             "erlab.interactive.imagetool._mainwindow.ItoolMenuBar",
@@ -309,6 +314,7 @@ def test_managed_window_actions_reveal_tree_and_figure_rows(
         assert manager.reveal_nodes((child_uid, second_uid, child_uid, "missing"))
         assert manager.tree_view.selected_imagetool_indices == [1]
         assert manager.tree_view.selected_childtool_uids == [child_uid]
+        assert manager._selected_layout_uids() == [child_uid, second_uid]
         assert not manager.reveal_nodes(("missing",))
 
         figure_tool.reveal_in_manager_action.trigger()
@@ -320,7 +326,24 @@ def test_managed_window_actions_reveal_tree_and_figure_rows(
             for item in figure_pane.list_widget.selectedItems()
         }
         assert selected_figure_uids == {figure_uid}
+        assert manager._selected_layout_uids() == [figure_uid]
         assert not manager.tree_view.selectedIndexes()
+
+        figure_pane.list_widget.clearSelection()
+        first_figure_item = manager._figure_collection.item_for_uid(figure_uid)
+        second_figure_item = manager._figure_collection.item_for_uid(second_figure_uid)
+        assert first_figure_item is not None
+        assert second_figure_item is not None
+        first_figure_item.setSelected(True)
+        second_figure_item.setSelected(True)
+        manager._figure_collection._selection_changed()
+        assert manager._selected_layout_uids() == [figure_uid, second_figure_uid]
+        assert manager.arrange_windows_action.isEnabled()
+        manager._figure_collection._show_menu(QtCore.QPoint())
+        figure_menu = manager._figure_collection._menu
+        assert figure_menu is not None
+        assert manager.arrange_windows_action in figure_menu.actions()
+        manager._figure_collection.close_menu()
 
         child_node = manager._child_node(child_uid)
         manager_ref = child_node._manager
@@ -330,6 +353,157 @@ def test_managed_window_actions_reveal_tree_and_figure_rows(
         manager._remove_childtool(child_uid)
         assert not child_node.reveal_in_manager()
         assert not child_tool.reveal_in_manager_action.isVisible()
+
+
+def test_arrange_selected_windows_accepts_and_cancels(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, test_data)
+        first = erlab.interactive.utils.ToolWindow()
+        second = erlab.interactive.utils.ToolWindow()
+        first_uid = manager.add_childtool(first, 0)
+        second_uid = manager.add_childtool(second, 0)
+        select_child_tool(manager, first_uid)
+        select_child_tool(manager, second_uid)
+        manager._update_actions()
+
+        first.hide()
+        second.showMinimized()
+        qtbot.wait_until(lambda: not first.isVisible() and second.isMinimized())
+        original = [
+            (window.isVisible(), window.windowState(), window.geometry())
+            for window in (first, second)
+        ]
+
+        assert manager.arrange_windows_action.isEnabled()
+        assert manager.arrange_windows_action in manager.view_menu.actions()
+        assert manager.arrange_windows_action in manager.tree_view._menu.actions()
+        manager.arrange_windows_action.trigger()
+        dialog = manager._actions_controller._window_layout_dialog
+        qtbot.wait_until(dialog.isVisible)
+        dialog.reject()
+        assert [
+            (window.isVisible(), window.windowState(), window.geometry())
+            for window in (first, second)
+        ] == original
+
+        manager.arrange_windows_action.trigger()
+        qtbot.wait_until(dialog.isVisible)
+        dialog.layout_buttons["grid_row"].click()
+        dialog.primary_count_spin.setValue(2)
+        dialog.spacing_spin.setValue(12)
+        dialog.accept()
+
+        expected = window_layout.window_layout_rects(
+            manager.screen().availableGeometry(), 2, "grid_row", 2, 12, False
+        )
+        qtbot.wait_until(
+            lambda: all(
+                window.isVisible() and not window.isMinimized()
+                for window in (first, second)
+            )
+        )
+        assert [first.frameGeometry(), second.frameGeometry()] == expected
+        qtbot.wait_until(
+            lambda: all(
+                manager._child_node(uid)._recent_geometry == window.geometry()
+                for uid, window in zip(
+                    (first_uid, second_uid), (first, second), strict=True
+                )
+            )
+        )
+
+
+def test_arrange_selected_windows_preserves_geometry_when_layout_does_not_fit(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    warnings: list[tuple[object, ...]] = []
+    monkeypatch.setattr(manager_actions, "frame_rects_fit_windows", lambda *_: False)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda *args, **_kwargs: warnings.append(args),
+    )
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, test_data)
+        windows = [
+            erlab.interactive.utils.ToolWindow(),
+            erlab.interactive.utils.ToolWindow(),
+        ]
+        for window in windows:
+            uid = manager.add_childtool(window, 0)
+            select_child_tool(manager, uid)
+        original = [window.geometry() for window in windows]
+
+        manager.arrange_selected_windows()
+        manager._actions_controller._window_layout_dialog.accept()
+
+        assert warnings
+        assert [window.geometry() for window in windows] == original
+
+
+def test_arrange_selected_windows_rolls_back_geometry_on_error(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    errors: list[tuple[object, ...]] = []
+    monkeypatch.setattr(manager_actions, "frame_rects_fit_windows", lambda *_: True)
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        lambda *args, **_kwargs: errors.append(args),
+    )
+    original_frame_margins = manager_actions.frame_margins
+    calls = 0
+
+    def fail_second_window(window):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ValueError("synthetic geometry failure")
+        return original_frame_margins(window)
+
+    monkeypatch.setattr(manager_actions, "frame_margins", fail_second_window)
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, test_data)
+        windows = [
+            erlab.interactive.utils.ToolWindow(),
+            erlab.interactive.utils.ToolWindow(),
+        ]
+        uids = [manager.add_childtool(window, 0) for window in windows]
+        for uid in uids:
+            select_child_tool(manager, uid)
+        windows[0].hide()
+        original = [
+            (window.isVisible(), window.windowState(), window.geometry())
+            for window in windows
+        ]
+
+        manager.arrange_selected_windows()
+        manager._actions_controller._window_layout_dialog.accept()
+
+        assert errors
+        assert [
+            (window.isVisible(), window.windowState(), window.geometry())
+            for window in windows
+        ] == original
 
 
 def test_reveal_nodes_restores_minimized_manager(

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -33,7 +33,6 @@ from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._provenance._model import full_data
 from erlab.interactive.imagetool._provenance._operations import GaussianFilterOperation
-from erlab.interactive.imagetool.controls import ItoolColormapControls
 from erlab.interactive.imagetool.manager import ImageToolManager, fetch, replace_data
 from erlab.interactive.imagetool.manager._dialogs import (
     _ChooseFromDataTreeDialog,
@@ -548,10 +547,7 @@ def test_manager_link_action_links_colors(
         assert proxy is not None
         assert proxy.link_colors is True
 
-        control = (
-            manager.get_imagetool(0).docks[1].widget().findChild(ItoolColormapControls)
-        )
-        assert control is not None
+        control = manager.get_imagetool(0).colormap_controls
         control._set_gamma(1.5)
         assert manager.get_imagetool(1).slicer_area.colormap_properties[
             "gamma"

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -11,11 +11,6 @@ from qtpy import QtCore, QtWidgets
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 import erlab.interactive.utils
 from erlab.interactive.imagetool import ImageTool, _history
-from erlab.interactive.imagetool.controls import (
-    ItoolBinningControls,
-    ItoolColormapControls,
-    ItoolCrosshairControls,
-)
 
 
 def _base_state() -> dict:
@@ -545,8 +540,7 @@ def test_history_group_coalesces_cursor_spinbox_steps(qtbot):
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
     win = ImageTool(data)
     qtbot.addWidget(win)
-    control = win.docks[0].widget().findChild(ItoolCrosshairControls)
-    assert control is not None
+    control = win.cursor_controls
     control.update_content()
     area = win.slicer_area
     start_index = area.current_indices[0]
@@ -565,8 +559,7 @@ def test_controls_history_grouping_skips_nested_controls_and_disconnects(qtbot) 
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
     win = ImageTool(data)
     qtbot.addWidget(win)
-    control = win.docks[1].widget().findChild(ItoolColormapControls)
-    assert control is not None
+    control = win.colormap_controls
     nested_spin = erlab.interactive.utils.BetterSpinBox(control.misc_controls)
     qtbot.addWidget(nested_spin)
     orphan_spin = erlab.interactive.utils.BetterSpinBox()
@@ -942,8 +935,7 @@ def test_history_group_coalesces_binning_spinbox_steps(qtbot):
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
     win = ImageTool(data)
     qtbot.addWidget(win)
-    control = win.docks[2].widget().findChild(ItoolBinningControls)
-    assert control is not None
+    control = win.binning_controls
     control.update_content()
     area = win.slicer_area
 
@@ -961,8 +953,7 @@ def test_history_group_records_gamma_slider_as_one_entry(qtbot):
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
     win = ImageTool(data)
     qtbot.addWidget(win)
-    control = win.docks[1].widget().findChild(ItoolColormapControls)
-    assert control is not None
+    control = win.colormap_controls
     area = win.slicer_area
     initial_gamma = area.colormap_properties["gamma"]
 
@@ -981,8 +972,7 @@ def test_history_group_coalesces_gamma_spinbox_steps(qtbot):
     data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
     win = ImageTool(data)
     qtbot.addWidget(win)
-    control = win.docks[1].widget().findChild(ItoolColormapControls)
-    assert control is not None
+    control = win.colormap_controls
     area = win.slicer_area
     initial_gamma = area.colormap_properties["gamma"]
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -987,8 +987,8 @@ def test_multicursor_restore_updates_cursor_combo(qtbot) -> None:
 
     restored = ImageTool.from_dataset(win.to_dataset())
     qtbot.addWidget(restored)
-    cursor_ctrl = restored.docks[0].widget().layout().itemAt(0).widget()
-    bin_ctrl = restored.docks[2].widget().layout().itemAt(0).widget()
+    cursor_ctrl = restored.cursor_controls
+    bin_ctrl = restored.binning_controls
     assert isinstance(cursor_ctrl, ItoolCrosshairControls)
     assert isinstance(bin_ctrl, ItoolBinningControls)
 
@@ -1004,7 +1004,7 @@ def test_multicursor_restore_updates_cursor_combo(qtbot) -> None:
 def test_cursor_combo_update_colors_resyncs_stale_count(qtbot) -> None:
     win = itool(_TEST_DATA["2D"], execute=False)
     qtbot.addWidget(win)
-    cursor_ctrl = win.docks[0].widget().layout().itemAt(0).widget()
+    cursor_ctrl = win.cursor_controls
     assert isinstance(cursor_ctrl, ItoolCrosshairControls)
 
     win.slicer_area.add_cursor()
@@ -1226,9 +1226,9 @@ def test_itool_dataset_metadata_fields_roundtrip(qtbot, tmp_path: pathlib.Path) 
     restored = ImageTool.from_dataset(ds)
     qtbot.addWidget(restored)
     restored_area = restored.slicer_area
-    cursor_ctrl = restored.docks[0].widget().layout().itemAt(0).widget()
-    color_ctrl = restored.docks[1].widget().layout().itemAt(0).widget()
-    bin_ctrl = restored.docks[2].widget().layout().itemAt(0).widget()
+    cursor_ctrl = restored.cursor_controls
+    color_ctrl = restored.colormap_controls
+    bin_ctrl = restored.binning_controls
     assert isinstance(cursor_ctrl, ItoolCrosshairControls)
     assert isinstance(color_ctrl, ItoolColormapControls)
     assert isinstance(bin_ctrl, ItoolBinningControls)
@@ -2414,8 +2414,7 @@ def test_point_value_context_menu_selects_associated_coord(qtbot) -> None:
     )
     win = itool(data, execute=False)
     qtbot.addWidget(win)
-    control = win.docks[0].widget().findChild(ItoolCrosshairControls)
-    assert control is not None
+    control = win.cursor_controls
     control.update_content()
 
     win.slicer_area.array_slicer.twin_coord_names = {"temp"}
@@ -4546,7 +4545,7 @@ def test_itool_general(qtbot, move_and_compare_values, use_dask) -> None:
     assert win.windowTitle() == "new_data"
 
     # Colormap combobox
-    cmap_ctrl = win.docks[1].widget().layout().itemAt(0).widget()
+    cmap_ctrl = win.colormap_controls
     assert isinstance(cmap_ctrl, ItoolColormapControls)
     cmap_ctrl.cb_colormap.load_all()
     cmap_ctrl.cb_colormap.showPopup()
@@ -6283,8 +6282,7 @@ def test_linked_cursor_entry_closes_before_unrecorded_linked_state(qtbot) -> Non
 
 def test_linked_grouped_cursor_undo_propagates(qtbot) -> None:
     win0, win1 = _linked_pair(qtbot)
-    control = win0.docks[0].widget().findChild(ItoolCrosshairControls)
-    assert control is not None
+    control = win0.cursor_controls
     control.update_content()
 
     control.spin_idx[0].stepBy(1)
@@ -6346,8 +6344,7 @@ def test_linked_gamma_undo_redo_propagates(qtbot) -> None:
 
 def test_linked_grouped_gamma_undo_propagates(qtbot) -> None:
     win0, win1 = _linked_pair(qtbot)
-    control = win0.docks[1].widget().findChild(ItoolColormapControls)
-    assert control is not None
+    control = win0.colormap_controls
 
     control.gamma_widget.slider.sliderPressed.emit()
     control.gamma_widget.setValue(1.2)
@@ -6809,8 +6806,7 @@ def test_eager_preview_from_dask_source_updates_readout(qtbot) -> None:
 
     win = ImageTool(data, auto_compute=False)
     qtbot.addWidget(win)
-    control = win.docks[0].widget().findChild(ItoolCrosshairControls)
-    assert control is not None
+    control = win.cursor_controls
 
     win.slicer_area.apply_func(lambda _darr: preview, preview=True)
     assert win.slicer_area.data_chunked
@@ -7157,6 +7153,108 @@ def test_itool_controls_visibility_menu_history_and_dataset_roundtrip(qtbot) -> 
     assert restored.slicer_area.state["controls_visible"] is False
 
     restored.close()
+    win.close()
+
+
+def test_itool_controls_scroll_and_elide_in_narrow_window(qtbot) -> None:
+    first_dim = "a_dimension_name_that_is_much_too_long_for_the_controls"
+    second_dim = "another_dimension_name_that_is_much_too_long_for_the_controls"
+    data = xr.DataArray(np.zeros((5, 6)), dims=(first_dim, second_dim))
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.show()
+
+    qtbot.waitUntil(lambda: win.cursor_controls.label_dim[0].toolTip() == first_dim)
+    bar = win.controls_bar
+    scroll_bar = bar.horizontalScrollBar()
+    previous_button = bar.findChild(
+        QtWidgets.QToolButton, "itoolControlsPreviousButton"
+    )
+    next_button = bar.findChild(QtWidgets.QToolButton, "itoolControlsNextButton")
+    assert previous_button is not None
+    assert next_button is not None
+
+    assert win.findChildren(QtWidgets.QDockWidget) == []
+    assert bar.findChildren(QtWidgets.QGroupBox) == []
+    assert len(bar.findChildren(QtWidgets.QFrame, "itoolControlsSeparator")) == 2
+    assert (
+        bar.horizontalScrollBarPolicy() == QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    )
+    assert bar.verticalScrollBarPolicy() == QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    assert not scroll_bar.isVisible()
+
+    for label, dimension in zip(win.cursor_controls.label_dim, data.dims, strict=True):
+        assert label.full_text == dimension
+        assert label.toolTip() == dimension
+        assert label.accessibleName() == dimension
+        assert label.sizeHint().width() < label.fontMetrics().horizontalAdvance(
+            dimension
+        )
+    for label, dimension in zip(win.binning_controls.labels, data.dims, strict=True):
+        assert label.full_text == dimension
+        assert label.toolTip() == dimension
+
+    qtbot.waitUntil(lambda: bar._contents.sizeHint().width() > bar.viewport().width())
+    content_width = bar._contents.sizeHint().width()
+    win.resize(260, win.height())
+    qtbot.waitUntil(lambda: scroll_bar.maximum() > 0)
+    assert win.width() == 260
+    assert win.minimumSizeHint().width() < content_width
+    assert previous_button.isHidden()
+    assert next_button.isVisible()
+    assert next_button.height() == bar.viewport().height()
+
+    qtbot.mouseClick(next_button, QtCore.Qt.MouseButton.LeftButton)
+    qtbot.waitUntil(lambda: scroll_bar.value() > 0)
+    assert previous_button.isVisible()
+    assert next_button.isVisible()
+    assert previous_button.height() == bar.viewport().height()
+
+    scroll_bar.setValue(scroll_bar.maximum())
+    assert previous_button.isVisible()
+    assert next_button.isHidden()
+    previous_value = scroll_bar.value()
+    qtbot.mouseClick(previous_button, QtCore.Qt.MouseButton.LeftButton)
+    assert scroll_bar.value() < previous_value
+
+    scroll_bar.setValue(0)
+    empty_wheel_event = QtGui.QWheelEvent(
+        QtCore.QPointF(5, 5),
+        QtCore.QPointF(5, 5),
+        QtCore.QPoint(),
+        QtCore.QPoint(),
+        QtCore.Qt.MouseButton.NoButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+        QtCore.Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    bar.wheelEvent(empty_wheel_event)
+    assert scroll_bar.value() == 0
+
+    wheel_event = QtGui.QWheelEvent(
+        QtCore.QPointF(5, 5),
+        QtCore.QPointF(5, 5),
+        QtCore.QPoint(),
+        QtCore.QPoint(0, -120),
+        QtCore.Qt.MouseButton.NoButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+        QtCore.Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    bar.wheelEvent(wheel_event)
+    assert scroll_bar.value() > 0
+
+    scroll_bar.setValue(0)
+    win.binning_controls.reset_btn.setFocus(QtCore.Qt.FocusReason.TabFocusReason)
+    qtbot.waitUntil(lambda: scroll_bar.value() > 0)
+
+    win.resize(bar._contents.sizeHint().width() + 20, win.height())
+    qtbot.waitUntil(lambda: scroll_bar.maximum() == 0)
+    assert previous_button.isHidden()
+    assert next_button.isHidden()
+    wheel_event.setAccepted(False)
+    bar.wheelEvent(wheel_event)
+    assert scroll_bar.value() == 0
     win.close()
 
 
@@ -12060,8 +12158,7 @@ def test_itool_masks_unsafe_values_for_display_only(qtbot) -> None:
     assert np.isinf(win.slicer_area.data.values[1, 0])
     assert win.slicer_area.data.values[1, 1] == 1e300
 
-    control = win.docks[0].widget().findChild(ItoolCrosshairControls)
-    assert control is not None
+    control = win.cursor_controls
     assert np.isnan(control._readout_value_to_float(np.array([np.inf, 1e300])))
 
     win.slicer_area.lock_levels(True)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -7204,9 +7204,13 @@ def test_itool_controls_scroll_and_elide_in_narrow_window(qtbot) -> None:
     ] == [0, 2, 4]
     assert all(
         label.alignment()
+        == (QtCore.Qt.AlignmentFlag.AlignHCenter | QtCore.Qt.AlignmentFlag.AlignVCenter)
+        for label in win.cursor_controls.label_dim
+    )
+    assert all(
+        label.alignment()
         == (QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter)
         for label in (
-            *win.cursor_controls.label_dim,
             *win.binning_controls.labels,
             *win.binning_controls.val_labels,
         )

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -34,6 +34,7 @@ from erlab.interactive._figurecomposer import (
 from erlab.interactive._figurecomposer._exceptions import (
     FigureComposerPlotSlicesSelectionError,
 )
+from erlab.interactive._widgets import _Separator
 from erlab.interactive.derivative import DerivativeTool, dtool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
 from erlab.interactive.imagetool import ImageTool, itool
@@ -7176,7 +7177,56 @@ def test_itool_controls_scroll_and_elide_in_narrow_window(qtbot) -> None:
 
     assert win.findChildren(QtWidgets.QDockWidget) == []
     assert bar.findChildren(QtWidgets.QGroupBox) == []
-    assert len(bar.findChildren(QtWidgets.QFrame, "itoolControlsSeparator")) == 2
+    separators = bar.findChildren(_Separator, "itoolControlsSeparator")
+    assert len(separators) == 2
+    assert all(
+        separator.orientation == QtCore.Qt.Orientation.Vertical and separator.inset == 0
+        for separator in separators
+    )
+    assert bar._layout.contentsMargins() == QtCore.QMargins(6, 6, 6, 6)
+    cursor_layout = win.cursor_controls.values_layouts[0]
+    binning_layout = win.binning_controls.gridlayout
+    assert [
+        cursor_layout.getItemPosition(cursor_layout.indexOf(widget))[0]
+        for widget in (
+            win.cursor_controls.btn_snap,
+            win.cursor_controls.cb_cursors,
+            win.cursor_controls.spin_dat,
+        )
+    ] == [0, 2, 4]
+    assert [
+        binning_layout.getItemPosition(binning_layout.indexOf(widget))[0]
+        for widget in (
+            win.binning_controls.labels[0],
+            win.binning_controls.spins[0],
+            win.binning_controls.val_labels[0],
+        )
+    ] == [0, 2, 4]
+    assert all(
+        label.alignment()
+        == (QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter)
+        for label in (
+            *win.cursor_controls.label_dim,
+            *win.binning_controls.labels,
+            *win.binning_controls.val_labels,
+        )
+    )
+    assert [
+        (cursor_layout.cellRect(row, 0).y(), cursor_layout.cellRect(row, 0).height())
+        for row in (0, 2, 4)
+    ] == [
+        (binning_layout.cellRect(row, 0).y(), binning_layout.cellRect(row, 0).height())
+        for row in (0, 2, 4)
+    ]
+    for layout in (*win.cursor_controls.values_layouts, binning_layout):
+        assert layout.verticalSpacing() == 0
+        assert all(
+            layout.rowMinimumHeight(row) == 3 and layout.rowStretch(row) == 1
+            for row in (1, 3)
+        )
+        spacer_heights = [layout.cellRect(row, 0).height() for row in (1, 3)]
+        assert min(spacer_heights) >= 3
+        assert abs(spacer_heights[0] - spacer_heights[1]) <= 1
     assert (
         bar.horizontalScrollBarPolicy() == QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
     )

--- a/tests/interactive/test_options_parameters.py
+++ b/tests/interactive/test_options_parameters.py
@@ -17,7 +17,72 @@ from erlab.interactive._options.parameters import (
     StylesheetListWidget,
     _stylesheet_names,
 )
-from erlab.interactive._widgets import _CenteredIconToolButton
+from erlab.interactive._widgets import _CenteredIconToolButton, _Separator
+
+
+@pytest.mark.parametrize(
+    ("orientation", "expected_hint"),
+    [
+        (QtCore.Qt.Orientation.Horizontal, QtCore.QSize(7, 1)),
+        (QtCore.Qt.Orientation.Vertical, QtCore.QSize(1, 7)),
+    ],
+)
+@pytest.mark.parametrize("background", ["#202020", "#f0f0f0"])
+@pytest.mark.parametrize("device_pixel_ratio", [1, 2])
+def test_separator_draws_inset_palette_aware_hairline(
+    qtbot,
+    orientation: QtCore.Qt.Orientation,
+    expected_hint: QtCore.QSize,
+    background: str,
+    device_pixel_ratio: int,
+) -> None:
+    separator = _Separator(orientation, inset=3)
+    qtbot.addWidget(separator)
+    separator.resize(21, 21)
+    palette = separator.palette()
+    palette.setColor(QtGui.QPalette.ColorRole.Window, QtGui.QColor(background))
+    palette.setColor(
+        QtGui.QPalette.ColorRole.WindowText,
+        QtGui.QColor("#ffffff" if background == "#202020" else "#202020"),
+    )
+    separator.setPalette(palette)
+
+    image_size = 21 * device_pixel_ratio
+    image = QtGui.QImage(image_size, image_size, QtGui.QImage.Format.Format_ARGB32)
+    image.setDevicePixelRatio(device_pixel_ratio)
+    background_color = palette.color(QtGui.QPalette.ColorRole.Window)
+    image.fill(background_color)
+    painter = QtGui.QPainter(image)
+    separator.render(painter, QtCore.QPoint())
+    painter.end()
+
+    assert separator.orientation == orientation
+    assert separator.inset == 3
+    assert separator.sizeHint() == expected_hint
+    assert separator.minimumSizeHint() == expected_hint
+    assert image.pixelColor(image_size // 2, image_size // 2) != background_color
+    if orientation == QtCore.Qt.Orientation.Horizontal:
+        painted_rows = sum(
+            any(
+                image.pixelColor(x, y) != background_color for x in range(image.width())
+            )
+            for y in range(image.height())
+        )
+        assert painted_rows == device_pixel_ratio
+    else:
+        painted_columns = sum(
+            any(
+                image.pixelColor(x, y) != background_color
+                for y in range(image.height())
+            )
+            for x in range(image.width())
+        )
+        assert painted_columns == device_pixel_ratio
+
+
+def test_separator_rejects_negative_inset() -> None:
+    with pytest.raises(ValueError, match="negative"):
+        _Separator(inset=-1)
 
 
 def test_colorlistwidget_initialization(qtbot):


### PR DESCRIPTION
## Summary

- add an **Arrange Selected Windows…** action to the manager View menu and tool context menus
- provide compact Illustrator-inspired, icon-only controls for row, column, and grid layouts; layout glyphs follow the selected left-to-right or right-to-left order
- distribute and resize selected windows across the current screen with configurable rows or columns and zero spacing by default
- preserve visual selection order, materialize deferred windows, restore hidden or minimized windows, and roll back geometry when a layout cannot be applied
- replace the ImageTool control docks and group boxes with a separator-based control strip that can shrink independently of its contents
- scroll overflowing controls with dynamic, full-height edge buttons, mouse wheels or trackpads, and keyboard focus while keeping native scrollbars hidden
- cap and elide long dimension labels in Cursor and Binning controls, with the full names available in tooltips

## User impact

Users can arrange multiple managed tool windows into equal cells without positioning each one manually. Individual ImageTool windows can also be made substantially narrower while all controls remain reachable, and unusually long dimension names no longer force the window wider.

## Testing

- QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/test_dialogs.py tests/interactive/imagetool/manager/test_mainwindow.py tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/test_history.py (717 passed)
- QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/workspace/test_document.py::test_manager_link_action_links_colors (1 passed)
- focused arrangement, responsive-control, and transform tests under PySide6 (3 passed)
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src
- uv run python -m scripts.ci_test_groups --check-partition