### PR TITLE
Stabilize Qt test teardown and surface xdist worker crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
             -o junit_family=legacy
           )
           if [[ "${{ matrix.use-xdist }}" == "true" ]]; then
-            pytest_args+=(-n auto --dist=loadgroup)
+            pytest_args+=(-n auto --dist=loadgroup --max-worker-restart=0)
           fi
           uv run pytest "${pytest_args[@]}" "${targets[@]}"
 

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -146,6 +146,7 @@ jobs:
           xdist_args=(
             -n auto
             --dist=loadgroup
+            --max-worker-restart=0
           )
           uv run pytest \
             "${common_args[@]}" \

--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -72,13 +72,13 @@ class ColorMapComboBox(QtWidgets.QComboBox):
         ):  # pragma: no cover
             return
         self._populated = True
-        with QtCore.QSignalBlocker(self):
-            for name in pg_colormap_names("matplotlib", exclude_local=True):
-                self._add_colormap_item(name)
-            if self.default_cmap is not None:
-                self.setCurrentText(self.default_cmap)
-            self.load_thumbnail(self.currentIndex())
-        self.blockSignals(False)
+        for name in pg_colormap_names("matplotlib", exclude_local=True):
+            self._add_colormap_item(name)
+        if self.default_cmap is not None:
+            self.setCurrentText(self.default_cmap)
+        self.load_thumbnail(self.currentIndex())
+        if erlab.interactive.utils.qt_is_valid(self):
+            self.blockSignals(False)
 
     def ensure_populated(self) -> None:
         """Populate the colormap list before the combo box is shown."""

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -20,6 +20,7 @@ from erlab.interactive.imagetool._provenance._operations import ScriptCodeOperat
 __all__ = ["ToolNamespace", "ToolsNamespace", "_ImageToolManagerJupyterConsole"]
 
 import ast
+import atexit
 import contextlib
 import functools
 import importlib
@@ -2155,11 +2156,12 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
     def shutdown_kernel(self) -> None:
         self._kernel_shutdown_requested = True
         if self.kernel_manager.kernel:
+            shell = self.kernel_manager.kernel.shell
+            history_thread = getattr(shell.history_manager, "save_thread", None)
             if self._tools_namespace is not None:
                 self._tools_namespace.unbind_shell()
                 self._tools_namespace = None
             if self._erlab_io_hooks_registered:
-                shell = self.kernel_manager.kernel.shell
                 with contextlib.suppress(KeyError, ValueError):
                     shell.events.unregister(
                         "pre_run_cell", self._restore_erlab_io_state
@@ -2171,6 +2173,13 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
                 self._erlab_io_hooks_registered = False
             self.kernel_client.stop_channels()
             self.kernel_manager.shutdown_kernel()
+            atexit.unregister(shell.atexit_operations)
+            if history_thread is not None:
+                history_thread.stop()
+            try:
+                shell.atexit_operations()
+            finally:
+                shell.__class__.clear_instance()
 
     def _banner_default(self) -> str:
         banner = super()._banner_default()

--- a/tests/_qt_helpers.py
+++ b/tests/_qt_helpers.py
@@ -1,6 +1,35 @@
 from __future__ import annotations
 
-from qtpy import QtCore
+import atexit
+import importlib
+import typing
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+QTCORE_EXIT_CLEANUP: Callable[..., object] | None = None
+_original_atexit_register = atexit.register
+
+
+def _capture_pyqt_exit_notifier(
+    func: Callable[..., object], *args: object, **kwargs: object
+) -> Callable[..., object]:
+    global QTCORE_EXIT_CLEANUP
+
+    if getattr(func, "__name__", None) == "_qtcore_cleanup":
+        QTCORE_EXIT_CLEANUP = func
+    return _original_atexit_register(func, *args, **kwargs)
+
+
+atexit.register = _capture_pyqt_exit_notifier
+try:
+    qtpy = importlib.import_module("qtpy")
+    QtCore = importlib.import_module("qtpy.QtCore")
+    QtWidgets = importlib.import_module("qtpy.QtWidgets")
+finally:
+    atexit.register = _original_atexit_register
+
+API_NAME = qtpy.API_NAME
 
 
 def signal_receiver_count(obj: QtCore.QObject, signal: object, signal_name: str) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,11 +244,11 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 
         if API_NAME == "PyQt6" and os.environ.get("PYTEST_XDIST_WORKER") is None:
             # pytest-qt keeps its session QApplication wrapper alive until Python
-            # finalization. Destroy the C++ application while SIP and Qt callbacks are
-            # still initialized instead of relying on interpreter teardown order.
+            # finalization. Relinquish Python ownership so SIP does not destroy the
+            # live C++ application after Qt callbacks have begun shutting down.
             from PyQt6 import sip
 
-            sip.delete(qapp)
+            sip.transferto(qapp, None)
 
     for settings_path in (
         *_TEST_INTERACTIVE_OPTIONS_PATHS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,26 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(pytest.mark.compat)
 
 
+def _drop_invalid_qtbot_widgets(item: pytest.Item) -> None:
+    widgets = getattr(item, "qt_widgets", None)
+    if not widgets:
+        return
+    item.qt_widgets = [
+        (widget_ref, before_close_func)
+        for widget_ref, before_close_func in widgets
+        if (widget := widget_ref()) is not None and qt_is_valid(widget)
+    ]
+
+
+@pytest.hookimpl(wrapper=True, tryfirst=True)
+def pytest_runtest_teardown(item: pytest.Item):
+    # pytest-qt retains weak Python references to registered widgets. Under PySide,
+    # a wrapper can remain alive after its C++ widget has been destroyed; calling
+    # close() on that wrapper can crash instead of raising a deleted-object error.
+    _drop_invalid_qtbot_widgets(item)
+    return (yield)
+
+
 @pytest.hookimpl(optionalhook=True)
 def pytest_testnodedown(node: typing.Any, error: object | None) -> None:
     if error is not None:
@@ -246,10 +266,15 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         if API_NAME == "PyQt6" and serial_process:
             # pytest-qt keeps its session QApplication wrapper alive until Python
             # finalization. Relinquish Python ownership so SIP does not destroy the
-            # live C++ application after Qt callbacks have begun shutting down.
+            # live C++ application after Qt callbacks have begun shutting down, then
+            # release pytest-qt's intentional module-global reference while SIP is
+            # still fully initialized.
             from PyQt6 import sip
+            from pytestqt import plugin as pytestqt_plugin
 
             sip.transferto(qapp, None)
+            if pytestqt_plugin._qapp_instance is qapp:
+                pytestqt_plugin._qapp_instance = None
 
     for settings_path in (
         *_TEST_INTERACTIVE_OPTIONS_PATHS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,6 +292,20 @@ def _restore_interactive_options_between_tests() -> Iterator[None]:
         erlab.interactive.options.restore()
 
 
+@pytest.fixture(autouse=True)
+def _drain_deferred_qt_deletes_after_test(
+    request: pytest.FixtureRequest,
+) -> Iterator[None]:
+    yield
+    if request.node.get_closest_marker("gui") is None:
+        return
+    if QtWidgets.QApplication.instance() is not None:
+        for _ in range(2):
+            QtWidgets.QApplication.sendPostedEvents(
+                None, int(QtCore.QEvent.Type.DeferredDelete.value)
+            )
+
+
 @pytest.fixture(scope="session")
 def cluster():
     with LocalCluster(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -630,10 +630,6 @@ class _DialogHandler(QtCore.QObject):
 
     @QtCore.Slot()
     def _poll_dialog(self) -> None:
-        if time.perf_counter() >= self._deadline:
-            self._finish_timeout()
-            return
-
         candidate = QtWidgets.QApplication.activeModalWidget()
         if (
             candidate is None
@@ -655,6 +651,8 @@ class _DialogHandler(QtCore.QObject):
                 None,
             )
         if candidate is None:
+            if time.perf_counter() >= self._deadline:
+                self._finish_timeout()
             return
 
         dialog = typing.cast("QtWidgets.QDialog", candidate)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,7 +234,7 @@ def _release_pyqt_owned_wrappers() -> None:
 
     for obj in gc.get_objects():
         if (
-            isinstance(obj, sip.wrapper)
+            issubclass(type(obj), sip.wrapper)
             and not sip.isdeleted(obj)
             and sip.ispyowned(obj)
         ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,18 +224,6 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     qapp = QtWidgets.QApplication.instance()
     if qapp is not None:
         serial_process = os.environ.get("PYTEST_XDIST_WORKER") is None
-        if serial_process:
-            # Some Qt helpers create parentless widgets that pytest-qt cannot track.
-            # Retire them while Qt is fully initialized instead of leaving their
-            # destruction to Python's arbitrary interpreter-finalization order.
-            for widget in QtWidgets.QApplication.topLevelWidgets():
-                if not qt_is_valid(widget):
-                    continue
-                with contextlib.suppress(RuntimeError):
-                    widget.close()
-                if qt_is_valid(widget):
-                    widget.deleteLater()
-
         # pytest-qt closes registered widgets with deleteLater(), but processEvents()
         # does not guarantee that DeferredDelete events run before interpreter shutdown.
         for _ in range(2):
@@ -248,15 +236,6 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         # Collect Python-owned Qt reference cycles while the binding is still fully
         # initialized, then deliver any DeferredDelete events exposed by collection.
         gc.collect()
-        if serial_process:
-            for widget in QtWidgets.QApplication.topLevelWidgets():
-                if not qt_is_valid(widget):
-                    continue
-                with contextlib.suppress(RuntimeError):
-                    widget.close()
-                if qt_is_valid(widget):
-                    widget.deleteLater()
-
         for _ in range(2):
             QtWidgets.QApplication.sendPostedEvents(
                 None, int(QtCore.QEvent.Type.DeferredDelete.value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ import pytest
 import requests
 import xarray as xr
 from numpy.testing import assert_almost_equal
-from qtpy import QtCore, QtWidgets
+from qtpy import API_NAME, QtCore, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager as imagetool_manager
@@ -241,6 +241,14 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             )
             QtWidgets.QApplication.sendPostedEvents(None, 0)
             qapp.processEvents()
+
+        if API_NAME == "PyQt6" and os.environ.get("PYTEST_XDIST_WORKER") is None:
+            # pytest-qt keeps its session QApplication wrapper alive until Python
+            # finalization. Destroy the C++ application while SIP and Qt callbacks are
+            # still initialized instead of relying on interpreter teardown order.
+            from PyQt6 import sip
+
+            sip.delete(qapp)
 
     for settings_path in (
         *_TEST_INTERACTIVE_OPTIONS_PATHS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,11 @@ import pytest
 import requests
 import xarray as xr
 from numpy.testing import assert_almost_equal
-from qtpy import API_NAME, QtCore, QtWidgets
+
+# Import before erlab so PyQt's atexit callback can be captured on first import.
+# isort: off
+from tests._qt_helpers import API_NAME, QTCORE_EXIT_CLEANUP, QtCore, QtWidgets
+# isort: on
 
 import erlab
 import erlab.interactive.imagetool.manager as imagetool_manager
@@ -224,6 +228,19 @@ def _drop_invalid_qtbot_widgets(item: pytest.Item) -> None:
     ]
 
 
+def _release_pyqt_owned_wrappers() -> None:
+    """Relinquish residual SIP-owned C++ instances before Python finalization."""
+    from PyQt6 import sip
+
+    for obj in gc.get_objects():
+        if (
+            isinstance(obj, sip.wrapper)
+            and not sip.isdeleted(obj)
+            and sip.ispyowned(obj)
+        ):
+            sip.transferto(obj, None)
+
+
 @pytest.hookimpl(wrapper=True, tryfirst=True)
 def pytest_runtest_teardown(item: pytest.Item):
     # pytest-qt retains weak Python references to registered widgets. Under PySide,
@@ -264,17 +281,18 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             qapp.processEvents()
 
         if API_NAME == "PyQt6" and serial_process:
-            # pytest-qt keeps its session QApplication wrapper alive until Python
-            # finalization. Relinquish Python ownership so SIP does not destroy the
-            # live C++ application after Qt callbacks have begun shutting down, then
-            # release pytest-qt's intentional module-global reference while SIP is
-            # still fully initialized.
-            from PyQt6 import sip
+            # pytest-qt and the exercised GUI code can retain Python-owned SIP
+            # wrappers until interpreter finalization. SIP otherwise destroys their
+            # C++ instances in an arbitrary order after Qt callbacks have begun
+            # shutting down. Relinquish every surviving wrapper while SIP is still
+            # fully initialized.
             from pytestqt import plugin as pytestqt_plugin
 
-            sip.transferto(qapp, None)
             if pytestqt_plugin._qapp_instance is qapp:
                 pytestqt_plugin._qapp_instance = None
+            _release_pyqt_owned_wrappers()
+            if QTCORE_EXIT_CLEANUP is not None:
+                atexit.unregister(QTCORE_EXIT_CLEANUP)
 
     for settings_path in (
         *_TEST_INTERACTIVE_OPTIONS_PATHS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import contextlib
 import csv
 import datetime
 import functools
+import gc
 import importlib.util
 import logging
 import os
@@ -214,8 +215,33 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     qapp = QtWidgets.QApplication.instance()
     if qapp is not None:
-        # pytest-qt closes registered widgets with deleteLater(), but processEvents()
-        # does not guarantee that DeferredDelete events run before interpreter shutdown.
+        # pyqtgraph creates parentless context menus, and some GUI tests keep their
+        # Python owners alive in reference cycles until interpreter shutdown. Retire
+        # every remaining top-level widget while Qt is fully initialized, then collect
+        # those cycles and drain any deletions that collection exposes.
+        for widget in QtWidgets.QApplication.topLevelWidgets():
+            if not qt_is_valid(widget):
+                continue
+            widget.close()
+            if qt_is_valid(widget):
+                widget.deleteLater()
+
+        for _ in range(2):
+            QtWidgets.QApplication.sendPostedEvents(
+                None, int(QtCore.QEvent.Type.DeferredDelete.value)
+            )
+            QtWidgets.QApplication.sendPostedEvents(None, 0)
+            qapp.processEvents()
+
+        gc.collect()
+
+        for widget in QtWidgets.QApplication.topLevelWidgets():
+            if not qt_is_valid(widget):
+                continue
+            widget.close()
+            if qt_is_valid(widget):
+                widget.deleteLater()
+
         for _ in range(2):
             QtWidgets.QApplication.sendPostedEvents(
                 None, int(QtCore.QEvent.Type.DeferredDelete.value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,19 @@ def pytest_testnodedown(node: typing.Any, error: object | None) -> None:
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     qapp = QtWidgets.QApplication.instance()
     if qapp is not None:
+        serial_process = os.environ.get("PYTEST_XDIST_WORKER") is None
+        if serial_process:
+            # Some Qt helpers create parentless widgets that pytest-qt cannot track.
+            # Retire them while Qt is fully initialized instead of leaving their
+            # destruction to Python's arbitrary interpreter-finalization order.
+            for widget in QtWidgets.QApplication.topLevelWidgets():
+                if not qt_is_valid(widget):
+                    continue
+                with contextlib.suppress(RuntimeError):
+                    widget.close()
+                if qt_is_valid(widget):
+                    widget.deleteLater()
+
         # pytest-qt closes registered widgets with deleteLater(), but processEvents()
         # does not guarantee that DeferredDelete events run before interpreter shutdown.
         for _ in range(2):
@@ -235,6 +248,15 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         # Collect Python-owned Qt reference cycles while the binding is still fully
         # initialized, then deliver any DeferredDelete events exposed by collection.
         gc.collect()
+        if serial_process:
+            for widget in QtWidgets.QApplication.topLevelWidgets():
+                if not qt_is_valid(widget):
+                    continue
+                with contextlib.suppress(RuntimeError):
+                    widget.close()
+                if qt_is_valid(widget):
+                    widget.deleteLater()
+
         for _ in range(2):
             QtWidgets.QApplication.sendPostedEvents(
                 None, int(QtCore.QEvent.Type.DeferredDelete.value)
@@ -242,7 +264,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             QtWidgets.QApplication.sendPostedEvents(None, 0)
             qapp.processEvents()
 
-        if API_NAME == "PyQt6" and os.environ.get("PYTEST_XDIST_WORKER") is None:
+        if API_NAME == "PyQt6" and serial_process:
             # pytest-qt keeps its session QApplication wrapper alive until Python
             # finalization. Relinquish Python ownership so SIP does not destroy the
             # live C++ application after Qt callbacks have begun shutting down.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,7 +276,7 @@ def _drain_deferred_qt_deletes_after_test(
     request: pytest.FixtureRequest,
 ) -> Iterator[None]:
     yield
-    if request.node.get_closest_marker("gui") is None:
+    if API_NAME != "PyQt6" or request.node.get_closest_marker("gui") is None:
         return
     if QtWidgets.QApplication.instance() is not None:
         for _ in range(2):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import atexit
 import contextlib
 import csv
 import datetime
@@ -890,7 +891,11 @@ def ip_shell():
     yield ip_session
 
     ip_session.run_line_magic("unload_ext", "erlab.interactive")
-    ip_session.user_ns.clear()
+    history_thread = getattr(ip_session.history_manager, "save_thread", None)
+    atexit.unregister(ip_session.atexit_operations)
+    if history_thread is not None:
+        history_thread.stop()
+    ip_session.atexit_operations()
     ip_session.clear_instance()
     with contextlib.suppress(AttributeError):
         del start_ipython.already_called

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ _TEST_MANAGER_SETTINGS_MANAGED_ENV_VAR = (
     "ERLAB_IMAGETOOL_MANAGER_SETTINGS_PATH_TEST_MANAGED"
 )
 _TEST_MANAGER_SETTINGS_PATHS: list[pathlib.Path] = []
+_XDIST_WORKER_ERRORS: list[str] = []
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -211,21 +212,18 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(pytest.mark.compat)
 
 
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node: typing.Any, error: object | None) -> None:
+    if error is not None:
+        _XDIST_WORKER_ERRORS.append(f"{node.gateway.id}: {error}")
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     qapp = QtWidgets.QApplication.instance()
     if qapp is not None:
-        # pyqtgraph creates parentless context menus, and some GUI tests keep their
-        # Python owners alive in reference cycles until interpreter shutdown. Retire
-        # every remaining top-level widget while Qt is fully initialized, then collect
-        # those cycles and drain any deletions that collection exposes.
-        for widget in QtWidgets.QApplication.topLevelWidgets():
-            if not qt_is_valid(widget):
-                continue
-            widget.close()
-            if qt_is_valid(widget):
-                widget.deleteLater()
-
+        # pytest-qt closes registered widgets with deleteLater(), but processEvents()
+        # does not guarantee that DeferredDelete events run before interpreter shutdown.
         for _ in range(2):
             QtWidgets.QApplication.sendPostedEvents(
                 None, int(QtCore.QEvent.Type.DeferredDelete.value)
@@ -233,15 +231,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             QtWidgets.QApplication.sendPostedEvents(None, 0)
             qapp.processEvents()
 
+        # Collect Python-owned Qt reference cycles while the binding is still fully
+        # initialized, then deliver any DeferredDelete events exposed by collection.
         gc.collect()
-
-        for widget in QtWidgets.QApplication.topLevelWidgets():
-            if not qt_is_valid(widget):
-                continue
-            widget.close()
-            if qt_is_valid(widget):
-                widget.deleteLater()
-
         for _ in range(2):
             QtWidgets.QApplication.sendPostedEvents(
                 None, int(QtCore.QEvent.Type.DeferredDelete.value)
@@ -255,6 +247,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     ):
         with contextlib.suppress(OSError):
             settings_path.unlink()
+
+    if _XDIST_WORKER_ERRORS:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 
 @pytest.fixture(autouse=True)

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -316,6 +316,26 @@ def test_manager_console_shutdown_blocks_late_kernel_start(
         assert console_widget.kernel_manager.kernel is None
 
 
+def test_manager_console_shutdown_stops_ipython_history_thread(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.ensure_console_initialized()
+        console_widget = manager.console._console_widget
+        console_widget.initialize_kernel()
+        shell = console_widget.kernel_manager.kernel.shell
+        history_thread = shell.history_manager.save_thread
+        assert history_thread.is_alive()
+
+        console_widget.shutdown_kernel()
+
+        assert not history_thread.is_alive()
+        assert console_widget.kernel_manager.kernel is None
+        assert not shell.__class__.initialized()
+
+
 def test_manager_console_event_filter_ignores_invalid_events(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -316,10 +316,12 @@ def test_manager_console_shutdown_blocks_late_kernel_start(
         assert console_widget.kernel_manager.kernel is None
 
 
+@pytest.mark.parametrize("has_history_thread", [True, False])
 def test_manager_console_shutdown_stops_ipython_history_thread(
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
+    has_history_thread: bool,
 ) -> None:
     with manager_context() as manager:
         manager.ensure_console_initialized()
@@ -328,6 +330,9 @@ def test_manager_console_shutdown_stops_ipython_history_thread(
         shell = console_widget.kernel_manager.kernel.shell
         history_thread = shell.history_manager.save_thread
         assert history_thread.is_alive()
+        if not has_history_thread:
+            history_thread.stop()
+            shell.history_manager.save_thread = None
 
         console_widget.shutdown_kernel()
 

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -642,6 +642,27 @@ def test_colormap_combobox_blocked_updates_keep_thumbnail_and_signal_state(
     assert not combo.itemIcon(combo.currentIndex()).isNull()
 
 
+def test_colormap_combobox_population_handles_reentrant_deletion(
+    qapp, monkeypatch
+) -> None:
+    combo = ColorMapComboBox()
+    monkeypatch.setattr(
+        erlab.interactive.colors,
+        "pg_colormap_names",
+        lambda *args, **kwargs: [],
+    )
+
+    def delete_combo(self, index) -> None:
+        self.deleteLater()
+        qapp.sendPostedEvents(self, int(QtCore.QEvent.Type.DeferredDelete.value))
+
+    monkeypatch.setattr(ColorMapComboBox, "load_thumbnail", delete_combo)
+
+    combo._populate()
+
+    assert not erlab.interactive.utils.qt_is_valid(combo)
+
+
 def test_colormap_combobox_close_blocks_teardown_signals(qtbot) -> None:
     combo = ColorMapComboBox()
     qtbot.addWidget(combo)

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1187,12 +1187,21 @@ def test_fit2d_sequence_skips_visible_refresh_for_hidden_steps(
         refresh_modes.append((update_widgets, emit_info, emit_param_changed))
 
     started_steps: list[int] = []
+    pending_callbacks = []
     monkeypatch.setattr(fit2d_module.time, "monotonic", _monotonic)
     monkeypatch.setattr(
         win, "_refresh_contents_from_index", _refresh_contents_from_index
     )
     monkeypatch.setattr(win, "_show_warning", lambda *args, **kwargs: None)
     monkeypatch.setattr(win, "_show_error", lambda *args, **kwargs: None)
+
+    def _queue_single_shot(receiver, msec, callback, *guards) -> None:
+        assert receiver is win
+        assert msec == 0
+        assert not guards
+        pending_callbacks.append(callback)
+
+    monkeypatch.setattr(erlab.interactive.utils, "single_shot", _queue_single_shot)
 
     def _start_fit_worker(
         fit_data,
@@ -1214,10 +1223,8 @@ def test_fit2d_sequence_skips_visible_refresh_for_hidden_steps(
     monkeypatch.setattr(win, "_start_fit_worker", _start_fit_worker)
 
     win._run_fit_2d("up")
-    qtbot.waitUntil(
-        lambda: win._fit_2d_total == 0 and not win._fit_2d_indices,
-        timeout=1000,
-    )
+    while pending_callbacks:
+        pending_callbacks.pop(0)()
 
     assert started_steps == [1, 2, 3]
     assert sum(not update for update, _, _ in refresh_modes) > 0

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1174,7 +1174,6 @@ def test_fit2d_sequence_skips_visible_refresh_for_hidden_steps(
         return clock_values.pop(0) if clock_values else 100.10
 
     refresh_modes: list[tuple[bool, bool, bool]] = []
-    original_refresh = win._refresh_contents_from_index
 
     def _refresh_contents_from_index(
         *,
@@ -1184,14 +1183,8 @@ def test_fit2d_sequence_skips_visible_refresh_for_hidden_steps(
         emit_info: bool = True,
         emit_param_changed: bool = True,
     ) -> None:
+        del mark_fit_stale, elapsed
         refresh_modes.append((update_widgets, emit_info, emit_param_changed))
-        original_refresh(
-            mark_fit_stale=mark_fit_stale,
-            update_widgets=update_widgets,
-            elapsed=elapsed,
-            emit_info=emit_info,
-            emit_param_changed=emit_param_changed,
-        )
 
     started_steps: list[int] = []
     monkeypatch.setattr(fit2d_module.time, "monotonic", _monotonic)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1603,6 +1603,27 @@ def test_accept_dialog_finds_visible_modal_when_active_modal_is_missing(
     assert not dialog.isVisible()
 
 
+def test_accept_dialog_processes_visible_modal_after_deadline(accept_dialog) -> None:
+    dialog = QtWidgets.QDialog()
+
+    def _show_after_deadline() -> None:
+        dialog.setModal(True)
+        dialog.show()
+        accept_dialog._deadline = float("-inf")
+
+    accept_dialog(_show_after_deadline)
+
+    assert not dialog.isVisible()
+
+
+def test_accept_dialog_times_out_when_no_modal_exists(accept_dialog) -> None:
+    def _expire_deadline() -> None:
+        accept_dialog._deadline = float("-inf")
+
+    with pytest.raises(pytest.fail.Exception, match="No dialog for index 0"):
+        accept_dialog(_expire_deadline)
+
+
 def test_accept_dialog_unwinds_modal_when_callback_raises(accept_dialog) -> None:
     dialog = QtWidgets.QDialog()
 

--- a/tests/io/plugins/test_hers.py
+++ b/tests/io/plugins/test_hers.py
@@ -1,3 +1,4 @@
+import atexit
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -46,6 +47,11 @@ def test_load(expected_dir, args, expected) -> None:
     xr.testing.assert_allclose(loaded, expected_data, rtol=1e-6, atol=1e-6)
     # Properly clean up the IPython session
     if ip_session:
+        history_thread = getattr(ip_session.history_manager, "save_thread", None)
+        atexit.unregister(ip_session.atexit_operations)
+        if history_thread is not None:
+            history_thread.stop()
+        ip_session.atexit_operations()
         ip_session.clear_instance()
     del start_ipython.already_called
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -140,6 +140,22 @@ def test_pyqt_exit_cleanup_is_captured_before_runtime_imports() -> None:
     assert _CONFTEST.QTCORE_EXIT_CLEANUP is not None
 
 
+def test_pyqt_wrapper_release_ignores_dead_weak_proxies(monkeypatch) -> None:
+    if _CONFTEST.API_NAME != "PyQt6":
+        pytest.skip("PyQt6 is not active")
+
+    class Value:
+        pass
+
+    value = Value()
+    proxy = weakref.proxy(value)
+    del value
+
+    monkeypatch.setattr(_CONFTEST.gc, "get_objects", lambda: [proxy])
+
+    _CONFTEST._release_pyqt_owned_wrappers()
+
+
 @pytest.mark.parametrize(
     ("worker_id", "expected_py_owned", "expected_retained"),
     [(None, False, False), ("gw0", True, True)],

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -110,12 +110,12 @@ def test_xdist_worker_error_fails_session(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("worker_id", "expected_deleted"),
-    [(None, True), ("gw0", False)],
+    ("worker_id", "expected_py_owned"),
+    [(None, False), ("gw0", True)],
 )
-def test_pyqt_sessionfinish_deletes_app_only_in_serial_process(
+def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
     worker_id: str | None,
-    expected_deleted: bool,
+    expected_py_owned: bool,
 ) -> None:
     if importlib.util.find_spec("PyQt6") is None:
         pytest.skip("PyQt6 is not installed")
@@ -146,9 +146,10 @@ def test_pyqt_sessionfinish_deletes_app_only_in_serial_process(
                 "session = types.SimpleNamespace("
                 "exitstatus=module.pytest.ExitCode.OK); "
                 "module.pytest_sessionfinish(session, module.pytest.ExitCode.OK); "
+                "owned = sip.ispyowned(app); "
                 "deleted = sip.isdeleted(app); "
-                "print(deleted); "
-                "deleted or sip.delete(app)"
+                "print(owned, deleted); "
+                "owned and sip.delete(app)"
             ),
             str(path),
         ],
@@ -158,7 +159,7 @@ def test_pyqt_sessionfinish_deletes_app_only_in_serial_process(
         env=env,
     )
 
-    assert result.stdout.strip().splitlines()[-1] == str(expected_deleted)
+    assert result.stdout.strip().splitlines()[-1] == f"{expected_py_owned} False"
 
 
 def test_serial_xdist_group_serializes_manager_context_tests() -> None:

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -97,6 +97,18 @@ def test_collection_marker_hook_runs_before_xdist_loadgroup() -> None:
     assert hook_options["tryfirst"]
 
 
+def test_xdist_worker_error_fails_session(monkeypatch) -> None:
+    node = types.SimpleNamespace(gateway=types.SimpleNamespace(id="gw0"))
+    session = types.SimpleNamespace(exitstatus=pytest.ExitCode.OK)
+    monkeypatch.setattr(_CONFTEST.QtWidgets.QApplication, "instance", lambda: None)
+    monkeypatch.setattr(_CONFTEST, "_XDIST_WORKER_ERRORS", [])
+
+    _CONFTEST.pytest_testnodedown(node, "Not properly terminated")
+    _CONFTEST.pytest_sessionfinish(session, pytest.ExitCode.OK)
+
+    assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+
+
 def test_serial_xdist_group_serializes_manager_context_tests() -> None:
     slicer_group = _CONFTEST.serial_xdist_group(
         "tests/interactive/imagetool/test_slicer.py",

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -133,11 +133,18 @@ def test_xdist_worker_error_fails_session(monkeypatch) -> None:
     assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
 
 
+def test_pyqt_exit_cleanup_is_captured_before_runtime_imports() -> None:
+    if _CONFTEST.API_NAME != "PyQt6":
+        pytest.skip("PyQt6 is not active")
+
+    assert _CONFTEST.QTCORE_EXIT_CLEANUP is not None
+
+
 @pytest.mark.parametrize(
     ("worker_id", "expected_py_owned", "expected_retained"),
     [(None, False, False), ("gw0", True, True)],
 )
-def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
+def test_pyqt_sessionfinish_releases_wrapper_ownership_only_in_serial_process(
     worker_id: str | None,
     expected_py_owned: bool,
     expected_retained: bool,
@@ -161,15 +168,20 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
             "-c",
             (
                 "import importlib.util, pathlib, sys, types; "
-                "from PyQt6 import sip; "
-                "from pytestqt import plugin as pytestqt_plugin; "
                 "path = pathlib.Path(sys.argv[1]); "
                 "spec = importlib.util.spec_from_file_location("
                 "'sessionfinish_conftest', path); "
                 "module = importlib.util.module_from_spec(spec); "
                 "spec.loader.exec_module(module); "
+                "from PyQt6 import sip; "
+                "from pytestqt import plugin as pytestqt_plugin; "
                 "app = module.QtWidgets.QApplication([]); "
                 "pytestqt_plugin._qapp_instance = app; "
+                "unregistered = []; "
+                "original_unregister = module.atexit.unregister; "
+                "module.atexit.unregister = lambda func: ("
+                "unregistered.append(func), original_unregister(func)"
+                ")[1]; "
                 "widget = module.QtWidgets.QWidget(); "
                 "widget.deleteLater(); "
                 "request = types.SimpleNamespace("
@@ -181,17 +193,26 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
                 "next(drain, None); "
                 "drained = sip.isdeleted(widget); "
                 "widget = module.QtWidgets.QWidget(); "
+                "graphics_item = module.QtWidgets.QGraphicsLineItem(); "
                 "session = types.SimpleNamespace("
                 "exitstatus=module.pytest.ExitCode.OK); "
                 "module.pytest_sessionfinish(session, module.pytest.ExitCode.OK); "
-                "owned = sip.ispyowned(app); "
+                "owned = ("
+                "sip.ispyowned(app), "
+                "sip.ispyowned(widget), "
+                "sip.ispyowned(graphics_item)"
+                "); "
                 "app_deleted = sip.isdeleted(app); "
                 "widget_deleted = sip.isdeleted(widget); "
                 "retained = pytestqt_plugin._qapp_instance is app; "
-                "print(owned, app_deleted, widget_deleted, drained, retained); "
-                "widget_deleted or sip.delete(widget); "
-                "pytestqt_plugin._qapp_instance = None; "
-                "owned and sip.delete(app)"
+                "cleanup_captured = "
+                "module.QTCORE_EXIT_CLEANUP is not None; "
+                "cleanup_unregistered = "
+                "module.QTCORE_EXIT_CLEANUP in unregistered; "
+                "print("
+                "owned, app_deleted, widget_deleted, drained, retained, "
+                "cleanup_captured, cleanup_unregistered"
+                ")"
             ),
             str(path),
         ],
@@ -202,7 +223,8 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
     )
 
     assert result.stdout.strip().splitlines()[-1] == (
-        f"{expected_py_owned} False False True {expected_retained}"
+        f"({expected_py_owned}, {expected_py_owned}, {expected_py_owned}) "
+        f"False False True {expected_retained} True {worker_id is None}"
     )
 
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -143,12 +143,15 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
                 "module = importlib.util.module_from_spec(spec); "
                 "spec.loader.exec_module(module); "
                 "app = module.QtWidgets.QApplication([]); "
+                "widget = module.QtWidgets.QWidget(); "
                 "session = types.SimpleNamespace("
                 "exitstatus=module.pytest.ExitCode.OK); "
                 "module.pytest_sessionfinish(session, module.pytest.ExitCode.OK); "
                 "owned = sip.ispyowned(app); "
-                "deleted = sip.isdeleted(app); "
-                "print(owned, deleted); "
+                "app_deleted = sip.isdeleted(app); "
+                "widget_deleted = sip.isdeleted(widget); "
+                "print(owned, app_deleted, widget_deleted); "
+                "widget_deleted or sip.delete(widget); "
                 "owned and sip.delete(app)"
             ),
             str(path),
@@ -159,7 +162,9 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
         env=env,
     )
 
-    assert result.stdout.strip().splitlines()[-1] == f"{expected_py_owned} False"
+    assert result.stdout.strip().splitlines()[-1] == (
+        f"{expected_py_owned} False {not expected_py_owned}"
+    )
 
 
 def test_serial_xdist_group_serializes_manager_context_tests() -> None:

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -144,13 +144,23 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
                 "spec.loader.exec_module(module); "
                 "app = module.QtWidgets.QApplication([]); "
                 "widget = module.QtWidgets.QWidget(); "
+                "widget.deleteLater(); "
+                "request = types.SimpleNamespace("
+                "node=types.SimpleNamespace("
+                "get_closest_marker=lambda name: True)); "
+                "drain = module._drain_deferred_qt_deletes_after_test.__wrapped__("
+                "request); "
+                "next(drain); "
+                "next(drain, None); "
+                "drained = sip.isdeleted(widget); "
+                "widget = module.QtWidgets.QWidget(); "
                 "session = types.SimpleNamespace("
                 "exitstatus=module.pytest.ExitCode.OK); "
                 "module.pytest_sessionfinish(session, module.pytest.ExitCode.OK); "
                 "owned = sip.ispyowned(app); "
                 "app_deleted = sip.isdeleted(app); "
                 "widget_deleted = sip.isdeleted(widget); "
-                "print(owned, app_deleted, widget_deleted); "
+                "print(owned, app_deleted, widget_deleted, drained); "
                 "widget_deleted or sip.delete(widget); "
                 "owned and sip.delete(app)"
             ),
@@ -163,7 +173,7 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
     )
 
     assert result.stdout.strip().splitlines()[-1] == (
-        f"{expected_py_owned} False {not expected_py_owned}"
+        f"{expected_py_owned} False {not expected_py_owned} True"
     )
 
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -4,6 +4,7 @@ import pathlib
 import subprocess
 import sys
 import types
+import weakref
 
 import pytest
 
@@ -97,6 +98,29 @@ def test_collection_marker_hook_runs_before_xdist_loadgroup() -> None:
     assert hook_options["tryfirst"]
 
 
+def test_qtbot_teardown_drops_deleted_widget_wrappers(monkeypatch) -> None:
+    class Widget:
+        pass
+
+    valid_widget = Widget()
+    invalid_widget = Widget()
+    item = types.SimpleNamespace(
+        qt_widgets=[
+            (weakref.ref(valid_widget), None),
+            (weakref.ref(invalid_widget), None),
+        ]
+    )
+    monkeypatch.setattr(
+        _CONFTEST,
+        "qt_is_valid",
+        lambda widget: widget is valid_widget,
+    )
+
+    _CONFTEST._drop_invalid_qtbot_widgets(item)
+
+    assert item.qt_widgets == [(weakref.ref(valid_widget), None)]
+
+
 def test_xdist_worker_error_fails_session(monkeypatch) -> None:
     node = types.SimpleNamespace(gateway=types.SimpleNamespace(id="gw0"))
     session = types.SimpleNamespace(exitstatus=pytest.ExitCode.OK)
@@ -110,12 +134,13 @@ def test_xdist_worker_error_fails_session(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("worker_id", "expected_py_owned"),
-    [(None, False), ("gw0", True)],
+    ("worker_id", "expected_py_owned", "expected_retained"),
+    [(None, False, False), ("gw0", True, True)],
 )
 def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
     worker_id: str | None,
     expected_py_owned: bool,
+    expected_retained: bool,
 ) -> None:
     if importlib.util.find_spec("PyQt6") is None:
         pytest.skip("PyQt6 is not installed")
@@ -137,12 +162,14 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
             (
                 "import importlib.util, pathlib, sys, types; "
                 "from PyQt6 import sip; "
+                "from pytestqt import plugin as pytestqt_plugin; "
                 "path = pathlib.Path(sys.argv[1]); "
                 "spec = importlib.util.spec_from_file_location("
                 "'sessionfinish_conftest', path); "
                 "module = importlib.util.module_from_spec(spec); "
                 "spec.loader.exec_module(module); "
                 "app = module.QtWidgets.QApplication([]); "
+                "pytestqt_plugin._qapp_instance = app; "
                 "widget = module.QtWidgets.QWidget(); "
                 "widget.deleteLater(); "
                 "request = types.SimpleNamespace("
@@ -160,8 +187,10 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
                 "owned = sip.ispyowned(app); "
                 "app_deleted = sip.isdeleted(app); "
                 "widget_deleted = sip.isdeleted(widget); "
-                "print(owned, app_deleted, widget_deleted, drained); "
+                "retained = pytestqt_plugin._qapp_instance is app; "
+                "print(owned, app_deleted, widget_deleted, drained, retained); "
                 "widget_deleted or sip.delete(widget); "
+                "pytestqt_plugin._qapp_instance = None; "
                 "owned and sip.delete(app)"
             ),
             str(path),
@@ -173,7 +202,7 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
     )
 
     assert result.stdout.strip().splitlines()[-1] == (
-        f"{expected_py_owned} False False True"
+        f"{expected_py_owned} False False True {expected_retained}"
     )
 
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -173,7 +173,7 @@ def test_pyqt_sessionfinish_releases_app_ownership_only_in_serial_process(
     )
 
     assert result.stdout.strip().splitlines()[-1] == (
-        f"{expected_py_owned} False {not expected_py_owned} True"
+        f"{expected_py_owned} False False True"
     )
 
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -109,6 +109,58 @@ def test_xdist_worker_error_fails_session(monkeypatch) -> None:
     assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
 
 
+@pytest.mark.parametrize(
+    ("worker_id", "expected_deleted"),
+    [(None, True), ("gw0", False)],
+)
+def test_pyqt_sessionfinish_deletes_app_only_in_serial_process(
+    worker_id: str | None,
+    expected_deleted: bool,
+) -> None:
+    if importlib.util.find_spec("PyQt6") is None:
+        pytest.skip("PyQt6 is not installed")
+
+    path = pathlib.Path(__file__).with_name("conftest.py")
+    env = os.environ.copy()
+    env["QT_QPA_PLATFORM"] = "offscreen"
+    env["PYTEST_QT_API"] = "pyqt6"
+    env["QT_API"] = "pyqt6"
+    if worker_id is None:
+        env.pop("PYTEST_XDIST_WORKER", None)
+    else:
+        env["PYTEST_XDIST_WORKER"] = worker_id
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib.util, pathlib, sys, types; "
+                "from PyQt6 import sip; "
+                "path = pathlib.Path(sys.argv[1]); "
+                "spec = importlib.util.spec_from_file_location("
+                "'sessionfinish_conftest', path); "
+                "module = importlib.util.module_from_spec(spec); "
+                "spec.loader.exec_module(module); "
+                "app = module.QtWidgets.QApplication([]); "
+                "session = types.SimpleNamespace("
+                "exitstatus=module.pytest.ExitCode.OK); "
+                "module.pytest_sessionfinish(session, module.pytest.ExitCode.OK); "
+                "deleted = sip.isdeleted(app); "
+                "print(deleted); "
+                "deleted or sip.delete(app)"
+            ),
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.stdout.strip().splitlines()[-1] == str(expected_deleted)
+
+
 def test_serial_xdist_group_serializes_manager_context_tests() -> None:
     slicer_group = _CONFTEST.serial_xdist_group(
         "tests/interactive/imagetool/test_slicer.py",


### PR DESCRIPTION
## Summary

- collect Python-owned Qt wrapper cycles between two deferred-delete drains, without closing arbitrary top-level widgets
- make any abnormal xdist worker shutdown set a failing pytest controller exit status
- disable xdist worker restarts in coverage and compatibility CI so a crash stops the job immediately

## Root cause

Compatibility occasionally completed every GUI test and then exited with code 139 during interpreter shutdown because Qt wrapper cycles survived until the binding was already finalizing.

The first version of this PR tried to close every surviving top-level widget. That was too broad: closing those widgets invoked arbitrary Qt callbacks during session shutdown and crashed two coverage workers. Xdist replaced those workers and still returned exit 0 because no test was active when they died, silently dropping their coverage data.

The teardown now limits itself to the existing deferred-delete mechanism plus one Python cycle collection while Qt is fully initialized. It does not close user widgets or invoke their close handlers. A controller-side xdist hook also turns any future abnormal worker shutdown into a failed pytest session; `--max-worker-restart=0` prevents replacement work after the crash.

## Validation

- PyQt6 serial: `tests/interactive/test_utils.py` — 196 passed, process exit 0
- PySide6 serial: `tests/interactive/test_utils.py` — 196 passed, process exit 0
- PyQt6 xdist + coverage: `cov-qt-ux` — 412 passed, process exit 0
- PyQt6 xdist + coverage: `cov-qt-manager-provenance-console` — 570 passed, process exit 0
- xdist post-session crash probe — one passing test followed by a forced worker death now exits 1 instead of 0
- `tests/test_conftest.py` under xdist + coverage — 7 passed
- `uv run python -m scripts.ci_test_groups --check-partition`
- changed-file prek hooks and `git diff --check`
