### PR TITLE
fix(manager): protect recent workspace history

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -364,8 +364,14 @@ workspace file to import into the current one.
 
 Saved ImageTool workspaces can be reloaded via {menuselection}`File --> Open Workspace…`
 ({kbd}`Ctrl+O`) or by dragging the `.itws` file back into the manager to recreate your
-windows exactly as they were. A list of recent workspaces is available in
-{menuselection}`File --> Open Recent`.
+windows exactly as they were. By default, the 20 most recent workspaces are available
+in {menuselection}`File --> Open Recent`. Change the number kept with
+{guilabel}`Recent workspace limit` under {guilabel}`Settings` → {guilabel}`I/O`.
+
+:::{versionchanged} 3.25.0
+{menuselection}`File --> Open Recent` now keeps 20 workspaces instead of 10 by
+default, and the limit can be changed in {guilabel}`Settings`.
+:::
 
 To check where the open manager is saved, choose {menuselection}`File --> Workspace Properties`
 ({kbd}`Alt+Return`).

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -278,6 +278,13 @@ class IOOptions(BaseModel):
         ),
         json_schema_extra={"ui_type": "directory_path"},
     )
+    recent_workspace_limit: int = Field(
+        default=20,
+        title="Recent workspace limit",
+        description="Maximum number of workspace files kept in File > Open Recent.",
+        ge=1,
+        le=50,
+    )
 
     dask: DaskOptions = Field(default_factory=DaskOptions, title="Dask")
     workspace: WorkspaceOptions = Field(

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -41,8 +41,8 @@ _METADATA_DERIVATION_COPYABLE_ROLE = _METADATA_DERIVATION_CODE_ROLE + 1
 _METADATA_DERIVATION_ROW_ROLE = _METADATA_DERIVATION_CODE_ROLE + 2
 _METADATA_DERIVATION_ACTIVATABLE_ROLE = _METADATA_DERIVATION_CODE_ROLE + 3
 _QWIDGETSIZE_MAX = 16777215
+_MANAGER_SETTINGS_PATH_ENV_VAR = "ERLAB_IMAGETOOL_MANAGER_SETTINGS_PATH"
 _RECENT_WORKSPACES_SETTINGS_KEY = "recent_workspaces"
-_MAX_RECENT_WORKSPACES = 10
 _DEPENDENCY_STATUS_LABELS: dict[str, str] = {
     "current": "Current",
     "changed": "Changed",
@@ -76,6 +76,11 @@ class _TrustedScriptReplayCancelled(RuntimeError):
 
 
 def _manager_settings() -> QtCore.QSettings:
+    if settings_path := os.environ.get(_MANAGER_SETTINGS_PATH_ENV_VAR):
+        return QtCore.QSettings(
+            settings_path,
+            QtCore.QSettings.Format.IniFormat,
+        )
     return QtCore.QSettings(
         QtCore.QSettings.Format.IniFormat,
         QtCore.QSettings.Scope.UserScope,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -26,7 +26,6 @@ import erlab.interactive.imagetool.viewer_linking
 from erlab.interactive.imagetool import _serialization
 from erlab.interactive.imagetool.manager import _desktop
 from erlab.interactive.imagetool.manager._widgets import (
-    _MAX_RECENT_WORKSPACES,
     _RECENT_WORKSPACES_SETTINGS_KEY,
     _WORKSPACE_SAVE_SHORTCUT_OBJECT_NAME,
     _WORKSPACE_SAVE_WAIT_DIALOG_THRESHOLD_SECONDS,
@@ -93,6 +92,8 @@ class _WorkspaceController:
     @staticmethod
     def _normalize_recent_workspace_paths(
         paths: Iterable[str | os.PathLike[str]],
+        *,
+        limit: int,
     ) -> list[pathlib.Path]:
         recent_paths: list[pathlib.Path] = []
         seen: set[str] = set()
@@ -105,11 +106,12 @@ class _WorkspaceController:
                 continue
             recent_paths.append(path)
             seen.add(key)
-            if len(recent_paths) >= _MAX_RECENT_WORKSPACES:
+            if len(recent_paths) >= limit:
                 break
         return recent_paths
 
     def _recent_workspace_paths(self) -> list[pathlib.Path]:
+        limit = erlab.interactive.options.model.io.recent_workspace_limit
         settings = _manager_settings()
         settings.sync()
         values = settings.value(_RECENT_WORKSPACES_SETTINGS_KEY, [])
@@ -119,12 +121,21 @@ class _WorkspaceController:
             stored_paths = [str(value) for value in values if value]
         else:
             stored_paths = []
-        return self._normalize_recent_workspace_paths(stored_paths)
+        recent_paths = self._normalize_recent_workspace_paths(
+            stored_paths,
+            limit=limit,
+        )
+        if len(stored_paths) > limit:
+            self._set_recent_workspace_paths(recent_paths)
+        return recent_paths
 
     def _set_recent_workspace_paths(
         self, paths: Iterable[str | os.PathLike[str]]
     ) -> None:
-        recent_paths = self._normalize_recent_workspace_paths(paths)
+        recent_paths = self._normalize_recent_workspace_paths(
+            paths,
+            limit=erlab.interactive.options.model.io.recent_workspace_limit,
+        )
         settings = _manager_settings()
         if recent_paths:
             settings.setValue(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,14 +76,19 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _TEST_OPTIONS_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH"
 _TEST_OPTIONS_MANAGED_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH_TEST_MANAGED"
 _TEST_INTERACTIVE_OPTIONS_PATHS: list[pathlib.Path] = []
+_TEST_MANAGER_SETTINGS_ENV_VAR = "ERLAB_IMAGETOOL_MANAGER_SETTINGS_PATH"
+_TEST_MANAGER_SETTINGS_MANAGED_ENV_VAR = (
+    "ERLAB_IMAGETOOL_MANAGER_SETTINGS_PATH_TEST_MANAGED"
+)
+_TEST_MANAGER_SETTINGS_PATHS: list[pathlib.Path] = []
 
 
 def pytest_configure(config: pytest.Config) -> None:
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
     if (
         _TEST_OPTIONS_ENV_VAR not in os.environ
         or os.environ.get(_TEST_OPTIONS_MANAGED_ENV_VAR) == "1"
     ):
-        worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
         settings_path = pathlib.Path(tempfile.gettempdir()) / (
             "erlabpy-test-interactive-options-"
             f"{worker_id}-{os.getpid()}-{uuid.uuid4().hex}.ini"
@@ -91,6 +96,18 @@ def pytest_configure(config: pytest.Config) -> None:
         os.environ[_TEST_OPTIONS_ENV_VAR] = str(settings_path)
         os.environ[_TEST_OPTIONS_MANAGED_ENV_VAR] = "1"
         _TEST_INTERACTIVE_OPTIONS_PATHS.append(settings_path)
+
+    if (
+        _TEST_MANAGER_SETTINGS_ENV_VAR not in os.environ
+        or os.environ.get(_TEST_MANAGER_SETTINGS_MANAGED_ENV_VAR) == "1"
+    ):
+        settings_path = pathlib.Path(tempfile.gettempdir()) / (
+            "erlabpy-test-imagetool-manager-"
+            f"{worker_id}-{os.getpid()}-{uuid.uuid4().hex}.ini"
+        )
+        os.environ[_TEST_MANAGER_SETTINGS_ENV_VAR] = str(settings_path)
+        os.environ[_TEST_MANAGER_SETTINGS_MANAGED_ENV_VAR] = "1"
+        _TEST_MANAGER_SETTINGS_PATHS.append(settings_path)
 
 
 def _load_ci_test_groups_module():
@@ -194,22 +211,23 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    for settings_path in _TEST_INTERACTIVE_OPTIONS_PATHS:
+    qapp = QtWidgets.QApplication.instance()
+    if qapp is not None:
+        # pytest-qt closes registered widgets with deleteLater(), but processEvents()
+        # does not guarantee that DeferredDelete events run before interpreter shutdown.
+        for _ in range(2):
+            QtWidgets.QApplication.sendPostedEvents(
+                None, int(QtCore.QEvent.Type.DeferredDelete.value)
+            )
+            QtWidgets.QApplication.sendPostedEvents(None, 0)
+            qapp.processEvents()
+
+    for settings_path in (
+        *_TEST_INTERACTIVE_OPTIONS_PATHS,
+        *_TEST_MANAGER_SETTINGS_PATHS,
+    ):
         with contextlib.suppress(OSError):
             settings_path.unlink()
-
-    qapp = QtWidgets.QApplication.instance()
-    if qapp is None:
-        return
-
-    # pytest-qt closes registered widgets with deleteLater(), but processEvents()
-    # does not guarantee that DeferredDelete events run before interpreter shutdown.
-    for _ in range(2):
-        QtWidgets.QApplication.sendPostedEvents(
-            None, int(QtCore.QEvent.Type.DeferredDelete.value)
-        )
-        QtWidgets.QApplication.sendPostedEvents(None, 0)
-        qapp.processEvents()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/interactive/imagetool/manager/conftest.py
+++ b/tests/interactive/imagetool/manager/conftest.py
@@ -5,13 +5,8 @@ import typing
 import numpy as np
 import pytest
 import xarray as xr
-from qtpy import QtCore
 
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
-from erlab.interactive.imagetool.manager._figurecomposer import _collection
-from erlab.interactive.imagetool.manager._workspace import (
-    _controller as workspace_controller,
-)
 
 if typing.TYPE_CHECKING:
     import pathlib
@@ -31,12 +26,8 @@ def isolated_recent_workspace_settings(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> pathlib.Path:
     settings_path = tmp_path / "recent-workspaces.ini"
-
-    def _settings() -> QtCore.QSettings:
-        return QtCore.QSettings(str(settings_path), QtCore.QSettings.Format.IniFormat)
-
-    _settings().clear()
-    monkeypatch.setattr(_collection, "_manager_settings", _settings)
-    monkeypatch.setattr(manager_widgets, "_manager_settings", _settings)
-    monkeypatch.setattr(workspace_controller, "_manager_settings", _settings)
+    monkeypatch.setenv(
+        manager_widgets._MANAGER_SETTINGS_PATH_ENV_VAR,
+        str(settings_path),
+    )
     return settings_path

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -48,6 +48,27 @@ from tests.interactive.imagetool.manager.helpers import (
 logger = logging.getLogger(__name__)
 
 
+def test_manager_settings_path_override(monkeypatch, tmp_path) -> None:
+    settings_path = tmp_path / "manager-settings.ini"
+    monkeypatch.setenv(
+        manager_widgets._MANAGER_SETTINGS_PATH_ENV_VAR,
+        str(settings_path),
+    )
+
+    settings = manager_widgets._manager_settings()
+    settings.setValue("test/value", 42)
+    settings.sync()
+
+    assert pathlib.Path(settings.fileName()) == settings_path
+    assert (
+        QtCore.QSettings(
+            str(settings_path),
+            QtCore.QSettings.Format.IniFormat,
+        ).value("test/value", type=int)
+        == 42
+    )
+
+
 def test_manager_runtime_icon_asset_exists() -> None:
     icon_path = pathlib.Path(manager_widgets._ICON_PATH)
 

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -1388,7 +1388,8 @@ def test_manager_recent_workspaces_dedupe_move_to_top_and_cap(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    paths = [tmp_path / f"workspace-{idx}.itws" for idx in range(12)]
+    limit = erlab.interactive.options.model.io.recent_workspace_limit
+    paths = [tmp_path / f"workspace-{idx}.itws" for idx in range(limit + 2)]
     for path in paths:
         path.touch()
 
@@ -1404,15 +1405,8 @@ def test_manager_recent_workspaces_dedupe_move_to_top_and_cap(
 
         assert manager._workspace_controller._recent_workspace_paths() == [
             paths[6].resolve(),
-            paths[11].resolve(),
-            paths[10].resolve(),
-            paths[9].resolve(),
-            paths[8].resolve(),
-            paths[7].resolve(),
-            paths[5].resolve(),
-            paths[4].resolve(),
-            paths[3].resolve(),
-            paths[2].resolve(),
+            *(path.resolve() for path in reversed(paths[7:])),
+            *(path.resolve() for path in reversed(paths[2:6])),
         ]
 
 
@@ -1429,7 +1423,8 @@ def test_manager_recent_workspace_normalization_and_settings(
     data_file.touch()
 
     assert workspace_controller._WorkspaceController._normalize_recent_workspace_paths(
-        [data_file, workspace, workspace]
+        [data_file, workspace, workspace],
+        limit=20,
     ) == [workspace.resolve()]
 
     with manager_context() as manager:
@@ -1455,6 +1450,49 @@ def test_manager_recent_workspace_normalization_and_settings(
             lambda: _ObjectSettings(),
         )
         assert manager._workspace_controller._recent_workspace_paths() == []
+
+
+def test_manager_recent_workspace_limit_setting_prunes_history(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    paths = [tmp_path / f"workspace-{idx}.itws" for idx in range(5)]
+    for path in paths:
+        path.touch()
+
+    with manager_context() as manager:
+        manager._workspace_controller._set_recent_workspace_paths(paths)
+        manager.open_settings()
+        dialog = manager._additional_windows.get("settings")
+        assert isinstance(dialog, erlab.interactive._options.OptionDialog)
+        limit_control = dialog.findChild(
+            QtWidgets.QSpinBox,
+            "settingsControl_user_io__recent_workspace_limit",
+        )
+        if limit_control is None:
+            raise AssertionError("Recent workspace limit setting was not found")
+
+        limit_control.setValue(3)
+        manager._workspace_controller._populate_open_recent_menu()
+
+        expected = [path.resolve() for path in paths[:3]]
+        assert manager._workspace_controller._recent_workspace_paths() == expected
+        assert manager_widgets._manager_settings().value(
+            manager_widgets._RECENT_WORKSPACES_SETTINGS_KEY
+        ) == [str(path) for path in expected]
+        actions = action_map_by_object_name(manager.open_recent_menu)
+        assert {
+            name
+            for name in actions
+            if name.startswith("manager_recent_workspace_action_")
+        } == {
+            "manager_recent_workspace_action_0",
+            "manager_recent_workspace_action_1",
+            "manager_recent_workspace_action_2",
+        }
 
 
 def test_manager_open_recent_workspace_flow(

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -23,6 +23,7 @@ from erlab.interactive._options.parameters import (
 )
 from erlab.interactive._options.schema import (
     AppOptions,
+    IOOptions,
     WorkspaceOptions,
     normalize_workspace_compression_mode,
 )
@@ -180,6 +181,19 @@ def test_dialog_default_directory_control_has_accessible_description(
     control = _control(dialog, "user", path, DirectoryPathWidget)
     description = _description(dialog, "user", path).text()
 
+    assert description
+    assert control.toolTip() == ""
+    assert control.accessibleDescription() == description
+
+
+def test_dialog_recent_workspace_limit_control(dialog: OptionDialog):
+    path = "io/recent_workspace_limit"
+    control = _control(dialog, "user", path, QtWidgets.QSpinBox)
+    description = _description(dialog, "user", path).text()
+
+    assert control.value() == 20
+    assert control.minimum() == 1
+    assert control.maximum() == 50
     assert description
     assert control.toolTip() == ""
     assert control.accessibleDescription() == description
@@ -958,6 +972,7 @@ def test_workspace_override_helpers_filter_to_curated_subset() -> None:
     assert "colors/cmap/name" in paths
     assert "colors/cmap/packages" not in paths
     assert "io/default_directory" not in paths
+    assert "io/recent_workspace_limit" not in paths
     assert "io/workspace/compression" in paths
     assert "io/workspace/compress" not in paths
     assert "figure/dpi" in paths
@@ -1018,6 +1033,7 @@ def test_options_get_set():
     assert options["io/workspace/use_incremental"] is True
     assert options["io/workspace/incremental_save_on_remote"] is False
     assert options["io/default_directory"] == ""
+    assert options["io/recent_workspace_limit"] == 20
     assert options["figure/dpi"] is None
 
     options["colors/cmap/name"] = "viridis"
@@ -1025,6 +1041,7 @@ def test_options_get_set():
     options["io/workspace/use_incremental"] = False
     options["io/workspace/incremental_save_on_remote"] = True
     options["io/default_directory"] = "~/data"
+    options["io/recent_workspace_limit"] = 35
     options["figure/stylesheets"] = ["classic", "missing-style"]
     options["figure/dpi"] = 150.0
 
@@ -1034,11 +1051,13 @@ def test_options_get_set():
     assert options["io/workspace/use_incremental"] is False
     assert options["io/workspace/incremental_save_on_remote"] is True
     assert options["io/default_directory"] == "~/data"
+    assert options["io/recent_workspace_limit"] == 35
     assert options["figure/stylesheets"] == ["classic", "missing-style"]
     assert options["figure/dpi"] == pytest.approx(150.0)
     assert options.model.io.workspace.compression == "blosclz3"
     assert not options.model.io.workspace.use_incremental
     assert options.model.io.workspace.incremental_save_on_remote
+    assert options.model.io.recent_workspace_limit == 35
     assert options.model.figure.stylesheets == ["classic", "missing-style"]
     assert options.model.figure.dpi == pytest.approx(150.0)
 
@@ -1058,6 +1077,12 @@ def test_options_get_set():
 
     options.restore()
     assert options["figure/dpi"] is None
+
+
+@pytest.mark.parametrize("value", [0, 51])
+def test_recent_workspace_limit_validates_bounds(value: int) -> None:
+    with pytest.raises(pydantic.ValidationError):
+        IOOptions(recent_workspace_limit=value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- isolate ImageTool Manager settings for the entire pytest process, including xdist workers, subprocesses, and late Qt callbacks
- keep 20 recent workspaces by default and add a user-only **Settings → I/O → Recent workspace limit** control with a range of 1–50
- prune persisted recent-workspace entries when the configured limit is lowered
- document the changed behavior for 3.25.0

## Root cause

Manager tests previously relied on module-local `QSettings` monkeypatches. Test paths could still reach the real user settings outside those patched call sites, allowing temporary `.itws` files to displace actual entries in **File → Open Recent**.

## User impact

Local test runs no longer modify the user's recent-workspace history. Users can retain more or fewer workspaces without storing this machine-specific preference inside `.itws` files.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_options.py tests/interactive/imagetool/manager/workspace/test_document.py` — 129 passed
- focused recent-workspace setting tests under PyQt6 and PySide6
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run mypy src`
- `uv run --directory docs make html SPHINXOPTS='-q'`
- repository commit hooks
