### PR TITLE
fix(interactive): persist tool plot appearance

### DIFF
--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -658,6 +658,7 @@ class Fit2DTool(Fit1DTool):
         self.cbar.set_dimensions(vert_pad=40)
         self.cbar.setPreferredWidth(60)
         self.plot_widget.addItem(self.cbar, 0, 2, 2, 1)
+        self._register_plot_appearance("data", self.cbar)
         self.image_plot_legend: pg.LegendItem = self.image_plot.addLegend(offset=(5, 5))
         self.image_plot_legend.setVisible(False)
         if hasattr(self.image_plot_legend, "sigSampleClicked"):  # pragma: no branch

--- a/src/erlab/interactive/_mesh.py
+++ b/src/erlab/interactive/_mesh.py
@@ -262,6 +262,10 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
         for cbar in (self.cbar_data, self.cbar_mesh, self.cbar_fft, self.cbar_mask):
             cbar.set_dimensions(horiz_pad=30, vert_pad=30)
             cbar.setPreferredWidth(60)
+        self._register_plot_appearance("data", self.cbar_data)
+        self._register_plot_appearance("mesh", self.cbar_mesh)
+        self._register_plot_appearance("fft", self.cbar_fft)
+        self._register_plot_appearance("mask", self.cbar_mask)
 
         for i in range(1, len(self.image_plots)):
             self.image_plots[i].setXLink(self.image_plots[0])

--- a/src/erlab/interactive/_plot_state.py
+++ b/src/erlab/interactive/_plot_state.py
@@ -1,0 +1,698 @@
+"""Semantic persistence for non-ImageTool plot appearance."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import math
+import typing
+import weakref
+
+import numpy as np
+import pydantic
+import pyqtgraph as pg
+from qtpy import QtCore
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from erlab.interactive.colors import BetterColorBarItem
+
+logger = logging.getLogger(__name__)
+
+TOOL_VIEW_STATE_ATTR = "tool_view_state"
+_TOOL_VIEW_STATE_VERSION = 1
+_MAX_SAVED_COLORMAP_STOPS = 256
+
+
+class _PlotStateModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="ignore", frozen=True)
+
+
+class NamedColormapState(_PlotStateModel):
+    """A colormap that can be reconstructed from its registered name."""
+
+    kind: typing.Literal["named"] = "named"
+    name: str = pydantic.Field(min_length=1)
+    reverse: bool = False
+
+
+class GradientStopState(_PlotStateModel):
+    """One normalized stop in a saved custom gradient."""
+
+    position: float = pydantic.Field(ge=0.0, le=1.0)
+    color: tuple[int, int, int, int]
+
+    @pydantic.field_validator("position")
+    @classmethod
+    def _position_must_be_finite(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("gradient stop positions must be finite")
+        return value
+
+    @pydantic.field_validator("color")
+    @classmethod
+    def _color_channels_must_be_bytes(
+        cls, value: tuple[int, int, int, int]
+    ) -> tuple[int, int, int, int]:
+        if any(channel < 0 or channel > 255 for channel in value):
+            raise ValueError("gradient color channels must be between 0 and 255")
+        return value
+
+
+class GradientColormapState(_PlotStateModel):
+    """An explicit pyqtgraph gradient."""
+
+    kind: typing.Literal["gradient"] = "gradient"
+    mode: typing.Literal["rgb", "hsv"] = "rgb"
+    stops: tuple[GradientStopState, ...] = pydantic.Field(min_length=2)
+
+
+ColormapState = typing.Annotated[
+    NamedColormapState | GradientColormapState,
+    pydantic.Field(discriminator="kind"),
+]
+
+
+class PowerNormState(_PlotStateModel):
+    """ERLab's power-normalization parameters."""
+
+    kind: typing.Literal["power"] = "power"
+    gamma: float = pydantic.Field(gt=0.0)
+    high_contrast: bool = False
+    zero_centered: bool = False
+
+    @pydantic.field_validator("gamma")
+    @classmethod
+    def _gamma_must_be_finite(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("gamma must be finite")
+        return value
+
+
+class PlotAppearanceState(_PlotStateModel):
+    """Backend-neutral color appearance for one semantic plot."""
+
+    colormap: ColormapState
+    norm: PowerNormState | None = None
+    levels: tuple[float, float] | None = None
+
+    @pydantic.field_validator("levels")
+    @classmethod
+    def _validate_levels(
+        cls, value: tuple[float, float] | None
+    ) -> tuple[float, float] | None:
+        if value is None:
+            return None
+        lower, upper = value
+        if not math.isfinite(lower) or not math.isfinite(upper) or lower > upper:
+            raise ValueError("color levels must be finite and nondecreasing")
+        return (lower, upper)
+
+
+class ToolViewState(_PlotStateModel):
+    """Saved appearance for the registered plots in one ToolWindow."""
+
+    version: typing.Literal[1] = 1
+    plots: dict[str, PlotAppearanceState] = pydantic.Field(default_factory=dict)
+
+
+def _parse_tool_view_state(payload: object) -> ToolViewState:
+    if isinstance(payload, bytes):
+        payload = payload.decode()
+    if not isinstance(payload, str):
+        raise TypeError("saved tool view state must be JSON text")
+    raw = json.loads(payload)
+    if not isinstance(raw, dict):
+        raise TypeError("saved tool view state must be a JSON object")
+    if raw.get("version", _TOOL_VIEW_STATE_VERSION) != _TOOL_VIEW_STATE_VERSION:
+        raise ValueError("unsupported saved tool view state version")
+    raw_plots = raw.get("plots", {})
+    if not isinstance(raw_plots, dict):
+        raise TypeError("saved tool view-state plots must be a JSON object")
+
+    plots: dict[str, PlotAppearanceState] = {}
+    for plot_id, state in raw_plots.items():
+        if not isinstance(plot_id, str) or not plot_id:
+            logger.warning("Ignoring saved plot appearance with an invalid plot ID")
+            continue
+        try:
+            plots[plot_id] = PlotAppearanceState.model_validate(state)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Ignoring invalid saved plot appearance for %s",
+                plot_id,
+                exc_info=True,
+            )
+    return ToolViewState(plots=plots)
+
+
+def _sample_colormap(cmap: pg.ColorMap) -> GradientColormapState:
+    positions, colors = cmap.getStops(pg.ColorMap.BYTE)
+    positions = np.asarray(positions, dtype=float)
+    colors = np.asarray(colors, dtype=np.uint8)
+    if positions.size > _MAX_SAVED_COLORMAP_STOPS:
+        indices = np.linspace(
+            0, positions.size - 1, _MAX_SAVED_COLORMAP_STOPS, dtype=int
+        )
+        positions = positions[indices]
+        colors = colors[indices]
+    return GradientColormapState(
+        stops=tuple(
+            GradientStopState(
+                position=float(position),
+                color=typing.cast(
+                    "tuple[int, int, int, int]",
+                    tuple(int(channel) for channel in color),
+                ),
+            )
+            for position, color in zip(positions, colors, strict=True)
+        )
+    )
+
+
+def _gradient_state(
+    state: Mapping[str, typing.Any],
+) -> GradientColormapState:
+    mode = state.get("mode", "rgb")
+    if mode not in {"rgb", "hsv"}:
+        mode = "rgb"
+    raw_stops = state.get("ticks", ())
+    stops = tuple(
+        GradientStopState(
+            position=float(position),
+            color=typing.cast(
+                "tuple[int, int, int, int]",
+                tuple(int(channel) for channel in color),
+            ),
+        )
+        for position, color in sorted(raw_stops, key=lambda stop: float(stop[0]))
+    )
+    return GradientColormapState(
+        mode=typing.cast('typing.Literal["rgb", "hsv"]', mode),
+        stops=stops,
+    )
+
+
+def _gradient_restore_payload(state: GradientColormapState) -> dict[str, object]:
+    return {
+        "mode": state.mode,
+        "ticks": [
+            (stop.position, stop.color)
+            for stop in sorted(state.stops, key=lambda stop: stop.position)
+        ],
+    }
+
+
+class _PlotAppearanceAdapter:
+    def __init__(
+        self,
+        target: object,
+        *,
+        changed: Callable[[str], None],
+        image_changed: Callable[[], None],
+    ) -> None:
+        self._target_ref = weakref.ref(target)
+        self._changed_callback = changed
+        self._image_changed_callback = image_changed
+        self._connections: list[tuple[object, object, Callable[..., None]]] = []
+        self._applying = False
+        self.manual_levels = False
+        self.desired_state: PlotAppearanceState | None = None
+
+    @property
+    def target(self) -> object | None:
+        return self._target_ref()
+
+    def _connect(
+        self,
+        owner: object,
+        signal: object,
+        slot: Callable[..., None],
+    ) -> None:
+        signal.connect(slot)  # type: ignore[attr-defined]
+        self._connections.append((owner, signal, slot))
+
+    def disconnect(self) -> None:
+        from erlab.interactive.utils import qt_is_valid
+
+        for owner, signal, slot in self._connections:
+            if not qt_is_valid(owner):
+                continue
+            with contextlib.suppress(RuntimeError, TypeError):
+                signal.disconnect(slot)  # type: ignore[attr-defined]
+        self._connections.clear()
+
+    def _changed(self, component: str) -> None:
+        if not self._applying:
+            self._changed_callback(component)
+
+    def _image_changed(self) -> None:
+        if not self._applying:
+            self._image_changed_callback()
+
+    def capture(self) -> PlotAppearanceState | None:
+        raise NotImplementedError
+
+    def apply(self, state: PlotAppearanceState) -> None:
+        raise NotImplementedError
+
+    def set_desired_state(self, state: PlotAppearanceState) -> None:
+        self.desired_state = state
+        self.manual_levels = state.levels is not None
+        self.apply(state)
+
+    def reapply(self) -> None:
+        if self.desired_state is not None:
+            self.apply(self.desired_state)
+
+
+class _BetterColorBarAdapter(_PlotAppearanceAdapter):
+    @property
+    def colorbar(self) -> BetterColorBarItem | None:
+        return typing.cast("BetterColorBarItem | None", self.target)
+
+    def __init__(
+        self,
+        target: BetterColorBarItem,
+        *,
+        changed: Callable[[str], None],
+        image_changed: Callable[[], None],
+    ) -> None:
+        super().__init__(target, changed=changed, image_changed=image_changed)
+        self._expanded_limits = False
+        self._connect(
+            target,
+            target.sigColorChanged,
+            lambda: self._changed("color"),
+        )
+        self._connect(
+            target,
+            target.sigLevelsChangeFinished,
+            lambda: self._changed("levels"),
+        )
+        for image_ref in tuple(target.images):
+            image = image_ref()
+            if image is not None:
+                self._connect(image, image.sigImageChanged, self._image_changed)
+
+    def capture(self) -> PlotAppearanceState | None:
+        colorbar = self.colorbar
+        if colorbar is None:
+            return None
+        image_ref = colorbar.primary_image
+        image = None if image_ref is None else image_ref()
+        if image is None:
+            return None
+        cmap = image.getColorMap()
+        if cmap is None:
+            return None
+        properties = colorbar.colormap_properties
+        if properties is None:
+            colormap: ColormapState = _sample_colormap(cmap)
+            norm = None
+        else:
+            colormap = NamedColormapState(
+                name=properties["cmap"],
+                reverse=properties["reverse"],
+            )
+            norm = PowerNormState(
+                gamma=properties["gamma"],
+                high_contrast=properties["high_contrast"],
+                zero_centered=properties["zero_centered"],
+            )
+        levels = None
+        if self.manual_levels:
+            levels = typing.cast(
+                "tuple[float, float]",
+                tuple(float(value) for value in colorbar.spanRegion()),
+            )
+        return PlotAppearanceState(
+            colormap=colormap,
+            norm=norm,
+            levels=levels,
+        )
+
+    def apply(self, state: PlotAppearanceState) -> None:
+        colorbar = self.colorbar
+        if colorbar is None:
+            return
+        self._applying = True
+        try:
+            if state.levels is not None:
+                image_ref = colorbar.primary_image
+                image = None if image_ref is None else image_ref()
+                if image is not None:
+                    data_limits = tuple(
+                        float(value) for value in image.quickMinMax(targetSize=2**16)
+                    )
+                    if all(math.isfinite(value) for value in data_limits):
+                        domain = (
+                            min(data_limits[0], state.levels[0]),
+                            max(data_limits[1], state.levels[1]),
+                        )
+                    else:
+                        domain = state.levels
+                        if domain[0] == domain[1]:
+                            lower = math.nextafter(domain[0], -math.inf)
+                            upper = math.nextafter(domain[1], math.inf)
+                            domain = (
+                                lower if math.isfinite(lower) else domain[0],
+                                upper if math.isfinite(upper) else domain[1],
+                            )
+                    if domain != data_limits:
+                        colorbar.setLimits(domain)
+                        self._expanded_limits = True
+                    elif self._expanded_limits:
+                        colorbar.setLimits(None)
+                        self._expanded_limits = False
+            if isinstance(state.colormap, NamedColormapState):
+                norm = state.norm or PowerNormState(gamma=1.0)
+                try:
+                    colorbar.set_colormap(
+                        state.colormap.name,
+                        gamma=norm.gamma,
+                        reverse=state.colormap.reverse,
+                        high_contrast=norm.high_contrast,
+                        zero_centered=norm.zero_centered,
+                    )
+                except RuntimeError:
+                    logger.warning(
+                        "Saved colormap %r is unavailable; applying its normalization "
+                        "to the current colormap",
+                        state.colormap.name,
+                    )
+                    fallback = colorbar.colormap_properties
+                    if fallback is not None and fallback["cmap"] != state.colormap.name:
+                        fallback_name = fallback["cmap"]
+                        colorbar.set_colormap(
+                            fallback_name,
+                            gamma=norm.gamma,
+                            reverse=state.colormap.reverse,
+                            high_contrast=norm.high_contrast,
+                            zero_centered=norm.zero_centered,
+                        )
+                        self.desired_state = state.model_copy(
+                            update={
+                                "colormap": NamedColormapState(
+                                    name=fallback_name,
+                                    reverse=state.colormap.reverse,
+                                )
+                            }
+                        )
+                    else:
+                        image_ref = colorbar.primary_image
+                        image = None if image_ref is None else image_ref()
+                        fallback_cmap = None if image is None else image.getColorMap()
+                        if image is not None and fallback_cmap is not None:
+                            colorbar.set_colormap(
+                                fallback_cmap,
+                                gamma=norm.gamma,
+                                reverse=state.colormap.reverse,
+                                high_contrast=norm.high_contrast,
+                                zero_centered=norm.zero_centered,
+                            )
+                            applied_cmap = image.getColorMap()
+                            if applied_cmap is not None:
+                                self.desired_state = state.model_copy(
+                                    update={
+                                        "colormap": _sample_colormap(applied_cmap),
+                                        "norm": None,
+                                    }
+                                )
+            else:
+                cmap = pg.ColorMap(
+                    [stop.position for stop in state.colormap.stops],
+                    [stop.color for stop in state.colormap.stops],
+                    name="saved-gradient",
+                )
+                if state.norm is None:
+                    colorbar.set_pg_colormap(cmap)
+                else:
+                    colorbar.set_colormap(
+                        cmap,
+                        gamma=state.norm.gamma,
+                        high_contrast=state.norm.high_contrast,
+                        zero_centered=state.norm.zero_centered,
+                    )
+            if state.levels is not None:
+                colorbar.setAutoLevels(False)
+                colorbar.setSpanRegion(state.levels)
+                for image_ref in tuple(colorbar.images):
+                    image = image_ref()
+                    if image is not None:
+                        image.setLevels(state.levels)
+        finally:
+            self._applying = False
+
+
+class _HistogramLUTAdapter(_PlotAppearanceAdapter):
+    @property
+    def histogram(self) -> pg.HistogramLUTItem | None:
+        return typing.cast("pg.HistogramLUTItem | None", self.target)
+
+    def __init__(
+        self,
+        target: pg.HistogramLUTItem,
+        *,
+        changed: Callable[[str], None],
+        image_changed: Callable[[], None],
+    ) -> None:
+        super().__init__(target, changed=changed, image_changed=image_changed)
+        self._level_change_started = False
+        self._connect(
+            target.gradient,
+            target.gradient.sigGradientChangeFinished,
+            lambda *_args: self._changed("color"),
+        )
+        self._connect(
+            target.region,
+            target.region.sigRegionChanged,
+            self._level_region_changed,
+        )
+        for line in target.region.lines:
+            self._connect(line, line.sigDragged, self._level_change_start)
+        self._connect(
+            target,
+            target.sigLevelChangeFinished,
+            self._level_change_finished,
+        )
+        image = target.imageItem()
+        if image is not None:
+            self._connect(image, image.sigImageChanged, self._image_changed)
+
+    def _level_change_start(self, *_args) -> None:
+        if not self._applying:
+            self._level_change_started = True
+
+    def _level_region_changed(self, *_args) -> None:
+        histogram = self.histogram
+        if histogram is not None and histogram.region.moving:
+            self._level_change_start()
+
+    def _level_change_finished(self, *_args) -> None:
+        if self._level_change_started:
+            self._level_change_started = False
+            self._changed("levels")
+
+    def capture(self) -> PlotAppearanceState | None:
+        histogram = self.histogram
+        if histogram is None:
+            return None
+        levels = None
+        if self.manual_levels and histogram.levelMode == "mono":
+            levels = typing.cast(
+                "tuple[float, float]",
+                tuple(float(value) for value in histogram.getLevels()),
+            )
+        return PlotAppearanceState(
+            colormap=_gradient_state(histogram.gradient.saveState()),
+            levels=levels,
+        )
+
+    def apply(self, state: PlotAppearanceState) -> None:
+        histogram = self.histogram
+        if histogram is None:
+            return
+        self._applying = True
+        try:
+            if isinstance(state.colormap, GradientColormapState):
+                histogram.gradient.restoreState(
+                    _gradient_restore_payload(state.colormap)
+                )
+            else:
+                try:
+                    cmap = pg.colormap.get(
+                        state.colormap.name,
+                        source="matplotlib",
+                        skipCache=True,
+                    )
+                except (FileNotFoundError, KeyError, ValueError):
+                    logger.warning(
+                        "Saved colormap %r is unavailable; keeping the current "
+                        "colormap",
+                        state.colormap.name,
+                    )
+                else:
+                    if state.colormap.reverse:
+                        cmap.reverse()
+                    histogram.gradient.setColorMap(cmap)
+            if state.levels is not None and histogram.levelMode == "mono":
+                histogram.setLevels(*state.levels)
+        finally:
+            self._applying = False
+
+
+class ToolPlotStateRegistry(QtCore.QObject):
+    """Track and persist registered plot appearance for one ToolWindow."""
+
+    def __init__(
+        self,
+        parent: QtCore.QObject,
+        *,
+        state_changed: Callable[[], None],
+        info_changed: Callable[[], None],
+    ) -> None:
+        super().__init__(parent)
+        self._state_changed = state_changed
+        self._info_changed = info_changed
+        self._adapters: dict[str, _PlotAppearanceAdapter] = {}
+        self._restored_states: dict[str, PlotAppearanceState] = {}
+        self._pending_changes: set[str] = set()
+        self._pending_reapply: set[str] = set()
+        self._flush_timer = QtCore.QTimer(self)
+        self._flush_timer.setSingleShot(True)
+        self._flush_timer.timeout.connect(self._flush_pending)
+        parent.destroyed.connect(self._disconnect_all)
+
+    def _adapter(
+        self,
+        plot_id: str,
+        target: object,
+    ) -> _PlotAppearanceAdapter:
+        from erlab.interactive.colors import BetterColorBarItem
+
+        registry_ref = weakref.ref(self)
+
+        def changed(component: str) -> None:
+            registry = registry_ref()
+            if registry is not None:
+                registry._queue_change(plot_id, component)
+
+        def image_changed() -> None:
+            registry = registry_ref()
+            if registry is not None:
+                registry._queue_reapply(plot_id)
+
+        if isinstance(target, BetterColorBarItem):
+            return _BetterColorBarAdapter(
+                target,
+                changed=changed,
+                image_changed=image_changed,
+            )
+        if isinstance(target, pg.HistogramLUTItem):
+            return _HistogramLUTAdapter(
+                target,
+                changed=changed,
+                image_changed=image_changed,
+            )
+        raise TypeError(
+            "plot appearance targets must be BetterColorBarItem or HistogramLUTItem"
+        )
+
+    def register(self, plot_id: str, target: object) -> None:
+        if not plot_id:
+            raise ValueError("plot appearance IDs must be non-empty strings")
+        if plot_id in self._pending_changes:
+            self._flush_pending()
+        previous = self._adapters.pop(plot_id, None)
+        desired_state = None
+        if previous is not None:
+            desired_state = previous.desired_state
+            previous.disconnect()
+        adapter = self._adapter(plot_id, target)
+        self._adapters[plot_id] = adapter
+        restored_state = self._restored_states.pop(plot_id, None)
+        if restored_state is not None:
+            adapter.set_desired_state(restored_state)
+        elif desired_state is not None:
+            adapter.set_desired_state(desired_state)
+
+    def _queue_change(self, plot_id: str, component: str) -> None:
+        adapter = self._adapters.get(plot_id)
+        if adapter is None:
+            return
+        if component == "levels":
+            adapter.manual_levels = True
+        state = adapter.capture()
+        if state is None:
+            return
+        adapter.desired_state = state
+        self._pending_changes.add(plot_id)
+        self._flush_timer.start(0)
+
+    def _queue_reapply(self, plot_id: str) -> None:
+        self._pending_reapply.add(plot_id)
+        self._flush_timer.start(0)
+
+    def _disconnect_all(self, *_args) -> None:
+        self._flush_timer.stop()
+        for adapter in self._adapters.values():
+            adapter.disconnect()
+        self._adapters.clear()
+        self._pending_changes.clear()
+        self._pending_reapply.clear()
+
+    def _flush_pending(self) -> None:
+        changed = False
+        for plot_id in tuple(self._pending_changes):
+            adapter = self._adapters.get(plot_id)
+            if adapter is None:
+                continue
+            if adapter.desired_state is not None:
+                changed = True
+        self._pending_changes.clear()
+
+        for plot_id in tuple(self._pending_reapply):
+            adapter = self._adapters.get(plot_id)
+            if adapter is not None:
+                adapter.reapply()
+        self._pending_reapply.clear()
+
+        if changed:
+            self._state_changed()
+            self._info_changed()
+
+    def state(self) -> ToolViewState:
+        self._flush_pending()
+        plots = dict(self._restored_states)
+        for plot_id, adapter in self._adapters.items():
+            state = adapter.capture()
+            if state is not None:
+                plots[plot_id] = state
+        return ToolViewState(plots=plots)
+
+    def state_json(self) -> str | None:
+        state = self.state()
+        if not state.plots:
+            return None
+        return state.model_dump_json()
+
+    def restore_json(self, payload: object | None) -> None:
+        if payload is None:
+            return
+        try:
+            state = _parse_tool_view_state(payload)
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid saved tool view state", exc_info=True)
+            return
+        self._restored_states = dict(state.plots)
+        for plot_id, adapter in self._adapters.items():
+            restored = self._restored_states.pop(plot_id, None)
+            if restored is not None:
+                adapter.set_desired_state(restored)
+
+    def reapply(self) -> None:
+        for adapter in self._adapters.values():
+            adapter.reapply()

--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -514,17 +514,12 @@ class _ColorBarEditWidget(QtWidgets.QWidget):
         gamma: float = self._gamma_widget.value()
         reverse: bool = self._reversed_check.isChecked()
         high_contrast: bool = self._high_contrast_check.isChecked()
-
-        for img_ref in self.cb.images:
-            img = img_ref()
-            if img is not None:
-                img.set_colormap(
-                    cmap_name,
-                    gamma,
-                    reverse=reverse,
-                    high_contrast=high_contrast,
-                    update=True,
-                )
+        self.cb.set_colormap(
+            cmap_name,
+            gamma,
+            reverse=reverse,
+            high_contrast=high_contrast,
+        )
 
     def populate_cmap_info(self) -> None:
         self._cmap_combo._populate()
@@ -551,6 +546,9 @@ class _ColorBarEditWidget(QtWidgets.QWidget):
 
 
 class BetterColorBarItem(pg.PlotItem):
+    sigColorChanged = QtCore.Signal()  #: :meta private:
+    sigLevelsChangeFinished = QtCore.Signal()  #: :meta private:
+
     def __init__(
         self,
         parent: QtWidgets.QWidget | None = None,
@@ -686,7 +684,19 @@ class BetterColorBarItem(pg.PlotItem):
     def limits(self) -> tuple[float, float]:
         if self._fixedlimits is not None:
             return self._fixedlimits
-        return self.primary_image().quickMinMax(targetSize=2**16)
+        image = self.primary_image()
+        limits = tuple(float(value) for value in image.quickMinMax(targetSize=2**16))
+        if all(np.isfinite(value) for value in limits):
+            return typing.cast("tuple[float, float]", limits)
+        levels = image.getLevels()
+        if levels is not None:
+            finite_levels = tuple(float(value) for value in levels)
+            if all(np.isfinite(value) for value in finite_levels):
+                return typing.cast(
+                    "tuple[float, float]",
+                    tuple(sorted(finite_levels)),
+                )
+        return (0.0, 1.0)
 
     def _normalized_transform(self) -> QtGui.QTransform:
         mn, mx = self.limits
@@ -792,7 +802,7 @@ class BetterColorBarItem(pg.PlotItem):
 
     @QtCore.Slot()
     def level_change_fin(self) -> None:
-        pass
+        self.sigLevelsChangeFinished.emit()
 
     def spanRegion(self) -> tuple[float, float]:
         return self._span_units_to_levels(self._span.getRegion())
@@ -856,7 +866,7 @@ class BetterColorBarItem(pg.PlotItem):
 
         # self.primary_image().sigImageChanged.connect(self.limit_changed)
         # self.primary_image().sigColorChanged.connect(self.color_changed)
-        self.primary_image().sigColorChanged.connect(self.limit_changed)
+        self.primary_image().sigColorChanged.connect(self._image_color_changed)
         # else:
         # print("hello")
 
@@ -874,6 +884,60 @@ class BetterColorBarItem(pg.PlotItem):
         self.image_changed()
         # self.color_changed()
         self.limit_changed()
+
+    @QtCore.Slot()
+    def _image_color_changed(self) -> None:
+        self.limit_changed()
+        self.sigColorChanged.emit()
+
+    @property
+    def colormap_properties(self) -> dict[str, typing.Any] | None:
+        """Return the semantic ERLab colormap settings for the primary image."""
+        if self._primary_image is None:
+            return None
+        image = self.primary_image()
+        if image is None:
+            return None
+        cmap = image.getColorMap()
+        if cmap is None:
+            return None
+        attrs = getattr(cmap, "_erlab_attrs", None)
+        if not isinstance(attrs, dict):
+            return None
+        return {
+            "cmap": cmap.name,
+            "gamma": float(attrs.get("gamma", 1.0)),
+            "reverse": bool(attrs.get("reverse", False)),
+            "high_contrast": bool(attrs.get("high_contrast", False)),
+            "zero_centered": bool(attrs.get("zero_centered", False)),
+        }
+
+    def set_colormap(
+        self,
+        cmap: pg.ColorMap | str,
+        gamma: float,
+        reverse: bool = False,
+        high_contrast: bool = False,
+        zero_centered: bool = False,
+    ) -> None:
+        """Apply one ERLab colormap configuration to every controlled image."""
+        for image_ref in tuple(self.images):
+            image = image_ref()
+            if image is not None:
+                image.set_colormap(
+                    cmap,
+                    gamma,
+                    reverse=reverse,
+                    high_contrast=high_contrast,
+                    zero_centered=zero_centered,
+                )
+
+    def set_pg_colormap(self, cmap: pg.ColorMap) -> None:
+        """Apply a raw pyqtgraph colormap to every controlled image."""
+        for image_ref in tuple(self.images):
+            image = image_ref()
+            if image is not None:
+                image.set_pg_colormap(cmap)
 
     def image_level_changed(self) -> None:
         levels = self.primary_image().getLevels()

--- a/src/erlab/interactive/derivative.py
+++ b/src/erlab/interactive/derivative.py
@@ -261,6 +261,7 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
             self.graphics_layout.addItem(self.hists[i], i, 1)
             plot.addItem(self.images[i])
             self.hists[i].setImageItem(self.images[i])
+            self._register_plot_appearance(("input", "result")[i], self.hists[i])
             # plot.showGrid(x=True, y=True, alpha=0.5)
 
         self.plots[0].setXLink(self.plots[1])

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -43,6 +43,7 @@ from qtpy import PYQT6, PYSIDE6, QtCore, QtGui, QtWidgets, uic
 
 import erlab
 from erlab.interactive import _qt_state
+from erlab.interactive._plot_state import TOOL_VIEW_STATE_ATTR, ToolPlotStateRegistry
 from erlab.interactive._widgets import _Separator
 from erlab.utils._code import (
     _parse_single_arg,
@@ -3252,6 +3253,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         ) = None
         self._managed_reveal_callback: Callable[[], bool] | None = None
         self._output_imagetool_targets: dict[str, str | QtWidgets.QWidget] = {}
+        self._plot_state_registry = ToolPlotStateRegistry(
+            self,
+            state_changed=self.sigStateChanged.emit,
+            info_changed=self.sigInfoChanged.emit,
+        )
         self._save_tool_data_references = False
         self._save_tool_data_reference_node_uids: frozenset[str] | None = None
         self._prev_states: collections.deque[M] = collections.deque(maxlen=5000)
@@ -3344,6 +3350,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if left is None or right is None:
             return left is right
         return left.model_dump() == right.model_dump()
+
+    def _register_plot_appearance(self, plot_id: str, target: object) -> None:
+        """Register a colorbar or histogram under a stable semantic plot ID."""
+        self._plot_state_registry.register(plot_id, target)
 
     @property
     def undoable(self) -> bool:
@@ -4955,6 +4965,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             "tool_window_state": _qt_state.qt_window_state_json(self),
             "erlab_version": erlab.__version__,
         }
+        view_state = self._plot_state_registry.state_json()
+        if view_state is not None:
+            attrs[TOOL_VIEW_STATE_ATTR] = view_state
         if self._source_spec is not None:
             attrs[_TOOL_SOURCE_SPEC_ATTR] = json.dumps(
                 self._source_spec.model_dump(mode="json")
@@ -5127,6 +5140,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
         Deferred restore work is flushed before serialization unless a subclass
         save hook explicitly preserves a raw persisted payload unchanged.
+
+        .. versionchanged:: 3.26.0
+           Colormaps, normalization settings, and manually selected color limits
+           for registered plots are included in saved tools and workspaces.
 
         Returns
         -------
@@ -5423,6 +5440,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     )
             tool._restore_persistence_payload(ds)
             tool._restore_persistence_data_items(data_items, ds)
+            tool._plot_state_registry.restore_json(ds.attrs.get(TOOL_VIEW_STATE_ATTR))
             tool.setWindowTitle(ds.attrs["tool_title"])
             if (
                 not _qt_state.restore_qt_window_state(
@@ -5434,6 +5452,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             tool._reset_history_stack()
             if not defer_restore_work:
                 tool._flush_restore_work()
+            tool._plot_state_registry.reapply()
             restore_succeeded = True
         finally:
             tool._restoring_from_dataset = previous_restoring
@@ -5585,6 +5604,8 @@ class AnalysisWindow(ToolWindow):
             # "refresh_all",
         ]:
             setattr(self, n, getattr(self.aw, n))
+        for index, histogram in enumerate(self.aw.hists):
+            self._register_plot_appearance(f"analysis-{index}", histogram)
         layout.addWidget(self.aw)
         layout.addWidget(self.controlgroup)
 

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Mapping
 
 import h5py
 import numpy as np
+import pyqtgraph as pg
 import pytest
 import xarray
 import xarray as xr
@@ -1839,6 +1840,65 @@ def test_manager_workspace_partially_loads_corrupted_child_with_warning(
         assert dialog.parent is manager
         assert f"0/childtools/{child_uid}" in dialog.kwargs["informative_text"]
         assert "Input DataArray must be 2D" in dialog.kwargs["detailed_text"]
+
+
+def test_manager_workspace_roundtrips_child_plot_appearance(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="source",
+    )
+    with manager_context() as manager:
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        child = DerivativeTool(data)
+        child_uid = manager.add_childtool(child, 0, show=False)
+        manager._workspace_controller._mark_workspace_clean()
+
+        histogram = child.hists[0]
+        histogram.gradient.setColorMap(
+            pg.colormap.get("plasma", source="matplotlib", skipCache=True)
+        )
+        histogram.gradient.sigGradientChangeFinished.emit(histogram.gradient)
+        histogram.region.lines[0].sigDragged.emit(histogram.region.lines[0])
+        histogram.setLevels(3.0, 18.0)
+        histogram.sigLevelChangeFinished.emit(histogram)
+        qtbot.wait_until(lambda: manager.is_workspace_modified)
+        expected_positions, expected_colors = histogram.gradient.colorMap().getStops(
+            pg.ColorMap.BYTE
+        )
+
+        fname = tmp_path / "child-plot-appearance.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+
+        node = manager._child_node(child_uid)
+        if node.pending_workspace_payload is not None:
+            assert node.materialize_pending_workspace_payload()
+        restored = node.tool_window
+        assert isinstance(restored, DerivativeTool)
+        assert restored.hists[0].getLevels() == pytest.approx((3.0, 18.0))
+        actual_positions, actual_colors = (
+            restored.hists[0].gradient.colorMap().getStops(pg.ColorMap.BYTE)
+        )
+        np.testing.assert_allclose(actual_positions, expected_positions)
+        np.testing.assert_array_equal(actual_colors, expected_colors)
+        assert not manager.is_workspace_modified
 
 
 def test_manager_workspace_no_loaded_windows_error_without_skipped_nodes(

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -413,6 +413,23 @@ def test_colorbar_normalized_helpers_handle_invalid_limits(qtbot, monkeypatch):
     assert colorbar._span_unit_to_level(0.5) == 5.0
 
 
+def test_colorbar_nonfinite_limits_and_missing_colormap_metadata() -> None:
+    image = BetterImageItem(np.zeros((2, 2)))
+    colorbar = BetterColorBarItem()
+
+    assert colorbar.colormap_properties is None
+
+    colorbar._primary_image = lambda: None
+    assert colorbar.colormap_properties is None
+
+    colorbar._primary_image = lambda: image
+    image.setImage(np.full((2, 2), np.nan), autoLevels=False)
+    image.setLevels((np.nan, np.nan))
+    with pytest.warns(RuntimeWarning, match="All-NaN slice"):
+        assert colorbar.limits == (0.0, 1.0)
+    assert colorbar.colormap_properties is None
+
+
 def test_colorbar_syncs_unset_levels_and_reset_paths(qtbot):
     image = BetterImageItem(np.arange(100, dtype=float).reshape(10, 10))
     image.set_colormap("viridis", gamma=1.0)

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -4,6 +4,7 @@ import typing
 from types import SimpleNamespace
 
 import numpy as np
+import pyqtgraph as pg
 import pytest
 import xarray as xr
 from pydantic import BaseModel, ValidationError
@@ -142,6 +143,49 @@ def test_dtool(qtbot, interpmode, smoothmode, nsmooth, method_idx) -> None:
         assert win_restored.source_auto_update is True
         assert win_restored.source_state == "stale"
         check_generated_code(win_restored)
+
+
+def test_dtool_plot_appearance_roundtrip_and_image_refresh(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape((5, 5)),
+        dims=("x", "y"),
+        name="data",
+    )
+    win = DerivativeTool(data)
+    qtbot.addWidget(win)
+
+    expected_colormaps: list[tuple[np.ndarray, np.ndarray]] = []
+    for index, (name, levels) in enumerate(
+        (("plasma", (3.0, 18.0)), ("cividis", (4.0, 20.0)))
+    ):
+        histogram = win.hists[index]
+        histogram.gradient.setColorMap(
+            pg.colormap.get(name, source="matplotlib", skipCache=True)
+        )
+        histogram.gradient.sigGradientChangeFinished.emit(histogram.gradient)
+        histogram.region.lines[0].sigDragged.emit(histogram.region.lines[0])
+        histogram.setLevels(*levels)
+        histogram.sigLevelChangeFinished.emit(histogram)
+        expected_colormaps.append(
+            histogram.gradient.colorMap().getStops(pg.ColorMap.BYTE)
+        )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, DerivativeTool)
+    for index, expected_levels in enumerate(((3.0, 18.0), (4.0, 20.0))):
+        assert restored.hists[index].getLevels() == pytest.approx(expected_levels)
+        actual_positions, actual_colors = (
+            restored.hists[index].gradient.colorMap().getStops(pg.ColorMap.BYTE)
+        )
+        expected_positions, expected_colors = expected_colormaps[index]
+        np.testing.assert_allclose(actual_positions, expected_positions)
+        np.testing.assert_array_equal(actual_colors, expected_colors)
+
+    restored.images[1].setImage(np.arange(100.0, 125.0).reshape(5, 5), autoLevels=True)
+    qtbot.wait_until(
+        lambda: restored.hists[1].getLevels() == pytest.approx((4.0, 20.0))
+    )
 
 
 def test_dtool_smoothing_copy_code_uses_readable_steps(qtbot) -> None:

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -5,6 +5,7 @@ import typing
 from collections.abc import Callable, Iterator
 
 import numpy as np
+import pyqtgraph as pg
 import pytest
 import scipy
 import xarray as xr
@@ -216,6 +217,13 @@ def test_goldtool_roundtrip_unfitted(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
     qtbot.addWidget(win)
     _configure_goldtool_state(win, fitted=False, spline=True)
+    win.hists[0].gradient.setColorMap(
+        pg.colormap.get("plasma", source="matplotlib", skipCache=True)
+    )
+    win.hists[0].gradient.sigGradientChangeFinished.emit(win.hists[0].gradient)
+    expected_positions, expected_colors = (
+        win.hists[0].gradient.colorMap().getStops(pg.ColorMap.BYTE)
+    )
 
     with tempfile.TemporaryDirectory() as tmp_dir_name:
         filename = f"{tmp_dir_name}/goldtool_unfitted.h5"
@@ -229,6 +237,11 @@ def test_goldtool_roundtrip_unfitted(qtbot, gold) -> None:
         assert win_restored.result is None
         assert not hasattr(win_restored, "edge_center")
         assert not hasattr(win_restored, "edge_stderr")
+        actual_positions, actual_colors = (
+            win_restored.hists[0].gradient.colorMap().getStops(pg.ColorMap.BYTE)
+        )
+        np.testing.assert_allclose(actual_positions, expected_positions)
+        np.testing.assert_array_equal(actual_colors, expected_colors)
 
 
 def test_fit1d_persistence_helper_edges(qtbot, monkeypatch, gold) -> None:

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -446,9 +446,19 @@ def test_fit2d_status_and_persistence_preserve_transpose_orientation(qtbot) -> N
     qtbot.addWidget(win)
     assert isinstance(win, Fit2DTool)
 
+    win.cbar.set_colormap("plasma", 0.6, reverse=True, high_contrast=True)
+    win.cbar.setSpanRegion((0.5, 1.0))
     win._do_transpose()
     win.y_index_spin.setValue(3)
     status = win.tool_status
+    assert win.cbar.colormap_properties == {
+        "cmap": "plasma",
+        "gamma": pytest.approx(0.6),
+        "reverse": True,
+        "high_contrast": True,
+        "zero_centered": False,
+    }
+    assert win.cbar.spanRegion() == pytest.approx((0.5, 1.0))
 
     win_restored = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win_restored)
@@ -463,11 +473,16 @@ def test_fit2d_status_and_persistence_preserve_transpose_orientation(qtbot) -> N
     assert isinstance(win_roundtripped, Fit2DTool)
     xr.testing.assert_identical(win_roundtripped.tool_data, data.transpose("x", "y"))
     assert win_roundtripped.y_index_spin.value() == 3
+    assert win_roundtripped.cbar.colormap_properties == win.cbar.colormap_properties
+    assert win_roundtripped.cbar.spanRegion() == pytest.approx((0.5, 1.0))
 
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) + 1.0
     win_roundtripped.update_data(updated)
     xr.testing.assert_identical(win_roundtripped.tool_data, updated.transpose("x", "y"))
+    qtbot.wait_until(
+        lambda: win_roundtripped.cbar.spanRegion() == pytest.approx((0.5, 1.0))
+    )
 
 
 def test_fit2d_saved_dims_ignore_missing_or_incompatible_state() -> None:

--- a/tests/interactive/test_mesh.py
+++ b/tests/interactive/test_mesh.py
@@ -321,6 +321,24 @@ def test_meshtool_autofind_and_persistence(
     assert warnings
     assert "No mesh data" in warnings[-1]
 
+    expected_appearance = []
+    for index, (colorbar, cmap) in enumerate(
+        zip(
+            (win.cbar_data, win.cbar_mesh, win.cbar_fft, win.cbar_mask),
+            ("plasma", "cividis", "magma", "viridis"),
+            strict=True,
+        )
+    ):
+        gamma = 0.6 + 0.1 * index
+        colorbar.set_colormap(cmap, gamma, reverse=bool(index % 2))
+        lower, upper = colorbar.limits
+        levels = (
+            float(lower + 0.2 * (upper - lower)),
+            float(lower + 0.8 * (upper - lower)),
+        )
+        colorbar.setSpanRegion(levels)
+        expected_appearance.append((colorbar.colormap_properties, levels))
+
     state_file = tmp_path / "meshtool_state.h5"
     saved_code = win.copy_code()
     win.to_file(state_file)
@@ -333,6 +351,18 @@ def test_meshtool_autofind_and_persistence(
     assert restored.data_name == "mesh_input"
     assert restored.copy_code() == saved_code
     xr.testing.assert_identical(restored.tool_data, win.tool_data)
+    for colorbar, (properties, levels) in zip(
+        (
+            restored.cbar_data,
+            restored.cbar_mesh,
+            restored.cbar_fft,
+            restored.cbar_mask,
+        ),
+        expected_appearance,
+        strict=True,
+    ):
+        assert colorbar.colormap_properties == properties
+        assert colorbar.spanRegion() == pytest.approx(levels)
 
     namespace: dict[str, object] = {
         "era": erlab.analysis,
@@ -354,6 +384,8 @@ def test_meshtool_deferred_restore_queues_initial_preview(
 ) -> None:
     win: MeshTool = meshtool(meshy_data, data_name="mesh_input", execute=False)
     qtbot.addWidget(win)
+    win.cbar_fft.set_colormap("plasma", 0.7, reverse=True)
+    win.cbar_fft.setSpanRegion((-1.0, 1.0))
     saved = win.to_dataset()
     calls: list[tuple[MeshTool, bool]] = []
     original = MeshTool.set_data_beforecalc
@@ -386,6 +418,16 @@ def test_meshtool_deferred_restore_queues_initial_preview(
     restored.show()
 
     qtbot.wait_until(lambda: calls == [(restored, True)], timeout=5000)
+    qtbot.wait_until(
+        lambda: restored.cbar_fft.spanRegion() == pytest.approx((-1.0, 1.0))
+    )
+    assert restored.cbar_fft.colormap_properties == {
+        "cmap": "plasma",
+        "gamma": pytest.approx(0.7),
+        "reverse": True,
+        "high_contrast": False,
+        "zero_centered": False,
+    }
 
 
 def test_meshtool_autofind_invalid_peaks_warns_and_keeps_values(

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -17,6 +17,7 @@ import qtpy
 import xarray as xr
 from qtpy import PYQT6, QtCore, QtGui, QtTest, QtWidgets
 
+import erlab.interactive._plot_state
 import erlab.interactive.colors
 import erlab.interactive.utils
 from erlab.interactive.imagetool._provenance._model import (
@@ -755,6 +756,255 @@ def test_tool_window_without_plot_appearance_attr_uses_defaults(qtbot) -> None:
     qtbot.addWidget(restored)
     assert isinstance(restored, _PlotPersistentTool)
     assert restored.colorbar.colormap_properties["cmap"] == "viridis"
+
+
+def test_plot_appearance_validation_and_colormap_sampling(caplog) -> None:
+    plot_state = erlab.interactive._plot_state
+
+    with pytest.raises(pydantic.ValidationError):
+        plot_state.GradientStopState(
+            position=np.nan,
+            color=(0, 0, 0, 255),
+        )
+    with pytest.raises(pydantic.ValidationError):
+        plot_state.GradientStopState(
+            position=0.5,
+            color=(0, 0, 0, 256),
+        )
+    with pytest.raises(pydantic.ValidationError):
+        plot_state.PowerNormState(gamma=np.inf)
+    with pytest.raises(pydantic.ValidationError):
+        plot_state.PlotAppearanceState(
+            colormap=plot_state.NamedColormapState(name="viridis"),
+            levels=(2.0, 1.0),
+        )
+    with pytest.raises(TypeError):
+        plot_state._parse_tool_view_state(1)
+    with pytest.raises(TypeError):
+        plot_state._parse_tool_view_state("[]")
+
+    payload = json.dumps(
+        {
+            "version": 1,
+            "plots": {
+                "": {
+                    "colormap": {
+                        "kind": "named",
+                        "name": "viridis",
+                    }
+                }
+            },
+        }
+    ).encode()
+    with caplog.at_level(logging.WARNING, logger="erlab.interactive._plot_state"):
+        parsed = plot_state._parse_tool_view_state(payload)
+    assert parsed.plots == {}
+
+    positions = np.linspace(0.0, 1.0, 300)
+    colors = np.column_stack(
+        (
+            np.linspace(0, 255, 300, dtype=np.uint8),
+            np.zeros(300, dtype=np.uint8),
+            np.full(300, 127, dtype=np.uint8),
+            np.full(300, 255, dtype=np.uint8),
+        )
+    )
+    sampled = plot_state._sample_colormap(pg.ColorMap(positions, colors))
+    assert len(sampled.stops) == 256
+    assert sampled.stops[0].position == 0.0
+    assert sampled.stops[-1].position == 1.0
+
+    gradient = plot_state._gradient_state(
+        {
+            "mode": "unsupported",
+            "ticks": [
+                (1.0, (255, 255, 255, 255)),
+                (0.0, (0, 0, 0, 255)),
+            ],
+        }
+    )
+    assert gradient.mode == "rgb"
+    assert tuple(stop.position for stop in gradient.stops) == (0.0, 1.0)
+
+
+def test_better_colorbar_plot_adapter_fallbacks(qtbot, caplog) -> None:
+    plot_state = erlab.interactive._plot_state
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    win = _PlotPersistentTool(data)
+    qtbot.addWidget(win)
+    adapter = win._plot_state_registry._adapters["data"]
+
+    custom = pg.ColorMap(
+        (0.0, 1.0),
+        ((10, 20, 30, 255), (240, 230, 220, 255)),
+    )
+    win.colorbar.set_pg_colormap(custom)
+    missing = plot_state.PlotAppearanceState(
+        colormap=plot_state.NamedColormapState(
+            name="__missing_erlab_colormap__",
+            reverse=True,
+        ),
+        norm=plot_state.PowerNormState(gamma=0.75),
+    )
+    with caplog.at_level(logging.WARNING, logger="erlab.interactive._plot_state"):
+        adapter.set_desired_state(missing)
+
+    assert isinstance(
+        adapter.desired_state.colormap,
+        plot_state.GradientColormapState,
+    )
+    assert adapter.desired_state.norm is None
+
+    gradient = plot_state.PlotAppearanceState(
+        colormap=plot_state.GradientColormapState(
+            stops=(
+                plot_state.GradientStopState(
+                    position=0.0,
+                    color=(0, 0, 0, 255),
+                ),
+                plot_state.GradientStopState(
+                    position=1.0,
+                    color=(255, 255, 255, 255),
+                ),
+            )
+        ),
+        norm=plot_state.PowerNormState(
+            gamma=0.5,
+            high_contrast=True,
+            zero_centered=True,
+        ),
+    )
+    adapter.set_desired_state(gradient)
+    assert win.colorbar.colormap_properties == {
+        "cmap": "saved-gradient",
+        "gamma": pytest.approx(0.5),
+        "reverse": False,
+        "high_contrast": True,
+        "zero_centered": True,
+    }
+
+    adapter._target_ref = lambda: None
+    assert adapter.capture() is None
+    adapter.apply(gradient)
+
+
+def test_histogram_plot_adapter_named_colormaps_and_level_changes(
+    qtbot, caplog
+) -> None:
+    plot_state = erlab.interactive._plot_state
+    image = pg.ImageItem(np.arange(25.0).reshape(5, 5))
+    histogram = pg.HistogramLUTItem(image=image)
+    changed: list[str] = []
+    adapter = plot_state._HistogramLUTAdapter(
+        histogram,
+        changed=changed.append,
+        image_changed=lambda: None,
+    )
+
+    named = plot_state.PlotAppearanceState(
+        colormap=plot_state.NamedColormapState(name="plasma", reverse=True),
+        levels=(2.0, 20.0),
+    )
+    adapter.set_desired_state(named)
+    assert histogram.getLevels() == pytest.approx((2.0, 20.0))
+    saved = adapter.capture()
+    assert isinstance(saved.colormap, plot_state.GradientColormapState)
+
+    positions_before, colors_before = histogram.gradient.colorMap().getStops(
+        pg.ColorMap.BYTE
+    )
+    missing = named.model_copy(
+        update={
+            "colormap": plot_state.NamedColormapState(name="__missing_erlab_colormap__")
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="erlab.interactive._plot_state"):
+        adapter.apply(missing)
+    positions_after, colors_after = histogram.gradient.colorMap().getStops(
+        pg.ColorMap.BYTE
+    )
+    np.testing.assert_array_equal(positions_after, positions_before)
+    np.testing.assert_array_equal(colors_after, colors_before)
+
+    histogram.region.moving = True
+    adapter._level_region_changed()
+    adapter._level_change_finished()
+    assert changed == ["levels"]
+    adapter._level_change_finished()
+    assert changed == ["levels"]
+
+    adapter._applying = True
+    adapter._level_change_start()
+    adapter._applying = False
+    assert not adapter._level_change_started
+
+    adapter._target_ref = lambda: None
+    assert adapter.capture() is None
+    adapter.apply(named)
+
+
+def test_plot_state_registry_defensive_paths(monkeypatch) -> None:
+    plot_state = erlab.interactive._plot_state
+    parent = QtCore.QObject()
+    state_changes: list[None] = []
+    info_changes: list[None] = []
+    registry = plot_state.ToolPlotStateRegistry(
+        parent,
+        state_changed=lambda: state_changes.append(None),
+        info_changed=lambda: info_changes.append(None),
+    )
+
+    assert registry.state_json() is None
+    registry.restore_json(None)
+    with pytest.raises(ValueError, match="non-empty"):
+        registry.register("", pg.HistogramLUTItem())
+    with pytest.raises(TypeError):
+        registry.register("unsupported", object())
+
+    restored = plot_state.ToolViewState(
+        plots={
+            "late": plot_state.PlotAppearanceState(
+                colormap=plot_state.NamedColormapState(name="viridis")
+            )
+        }
+    )
+    registry.restore_json(restored.model_dump_json())
+    histogram = pg.HistogramLUTItem()
+    registry.register("late", histogram)
+    assert "late" not in registry._restored_states
+
+    registry._queue_change("missing", "color")
+    adapter = registry._adapters["late"]
+    adapter._target_ref = lambda: None
+    registry._queue_change("late", "color")
+
+    adapter.desired_state = None
+    registry._pending_changes.update(("late", "missing"))
+    registry._flush_pending()
+    assert not state_changes
+    assert not info_changes
+
+    base_adapter = plot_state._PlotAppearanceAdapter(
+        parent,
+        changed=lambda _component: None,
+        image_changed=lambda: None,
+    )
+    with pytest.raises(NotImplementedError):
+        base_adapter.capture()
+    with pytest.raises(NotImplementedError):
+        base_adapter.apply(
+            plot_state.PlotAppearanceState(
+                colormap=plot_state.NamedColormapState(name="viridis")
+            )
+        )
+    base_adapter._connect(parent, parent.destroyed, lambda: None)
+    monkeypatch.setattr(erlab.interactive.utils, "qt_is_valid", lambda _obj: False)
+    base_adapter.disconnect()
+    assert base_adapter._connections == []
 
 
 def test_tool_window_direct_restore_runs_deferred_task_eagerly(qtbot) -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -11,11 +11,13 @@ import warnings
 import lmfit
 import numpy as np
 import pydantic
+import pyqtgraph as pg
 import pytest
 import qtpy
 import xarray as xr
 from qtpy import PYQT6, QtCore, QtGui, QtTest, QtWidgets
 
+import erlab.interactive.colors
 import erlab.interactive.utils
 from erlab.interactive.imagetool._provenance._model import (
     ToolProvenanceSpec,
@@ -182,6 +184,36 @@ class _PersistentTool(erlab.interactive.utils.ToolWindow[_PersistentToolState]):
 
     def update_data(self, new_data: xr.DataArray) -> None:
         self._data = new_data
+
+
+class _PlotPersistentTool(_PersistentTool):
+    tool_name = "plot-persistent-dummy"
+
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__(data)
+        self.graphics = pg.GraphicsLayoutWidget()
+        self.setCentralWidget(self.graphics)
+        self.image_plot = self.graphics.addPlot(row=0, col=0)
+        self.image = xImageItem(axisOrder="row-major")
+        self.image.setImage(np.asarray(data))
+        self.image.set_colormap("viridis", 1.0)
+        self.image_plot.addItem(self.image)
+        self.colorbar = erlab.interactive.colors.BetterColorBarItem(image=self.image)
+        self.graphics.addItem(self.colorbar, row=0, col=1)
+        self._register_plot_appearance("data", self.colorbar)
+
+    def replace_plot(self) -> erlab.interactive.colors.BetterColorBarItem:
+        old_colorbar = self.colorbar
+        self.graphics.removeItem(old_colorbar)
+        self.image_plot.removeItem(self.image)
+        self.image = xImageItem(axisOrder="row-major")
+        self.image.setImage(np.asarray(self.tool_data))
+        self.image.set_colormap("viridis", 1.0)
+        self.image_plot.addItem(self.image)
+        self.colorbar = erlab.interactive.colors.BetterColorBarItem(image=self.image)
+        self.graphics.addItem(self.colorbar, row=0, col=1)
+        self._register_plot_appearance("data", self.colorbar)
+        return old_colorbar
 
 
 class _DeferredRestoreToolState(pydantic.BaseModel):
@@ -428,6 +460,301 @@ def test_tool_window_from_dataset_starts_with_clean_history(qtbot) -> None:
     assert duplicated.tool_status == _PersistentToolState(value=1)
     assert not duplicated.undoable
     assert not duplicated.redoable
+
+
+def test_tool_window_plot_appearance_roundtrip_duplicate_and_rebuild(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(100.0).reshape(10, 10),
+        dims=("y", "x"),
+        name="data",
+    )
+    win = _PlotPersistentTool(data)
+    qtbot.addWidget(win)
+    state_changes: list[None] = []
+    info_changes: list[None] = []
+    data_changes: list[None] = []
+    win.sigStateChanged.connect(lambda: state_changes.append(None))
+    win.sigInfoChanged.connect(lambda: info_changes.append(None))
+    win.sigDataChanged.connect(lambda: data_changes.append(None))
+
+    win.colorbar.set_colormap(
+        "plasma",
+        0.4,
+        reverse=True,
+        high_contrast=True,
+        zero_centered=True,
+    )
+    win.colorbar.setSpanRegion((10.0, 60.0))
+
+    qtbot.wait_until(lambda: len(state_changes) == 1)
+    assert len(info_changes) == 1
+    assert len(data_changes) == 0
+    saved = win.to_dataset()
+    view_state = json.loads(saved.attrs["tool_view_state"])
+    assert view_state["version"] == 1
+    assert set(view_state["plots"]) == {"data"}
+
+    for restored in (
+        erlab.interactive.utils.ToolWindow.from_dataset(saved),
+        win.duplicate(),
+    ):
+        qtbot.addWidget(restored)
+        assert isinstance(restored, _PlotPersistentTool)
+        assert restored.colorbar.colormap_properties == {
+            "cmap": "plasma",
+            "gamma": pytest.approx(0.4),
+            "reverse": True,
+            "high_contrast": True,
+            "zero_centered": True,
+        }
+        assert restored.colorbar.spanRegion() == pytest.approx((10.0, 60.0))
+
+        restored.image.setImage(
+            np.arange(100.0, 200.0).reshape(10, 10),
+            autoLevels=True,
+        )
+        qtbot.wait_until(
+            lambda restored=restored: (
+                restored.colorbar.spanRegion() == pytest.approx((10.0, 60.0))
+            )
+        )
+
+    old_colorbar = win.replace_plot()
+    assert win.colorbar.colormap_properties == {
+        "cmap": "plasma",
+        "gamma": pytest.approx(0.4),
+        "reverse": True,
+        "high_contrast": True,
+        "zero_centered": True,
+    }
+    assert win.colorbar.spanRegion() == pytest.approx((10.0, 60.0))
+
+    old_colorbar.set_colormap("magma", 1.0)
+    qtbot.wait(1)
+    assert win.colorbar.colormap_properties["cmap"] == "plasma"
+
+
+def test_tool_window_custom_plot_colormap_roundtrip(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    win = _PlotPersistentTool(data)
+    qtbot.addWidget(win)
+    custom = pg.ColorMap(
+        (0.0, 0.35, 1.0),
+        ((5, 10, 20, 255), (60, 120, 180, 200), (250, 240, 220, 255)),
+    )
+    win.colorbar.set_pg_colormap(custom)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _PlotPersistentTool)
+    assert restored.colorbar.colormap_properties is None
+    actual_positions, actual_colors = restored.image.getColorMap().getStops(
+        pg.ColorMap.BYTE
+    )
+    expected_positions, expected_colors = custom.getStops(pg.ColorMap.BYTE)
+    np.testing.assert_allclose(actual_positions, expected_positions)
+    np.testing.assert_array_equal(actual_colors, expected_colors)
+
+
+def test_tool_window_equal_plot_limits_roundtrip(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    win = _PlotPersistentTool(data)
+    qtbot.addWidget(win)
+    win.colorbar.setSpanRegion((5.0, 5.0))
+
+    saved = win.to_dataset()
+    assert json.loads(saved.attrs["tool_view_state"])["plots"]["data"]["levels"] == [
+        5.0,
+        5.0,
+    ]
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _PlotPersistentTool)
+    assert restored.colorbar.spanRegion() == pytest.approx((5.0, 5.0))
+    assert restored.image.getLevels() == pytest.approx((5.0, 5.0))
+
+
+@pytest.mark.parametrize("levels", [(5.0, 20.0), (5.0, 5.0)])
+def test_tool_window_plot_appearance_survives_nonfinite_image_range(
+    qtbot, levels: tuple[float, float]
+) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    win = _PlotPersistentTool(data)
+    qtbot.addWidget(win)
+    win.colorbar.setSpanRegion(levels)
+    qtbot.wait_until(lambda: win.colorbar.spanRegion() == pytest.approx(levels))
+
+    win.image.setImage(np.full((5, 5), np.nan), autoLevels=True)
+    qtbot.wait_until(lambda: win.colorbar.spanRegion() == pytest.approx(levels))
+
+    assert win.image.getLevels() == pytest.approx(levels)
+    saved = json.loads(win.to_dataset().attrs["tool_view_state"])
+    assert saved["plots"]["data"]["levels"] == list(levels)
+
+
+def test_tool_window_preserves_plot_state_awaiting_registration(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    saved = _PlotPersistentTool(data).to_dataset()
+    view_state = json.loads(saved.attrs["tool_view_state"])
+    view_state["plots"]["deferred"] = view_state["plots"]["data"]
+    saved.attrs["tool_view_state"] = json.dumps(view_state)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _PlotPersistentTool)
+
+    resaved = json.loads(restored.to_dataset().attrs["tool_view_state"])
+    assert resaved["plots"]["deferred"] == view_state["plots"]["deferred"]
+
+
+def test_tool_window_plot_registry_disconnects_before_qt_children(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    win = _PlotPersistentTool(data)
+    qtbot.addWidget(win)
+    registry = win._plot_state_registry
+    assert registry._adapters
+
+    win.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    qtbot.wait_until(lambda: not qt_is_valid(win), timeout=1000)
+
+    assert registry._adapters == {}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{not-json",
+        json.dumps({"version": 999, "plots": {}}),
+        json.dumps({"version": 1, "plots": []}),
+    ],
+)
+def test_tool_window_ignores_invalid_plot_appearance(
+    qtbot, caplog, payload: str
+) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    saved = _PlotPersistentTool(data).to_dataset()
+    saved.attrs["tool_view_state"] = payload
+
+    with caplog.at_level(logging.WARNING, logger="erlab.interactive._plot_state"):
+        restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _PlotPersistentTool)
+    assert restored.colorbar.colormap_properties["cmap"] == "viridis"
+    assert "Ignoring invalid saved tool view state" in caplog.text
+
+
+def test_tool_window_plot_appearance_skips_bad_plot_and_missing_colormap(
+    qtbot, caplog
+) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    saved = _PlotPersistentTool(data).to_dataset()
+    view_state = json.loads(saved.attrs["tool_view_state"])
+    view_state["plots"]["data"] = {
+        "colormap": {
+            "kind": "named",
+            "name": "__missing_erlab_colormap__",
+            "reverse": True,
+        },
+        "norm": {
+            "kind": "power",
+            "gamma": 0.75,
+            "high_contrast": True,
+            "zero_centered": True,
+        },
+        "levels": [5.0, 20.0],
+    }
+    view_state["plots"]["invalid"] = {"colormap": {"kind": "gradient", "stops": []}}
+    saved.attrs["tool_view_state"] = json.dumps(view_state)
+
+    with caplog.at_level(logging.WARNING, logger="erlab.interactive._plot_state"):
+        restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _PlotPersistentTool)
+    assert restored.colorbar.colormap_properties == {
+        "cmap": "viridis",
+        "gamma": pytest.approx(0.75),
+        "reverse": True,
+        "high_contrast": True,
+        "zero_centered": True,
+    }
+    assert restored.colorbar.spanRegion() == pytest.approx((5.0, 20.0))
+    assert "Ignoring invalid saved plot appearance for invalid" in caplog.text
+    assert "__missing_erlab_colormap__" in caplog.text
+    assert (
+        sum(
+            "__missing_erlab_colormap__" in record.getMessage()
+            for record in caplog.records
+        )
+        == 1
+    )
+
+    caplog.clear()
+    restored.image.setImage(
+        np.arange(100.0, 125.0).reshape(5, 5),
+        autoLevels=True,
+    )
+    qtbot.wait_until(
+        lambda: restored.colorbar.spanRegion() == pytest.approx((5.0, 20.0))
+    )
+    assert restored.colorbar.colormap_properties == {
+        "cmap": "viridis",
+        "gamma": pytest.approx(0.75),
+        "reverse": True,
+        "high_contrast": True,
+        "zero_centered": True,
+    }
+    assert "__missing_erlab_colormap__" not in caplog.text
+    canonical = json.loads(restored.to_dataset().attrs["tool_view_state"])
+    assert canonical["plots"]["data"]["colormap"] == {
+        "kind": "named",
+        "name": "viridis",
+        "reverse": True,
+    }
+
+
+def test_tool_window_without_plot_appearance_attr_uses_defaults(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("y", "x"),
+        name="data",
+    )
+    saved = _PlotPersistentTool(data).to_dataset()
+    del saved.attrs["tool_view_state"]
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, _PlotPersistentTool)
+    assert restored.colorbar.colormap_properties["cmap"] == "viridis"
 
 
 def test_tool_window_direct_restore_runs_deferred_task_eagerly(qtbot) -> None:


### PR DESCRIPTION
## Summary

- persist colormaps, power-normalization settings, and manually selected color limits for non-ImageTool plots in versioned `ToolWindow` view state
- register Fit2D, MeshTool, DerivativeTool, and AnalysisWindow plot targets under stable semantic IDs
- restore appearance through file saves, duplication, manager workspaces, deferred plot/data refreshes, and missing-colormap fallbacks
- tolerate malformed saved entries, all-NaN image ranges, equal limits, and plots that register after state restoration

## Why

Colormap, normalization, and color-limit changes made through non-ImageTool plot controls were transient. They were lost when a tool was duplicated or saved and restored, including when the tool was stored in an ImageTool Manager workspace.

## User impact

Users can now reopen or duplicate supported tools without having to recreate their plot appearance. Plot changes also mark managed workspace state dirty so the updated appearance is included in the next workspace save.

## Validation

- 183 focused ToolWindow, tool, and manager-workspace tests passed under PyQt6
- 473 base colorbar and ImageTool tests passed with clean Qt teardown
- 6 focused persistence and teardown tests passed under PySide6
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`
