### PR TITLE
fix(figurecomposer): support negative colorbar indices

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
@@ -1930,6 +1930,15 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
             MethodCallPolicy.AX_KEYWORD,
         ),
         controls=(
+            _int_kwarg(
+                "Mappable index",
+                "index",
+                "figureComposerERLabNiceColorbarIndexEdit",
+                "Mappable index to use when inferring from the target axes.",
+                default=-1,
+                minimum=-999,
+                maximum=999,
+            ),
             _float_kwarg(
                 "Width",
                 "width",
@@ -2016,7 +2025,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "figureComposerERLabProportionalColorbarIndexEdit",
                 "Mappable index to use when inferring from the target axes.",
                 default=-1,
-                minimum=-1,
+                minimum=-999,
                 maximum=999,
             ),
             _bool_kwarg_combo(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -1675,6 +1675,9 @@ def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
     }
 
     page = select_method(3)
+    nice_colorbar_index = spin_box(page, "figureComposerERLabNiceColorbarIndexEdit")
+    assert nice_colorbar_index.value() == -1
+    nice_colorbar_index.setValue(-2)
     double_spin_box(page, "figureComposerERLabNiceColorbarWidthEdit").setValue(10.0)
     double_spin_box(page, "figureComposerERLabNiceColorbarAspectEdit").setValue(4.0)
     double_spin_box(page, "figureComposerERLabNiceColorbarPadEdit").setValue(2.0)
@@ -1686,6 +1689,7 @@ def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
         page, "figureComposerERLabNiceColorbarTickLabelsEdit", "low, mid, high"
     )
     assert operation(3).method_kwargs == {
+        "index": -2,
         "width": 10.0,
         "aspect": 4.0,
         "pad": 2.0,
@@ -1697,11 +1701,15 @@ def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
     }
 
     page = select_method(4)
-    spin_box(page, "figureComposerERLabProportionalColorbarIndexEdit").setValue(0)
+    proportional_colorbar_index = spin_box(
+        page, "figureComposerERLabProportionalColorbarIndexEdit"
+    )
+    assert proportional_colorbar_index.value() == -1
+    proportional_colorbar_index.setValue(-2)
     set_combo(page, "figureComposerERLabProportionalColorbarImageOnlyCombo", "True")
     set_line_edit(page, "figureComposerERLabProportionalColorbarTicksEdit", "[0, 1]")
     assert operation(4).method_kwargs == {
-        "index": 0,
+        "index": -2,
         "image_only": True,
         "ticks": [0, 1],
     }


### PR DESCRIPTION
## Summary

- allow the `proportional_colorbar` mappable index control to select negative indices beyond the default `-1`
- expose the same index control in the `nice_colorbar` Figure Composer UI
- cover the default and negative-index recipe updates for both controls

## Root cause

The `proportional_colorbar` method catalog limited the spin box minimum to `-1`, even though the plotting API uses normal Python indexing and accepts earlier mappables through values such as `-2`. The `nice_colorbar` catalog also omitted this pass-through parameter entirely.

## User impact

Figure Composer users can now select any displayed mappable index from `-999` through `999` for either colorbar helper. Both controls retain the API default of `-1`.

## Validation

- `QT_QPA_PLATFORM=offscreen QT_API=pyqt6 uv run pytest tests/interactive/imagetool/manager/figurecomposer/test_method.py::test_figure_composer_erlab_method_controls_update_recipe -q`
- `QT_QPA_PLATFORM=offscreen QT_API=pyside6 uv run pytest tests/interactive/imagetool/manager/figurecomposer/test_method.py::test_figure_composer_erlab_method_controls_update_recipe -q`
- `uv run ruff check src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py tests/interactive/imagetool/manager/figurecomposer/test_method.py`
- `uv run ruff format --check src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py tests/interactive/imagetool/manager/figurecomposer/test_method.py`
- `git diff --check`
