### PR TITLE
fix(imagetool): clarify missing workspace backing files

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -11,6 +11,7 @@ import uuid
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.manager._workspace._saving as workspace_saving
 import erlab.interactive.imagetool.slicer
 from erlab.interactive.imagetool import _kspace_conversion
 from erlab.interactive.imagetool._mainwindow import ImageTool
@@ -1409,17 +1410,44 @@ class _ActionsController:
             ),
         )
 
-    def _show_workspace_save_worker_error(self, error_text: str) -> None:
-        logger.error(
-            "Error while saving workspace\n%s",
-            error_text,
-            extra={"suppress_ui_alert": True},
-        )
+    def _show_workspace_save_worker_error(
+        self, error: workspace_saving._WorkspaceSaveError
+    ) -> None:
+        source_path = error.missing_source_path
+        if source_path is None:
+            title = "Error"
+            text = "An error occurred while saving the workspace file."
+            logger.error(
+                "Error while saving workspace\n%s",
+                error.traceback_text,
+                extra={"suppress_ui_alert": True},
+            )
+        else:
+            title = "Workspace Backing File Missing"
+            text = (
+                "ImageTool Manager could not save this workspace because it still "
+                "needs data from a workspace file that was moved or deleted:\n\n"
+                f"{source_path}\n\n"
+                "Restore the file to this location and try again. This may be a source "
+                "workspace containing deferred items rather than the workspace you "
+                "were trying to save.\n\n"
+                "If the file was permanently deleted, items that were not loaded into "
+                "memory cannot be recovered. Items already loaded may remain available "
+                "in the current session."
+            )
+            logger.error(
+                "Error while saving workspace; backing file is missing: %s\n%s",
+                source_path,
+                error.traceback_text,
+                extra={"suppress_ui_alert": True},
+            )
         erlab.interactive.utils.MessageDialog.critical(
             self._manager,
-            "Error",
-            "An error occurred while saving the workspace file.",
-            detailed_text=erlab.interactive.utils._format_traceback(error_text),
+            title,
+            text,
+            detailed_text=erlab.interactive.utils._format_traceback(
+                error.traceback_text
+            ),
         )
 
     def add_widget(self, widget: QtWidgets.QWidget) -> None:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -88,6 +88,7 @@ if typing.TYPE_CHECKING:
     import numpy as np
     import xarray as xr
 
+    import erlab.interactive.imagetool.manager._workspace._saving as workspace_saving
     from erlab.interactive._figurecomposer import (
         FigureAxesSelectionState,
         FigureOperationState,
@@ -2646,8 +2647,10 @@ class ImageToolManager(_ImageToolManagerBase):
     def _show_operation_error(self, log_message: str, text: str) -> None:
         self._actions_controller._show_operation_error(log_message, text)
 
-    def _show_workspace_save_worker_error(self, error_text: str) -> None:
-        self._actions_controller._show_workspace_save_worker_error(error_text)
+    def _show_workspace_save_worker_error(
+        self, error: workspace_saving._WorkspaceSaveError
+    ) -> None:
+        self._actions_controller._show_workspace_save_worker_error(error)
 
     def add_widget(self, widget: QtWidgets.QWidget) -> None:
         self._actions_controller.add_widget(widget)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -1424,7 +1424,9 @@ class _WorkspaceController:
         fname: str | os.PathLike[str],
         snapshot: workspace_saving._WorkspaceSaveSnapshot,
         *,
-        on_finished: Callable[[bool, float, str], None],
+        on_finished: Callable[
+            [float, workspace_saving._WorkspaceSaveError | None], None
+        ],
         on_start_error: Callable[[], None] | None = None,
     ) -> bool:
         thread_pool = QtCore.QThreadPool.globalInstance()
@@ -1437,7 +1439,10 @@ class _WorkspaceController:
         worker = workspace_saving._WorkspaceSaveWorker(fname, snapshot)
         previous_action_states = self._set_workspace_save_actions_enabled(False)
 
-        def _finish(ok: bool, elapsed: float, error_text: str) -> None:
+        def _finish(
+            elapsed: float,
+            error: workspace_saving._WorkspaceSaveError | None,
+        ) -> None:
             self._manager._workspace_state.save_in_progress = False
             self._restore_workspace_save_actions_enabled(previous_action_states)
             self._manager._update_actions()
@@ -1447,7 +1452,7 @@ class _WorkspaceController:
             if receiver is not None:
                 receiver.deleteLater()
             try:
-                on_finished(ok, elapsed, error_text)
+                on_finished(elapsed, error)
             except Exception:
                 logger.exception(
                     "Error while finishing workspace save",
@@ -1506,9 +1511,8 @@ class _WorkspaceController:
         old_workspace_path: pathlib.Path | None,
         backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]],
         snapshot: workspace_saving._WorkspaceSaveSnapshot,
-        ok: bool,
         worker_elapsed: float,
-        error_text: str,
+        error: workspace_saving._WorkspaceSaveError | None,
         origin: QtWidgets.QWidget | None,
         snapshot_elapsed: float,
         started_at: float,
@@ -1528,9 +1532,9 @@ class _WorkspaceController:
                 extra={"suppress_ui_alert": True},
             )
             return False
-        if not ok:
+        if error is not None:
             self._manager._status_bar.clearMessage()
-            self._manager._show_workspace_save_worker_error(error_text)
+            self._manager._show_workspace_save_worker_error(error)
             if restore_focus:
                 self._restore_focus_after_workspace_save(origin)
             return False
@@ -1600,9 +1604,8 @@ class _WorkspaceController:
         old_workspace_path: pathlib.Path | None,
         backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]],
         snapshot: workspace_saving._WorkspaceSaveSnapshot,
-        ok: bool,
         worker_elapsed: float,
-        error_text: str,
+        error: workspace_saving._WorkspaceSaveError | None,
         origin: QtWidgets.QWidget | None,
         snapshot_elapsed: float,
         started_at: float,
@@ -1616,9 +1619,8 @@ class _WorkspaceController:
                 old_workspace_path=old_workspace_path,
                 backing_snapshot=backing_snapshot,
                 snapshot=snapshot,
-                ok=ok,
                 worker_elapsed=worker_elapsed,
-                error_text=error_text,
+                error=error,
                 origin=origin,
                 snapshot_elapsed=snapshot_elapsed,
                 started_at=started_at,
@@ -1707,22 +1709,19 @@ class _WorkspaceController:
         return self._start_workspace_save_worker(
             workspace_path,
             snapshot,
-            on_finished=lambda ok, elapsed, error_text: (
-                self._finish_background_workspace_save(
-                    document_id=document_id,
-                    workspace_path=workspace_path,
-                    old_workspace_path=old_workspace_path,
-                    backing_snapshot=backing_snapshot,
-                    snapshot=snapshot,
-                    ok=ok,
-                    worker_elapsed=elapsed,
-                    error_text=error_text,
-                    origin=origin,
-                    snapshot_elapsed=snapshot_elapsed,
-                    started_at=started_at,
-                    restore_focus=restore_focus,
-                    on_finished=on_finished,
-                )
+            on_finished=lambda elapsed, error: self._finish_background_workspace_save(
+                document_id=document_id,
+                workspace_path=workspace_path,
+                old_workspace_path=old_workspace_path,
+                backing_snapshot=backing_snapshot,
+                snapshot=snapshot,
+                worker_elapsed=elapsed,
+                error=error,
+                origin=origin,
+                snapshot_elapsed=snapshot_elapsed,
+                started_at=started_at,
+                restore_focus=restore_focus,
+                on_finished=on_finished,
             ),
             on_start_error=_start_error,
         )
@@ -1795,7 +1794,10 @@ class _WorkspaceController:
                 access.release()
             raise RuntimeError("Workspace save snapshot was not created")
 
-        def _finish_save_as(ok: bool, worker_elapsed: float, error_text: str) -> None:
+        def _finish_save_as(
+            worker_elapsed: float,
+            error: workspace_saving._WorkspaceSaveError | None,
+        ) -> None:
             nonlocal access
             total_elapsed = time.perf_counter() - started_at
             logger.debug(
@@ -1819,9 +1821,9 @@ class _WorkspaceController:
                 if on_finished is not None:
                     on_finished(False)
                 return
-            if not ok:
+            if error is not None:
                 self._manager._status_bar.clearMessage()
-                self._manager._show_workspace_save_worker_error(error_text)
+                self._manager._show_workspace_save_worker_error(error)
                 access.release()
                 self._restore_focus_after_workspace_save(origin)
                 if on_finished is not None:
@@ -1942,7 +1944,10 @@ class _WorkspaceController:
             )
             return False
 
-        def _finish_compaction(ok: bool, _elapsed: float, error_text: str) -> None:
+        def _finish_compaction(
+            _elapsed: float,
+            error: workspace_saving._WorkspaceSaveError | None,
+        ) -> None:
             if self._manager._workspace_state.document_id != document_id:
                 logger.info(
                     "Ignoring completed shutdown compaction for inactive document",
@@ -1951,10 +1956,10 @@ class _WorkspaceController:
                 if on_finished is not None:
                     on_finished()
                 return
-            if not ok:
+            if error is not None:
                 logger.error(
                     "Failed to compact workspace before shutdown%s",
-                    f":\n{error_text}" if error_text else "",
+                    f":\n{error.traceback_text}",
                     extra={"suppress_ui_alert": True},
                 )
             else:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -80,24 +80,34 @@ class _WorkspaceSaveSnapshot:
             self.full_tree.close()
 
 
+@dataclass(frozen=True)
+class _WorkspaceSaveError:
+    traceback_text: str
+    missing_source_path: str | None = None
+
+
 class _WorkspaceSaveWorkerSignals(QtCore.QObject):
-    finished = QtCore.Signal(bool, float, str)
+    finished = QtCore.Signal(float, object)
 
 
 class _WorkspaceSaveResultReceiver(QtCore.QObject):
     def __init__(
         self,
         *,
-        callback: Callable[[bool, float, str], None] | None = None,
+        callback: Callable[[float, _WorkspaceSaveError | None], None] | None = None,
         parent: QtCore.QObject | None = None,
     ) -> None:
         super().__init__(parent)
         self._callback = callback
 
-    @QtCore.Slot(bool, float, str)
-    def finish(self, ok: bool, elapsed: float, error_text: str) -> None:
+    @QtCore.Slot(float, object)
+    def finish(
+        self,
+        elapsed: float,
+        error: _WorkspaceSaveError | None,
+    ) -> None:
         if self._callback is not None:
-            self._callback(ok, elapsed, error_text)
+            self._callback(elapsed, error)
 
 
 class _WorkspaceSaveWorker(QtCore.QRunnable):
@@ -113,8 +123,7 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
 
     def run(self) -> None:
         start_time = time.perf_counter()
-        error_text = ""
-        ok = False
+        error: _WorkspaceSaveError | None = None
         try:
             if self._snapshot.file_repack:
                 workspace_storage._write_full_workspace_tree_file(
@@ -144,13 +153,17 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
                     copy_group_sources=self._snapshot.copy_group_sources,
                     compression_mode=self._snapshot.compression_mode,
                 )
-            ok = True
+        except workspace_storage._WorkspaceBackingFileNotFoundError as exc:
+            error = _WorkspaceSaveError(
+                traceback_text=traceback.format_exc(),
+                missing_source_path=exc.source_path,
+            )
         except Exception:
-            error_text = traceback.format_exc()
+            error = _WorkspaceSaveError(traceback_text=traceback.format_exc())
         finally:
             with contextlib.suppress(Exception):
                 self._snapshot.close()
-        self.signals.finished.emit(ok, time.perf_counter() - start_time, error_text)
+        self.signals.finished.emit(time.perf_counter() - start_time, error)
 
 
 class _WorkspaceSaver:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -50,6 +50,18 @@ _WorkspaceCopyGroupWithSource: typing.TypeAlias = tuple[
 ]
 
 
+class _WorkspaceBackingFileNotFoundError(FileNotFoundError):
+    """A workspace payload source disappeared before it could be copied."""
+
+    def __init__(self, source_path: str | os.PathLike[str]) -> None:
+        self.source_path = os.fsdecode(source_path)
+        super().__init__(
+            errno.ENOENT,
+            "Workspace backing file is missing",
+            self.source_path,
+        )
+
+
 @dataclass(frozen=True)
 class _WorkspaceDocumentLockInfo:
     path: str
@@ -725,26 +737,27 @@ def _write_full_workspace_tree_file(
             _write_root_attrs_to_open_workspace_file(tmp_file, root_attrs, replace=True)
 
         for source_fname, copy_jobs in copy_jobs_by_source.items():
-            with (
-                workspace_arrays._workspace_file_lock(source_fname),
-                h5py.File(source_fname, "r") as source_file,
-                h5py.File(tmp_fname, "a") as tmp_file,
-            ):
-                for source_path, destination_path, attrs, required in copy_jobs:
-                    destination_path = destination_path.strip("/")
-                    if workspace_arrays._copy_workspace_h5_group_to_open_file(
-                        source_file,
-                        tmp_file,
-                        source_path,
-                        destination_path,
-                        attrs,
-                    ):
-                        copied_paths.add(destination_path)
-                    elif required:
-                        raise ValueError(
-                            "Required workspace payload group "
-                            f"{source_path!r} was not found in {source_fname!r}"
-                        )
+            with workspace_arrays._workspace_file_lock(source_fname):
+                try:
+                    source_file = h5py.File(source_fname, "r")
+                except FileNotFoundError as exc:
+                    raise _WorkspaceBackingFileNotFoundError(source_fname) from exc
+                with source_file, h5py.File(tmp_fname, "a") as tmp_file:
+                    for source_path, destination_path, attrs, required in copy_jobs:
+                        destination_path = destination_path.strip("/")
+                        if workspace_arrays._copy_workspace_h5_group_to_open_file(
+                            source_file,
+                            tmp_file,
+                            source_path,
+                            destination_path,
+                            attrs,
+                        ):
+                            copied_paths.add(destination_path)
+                        elif required:
+                            raise ValueError(
+                                "Required workspace payload group "
+                                f"{source_path!r} was not found in {source_fname!r}"
+                            )
 
         if tree is not None:
             for node in sorted(tree.subtree, key=lambda value: value.path.count("/")):

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -1131,7 +1131,9 @@ def test_manager_shutdown_compaction_logs_failure(
         with caplog.at_level(logging.ERROR):
             assert manager._workspace_controller._compact_workspace_before_shutdown()
             assert len(pool.workers) == 1
-            pool.workers[0].finish(ok=False, error_text="compact failed")
+            pool.workers[0].finish(
+                error=workspace_saving._WorkspaceSaveError("compact failed"),
+            )
             qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
 
     assert "Failed to compact workspace before shutdown" in caplog.text
@@ -1307,10 +1309,13 @@ class _DeferredWorkspaceSaveWorker:
         self._snapshot = snapshot
 
     def finish(
-        self, *, ok: bool = True, elapsed: float = 0.0, error_text: str = ""
+        self,
+        *,
+        elapsed: float = 0.0,
+        error: workspace_saving._WorkspaceSaveError | None = None,
     ) -> None:
         self._snapshot.close()
-        self.signals.finished.emit(ok, elapsed, error_text)
+        self.signals.finished.emit(elapsed, error)
 
 
 class _DeferredWorkspaceSaveThreadPool:
@@ -1374,6 +1379,40 @@ def _compact_workspace_before_shutdown_and_wait(
     return requested
 
 
+def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
+    missing_source = tmp_path / "deleted-source.itws"
+    target = tmp_path / "target.itws"
+    snapshot = workspace_saving._WorkspaceSaveSnapshot(
+        generation=0,
+        root_attrs=_transaction_test_root_attrs(),
+        delta_save_count=0,
+        full_tree=xr.DataTree(),
+        copy_group_sources=(
+            (
+                str(missing_source),
+                "0/imagetool",
+                "0/imagetool",
+                None,
+            ),
+        ),
+    )
+    worker = workspace_saving._WorkspaceSaveWorker(target, snapshot)
+    results: list[tuple[float, workspace_saving._WorkspaceSaveError | None]] = []
+    receiver = workspace_saving._WorkspaceSaveResultReceiver(
+        callback=lambda elapsed, error: results.append((elapsed, error)),
+        parent=worker.signals,
+    )
+    worker.signals.finished.connect(receiver.finish)
+
+    worker.run()
+
+    assert len(results) == 1
+    _elapsed, error = results[0]
+    assert isinstance(error, workspace_saving._WorkspaceSaveError)
+    assert error.missing_source_path == str(missing_source)
+    assert error.traceback_text
+
+
 def test_manager_async_save_request_error_paths(
     qtbot,
     monkeypatch,
@@ -1390,10 +1429,19 @@ def test_manager_async_save_request_error_paths(
 
     monkeypatch.setattr(erlab.interactive.utils.MessageDialog, "critical", _critical)
     with manager_context() as manager:
-        manager._show_workspace_save_worker_error("Traceback text")
+        manager._show_workspace_save_worker_error(
+            workspace_saving._WorkspaceSaveError("Traceback text")
+        )
         assert critical_calls[-1][2] == (
             "An error occurred while saving the workspace file."
         )
+
+        missing_error = workspace_saving._WorkspaceSaveError(
+            traceback_text="Missing source traceback",
+            missing_source_path=str(tmp_path / "deleted-source.itws"),
+        )
+        manager._show_workspace_save_worker_error(missing_error)
+        assert len(critical_calls) == 2
 
         manager._workspace_state.path = tmp_path / "workspace.itws"
         manager._workspace_state.save_in_progress = True
@@ -1667,7 +1715,7 @@ def test_manager_background_workspace_save_failure_restores_state(
             lambda title, text: operation_errors.append((title, text)),
         )
         _fname = _bind_dirty_workspace_for_save_test(manager, tmp_path)
-        errors: list[str] = []
+        errors: list[workspace_saving._WorkspaceSaveError] = []
         monkeypatch.setattr(
             manager._workspace_controller.saving,
             "_workspace_save_snapshot",
@@ -1679,11 +1727,13 @@ def test_manager_background_workspace_save_failure_restores_state(
         assert manager._workspace_controller.save()
         assert manager._workspace_state.save_in_progress
 
-        pool.workers[0].finish(ok=False, error_text="worker boom")
+        pool.workers[0].finish(
+            error=workspace_saving._WorkspaceSaveError("worker boom"),
+        )
         qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
 
         assert errors
-        assert "worker boom" in errors[-1]
+        assert "worker boom" in errors[-1].traceback_text
         assert manager.save_action.isEnabled()
         assert manager.save_as_action.isEnabled()
         assert manager.compact_workspace_action.isEnabled()
@@ -4033,7 +4083,7 @@ def test_workspace_save_worker_start_and_finish_error_branches(
             on_finished=lambda *_args: (_ for _ in ()).throw(RuntimeError("boom")),
         )
         assert pool.worker is not None
-        pool.worker.signals.finished.emit(True, 0.1, "")
+        pool.worker.signals.finished.emit(0.1, None)
         assert errors == [
             (
                 "Error while saving workspace",
@@ -4084,9 +4134,8 @@ def test_background_workspace_save_finish_branches(
             snapshot=typing.cast(
                 "workspace_saving._WorkspaceSaveSnapshot", types.SimpleNamespace()
             ),
-            ok=True,
             worker_elapsed=0.1,
-            error_text="",
+            error=None,
             origin=None,
             snapshot_elapsed=0.0,
             started_at=time.perf_counter(),
@@ -4117,9 +4166,8 @@ def test_background_workspace_save_finish_branches(
             snapshot=typing.cast(
                 "workspace_saving._WorkspaceSaveSnapshot", types.SimpleNamespace()
             ),
-            ok=True,
             worker_elapsed=0.1,
-            error_text="",
+            error=None,
             origin=None,
             snapshot_elapsed=0.0,
             started_at=time.perf_counter(),
@@ -4213,20 +4261,23 @@ def test_workspace_save_and_save_as_error_continuation_branches(
             "_workspace_full_save_snapshot",
             lambda generation, **_kwargs: snapshot(generation),
         )
-        worker_errors: list[str] = []
+        worker_errors: list[workspace_saving._WorkspaceSaveError] = []
         monkeypatch.setattr(
             manager, "_show_workspace_save_worker_error", worker_errors.append
         )
 
         def _fail_worker(_fname, _snapshot, *, on_finished, on_start_error=None):
             del on_start_error
-            on_finished(False, 0.1, "write failed")
+            on_finished(
+                0.1,
+                workspace_saving._WorkspaceSaveError("write failed"),
+            )
             return True
 
         monkeypatch.setattr(controller, "_start_workspace_save_worker", _fail_worker)
         finished.clear()
         assert controller.save_as(native=False, on_finished=finished.append)
-        assert worker_errors == ["write failed"]
+        assert [error.traceback_text for error in worker_errors] == ["write failed"]
         assert finished == [False]
 
         manager._workspace_controller._mark_workspace_clean()
@@ -4236,7 +4287,7 @@ def test_workspace_save_and_save_as_error_continuation_branches(
         ):
             del on_start_error
             manager._workspace_controller._mark_node_state_dirty(uid)
-            on_finished(True, 0.1, "")
+            on_finished(0.1, None)
             return True
 
         monkeypatch.setattr(
@@ -4303,7 +4354,7 @@ def test_workspace_save_completion_ignores_inactive_document(
             del on_start_error
             manager._workspace_state.advance_document_identity()
             manager._workspace_state.path = tmp_path / "replacement.itws"
-            on_finished(True, 0.1, "")
+            on_finished(0.1, None)
             return True
 
         monkeypatch.setattr(
@@ -4357,7 +4408,7 @@ def test_workspace_save_as_completion_ignores_inactive_document(
         ) -> bool:
             del on_start_error
             manager._workspace_state.advance_document_identity()
-            on_finished(True, 0.1, "")
+            on_finished(0.1, None)
             return True
 
         monkeypatch.setattr(

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -189,6 +189,35 @@ def test_write_full_workspace_tree_file_skips_missing_copy_source_group(
     assert _read_transaction_test_value(fname) == 3.0
 
 
+def test_write_full_workspace_tree_file_reports_missing_backing_source(
+    tmp_path,
+) -> None:
+    fname = tmp_path / "missing-backing-source-target.itws"
+    missing_source = tmp_path / "deleted-source.itws"
+    _write_transaction_test_workspace(fname)
+    original_contents = fname.read_bytes()
+
+    with pytest.raises(
+        workspace_storage._WorkspaceBackingFileNotFoundError
+    ) as exc_info:
+        workspace_storage._write_full_workspace_tree_file(
+            fname,
+            None,
+            _transaction_test_root_attrs(),
+            copy_group_sources=(
+                (
+                    str(missing_source),
+                    "0/imagetool",
+                    "0/imagetool",
+                    None,
+                ),
+            ),
+        )
+
+    assert exc_info.value.source_path == str(missing_source)
+    assert fname.read_bytes() == original_contents
+
+
 def test_write_full_workspace_tree_file_replaces_stale_root_attrs(tmp_path) -> None:
 
     fname = tmp_path / "root-attrs.itws"


### PR DESCRIPTION
## Summary

- detect when workspace saving still needs data from a backing `.itws` file that was moved or deleted
- show the missing path, restoration guidance, and the limits of recovery instead of the generic save error
- preserve the generic error path for unrelated failures and keep the destination workspace unchanged when a backing source is missing
- use a single background-save result contract: `None` for success and a structured error for failure

## Root cause

Deferred workspace payloads can continue to reference groups in the workspace file they were loaded from. On platforms that allow open files to be moved or deleted, that backing file can disappear while the workspace remains open. A later full save then fails when it tries to reopen the source file, but the previous worker interface reduced every exception to a traceback string, so the manager could only show its generic save error.

## Validation

- focused workspace-save regression tests under PyQt6 (`10 passed` in the expanded pass; `5 passed` in the final touched-path pass)
- focused workspace-save regression tests under PySide6 (`7 passed` in the expanded pass; `5 passed` in the final touched-path pass)
- `uv run ruff check` on all touched files
- `uv run mypy` on all touched runtime modules
- `git diff --check`
- repository commit hooks, including Ruff and Commitizen
