### PR TITLE
feat(interactive): add reveal-in-manager shortcut

### DIFF
--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -485,6 +485,10 @@ class ImageTool(BaseImageTool):
         )
         self.reveal_in_manager_act.setObjectName("itool_reveal_in_manager_action")
         self.reveal_in_manager_act.setIcon(QtGui.QIcon.fromTheme("go-jump"))
+        self.reveal_in_manager_act.setShortcut("Ctrl+Shift+M")
+        self.reveal_in_manager_act.setShortcutContext(
+            QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
         self.reveal_in_manager_act.setVisible(False)
         self.reveal_in_manager_act.triggered.connect(self._reveal_in_manager)
 

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3319,6 +3319,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         )
         self.reveal_in_manager_action.setObjectName("tool_reveal_in_manager_action")
         self.reveal_in_manager_action.setIcon(QtGui.QIcon.fromTheme("go-jump"))
+        self.reveal_in_manager_action.setShortcut("Ctrl+Shift+M")
+        self.reveal_in_manager_action.setShortcutContext(
+            QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
         self.reveal_in_manager_action.triggered.connect(self._reveal_in_manager)
         self._tool_window_menu.addAction(self.reveal_in_manager_action)
         typing.cast("QtGui.QAction", self._tool_window_menu.menuAction()).setVisible(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -300,6 +300,21 @@ def test_managed_window_actions_reveal_tree_and_figure_rows(
         assert child_tool._tool_window_menu.menuAction().isVisible()
         assert figure_tool._tool_window_menu.menuAction().isVisible()
 
+        reveal_shortcut = QtGui.QKeySequence("Ctrl+Shift+M")
+        for reveal_action in (
+            root_tool.reveal_in_manager_act,
+            child_tool.reveal_in_manager_action,
+            figure_tool.reveal_in_manager_action,
+        ):
+            assert (
+                reveal_action.shortcut().matches(reveal_shortcut)
+                == QtGui.QKeySequence.SequenceMatch.ExactMatch
+            )
+            assert (
+                reveal_action.shortcutContext()
+                == QtCore.Qt.ShortcutContext.WidgetWithChildrenShortcut
+            )
+
         manager.tree_view.clearSelection()
         root_tool.reveal_in_manager_act.trigger()
         assert manager.tree_view.selected_imagetool_indices == [0]


### PR DESCRIPTION
## Summary

- bind `Ctrl+Shift+M` (`Command+Shift+M` on macOS) to **Reveal in ImageTool Manager** for managed ImageTools
- apply the same shortcut to `ToolWindow`-based child tools, including Figure Composer
- use whole-window shortcut scope so the action remains available while a child widget has focus
- cover the shortcut and context for root ImageTools, child tools, and Figure Composer

This provides quick keyboard navigation back to the corresponding manager entry while preserving macOS's standard `Command+M` minimize shortcut.

## Testing

- `QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/manager/test_mainwindow.py::test_managed_window_actions_reveal_tree_and_figure_rows -q` (PyQt6)
- `QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/imagetool/manager/test_mainwindow.py::test_managed_window_actions_reveal_tree_and_figure_rows -q` (PySide6)
- `uv run ruff check src/erlab/interactive/imagetool/_mainwindow.py src/erlab/interactive/utils.py tests/interactive/imagetool/manager/test_mainwindow.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/_mainwindow.py src/erlab/interactive/utils.py tests/interactive/imagetool/manager/test_mainwindow.py`
