### PR TITLE
fix(manager): bundle pandas metadata for Figure Composer

### DIFF
--- a/manager.spec
+++ b/manager.spec
@@ -5,7 +5,7 @@ import pathlib
 import sys
 
 import pyinstaller_versionfile
-from PyInstaller.utils.hooks import collect_all
+from PyInstaller.utils.hooks import collect_all, copy_metadata
 
 erlab_version_str = importlib.metadata.version("erlab")
 
@@ -29,7 +29,8 @@ manager_dir = (
     / "interactive/imagetool/manager"
 )
 
-datas = []
+# Dask checks pandas distribution metadata when tokenizing xarray indexes.
+datas = copy_metadata("pandas")
 binaries = []
 hiddenimports = [
     "PyQt6",

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -1060,6 +1060,12 @@ def test_manager_packaging_includes_pdf_backend() -> None:
     assert '"matplotlib.backends.backend_pdf"' in spec_text
 
 
+def test_manager_packaging_includes_pandas_metadata() -> None:
+    spec_text = pathlib.Path("manager.spec").read_text()
+
+    assert 'copy_metadata("pandas")' in spec_text
+
+
 def test_launch_new_manager_instance_uses_detached_source_process(monkeypatch) -> None:
     calls: list[tuple[list[str], dict[str, typing.Any]]] = []
 


### PR DESCRIPTION
## Summary

- copy pandas distribution metadata into the standalone ImageTool Manager bundle
- add a packaging regression check for the metadata declaration

## Root cause

Figure Composer persists Dask-backed xarray selections while rendering Plot Slices.
Dask tokenization checks pandas through distribution metadata when coordinates use
pandas indexes. PyInstaller bundled the importable pandas package, but not its
`dist-info` metadata, so the packaged app incorrectly reported pandas as missing.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/manager/test_app.py` — 41 passed
- `QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/manager/figurecomposer/test_plot_slices_cache.py` — 6 passed
- verified the PyInstaller `COLLECT` output contains `pandas-3.0.3.dist-info`
