### PR TITLE
fix(imagetool): restore analysis provenance editing

### DIFF
--- a/src/erlab/interactive/imagetool/_provenance/_graph.py
+++ b/src/erlab/interactive/imagetool/_provenance/_graph.py
@@ -501,6 +501,7 @@ def _validate_script_provenance(
     has_replay_step = False
     active_available = spec.active_name in available_names
     current_name: str | None = spec.active_name if active_available else None
+
     if spec.seed_code:
         has_replay_step = True
         if strict_replay_code:
@@ -1217,11 +1218,15 @@ def _compile_spec(
                 )
                 if pending_output_name is None:  # pragma: no cover - validation guard.
                     raise ReplayGraphError("Script provenance has no replay code")
+                operation_name = (
+                    active_name if index == len(operations) - 1 else pending_output_name
+                )
                 pending_codes.append(
                     _operation_replay_code(
                         operation,
-                        active_name=pending_output_name,
+                        active_name=operation_name,
                         context_name=pending_output_name,
+                        parent_name=pending_output_name,
                         reserved_names=graph.reserved_names,
                     )
                 )

--- a/src/erlab/interactive/imagetool/_provenance/_graph.py
+++ b/src/erlab/interactive/imagetool/_provenance/_graph.py
@@ -589,6 +589,9 @@ def _validate_script_provenance(
             current_name = preferred_name
             available_names.add(preferred_name)
             active_available = preferred_name == spec.active_name
+        elif index == len(spec.operations) - 1:
+            current_name = spec.active_name
+            active_available = True
         else:
             active_available = active_available or current_name == spec.active_name
     if not has_replay_step:

--- a/src/erlab/interactive/imagetool/_provenance/_model.py
+++ b/src/erlab/interactive/imagetool/_provenance/_model.py
@@ -3125,7 +3125,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             raise ValueError("This provenance row cannot be replayed as a prefix")
         end = ref.operation_index + 1
         if self.kind in {"script", "file"}:
-            return self.model_copy(update={"steps": self.steps[:end]})
+            return self._prefix_with_steps(self.steps[:end])
         return self.model_copy(
             update={"source_operations": self.source_operations[:end]}
         )
@@ -3135,10 +3135,38 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         if ref.kind != "operation" or ref.operation_index is None:
             return self._prefix_through_ref(ref)
         if self.kind in {"script", "file"}:
-            return self.model_copy(update={"steps": self.steps[: ref.operation_index]})
+            return self._prefix_with_steps(self.steps[: ref.operation_index])
         return self.model_copy(
             update={"source_operations": self.source_operations[: ref.operation_index]}
         )
+
+    def _prefix_with_steps(self, steps: Sequence[ReplayStep]) -> ToolProvenanceSpec:
+        """Return a replay prefix with the name produced by its final step."""
+        updates: dict[str, typing.Any] = {"steps": tuple(steps)}
+        if len(steps) == len(self.steps):
+            return self.model_copy(update=updates)
+        if self.kind == "script":
+            current_name = (
+                self.active_name
+                if self.seed_code is None
+                else self._script_seed_output_name()
+            )
+            for step in steps:
+                operation = step.operation
+                if _operation_is(operation, "script_code"):
+                    code = typing.cast("str | None", getattr(operation, "code", None))
+                    if code is not None and self.active_name is not None:
+                        current_name = _script_codes_output_name(
+                            (code,),
+                            active_name=self.active_name,
+                            current_name=current_name,
+                        )
+                    continue
+                if preferred_name := operation.preferred_replay_output_name():
+                    current_name = preferred_name
+            if current_name is not None:
+                updates["active_name"] = current_name
+        return self.model_copy(update=updates)
 
     def _script_seed_output_name(self) -> str | None:
         """Return the variable produced by this script spec's seed code."""

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
@@ -326,6 +326,26 @@ class _ProvenanceEditController:
                     return names
         return ()
 
+    def _script_spec_replayable_for_node(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        spec: ToolProvenanceSpec,
+    ) -> bool:
+        external_input_names = set(self._script_replay_source_input_names(spec))
+        if external_input_names and not node.has_replay_source:
+            return False
+        if external_input_names:
+            return script_provenance_replayable(
+                spec,
+                external_input_names=external_input_names,
+            ) or script_provenance_requires_trust(
+                spec,
+                external_input_names=external_input_names,
+            )
+        return script_provenance_replayable(spec) or script_provenance_requires_trust(
+            spec
+        )
+
     def can_reorder_steps(self) -> tuple[bool, str]:
         node = self._metadata_node()
         if not self._node_editable(node):
@@ -715,10 +735,7 @@ class _ProvenanceEditController:
                 return True, ""
         if spec.kind == "script":
             input_spec = spec._prefix_before_ref(row.edit_ref)
-            if not (
-                script_provenance_replayable(input_spec)
-                or script_provenance_requires_trust(input_spec)
-            ):
+            if not self._script_spec_replayable_for_node(node, input_spec):
                 return False, "This script step cannot be replayed."
         active_filter_ref = self._active_filter_ref(node, spec)
         if (
@@ -771,10 +788,7 @@ class _ProvenanceEditController:
         if candidate == spec:
             return False, "Already at this provenance step."
         if spec.kind == "script":
-            if not (
-                script_provenance_replayable(candidate)
-                or script_provenance_requires_trust(candidate)
-            ):
+            if not self._script_spec_replayable_for_node(node, candidate):
                 return False, "This script step cannot be replayed."
             if not all(
                 self._manager._script_input_can_reload(

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
@@ -684,10 +684,7 @@ class _ProvenanceEditController:
                     )
             except (IndexError, ValueError):
                 return False, "This script row is not a replayable step."
-            if not (
-                script_provenance_replayable(candidate)
-                or script_provenance_requires_trust(candidate)
-            ):
+            if not self._script_spec_replayable_for_node(node, candidate):
                 return False, "Deleting this script step would make replay invalid."
         if spec.kind in {"full_data", "public_data", "selection"}:
             if row.scope == "source" and node.parent_uid is not None:

--- a/tests/interactive/imagetool/manager/provenance/test_operation_editing.py
+++ b/tests/interactive/imagetool/manager/provenance/test_operation_editing.py
@@ -1580,14 +1580,20 @@ def test_analysis_tool_provenance_prefixes_are_editable_and_replayable(
 ) -> None:
     assert tool_cls.COPY_PROVENANCE is not None
     file_spec = _manager_provenance_file_spec(pathlib.Path("scan.h5"))
+    seed_code = (
+        typing.cast("str", file_spec.seed_code) if file_backed else "derived = data"
+    )
+    file_load_source = file_spec.file_load_source if file_backed else None
+    if file_load_source is not None:
+        file_load_source = file_load_source.model_copy(
+            update={"load_code": seed_code.replace("derived =", "data =", 1)}
+        )
     spec = script(
         *operations,
         start_label=f"Start from current {case_name} input data",
-        seed_code=(
-            typing.cast("str", file_spec.seed_code) if file_backed else "derived = data"
-        ),
+        seed_code=seed_code,
         active_name=active_name,
-        file_load_source=file_spec.file_load_source if file_backed else None,
+        file_load_source=file_load_source,
     )
     node = _fake_edit_node(spec)
     if not file_backed:
@@ -1624,3 +1630,23 @@ def test_analysis_tool_provenance_prefixes_are_editable_and_replayable(
             ) is not None
         if should_be_editable:
             assert controller.can_edit_row(row) == (True, "")
+        if row.replay_ref is None or row.replay_ref.kind != "operation":
+            continue
+        group = provenance_edit_controller._editable_group_range_for_ref(
+            spec,
+            row.replay_ref,
+        )
+        if group is None:
+            deletion_candidate = spec._replace_operation_ref(row.replay_ref, ())
+        else:
+            deletion_candidate = spec._replace_operation_range_ref(
+                row.replay_ref,
+                group[0],
+                group[1],
+                (),
+            )
+        should_be_deletable = controller._script_spec_replayable_for_node(
+            node,
+            deletion_candidate,
+        )
+        assert controller.can_delete_row(row)[0] is should_be_deletable

--- a/tests/interactive/imagetool/manager/provenance/test_operation_editing.py
+++ b/tests/interactive/imagetool/manager/provenance/test_operation_editing.py
@@ -10,6 +10,12 @@ from qtpy import QtCore, QtWidgets
 import erlab
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
+from erlab.interactive._fit1d import Fit1DTool
+from erlab.interactive._fit2d import Fit2DTool
+from erlab.interactive._mesh import MeshTool
+from erlab.interactive.derivative import DerivativeTool
+from erlab.interactive.fermiedge import GoldTool, ResolutionTool
+from erlab.interactive.imagetool import _kspace_conversion
 from erlab.interactive.imagetool._provenance._model import (
     DerivationEntry,
     ToolProvenanceOperation,
@@ -20,20 +26,29 @@ from erlab.interactive.imagetool._provenance._model import (
     full_data,
     script,
     selection,
+    stamp_operation_group,
 )
 from erlab.interactive.imagetool._provenance._operations import (
     AffineCoordOperation,
     DivideByCoordOperation,
     GaussianFilterOperation,
+    ImageDerivativeOperation,
     IselOperation,
+    KspaceConfigurationOperation,
+    KspaceConvertOperation,
+    KspaceSetNormalOperation,
     LeadingEdgeOperation,
+    ModelFitOperation,
     NormalizeOperation,
     QSelAggregationOperation,
     QSelOperation,
+    RemoveMeshOperation,
     ScriptCodeOperation,
     SelOperation,
     SortByOperation,
     TransposeOperation,
+    UniformInterpolationOperation,
+    _ModelFitParameterSpec,
 )
 from erlab.interactive.imagetool.dialogs import SelectionDialog
 from erlab.interactive.imagetool.manager._provenance_edit import (
@@ -42,6 +57,7 @@ from erlab.interactive.imagetool.manager._provenance_edit import (
 from erlab.interactive.imagetool.manager._provenance_edit import (
     _editors as provenance_editors,
 )
+from erlab.interactive.kspace import KspaceTool
 
 from ._common import (
     _fake_edit_controller,
@@ -1424,3 +1440,187 @@ def test_tool_provenance_spec_row_reference_helpers_cover_edge_branches() -> Non
     assert file_spec._operation_for_ref(stage_ref) == sel
     assert file_spec._prefix_through_ref(_ProvenanceStepRef("file_load")).steps == ()
     assert file_spec._prefix_before_ref(stage_ref).operations == (isel,)
+
+
+def _analysis_tool_provenance_cases() -> tuple[
+    tuple[
+        str,
+        type,
+        tuple[ToolProvenanceOperation, ...],
+        str,
+    ],
+    ...,
+]:
+    kspace_operations = stamp_operation_group(
+        (
+            KspaceConfigurationOperation(configuration=2),
+            KspaceSetNormalOperation(alpha=1.0, beta=2.0, delta=3.0),
+            KspaceConvertOperation(bounds=None, resolution=None),
+        ),
+        kind=_kspace_conversion.KSPACE_CONVERSION_GROUP_KIND,
+    )
+    model_fit = ModelFitOperation(
+        fit_dim="x",
+        model="PolynomialModel",
+        model_kwargs={"degree": 1},
+        parameters={
+            "c0": _ModelFitParameterSpec(value=0.0),
+            "c1": _ModelFitParameterSpec(value=1.0),
+        },
+        method="leastsq",
+        parameter="c1",
+        output="value",
+    )
+    remove_mesh = RemoveMeshOperation(
+        first_order_peaks=((5, 5), (5, 7), (5, 3)),
+        order=1,
+        n_pad=0,
+        roi_hw=2,
+        output="corrected",
+    )
+    return (
+        (
+            DerivativeTool.tool_name,
+            DerivativeTool,
+            (
+                UniformInterpolationOperation(sizes={"x": 5}),
+                GaussianFilterOperation(sigma={"x": 1.0}),
+                ImageDerivativeOperation(
+                    method="diffn",
+                    kwargs={"coord": "x", "order": 2},
+                ),
+                TransposeOperation(),
+            ),
+            "result",
+        ),
+        (
+            KspaceTool.tool_name,
+            KspaceTool,
+            kspace_operations,
+            "converted",
+        ),
+        (
+            GoldTool.tool_name,
+            GoldTool,
+            (
+                ScriptCodeOperation(
+                    label="Fit and correct current data",
+                    code="corrected = derived",
+                ),
+            ),
+            "corrected",
+        ),
+        (
+            ResolutionTool.tool_name,
+            ResolutionTool,
+            (
+                ScriptCodeOperation(
+                    label="Fit the current averaged edge distribution",
+                    code="result = derived",
+                ),
+            ),
+            "result",
+        ),
+        (
+            Fit1DTool.tool_name,
+            Fit1DTool,
+            (
+                ScriptCodeOperation(
+                    label="Fit current data with the current model",
+                    code="result = derived",
+                ),
+            ),
+            "result",
+        ),
+        (
+            Fit2DTool.tool_name,
+            Fit2DTool,
+            (
+                IselOperation(kwargs={"y": slice(0, 3)}),
+                model_fit,
+            ),
+            "parameter_values",
+        ),
+        (
+            f"{Fit2DTool.tool_name}-stderr",
+            Fit2DTool,
+            (
+                IselOperation(kwargs={"y": slice(0, 3)}),
+                model_fit.model_copy(update={"output": "stderr"}),
+            ),
+            "parameter_stderr",
+        ),
+        (
+            f"{MeshTool.tool_name}-corrected",
+            MeshTool,
+            (remove_mesh,),
+            "corrected",
+        ),
+        (
+            f"{MeshTool.tool_name}-mesh",
+            MeshTool,
+            (remove_mesh.model_copy(update={"output": "mesh"}),),
+            "mesh",
+        ),
+    )
+
+
+@pytest.mark.parametrize("file_backed", [False, True], ids=["memory", "file"])
+@pytest.mark.parametrize(
+    ("case_name", "tool_cls", "operations", "active_name"),
+    _analysis_tool_provenance_cases(),
+    ids=[case[0] for case in _analysis_tool_provenance_cases()],
+)
+def test_analysis_tool_provenance_prefixes_are_editable_and_replayable(
+    case_name: str,
+    tool_cls: type,
+    operations: tuple[ToolProvenanceOperation, ...],
+    active_name: str,
+    file_backed: bool,
+) -> None:
+    assert tool_cls.COPY_PROVENANCE is not None
+    file_spec = _manager_provenance_file_spec(pathlib.Path("scan.h5"))
+    spec = script(
+        *operations,
+        start_label=f"Start from current {case_name} input data",
+        seed_code=(
+            typing.cast("str", file_spec.seed_code) if file_backed else "derived = data"
+        ),
+        active_name=active_name,
+        file_load_source=file_spec.file_load_source if file_backed else None,
+    )
+    node = _fake_edit_node(spec)
+    if not file_backed:
+        node.replay_source_data = xr.DataArray(
+            np.arange(5.0),
+            dims=("x",),
+        )
+        node.has_replay_source = True
+    controller = _fake_edit_controller(node)
+
+    rows = list(spec.display_rows())
+    for row in rows:
+        rows.extend(row.children)
+
+    for row in rows:
+        if row.replay_ref is not None:
+            prefix = spec._prefix_through_ref(row.replay_ref)
+            assert controller._script_spec_replayable_for_node(node, prefix), (
+                f"{case_name} row {row.replay_ref!r} has a non-replayable prefix"
+            )
+        if row.edit_ref is None:
+            continue
+        if row.edit_ref.kind == "file_load":
+            should_be_editable = True
+        else:
+            operation = spec._operation_for_ref(row.edit_ref)
+            should_be_editable = (
+                isinstance(operation, ScriptCodeOperation)
+                and operation.copyable
+                and operation.code is not None
+            ) or provenance_editors._dialog_match_for_operation_ref(
+                spec,
+                row.edit_ref,
+            ) is not None
+        if should_be_editable:
+            assert controller.can_edit_row(row) == (True, "")

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -4342,6 +4342,42 @@ def test_tool_provenance_script_flat_step_prefix_and_fallback_rows() -> None:
     )
 
 
+def test_tool_provenance_script_prefix_tracks_active_output_name() -> None:
+    spec = script(
+        UniformInterpolationOperation(sizes={"x": 5}),
+        GaussianFilterOperation(sigma={"x": 1.0}),
+        ImageDerivativeOperation(
+            method="diffn",
+            kwargs={"coord": "x", "order": 2},
+        ),
+        TransposeOperation(),
+        start_label="Start from current dtool input data",
+        seed_code="derived = data",
+        active_name="result",
+    )
+
+    expected_before = ("derived", "processed_data", "processed_data", "result")
+    expected_through = ("processed_data", "processed_data", "result", "result")
+    for operation_index in range(len(spec.operations)):
+        ref = _ProvenanceStepRef(
+            "operation",
+            operation_index=operation_index,
+        )
+        before = spec._prefix_before_ref(ref)
+        through = spec._prefix_through_ref(ref)
+
+        assert before.active_name == expected_before[operation_index]
+        assert through.active_name == expected_through[operation_index]
+        assert script_provenance_replayable(
+            before,
+            external_input_names={"data"},
+        )
+        assert script_provenance_replayable(
+            through,
+            external_input_names={"data"},
+        )
+
+
 def test_tool_provenance_operation_group_replacement_preserves_script_context() -> None:
     grouped = stamp_operation_group(
         (

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -132,6 +132,28 @@ def _file_spec(path: pathlib.Path | str, *, selected_index: int = 0):
     )
 
 
+def test_script_compiler_assigns_final_output_after_pending_seed() -> None:
+    data = xr.DataArray(
+        np.arange(3.0)[None, :],
+        dims=("singleton", "x"),
+    )
+    spec = script(
+        SqueezeOperation(),
+        start_label="Start from data",
+        seed_code="intermediate = data",
+        active_name="result",
+    )
+
+    assert script_provenance_replayable(
+        spec,
+        external_input_names={"data"},
+    )
+    xr.testing.assert_identical(
+        replay_script_provenance(spec, {"data": data}),
+        data.squeeze(),
+    )
+
+
 def _erlab_file_spec(path: pathlib.Path | str, loader: str):
     return file_load(
         start_label=f"Load {path}",


### PR DESCRIPTION
## Summary

- keep each truncated script-provenance prefix aligned with the variable produced by its final step
- allow edit and revert validation to use retained in-memory replay sources
- align script validation with generated replay code for final structured operations
- add a shared file-backed and in-memory provenance contract for every manager-integrated analysis tool type

## Root cause

Analysis-tool provenance recipes can change their active output name between steps. Prefix construction retained the complete recipe's final active name, so intermediate rows could be rejected as non-replayable even though their code was valid. In-memory rows were also validated without accounting for the replay source retained by their manager node.

Existing tests exercised complete recipes and final outputs, but did not check editability and replayability for every displayed provenance prefix across all analysis tool types.

## User impact

Editable provenance rows produced by DerivativeTool, KspaceTool, GoldTool, ResolutionTool, Fit1DTool, Fit2DTool, and MeshTool remain editable for both file-backed and in-memory inputs. The separate ImageTool hierarchy behavior is unchanged.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/test_provenance.py tests/interactive/imagetool/manager/provenance` — 571 passed
- analysis-tool provenance smoke tests — 8 passed
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- targeted `uv run mypy ...` — no issues
