### PR TITLE
refactor(analysis.transform): add overlap averaging option

### DIFF
--- a/src/erlab/analysis/transform.py
+++ b/src/erlab/analysis/transform.py
@@ -713,6 +713,7 @@ def symmetrize(
     *,
     center: float = 0.0,
     subtract: bool = False,
+    average: bool = False,
     mode: typing.Literal["full", "valid"] = "full",
     part: typing.Literal["both", "below", "above"] = "both",
     interp_kw: dict[str, typing.Any] | None = None,
@@ -721,8 +722,8 @@ def symmetrize(
     Symmetrize a DataArray along a specified dimension around a given center.
 
     This function takes an input DataArray and symmetrizes its values along the
-    specified dimension by reflecting and summing the data in regions below and above a
-    given center.
+    specified dimension by reflecting and combining the data in regions below and
+    above a given center.
 
     The operation assumes that the coordinate corresponding to the dimension is evenly
     spaced. Internally, the function interpolates the data to a shifted coordinate grid
@@ -742,6 +743,10 @@ def symmetrize(
         If True, the reflected part is subtracted from the original data instead of
         being added, resulting in an antisymmetrized output instead of a symmetrized
         one. Default is False (i.e., the reflected part is added).
+    average : bool, optional
+        If True, divide the summed or subtracted values by 2 where the original and
+        reflected coordinate ranges overlap. Values outside the overlapping region
+        remain unchanged when ``mode="full"``. Default is False.
     mode: {'valid', 'full'}, optional
         How to handle the parts of the symmetrized data that does not overlap with the
         original data. If 'valid', only the part that exists in both the original and
@@ -758,8 +763,8 @@ def symmetrize(
     Returns
     -------
     DataArray
-        A symmetrized DataArray where each value is the sum of its original and
-        reflected counterpart.
+        A symmetrized DataArray containing the sum or difference of each value and its
+        reflected counterpart, optionally divided by 2 in the overlapping region.
 
     Examples
     --------
@@ -848,6 +853,15 @@ def symmetrize(
 
         # Symmetrize
         sym_below = (below - above) if subtract else (below + above)
+        if average:
+            overlap_size = min(n_below, n_above)
+            overlap_divisor = np.ones(sym_below.sizes[dim], dtype=float)
+            overlap_divisor[-overlap_size:] = 2.0
+            sym_below = sym_below / xr.DataArray(
+                overlap_divisor,
+                dims=(dim,),
+                coords={dim: sym_below[dim]},
+            )
 
         # Retain coordinate attributes
         sym_below = sym_below.assign_coords(

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_analysis.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_analysis.py
@@ -1069,6 +1069,7 @@ class SymmetrizeOperation(ToolProvenanceOperation):
             defaults={
                 "center": 0.0,
                 "subtract": False,
+                "average": False,
                 "mode": "full",
                 "part": "both",
             },
@@ -1078,6 +1079,7 @@ class SymmetrizeOperation(ToolProvenanceOperation):
     dim: ProvenanceHashable
     center: float
     subtract: bool = False
+    average: bool = False
     mode: typing.Literal["full", "valid"] = "full"
     part: typing.Literal["both", "below", "above"] = "both"
 
@@ -1087,6 +1089,7 @@ class SymmetrizeOperation(ToolProvenanceOperation):
             "dim": self.dim,
             "center": self.center,
             "subtract": self.subtract,
+            "average": self.average,
             "mode": self.mode,
             "part": self.part,
         }

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -3974,6 +3974,14 @@ class SymmetrizeDialog(DataTransformDialog):
         )
         option_group_layout.addWidget(self.subtract_check)
 
+        self.average_check = QtWidgets.QCheckBox("Average overlap")
+        self.average_check.setChecked(False)
+        self.average_check.setToolTip(
+            "Divide the summed or subtracted intensity by 2 where the original and "
+            "reflected coordinate ranges overlap."
+        )
+        option_group_layout.addWidget(self.average_check)
+
         option_mode = QtWidgets.QWidget()
         option_group_layout.addWidget(option_mode)
         option_mode_layout = QtWidgets.QHBoxLayout()
@@ -4024,6 +4032,7 @@ class SymmetrizeDialog(DataTransformDialog):
                 np.round(self._center_spin.value(), self._center_spin.decimals())
             ),
             "subtract": self.subtract_check.isChecked(),
+            "average": self.average_check.isChecked(),
             "mode": ("full", "valid")[
                 next(i for i, opt in enumerate(self.opt_mode) if opt.isChecked())
             ],
@@ -4050,6 +4059,7 @@ class SymmetrizeDialog(DataTransformDialog):
             raise ValueError(f"Dimension {operation.dim!r} is not available")
         self._center_spin.setValue(float(operation.center))
         self.subtract_check.setChecked(operation.subtract)
+        self.average_check.setChecked(operation.average)
         self.opt_mode[0 if operation.mode == "full" else 1].setChecked(True)
         part_index = {"both": 0, "below": 1, "above": 2}[operation.part]
         self.opt_part[part_index].setChecked(True)

--- a/tests/analysis/test_transform.py
+++ b/tests/analysis/test_transform.py
@@ -479,6 +479,43 @@ def test_symmetrize_subtract():
     np.testing.assert_allclose(sym_da.values, expected, rtol=1e-5)
 
 
+@pytest.mark.parametrize(
+    ("mode", "subtract", "expected"),
+    [
+        (
+            "full",
+            False,
+            [1.5, 1.5, 2.5, 3.5, 4.5, 5.0, 5.0, 4.5, 3.5, 2.5, 1.5, 1.5],
+        ),
+        (
+            "full",
+            True,
+            [1.5, 1.0, 1.0, 1.0, 1.0, 0.5, -0.5, -1.0, -1.0, -1.0, -1.0, -1.5],
+        ),
+        (
+            "valid",
+            False,
+            [1.5, 2.5, 3.5, 4.5, 5.0, 5.0, 4.5, 3.5, 2.5, 1.5],
+        ),
+    ],
+)
+def test_symmetrize_average(mode, subtract, expected):
+    da = xr.DataArray(
+        np.array([1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0], dtype=float),
+        dims="x",
+        coords={"x": np.linspace(-6, 5, 12)},
+    )
+    sym_da = symmetrize(
+        da,
+        "x",
+        center=0.0,
+        subtract=subtract,
+        average=True,
+        mode=mode,
+    )
+    np.testing.assert_allclose(sym_da.values, expected, rtol=1e-5)
+
+
 def test_symmetrize_non_uniform() -> None:
     # Test that symmetrize raises an error when the coordinate is non-uniform.
     da = xr.DataArray(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -9609,6 +9609,7 @@ def _restore_dialog_data() -> xr.DataArray:
                 part="below",
                 mode="full",
                 subtract=True,
+                average=True,
             ),
             SymmetrizeOperation(
                 dim="x",
@@ -9616,6 +9617,7 @@ def _restore_dialog_data() -> xr.DataArray:
                 part="below",
                 mode="full",
                 subtract=True,
+                average=True,
             ),
         ),
         (
@@ -11141,6 +11143,7 @@ def test_itool_symmetrize(qtbot, accept_dialog, monkeypatch) -> None:
     def _set_dialog_params(dialog: SymmetrizeDialog) -> None:
         dialog._dim_combo.setCurrentIndex(2)
         dialog._center_spin.setValue(2.0)
+        dialog.average_check.setChecked(True)
         with qtbot.wait_signal(dialog._sigCodeCopied):
             dialog.copy_button.click()
         dialog.launch_mode_combo.setCurrentText("Replace Current")
@@ -11148,7 +11151,7 @@ def test_itool_symmetrize(qtbot, accept_dialog, monkeypatch) -> None:
     accept_dialog(win.mnb._symmetrize, pre_call=_set_dialog_params)
     xarray.testing.assert_identical(
         win.slicer_area._data.rename(None),
-        erlab.analysis.transform.symmetrize(data, "z", center=2),
+        erlab.analysis.transform.symmetrize(data, "z", center=2, average=True),
     )
 
     namespace = _exec_generated_code(
@@ -11159,7 +11162,7 @@ def test_itool_symmetrize(qtbot, accept_dialog, monkeypatch) -> None:
     assert isinstance(result, xr.DataArray)
     xarray.testing.assert_identical(
         result,
-        erlab.analysis.transform.symmetrize(data, "z", center=2),
+        erlab.analysis.transform.symmetrize(data, "z", center=2, average=True),
     )
     win.close()
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -525,7 +525,7 @@ def _representative_structured_operations() -> tuple[ToolProvenanceOperation, ..
             reducer="mean",
         ),
         ThinOperation(mode="per_dim", factors={"x": 2}),
-        SymmetrizeOperation(dim="x", center=1.0),
+        SymmetrizeOperation(dim="x", center=1.0, average=True),
         SymmetrizeNfoldOperation(
             fold=4,
             axes=("x", "y"),
@@ -3395,7 +3395,12 @@ def test_tool_provenance_apply_analysis_operations(monkeypatch) -> None:
 
     symmetrize_spec = full_data(
         SymmetrizeOperation(
-            dim="x", center=1.0, subtract=True, mode="valid", part="below"
+            dim="x",
+            center=1.0,
+            subtract=True,
+            average=True,
+            mode="valid",
+            part="below",
         )
     )
     assert symmetrize_spec.apply(data).attrs["last_op"] == "symmetrize"
@@ -6475,9 +6480,9 @@ def test_console_pattern_matches_public_parameter_aliases() -> None:
 
 def test_console_pattern_matches_new_replayable_operations() -> None:
     data = xr.DataArray(
-        np.arange(6.0).reshape(2, 3),
+        np.arange(8.0).reshape(2, 4),
         dims=("x", "eV"),
-        coords={"x": [0.0, 1.0], "eV": [0.0, 1.0, 2.0]},
+        coords={"x": [0.0, 1.0], "eV": [0.0, 1.0, 2.0, 3.0]},
     )
 
     aggregate_operation = operation_from_console_call(
@@ -6501,6 +6506,17 @@ def test_console_pattern_matches_new_replayable_operations() -> None:
             receiver_data=data,
         )
     )
+    symmetrize_operation = operation_from_console_call(
+        ConsoleCall(
+            func=erlab.analysis.transform.symmetrize,
+            kwargs={"dim": "eV", "center": 1.5, "average": True},
+            display_code=(
+                "era.transform.symmetrize(data, dim='eV', center=1.5, average=True)"
+            ),
+            has_extra_tracked_inputs=False,
+            receiver_data=data,
+        )
+    )
 
     assert aggregate_operation == QSelAggregationOperation(dims=("x",), func="sum")
     assert leading_edge_operation == LeadingEdgeOperation(
@@ -6508,9 +6524,23 @@ def test_console_pattern_matches_new_replayable_operations() -> None:
         dim="eV",
         direction="negative",
     )
+    assert symmetrize_operation == SymmetrizeOperation(
+        dim="eV",
+        center=1.5,
+        average=True,
+    )
     xr.testing.assert_identical(
         aggregate_operation.apply(data),
         data.qsel.sum("x"),
+    )
+    xr.testing.assert_identical(
+        symmetrize_operation.apply(data),
+        erlab.analysis.transform.symmetrize(
+            data,
+            dim="eV",
+            center=1.5,
+            average=True,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

- add an opt-in `average` flag to `era.transform.symmetrize`
- divide summed or subtracted intensity by 2 only where the original and reflected coordinate ranges overlap, while preserving non-overlapping tails in `mode="full"`
- expose overlap averaging in the ImageTool Symmetrize dialog and preserve it through provenance serialization, replay, console capture, and copied code
- retain the existing summed behavior by default

## Validation

- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `uv run mypy src/erlab/analysis/transform.py src/erlab/interactive/imagetool/_provenance/_operations/_analysis.py src/erlab/interactive/imagetool/dialogs.py`
- `uv run pytest tests/analysis/test_transform.py` (39 passed)
- focused PyQt6 dialog and provenance tests (20 passed)
- focused PySide6 dialog tests (18 passed)
- structured provenance and generated-code tests (44 passed)
