### PR TITLE
fix(manager): preserve deferred coordinate order

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -205,7 +205,10 @@ class _PendingWorkspacePayloads:
         loaded_coords = {
             key: coord.copy(deep=False).load() for key, coord in data.coords.items()
         }
-        return data.copy(deep=False).assign_coords(loaded_coords)
+        loaded = data.copy(deep=False).assign_coords(loaded_coords)
+        return erlab.utils.array.sort_coord_order(
+            loaded, tuple(data.coords), dims_first=False
+        )
 
     def _pending_workspace_imagetool_metadata_data(
         self, node: _ImageToolWrapper | _ManagedWindowNode

--- a/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
@@ -258,6 +258,7 @@ def test_pending_workspace_metadata_loads_only_coords() -> None:
     loaded = pending_cls._pending_workspace_data_with_loaded_coords(data)
 
     assert loaded.chunks == data.chunks
+    assert tuple(loaded.coords) == tuple(data.coords)
     assert loaded.coords["x"].chunks is None
     assert loaded.coords["y"].chunks is None
     assert loaded.coords["temperature"].chunks is None


### PR DESCRIPTION
## Summary

- preserve the existing coordinate order when deferred ImageTool metadata loads coordinate values
- keep dimension coordinates at the top of deferred summary HTML
- add regression coverage for coordinate-order preservation

## Why

The deferred workspace path sorted coordinates before loading their values, but `xarray.DataArray.assign_coords()` rebuilt indexed dimension coordinates after auxiliary and scalar coordinates. The HTML formatter then rendered that reordered mapping, placing dimensions at the bottom even though the live ImageTool summary kept them first.

## User impact

Deferred ImageTool summaries now present coordinates in the same dimension-first order as live summaries. This is an internal refactor for 3.25.1 and does not change the public API.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/workspace/test_pending_preview.py` (19 passed)
- `uv run ruff check src/erlab/interactive/imagetool/manager/_workspace/_pending.py tests/interactive/imagetool/manager/workspace/test_pending_preview.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/manager/_workspace/_pending.py tests/interactive/imagetool/manager/workspace/test_pending_preview.py`
- `git diff --check`
- commit hooks passed
