### PR TITLE
fix(manager): move data size to details

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1918,12 +1918,10 @@ class ImageToolManager(_ImageToolManagerBase):
         pending = self._workspace_controller.loading.pending
         return pending._materialize_pending_workspace_payload(node)
 
-    def _pending_workspace_info_text(
+    def _pending_workspace_info(
         self, node: _ImageToolWrapper | _ManagedWindowNode
-    ) -> str | None:
-        return self._workspace_controller.loading.pending._pending_workspace_info_text(
-            node
-        )
+    ) -> tuple[str | None, int | None]:
+        return self._workspace_controller.loading.pending._pending_workspace_info(node)
 
     def _pending_workspace_imagetool_preview_image(
         self, node: _ImageToolWrapper | _ManagedWindowNode

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -244,15 +244,13 @@ class _PendingWorkspacePayloads:
                 data = self._pending_workspace_data_with_saved_dim_order(data, attrs)
                 data = erlab.utils.array._restore_nonuniform_dims(data)
                 data = erlab.utils.array.sort_coord_order(data)
-                additional_info = [f"Added {node.added_time_display}"]
                 try:
                     metadata_data = self._pending_workspace_data_with_loaded_coords(
                         data
                     )
                     text = erlab.utils.formatting.format_darr_html(
                         metadata_data,
-                        show_size=True,
-                        additional_info=additional_info,
+                        show_size=False,
                     )
                 except Exception:
                     logger.debug(
@@ -261,9 +259,8 @@ class _PendingWorkspacePayloads:
                     )
                     text = erlab.utils.formatting.format_darr_html(
                         data,
-                        show_size=True,
+                        show_size=False,
                         load_values=False,
-                        additional_info=additional_info,
                     )
                 return erlab.interactive.utils._apply_qt_accent_color(text)
             finally:
@@ -295,7 +292,6 @@ class _PendingWorkspacePayloads:
         )
         if source_state is not None:
             lines.append(f"<p>Source: {html.escape(source_state)}</p>")
-        lines.append(f"<p>Added {html.escape(node.added_time_display)}</p>")
         return erlab.interactive.utils._apply_qt_accent_color("".join(lines))
 
     def _pending_workspace_info_text(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -221,12 +221,12 @@ class _PendingWorkspacePayloads:
         }
         return data.copy(deep=False).assign_coords(scalar_coords)
 
-    def _pending_workspace_imagetool_info_text(
+    def _pending_workspace_imagetool_info(
         self, node: _ImageToolWrapper | _ManagedWindowNode
-    ) -> str | None:
+    ) -> tuple[str | None, int | None]:
         pending = node.pending_workspace_memory_payload
         if pending is None:
-            return None
+            return None, None
         workspace_path, payload_path = pending
         try:
             ds = self._loader._read_workspace_imagetool_payload_dataset(
@@ -235,7 +235,7 @@ class _PendingWorkspacePayloads:
             try:
                 ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
                 if _ITOOL_DATA_NAME not in ds:
-                    return None
+                    return None, None
                 name = None if node.name == "" else node.name
                 data = ds[_ITOOL_DATA_NAME].rename(name)
                 attrs = node.pending_workspace_payload_attrs
@@ -244,6 +244,7 @@ class _PendingWorkspacePayloads:
                 data = self._pending_workspace_data_with_saved_dim_order(data, attrs)
                 data = erlab.utils.array._restore_nonuniform_dims(data)
                 data = erlab.utils.array.sort_coord_order(data)
+                data_size = data.nbytes
                 try:
                     metadata_data = self._pending_workspace_data_with_loaded_coords(
                         data
@@ -262,7 +263,10 @@ class _PendingWorkspacePayloads:
                         show_size=False,
                         load_values=False,
                     )
-                return erlab.interactive.utils._apply_qt_accent_color(text)
+                return (
+                    erlab.interactive.utils._apply_qt_accent_color(text),
+                    data_size,
+                )
             finally:
                 ds.close()
         except Exception:
@@ -272,7 +276,7 @@ class _PendingWorkspacePayloads:
                 workspace_path,
                 exc_info=True,
             )
-            return None
+            return None, None
 
     def _pending_workspace_tool_info_text(
         self, node: _ImageToolWrapper | _ManagedWindowNode
@@ -294,16 +298,16 @@ class _PendingWorkspacePayloads:
             lines.append(f"<p>Source: {html.escape(source_state)}</p>")
         return erlab.interactive.utils._apply_qt_accent_color("".join(lines))
 
-    def _pending_workspace_info_text(
+    def _pending_workspace_info(
         self, node: _ImageToolWrapper | _ManagedWindowNode
-    ) -> str | None:
+    ) -> tuple[str | None, int | None]:
         match node.pending_workspace_payload_kind:
             case "imagetool":
-                return self._pending_workspace_imagetool_info_text(node)
+                return self._pending_workspace_imagetool_info(node)
             case "tool":
-                return self._pending_workspace_tool_info_text(node)
+                return self._pending_workspace_tool_info_text(node), None
             case _:
-                return None
+                return None, None
 
     @staticmethod
     def _pending_workspace_tool_preview_image(

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -1054,14 +1054,11 @@ class _ManagedWindowNode(QtCore.QObject):
             return pending_info
         data = self._metadata_data()
         if data is None:
-            return erlab.interactive.utils._apply_qt_accent_color(
-                f"Added {self.added_time_display}"
-            )
+            return ""
         data = erlab.utils.array.sort_coord_order(data)
         text = erlab.utils.formatting.format_darr_html(
             data,
-            show_size=True,
-            additional_info=[f"Added {self.added_time_display}"],
+            show_size=False,
         )
         return erlab.interactive.utils._apply_qt_accent_color(text)
 
@@ -1255,14 +1252,36 @@ class _ManagedWindowNode(QtCore.QObject):
                 "Kind",
                 kind_value,
             ),
+        ]
+
+        data = self._metadata_data()
+        size_data = data
+        if size_data is None and self.pending_workspace_memory_payload is not None:
+            try:
+                size_data = self.manager._pending_workspace_imagetool_metadata_data(
+                    self
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to read data size for pending workspace node %s",
+                    self.uid,
+                    exc_info=True,
+                )
+        if size_data is not None:
+            fields.append(
+                _MetadataField(
+                    "Size",
+                    erlab.utils.formatting.format_nbytes(size_data.nbytes),
+                )
+            )
+        fields.append(
             _MetadataField(
                 "Added",
                 self.added_time_display,
                 monospace=True,
-            ),
-        ]
+            )
+        )
 
-        data = self._metadata_data()
         load_source_details = self._load_source_details()
         if load_source_details is not None:
             fields.append(

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -436,6 +436,7 @@ class _ManagedWindowNode(QtCore.QObject):
             tuple[
                 tuple[typing.Literal["imagetool", "tool"], tuple[pathlib.Path, str]],
                 str,
+                int | None,
             ]
             | None
         ) = None
@@ -1049,7 +1050,7 @@ class _ManagedWindowNode(QtCore.QObject):
             return erlab.interactive.utils._apply_qt_accent_color(
                 self.tool_window.info_text
             )
-        pending_info = self._pending_workspace_info_text()
+        pending_info, _ = self._pending_workspace_info()
         if pending_info is not None:
             return pending_info
         data = self._metadata_data()
@@ -1062,21 +1063,24 @@ class _ManagedWindowNode(QtCore.QObject):
         )
         return erlab.interactive.utils._apply_qt_accent_color(text)
 
-    def _pending_workspace_info_text(self) -> str | None:
+    def _pending_workspace_info(self) -> tuple[str | None, int | None]:
         pending = self._pending_workspace_payload
         kind = self._pending_workspace_payload_kind
         if pending is None or kind is None:
-            return None
+            return None, None
         cache_key = (kind, pending)
         if (
             self._pending_workspace_metadata_cache is not None
             and self._pending_workspace_metadata_cache[0] == cache_key
         ):
-            return self._pending_workspace_metadata_cache[1]
-        text = self.manager._pending_workspace_info_text(self)
+            return (
+                self._pending_workspace_metadata_cache[1],
+                self._pending_workspace_metadata_cache[2],
+            )
+        text, data_size = self.manager._pending_workspace_info(self)
         if text is not None:
-            self._pending_workspace_metadata_cache = (cache_key, text)
-        return text
+            self._pending_workspace_metadata_cache = (cache_key, text, data_size)
+        return text, data_size
 
     @property
     def tree_uid_text(self) -> str:
@@ -1255,23 +1259,14 @@ class _ManagedWindowNode(QtCore.QObject):
         ]
 
         data = self._metadata_data()
-        size_data = data
-        if size_data is None and self.pending_workspace_memory_payload is not None:
-            try:
-                size_data = self.manager._pending_workspace_imagetool_metadata_data(
-                    self
-                )
-            except Exception:
-                logger.debug(
-                    "Failed to read data size for pending workspace node %s",
-                    self.uid,
-                    exc_info=True,
-                )
-        if size_data is not None:
+        data_size = data.nbytes if data is not None else None
+        if data_size is None and self.pending_workspace_memory_payload is not None:
+            _, data_size = self._pending_workspace_info()
+        if data_size is not None:
             fields.append(
                 _MetadataField(
                     "Size",
-                    erlab.utils.formatting.format_nbytes(size_data.nbytes),
+                    erlab.utils.formatting.format_nbytes(data_size),
                 )
             )
         fields.append(

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -215,7 +215,11 @@ def test_manager_added_time_display_uses_zone_name_and_offset(
             )
             == expected
         )
-        assert f"Added {expected}" in node.info_text
+        assert next(
+            field.value for field in node.metadata_fields if field.label == "Size"
+        ) == erlab.utils.formatting.format_nbytes(test_data.nbytes)
+        assert expected not in node.info_text
+        assert "Size " not in node.info_text
 
 
 def test_imagetool_dataset_uses_window_state_and_keeps_rect_fallback(

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -2049,8 +2049,9 @@ def test_pending_workspace_data_roles_match_materialized_filtered_nonuniform_dat
         assert pending_source.chunks is not None
         pending_source = pending_source.compute()
         pending_displayed = pending_displayed.compute()
-        info = loader.pending._pending_workspace_imagetool_info_text(node)
+        info, data_size = loader.pending._pending_workspace_imagetool_info(node)
         assert info is not None
+        assert data_size == data.nbytes
         assert "sample_temp_idx" not in info
     finally:
         loader._close_workspace_reference_datasets(reference_datasets)

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -1555,6 +1555,9 @@ def test_wrapper_pending_workspace_branch_helpers(
             tmp_path / "source.itws", "0/imagetool"
         )
         assert wrapper._metadata_data() is None
+        fields = {field.label: field.value for field in wrapper.metadata_fields}
+        assert "Size" not in fields
+        assert fields["Added"] == wrapper.added_time_display
         assert wrapper._pending_workspace_load_source_details() is None
 
         for raw_state in (b"\xff", "{not-json", json.dumps({"file_path": 1})):
@@ -1643,7 +1646,7 @@ def test_wrapper_pending_workspace_branch_helpers(
             created_time="2026-01-02T03:04:05+00:00",
         )
         try:
-            assert "Added" in empty_node.info_text
+            assert empty_node.info_text == ""
             assert empty_node.persistence_data_backing() == (None, ())
         finally:
             empty_node.deleteLater()

--- a/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
@@ -218,6 +218,10 @@ def test_manager_pending_memory_sidebar_shows_metadata_without_materializing(
         assert "sample" in info_text
         assert "TiSe2" in info_text
         assert "temperature" in info_text
+        assert "Added" not in info_text
+        assert "Size " not in info_text
+        fields = {field.label: field.value for field in wrapper.metadata_fields}
+        assert fields["Size"] == erlab.utils.formatting.format_nbytes(data.nbytes)
         assert wrapper.pending_workspace_memory_payload is not None
 
         wrapper.name = "renamed_metadata"
@@ -306,6 +310,8 @@ def test_pending_workspace_metadata_coord_load_failure_falls_back(
     assert "float64 [2]" in info
     assert "float64 [3]" in info
     assert "float64 scalar" in info
+    assert "Added" not in info
+    assert "Size " not in info
     assert node.pending_workspace_memory_payload == (fname, "0/imagetool")
 
 
@@ -1027,6 +1033,7 @@ def test_pending_toolwindow_metadata_and_preview_helpers(
         assert "NestedTool" in text
         assert "source_data" in text
         assert "stale" in text
+        assert "Added" not in text
         assert loader.pending._pending_workspace_info_text(node) == text
 
         preview = node.pending_workspace_tool_preview_image()

--- a/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
@@ -222,6 +222,7 @@ def test_manager_pending_memory_sidebar_shows_metadata_without_materializing(
         assert "Size " not in info_text
         fields = {field.label: field.value for field in wrapper.metadata_fields}
         assert fields["Size"] == erlab.utils.formatting.format_nbytes(data.nbytes)
+        assert not wrapper._workspace_reference_datasets
         assert wrapper.pending_workspace_memory_payload is not None
 
         wrapper.name = "renamed_metadata"
@@ -304,8 +305,9 @@ def test_pending_workspace_metadata_coord_load_failure_falls_back(
 
     with manager_context() as manager:
         pending_payloads = manager._workspace_controller.loading.pending
-        info = pending_payloads._pending_workspace_imagetool_info_text(node)
+        info, data_size = pending_payloads._pending_workspace_imagetool_info(node)
     assert info is not None
+    assert data_size == data.nbytes
     assert "pending" in info
     assert "float64 [2]" in info
     assert "float64 [3]" in info
@@ -1034,7 +1036,7 @@ def test_pending_toolwindow_metadata_and_preview_helpers(
         assert "source_data" in text
         assert "stale" in text
         assert "Added" not in text
-        assert loader.pending._pending_workspace_info_text(node) == text
+        assert loader.pending._pending_workspace_info(node) == (text, None)
 
         preview = node.pending_workspace_tool_preview_image()
         assert preview is not None
@@ -1114,7 +1116,7 @@ def test_pending_toolwindow_metadata_and_preview_helpers(
         )
         assert loader.pending._pending_workspace_tool_info_text(no_pending) is None
         assert loader.pending._pending_workspace_tool_preview_image(no_pending) is None
-        assert loader.pending._pending_workspace_info_text(no_pending) is None
+        assert loader.pending._pending_workspace_info(no_pending) == (None, None)
 
 
 def test_pending_workspace_preview_and_metadata_reader_fallbacks(
@@ -1192,8 +1194,9 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
             name="pending",
             added_time_display="Today",
         )
-        info = loader.pending._pending_workspace_imagetool_info_text(node)
+        info, data_size = loader.pending._pending_workspace_imagetool_info(node)
         assert info is not None
+        assert data_size == data.nbytes
         assert "pending" in info
         preview = loader.pending._pending_workspace_imagetool_preview_image(node)
         assert preview is not None
@@ -1296,12 +1299,32 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
             name="missing",
             added_time_display="Today",
         )
-        assert (
-            loader.pending._pending_workspace_imagetool_info_text(missing_node) is None
+        assert loader.pending._pending_workspace_imagetool_info(missing_node) == (
+            None,
+            None,
         )
         assert (
             loader.pending._pending_workspace_imagetool_preview_image(missing_node)
             is None
+        )
+
+        missing_data_fname = tmp_path / "pending-preview-missing-data.itws"
+        assert workspace_arrays._write_workspace_dataset_group_h5py(
+            missing_data_fname,
+            "0/imagetool",
+            xr.Dataset({"other": xr.DataArray([1.0], dims="x")}),
+        )
+        missing_data_node = types.SimpleNamespace(
+            pending_workspace_memory_payload=(
+                missing_data_fname,
+                "0/imagetool",
+            ),
+            pending_workspace_payload_attrs=None,
+            name="missing",
+        )
+        assert loader.pending._pending_workspace_imagetool_info(missing_data_node) == (
+            None,
+            None,
         )
 
         no_pending = types.SimpleNamespace(
@@ -1310,7 +1333,10 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
             name="missing",
             added_time_display="Today",
         )
-        assert loader.pending._pending_workspace_imagetool_info_text(no_pending) is None
+        assert loader.pending._pending_workspace_imagetool_info(no_pending) == (
+            None,
+            None,
+        )
         assert (
             loader.pending._pending_workspace_imagetool_preview_image(no_pending)
             is None


### PR DESCRIPTION
## Summary

- remove the duplicate added timestamp from ImageToolManager rich summaries
- move the array byte count into the Details tab as `Size`
- preserve size metadata for unopened workspace entries without materializing their data

## Why

The rich summary independently displayed both the added timestamp and data size even though node metadata already has a structured Details tab. Keeping those values in Details makes the summary easier to scan while retaining the array name, dimensions, coordinates, and attributes.

## User impact

Selected tools now show `Size` alongside `Kind` and `Added` in Details. Live tools, pending workspace tools, coordinate-loading fallbacks, and nodes without data use the same presentation.

## Validation

- `uv run ruff format --check` on the changed files
- `uv run ruff check` on the changed files
- PyQt6 workspace tests: 132 passed
- focused PySide6 manager tests: 5 passed
- focused changed-line coverage: no missing modified runtime lines
