### PR TITLE
fix(interactive): show wait indicators on Windows and Linux

### DIFF
--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -635,8 +635,58 @@ class _WaitDialog(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_MacAlwaysShowToolWindow)
 
     def set_message(self, message: str) -> None:
+        if not qt_is_valid(self, self._label):
+            return
         self._label.setText(message)
         self.adjustSize()
+
+
+class _WaitPanel(QtWidgets.QFrame):
+    def __init__(self, parent: QtWidgets.QWidget, message: str) -> None:
+        super().__init__(parent.window())
+        self.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+        self.setAutoFillBackground(True)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(24, 20, 24, 20)
+        self._label = QtWidgets.QLabel(message)
+        layout.addWidget(self._label)
+
+        # Keep native window modality without presenting a second wait surface.
+        self._modal_guard = QtWidgets.QDialog(self)
+        self._modal_guard.setModal(True)
+        self._modal_guard.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        self._modal_guard.setAttribute(QtCore.Qt.WidgetAttribute.WA_DontShowOnScreen)
+
+    def open(self) -> None:
+        if not qt_is_valid(self, self._modal_guard):
+            return
+        self._modal_guard.open()
+        self.show_centered()
+
+    def close(self) -> bool:
+        if qt_is_valid(self._modal_guard):
+            self._modal_guard.close()
+            if qt_is_valid(self._modal_guard):
+                self._modal_guard.deleteLater()
+        return super().close()
+
+    def show_centered(self) -> None:
+        if not qt_is_valid(self):
+            return
+        parent = self.parentWidget()
+        if parent is None or not qt_is_valid(parent):
+            return
+        self.adjustSize()
+        self.move(parent.rect().center() - self.rect().center())
+        self.show()
+        self.raise_()
+        self.repaint()
+
+    def set_message(self, message: str) -> None:
+        if not qt_is_valid(self, self._label):
+            return
+        self._label.setText(message)
+        self.show_centered()
 
 
 class _SuppressedWaitDialog:
@@ -647,7 +697,7 @@ class _SuppressedWaitDialog:
 @contextlib.contextmanager
 def wait_dialog(
     parent: QtWidgets.QWidget, message: str
-) -> Iterator[_WaitDialog | _SuppressedWaitDialog]:
+) -> Iterator[_WaitDialog | _WaitPanel | _SuppressedWaitDialog]:
     """Show a wait dialog while executing a block of code.
 
     This context manager creates a simple dialog with a message while the block of code
@@ -671,17 +721,23 @@ def wait_dialog(
         yield _SuppressedWaitDialog()
         return
 
-    dialog = _WaitDialog(parent, message)
+    if sys.platform == "darwin":
+        indicator = _WaitDialog(parent, message)
+    else:
+        indicator = _WaitPanel(parent, message)
+
     _WAIT_DIALOG_DEPTH += 1
     try:
-        dialog.open()
-        yield dialog
+        indicator.open()
+        yield indicator
     finally:
         try:
-            try:
-                dialog.close()
-            finally:
-                dialog.deleteLater()
+            if qt_is_valid(indicator):
+                try:
+                    indicator.close()
+                finally:
+                    if qt_is_valid(indicator):
+                        indicator.deleteLater()
         finally:
             _WAIT_DIALOG_DEPTH -= 1
 

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -640,22 +640,75 @@ class _WaitDialog(QtWidgets.QDialog):
         self._label.setText(message)
         self.adjustSize()
 
+    def _finish(self) -> None:
+        if not qt_is_valid(self):
+            return
+        self.close()
+        if qt_is_valid(self):
+            self.deleteLater()
 
-class _WaitPanel(QtWidgets.QFrame):
+
+class _WaitModalGuard(QtWidgets.QDialog):
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
+        super().__init__(parent)
+        self.setModal(True)
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DontShowOnScreen)
+        self._dispatcher: QtCore.QAbstractEventDispatcher | None = None
+        self._event_loop_passes = 0
+
+    def release_after_event_drain(self) -> None:
+        if not qt_is_valid(self) or self._dispatcher is not None:
+            return
+        dispatcher = QtCore.QAbstractEventDispatcher.instance()
+        if dispatcher is None or not qt_is_valid(dispatcher):
+            self._release()
+            return
+        self._dispatcher = dispatcher
+        # Dispatcher signal order differs across QPA backends. Two wake boundaries
+        # keep modality active for at least one complete native-event drain.
+        dispatcher.awake.connect(self._event_loop_awake)
+        QtCore.QTimer.singleShot(0, self._continue_event_drain)
+
+    @QtCore.Slot()
+    def _event_loop_awake(self) -> None:
+        if not qt_is_valid(self):
+            return
+        self._event_loop_passes += 1
+        if self._event_loop_passes < 2:
+            QtCore.QTimer.singleShot(0, self._continue_event_drain)
+            return
+        self._release()
+
+    @QtCore.Slot()
+    def _continue_event_drain(self) -> None:
+        if self._dispatcher is not None and qt_is_valid(self._dispatcher):
+            self._dispatcher.wakeUp()
+
+    def _release(self) -> None:
+        dispatcher = self._dispatcher
+        self._dispatcher = None
+        if dispatcher is not None and qt_is_valid(dispatcher):
+            with contextlib.suppress(TypeError, RuntimeError):
+                dispatcher.awake.disconnect(self._event_loop_awake)
+        if not qt_is_valid(self):
+            return
+        panel = self.parentWidget()
+        self.close()
+        if panel is not None and qt_is_valid(panel):
+            panel.deleteLater()
+        elif qt_is_valid(self):
+            self.deleteLater()
+
+
+class _WaitPanel(QtWidgets.QLabel):
     def __init__(self, parent: QtWidgets.QWidget, message: str) -> None:
-        super().__init__(parent.window())
+        super().__init__(message, parent.window())
+        self.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+        self.setMargin(20)
         self.setAutoFillBackground(True)
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.setContentsMargins(24, 20, 24, 20)
-        self._label = QtWidgets.QLabel(message)
-        layout.addWidget(self._label)
-
-        # Keep native window modality without presenting a second wait surface.
-        self._modal_guard = QtWidgets.QDialog(self)
-        self._modal_guard.setModal(True)
-        self._modal_guard.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
-        self._modal_guard.setAttribute(QtCore.Qt.WidgetAttribute.WA_DontShowOnScreen)
+        self._modal_guard = _WaitModalGuard(self)
 
     def open(self) -> None:
         if not qt_is_valid(self, self._modal_guard):
@@ -663,30 +716,37 @@ class _WaitPanel(QtWidgets.QFrame):
         self._modal_guard.open()
         self.show_centered()
 
-    def close(self) -> bool:
-        if qt_is_valid(self._modal_guard):
-            self._modal_guard.close()
-            if qt_is_valid(self._modal_guard):
-                self._modal_guard.deleteLater()
-        return super().close()
-
     def show_centered(self) -> None:
         if not qt_is_valid(self):
             return
         parent = self.parentWidget()
         if parent is None or not qt_is_valid(parent):
             return
+        previous_geometry = self.geometry() if self.isVisible() else QtCore.QRect()
         self.adjustSize()
         self.move(parent.rect().center() - self.rect().center())
         self.show()
         self.raise_()
+        dirty_region = self.geometry()
+        if previous_geometry.isValid():
+            dirty_region = dirty_region.united(previous_geometry)
+        parent.repaint(dirty_region)
         self.repaint()
 
     def set_message(self, message: str) -> None:
-        if not qt_is_valid(self, self._label):
+        if not qt_is_valid(self):
             return
-        self._label.setText(message)
+        self.setText(message)
         self.show_centered()
+
+    def _finish(self) -> None:
+        if not qt_is_valid(self):
+            return
+        self.hide()
+        if qt_is_valid(self._modal_guard):
+            self._modal_guard.release_after_event_drain()
+        else:
+            self.deleteLater()
 
 
 class _SuppressedWaitDialog:
@@ -733,11 +793,7 @@ def wait_dialog(
     finally:
         try:
             if qt_is_valid(indicator):
-                try:
-                    indicator.close()
-                finally:
-                    if qt_is_valid(indicator):
-                        indicator.deleteLater()
+                indicator._finish()
         finally:
             _WAIT_DIALOG_DEPTH -= 1
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1033,8 +1033,14 @@ def test_wait_dialog_uses_platform_indicator_and_suppresses_nested(
 
     with erlab.interactive.utils.wait_dialog(parent, "Outer") as outer:
         assert isinstance(outer, getattr(erlab.interactive.utils, indicator_type_name))
-        assert outer.layout().getContentsMargins() == (24, 20, 24, 20)
-        assert outer.sizeHint().height() >= outer._label.sizeHint().height() + 20 * 2
+        if isinstance(outer, erlab.interactive.utils._WaitDialog):
+            assert outer.layout().getContentsMargins() == (24, 20, 24, 20)
+            assert (
+                outer.sizeHint().height() >= outer._label.sizeHint().height() + 20 * 2
+            )
+        else:
+            assert outer.margin() == 20
+            assert outer.sizeHint().height() >= outer.fontMetrics().height() + 20 * 2
         outer.set_message("A substantially longer outer message")
         updated_width = outer.sizeHint().width()
 
@@ -1068,18 +1074,23 @@ def test_wait_panel_paints_synchronously_and_repaints_message_updates(
         assert isinstance(panel, RecordingWaitPanel)
         assert panel.parentWidget() is window
         assert paint_sizes
-        initial_paint_count = len(paint_sizes)
         initial_width = panel.width()
 
-        panel.set_message("A substantially longer wait-panel message")
+        for message in (
+            "Loading workspace... (1/12)",
+            "Loading workspace... (2/12)",
+            "Loading workspace... (12/12)",
+        ):
+            paint_count = len(paint_sizes)
+            panel.set_message(message)
+            assert len(paint_sizes) > paint_count
 
-        assert len(paint_sizes) > initial_paint_count
         assert panel.width() > initial_width
         center_delta = panel.geometry().center() - window.rect().center()
         assert center_delta.manhattanLength() <= 1
 
 
-def test_wait_panel_blocks_parent_input_without_showing_modal_guard(
+def test_wait_panel_discards_input_queued_during_synchronous_work(
     qtbot, monkeypatch
 ) -> None:
     monkeypatch.setattr(erlab.interactive.utils.sys, "platform", "win32")
@@ -1098,6 +1109,16 @@ def test_wait_panel_blocks_parent_input_without_showing_modal_guard(
 
     button.clicked.connect(_record_click)
     click_position = button.mapTo(window, button.rect().center())
+    click_attempted = False
+
+    def _click_parent_window() -> None:
+        nonlocal click_attempted
+        click_attempted = True
+        QtTest.QTest.mouseClick(
+            window.windowHandle(),
+            QtCore.Qt.MouseButton.LeftButton,
+            pos=click_position,
+        )
 
     with erlab.interactive.utils.wait_dialog(window, "Blocking input") as panel:
         assert isinstance(panel, erlab.interactive.utils._WaitPanel)
@@ -1110,17 +1131,18 @@ def test_wait_panel_blocks_parent_input_without_showing_modal_guard(
         assert not modal_handle.isVisible()
         assert not modal_handle.isExposed()
 
-        QtCore.QTimer.singleShot(
-            0,
-            lambda: QtTest.QTest.mouseClick(
-                window.windowHandle(),
-                QtCore.Qt.MouseButton.LeftButton,
-                pos=click_position,
-            ),
-        )
-        QtWidgets.QApplication.processEvents()
-        assert click_count == 0
+        QtCore.QTimer.singleShot(0, _click_parent_window)
 
+    assert not panel.isVisible()
+    assert QtWidgets.QApplication.activeModalWidget() is modal_guard
+    qtbot.waitUntil(
+        lambda: QtWidgets.QApplication.activeModalWidget() is not modal_guard,
+        timeout=1000,
+    )
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+
+    assert click_attempted
+    assert click_count == 0
     assert QtWidgets.QApplication.activeModalWidget() is not modal_guard
     QtTest.QTest.mouseClick(
         window.windowHandle(),
@@ -1129,6 +1151,25 @@ def test_wait_panel_blocks_parent_input_without_showing_modal_guard(
     )
     QtWidgets.QApplication.processEvents()
     assert click_count == 1
+
+
+def test_wait_panel_pending_input_drain_is_safe_if_parent_is_destroyed(
+    qtbot, monkeypatch
+) -> None:
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", "win32")
+    parent = QtWidgets.QWidget()
+
+    with erlab.interactive.utils.wait_dialog(parent, "Lifetime check") as panel:
+        assert isinstance(panel, erlab.interactive.utils._WaitPanel)
+        modal_guard = panel._modal_guard
+
+    assert qt_is_valid(panel, modal_guard)
+    parent.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    assert not qt_is_valid(parent)
+    assert not qt_is_valid(panel)
+    assert not qt_is_valid(modal_guard)
+    QtWidgets.QApplication.processEvents()
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1020,50 +1020,195 @@ def test_accept_dialog_unwinds_modal_when_callback_raises(accept_dialog) -> None
     assert not dialog.isVisible()
 
 
-def test_wait_dialog_suppresses_nested_dialog(qtbot) -> None:
+@pytest.mark.parametrize(
+    ("platform", "indicator_type_name"),
+    [("darwin", "_WaitDialog"), ("win32", "_WaitPanel")],
+)
+def test_wait_dialog_uses_platform_indicator_and_suppresses_nested(
+    qtbot, monkeypatch, platform: str, indicator_type_name: str
+) -> None:
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", platform)
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
 
     with erlab.interactive.utils.wait_dialog(parent, "Outer") as outer:
-        assert isinstance(outer, erlab.interactive.utils._WaitDialog)
+        assert isinstance(outer, getattr(erlab.interactive.utils, indicator_type_name))
         assert outer.layout().getContentsMargins() == (24, 20, 24, 20)
         assert outer.sizeHint().height() >= outer._label.sizeHint().height() + 20 * 2
-        outer.set_message("Outer updated")
+        outer.set_message("A substantially longer outer message")
+        updated_width = outer.sizeHint().width()
 
         with erlab.interactive.utils.wait_dialog(parent, "Inner") as inner:
-            assert not isinstance(inner, QtWidgets.QDialog)
+            assert isinstance(inner, erlab.interactive.utils._SuppressedWaitDialog)
             inner.set_message("Inner ignored")
-            assert outer._label.text() == "Outer updated"
+            assert outer.sizeHint().width() == updated_width
 
 
-def test_wait_dialog_constructor_failure_does_not_suppress_later_dialogs(
+def test_wait_panel_paints_synchronously_and_repaints_message_updates(
     qtbot, monkeypatch
 ) -> None:
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", "win32")
+    paint_sizes: list[QtCore.QSize] = []
+
+    class RecordingWaitPanel(erlab.interactive.utils._WaitPanel):
+        def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
+            paint_sizes.append(self.size())
+            super().paintEvent(event)
+
+    monkeypatch.setattr(erlab.interactive.utils, "_WaitPanel", RecordingWaitPanel)
+    window = QtWidgets.QMainWindow()
+    child = QtWidgets.QWidget()
+    window.setCentralWidget(child)
+    window.resize(640, 360)
+    qtbot.addWidget(window)
+    with qtbot.waitExposed(window):
+        window.show()
+
+    with erlab.interactive.utils.wait_dialog(child, "Short") as panel:
+        assert isinstance(panel, RecordingWaitPanel)
+        assert panel.parentWidget() is window
+        assert paint_sizes
+        initial_paint_count = len(paint_sizes)
+        initial_width = panel.width()
+
+        panel.set_message("A substantially longer wait-panel message")
+
+        assert len(paint_sizes) > initial_paint_count
+        assert panel.width() > initial_width
+        center_delta = panel.geometry().center() - window.rect().center()
+        assert center_delta.manhattanLength() <= 1
+
+
+def test_wait_panel_blocks_parent_input_without_showing_modal_guard(
+    qtbot, monkeypatch
+) -> None:
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", "win32")
+    window = QtWidgets.QMainWindow()
+    button = QtWidgets.QPushButton()
+    window.setCentralWidget(button)
+    window.resize(640, 360)
+    qtbot.addWidget(window)
+    with qtbot.waitExposed(window):
+        window.show()
+    click_count = 0
+
+    def _record_click() -> None:
+        nonlocal click_count
+        click_count += 1
+
+    button.clicked.connect(_record_click)
+    click_position = button.mapTo(window, button.rect().center())
+
+    with erlab.interactive.utils.wait_dialog(window, "Blocking input") as panel:
+        assert isinstance(panel, erlab.interactive.utils._WaitPanel)
+        modal_guard = panel._modal_guard
+        assert modal_guard.windowModality() == QtCore.Qt.WindowModality.WindowModal
+        assert modal_guard.testAttribute(QtCore.Qt.WidgetAttribute.WA_DontShowOnScreen)
+        assert QtWidgets.QApplication.activeModalWidget() is modal_guard
+        modal_handle = modal_guard.windowHandle()
+        assert modal_handle is not None
+        assert not modal_handle.isVisible()
+        assert not modal_handle.isExposed()
+
+        QtCore.QTimer.singleShot(
+            0,
+            lambda: QtTest.QTest.mouseClick(
+                window.windowHandle(),
+                QtCore.Qt.MouseButton.LeftButton,
+                pos=click_position,
+            ),
+        )
+        QtWidgets.QApplication.processEvents()
+        assert click_count == 0
+
+    assert QtWidgets.QApplication.activeModalWidget() is not modal_guard
+    QtTest.QTest.mouseClick(
+        window.windowHandle(),
+        QtCore.Qt.MouseButton.LeftButton,
+        pos=click_position,
+    )
+    QtWidgets.QApplication.processEvents()
+    assert click_count == 1
+
+
+@pytest.mark.parametrize(
+    ("platform", "indicator_type_name"),
+    [("darwin", "_WaitDialog"), ("win32", "_WaitPanel")],
+)
+def test_wait_indicator_constructor_failure_does_not_suppress_later_indicators(
+    qtbot, monkeypatch, platform: str, indicator_type_name: str
+) -> None:
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", platform)
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     original_depth = erlab.interactive.utils._WAIT_DIALOG_DEPTH
 
-    class BrokenWaitDialog:
+    class BrokenWaitIndicator:
         def __init__(self, *_args, **_kwargs) -> None:
-            raise RuntimeError("dialog construction failed")
+            raise RuntimeError("indicator construction failed")
 
-    original_wait_dialog = erlab.interactive.utils._WaitDialog
-    monkeypatch.setattr(erlab.interactive.utils, "_WaitDialog", BrokenWaitDialog)
-    try:
-        with (
-            pytest.raises(RuntimeError, match="dialog construction failed"),
-            erlab.interactive.utils.wait_dialog(parent, "Broken"),
-        ):
-            pass
-    finally:
-        monkeypatch.setattr(
-            erlab.interactive.utils, "_WaitDialog", original_wait_dialog
-        )
+    original_indicator_type = getattr(erlab.interactive.utils, indicator_type_name)
+    monkeypatch.setattr(
+        erlab.interactive.utils, indicator_type_name, BrokenWaitIndicator
+    )
+    with (
+        pytest.raises(RuntimeError, match="indicator construction failed"),
+        erlab.interactive.utils.wait_dialog(parent, "Broken"),
+    ):
+        pass
 
     current_depth = erlab.interactive.utils._WAIT_DIALOG_DEPTH
     assert current_depth == original_depth
-    with erlab.interactive.utils.wait_dialog(parent, "Outer") as dialog:
-        assert isinstance(dialog, erlab.interactive.utils._WaitDialog)
+    monkeypatch.setattr(
+        erlab.interactive.utils, indicator_type_name, original_indicator_type
+    )
+    with erlab.interactive.utils.wait_dialog(parent, "Outer") as indicator:
+        assert isinstance(indicator, original_indicator_type)
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_wait_indicator_parent_destruction_is_safe(
+    qtbot, monkeypatch, platform: str
+) -> None:
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", platform)
+    parent = QtWidgets.QWidget()
+    original_depth = erlab.interactive.utils._WAIT_DIALOG_DEPTH
+
+    with erlab.interactive.utils.wait_dialog(parent, "Lifetime check") as indicator:
+        modal_guard = getattr(indicator, "_modal_guard", None)
+        parent.deleteLater()
+        QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+        assert not qt_is_valid(parent)
+        assert not qt_is_valid(indicator)
+        if modal_guard is not None:
+            assert not qt_is_valid(modal_guard)
+
+    assert original_depth == erlab.interactive.utils._WAIT_DIALOG_DEPTH
+
+
+@pytest.mark.parametrize(
+    ("platform", "indicator_type_name"),
+    [("darwin", "_WaitDialog"), ("win32", "_WaitPanel")],
+)
+def test_wait_indicator_body_exception_restores_depth(
+    qtbot, monkeypatch, platform: str, indicator_type_name: str
+) -> None:
+    monkeypatch.setattr(erlab.interactive.utils.sys, "platform", platform)
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    original_depth = erlab.interactive.utils._WAIT_DIALOG_DEPTH
+
+    with (
+        pytest.raises(RuntimeError, match="operation failed"),
+        erlab.interactive.utils.wait_dialog(parent, "Outer"),
+    ):
+        raise RuntimeError("operation failed")
+
+    assert original_depth == erlab.interactive.utils._WAIT_DIALOG_DEPTH
+    with erlab.interactive.utils.wait_dialog(parent, "Later") as indicator:
+        assert isinstance(
+            indicator, getattr(erlab.interactive.utils, indicator_type_name)
+        )
 
 
 def test_set_widget_cursor_skips_native_cursor_updates_on_macos(

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1135,6 +1135,7 @@ def test_wait_panel_discards_input_queued_during_synchronous_work(
 
     assert not panel.isVisible()
     assert QtWidgets.QApplication.activeModalWidget() is modal_guard
+    modal_guard._continue_event_drain()
     qtbot.waitUntil(
         lambda: QtWidgets.QApplication.activeModalWidget() is not modal_guard,
         timeout=1000,
@@ -1170,6 +1171,67 @@ def test_wait_panel_pending_input_drain_is_safe_if_parent_is_destroyed(
     assert not qt_is_valid(panel)
     assert not qt_is_valid(modal_guard)
     QtWidgets.QApplication.processEvents()
+
+
+def test_wait_panel_releases_without_event_dispatcher(qtbot, monkeypatch) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    panel = erlab.interactive.utils._WaitPanel(parent, "No dispatcher")
+    modal_guard = panel._modal_guard
+    monkeypatch.setattr(
+        QtCore.QAbstractEventDispatcher,
+        "instance",
+        lambda: None,
+    )
+
+    modal_guard.release_after_event_drain()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+
+    assert not qt_is_valid(panel)
+    assert not qt_is_valid(modal_guard)
+
+
+def test_wait_panel_ignores_centering_after_reparenting(qtbot) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    panel = erlab.interactive.utils._WaitPanel(parent, "Detached")
+    qtbot.addWidget(panel)
+    panel.setParent(None)
+
+    panel.show_centered()
+
+    assert not panel.isVisible()
+
+
+def test_wait_panel_finishes_after_modal_guard_is_destroyed(qtbot) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    panel = erlab.interactive.utils._WaitPanel(parent, "Missing guard")
+    modal_guard = panel._modal_guard
+    modal_guard.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    assert qt_is_valid(panel)
+    assert not qt_is_valid(modal_guard)
+
+    panel._finish()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+
+    assert not qt_is_valid(panel)
+
+
+def test_wait_modal_guard_finishes_after_reparenting(qtbot) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    panel = erlab.interactive.utils._WaitPanel(parent, "Detached guard")
+    modal_guard = panel._modal_guard
+    qtbot.addWidget(modal_guard)
+    modal_guard.setParent(None)
+
+    modal_guard._release()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+
+    assert qt_is_valid(panel)
+    assert not qt_is_valid(modal_guard)
 
 
 @pytest.mark.parametrize(
@@ -1223,6 +1285,16 @@ def test_wait_indicator_parent_destruction_is_safe(
         assert not qt_is_valid(indicator)
         if modal_guard is not None:
             assert not qt_is_valid(modal_guard)
+
+        indicator.set_message("Ignored after destruction")
+        indicator._finish()
+        if modal_guard is not None:
+            indicator.open()
+            indicator.show_centered()
+            modal_guard.release_after_event_drain()
+            modal_guard._event_loop_awake()
+            modal_guard._continue_event_drain()
+            modal_guard._release()
 
     assert original_depth == erlab.interactive.utils._WAIT_DIALOG_DEPTH
 


### PR DESCRIPTION
## Summary

- keep the existing native `QDialog` wait surface on macOS
- use a parent-owned styled `QLabel` panel on Windows and Linux so the visible text widget paints synchronously
- repaint every workspace progress update without pumping the application event loop
- preserve window-modal input blocking until Qt completes a post-work native-event drain
- retain nested suppression and safe parent/guard destruction under both Qt bindings

## Root cause

`QDialog.open()` returns immediately. On Windows, synchronous workspace loading
occupied the GUI thread before the native wait surface received its initial
exposure and paint. A parent-owned panel avoids that exposure dependency.

The first panel implementation put the text in a child `QLabel` and repainted
the containing `QFrame`. With the event loop blocked, that did not reliably
present each child-label update on Windows. The panel is now the `QLabel`
itself, matching the Windows reproducer, and repaints both its changed area in
the parent and the text widget directly.

The invisible modal guard also previously closed before Qt resumed event
dispatch. Input queued during synchronous work could therefore be delivered
after cleanup on a backend that did not reject it natively. The guard now stays
active across two dispatcher wake boundaries, ensuring at least one complete
post-work native-event pass before it releases. This does not call
`processEvents()` or create a nested event loop.

## User impact

Wait messages and workspace-loading progress counts update on Windows and Linux
without changing the `wait_dialog()` context-manager API. Clicks queued while a
synchronous operation is running are discarded before the parent becomes
interactive again. macOS retains its existing native appearance.

## Validation

- `QT_QPA_PLATFORM=offscreen QT_API=pyqt6 uv run pytest -q tests/interactive/test_utils.py` (`175 passed`)
- `QT_QPA_PLATFORM=offscreen QT_API=pyside6 uv run pytest -q tests/interactive/test_utils.py` (`175 passed`)
- workspace save/load round trip under PyQt6 and PySide6
- `uv run mypy src/erlab/interactive/utils.py`
- `uv run ruff format --check .`
- `uv run ruff check .`

The tests cover repeated synchronous progress repaints, input queued until after
context exit, post-work modal release, nested suppression, exceptions, and
parent destruction before the deferred drain completes.
