### PR TITLE
fix(figure-composer): restore PDF export in bundled app

### DIFF
--- a/manager.spec
+++ b/manager.spec
@@ -31,7 +31,13 @@ manager_dir = (
 
 datas = []
 binaries = []
-hiddenimports = ["PyQt6", "dask", "distributed", "hdf5plugin"]
+hiddenimports = [
+    "PyQt6",
+    "dask",
+    "distributed",
+    "hdf5plugin",
+    "matplotlib.backends.backend_pdf",
+]
 
 
 def find_libomp_dylib():

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -3344,6 +3344,27 @@ def test_figure_composer_export_uses_style_context(qtbot, monkeypatch, recwarn) 
     )
 
 
+def test_figure_composer_exports_pdf(qtbot, monkeypatch, tmp_path) -> None:
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="data",
+    )
+    tool = FigureComposerTool(data)
+    qtbot.addWidget(tool)
+    export_path = tmp_path / "figure.pdf"
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *args, **kwargs: (str(export_path), ""),
+    )
+
+    tool.export_figure()
+
+    assert export_path.read_bytes().startswith(b"%PDF")
+
+
 def test_figure_composer_preview_suppresses_collapsed_layout_warning(
     qtbot, monkeypatch, recwarn
 ) -> None:

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -1054,6 +1054,12 @@ def test_manager_packaging_declares_desktop_integration_metadata() -> None:
     assert '"win32com.shell.shell"' in spec_text
 
 
+def test_manager_packaging_includes_pdf_backend() -> None:
+    spec_text = pathlib.Path("manager.spec").read_text()
+
+    assert '"matplotlib.backends.backend_pdf"' in spec_text
+
+
 def test_launch_new_manager_instance_uses_detached_source_process(monkeypatch) -> None:
     calls: list[tuple[list[str], dict[str, typing.Any]]] = []
 


### PR DESCRIPTION
## Summary

- include Matplotlib's PDF backend in the standalone ImageTool Manager bundle
- add a packaging regression test for the hidden backend dependency
- exercise Figure Composer PDF export and validate the generated file header

## Root cause

Matplotlib selects `matplotlib.backends.backend_pdf` dynamically from the `.pdf` filename suffix. PyInstaller's static analysis included the Qt, Agg, and SVG backends used elsewhere, but omitted the PDF backend. Figure Composer therefore exported PDF correctly from a source environment but raised `ModuleNotFoundError` in the bundled application.

## User impact

Figure Composer can export PDF files from the standalone ImageTool Manager again. PNG and SVG export behavior is unchanged.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/test_app.py::test_manager_packaging_declares_desktop_integration_metadata tests/interactive/imagetool/manager/test_app.py::test_manager_packaging_includes_pdf_backend tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py::test_figure_composer_export_uses_style_context tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py::test_figure_composer_exports_pdf` (`4 passed`)
- `uv run ruff format --check manager.spec tests/interactive/imagetool/manager/test_app.py tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py`
- `uv run ruff check manager.spec tests/interactive/imagetool/manager/test_app.py tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py`
- `git diff --check`
- `uv run --no-editable pyinstaller --noconfirm manager.spec`
- inspected the frozen archive and confirmed `matplotlib.backends.backend_pdf` and `_backend_pdf_ps` are present
