### PR TITLE
fix(interactive): make plot registry teardown binding-safe

### DIFF
--- a/src/erlab/interactive/_plot_state.py
+++ b/src/erlab/interactive/_plot_state.py
@@ -554,7 +554,10 @@ class ToolPlotStateRegistry(QtCore.QObject):
         state_changed: Callable[[], None],
         info_changed: Callable[[], None],
     ) -> None:
-        super().__init__(parent)
+        # The registry must outlive the observed window's QObject child teardown so
+        # PySide6 can deliver ``destroyed`` while the cleanup receiver is still valid.
+        # ToolWindow keeps the Python owner reference until the window is destroyed.
+        super().__init__()
         self._state_changed = state_changed
         self._info_changed = info_changed
         self._adapters: dict[str, _PlotAppearanceAdapter] = {}
@@ -564,7 +567,7 @@ class ToolPlotStateRegistry(QtCore.QObject):
         self._flush_timer = QtCore.QTimer(self)
         self._flush_timer.setSingleShot(True)
         self._flush_timer.timeout.connect(self._flush_pending)
-        parent.destroyed.connect(self._disconnect_all)
+        parent.destroyed.connect(self._dispose)
 
     def _adapter(
         self,
@@ -636,13 +639,17 @@ class ToolPlotStateRegistry(QtCore.QObject):
         self._pending_reapply.add(plot_id)
         self._flush_timer.start(0)
 
-    def _disconnect_all(self, *_args) -> None:
+    def _dispose(self, *_args) -> None:
         self._flush_timer.stop()
         for adapter in self._adapters.values():
             adapter.disconnect()
         self._adapters.clear()
+        self._restored_states.clear()
         self._pending_changes.clear()
         self._pending_reapply.clear()
+        self._state_changed = lambda: None
+        self._info_changed = lambda: None
+        self.deleteLater()
 
     def _flush_pending(self) -> None:
         changed = False

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -625,7 +625,7 @@ def test_tool_window_preserves_plot_state_awaiting_registration(qtbot) -> None:
     assert resaved["plots"]["deferred"] == view_state["plots"]["deferred"]
 
 
-def test_tool_window_plot_registry_disconnects_before_qt_children(qtbot) -> None:
+def test_tool_window_plot_registry_outlives_window_for_cleanup(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25.0).reshape(5, 5),
         dims=("y", "x"),
@@ -635,12 +635,15 @@ def test_tool_window_plot_registry_disconnects_before_qt_children(qtbot) -> None
     qtbot.addWidget(win)
     registry = win._plot_state_registry
     assert registry._adapters
+    assert registry.parent() is None
 
     win.deleteLater()
     QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
     qtbot.wait_until(lambda: not qt_is_valid(win), timeout=1000)
-
     assert registry._adapters == {}
+
+    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    qtbot.wait_until(lambda: not qt_is_valid(registry), timeout=1000)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- keep `ToolPlotStateRegistry` alive while `ToolWindow.destroyed` performs cleanup
- synchronously stop pending work, disconnect plot adapters, and release retained state before deferred registry deletion
- cover the intended QObject ownership and deletion sequence with a regression test

## Root cause

[Compatibility #189](https://github.com/kmnhan/erlabpy/actions/runs/30131946834) failed in the PySide6 jobs with `AttributeError: Slot 'ToolPlotStateRegistry::' not found` during recursive ImageTool workspace round-trip testing. The registry was both a QObject child of the window and the receiver of the window's `destroyed` signal. During PySide6 teardown, that allowed signal delivery to target a receiver whose binding-level Qt metadata was already being dismantled.

The registry now has an explicit lifetime independent of the observed window's QObject child tree. It remains valid for the destruction callback, clears its connections and retained callbacks synchronously, and then deletes itself with `deleteLater()`.

## Impact

This makes ImageTool teardown binding-neutral without changing plot-state persistence or workspace behavior while the tool is alive. The registry only outlives the window for the deferred cleanup cycle and is inert during that interval.

## Validation

- PySide6 workspace document module: 69 passed
- PyQt6 workspace document module: 69 passed
- PySide6 plot-state selection: 12 passed
- PyQt6 plot-state selection: 12 passed
- PySide6 `tests/interactive/test_utils.py`: 195 passed
- PyQt6 `tests/interactive/test_utils.py`: 195 passed
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run mypy src`
- repository commit hooks
