### PR TITLE
test(imagetool): use shared generated-code namespaces

### DIFF
--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -220,18 +220,15 @@ def _press_alt(monkeypatch):
 def _exec_generated_code(
     code: str, namespace: dict[str, typing.Any]
 ) -> dict[str, typing.Any]:
-    locals_ns = dict(namespace)
-    exec(  # noqa: S102
-        code,
-        {
-            "np": np,
-            "xr": xr,
-            "erlab": erlab,
-            "era": erlab.analysis,
-        },
-        locals_ns,
-    )
-    return locals_ns
+    exec_namespace = {
+        "np": np,
+        "xr": xr,
+        "erlab": erlab,
+        "era": erlab.analysis,
+        **namespace,
+    }
+    exec(code, exec_namespace)  # noqa: S102
+    return exec_namespace
 
 
 def _exec_data_fragment(

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -159,18 +159,15 @@ from erlab.interactive.imagetool._provenance._operations import (
 def _exec_generated_code(
     code: str, namespace: dict[str, typing.Any]
 ) -> dict[str, typing.Any]:
-    locals_ns = dict(namespace)
-    exec(  # noqa: S102
-        code,
-        {
-            "np": np,
-            "xr": xr,
-            "erlab": erlab,
-            "era": erlab.analysis,
-        },
-        locals_ns,
-    )
-    return locals_ns
+    exec_namespace = {
+        "np": np,
+        "xr": xr,
+        "erlab": erlab,
+        "era": erlab.analysis,
+        **namespace,
+    }
+    exec(code, exec_namespace)  # noqa: S102
+    return exec_namespace
 
 
 def _generated_call_names(code: str) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary

- execute generated ImageTool code in one explicit namespace in the affected tests
- align the test harness with ImageTool replay and normal script or notebook execution
- leave the generated nonuniform-dimension expressions unchanged

## Root cause

The compatibility suite passed generated inputs only through a separate `locals`
mapping. On Python 3.11, `exec` with distinct globals and locals uses class-body
semantics, so list and dictionary comprehensions could not resolve `data`. Python
3.12 and newer masked this mismatch by inlining comprehensions.

## Validation

- `QT_QPA_PLATFORM=offscreen PYTEST_QT_API=pyqt6 QT_API=pyqt6 uv run pytest -q tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/test_provenance.py` (`678 passed` on Python 3.11)
- focused failing tests under Python 3.11 with PyQt6 (`3 passed`)
- focused failing tests under Python 3.11 with PySide6 (`3 passed`)
- `uv run ruff check tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/test_provenance.py`
- `uv run ruff format --check tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/test_provenance.py`
