### PR TITLE
fix(figurecomposer): keep managed composers reopenable

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -1135,6 +1135,17 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             super().hideEvent(event)
 
     def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        # Managed composers stay registered after a native window close and can be
+        # reopened. Preserve their live editors unless the owner is deleting them.
+        if (
+            event is not None
+            and self._is_in_manager()
+            and not self.testAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
+            and not erlab.interactive.utils._application_quit_requested()
+        ):
+            event.ignore()
+            self.hide()
+            return
         self.operation_editor.flush_pending_commits()
         self._flush_pending_figure_resize_history_write()
         self._closing = True

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -1674,6 +1674,62 @@ def test_figure_composer_hide_cancels_deferred_figure_window(
     assert calls == []
 
 
+def test_managed_figure_composer_close_hides_and_reopens_plot(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        tool = FigureComposerTool(
+            xr.DataArray(
+                np.arange(4.0),
+                dims=("x",),
+                coords={"x": np.arange(4.0)},
+            )
+        )
+        figure_uid = manager.add_figuretool(tool, show=True)
+        qtbot.waitUntil(
+            lambda: (
+                tool.isVisible()
+                and tool._figure_window is not None
+                and tool._figure_window.isVisible()
+            ),
+            timeout=5000,
+        )
+        figure_window = tool.figure_window
+
+        tool.close()
+
+        assert figure_uid in manager._tool_graph.nodes
+        assert not tool.isVisible()
+        assert not tool._closing
+        assert tool._figure_window is figure_window
+        assert not figure_window.isVisible()
+
+        manager.show_childtool(figure_uid)
+        qtbot.waitUntil(
+            lambda: tool.isVisible() and figure_window.isVisible(),
+            timeout=5000,
+        )
+
+        resized_width = tool.layout_panel.width_spin.value() + 0.5
+        tool.layout_panel.width_spin.setValue(resized_width)
+        tool.layout_panel.width_spin.editingFinished.emit()
+        assert np.isclose(tool.tool_status.setup.figsize[0], resized_width)
+
+        figure_window.hide()
+        tool.show_figure_button.click()
+        tool.show_figure_button.click()
+        qtbot.waitUntil(figure_window.isVisible, timeout=5000)
+
+        manager._remove_childtool(figure_uid)
+        qtbot.waitUntil(
+            lambda: not erlab.interactive.utils.qt_is_valid(tool),
+            timeout=5000,
+        )
+
+
 def test_figure_composer_show_composer_from_figure_window(qtbot, monkeypatch) -> None:
     tool = FigureComposerTool(_figure_composer_image_source("data"))
     qtbot.addWidget(tool)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2064,6 +2064,9 @@ def test_plot_with_matplotlib_executes_in_manager(qtbot, monkeypatch) -> None:
     win.slicer_area.manual_limits.clear()
 
     class _Manager:
+        def _node_uid_from_window(self, _window):
+            return None
+
         def target_from_slicer_area(self, slicer_area):
             assert slicer_area is win.slicer_area
             return 0
@@ -2137,6 +2140,9 @@ def test_plot_with_matplotlib_accepts_spaced_selection_dim(qtbot, monkeypatch) -
     warnings_shown: list[tuple[QtWidgets.QWidget | None, str, str]] = []
 
     class _Manager:
+        def _node_uid_from_window(self, _window):
+            return None
+
         def target_from_slicer_area(self, slicer_area):
             assert slicer_area is win.slicer_area
             return 0
@@ -2240,6 +2246,9 @@ def test_plot_with_matplotlib_preserves_state_with_editable_selection_dim(
     win.slicer_area.set_manual_limits({"alpha": [1.0, 3.0], "eV": [0.5, 2.5]})
 
     class _Manager:
+        def _node_uid_from_window(self, _window):
+            return None
+
         def target_from_slicer_area(self, slicer_area):
             assert slicer_area is win.slicer_area
             return 0


### PR DESCRIPTION
## Summary

- treat native close requests for manager-owned Figure Composer windows as hide operations
- preserve live editors and restore Show Plot behavior after reopening the same composer
- keep full teardown for manager removal and application shutdown
- cover close, reopen, editing, repeated Show Plot clicks, and final manager removal

## Root cause

Closing a managed Figure Composer ran its permanent teardown, set `_closing = True`, released its editor panels, and closed the plot window. The ImageTool Manager retained and later reopened that same object, so every subsequent Show Plot request returned immediately without a warning or log.

## Validation

- `QT_QPA_PLATFORM=offscreen QT_API=pyqt6 uv run pytest -q tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py` — 146 passed
- focused lifecycle tests under PySide6 — 4 passed
- `uv run ruff format --check src/erlab/interactive/_figurecomposer/_tool.py tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py`
- `uv run ruff check src/erlab/interactive/_figurecomposer/_tool.py tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py`
- `uv run mypy src/erlab/interactive/_figurecomposer/_tool.py`
- `git diff --check`
