### PR TITLE
fix(figure-composer): honor subplot ordering

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_model/_axes.py
+++ b/src/erlab/interactive/_figurecomposer/_model/_axes.py
@@ -40,18 +40,32 @@ def _compact_axes_code(
     ):
         return "axs"
 
-    rows = tuple(sorted({row for row, _col in axes_tuple}))
-    cols = tuple(sorted({col for _row, col in axes_tuple}))
-    if not _is_contiguous(rows) or not _is_contiguous(cols):
+    bounds = _compact_axes_bounds(axes_tuple)
+    if bounds is None:
         return None
-    rectangular_axes = tuple((row, col) for row in rows for col in cols)
-    if set(axes_tuple) != set(rectangular_axes):
-        return None
+    row_start, row_stop, col_start, col_stop = bounds
     return (
         "axs["
-        f"{_axis_index_code(rows[0], rows[-1] + 1, nrows)}, "
-        f"{_axis_index_code(cols[0], cols[-1] + 1, ncols)}"
+        f"{_axis_index_code(row_start, row_stop, nrows)}, "
+        f"{_axis_index_code(col_start, col_stop, ncols)}"
         "]"
+    )
+
+
+def _compact_axes_index(
+    axes: Sequence[tuple[int, int]],
+    *,
+    nrows: int | None = None,
+    ncols: int | None = None,
+) -> tuple[int | slice, int | slice] | None:
+    """Return NumPy indices that preserve a rectangular axes selection."""
+    bounds = _compact_axes_bounds(tuple(dict.fromkeys(axes)))
+    if bounds is None:
+        return None
+    row_start, row_stop, col_start, col_stop = bounds
+    return (
+        _axis_index(row_start, row_stop, nrows),
+        _axis_index(col_start, col_stop, ncols),
     )
 
 
@@ -74,8 +88,32 @@ def _compact_axes_iterable_code(
     return f"({items})"
 
 
+def _compact_axes_bounds(
+    axes: Sequence[tuple[int, int]],
+) -> tuple[int, int, int, int] | None:
+    axes_tuple = tuple(dict.fromkeys(axes))
+    if not axes_tuple:
+        return None
+    rows = tuple(sorted({row for row, _col in axes_tuple}))
+    cols = tuple(sorted({col for _row, col in axes_tuple}))
+    if not _is_contiguous(rows) or not _is_contiguous(cols):
+        return None
+    rectangular_axes = tuple((row, col) for row in rows for col in cols)
+    if set(axes_tuple) != set(rectangular_axes):
+        return None
+    return rows[0], rows[-1] + 1, cols[0], cols[-1] + 1
+
+
 def _is_contiguous(values: Sequence[int]) -> bool:
     return bool(values) and list(values) == list(range(values[0], values[-1] + 1))
+
+
+def _axis_index(start: int, stop: int, size: int | None) -> int | slice:
+    if stop == start + 1:
+        return start
+    if start == 0 and size is not None and stop == size:
+        return slice(None)
+    return slice(None if start == 0 else start, stop)
 
 
 def _axis_index_code(start: int, stop: int, size: int | None) -> str:

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
@@ -176,6 +176,7 @@ class MethodControlSpec:
     arg_index: int | None = None
     key: str | None = None
     options: tuple[str, ...] = ()
+    option_labels: tuple[str, ...] = ()
     default: typing.Any = None
     minimum: int | float | None = None
     maximum: int | float | None = None
@@ -424,6 +425,7 @@ def _kwarg_combo(
     tooltip: str,
     *,
     none_label: str | None = None,
+    option_labels: Sequence[str] = (),
 ) -> MethodControlSpec:
     return MethodControlSpec(
         kind=MethodControlKind.KWARG_COMBO,
@@ -432,6 +434,7 @@ def _kwarg_combo(
         object_name=object_name,
         tooltip=tooltip,
         options=tuple(options),
+        option_labels=tuple(option_labels),
         default=default,
         none_label=none_label,
     )
@@ -655,7 +658,10 @@ _SCALE_OPTIONS = tuple(matplotlib.scale.get_scale_names())
 _DEFAULT_SCALE = "log" if "log" in _SCALE_OPTIONS else _SCALE_OPTIONS[0]
 
 
-_FLATTEN_ORDER_OPTIONS = ("C", "F", "A", "K")
+_FLATTEN_ORDER_OPTIONS = ("C", "F")
+
+
+_FLATTEN_ORDER_LABELS = ("C (Row)", "F (Column)")
 
 
 _COLORBAR_ORIENTATION_OPTIONS = ("vertical", "horizontal")
@@ -1835,6 +1841,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
         target_domain=MethodTargetDomain.AXES,
         call_policy=MethodCallPolicy.AXES_POSITIONAL,
         text_values_policy=MethodTextValuesPolicy.KWARG,
+        preserves_empty_text=True,
         controls=(
             _int_kwarg(
                 "Start from",
@@ -1852,6 +1859,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "C",
                 "figureComposerERLabLabelSubplotsOrderCombo",
                 "Flattening order used to match labels to axes.",
+                option_labels=_FLATTEN_ORDER_LABELS,
             ),
             *_label_subplots_text_controls(
                 "figureComposerERLabLabelSubplots",
@@ -1910,6 +1918,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "C",
                 "figureComposerERLabLabelPropertiesOrderCombo",
                 "Flattening order used to match property values to axes.",
+                option_labels=_FLATTEN_ORDER_LABELS,
             ),
             *_label_subplots_text_controls(
                 "figureComposerERLabLabelProperties",
@@ -2088,6 +2097,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "C",
                 "figureComposerERLabSetTitlesOrderCombo",
                 "Flattening order used to match titles to axes.",
+                option_labels=_FLATTEN_ORDER_LABELS,
             ),
         ),
     ),
@@ -2108,6 +2118,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "C",
                 "figureComposerERLabSetXLabelsOrderCombo",
                 "Flattening order used to match x labels to axes.",
+                option_labels=_FLATTEN_ORDER_LABELS,
             ),
         ),
     ),
@@ -2128,6 +2139,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "C",
                 "figureComposerERLabSetYLabelsOrderCombo",
                 "Flattening order used to match y labels to axes.",
+                option_labels=_FLATTEN_ORDER_LABELS,
             ),
         ),
     ),

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
@@ -63,6 +63,7 @@ from erlab.interactive._figurecomposer._operations._method._state import (
     _method_has_transform_control,
     _method_kwarg_value,
     _method_transfer_updates,
+    _normalized_method_control_value,
     _optional_float_from_text,
     _optional_int_from_text,
     _optional_literal_from_text,
@@ -650,15 +651,20 @@ def _add_method_control_row(
                         _method_kwarg_value(target, key, control.default)
                     )
 
+            def control_value_getter(
+                target: FigureOperationState,
+            ) -> typing.Any:
+                return _normalized_method_control_value(
+                    control, kwarg_value_getter(target)
+                )
+
             mixed = editor.batch_is_mixed(
                 operation,
-                kwarg_value_getter,
+                control_value_getter,
             )
             if control.none_label is None:
-                current = None if mixed else str(kwarg_value_getter(operation))
+                current = None if mixed else str(control_value_getter(operation))
                 if control.option_labels:
-                    if current not in control.options:
-                        current = str(control.default)
                     combo = editor.labeled_combo(
                         control.options,
                         control.option_labels,
@@ -1594,7 +1600,11 @@ def _update_current_method_text_values(
         spec = _method_spec(operation)
         values = (
             ()
-            if not text and spec.text_values_policy == MethodTextValuesPolicy.KWARG
+            if (
+                not text.strip()
+                and "\n" not in text
+                and spec.text_values_policy == MethodTextValuesPolicy.KWARG
+            )
             else _text_tuple_from_text(text, preserve_empty=spec.preserves_empty_text)
         )
         return operation.model_copy(update={"text_values": values})

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
@@ -271,7 +271,7 @@ def _build_method_editor(
             layout,
             "Text",
             text_edit,
-            "One text value per line for methods that apply labels or annotations.",
+            "One text value per line. A blank line leaves the matching axis empty.",
         )
 
     for control in spec.controls:
@@ -655,13 +655,26 @@ def _add_method_control_row(
                 kwarg_value_getter,
             )
             if control.none_label is None:
-                combo = editor.combo(
-                    control.options,
-                    None if mixed else str(kwarg_value_getter(operation)),
-                    _method_kwarg_callback(editor, key),
-                    parent=layout.parentWidget(),
-                    mixed=mixed,
-                )
+                current = None if mixed else str(kwarg_value_getter(operation))
+                if control.option_labels:
+                    if current not in control.options:
+                        current = str(control.default)
+                    combo = editor.labeled_combo(
+                        control.options,
+                        control.option_labels,
+                        current,
+                        _method_kwarg_callback(editor, key),
+                        parent=layout.parentWidget(),
+                        mixed=mixed,
+                    )
+                else:
+                    combo = editor.combo(
+                        control.options,
+                        current,
+                        _method_kwarg_callback(editor, key),
+                        parent=layout.parentWidget(),
+                        mixed=mixed,
+                    )
             else:
                 combo = editor.optional_name_combo(
                     control.options,
@@ -1579,12 +1592,11 @@ def _update_current_method_text_values(
         _operation_index: int, operation: FigureOperationState
     ) -> FigureOperationState:
         spec = _method_spec(operation)
-        return operation.model_copy(
-            update={
-                "text_values": _text_tuple_from_text(
-                    text, preserve_empty=spec.preserves_empty_text
-                )
-            }
+        values = (
+            ()
+            if not text and spec.text_values_policy == MethodTextValuesPolicy.KWARG
+            else _text_tuple_from_text(text, preserve_empty=spec.preserves_empty_text)
         )
+        return operation.model_copy(update={"text_values": values})
 
     editor.request_transform(update_text_values)

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_execution.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_execution.py
@@ -44,6 +44,7 @@ from erlab.interactive._figurecomposer._operations._method._state import (
     _label_values,
     _method_args,
     _method_has_transform_control,
+    _method_kwargs,
     _subplots_adjust_values,
 )
 from erlab.interactive._figurecomposer._rendering import (
@@ -259,8 +260,7 @@ def _render_args_kwargs(
             default_axis=axis if default_axis is None else default_axis,
         )
     )
-    kwargs = dict(spec.default_kwargs)
-    kwargs.update(operation.method_kwargs)
+    kwargs = _method_kwargs(operation, spec)
     if (
         _is_axes_errorbar_method(spec)
         and operation.method_plot_data_mode == "from_data"
@@ -301,8 +301,7 @@ def _code_args_kwargs(
     axis_code: str | None = None,
 ) -> tuple[tuple[typing.Any, ...], dict[str, typing.Any]]:
     args = list(_method_code_call_args(tool, operation, spec))
-    kwargs = dict(spec.default_kwargs)
-    kwargs.update(operation.method_kwargs)
+    kwargs = _method_kwargs(operation, spec)
     if (
         _is_axes_errorbar_method(spec)
         and operation.method_plot_data_mode == "from_data"

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_state.py
@@ -82,6 +82,27 @@ def _method_kwarg_value(
     return operation.method_kwargs.get(key, default)
 
 
+def _normalized_method_control_value(
+    control: MethodControlSpec, value: typing.Any
+) -> typing.Any:
+    if control.option_labels and str(value) not in control.options:
+        return control.default
+    return value
+
+
+def _method_kwargs(
+    operation: FigureOperationState, spec: MethodSpec
+) -> dict[str, typing.Any]:
+    kwargs = dict(spec.default_kwargs)
+    kwargs.update(operation.method_kwargs)
+    for control in spec.controls:
+        if control.key is not None and control.key in kwargs:
+            kwargs[control.key] = _normalized_method_control_value(
+                control, kwargs[control.key]
+            )
+    return kwargs
+
+
 def _is_axes_plot_method(spec: MethodSpec) -> bool:
     return is_axes_plot_data_method(spec.family, spec.name)
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices/_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices/_editor.py
@@ -571,8 +571,9 @@ def _build_plot_slices_editor(
         object_name="figureComposerPlotSlicesViewPanelsSection",
     )
     order_mixed = editor.batch_is_mixed(operation, lambda target: target.order)
-    order_combo = editor.combo(
+    order_combo = editor.labeled_combo(
         ["C", "F"],
+        ["C (Row)", "F (Column)"],
         None if order_mixed else operation.order,
         lambda text: editor.request_update_rebuild(order=text),
         parent=view_page,

--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -18,7 +18,10 @@ from erlab.interactive._figurecomposer._defaults import (
     _figure_style_context,
     _tool_figure_options_context,
 )
-from erlab.interactive._figurecomposer._model._axes import _axes_expression_value
+from erlab.interactive._figurecomposer._model._axes import (
+    _axes_expression_value,
+    _compact_axes_index,
+)
 from erlab.interactive._figurecomposer._model._gridspec import (
     _gridspec_all_axes_ids,
     _gridspec_region_valid,
@@ -289,9 +292,17 @@ def _axes_from_selection(
 
     if selection.invalid_axes(tool._document.recipe.setup):
         raise ValueError("Selected axes are outside the current figure layout")
-    selected = [
-        axs[row, col] for row, col in selection.valid_axes(tool._document.recipe.setup)
-    ]
+    setup = tool._document.recipe.setup
+    valid_axes = selection.valid_axes(setup)
+    if not for_plot_slices:
+        compact_index = _compact_axes_index(
+            valid_axes,
+            nrows=setup.nrows,
+            ncols=setup.ncols,
+        )
+        if compact_index is not None:
+            return axs[compact_index]
+    selected = [axs[row, col] for row, col in valid_axes]
     if not selected:
         raise ValueError("No axes are selected for this operation")
     if for_plot_slices:

--- a/src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
@@ -950,6 +950,37 @@ class FigureOperationEditor(QtWidgets.QWidget):
         adapter.connect_commit(self.connect_signal, changed)
         return combo
 
+    def labeled_combo(
+        self,
+        values: Sequence[str],
+        labels: Sequence[str],
+        current: str | None,
+        changed: Callable[[str], None],
+        *,
+        parent: QtWidgets.QWidget | None = None,
+        mixed: bool = False,
+        enabled: bool = True,
+    ) -> QtWidgets.QComboBox:
+        if len(values) != len(labels):
+            raise ValueError("combo values and labels must have the same length")
+        combo = QtWidgets.QComboBox(parent or self._current_page() or self)
+        self.mark_control(combo)
+        adapter = ComboBoxDataControlAdapter(combo)
+        if mixed:
+            adapter.set_mixed(True)
+        for value, label in zip(values, labels, strict=True):
+            combo.addItem(label, value)
+        if not mixed and current is not None:
+            index = combo.findData(current)
+            if index >= 0:
+                combo.setCurrentIndex(index)
+        combo.setEnabled(enabled)
+        adapter.connect_commit(
+            self.connect_signal,
+            lambda value: changed(typing.cast("str", value)),
+        )
+        return combo
+
     def source_combo(
         self,
         values: Sequence[str],

--- a/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
@@ -443,6 +443,19 @@ def test_figure_composer_axes_helpers_parse_safe_expressions() -> None:
 
     assert figurecomposer_axes._compact_axes_code(()) is None
     assert figurecomposer_axes._compact_axes_iterable_code((), nrows=2, ncols=2) is None
+    assert figurecomposer_axes._compact_axes_index(
+        ((0, 0), (0, 1), (1, 0), (1, 1)),
+        nrows=2,
+        ncols=2,
+    ) == (slice(None), slice(None))
+    assert (
+        figurecomposer_axes._compact_axes_index(
+            ((0, 0), (1, 1)),
+            nrows=2,
+            ncols=2,
+        )
+        is None
+    )
     assert figurecomposer_axes._axes_expression_value("axs", axs) is axs
     assert figurecomposer_axes._axes_expression_value("ax", axs) == "ax00"
     assert figurecomposer_axes._axes_expression_value("axs[-1, 0]", axs) == "ax10"
@@ -902,7 +915,7 @@ def test_figure_composer_rendering_helpers_cover_selection_edges(qtbot) -> None:
     tool = FigureComposerTool(
         data,
         recipe=FigureRecipeState(
-            setup=FigureSubplotsState(nrows=1, ncols=1, sharex=False, sharey=False),
+            setup=FigureSubplotsState(nrows=2, ncols=2, sharex=False, sharey=False),
             sources=(FigureSourceState(name="data", label="data"),),
             primary_source="data",
         ),
@@ -911,7 +924,35 @@ def test_figure_composer_rendering_helpers_cover_selection_edges(qtbot) -> None:
     assert "sharex" not in figurecomposer_rendering._setup_kwargs(tool._document)
     assert "sharey" not in figurecomposer_rendering._setup_kwargs(tool._document)
 
-    fig, axs = plt.subplots(1, 1, squeeze=False)
+    fig, axs = plt.subplots(2, 2, squeeze=False)
+    rectangular = figurecomposer_rendering._axes_from_selection(
+        tool,
+        FigureAxesSelectionState(axes=((0, 0), (0, 1), (1, 0), (1, 1))),
+        axs,
+        for_plot_slices=False,
+    )
+    assert isinstance(rectangular, np.ndarray)
+    assert rectangular.shape == (2, 2)
+    assert rectangular[1, 0] is axs[1, 0]
+
+    plot_slices_axes = figurecomposer_rendering._axes_from_selection(
+        tool,
+        FigureAxesSelectionState(axes=((0, 0), (0, 1), (1, 0), (1, 1))),
+        axs,
+        for_plot_slices=True,
+    )
+    assert isinstance(plot_slices_axes, np.ndarray)
+    assert plot_slices_axes.shape == (4,)
+
+    irregular = figurecomposer_rendering._axes_from_selection(
+        tool,
+        FigureAxesSelectionState(axes=((0, 0), (1, 1))),
+        axs,
+        for_plot_slices=False,
+    )
+    assert isinstance(irregular, np.ndarray)
+    assert irregular.shape == (2,)
+
     with pytest.raises(ValueError, match="outside the current figure"):
         figurecomposer_rendering._axes_from_selection(
             tool,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
@@ -448,6 +448,11 @@ def test_figure_composer_axes_helpers_parse_safe_expressions() -> None:
         nrows=2,
         ncols=2,
     ) == (slice(None), slice(None))
+    assert figurecomposer_axes._compact_axes_index(
+        ((0, 0), (0, 1)),
+        nrows=2,
+        ncols=3,
+    ) == (0, slice(None, 2))
     assert (
         figurecomposer_axes._compact_axes_index(
             ((0, 0), (1, 1)),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -15,6 +15,7 @@ import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
 import erlab.interactive._figurecomposer._tool as figurecomposer_tool_module
 import erlab.interactive._figurecomposer._ui._tick_params as figurecomposer_tick_params
 import erlab.interactive._stylesheets
+import erlab.plotting as eplt
 from erlab.interactive._figurecomposer import (
     FigureAxesSelectionState,
     FigureComposerTool,
@@ -1493,6 +1494,141 @@ def test_figure_composer_batch_incompatible_methods_disable_editor(qtbot) -> Non
     )
 
 
+@pytest.mark.parametrize(
+    ("method_name", "method_args", "text_values"),
+    [
+        (
+            "label_subplots",
+            (),
+            tuple(f"label-{index}" for index in range(9)),
+        ),
+        (
+            "label_subplot_properties",
+            ({"value": list(range(9))},),
+            (),
+        ),
+        (
+            "set_titles",
+            (),
+            tuple(f"title-{index}" for index in range(9)),
+        ),
+        (
+            "set_xlabels",
+            (),
+            tuple(f"x-{index}" for index in range(9)),
+        ),
+        (
+            "set_ylabels",
+            (),
+            tuple(f"y-{index}" for index in range(9)),
+        ),
+    ],
+)
+def test_figure_composer_ordered_methods_preserve_rectangular_axes(
+    qtbot, monkeypatch, method_name, method_args, text_values
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    axes = FigureAxesSelectionState(
+        axes=tuple((row, col) for row in range(3) for col in range(3))
+    )
+    operation = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name=method_name,
+        axes=axes,
+    ).model_copy(
+        update={
+            "method_args": method_args,
+            "method_kwargs": {"order": "F"},
+            "text_values": text_values,
+        }
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=3, ncols=3),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    calls: list[tuple[tuple[int, ...], str | None]] = []
+
+    def capture_axes(axes, *_args, **kwargs) -> None:
+        calls.append((np.asarray(axes, dtype=object).shape, kwargs.get("order")))
+
+    monkeypatch.setattr(eplt, method_name, capture_axes)
+
+    preview_figure = plt.figure()
+    figurecomposer_rendering._render_into_figure(
+        tool, preview_figure, sync_visible=False
+    )
+    assert calls == [((3, 3), "F")]
+
+    calls.clear()
+    namespace: dict[str, typing.Any] = {"data": data}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    assert calls == [((3, 3), "F")]
+
+    plt.close(preview_figure)
+    plt.close(namespace["fig"])
+
+
+def test_figure_composer_label_subplots_preserves_empty_text_rows(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    operation = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name="label_subplots",
+        axes=FigureAxesSelectionState(axes=((0, 0), (0, 1), (0, 2))),
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(nrows=1, ncols=3),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool.operation_editor.select_section("method")
+    text_edit = tool.operation_editor.stack.currentWidget().findChild(
+        QtWidgets.QPlainTextEdit,
+        "figureComposerMethodTextValuesEdit",
+    )
+    assert text_edit is not None
+
+    text_edit.setPlainText("first\n\nthird")
+    operation = tool.tool_status.operations[0]
+    assert operation.text_values == ("first", "", "third")
+    _args, kwargs = method_execution._render_args_kwargs(
+        tool,
+        operation,
+        method_catalog._method_spec(operation),
+    )
+    assert kwargs["values"] == ["first", "", "third"]
+
+    namespace: dict[str, typing.Any] = {"data": data}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    assert all(len(axis.artists) == 1 for axis in namespace["axs"].flat)
+    plt.close(namespace["fig"])
+
+    text_edit.setPlainText("")
+    assert tool.tool_status.operations[0].text_values == ()
+
+
 def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
@@ -1613,7 +1749,12 @@ def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
         edit.editingFinished.emit()
 
     def set_combo(page: QtWidgets.QWidget, name: str, text: str) -> None:
-        _activate_combo_text(combo_box(page, name), text)
+        combo = combo_box(page, name)
+        index = combo.findData(text)
+        if index >= 0:
+            _activate_combo_index(combo, index)
+        else:
+            _activate_combo_text(combo, text)
 
     def operation(row: int) -> FigureOperationState:
         return tool.tool_status.operations[row]
@@ -1623,6 +1764,11 @@ def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
     assert operation(0).method_args == (True,)
 
     page = select_method(1)
+    order_combo = combo_box(page, "figureComposerERLabLabelSubplotsOrderCombo")
+    assert [order_combo.itemData(index) for index in range(order_combo.count())] == [
+        "C",
+        "F",
+    ]
     spin_box(page, "figureComposerERLabLabelSubplotsStartEdit").setValue(3)
     set_combo(page, "figureComposerERLabLabelSubplotsOrderCombo", "F")
     set_combo(page, "figureComposerERLabLabelSubplotsLocCombo", "lower right")

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -1628,6 +1628,65 @@ def test_figure_composer_label_subplots_preserves_empty_text_rows(qtbot) -> None
     text_edit.setPlainText("")
     assert tool.tool_status.operations[0].text_values == ()
 
+    text_edit.setPlainText(" \t ")
+    operation = tool.tool_status.operations[0]
+    assert operation.text_values == ()
+    _args, kwargs = method_execution._render_args_kwargs(
+        tool,
+        operation,
+        method_catalog._method_spec(operation),
+    )
+    assert "values" not in kwargs
+
+
+@pytest.mark.parametrize("legacy_order", ["A", "K"])
+def test_figure_composer_legacy_method_order_normalizes_to_c(
+    qtbot, monkeypatch, legacy_order
+) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    operation = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name="label_subplots",
+    ).model_copy(update={"method_kwargs": {"order": legacy_order}})
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    spec = method_catalog._method_spec(operation)
+    assert (
+        method_execution._render_args_kwargs(tool, operation, spec)[1]["order"] == "C"
+    )
+
+    tool.operation_editor.select_section("method")
+    order_combo = tool.operation_editor.stack.currentWidget().findChild(
+        QtWidgets.QComboBox,
+        "figureComposerERLabLabelSubplotsOrderCombo",
+    )
+    assert order_combo is not None
+    assert order_combo.currentData() == "C"
+
+    calls: list[str] = []
+
+    def capture_order(_axes, **kwargs) -> None:
+        calls.append(kwargs["order"])
+
+    monkeypatch.setattr(eplt, "label_subplots", capture_order)
+    preview_figure = plt.figure()
+    figurecomposer_rendering._render_into_figure(
+        tool, preview_figure, sync_visible=False
+    )
+    namespace: dict[str, typing.Any] = {"data": data}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    assert calls == ["C", "C"]
+    plt.close(preview_figure)
+    plt.close(namespace["fig"])
+
 
 def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
     data = xr.DataArray(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -2215,6 +2215,10 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     assert view_page is not None
     assert crop_check is not None
     assert order_combo is not None
+    assert [order_combo.itemData(index) for index in range(order_combo.count())] == [
+        "C",
+        "F",
+    ]
     assert transpose_check is not None
     assert same_limits_combo is not None
     assert axis_combo is not None

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -1966,6 +1966,38 @@ def test_figure_composer_editor_factories_preserve_mixed_and_missing_values(
     _activate_combo_index(mixed_name_combo, mixed_name_combo.currentIndex())
     assert committed == before
 
+    with pytest.raises(ValueError, match="same length"):
+        tool.operation_editor.labeled_combo(
+            ("C",),
+            ("Row", "Column"),
+            None,
+            committed.append,
+        )
+
+    mixed_labeled_combo = tool.operation_editor.labeled_combo(
+        ("C", "F"),
+        ("Row", "Column"),
+        None,
+        committed.append,
+        mixed=True,
+    )
+    before = list(committed)
+    assert mixed_labeled_combo.currentData() is _editor_controls.MIXED_VALUE
+    _activate_combo_index(
+        mixed_labeled_combo,
+        mixed_labeled_combo.currentIndex(),
+    )
+    assert committed == before
+
+    unmatched_labeled_combo = tool.operation_editor.labeled_combo(
+        ("C", "F"),
+        ("Row", "Column"),
+        "K",
+        committed.append,
+    )
+    assert unmatched_labeled_combo.findData("K") == -1
+    assert unmatched_labeled_combo.currentData() == "C"
+
     mixed_check = tool.operation_editor.check_box(False, committed.append, mixed=True)
     assert mixed_check.checkState() == QtCore.Qt.CheckState.PartiallyChecked
     before = list(committed)

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -225,24 +225,25 @@ def test_explorer_close_stops_preview_workers(
 
 
 def test_explorer_close_ignores_busy_preview_workers(
-    qtbot, example_loader, example_data_dir: pathlib.Path
+    qtbot,
 ) -> None:
     class _BusyDataExplorer(_DataExplorer):
-        def __init__(self, *args, **kwargs) -> None:
+        def __init__(self) -> None:
+            QtWidgets.QMainWindow.__init__(self)
             self.stopped_preview_workers = False
             self.defer_preview_stop = True
-            super().__init__(*args, **kwargs)
 
         def _stop_preview_workers(
             self, timeout_ms: int = _PREVIEW_WORKER_STOP_TIMEOUT_MS
         ) -> bool:
+            del timeout_ms
             self.stopped_preview_workers = True
             if self.defer_preview_stop:
                 self._preview_stopping = True
                 return False
             return True
 
-    explorer = _BusyDataExplorer(root_path=example_data_dir, loader_name="example")
+    explorer = _BusyDataExplorer()
     qtbot.addWidget(explorer)
     event = QtGui.QCloseEvent()
 


### PR DESCRIPTION
## Summary

- preserve rectangular axes selections as 2D arrays during live rendering, so `order="C"` and `order="F"` affect subplot labels, property labels, titles, x-labels, and y-labels consistently with generated code
- expose only `C (Row)` and `F (Column)` in order controls while keeping the stored arguments as Matplotlib-compatible `"C"` and `"F"`
- preserve blank lines as empty entries in multiline `label_subplots` input, while an entirely empty field still requests automatic labels
- retain the established handling for irregular selections, GridSpec axes, Plot Slices, and advanced axes expressions

## Root cause

The live renderer flattened contiguous rectangular axes selections before passing them to plotting methods. Once flattened, NumPy could no longer distinguish row-major from column-major traversal, so changing `order` had no visible effect even though generated code used the original 2D axes array.

## Impact

Figure Composer previews now match copied/generated code for every operation that exposes `order`. The simplified order choices make the traversal direction explicit, and blank multiline rows can intentionally skip selected axes.

## Testing

- `QT_QPA_PLATFORM=offscreen QT_API=pyqt6 uv run pytest -q tests/interactive/imagetool/manager/figurecomposer` — 686 passed
- `QT_QPA_PLATFORM=offscreen QT_API=pyside6 uv run pytest -q tests/interactive/imagetool/manager/figurecomposer` — 686 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check origin/main...HEAD`
