### PR TITLE
fix(manager): harden spreadsheet metadata teardown

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_spreadsheet_metadata.py
+++ b/src/erlab/interactive/imagetool/manager/_spreadsheet_metadata.py
@@ -1203,13 +1203,9 @@ class _SpreadsheetMetadataDialog(QtWidgets.QDialog):
         )
         menu = QtWidgets.QMenu("Column Mapping", self.mapping_table)
         self._mapping_context_menu = menu
-
-        def clear_menu(_destroyed: object | None = None) -> None:
-            if self._mapping_context_menu is menu:
-                self._mapping_context_menu = None
-
-        menu.destroyed.connect(clear_menu)
-        menu.aboutToHide.connect(menu.deleteLater)
+        menu.aboutToHide.connect(
+            lambda *, popup=menu: self._release_mapping_context_menu(popup)
+        )
         for text, object_name, offset in (
             ("Move Up", "spreadsheet_metadata_move_mapping_up", -1),
             ("Move Down", "spreadsheet_metadata_move_mapping_down", 1),
@@ -1233,6 +1229,12 @@ class _SpreadsheetMetadataDialog(QtWidgets.QDialog):
         menu.addAction(remove_action)
         viewport = typing.cast("QtWidgets.QWidget", self.mapping_table.viewport())
         menu.popup(viewport.mapToGlobal(position))
+
+    def _release_mapping_context_menu(self, menu: QtWidgets.QMenu) -> None:
+        if self._mapping_context_menu is menu:
+            self._mapping_context_menu = None
+        if erlab.interactive.utils.qt_is_valid(menu):
+            menu.deleteLater()
 
     def _move_current_mapping(self, offset: int) -> None:
         item = self.mapping_table.currentItem()

--- a/tests/interactive/imagetool/manager/test_dialogs.py
+++ b/tests/interactive/imagetool/manager/test_dialogs.py
@@ -1543,6 +1543,7 @@ def test_spreadsheet_metadata_mapping_reorder_controls_mapping_order(
     first_context_menu.aboutToHide.emit()
     qtbot.waitUntil(lambda: not erlab.interactive.utils.qt_is_valid(first_context_menu))
     assert dialog._mapping_context_menu is context_menu
+    dialog._release_mapping_context_menu(first_context_menu)
     actions = {action.objectName(): action for action in context_menu.actions()}
     assert actions["spreadsheet_metadata_move_mapping_up"].isEnabled()
     assert actions["spreadsheet_metadata_move_mapping_down"].isEnabled()

--- a/tests/interactive/imagetool/manager/test_dialogs.py
+++ b/tests/interactive/imagetool/manager/test_dialogs.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import textwrap
 import threading
+import time
 import types
 import typing
 
@@ -1035,11 +1036,15 @@ def test_spreadsheet_discovery_preview_requires_file_name() -> None:
     assert result == "RuntimeError: A file name is required for metadata preview"
 
 
-def test_spreadsheet_discovery_does_not_delay_application_exit() -> None:
+def test_spreadsheet_discovery_does_not_delay_application_exit(
+    tmp_path: pathlib.Path,
+) -> None:
     script = textwrap.dedent(
         """
-        import threading
+        import pathlib
         import queue
+        import sys
+        import threading
 
         from qtpy import QtCore, QtWidgets
 
@@ -1048,10 +1053,12 @@ def test_spreadsheet_discovery_does_not_delay_application_exit() -> None:
         )
 
         started = threading.Event()
+        started_path = pathlib.Path(sys.argv[1])
 
         class Source:
             def get_sheet_names(self):
                 started.set()
+                started_path.touch()
                 threading.Event().wait(30)
                 return ["Measurements"]
 
@@ -1087,18 +1094,44 @@ def test_spreadsheet_discovery_does_not_delay_application_exit() -> None:
         if name.startswith(("COV_CORE_", "COVERAGE_")):
             environment.pop(name)
 
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        check=False,
-        capture_output=True,
+    started_path = tmp_path / "spreadsheet-discovery-started"
+    process = subprocess.Popen(
+        [sys.executable, "-c", script, str(started_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=environment,
         text=True,
-        timeout=3,
     )
+    startup_deadline = time.monotonic() + 15
+    while (
+        not started_path.exists()
+        and process.poll() is None
+        and time.monotonic() < startup_deadline
+    ):
+        time.sleep(0.01)
 
-    assert result.returncode == 0
-    assert result.stdout == "event-loop-returned\n"
-    assert "RuntimeError" not in result.stderr
+    if not started_path.exists():
+        if process.poll() is None:
+            process.kill()
+        stdout, stderr = process.communicate()
+        pytest.fail(
+            "Spreadsheet discovery did not start within 15 seconds.\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+
+    try:
+        stdout, stderr = process.communicate(timeout=3)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        stdout, stderr = process.communicate()
+        pytest.fail(
+            "The Qt event loop did not return within 3 seconds after spreadsheet "
+            f"discovery started.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+
+    assert process.returncode == 0
+    assert stdout == "event-loop-returned\n"
+    assert "RuntimeError" not in stderr
 
 
 def test_spreadsheet_metadata_dialog_restores_excel_source(
@@ -1499,12 +1532,24 @@ def test_spreadsheet_metadata_mapping_reorder_controls_mapping_order(
     dialog._show_mapping_context_menu(
         dialog.mapping_table.visualItemRect(current_item).center()
     )
+    first_context_menu = dialog._mapping_context_menu
+    assert first_context_menu is not None
+    dialog._show_mapping_context_menu(
+        dialog.mapping_table.visualItemRect(current_item).center()
+    )
     context_menu = dialog._mapping_context_menu
     assert context_menu is not None
+    assert context_menu is not first_context_menu
+    first_context_menu.aboutToHide.emit()
+    qtbot.waitUntil(lambda: not erlab.interactive.utils.qt_is_valid(first_context_menu))
+    assert dialog._mapping_context_menu is context_menu
     actions = {action.objectName(): action for action in context_menu.actions()}
     assert actions["spreadsheet_metadata_move_mapping_up"].isEnabled()
     assert actions["spreadsheet_metadata_move_mapping_down"].isEnabled()
     actions["spreadsheet_metadata_move_mapping_up"].trigger()
+    context_menu.aboutToHide.emit()
+    qtbot.waitUntil(lambda: not erlab.interactive.utils.qt_is_valid(context_menu))
+    assert dialog._mapping_context_menu is None
 
     dialog.accept()
     source = dialog.selected_source()


### PR DESCRIPTION
## Summary

- separate spreadsheet discovery startup from the application-exit deadline in the shutdown regression test
- release mapping context menus while their Qt wrappers are still valid instead of running Python from `QObject.destroyed`
- cover overlapping transient menus so an older menu cannot clear the current menu reference

## Root cause

The compatibility suite runs all GUI tests sequentially. The shutdown regression gave a fresh Python process only three seconds for imports, Qt startup, worker startup, event-loop return, and interpreter exit, so full-suite load was misreported as a worker shutdown hang across every Python/Qt lane.

On PyQt6 with Python 3.11 and 3.12, later dialog tests also segfaulted when a mapping menu's `destroyed` callback captured the dialog and menu wrappers during deferred teardown.

## Impact

Compatibility still verifies that active spreadsheet discovery cannot delay application exit, but starts the three-second exit deadline only after the worker is confirmed running. Mapping menus no longer invoke Python during Qt object destruction.

## Validation

- [Compatibility workflow](https://github.com/kmnhan/erlabpy/actions/runs/29997929522): all 8 Python 3.11–3.14 × PyQt6/PySide6 jobs passed
- sequential manager provenance/console/dialog group with PyQt6: 568 passed
- sequential manager provenance/console/dialog group with PySide6: 568 passed
- `uv run pytest tests/interactive/imagetool/manager/test_dialogs.py --cov=erlab --cov-report=json:/tmp/erlab-spreadsheet-coverage.json -q`: 70 passed; changed runtime lines and branches covered
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- all PR checks passed, including `codecov/patch`
