### PR TITLE
fix(manager): bundle xarray-lmfit version metadata

### DIFF
--- a/manager.spec
+++ b/manager.spec
@@ -29,8 +29,9 @@ manager_dir = (
     / "interactive/imagetool/manager"
 )
 
-# Dask checks pandas distribution metadata when tokenizing xarray indexes.
-datas = copy_metadata("pandas")
+# Dask checks pandas distribution metadata when tokenizing xarray indexes, and
+# xarray-lmfit reads its version from distribution metadata.
+datas = copy_metadata("pandas") + copy_metadata("xarray-lmfit")
 binaries = []
 hiddenimports = [
     "PyQt6",

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -1060,10 +1060,11 @@ def test_manager_packaging_includes_pdf_backend() -> None:
     assert '"matplotlib.backends.backend_pdf"' in spec_text
 
 
-def test_manager_packaging_includes_pandas_metadata() -> None:
+def test_manager_packaging_includes_distribution_metadata() -> None:
     spec_text = pathlib.Path("manager.spec").read_text()
 
     assert 'copy_metadata("pandas")' in spec_text
+    assert 'copy_metadata("xarray-lmfit")' in spec_text
 
 
 def test_launch_new_manager_instance_uses_detached_source_process(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- bundle the `xarray-lmfit` distribution metadata in standalone ImageTool Manager builds
- extend the packaging regression test to cover the added metadata

## Root cause

The manager info panel displays `xarray_lmfit.__version__`. The package obtains
that value through `importlib.metadata` and falls back to `0.0.0` when its
distribution metadata is unavailable. PyInstaller included the package modules
but omitted `xarray_lmfit-*.dist-info`, so standalone builds showed the fallback
instead of the installed version.

## User impact

The standalone ImageTool Manager info panel now reports the actual bundled
xarray-lmfit version.

## Validation

- `uv run pytest tests/interactive/imagetool/manager/test_app.py::test_manager_packaging_includes_distribution_metadata`
- `uv run ruff format --check manager.spec tests/interactive/imagetool/manager/test_app.py`
- `uv run ruff check manager.spec tests/interactive/imagetool/manager/test_app.py`
- verified `copy_metadata("xarray-lmfit")` resolves
  `xarray_lmfit-0.5.5.dist-info` in the build environment
