### PR TITLE
fix(figurecomposer): stabilize rendering and saved source snapshots

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -372,12 +372,7 @@ def _render_error_text(error: Exception) -> str:
 
 
 def _set_preview_draw_error(tool: FigureComposerTool, error: Exception) -> None:
-    current = tool._current_operation()
-    if current is None:
-        return
-    errors = dict(tool._operation_render_errors)
-    errors[current[1].operation_id] = _render_error_text(error)
-    tool._set_operation_render_errors(errors)
+    tool._set_preview_render_error(_render_error_text(error))
 
 
 def _render_preview(
@@ -406,10 +401,16 @@ def _render_preview(
             except Exception as exc:
                 _set_preview_draw_error(tool, exc)
             else:
+                tool._set_preview_render_error(None)
                 preview_cached = tool._cache_live_canvas_preview(redraw=False)
                 tool.canvas.flush_events()
         elif (window := _valid_figure_window(tool)) is not None and window.isVisible():
-            window.canvas.draw_idle()
+            try:
+                window.canvas.draw()
+            except Exception as exc:
+                _set_preview_draw_error(tool, exc)
+            else:
+                tool._set_preview_render_error(None)
     finally:
         if not preview_cached:
             tool._mark_preview_pixmap_stale()

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -134,6 +134,7 @@ from erlab.interactive._figurecomposer._rendering import (
     _axes_from_selection,
     _iter_axes,
     _live_layout_axes,
+    _render_error_text,
     _render_into_figure,
     _render_preview,
     _rendered_output_figure,
@@ -364,6 +365,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self._preview_render_update_pending = False
         self._preview_render_update_generation = 0
         self._operation_render_errors: dict[str, str] = {}
+        self._preview_render_error: str | None = None
         self._plot_slices_cache = _PlotSlicesSelectionCache()
         self._plot_slices_cache_source_revision = -1
         self._figure_resize_render_generation = 0
@@ -2671,6 +2673,22 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         current = self._current_operation()
         self._update_source_status(current[1] if current is not None else None)
 
+    def _set_preview_render_error(self, error: str | None) -> None:
+        if error == self._preview_render_error:
+            return
+        self._preview_render_error = error
+        status_bar = self.statusBar()
+        if status_bar is None:
+            status_bar = QtWidgets.QStatusBar(self)
+            self.setStatusBar(status_bar)
+        status_bar.setObjectName("figureComposerPreviewRenderStatus")
+        if error is None:
+            status_bar.clearMessage()
+            status_bar.hide()
+        else:
+            status_bar.showMessage(f"Preview render error: {error}")
+            status_bar.show()
+
     @QtCore.Slot()
     def _operation_editor_validation_changed(self) -> None:
         self._refresh_operation_list()
@@ -4787,10 +4805,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 QtGui.QImage.Format.Format_RGBA8888,
             )
             preview = QtGui.QPixmap.fromImage(image.copy())
-        except Exception:
+        except Exception as exc:
+            self._set_preview_render_error(_render_error_text(exc))
             return False
         if preview.isNull():
             return False
+        self._set_preview_render_error(None)
         self._preview_pixmap_cache = preview
         self._preview_pixmap_generation += 1
         self._preview_thumbnail_cache.clear()
@@ -4815,10 +4835,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                     with _figure_draw_context():
                         canvas.draw()
                     width, height = canvas.get_width_height()
-                except Exception:
+                except Exception as exc:
+                    self._set_preview_render_error(_render_error_text(exc))
                     return None
                 if width <= 0 or height <= 0:
                     return None
+                self._set_preview_render_error(None)
                 image = QtGui.QImage(
                     canvas.buffer_rgba(),
                     width,

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -2677,10 +2677,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if error == self._preview_render_error:
             return
         self._preview_render_error = error
-        status_bar = self.statusBar()
-        if status_bar is None:
-            status_bar = QtWidgets.QStatusBar(self)
-            self.setStatusBar(status_bar)
+        status_bar = typing.cast("QtWidgets.QStatusBar", self.statusBar())
         status_bar.setObjectName("figureComposerPreviewRenderStatus")
         if error is None:
             status_bar.clearMessage()

--- a/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
@@ -243,7 +243,7 @@ class _FigureComposerWorkflowController(QtCore.QObject):
         reserved = set(reserved_sources)
         for target in resolved_targets:
             node = self._host._node_for_target(target)
-            data = node.current_source_data()
+            data = node.data_for_role("displayed")
             source = self._figure_source_from_node(node, data, reserved)
             source_data[source.name] = data
             sources.append(source)
@@ -575,9 +575,13 @@ class _FigureComposerWorkflowController(QtCore.QObject):
         if not isinstance(tool, FigureComposerTool):
             return False
 
-        data = source_node.current_source_data()
+        current_source = self._figure_source_state(tool, source_name)
+        if current_source is None:
+            return False
+        data_role = current_source.data_role
+        data = source_node.data_for_role(data_role)
         source = FigureSourceState.from_script_input(
-            self._host._script_input_for_node(source_node)
+            self._host._script_input_for_node(source_node, data_role=data_role)
         )
         if not tool.replace_source(source_name, source, data):
             return False

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -89,6 +89,56 @@ class _WorkspaceController:
         self._background_save_requested = False
         self._shutdown_compaction_attempted = False
 
+    def _tool_data_reference_matches_current_snapshot(
+        self, reference: Mapping[str, typing.Any]
+    ) -> bool:
+        if reference.get("kind") != "manager_node":
+            return True
+        node_uid = reference.get("node_uid")
+        if not isinstance(node_uid, str) or not node_uid:
+            return False
+        node = self._manager._tool_graph.nodes.get(node_uid)
+        if node is None:
+            return False
+        data_role = reference.get("data_role", "displayed")
+        if data_role not in {"source", "displayed"}:
+            return False
+        snapshot_token = reference.get("node_snapshot_token")
+        return snapshot_token is None or (
+            isinstance(snapshot_token, str)
+            and snapshot_token != ""
+            and snapshot_token == node.snapshot_token_for_role(data_role)
+        )
+
+    def _tool_data_reference_matches_current_data(
+        self, reference: Mapping[str, typing.Any], data: xr.DataArray
+    ) -> bool:
+        if not self._tool_data_reference_matches_current_snapshot(reference):
+            return False
+        if reference.get("kind") != "manager_node":
+            return True
+        node_uid = typing.cast("str", reference.get("node_uid"))
+        node = self._manager._tool_graph.nodes[node_uid]
+        data_role = typing.cast(
+            "typing.Literal['source', 'displayed']",
+            reference.get("data_role", "displayed"),
+        )
+        try:
+            resolved = node.data_for_role(data_role)
+        except Exception:
+            return False
+        return erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            resolved, data
+        )
+
+    def _commit_saved_tool_data_references(
+        self, snapshot: workspace_saving._WorkspaceSaveSnapshot
+    ) -> None:
+        for uid, references in snapshot.serialized_tool_data_references:
+            node = self._manager._tool_graph.nodes.get(uid)
+            if node is not None and not node.is_imagetool:
+                node._set_workspace_tool_data_references(references)
+
     @staticmethod
     def _normalize_recent_workspace_paths(
         paths: Iterable[str | os.PathLike[str]],
@@ -601,7 +651,8 @@ class _WorkspaceController:
             reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] = {}
             try:
                 with tool._save_tool_data_reference_context(
-                    self._manager._tool_graph.nodes
+                    self._manager._tool_graph.nodes,
+                    reference_validator=self._tool_data_reference_matches_current_data,
                 ):
                     ds = tool.to_dataset()
                 references = type(tool)._saved_tool_data_references(ds)
@@ -1571,6 +1622,7 @@ class _WorkspaceController:
             self._manager._workspace_state.schema_version = (
                 workspace_format._current_workspace_schema_version()
             )
+        self._commit_saved_tool_data_references(snapshot)
         self._manager._workspace_state.needs_full_save = False
         self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
         self._manager._workspace_state.set_repack_estimate(
@@ -1865,6 +1917,7 @@ class _WorkspaceController:
                         on_finished(False)
                     return
 
+            self._commit_saved_tool_data_references(snapshot)
             self._manager._workspace_state.needs_full_save = False
             self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
             self._manager._workspace_state.set_repack_estimate(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -415,6 +415,21 @@ class _WorkspaceLoader:
         if pending is None:
             raise ValueError("Node has no pending ImageTool workspace payload")
         workspace_path, payload_path = pending
+        return self._workspace_imagetool_reference_dataset_at(
+            workspace_path,
+            payload_path,
+            owner_node=owner_node,
+            reference_datasets=reference_datasets,
+        )
+
+    def _workspace_imagetool_reference_dataset_at(
+        self,
+        workspace_path: str | os.PathLike[str],
+        payload_path: str,
+        *,
+        owner_node: _ImageToolWrapper | _ManagedWindowNode | None = None,
+        reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] | None = None,
+    ) -> xr.Dataset:
         key = self._workspace_reference_key(workspace_path, payload_path)
 
         def _open() -> xr.Dataset:
@@ -432,6 +447,49 @@ class _WorkspaceLoader:
         if owner_node is not None:
             return owner_node._workspace_reference_dataset(key, _open)
         raise RuntimeError("Pending workspace reference data requires an owner")
+
+    def _saved_workspace_reference_source_data(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        *,
+        snapshot_token: str,
+        data_role: ScriptInputDataRole,
+        owner_node: _ImageToolWrapper | _ManagedWindowNode | None,
+        reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] | None,
+    ) -> xr.DataArray | None:
+        if not node.is_imagetool:
+            return None
+        pending_owner = (
+            None if owner_node is None else owner_node.pending_workspace_tool_payload
+        )
+        workspace_path = (
+            pending_owner[0]
+            if pending_owner is not None
+            else self._manager._workspace_state.path
+        )
+        if workspace_path is None:
+            return None
+        payload_path = self._controller.saving._workspace_payload_path(node.uid)
+        opened = self._workspace_imagetool_reference_dataset_at(
+            workspace_path,
+            payload_path,
+            owner_node=owner_node,
+            reference_datasets=reference_datasets,
+        )
+        ds = workspace_format._restore_workspace_dataset_attrs(opened.copy(deep=False))
+        saved_token = workspace_format._decode_workspace_attr_text(
+            ds.attrs.get("manager_node_snapshot_token")
+            if data_role == "displayed"
+            else ds.attrs.get("manager_node_source_snapshot_token")
+        )
+        if saved_token != snapshot_token:
+            return None
+        return self.pending._workspace_imagetool_source_data(
+            node,
+            opened,
+            attrs=None,
+            data_role=data_role,
+        )
 
     @staticmethod
     def _workspace_imagetool_payload_data(ds: xr.Dataset) -> xr.DataArray:
@@ -514,6 +572,22 @@ class _WorkspaceLoader:
             if data_role not in {"source", "displayed"}:
                 return None
             try:
+                source_node = self._manager._node_for_target(target)
+                snapshot_token = payload.get("node_snapshot_token")
+                if (
+                    isinstance(snapshot_token, str)
+                    and snapshot_token
+                    and snapshot_token != source_node.snapshot_token_for_role(data_role)
+                ):
+                    saved_data = self._saved_workspace_reference_source_data(
+                        source_node,
+                        snapshot_token=snapshot_token,
+                        data_role=typing.cast("ScriptInputDataRole", data_role),
+                        owner_node=owner_node,
+                        reference_datasets=reference_datasets,
+                    )
+                    if saved_data is not None:
+                        return saved_data
                 return _source_data_for_target(
                     target,
                     typing.cast("ScriptInputDataRole", data_role),

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -172,11 +172,25 @@ class _PendingWorkspacePayloads:
             owner_node=owner_node,
             reference_datasets=reference_datasets,
         )
+        return self._workspace_imagetool_source_data(
+            node,
+            opened,
+            attrs=node.pending_workspace_payload_attrs,
+            data_role=data_role,
+        )
+
+    def _workspace_imagetool_source_data(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        opened: xr.Dataset,
+        *,
+        attrs: Mapping[typing.Any, typing.Any] | None,
+        data_role: ScriptInputDataRole,
+    ) -> xr.DataArray:
         ds = workspace_format._restore_workspace_dataset_attrs(opened.copy(deep=False))
         ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
         name = None if node.name == "" else node.name
         data = self._loader._workspace_imagetool_payload_data(ds).rename(name)
-        attrs = node.pending_workspace_payload_attrs
         if attrs is None:
             attrs = ds.attrs
         data = self._pending_workspace_data_with_saved_dim_order(data, attrs)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -74,6 +74,9 @@ class _WorkspaceSaveSnapshot:
     attr_updates: tuple[
         tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]], ...
     ] = ()
+    serialized_tool_data_references: tuple[
+        tuple[str, dict[str, dict[str, typing.Any]]], ...
+    ] = ()
 
     def close(self) -> None:
         if self.full_tree is not None:
@@ -175,6 +178,56 @@ class _WorkspaceSaver:
         self._manager = manager
         self._controller = controller
 
+    @staticmethod
+    def _serialized_tool_data_references(
+        datasets: Iterable[xr.Dataset],
+    ) -> tuple[tuple[str, dict[str, dict[str, typing.Any]]], ...]:
+        references_by_uid: dict[str, dict[str, dict[str, typing.Any]]] = {}
+        for ds in datasets:
+            if ds.attrs.get("manager_node_kind") != "tool":
+                continue
+            uid = ds.attrs.get("manager_node_uid")
+            if not isinstance(uid, str) or not uid:
+                continue
+            references_by_uid[uid] = (
+                erlab.interactive.utils.ToolWindow._saved_tool_data_references(ds)
+            )
+        return tuple(sorted(references_by_uid.items()))
+
+    @classmethod
+    def _serialized_tool_data_references_from_tree(
+        cls,
+        tree: xr.DataTree,
+        *,
+        exclude_payload_paths: Iterable[str] = (),
+    ) -> tuple[tuple[str, dict[str, dict[str, typing.Any]]], ...]:
+        excluded = {path.strip("/") for path in exclude_payload_paths}
+        return cls._serialized_tool_data_references(
+            node.to_dataset(inherit=False)
+            for node in tree.subtree
+            if node.path.strip("/") not in excluded
+        )
+
+    @classmethod
+    def _serialized_tool_data_references_from_delta(
+        cls,
+        rewrite_groups: Iterable[tuple[str, dict[str, xr.Dataset]]],
+        attr_updates: Iterable[
+            tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
+        ],
+    ) -> tuple[tuple[str, dict[str, dict[str, typing.Any]]], ...]:
+        datasets = [
+            ds
+            for _group_path, constructor in rewrite_groups
+            for ds in constructor.values()
+        ]
+        datasets.extend(
+            ds
+            for _payload_path, _attrs, (_node_path, constructor) in attr_updates
+            for ds in constructor.values()
+        )
+        return cls._serialized_tool_data_references(datasets)
+
     def _annotate_workspace_dataset(
         self,
         ds: xr.Dataset,
@@ -273,7 +326,10 @@ class _WorkspaceSaver:
             if not tool.can_save_and_load():
                 return
             with tool._save_tool_data_reference_context(
-                self._manager._tool_graph.nodes
+                self._manager._tool_graph.nodes,
+                reference_validator=(
+                    self._controller._tool_data_reference_matches_current_data
+                ),
             ):
                 ds = tool.to_dataset()
             ds.attrs["tool_title"] = _strip_workspace_modified_placeholder(
@@ -751,6 +807,11 @@ class _WorkspaceSaver:
         serialize_uids.update(
             uid for uid in state.dirty_state if uid in self._manager._tool_graph.nodes
         )
+        serialize_uids.update(
+            self._workspace_stale_reference_rewrite_uids(
+                frozenset(self._manager._tool_graph.nodes)
+            )
+        )
         return serialize_uids
 
     def _workspace_full_save_manifest_first_snapshot(
@@ -985,6 +1046,9 @@ class _WorkspaceSaver:
             copy_source=str(workspace_path),
             copy_groups=tuple(copy_groups),
             copy_group_sources=tuple(copy_group_sources),
+            serialized_tool_data_references=(
+                self._serialized_tool_data_references_from_tree(tree)
+            ),
         )
 
     def _write_full_workspace_file(
@@ -1010,6 +1074,7 @@ class _WorkspaceSaver:
                 copy_group_sources=snapshot.copy_group_sources,
                 compression_mode=snapshot.compression_mode,
             )
+            self._controller._commit_saved_tool_data_references(snapshot)
         finally:
             snapshot.close()
 
@@ -1068,7 +1133,23 @@ class _WorkspaceSaver:
                 continue
             if tool._persistence_reference_node_uids() - available_uids:
                 rewrite_uids.append(uid)
+                continue
+            references = node._workspace_tool_data_references
+            if not references:
+                continue
+            if not self._workspace_tool_references_match_current_snapshots(
+                references.values()
+            ):
+                rewrite_uids.append(uid)
         return sorted(rewrite_uids, key=self._workspace_node_path)
+
+    def _workspace_tool_references_match_current_snapshots(
+        self, references: Iterable[Mapping[str, typing.Any]]
+    ) -> bool:
+        return all(
+            self._controller._tool_data_reference_matches_current_snapshot(reference)
+            for reference in references
+        )
 
     def _save_workspace_delta(self, fname: str | os.PathLike[str]) -> None:
         delta_save_count = self._manager._workspace_state.delta_save_count + 1
@@ -1085,6 +1166,7 @@ class _WorkspaceSaver:
                 snapshot.root_attrs,
                 compression_mode=snapshot.compression_mode,
             )
+            self._controller._commit_saved_tool_data_references(snapshot)
             self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
             self._manager._workspace_state.set_repack_estimate(
                 estimated_obsolete_bytes=snapshot.estimated_obsolete_bytes,
@@ -1365,11 +1447,8 @@ class _WorkspaceSaver:
                 continue
             if kind != "manager_node":
                 return False
-            referenced_uid = reference.get("node_uid")
-            if (
-                not isinstance(referenced_uid, str)
-                or not referenced_uid
-                or referenced_uid not in self._manager._tool_graph.nodes
+            if not self._controller._tool_data_reference_matches_current_snapshot(
+                reference
             ):
                 return False
         return True
@@ -1461,6 +1540,11 @@ class _WorkspaceSaver:
             compression_mode=self._workspace_compression_mode(),
             rewrite_groups=tuple(rewrite_groups),
             attr_updates=tuple(attr_updates),
+            serialized_tool_data_references=(
+                self._serialized_tool_data_references_from_delta(
+                    rewrite_groups, attr_updates
+                )
+            ),
         )
 
     def _workspace_save_snapshot(
@@ -1542,6 +1626,16 @@ class _WorkspaceSaver:
             copy_source=copy_source,
             copy_groups=copy_groups,
             copy_group_sources=pending_copy_groups,
+            serialized_tool_data_references=(
+                self._serialized_tool_data_references_from_tree(
+                    tree,
+                    exclude_payload_paths=(
+                        destination_path
+                        for _source_path, destination_path, attrs in copy_groups
+                        if attrs is None
+                    ),
+                )
+            ),
         )
 
     def _workspace_file_repack_snapshot(
@@ -1660,6 +1754,10 @@ class _WorkspaceSaver:
                     else:
                         tool = node.tool_window
                         if tool is None or not tool.can_save_and_load():
+                            continue
+                        if not self._workspace_tool_references_match_current_snapshots(
+                            node._workspace_tool_data_references.values()
+                        ):
                             continue
                 kind = "imagetool" if node.is_imagetool else "tool"
                 source_path = identities.get((uid, kind))

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -566,6 +566,9 @@ class _ManagedWindowNode(QtCore.QObject):
             value.slicer_area.sigHistoryChanged.connect(
                 self._handle_imagetool_state_changed
             )
+            value.slicer_area.sigShapeChanged.connect(
+                self._handle_imagetool_displayed_layout_changed
+            )
             value.slicer_area.sigDataEdited.connect(self._handle_imagetool_data_edited)
             value.slicer_area.sigSourceDataChanged.connect(
                 self._handle_imagetool_source_data_changed
@@ -708,6 +711,10 @@ class _ManagedWindowNode(QtCore.QObject):
         with contextlib.suppress(TypeError, RuntimeError):
             old.slicer_area.sigHistoryChanged.disconnect(
                 self._handle_imagetool_state_changed
+            )
+        with contextlib.suppress(TypeError, RuntimeError):
+            old.slicer_area.sigShapeChanged.disconnect(
+                self._handle_imagetool_displayed_layout_changed
             )
         with contextlib.suppress(TypeError, RuntimeError):
             old.slicer_area.sigDataEdited.disconnect(self._handle_imagetool_data_edited)
@@ -2160,6 +2167,10 @@ class _ManagedWindowNode(QtCore.QObject):
             return
         self.manager._note_interaction_activity()
         self.manager._mark_node_state_dirty(self.uid)
+
+    @QtCore.Slot()
+    def _handle_imagetool_displayed_layout_changed(self) -> None:
+        self._advance_displayed_snapshot_token(defer_refresh=True)
 
     @QtCore.Slot()
     def _handle_imagetool_data_edited(self) -> None:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3372,6 +3372,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         )
         self._save_tool_data_references = False
         self._save_tool_data_reference_node_uids: frozenset[str] | None = None
+        self._save_tool_data_reference_validator: (
+            Callable[[Mapping[str, typing.Any], xr.DataArray], bool] | None
+        ) = None
         self._prev_states: collections.deque[M] = collections.deque(maxlen=5000)
         self._next_states: collections.deque[M] = collections.deque(maxlen=5000)
         self._write_history = True
@@ -5162,20 +5165,28 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     @contextlib.contextmanager
     def _save_tool_data_reference_context(
-        self, available_node_uids: Iterable[str] | None = None
+        self,
+        available_node_uids: Iterable[str] | None = None,
+        *,
+        reference_validator: (
+            Callable[[Mapping[str, typing.Any], xr.DataArray], bool] | None
+        ) = None,
     ) -> Iterator[None]:
         """Temporarily prefer manager references over embedded data payloads."""
         previous_enabled = self._save_tool_data_references
         previous_uids = self._save_tool_data_reference_node_uids
+        previous_validator = self._save_tool_data_reference_validator
         self._save_tool_data_references = True
         self._save_tool_data_reference_node_uids = (
             None if available_node_uids is None else frozenset(available_node_uids)
         )
+        self._save_tool_data_reference_validator = reference_validator
         try:
             yield
         finally:
             self._save_tool_data_references = previous_enabled
             self._save_tool_data_reference_node_uids = previous_uids
+            self._save_tool_data_reference_validator = previous_validator
 
     @staticmethod
     def _reference_resolves_current_tool_data(
@@ -5220,6 +5231,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         kind = payload.get("kind")
         if not isinstance(kind, str) or not kind:
             raise ValueError("tool data reference payload must define a non-empty kind")
+        validator = self._save_tool_data_reference_validator
+        if validator is not None and not validator(payload, data):
+            return None
         return payload
 
     def _saved_tool_data_dataset(self) -> xr.Dataset:

--- a/src/erlab/plotting/general.py
+++ b/src/erlab/plotting/general.py
@@ -223,6 +223,14 @@ def _imshow_nonuniform(
     return im
 
 
+def _validate_image_norm(norm: matplotlib.colors.Normalize, values: np.ndarray) -> None:
+    """Resolve data-dependent limits before an image artist is added."""
+    norm.autoscale_None(np.ma.masked_invalid(values, copy=False))
+    if norm.vmin is None or norm.vmax is None:
+        return
+    norm(np.asarray((norm.vmin, norm.vmax)))
+
+
 def plot_array(
     arr: xr.DataArray,
     ax: matplotlib.axes.Axes | None = None,
@@ -350,10 +358,13 @@ def plot_array(
     if func is not None:
         arr = func(arr.copy(deep=True), **func_args)
 
+    values = arr.values
+    _validate_image_norm(norm, values)
+
     if erlab.utils.array.is_dims_uniform(arr, rtol=rtol, atol=atol):
         improps.setdefault("interpolation", "none")
         img = ax.imshow(
-            arr.values, norm=norm, extent=array_extent(arr, rtol, atol), **improps
+            values, norm=norm, extent=array_extent(arr, rtol, atol), **improps
         )
     else:
         improps.setdefault("interpolation", "nearest")
@@ -361,7 +372,7 @@ def plot_array(
             ax,
             x=arr[arr.dims[1]].values,
             y=arr[arr.dims[0]].values,
-            A=arr.values,
+            A=values,
             norm=norm,
             **improps,
         )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -1099,21 +1099,31 @@ def test_figure_composer_redraw_and_preview_cache_edges(qtbot, monkeypatch) -> N
     )
 
 
-def test_figure_composer_preview_draw_error_ignores_missing_operation(qtbot) -> None:
+def test_figure_composer_preview_draw_error_is_not_assigned_to_operation(
+    qtbot,
+) -> None:
     data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    operation = FigureOperationState.line(label="line", source="data")
     tool = FigureComposerTool(
         data,
         recipe=FigureRecipeState(
             sources=(FigureSourceState(name="data"),),
-            operations=(),
+            operations=(operation,),
             primary_source="data",
         ),
     )
     qtbot.addWidget(tool)
+    tool.operation_panel.operation_list.setCurrentItem(
+        tool.operation_panel.operation_list.topLevelItem(0)
+    )
 
     figurecomposer_rendering._set_preview_draw_error(tool, RuntimeError("boom"))
 
     assert tool._operation_render_errors == {}
+    assert tool._preview_render_error == "RuntimeError: boom"
+    status = tool.findChild(QtWidgets.QStatusBar, "figureComposerPreviewRenderStatus")
+    assert status is not None
+    assert not status.isHidden()
 
 
 def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -1126,6 +1126,38 @@ def test_figure_composer_preview_draw_error_is_not_assigned_to_operation(
     assert not status.isHidden()
 
 
+def test_figure_composer_preview_draw_failures_are_figure_level(
+    qtbot, monkeypatch
+) -> None:
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    tool = FigureComposerTool(data)
+    qtbot.addWidget(tool)
+    tool.show_figure_window(activate=False)
+    qtbot.waitUntil(lambda: tool.figure_window.isVisible(), timeout=1000)
+
+    def fail_live_draw() -> None:
+        raise RuntimeError("live draw failed")
+
+    monkeypatch.setattr(tool.canvas, "draw", fail_live_draw)
+
+    assert not tool._cache_live_canvas_preview(redraw=True)
+    assert tool._preview_render_error == "RuntimeError: live draw failed"
+
+    tool._set_preview_render_error(None)
+    figurecomposer_rendering._render_preview(tool, show_window=False)
+    assert tool._preview_render_error == "RuntimeError: live draw failed"
+
+    def fail_fallback_draw(_canvas) -> None:
+        raise RuntimeError("fallback draw failed")
+
+    monkeypatch.setattr(FigureCanvasAgg, "draw", fail_fallback_draw)
+
+    assert tool._fallback_preview_pixmap() is None
+    assert tool._preview_render_error == "RuntimeError: fallback draw failed"
+
+
 def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
     data = xr.DataArray(
         np.arange(12.0).reshape(3, 2, 2),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -14,6 +14,7 @@ import erlab.interactive._figurecomposer._tool as figurecomposer_tool_module
 import erlab.interactive._stylesheets
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
+import erlab.interactive.imagetool.manager._workspace._saving as workspace_saving
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 from erlab.interactive._figurecomposer import (
     FigureComposerTool,
@@ -1273,6 +1274,144 @@ def test_manager_workspace_figure_sources_save_as_references(
         source_data = restored.source_data()
         xr.testing.assert_identical(source_data["first"], first)
         xr.testing.assert_identical(source_data["second"], second)
+
+
+def test_manager_figure_workspace_reference_helper_edges(
+    qtbot,
+    monkeypatch,
+    tmp_path: Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        name="data",
+    )
+
+    with manager_context() as manager:
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+
+        controller = manager._workspace_controller
+        loader = controller.loading
+        saver = controller.saving
+        root_node = manager._node_for_target(0)
+        figure_node = manager._child_node(figure_uid)
+        stale_revision = "stale-snapshot"
+        current_reference = {
+            "kind": "manager_node",
+            "node_uid": root_node.uid,
+            "node_snapshot_token": root_node.snapshot_token,
+            "data_role": "displayed",
+        }
+
+        assert not controller._tool_data_reference_matches_current_snapshot(
+            {"kind": "manager_node", "node_uid": ""}
+        )
+        assert not controller._tool_data_reference_matches_current_snapshot(
+            {
+                "kind": "manager_node",
+                "node_uid": root_node.uid,
+                "data_role": "invalid",
+            }
+        )
+
+        def unavailable_data(_data_role: str) -> xr.DataArray:
+            raise RuntimeError("unavailable")
+
+        with monkeypatch.context() as context:
+            context.setattr(root_node, "data_for_role", unavailable_data)
+            assert not controller._tool_data_reference_matches_current_data(
+                current_reference, data
+            )
+
+        snapshot = workspace_saving._WorkspaceSaveSnapshot(
+            generation=0,
+            root_attrs={},
+            delta_save_count=0,
+            serialized_tool_data_references=(
+                ("missing", {}),
+                (root_node.uid, {}),
+            ),
+        )
+        controller._commit_saved_tool_data_references(snapshot)
+
+        invalid_tool_dataset = xr.Dataset(
+            attrs={"manager_node_kind": "tool", "manager_node_uid": ""}
+        )
+        assert saver._serialized_tool_data_references((invalid_tool_dataset,)) == ()
+        assert figure_uid not in saver._workspace_stale_reference_rewrite_uids(
+            frozenset(manager._tool_graph.nodes)
+        )
+
+        assert (
+            loader._saved_workspace_reference_source_data(
+                figure_node,
+                snapshot_token=stale_revision,
+                data_role="displayed",
+                owner_node=None,
+                reference_datasets={},
+            )
+            is None
+        )
+        assert (
+            loader._saved_workspace_reference_source_data(
+                root_node,
+                snapshot_token=stale_revision,
+                data_role="displayed",
+                owner_node=None,
+                reference_datasets={},
+            )
+            is None
+        )
+
+        workspace_path = tmp_path / "reference-helper-edges.itws"
+        saver._save_workspace_document(workspace_path, force_full=True)
+        adopt_workspace_path(manager, workspace_path)
+        reference_datasets: dict[tuple[Path, str], xr.Dataset] = {}
+        try:
+            assert (
+                loader._saved_workspace_reference_source_data(
+                    root_node,
+                    snapshot_token=stale_revision,
+                    data_role="displayed",
+                    owner_node=figure_node,
+                    reference_datasets=reference_datasets,
+                )
+                is None
+            )
+            _parent_data, resolver = loader._workspace_tool_restore_references(
+                xr.Dataset(),
+                parent_target=None,
+                owner_node=figure_node,
+                reference_datasets=reference_datasets,
+            )
+            xr.testing.assert_identical(
+                resolver(
+                    {
+                        "kind": "manager_node",
+                        "node_uid": root_node.uid,
+                        "data_role": "displayed",
+                    }
+                ),
+                root_node.data_for_role("displayed"),
+            )
+            xr.testing.assert_identical(
+                resolver(
+                    {
+                        **current_reference,
+                        "node_snapshot_token": stale_revision,
+                    }
+                ),
+                root_node.data_for_role("displayed"),
+            )
+        finally:
+            loader._close_workspace_reference_datasets(reference_datasets)
 
 
 def test_manager_workspace_embeds_figure_snapshot_after_source_transpose(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -14,6 +14,7 @@ import erlab.interactive._figurecomposer._tool as figurecomposer_tool_module
 import erlab.interactive._stylesheets
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
+import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 from erlab.interactive._figurecomposer import (
     FigureComposerTool,
     FigureOperationState,
@@ -27,9 +28,13 @@ from erlab.interactive.imagetool.manager._figurecomposer import _collection
 from tests.interactive.imagetool.manager.helpers import (
     _exec_generated_code,
     activate_widget_shortcut,
+    adopt_workspace_path,
     select_child_tool,
     select_tools,
     trigger_menu_action,
+)
+from tests.interactive.imagetool.manager.workspace._support import (
+    _request_workspace_save_as_and_wait,
 )
 
 from ._common import (
@@ -1268,6 +1273,306 @@ def test_manager_workspace_figure_sources_save_as_references(
         source_data = restored.source_data()
         xr.testing.assert_identical(source_data["first"], first)
         xr.testing.assert_identical(source_data["second"], second)
+
+
+def test_manager_workspace_embeds_figure_snapshot_after_source_transpose(
+    qtbot,
+    monkeypatch,
+    tmp_path: Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("kx", "eV"),
+        coords={
+            "kx": [-0.5, 0.0, 0.5],
+            "eV": [-1.0, -0.5, 0.0, 0.5],
+        },
+        name="cut",
+    )
+
+    with manager_context() as manager:
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure_tool = _materialized_figure_tool(manager, figure_uid)
+        primary_source = figure_tool.tool_status.primary_source
+        captured = figure_tool.source_data()[primary_source]
+        assert captured.dims == data.dims
+
+        [operation] = figure_tool.tool_status.operations
+        figure_tool.tool_status = figure_tool.tool_status.model_copy(
+            update={"operations": (operation.model_copy(update={"transpose": True}),)}
+        )
+        source_state = figure_tool.source_states()[0]
+        root_node = manager._tool_graph.root_wrappers[0]
+        assert source_state.node_snapshot_token == root_node.snapshot_token
+
+        workspace_path = tmp_path / "figure-source-transpose.itws"
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_save_dialog",
+            lambda **_kwargs: workspace_path,
+        )
+        assert _request_workspace_save_as_and_wait(qtbot, manager, native=False)
+        saved_figure = workspace_arrays._read_workspace_dataset_group_h5py(
+            workspace_path,
+            f"figures/{figure_uid}/tool",
+            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+        )
+        assert saved_figure is not None
+        saved_references = FigureComposerTool._saved_tool_data_references(saved_figure)
+        assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in saved_references
+        assert (
+            manager._child_node(figure_uid)._workspace_tool_data_references
+            == saved_references
+        )
+        manager._workspace_controller._mark_workspace_clean()
+
+        root.slicer_area.transpose_main_image()
+
+        assert root_node.data_for_role("displayed").dims == ("eV", "kx")
+        assert root_node.snapshot_token != source_state.node_snapshot_token
+        assert figure_tool.source_data()[primary_source].dims == data.dims
+
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=False
+        )
+        rewritten_figure = workspace_arrays._read_workspace_dataset_group_h5py(
+            workspace_path,
+            f"figures/{figure_uid}/tool",
+            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+        )
+        assert rewritten_figure is not None
+        rewritten_references = FigureComposerTool._saved_tool_data_references(
+            rewritten_figure
+        )
+        assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME not in rewritten_references
+        assert (
+            rewritten_figure[erlab.interactive.utils._SAVED_TOOL_DATA_NAME].size
+            == data.size
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+
+        restored = _materialized_figure_tool(manager, figure_uid)
+        restored_source = restored.source_data()[restored.tool_status.primary_source]
+        xr.testing.assert_identical(restored_source, data)
+        assert restored.tool_status.operations[0].transpose is True
+
+        figure = Figure()
+        figurecomposer_tool_module._render_into_figure(
+            restored, figure, sync_visible=False
+        )
+        assert figure.axes[0].images[0].get_array().shape == data.T.shape
+
+
+def test_manager_failed_save_keeps_last_saved_figure_references(
+    qtbot,
+    monkeypatch,
+    tmp_path: Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("kx", "eV"),
+        coords={
+            "kx": [-0.5, 0.0, 0.5],
+            "eV": [-1.0, -0.5, 0.0, 0.5],
+        },
+        name="cut",
+    )
+
+    with manager_context() as manager:
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        _materialized_figure_tool(manager, figure_uid)
+        figure_node = manager._child_node(figure_uid)
+
+        workspace_path = tmp_path / "failed-figure-source-transpose.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+        adopt_workspace_path(manager, workspace_path)
+        saved_references = dict(figure_node._workspace_tool_data_references)
+        assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in saved_references
+        manager._workspace_controller._mark_workspace_clean()
+
+        root.slicer_area.transpose_main_image()
+
+        def _raise_write_error(*_args, **_kwargs) -> None:
+            raise RuntimeError("write failed")
+
+        monkeypatch.setattr(
+            workspace_storage,
+            "_write_workspace_transaction_file",
+            _raise_write_error,
+        )
+
+        with pytest.raises(RuntimeError, match="write failed"):
+            manager._workspace_controller.saving._save_workspace_document(
+                workspace_path, force_full=False
+            )
+
+        assert figure_node._workspace_tool_data_references == saved_references
+
+
+def test_manager_full_save_fallback_preserves_figure_source_snapshot(
+    qtbot,
+    monkeypatch,
+    tmp_path: Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("kx", "eV"),
+        coords={
+            "kx": [-0.5, 0.0, 0.5],
+            "eV": [-1.0, -0.5, 0.0, 0.5],
+        },
+        name="cut",
+    )
+
+    with manager_context() as manager:
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+        figure = _materialized_figure_tool(manager, figure_uid)
+        source_name = figure.tool_status.primary_source
+
+        source_path = tmp_path / "full-save-source.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            source_path, force_full=True
+        )
+        adopt_workspace_path(manager, source_path)
+        manager._workspace_controller._mark_workspace_clean()
+
+        root.slicer_area.transpose_main_image()
+        monkeypatch.setattr(
+            manager._workspace_controller.saving,
+            "_workspace_full_save_manifest_first_snapshot",
+            lambda *_args, **_kwargs: None,
+        )
+        target_path = tmp_path / "full-save-target.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            target_path, force_full=True
+        )
+
+        saved_figure = workspace_arrays._read_workspace_dataset_group_h5py(
+            target_path,
+            f"figures/{figure_uid}/tool",
+            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+        )
+        assert saved_figure is not None
+        assert (
+            erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+            not in FigureComposerTool._saved_tool_data_references(saved_figure)
+        )
+        assert manager._child_node(figure_uid)._workspace_tool_data_references == {}
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            target_path,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        restored = _materialized_figure_tool(manager, figure_uid)
+        xr.testing.assert_identical(restored.source_data()[source_name], data)
+
+
+def test_manager_incremental_save_preserves_pending_figure_snapshot(
+    qtbot,
+    tmp_path: Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("kx", "eV"),
+        coords={"kx": [-0.5, 0.0, 0.5], "eV": [-1.0, -0.5, 0.0, 0.5]},
+        name="pending_cut",
+    )
+
+    with manager_context() as manager:
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+        assert figure_uid is not None
+
+        workspace_path = tmp_path / "pending-figure-source-transpose.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+
+        source_node = manager._tool_graph.root_wrappers[0]
+        figure_node = manager._child_node(figure_uid)
+        assert figure_node.pending_workspace_tool_payload is not None
+        if source_node.pending_workspace_memory_payload is not None:
+            assert source_node.materialize_pending_workspace_payload()
+        assert source_node.imagetool is not None
+        assert figure_node.pending_workspace_tool_payload is not None
+
+        source_node.slicer_area.transpose_main_image()
+        assert source_node.data_for_role("displayed").dims == ("eV", "kx")
+
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=False
+        )
+        rewritten_figure = workspace_arrays._read_workspace_dataset_group_h5py(
+            workspace_path,
+            f"figures/{figure_uid}/tool",
+            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+        )
+        assert rewritten_figure is not None
+        assert (
+            erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+            not in FigureComposerTool._saved_tool_data_references(rewritten_figure)
+        )
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        restored = _materialized_figure_tool(manager, figure_uid)
+        restored_source = restored.source_data()[restored.tool_status.primary_source]
+        xr.testing.assert_identical(restored_source, data)
 
 
 def test_manager_pending_figure_source_reference_uses_saved_imagetool_dim_order(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_sources.py
@@ -550,6 +550,21 @@ def test_manager_figure_source_helper_edge_contracts(
             )
 
         with monkeypatch.context() as context:
+            context.setattr(
+                manager._figure_workflows,
+                "_figure_source_live_node",
+                lambda *_args: manager._node_for_target(0),
+            )
+            context.setattr(
+                manager._figure_workflows,
+                "_figure_source_state",
+                lambda *_args: None,
+            )
+            assert not manager._figure_workflows._refresh_figure_source(
+                figure_uid, source_alias
+            )
+
+        with monkeypatch.context() as context:
             context.setattr(manager, "_figure_uids", lambda: ("missing",))
             manager._figure_workflows._refresh_figure_source_controls()
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
@@ -29,9 +29,6 @@ from erlab.interactive._figurecomposer._operations._method import (
 from erlab.interactive._figurecomposer._operations._method import (
     _execution as method_execution,
 )
-from erlab.interactive._figurecomposer._ui import (
-    _operation_panel as figurecomposer_operation_panel,
-)
 
 from ._common import (
     _activate_combo_text,
@@ -1238,15 +1235,15 @@ def test_figure_composer_method_draw_time_text_error_is_non_modal(qtbot) -> None
 
     tool._redraw_plot(show_window=True)
 
-    render_error = tool._operation_render_errors[title_operation.operation_id]
+    assert tool._operation_render_errors == {}
+    render_error = tool._preview_render_error
+    assert render_error is not None
     assert "ValueError" in render_error
     assert "ParseException" in render_error
-    item = tool.operation_panel.operation_list.topLevelItem(1)
-    assert item is not None
-    assert _operation_status_codes(tool, 1) == ("render_error",)
-    assert "ParseException" in item.toolTip(
-        figurecomposer_operation_panel._OPERATION_LIST_STATUS_COLUMN
-    )
+    assert _operation_status_codes(tool, 1) == ()
+    status = tool.findChild(QtWidgets.QStatusBar, "figureComposerPreviewRenderStatus")
+    assert status is not None
+    assert not status.isHidden()
 
     tool._replace_operation(
         1,
@@ -1254,7 +1251,7 @@ def test_figure_composer_method_draw_time_text_error_is_non_modal(qtbot) -> None
     )
     tool._redraw_plot(show_window=True)
 
-    assert title_operation.operation_id not in tool._operation_render_errors
-    item = tool.operation_panel.operation_list.topLevelItem(1)
-    assert item is not None
+    assert tool._operation_render_errors == {}
+    assert tool._preview_render_error is None
     assert _operation_status_codes(tool, 1) == ()
+    assert status.isHidden()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
@@ -10,6 +10,8 @@ import pytest
 import xarray as xr
 from matplotlib import colors as mcolors
 from matplotlib import style as mpl_style
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 from qtpy import QtCore, QtWidgets
 
 import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
@@ -25,6 +27,7 @@ from erlab.interactive._figurecomposer import (
     FigureGridSpecGridState,
     FigureGridSpecLayoutState,
     FigureGridSpecSpanState,
+    FigureMethodFamily,
     FigureOperationKind,
     FigureOperationState,
     FigureRecipeState,
@@ -92,6 +95,43 @@ def _activate_source_selection_mode(
     assert index >= 0
     combo.setCurrentIndex(index)
     combo.activated.emit(index)
+
+
+def test_figure_composer_invalid_image_norm_is_owned_by_image_step(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(1.0, 10.0).reshape(3, 3),
+        dims=("eV", "kx"),
+        coords={"eV": [-1.0, 0.0, 1.0], "kx": [-0.5, 0.0, 0.5]},
+        name="data",
+    )
+    valid_image = FigureOperationState.plot_array(label="valid image", source="data")
+    invalid_image = FigureOperationState.plot_array(
+        label="invalid image", source="data"
+    ).model_copy(update={"vmax": 0.0})
+    fermiline = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name="fermiline",
+    )
+    labels = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name="label_subplots",
+    )
+    tool = FigureComposerTool.from_sources(
+        {"data": data},
+        sources=(FigureSourceState(name="data"),),
+        operations=(valid_image, invalid_image, fermiline, labels),
+        primary_source="data",
+    )
+    qtbot.addWidget(tool)
+    figure = Figure()
+    canvas = FigureCanvasAgg(figure)
+
+    figurecomposer_rendering._render_into_figure(tool, figure, sync_visible=False)
+    canvas.draw()
+
+    assert set(tool._operation_render_errors) == {invalid_image.operation_id}
+    assert "minvalue" in tool._operation_render_errors[invalid_image.operation_id]
+    assert len(figure.axes[0].images) == 1
 
 
 def test_figure_composer_plot_array_source_selector_clears_legacy_selection(

--- a/tests/plotting/test_general.py
+++ b/tests/plotting/test_general.py
@@ -14,6 +14,46 @@ from erlab.plotting.general import (
 )
 
 
+@pytest.mark.parametrize(
+    "x",
+    [
+        np.array([0.0, 1.0, 2.0]),
+        np.array([0.0, 1.0, 3.0]),
+    ],
+    ids=("uniform", "nonuniform"),
+)
+def test_plot_array_validates_norm_before_adding_image(x) -> None:
+    data = xr.DataArray(
+        np.arange(1.0, 7.0).reshape(2, 3),
+        dims=("y", "x"),
+        coords={"y": [0.0, 1.0], "x": x},
+    )
+    figure, axis = plt.subplots()
+    try:
+        with pytest.raises(ValueError, match="minvalue"):
+            plot_array(data, ax=axis, vmax=0.0, colorbar=True)
+        assert not axis.images
+        assert figure.axes == [axis]
+    finally:
+        plt.close(figure)
+
+
+@pytest.mark.parametrize("invalid", [np.nan, np.inf], ids=("nan", "infinity"))
+def test_plot_array_norm_ignores_nonfinite_data(invalid: float) -> None:
+    data = xr.DataArray(
+        np.array([[1.0, 2.0], [invalid, 4.0]]),
+        dims=("y", "x"),
+    )
+    figure, axis = plt.subplots()
+    try:
+        image = plot_array(data, ax=axis)
+        figure.canvas.draw()
+        assert image.norm.vmin == 1.0
+        assert image.norm.vmax == 4.0
+    finally:
+        plt.close(figure)
+
+
 def test_plot_slices_selects_slice_stack_once_per_map(monkeypatch) -> None:
     eV = np.array([0.0, 1.0, 2.0])
     y = np.array([0.0, 1.0, 2.0, 3.0])

--- a/tests/plotting/test_general.py
+++ b/tests/plotting/test_general.py
@@ -5,6 +5,7 @@ import pytest
 import xarray as xr
 
 import erlab.accessors.general as accessor_general
+import erlab.plotting.general as plotting_general
 from erlab.plotting.general import (
     clean_labels,
     fermiline,
@@ -52,6 +53,16 @@ def test_plot_array_norm_ignores_nonfinite_data(invalid: float) -> None:
         assert image.norm.vmax == 4.0
     finally:
         plt.close(figure)
+
+
+def test_validate_image_norm_allows_unresolved_limits(monkeypatch) -> None:
+    norm = matplotlib.colors.Normalize()
+    monkeypatch.setattr(norm, "autoscale_None", lambda _values: None)
+
+    plotting_general._validate_image_norm(norm, np.arange(4.0))
+
+    assert norm.vmin is None
+    assert norm.vmax is None
 
 
 def test_plot_slices_selects_slice_stack_once_per_map(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- attribute invalid image normalization failures to the image operation that raised them while reporting final canvas draw failures at figure level
- preserve the displayed ImageTool orientation used to create and refresh Figure Composer sources
- track role-specific snapshot revisions and embed captured Figure data when a live or deferred source reference becomes stale
- commit serialized reference metadata to live workspace nodes only after successful incremental, full, or Save As writes
- keep full-save copy reuse from carrying stale Figure references forward

## Root cause

Image normalization errors were deferred until the final Matplotlib canvas draw, where the UI associated them with the currently selected operation instead of the operation that created the invalid artist. Separately, Figure Composer source references did not consistently represent the displayed ImageTool layout, and a newly saved live Figure did not adopt the reference metadata written to disk. Later incremental or copy-reusing saves could therefore preserve a stale reference and restore the source with a different dimension order.

## User impact

The intentionally invalid image step now owns its error without marking unrelated steps. Figure sources retain their captured orientation across deferred loading, incremental saves, full saves, Save As, and reopen cycles.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/figurecomposer` — 685 passed
- workspace loading/pending/persistence/saving suites — 228 passed
- focused PySide6 regression suite — 13 passed
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run mypy src`
- `git diff --check`

The branch was rebased onto current `main`; CI will validate the rebased head.
