### PR TITLE
fix(analysis.transform): preserve symmetrize contributions

### DIFF
--- a/src/erlab/analysis/transform.py
+++ b/src/erlab/analysis/transform.py
@@ -847,9 +847,21 @@ def symmetrize(
                 above = above.assign_coords({dim: below[dim]})
             case "full":
                 if n_below > n_above:
-                    above = above.interp({dim: below[dim]}).fillna(0.0)
+                    above = (
+                        above.assign_coords(
+                            {dim: below[dim].isel({dim: slice(-n_above, None)})}
+                        )
+                        .reindex({dim: below[dim]}, fill_value=0.0)
+                        .fillna(0.0)
+                    )
                 else:
-                    below = below.interp({dim: above[dim]}).fillna(0.0)
+                    below = (
+                        below.assign_coords(
+                            {dim: above[dim].isel({dim: slice(-n_below, None)})}
+                        )
+                        .reindex({dim: above[dim]}, fill_value=0.0)
+                        .fillna(0.0)
+                    )
 
         # Symmetrize
         sym_below = (below - above) if subtract else (below + above)
@@ -861,6 +873,7 @@ def symmetrize(
                 overlap_divisor,
                 dims=(dim,),
                 coords={dim: sym_below[dim]},
+                name=sym_below.name,
             )
 
         # Retain coordinate attributes

--- a/tests/analysis/test_transform.py
+++ b/tests/analysis/test_transform.py
@@ -479,6 +479,31 @@ def test_symmetrize_subtract():
     np.testing.assert_allclose(sym_da.values, expected, rtol=1e-5)
 
 
+@pytest.mark.parametrize("use_dask", [False, True], ids=["numpy", "dask"])
+def test_symmetrize_average_multidimensional_singleton_halves(
+    use_dask: bool,
+) -> None:
+    da = xr.DataArray(
+        [[1.0, 4.0], [2.0, 6.0]],
+        dims=("batch", "x"),
+        coords={"batch": ["a", "b"], "x": [1.1, 1.2]},
+        name="intensity",
+        attrs={"units": "counts"},
+    )
+    if use_dask:
+        da = da.chunk()
+    expected_sum = da.copy(data=[[5.0, 5.0], [8.0, 8.0]])
+    expected_average = da.copy(data=[[2.5, 2.5], [4.0, 4.0]])
+
+    summed = symmetrize(da, "x", center=1.15)
+    averaged = symmetrize(da, "x", center=1.15, average=True)
+
+    xr.testing.assert_allclose(summed, expected_sum)
+    xr.testing.assert_allclose(averaged, expected_average)
+    assert averaged.name == da.name
+    assert averaged.attrs == da.attrs
+
+
 @pytest.mark.parametrize(
     ("mode", "subtract", "expected"),
     [
@@ -504,6 +529,7 @@ def test_symmetrize_average(mode, subtract, expected):
         np.array([1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0], dtype=float),
         dims="x",
         coords={"x": np.linspace(-6, 5, 12)},
+        name="intensity",
     )
     sym_da = symmetrize(
         da,
@@ -514,6 +540,7 @@ def test_symmetrize_average(mode, subtract, expected):
         mode=mode,
     )
     np.testing.assert_allclose(sym_da.values, expected, rtol=1e-5)
+    assert sym_da.name == da.name
 
 
 def test_symmetrize_non_uniform() -> None:


### PR DESCRIPTION
## Summary

- align the original and reflected halves positionally on the symmetric shifted grid instead of interpolating one half onto the other
- keep both contributions for multidimensional data when each half contains a single sample, so overlap averaging divides exactly the positions where two values were added
- preserve the input `DataArray` name when applying the overlap divisor
- cover NumPy and Dask arrays with named multidimensional regression data

## Root cause

The shifted halves already occupy matching positions, but interpolating a one-sample multidimensional half through SciPy can produce `NaN`, which is then filled with zero. The count-based overlap mask still treats that position as having two contributions. Separately, division by an unnamed `DataArray` clears the result name in xarray.

## Validation

- `uv run ruff format --check src/erlab/analysis/transform.py tests/analysis/test_transform.py`
- `uv run ruff check src/erlab/analysis/transform.py tests/analysis/test_transform.py`
- `uv run mypy src/erlab/analysis/transform.py`
- `uv run pytest tests/analysis/test_transform.py` (41 passed)
- focused ImageTool and provenance tests (2 passed)
- singleton-half regression with runtime warnings promoted to errors (2 passed)
- contribution-support sweep across 5,256 combinations of sizes, coordinate scales, centers, axis directions, modes, and returned parts (0 failures)
