### PR TITLE
fix(ci): run smoke tests without a display server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Qt runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libegl1
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      DISPLAY: ":99.0"
+      MPLBACKEND: Agg
+      QT_QPA_PLATFORM: offscreen
     strategy:
       fail-fast: false
       matrix:
@@ -240,11 +241,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - uses: pyvista/setup-headless-display-action@v4
-        with:
-          pyvista: false
-          qt: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary

- run compatibility smoke tests with Qt’s offscreen platform and Matplotlib’s non-GUI Agg backend
- replace the Xvfb-based headless-display action with a targeted `libegl1` runtime installation
- keep the PyQt6 and PySide6 binding matrix while avoiding hundreds of hidden Matplotlib Qt windows during interpreter shutdown

## Root cause

The headless-display action exposed an Xvfb display, so Matplotlib automatically selected QtAgg for otherwise backend-independent plotting tests. `plt.close()` removed figure managers from Matplotlib’s registry but left hundreds of hidden Qt top-level windows alive until interpreter shutdown. PyQt6 intermittently segfaulted while destroying those windows after pytest had reported every test as passing.

The smoke suite still exercises real Qt widgets through both bindings, but it does not need an X server. Setting `QT_QPA_PLATFORM=offscreen` preserves those widget tests, while `MPLBACKEND=Agg` keeps ordinary plotting tests out of the Qt window lifecycle.

Removing the headless-display action also removed its Linux Qt library installation. The initial PR run showed that both bindings require `libEGL.so.1` while importing QtGui, even with the offscreen platform. The workflow therefore installs `libegl1` explicitly without starting Xvfb or setting `DISPLAY`.

## Validation

- `MPLBACKEND=Agg QT_QPA_PLATFORM=offscreen PYTEST_QT_API=pyqt6 QT_API=pyqt6 … pytest -m compat …` (831 passed)
- `MPLBACKEND=Agg QT_QPA_PLATFORM=offscreen PYTEST_QT_API=pyside6 QT_API=pyside6 … pytest -m compat …` (831 passed)
- PR #494 Linux smoke matrix: all five Python/Qt compatibility lanes passed
- `uv run prek run --files .github/workflows/ci.yml`
- `uv run python -m scripts.ci_test_groups --check-partition`
- `git diff --check`