### PR TITLE
fix(interactive): stabilize queued Qt restore events

### DIFF
--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -955,10 +955,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
         ):
             return
         self._pending_splitter_restore_queued = True
-        erlab.interactive.utils.single_shot(
-            self, 0, self._apply_pending_splitter_restore
+        QtCore.QMetaObject.invokeMethod(
+            self,
+            "_apply_pending_splitter_restore",
+            QtCore.Qt.ConnectionType.QueuedConnection,
         )
 
+    @QtCore.Slot()
     def _apply_pending_splitter_restore(self) -> None:
         sizes = self._pending_splitter_sizes
         if sizes is None:
@@ -969,10 +972,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._apply_splitter_sizes(sizes)
         # QSplitter may not report the restored sizes until the next layout pass.
         # Keep the serialized sizes pending for state reads until then.
-        erlab.interactive.utils.single_shot(
-            self, 0, self._finish_pending_splitter_restore
+        QtCore.QMetaObject.invokeMethod(
+            self,
+            "_finish_pending_splitter_restore",
+            QtCore.Qt.ConnectionType.QueuedConnection,
         )
 
+    @QtCore.Slot()
     def _finish_pending_splitter_restore(self) -> None:
         self._pending_splitter_sizes = None
         self._pending_splitter_restore_queued = False
@@ -3732,6 +3738,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
         )
         if has_deferred_show_work and not self._deferred_show_restore_queued:
             self._deferred_show_restore_queued = True
-            erlab.interactive.utils.single_shot(
-                self, 0, self._flush_deferred_show_restore
+            QtCore.QMetaObject.invokeMethod(
+                self,
+                "_flush_deferred_show_restore",
+                QtCore.Qt.ConnectionType.QueuedConnection,
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ import erlab.interactive.imagetool.manager._server as imagetool_manager_server
 from erlab.interactive.utils import (
     _is_deleted_qt_wrapper_error,
     _WaitDialog,
+    _WaitModalGuard,
     qt_is_valid,
 )
 from erlab.io.dataloader import LoaderBase
@@ -616,8 +617,23 @@ class _DialogHandler(QtCore.QObject):
         if (
             candidate is None
             or candidate is self._ignored_dialog
-            or isinstance(candidate, _WaitDialog)
+            or isinstance(candidate, (_WaitDialog, _WaitModalGuard))
         ):
+            candidate = next(
+                (
+                    widget
+                    for widget in QtWidgets.QApplication.topLevelWidgets()
+                    if (
+                        isinstance(widget, QtWidgets.QDialog)
+                        and widget is not self._ignored_dialog
+                        and not isinstance(widget, (_WaitDialog, _WaitModalGuard))
+                        and widget.isVisible()
+                        and widget.isModal()
+                    )
+                ),
+                None,
+            )
+        if candidate is None:
             return
 
         dialog = typing.cast("QtWidgets.QDialog", candidate)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1588,6 +1588,21 @@ def test_accept_dialog_queries_modal_state_on_gui_thread(
     assert all(thread == qapp.thread() for thread in query_threads)
 
 
+def test_accept_dialog_finds_visible_modal_when_active_modal_is_missing(
+    accept_dialog, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "activeModalWidget",
+        lambda: None,
+    )
+    dialog = QtWidgets.QDialog()
+
+    accept_dialog(dialog.exec)
+
+    assert not dialog.isVisible()
+
+
 def test_accept_dialog_unwinds_modal_when_callback_raises(accept_dialog) -> None:
     dialog = QtWidgets.QDialog()
 


### PR DESCRIPTION
## Summary

- deliver ImageTool's deferred show and splitter-restoration stages as queued Qt meta-object calls owned by the receiving `ImageSlicerArea`
- let the test dialog handler find visible modal dialogs when `activeModalWidget()` is temporarily unavailable under Xvfb
- exclude ImageTool wait indicators from the dialog fallback and cover the fallback behavior directly

## Root cause

[Compatibility run 30143232170](https://github.com/kmnhan/erlabpy/actions/runs/30143232170) ran after #505 was merged. The original `ToolPlotStateRegistry::` teardown failure was gone, and the PySide6 3.13 and 3.14 lanes completed successfully. Two independent order-sensitive failures still kept the workflow red:

- PySide6 3.12 timed out waiting for a deferred ImageTool splitter restore to settle. The restore used a chain of contextless Python `QTimer.singleShot` closures even though every stage targeted the same living QObject.
- PySide6 3.11 displayed the workspace save dialog, but the test handler missed it because `QApplication.activeModalWidget()` returned no usable dialog under Xvfb.

The splitter state machine now uses `QMetaObject.invokeMethod(..., QueuedConnection)` with registered Qt slots, so queued delivery is tied to the receiver's QObject lifetime. The dialog handler remains on the GUI thread and falls back to visible modal top-level dialogs without accepting wait indicators.

## Impact

This preserves deferred ImageTool construction and exact saved splitter geometry while making the queued restore path binding-neutral. The dialog change affects test infrastructure only; production file-dialog behavior is unchanged.

## Validation

- PySide6 focused failure paths: 6 passed
- PyQt6 focused failure paths: 6 passed
- PySide6 workspace saving module: 108 passed
- PySide6 ImageTool module: 430 passed
- PySide6 shared Qt utilities: 196 passed
- PyQt6 combined touched modules: 734 passed
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run mypy src`
- repository commit hooks

The full Compatibility workflow will be dispatched against this branch as the acceptance check.
