### PR TITLE
feat(interactive): sync linked ImageTool splitter layouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
           mapfile -t targets < "$RUNNER_TEMP/targets.txt"
           pytest_args=(
             -o faulthandler_timeout=300
+            -o faulthandler_exit_on_timeout=true
             --cov erlab
             --cov-report=
             --junitxml "junit-${{ matrix.group }}.xml"
@@ -269,6 +270,7 @@ jobs:
             uv run pytest \
             -m compat \
             -o faulthandler_timeout=300 \
+            -o faulthandler_exit_on_timeout=true \
             --junitxml "junit-smoke-${{ matrix.python-version }}-${{ matrix.qt-api }}.xml" \
             -o junit_family=legacy \
             "${targets[@]}"

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -141,6 +141,7 @@ jobs:
           common_args=(
             -v
             -o faulthandler_timeout=300
+            -o faulthandler_exit_on_timeout=true
             -o junit_family=legacy
           )
           xdist_args=(

--- a/docs/source/user-guide/interactive/imagetool.md
+++ b/docs/source/user-guide/interactive/imagetool.md
@@ -222,7 +222,8 @@ Every ImageTool window is built from an {class}`ImageSlicerArea <erlab.interacti
 
 - When comparing data in several ImageTool windows, you can link them either at creation
   (`eri.itool([data1, data2], link=True)`) or inside the manager. Linked windows
-  maintain synchronized slicing positions, bin widths, and cursor counts.
+  maintain synchronized slicing positions, bin widths, cursor counts, and plot layout
+  proportions.
 
 (imagetool-cursors)=
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -244,8 +244,8 @@ and right-click context menus:
 
 - {guilabel}`Link` / {guilabel}`Unlink`
 
-  {kbd}`Ctrl+L` links the selected windows so they share cursors and slices;
-  {kbd}`Ctrl+Shift+L` removes the links.
+  {kbd}`Ctrl+L` links the selected windows so they share cursors, slices, and plot
+  layout proportions. {kbd}`Ctrl+Shift+L` removes the links.
 
 - {guilabel}`Offload to Workspace`
 

--- a/src/erlab/interactive/imagetool/_history.py
+++ b/src/erlab/interactive/imagetool/_history.py
@@ -137,20 +137,17 @@ def _changed_paths(
     return {
         path
         for path in paths
-        if not (path == "splitter_sizes" or path.startswith("splitter_sizes."))
-        and prev_flat.get(path, _MISSING) != curr_flat.get(path, _MISSING)
+        if prev_flat.get(path, _MISSING) != curr_flat.get(path, _MISSING)
     }
 
 
 def changed_paths(
-    prev: Mapping[str, typing.Any], curr: Mapping[str, typing.Any]
+    prev: Mapping[str, typing.Any],
+    curr: Mapping[str, typing.Any],
 ) -> frozenset[_StatePath]:
     paths: set[_StatePath] = set()
 
     def visit(old: typing.Any, new: typing.Any, prefix: _StatePath = ()) -> None:
-        if prefix and prefix[0] == "splitter_sizes":
-            return
-
         if isinstance(old, Mapping) and isinstance(new, Mapping):
             for key in set(old) | set(new):
                 visit(
@@ -556,6 +553,14 @@ def _describe_state_change_rows(
         summaries.append("Axis inversion changed")
         details.append(_detail_note("Axis inversion changed"))
         _consume(changes, "axis_inversions", prefixes=("axis_inversions",))
+
+    if any(
+        path == "splitter_sizes" or path.startswith("splitter_sizes.")
+        for path in changes
+    ):
+        summaries.append("Plot layout changed")
+        details.append(_detail_note("Plot layout proportions changed"))
+        _consume(changes, "splitter_sizes", prefixes=("splitter_sizes",))
 
     if any(
         path == "filter_operation" or path.startswith("filter_operation.")

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -385,10 +385,19 @@ class _ActionsController:
 
     def link_selected(self, link_colors: bool = True, deselect: bool = True) -> None:
         """Link selected ImageTool windows."""
+        targets = self._manager._selected_imagetool_targets()
+        current = self._manager.tree_view.currentIndex().internalPointer()
+        if isinstance(current, _ImageToolWrapper):
+            current_target: int | str | None = current.index
+        elif isinstance(current, str) and self._manager._is_imagetool_target(current):
+            current_target = current
+        else:
+            current_target = None
+        if current_target in targets:
+            targets.remove(current_target)
+            targets.insert(0, current_target)
         self._manager.unlink_selected(deselect=False)
-        self._manager.link_imagetools(
-            *self._manager._selected_imagetool_targets(), link_colors=link_colors
-        )
+        self._manager.link_imagetools(*targets, link_colors=link_colors)
         if deselect:
             self._manager.tree_view.deselect_all()
 
@@ -1023,16 +1032,42 @@ class _ActionsController:
             nodes.append(node)
             if node.imagetool is not None:
                 slicers.append(node.slicer_area)
+        pending_payloads = self._manager._workspace_controller.loading.pending
+        source_node = nodes[0]
+        source_layout = (
+            (
+                source_node.slicer_area.splitter_sizes,
+                source_node.slicer_area.data.ndim,
+            )
+            if source_node.imagetool is not None
+            else pending_payloads._pending_workspace_splitter_layout(source_node)
+        )
+        if source_layout is None and slicers:
+            source_layout = (slicers[0].splitter_sizes, slicers[0].data.ndim)
         if len(slicers) > 1:
             linker = erlab.interactive.imagetool.viewer_linking.SlicerLinkProxy(
                 *slicers,
                 link_colors=link_colors,
+                align_splitters=False,
             )
             self._manager._link_registry.append(linker)
         link_key = uuid.uuid4().hex
         for node in nodes:
             node.set_workspace_link_state(link_key, link_colors=link_colors)
             self._manager._mark_node_state_dirty(node.uid)
+        if source_layout is not None:
+            sizes, source_ndim = source_layout
+            erlab.interactive.imagetool.viewer_linking.apply_splitter_layout(
+                slicers,
+                sizes,
+                source_ndim,
+            )
+            for node in nodes:
+                pending_payloads._set_pending_workspace_splitter_layout(
+                    node,
+                    sizes,
+                    source_ndim,
+                )
         self._manager._sigReloadLinkers.emit()
 
     def name_of_imagetool(self, index: int) -> str:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -1183,6 +1183,7 @@ class _WorkspaceLoader:
             linker = erlab.interactive.imagetool.viewer_linking.SlicerLinkProxy(
                 *slicers,
                 link_colors=group_colors.get(link_group, True),
+                align_splitters=False,
             )
             self._manager._link_registry.append(linker)
             self._manager._sigReloadLinkers.emit()
@@ -1209,6 +1210,7 @@ class _WorkspaceLoader:
         linker = erlab.interactive.imagetool.viewer_linking.SlicerLinkProxy(
             *(linked_node.slicer_area for linked_node in linked_nodes),
             link_colors=node.workspace_link_colors,
+            align_splitters=False,
         )
         self._manager._link_registry.append(linker)
         self._manager._sigReloadLinkers.emit()

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -86,6 +86,85 @@ class _PendingWorkspacePayloads:
         self._controller = controller
 
     @staticmethod
+    def _pending_workspace_state(
+        node: _ImageToolWrapper | _ManagedWindowNode,
+    ) -> tuple[dict[str, typing.Any], dict[str, typing.Any]] | None:
+        attrs = node.pending_workspace_payload_attrs
+        if attrs is None:
+            return None
+        raw_state = attrs.get("itool_state")
+        if isinstance(raw_state, bytes):
+            try:
+                raw_state = raw_state.decode()
+            except UnicodeDecodeError:
+                return None
+        if not isinstance(raw_state, str):
+            return None
+        try:
+            state = json.loads(raw_state)
+        except Exception:
+            logger.debug("Ignoring invalid pending ImageTool state", exc_info=True)
+            return None
+        if not isinstance(state, collections.abc.Mapping):
+            return None
+        return attrs, dict(state)
+
+    @classmethod
+    def _pending_workspace_splitter_layout(
+        cls,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+    ) -> tuple[list[list[int]], int] | None:
+        pending_state = cls._pending_workspace_state(node)
+        if pending_state is None:
+            return None
+        _, state = pending_state
+        slice_state = state.get("slice")
+        sizes = state.get("splitter_sizes")
+        if not isinstance(slice_state, collections.abc.Mapping) or not isinstance(
+            sizes, list
+        ):
+            return None
+        dims = slice_state.get("dims")
+        if not isinstance(dims, (list, tuple)):
+            return None
+        try:
+            normalized_sizes = [
+                [int(value) for value in splitter_sizes]
+                for splitter_sizes in sizes
+                if isinstance(splitter_sizes, list)
+            ]
+        except (TypeError, ValueError):
+            return None
+        if len(normalized_sizes) != len(sizes):
+            return None
+        return normalized_sizes, len(dims)
+
+    @classmethod
+    def _set_pending_workspace_splitter_layout(
+        cls,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        sizes: list[list[int]],
+        source_ndim: int,
+    ) -> bool:
+        pending_state = cls._pending_workspace_state(node)
+        if pending_state is None:
+            return False
+        attrs, state = pending_state
+        slice_state = state.get("slice")
+        if not isinstance(slice_state, collections.abc.Mapping):
+            return False
+        dims = slice_state.get("dims")
+        if not isinstance(dims, (list, tuple)) or len(dims) != source_ndim:
+            return False
+        if state.get("splitter_sizes") == sizes:
+            return False
+        state["splitter_sizes"] = copy.deepcopy(sizes)
+        attrs["itool_state"] = json.dumps(state)
+        node.update_pending_workspace_payload_attrs(attrs)
+        node._clear_pending_workspace_link_slicer_cache()
+        return True
+
+    @staticmethod
     def _pending_workspace_data_with_saved_dim_order(
         data: xr.DataArray, attrs: Mapping[typing.Any, typing.Any]
     ) -> xr.DataArray:
@@ -1349,6 +1428,14 @@ class _PendingWorkspacePayloads:
         funcname: str,
         arguments: dict[str, typing.Any],
     ) -> bool:
+        if funcname == "_set_linked_splitter_sizes":
+            if array_slicer._obj.ndim != int(arguments["source_ndim"]):
+                return False
+            sizes = arguments["sizes"]
+            if not isinstance(sizes, list):
+                return False
+            state["splitter_sizes"] = copy.deepcopy(sizes)
+            return True
         if funcname in {"refresh", "refresh_current"}:
             return False
         if funcname == "view_all":

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -3942,20 +3942,25 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self, watched: QtCore.QObject | None, event: QtCore.QEvent | None
     ) -> bool:
         if watched in self._splitter_handles and event is not None:
-            if event.type() == QtCore.QEvent.Type.MouseButtonPress:
+            event_type = event.type()
+            if event_type == QtCore.QEvent.Type.MouseButtonPress:
                 mouse_event = typing.cast("QtGui.QMouseEvent", event)
                 if mouse_event.button() == QtCore.Qt.MouseButton.LeftButton:
                     self._begin_splitter_move(self._splitter_handles[watched])
-            elif event.type() == QtCore.QEvent.Type.MouseButtonRelease:
-                mouse_event = typing.cast("QtGui.QMouseEvent", event)
-                if mouse_event.button() == QtCore.Qt.MouseButton.LeftButton:
-                    generation = self._splitter_move_generation
-                    erlab.interactive.utils.single_shot(
-                        self,
-                        0,
-                        lambda: self._finish_splitter_move(generation),
-                        watched,
-                    )
+            elif self._splitter_move_active and (
+                event_type == QtCore.QEvent.Type.UngrabMouse
+                or (
+                    event_type == QtCore.QEvent.Type.MouseButtonRelease
+                    and typing.cast("QtGui.QMouseEvent", event).button()
+                    == QtCore.Qt.MouseButton.LeftButton
+                )
+            ):
+                generation = self._splitter_move_generation
+                erlab.interactive.utils.single_shot(
+                    self,
+                    0,
+                    lambda: self._finish_splitter_move(generation),
+                )
         return super().eventFilter(watched, event)
 
     def changeEvent(self, evt: QtCore.QEvent | None) -> None:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -989,12 +989,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
             return
         history_group_active = self._history_group_active
         try:
-            if history_group_active:
-                current_sizes = [
-                    self._splitters[index].sizes()
-                    for index in self._splitter_move_indices
-                ]
-                if current_sizes != self._splitter_move_start_sizes:
+            current_sizes = [
+                self._splitters[index].sizes() for index in self._splitter_move_indices
+            ]
+            if current_sizes != self._splitter_move_start_sizes:
+                if history_group_active:
                     # Non-opaque QSplitters commit their final sizes only after the
                     # handle's release handler runs. Commit the rendered result once,
                     # at the gesture boundary.
@@ -1002,6 +1001,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
                         self._capture_splitter_layout(self._splitter_move_indices),
                         self.data.ndim,
                     )
+                elif self._splitter_layout is not None:
+                    # Closing the tool can discard the history group before the
+                    # queued release handler runs. Restore the last committed layout
+                    # instead of leaving the uncommitted drag visible on reopen.
+                    self._apply_splitter_sizes(self._splitter_layout)
         finally:
             self._splitter_move_active = False
             self._splitter_move_indices = ()
@@ -3953,16 +3957,6 @@ class ImageSlicerArea(QtWidgets.QWidget):
                         watched,
                     )
         return super().eventFilter(watched, event)
-
-    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
-        super().resizeEvent(event)
-        if (
-            self._secondary_plots_materialized
-            and self._splitter_layout is not None
-            and self._pending_splitter_sizes is None
-            and not (self._splitter_move_active and self._history_group_active)
-        ):
-            self._apply_splitter_sizes(self._splitter_layout)
 
     def changeEvent(self, evt: QtCore.QEvent | None) -> None:
         if evt is not None and evt.type() == QtCore.QEvent.Type.PaletteChange:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -296,6 +296,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._pending_plotitem_states: list[PlotItemState] | None = None
         self._pending_splitter_sizes: list[list[int]] | None = None
         self._pending_splitter_restore_queued = False
+        # Requested relative weights, independent of Qt's constrained pixel sizes.
+        self._splitter_layout: list[list[int]] | None = None
+        self._splitter_handles: dict[QtWidgets.QSplitterHandle, int] = {}
+        self._splitter_move_active = False
+        self._splitter_move_indices: tuple[int, ...] = ()
+        self._splitter_move_start_sizes: list[list[int]] | None = None
+        self._splitter_move_generation = 0
         self._deferred_show_restore_queued = False
         self._axes_signals_connected = False
         self._axes_signal_connected_indices: set[int] = set()
@@ -619,6 +626,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 # inactive axes after their placeholder widgets exist.
                 for index in self._secondary_plot_construction_order():
                     self._build_axes_widget(index)
+                self._install_splitter_handle_event_filters()
                 if hasattr(self, "_array_slicer"):
                     cached_cursor_colors = [
                         QtGui.QColor(color) for color in self.cursor_colors
@@ -919,16 +927,100 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def splitter_sizes(self) -> list[list[int]]:
         if self._pending_splitter_sizes is not None:
             return copy.deepcopy(self._pending_splitter_sizes)
+        if self._splitter_layout is not None:
+            return copy.deepcopy(self._splitter_layout)
         return [s.sizes() for s in self._splitters]
 
     @splitter_sizes.setter
     def splitter_sizes(self, sizes: list[list[int]]) -> None:
         if self._secondary_plots_materialized:
-            self._apply_splitter_sizes(self._normalize_splitter_sizes(sizes))
+            sizes = self._normalize_splitter_sizes(sizes)
+            self._splitter_layout = copy.deepcopy(sizes)
+            self._apply_splitter_sizes(sizes)
             self._pending_splitter_sizes = None
             self._pending_splitter_restore_queued = False
         else:
+            self._splitter_layout = copy.deepcopy(sizes)
             self._pending_splitter_sizes = copy.deepcopy(sizes)
+
+    @link_slicer
+    @record_history
+    def _set_linked_splitter_sizes(
+        self, sizes: list[list[int]], source_ndim: int
+    ) -> None:
+        if self.data.ndim != source_ndim:
+            return
+        self.splitter_sizes = sizes
+
+    def _install_splitter_handle_event_filters(self) -> None:
+        for splitter_index, splitter in enumerate(self._splitters):
+            for handle_index in range(1, splitter.count()):
+                handle = splitter.handle(handle_index)
+                if handle is not None and handle not in self._splitter_handles:
+                    handle.installEventFilter(self)
+                    self._splitter_handles[handle] = splitter_index
+
+    def _begin_splitter_move(self, splitter_index: int) -> None:
+        self.end_history_group()
+        self._splitter_move_generation += 1
+        self._splitter_move_active = True
+        coupled_index = {1: 4, 4: 1}.get(splitter_index)
+        self._splitter_move_indices = (
+            (splitter_index,)
+            if coupled_index is None
+            else (splitter_index, coupled_index)
+        )
+        self._splitter_move_start_sizes = [
+            self._splitters[index].sizes() for index in self._splitter_move_indices
+        ]
+        self.begin_history_group(None)
+        transaction_id = (
+            self.next_linked_history_transaction_id()
+            if self.is_linked or self._managed_link_sync_enabled(color=False)
+            else None
+        )
+        self.begin_history_entry(transaction_id)
+
+    def _finish_splitter_move(self, generation: int | None = None) -> None:
+        stale_generation = (
+            generation is not None and generation != self._splitter_move_generation
+        )
+        if not self._splitter_move_active or stale_generation:
+            return
+        history_group_active = self._history_group_active
+        try:
+            if history_group_active:
+                current_sizes = [
+                    self._splitters[index].sizes()
+                    for index in self._splitter_move_indices
+                ]
+                if current_sizes != self._splitter_move_start_sizes:
+                    # Non-opaque QSplitters commit their final sizes only after the
+                    # handle's release handler runs. Commit the rendered result once,
+                    # at the gesture boundary.
+                    self._set_linked_splitter_sizes(
+                        self._capture_splitter_layout(self._splitter_move_indices),
+                        self.data.ndim,
+                    )
+        finally:
+            self._splitter_move_active = False
+            self._splitter_move_indices = ()
+            self._splitter_move_start_sizes = None
+            if history_group_active:
+                self.end_history_group()
+
+    def _capture_splitter_layout(
+        self, splitter_indices: tuple[int, ...]
+    ) -> list[list[int]]:
+        if self._splitter_layout is None:
+            self._splitter_layout = [splitter.sizes() for splitter in self._splitters]
+        else:
+            self._splitter_layout = self._normalize_splitter_sizes(
+                self._splitter_layout
+            )
+            for index in splitter_indices:
+                self._splitter_layout[index] = self._splitters[index].sizes()
+        return copy.deepcopy(self._splitter_layout)
 
     def _apply_splitter_sizes(self, sizes: list[list[int]]) -> None:
         for s, size in zip(self._splitters, sizes, strict=True):
@@ -969,6 +1061,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             return
         sizes = self._normalize_splitter_sizes(sizes)
         self._pending_splitter_sizes = copy.deepcopy(sizes)
+        self._splitter_layout = copy.deepcopy(sizes)
         self._apply_splitter_sizes(sizes)
         # QSplitter may not report the restored sizes until the next layout pass.
         # Keep the serialized sizes pending for state reads until then.
@@ -1393,6 +1486,43 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._write_history = original
 
     @contextlib.contextmanager
+    def history_neutral(self):
+        """Exclude a state mutation from any open history entry."""
+        pending_entry = self._pending_history_entry
+        before_state = (
+            self._history_state_snapshot() if pending_entry is not None else None
+        )
+        try:
+            with self.history_suppressed():
+                yield
+        finally:
+            if (
+                pending_entry is not None
+                and before_state is not None
+                and self._pending_history_entry is pending_entry
+                and erlab.interactive.utils.qt_is_valid(self)
+            ):
+                after_state = self._history_state_snapshot()
+                neutral_paths = _history.changed_paths(before_state, after_state)
+                if neutral_paths:
+                    pending_entry.before_state = typing.cast(
+                        "dict[str, typing.Any]",
+                        _history.patch_state(
+                            pending_entry.before_state,
+                            after_state,
+                            neutral_paths,
+                        ),
+                    )
+                    pending_entry.after_state = typing.cast(
+                        "dict[str, typing.Any]",
+                        _history.patch_state(
+                            pending_entry.after_state,
+                            after_state,
+                            neutral_paths,
+                        ),
+                    )
+
+    @contextlib.contextmanager
     def link_sync_suppressed(self):
         self._link_sync_suppressed += 1
         try:
@@ -1410,17 +1540,33 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     @QtCore.Slot()
     def begin_history_group(
-        self, timeout_ms: int = _HISTORY_GROUP_IDLE_TIMEOUT_MS
+        self, timeout_ms: int | None = _HISTORY_GROUP_IDLE_TIMEOUT_MS
     ) -> None:
         self._history_group_active = True
-        self._history_group_timer.start(timeout_ms)
+        if timeout_ms is None:
+            self._history_group_timer.stop()
+        else:
+            self._history_group_timer.start(timeout_ms)
 
     @QtCore.Slot()
     def end_history_group(self) -> None:
+        transaction_id = (
+            self._pending_history_entry.transaction_id
+            if self._pending_history_entry is not None
+            else None
+        )
         self.finalize_history_entry()
         if erlab.interactive.utils.qt_is_valid(self._history_group_timer):
             self._history_group_timer.stop()
         self._history_group_active = False
+        if transaction_id is not None and self._linking_proxy is not None:
+            for target in tuple(self.linked_slicers):
+                target._finalize_linked_history_transaction(transaction_id)
+
+    def _finalize_linked_history_transaction(self, transaction_id: str) -> None:
+        entry = self._pending_history_entry
+        if entry is not None and entry.transaction_id == transaction_id:
+            self.finalize_history_entry()
 
     def _discard_pending_history_entry(self) -> None:
         self._pending_history_entry = None
@@ -1430,9 +1576,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self._history_group_timer.stop()
 
     def _history_state_snapshot(self) -> ImageSlicerState:
-        state = copy.deepcopy(self.state)
-        state.pop("splitter_sizes", None)
-        return state
+        return copy.deepcopy(self.state)
 
     def next_linked_history_transaction_id(self) -> str:
         if (
@@ -1534,8 +1678,43 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 emit_filter_edited=emit_filter_edited,
             )
 
+    @staticmethod
+    def _is_splitter_history_entry(entry: _history.HistoryEntry) -> bool:
+        return bool(entry.changed_paths) and all(
+            bool(path) and path[0] == "splitter_sizes" for path in entry.changed_paths
+        )
+
+    @staticmethod
+    def _mapped_splitter_history_entry(
+        source_entry: _history.HistoryEntry,
+        current: ImageSlicerState,
+        *,
+        undo: bool,
+    ) -> _history.HistoryEntry:
+        source_state = source_entry.before_state if undo else source_entry.after_state
+        destination = _history.patch_state(
+            current,
+            source_state,
+            source_entry.changed_paths,
+        )
+        if undo:
+            before_state, after_state = destination, copy.deepcopy(current)
+        else:
+            before_state, after_state = copy.deepcopy(current), destination
+        return _history.HistoryEntry(
+            before_state=typing.cast("dict[str, typing.Any]", before_state),
+            after_state=typing.cast("dict[str, typing.Any]", after_state),
+            changed_paths=source_entry.changed_paths,
+            transaction_id=source_entry.transaction_id,
+            created_at=source_entry.created_at,
+        )
+
     def _apply_matching_linked_history_entry(
-        self, transaction_id: str, *, undo: bool
+        self,
+        source_entry: _history.HistoryEntry,
+        source_ndim: int,
+        *,
+        undo: bool,
     ) -> None:
         self.end_history_group()
         stack = self._prev_states if undo else self._next_states
@@ -1543,16 +1722,27 @@ class ImageSlicerArea(QtWidgets.QWidget):
             (
                 candidate
                 for candidate in reversed(stack)
-                if candidate.transaction_id == transaction_id
+                if candidate.transaction_id == source_entry.transaction_id
             ),
             None,
         )
-        if entry is None or not _history.entry_matches_current(
-            entry, self._history_state_snapshot(), undo=undo
-        ):
-            return
-
-        stack.remove(entry)
+        current = self._history_state_snapshot()
+        if entry is None:
+            if (
+                self.data.ndim != source_ndim
+                or not self._is_splitter_history_entry(source_entry)
+                or not _history.entry_matches_current(source_entry, current, undo=undo)
+            ):
+                return
+            entry = self._mapped_splitter_history_entry(
+                source_entry,
+                current,
+                undo=undo,
+            )
+        else:
+            if not _history.entry_matches_current(entry, current, undo=undo):
+                return
+            stack.remove(entry)
         self._apply_history_entry(entry, undo=undo)
         if undo:
             self._next_states.append(entry)
@@ -1563,10 +1753,29 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def _propagate_history_entry(
         self, entry: _history.HistoryEntry, *, undo: bool
     ) -> None:
-        if entry.transaction_id is None or self._linking_proxy is None:
+        if entry.transaction_id is None:
             return
-        for target in tuple(self.linked_slicers):
-            target._apply_matching_linked_history_entry(entry.transaction_id, undo=undo)
+        if self._linking_proxy is not None:
+            for target in tuple(self.linked_slicers):
+                target._apply_matching_linked_history_entry(
+                    entry,
+                    self.data.ndim,
+                    undo=undo,
+                )
+        if any(path and path[0] == "splitter_sizes" for path in entry.changed_paths):
+            self._sync_managed_workspace_link(
+                "_set_linked_splitter_sizes",
+                {
+                    "sizes": self.splitter_sizes,
+                    "source_ndim": self.data.ndim,
+                },
+                tuple(self.data.dims),
+                False,
+                False,
+                False,
+                entry.transaction_id,
+                False,
+            )
 
     @QtCore.Slot()
     def write_state(self) -> None:
@@ -3675,8 +3884,10 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if self.data.ndim == 4:
             full = r0 + r1 - d
             sizes[3] = (full / 4, full / 4, full / 2)
-        for split, sz in zip(self._splitters, sizes, strict=True):
-            split.setSizes(tuple(round(s * scale) for s in sz))
+        splitter_sizes = [[round(size * scale) for size in row] for row in sizes]
+        if self._pending_splitter_sizes is None:
+            self._splitter_layout = copy.deepcopy(splitter_sizes)
+        self._apply_splitter_sizes(splitter_sizes)
 
         for i in range(8):
             visible: bool = i not in invalid
@@ -3722,6 +3933,36 @@ class ImageSlicerArea(QtWidgets.QWidget):
         elif value == self.array_slicer.snap_to_data:
             return
         self.array_slicer.snap_to_data = value
+
+    def eventFilter(
+        self, watched: QtCore.QObject | None, event: QtCore.QEvent | None
+    ) -> bool:
+        if watched in self._splitter_handles and event is not None:
+            if event.type() == QtCore.QEvent.Type.MouseButtonPress:
+                mouse_event = typing.cast("QtGui.QMouseEvent", event)
+                if mouse_event.button() == QtCore.Qt.MouseButton.LeftButton:
+                    self._begin_splitter_move(self._splitter_handles[watched])
+            elif event.type() == QtCore.QEvent.Type.MouseButtonRelease:
+                mouse_event = typing.cast("QtGui.QMouseEvent", event)
+                if mouse_event.button() == QtCore.Qt.MouseButton.LeftButton:
+                    generation = self._splitter_move_generation
+                    erlab.interactive.utils.single_shot(
+                        self,
+                        0,
+                        lambda: self._finish_splitter_move(generation),
+                        watched,
+                    )
+        return super().eventFilter(watched, event)
+
+    def resizeEvent(self, event: QtGui.QResizeEvent | None) -> None:
+        super().resizeEvent(event)
+        if (
+            self._secondary_plots_materialized
+            and self._splitter_layout is not None
+            and self._pending_splitter_sizes is None
+            and not (self._splitter_move_active and self._history_group_active)
+        ):
+            self._apply_splitter_sizes(self._splitter_layout)
 
     def changeEvent(self, evt: QtCore.QEvent | None) -> None:
         if evt is not None and evt.type() == QtCore.QEvent.Type.PaletteChange:

--- a/src/erlab/interactive/imagetool/viewer_linking.py
+++ b/src/erlab/interactive/imagetool/viewer_linking.py
@@ -215,6 +215,19 @@ def link_slicer(
     return my_decorator
 
 
+def apply_splitter_layout(
+    slicers: Iterable[ImageSlicerArea],
+    sizes: list[list[int]],
+    source_ndim: int,
+) -> None:
+    """Apply a layout to compatible slicers outside user history."""
+    for slicer in tuple(slicers):
+        if slicer.data.ndim != source_ndim:
+            continue
+        with slicer.history_neutral():
+            slicer.splitter_sizes = sizes
+
+
 class SlicerLinkProxy:
     """Internal class for handling linked `ImageSlicerArea` s.
 
@@ -224,11 +237,20 @@ class SlicerLinkProxy:
         The slicers to link.
     link_colors
         Whether to sync color related changes, by default `True`.
+    align_splitters
+        Whether compatible slicers should adopt the existing linked layout when joining
+        the link, by default `True`.
 
     """
 
-    def __init__(self, *slicers: ImageSlicerArea, link_colors: bool = True) -> None:
+    def __init__(
+        self,
+        *slicers: ImageSlicerArea,
+        link_colors: bool = True,
+        align_splitters: bool = True,
+    ) -> None:
         self.link_colors = link_colors
+        self._align_splitters = align_splitters
 
         self._children: weakref.WeakSet[ImageSlicerArea] = weakref.WeakSet()
         for s in slicers:
@@ -252,12 +274,34 @@ class SlicerLinkProxy:
             if slicer_area._linking_proxy == self:
                 return
             raise ValueError("Already linked to another proxy.")
+        splitter_source = None
+        if self._align_splitters:
+            splitter_source = next(
+                (
+                    child
+                    for child in self.children
+                    if child.data.ndim == slicer_area.data.ndim
+                ),
+                None,
+            )
         self.children.add(slicer_area)
         slicer_area._linking_proxy = self
+        if splitter_source is not None:
+            self.align_splitter_sizes(splitter_source)
 
     def remove(self, slicer_area: ImageSlicerArea) -> None:
         self.children.remove(slicer_area)
         slicer_area._linking_proxy = None
+
+    def align_splitter_sizes(self, source: ImageSlicerArea) -> None:
+        """Align compatible linked layouts to ``source`` without recording history."""
+        if source not in self.children:
+            raise ValueError("Source is not linked to this proxy.")
+        apply_splitter_layout(
+            self.children,
+            source.splitter_sizes,
+            source.data.ndim,
+        )
 
     def sync(
         self,
@@ -293,6 +337,11 @@ class SlicerLinkProxy:
         if color and not self.link_colors:
             return
         for target in self.children.difference({source}):
+            if (
+                funcname == "_set_linked_splitter_sizes"
+                and target.data.ndim != arguments["source_ndim"]
+            ):
+                continue
             converted_args = self.convert_args(
                 source,
                 target,

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -251,6 +251,61 @@ def test_link_selected_aligns_to_current_imagetool(
             assert not manager.get_imagetool(index).slicer_area.undoable
 
 
+def test_link_selected_aligns_to_current_child_imagetool(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.zeros((5, 5)), dims=("x", "y"))
+        parent = itool(data, manager=False, execute=False)
+        target = itool(data, manager=False, execute=False)
+        child = itool(data, manager=False, execute=False)
+        assert isinstance(parent, erlab.interactive.imagetool.ImageTool)
+        assert isinstance(target, erlab.interactive.imagetool.ImageTool)
+        assert isinstance(child, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(parent, show=False)
+        manager.add_imagetool(target, show=False)
+        child_uid = manager.add_imagetool_child(
+            child,
+            0,
+            show=False,
+            source_spec=full_data(),
+            source_auto_update=True,
+        )
+
+        child_sizes = child.slicer_area.splitter_sizes
+        child_sizes[0] = [300, 100]
+        child.slicer_area.splitter_sizes = child_sizes
+        target_sizes = target.slicer_area.splitter_sizes
+        target_sizes[0] = [100, 300]
+        target.slicer_area.splitter_sizes = target_sizes
+        child.slicer_area.flush_history()
+        target.slicer_area.flush_history()
+
+        select_tools(manager, [1])
+        select_child_tool(manager, child_uid)
+        child_index = manager.tree_view._model._row_index(child_uid)
+        manager.tree_view.selectionModel().setCurrentIndex(
+            child_index,
+            QtCore.QItemSelectionModel.SelectionFlag.NoUpdate,
+        )
+
+        manager.link_selected(deselect=False)
+
+        np.testing.assert_allclose(
+            np.asarray(target.slicer_area.splitter_sizes[0])
+            / sum(target.slicer_area.splitter_sizes[0]),
+            np.asarray(child.slicer_area.splitter_sizes[0])
+            / sum(child.slicer_area.splitter_sizes[0]),
+            atol=0.01,
+        )
+        assert not child.slicer_area.undoable
+        assert not target.slicer_area.undoable
+
+
 def test_link_badge_falls_back_to_live_linker(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -210,6 +210,47 @@ def test_childtool_hover_preview_hides_missing_imageitem_pixmap(
     assert not delegate.preview_popup.isVisible()
 
 
+def test_link_selected_aligns_to_current_imagetool(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for sizes in ([300, 100], [100, 300]):
+            tool = itool(
+                xr.DataArray(np.zeros((5, 5)), dims=("x", "y")),
+                manager=False,
+                execute=False,
+            )
+            assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+            splitter_sizes = tool.slicer_area.splitter_sizes
+            splitter_sizes[0] = list(sizes)
+            tool.slicer_area.splitter_sizes = splitter_sizes
+            tool.slicer_area.flush_history()
+            manager.add_imagetool(tool, show=False)
+
+        select_tools(manager, [0, 1])
+        selection_model = manager.tree_view.selectionModel()
+        selection_model.setCurrentIndex(
+            manager.tree_view._model._row_index(1),
+            QtCore.QItemSelectionModel.SelectionFlag.NoUpdate,
+        )
+        source_sizes = manager.get_imagetool(1).slicer_area._splitters[0].sizes()
+
+        manager.link_selected(deselect=False)
+
+        target_sizes = manager.get_imagetool(0).slicer_area._splitters[0].sizes()
+        np.testing.assert_allclose(
+            np.asarray(target_sizes) / sum(target_sizes),
+            np.asarray(source_sizes) / sum(source_sizes),
+            atol=0.01,
+        )
+        for index in (0, 1):
+            assert not manager.get_imagetool(index).slicer_area.undoable
+
+
 def test_link_badge_falls_back_to_live_linker(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -18,6 +18,7 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._loading as workspace_loading
 import erlab.interactive.imagetool.manager._workspace._pending as workspace_pending
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.viewer_linking as imagetool_viewer_linking
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._model import FileDataSelection, full_data
@@ -310,6 +311,74 @@ def test_link_selected_uses_pending_current_imagetool_layout(
         assert not target.undoable
 
 
+@pytest.mark.parametrize("materialize_target", [False, True])
+def test_link_imagetools_handles_missing_pending_source_layout(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    materialize_target: bool,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for offset in (0, 100):
+            root = itool(
+                xr.DataArray(
+                    np.arange(offset, offset + 25).reshape((5, 5)),
+                    dims=("x", "y"),
+                ),
+                manager=False,
+                execute=False,
+            )
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+            root.hide()
+
+        fname = tmp_path / "missing-pending-source-layout.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        wrappers = [manager._tool_graph.root_wrappers[index] for index in range(2)]
+        wrappers[0].update_pending_workspace_payload_attrs({"itool_state": "{"})
+        target = manager.get_imagetool(1).slicer_area if materialize_target else None
+        expected_sizes = target.splitter_sizes if target is not None else None
+        apply_calls: list[
+            tuple[
+                tuple[erlab.interactive.imagetool.ImageSlicerArea, ...],
+                list[list[int]],
+                int,
+            ]
+        ] = []
+        original_apply = imagetool_viewer_linking.apply_splitter_layout
+
+        def record_apply(slicers, sizes, source_ndim) -> None:
+            slicers = tuple(slicers)
+            apply_calls.append((slicers, sizes, source_ndim))
+            original_apply(slicers, sizes, source_ndim)
+
+        monkeypatch.setattr(
+            imagetool_viewer_linking, "apply_splitter_layout", record_apply
+        )
+
+        manager.link_imagetools(0, 1, link_colors=False)
+
+        assert wrappers[0].workspace_link_key == wrappers[1].workspace_link_key
+        if target is None:
+            assert apply_calls == []
+        else:
+            assert len(apply_calls) == 1
+            slicers, sizes, source_ndim = apply_calls[0]
+            assert slicers == (target,)
+            assert sizes == expected_sizes
+            assert source_ndim == target.data.ndim
+
+
 def test_materializing_restored_link_preserves_saved_layouts(
     qtbot,
     tmp_path,
@@ -400,6 +469,30 @@ def test_pending_link_state_operation_variants_update_saved_state(
 
         array_slicer, state = new_state()
         try:
+            assert not loader.pending._update_pending_link_state_for_operation(
+                state,
+                array_slicer,
+                source,
+                "_set_linked_splitter_sizes",
+                {"sizes": [[1, 2]], "source_ndim": data.ndim + 1},
+            )
+            assert not loader.pending._update_pending_link_state_for_operation(
+                state,
+                array_slicer,
+                source,
+                "_set_linked_splitter_sizes",
+                {"sizes": ((1, 2),), "source_ndim": data.ndim},
+            )
+            splitter_sizes = [[1, 2]]
+            assert loader.pending._update_pending_link_state_for_operation(
+                state,
+                array_slicer,
+                source,
+                "_set_linked_splitter_sizes",
+                {"sizes": splitter_sizes, "source_ndim": data.ndim},
+            )
+            assert state["splitter_sizes"] == splitter_sizes
+            assert state["splitter_sizes"] is not splitter_sizes
             assert not loader.pending._update_pending_link_state_for_operation(
                 state, array_slicer, source, "refresh", {}
             )
@@ -960,6 +1053,77 @@ def test_pending_workspace_saved_dim_order_handles_invalid_state(monkeypatch) ->
         )
         is data
     )
+
+
+@pytest.mark.parametrize(
+    "raw_state",
+    [
+        b"\xff",
+        1,
+        "{",
+        "[]",
+        "{}",
+        json.dumps({"slice": {"dims": "xy"}, "splitter_sizes": []}),
+        json.dumps({"slice": {"dims": ["x"]}, "splitter_sizes": [["bad"]]}),
+        json.dumps({"slice": {"dims": ["x"]}, "splitter_sizes": [[1], "bad"]}),
+    ],
+    ids=[
+        "invalid-utf8",
+        "non-string",
+        "invalid-json",
+        "non-mapping",
+        "missing-layout",
+        "invalid-dims",
+        "invalid-size",
+        "invalid-row",
+    ],
+)
+def test_pending_workspace_splitter_layout_rejects_invalid_state(
+    raw_state: typing.Any,
+) -> None:
+    node = types.SimpleNamespace(
+        pending_workspace_payload_attrs={"itool_state": raw_state}
+    )
+
+    assert (
+        workspace_pending._PendingWorkspacePayloads._pending_workspace_splitter_layout(
+            node
+        )
+        is None
+    )
+
+
+def test_pending_workspace_splitter_layout_update_validates_destination() -> None:
+    class PendingNode:
+        def __init__(self, state: typing.Any) -> None:
+            self.attrs = {"itool_state": json.dumps(state)}
+            self.cache_clear_count = 0
+
+        @property
+        def pending_workspace_payload_attrs(self) -> dict[str, typing.Any]:
+            return dict(self.attrs)
+
+        def update_pending_workspace_payload_attrs(
+            self, attrs: dict[str, typing.Any]
+        ) -> None:
+            self.attrs = dict(attrs)
+
+        def _clear_pending_workspace_link_slicer_cache(self) -> None:
+            self.cache_clear_count += 1
+
+    pending_cls = workspace_pending._PendingWorkspacePayloads
+    node = PendingNode({"slice": [], "splitter_sizes": [[1, 2]]})
+    assert not pending_cls._set_pending_workspace_splitter_layout(node, [[2, 1]], 2)
+
+    node = PendingNode({"slice": {"dims": ["x"]}, "splitter_sizes": [[1, 2]]})
+    assert not pending_cls._set_pending_workspace_splitter_layout(node, [[2, 1]], 2)
+    assert not pending_cls._set_pending_workspace_splitter_layout(node, [[1, 2]], 1)
+
+    sizes = [[2, 1]]
+    assert pending_cls._set_pending_workspace_splitter_layout(node, sizes, 1)
+    sizes[0][0] = 99
+    assert json.loads(node.attrs["itool_state"])["splitter_sizes"] == [[2, 1]]
+    assert node.cache_clear_count == 1
 
 
 def test_pending_workspace_source_data_decodes_saved_state_attrs(

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -11,7 +11,7 @@ import h5py
 import numpy as np
 import pytest
 import xarray as xr
-from qtpy import QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
@@ -150,6 +150,218 @@ def test_manager_save_updates_pending_linked_partner_state(
         )
         reloaded_partner = manager.get_imagetool(1).slicer_area
         assert reloaded_partner.array_slicer.get_index(0, 0) == 3
+
+
+def test_pending_linked_splitter_sizes_follow_undo_redo(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for offset in (0, 100):
+            data = xr.DataArray(
+                np.arange(offset, offset + 25, dtype=np.float64).reshape((5, 5)),
+                dims=("x", "y"),
+            )
+            root = itool(data, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+            root.hide()
+        manager.link_imagetools(0, 1, link_colors=False)
+
+        fname = tmp_path / "pending-linked-splitters.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        wrappers = [manager._tool_graph.root_wrappers[index] for index in range(2)]
+        loaded = manager.get_imagetool(0).slicer_area
+        loaded.flush_history()
+        pending_attrs = wrappers[1].pending_workspace_payload_attrs
+        assert pending_attrs is not None
+        initial_sizes = json.loads(pending_attrs["itool_state"])["splitter_sizes"]
+        changed_sizes = [[300, 100], *loaded.splitter_sizes[1:]]
+
+        loaded._set_linked_splitter_sizes(changed_sizes, loaded.data.ndim)
+
+        def pending_sizes() -> list[list[int]]:
+            attrs = wrappers[1].pending_workspace_payload_attrs
+            assert attrs is not None
+            return json.loads(attrs["itool_state"])["splitter_sizes"]
+
+        def proportions(sizes: list[int]) -> np.ndarray:
+            return np.asarray(sizes) / sum(sizes)
+
+        np.testing.assert_allclose(
+            proportions(pending_sizes()[0]), proportions(changed_sizes[0])
+        )
+        assert wrappers[1].pending_workspace_memory_payload is not None
+
+        loaded.undo()
+        np.testing.assert_allclose(
+            proportions(pending_sizes()[0]),
+            proportions(initial_sizes[0]),
+            atol=0.001,
+        )
+
+        loaded.redo()
+        np.testing.assert_allclose(
+            proportions(pending_sizes()[0]),
+            proportions(changed_sizes[0]),
+            atol=0.001,
+        )
+
+        partner = manager.get_imagetool(1).slicer_area
+        loaded.undo()
+        for area in (loaded, partner):
+            np.testing.assert_allclose(
+                proportions(area.splitter_sizes[0]),
+                proportions(initial_sizes[0]),
+                atol=0.001,
+            )
+        assert partner.redoable
+
+        partner.redo()
+        for area in (loaded, partner):
+            np.testing.assert_allclose(
+                proportions(area.splitter_sizes[0]),
+                proportions(changed_sizes[0]),
+                atol=0.001,
+            )
+
+
+@pytest.mark.parametrize("materialize_target_before_link", [False, True])
+def test_link_selected_uses_pending_current_imagetool_layout(
+    qtbot,
+    tmp_path,
+    materialize_target_before_link: bool,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for sizes in ([300, 100], [100, 300]):
+            root = itool(
+                xr.DataArray(np.zeros((5, 5)), dims=("x", "y")),
+                manager=False,
+                execute=False,
+            )
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            splitter_sizes = root.slicer_area.splitter_sizes
+            splitter_sizes[0] = list(sizes)
+            root.slicer_area.splitter_sizes = splitter_sizes
+            manager.add_imagetool(root, show=False)
+            root.hide()
+
+        fname = tmp_path / "pending-link-layout-source.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        wrappers = [manager._tool_graph.root_wrappers[index] for index in range(2)]
+        source_attrs = wrappers[1].pending_workspace_payload_attrs
+        assert source_attrs is not None
+        expected_sizes = json.loads(source_attrs["itool_state"])["splitter_sizes"][0]
+        target = (
+            manager.get_imagetool(0).slicer_area
+            if materialize_target_before_link
+            else None
+        )
+
+        select_tools(manager, [0, 1])
+        manager.tree_view.selectionModel().setCurrentIndex(
+            manager.tree_view._model._row_index(1),
+            QtCore.QItemSelectionModel.SelectionFlag.NoUpdate,
+        )
+        manager.link_selected(deselect=False)
+
+        for wrapper in wrappers:
+            updated_attrs = wrapper.pending_workspace_payload_attrs
+            if updated_attrs is None:
+                continue
+            updated_sizes = json.loads(updated_attrs["itool_state"])["splitter_sizes"][
+                0
+            ]
+            np.testing.assert_allclose(
+                np.asarray(updated_sizes) / sum(updated_sizes),
+                np.asarray(expected_sizes) / sum(expected_sizes),
+                atol=0.01,
+            )
+
+        if target is None:
+            target = manager.get_imagetool(0).slicer_area
+        actual_sizes = target.splitter_sizes[0]
+        np.testing.assert_allclose(
+            np.asarray(actual_sizes) / sum(actual_sizes),
+            np.asarray(expected_sizes) / sum(expected_sizes),
+            atol=0.01,
+        )
+        assert wrappers[1].pending_workspace_memory_payload is not None
+        assert not target.undoable
+
+
+def test_materializing_restored_link_preserves_saved_layouts(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for sizes in ([300, 100], [100, 300]):
+            root = itool(
+                xr.DataArray(np.zeros((5, 5)), dims=("x", "y")),
+                manager=False,
+                execute=False,
+            )
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+            splitter_sizes = root.slicer_area.splitter_sizes
+            splitter_sizes[0] = list(sizes)
+            root.slicer_area.splitter_sizes = splitter_sizes
+            root.hide()
+        manager.link_imagetools(0, 1)
+
+        # Linked tools saved before splitter synchronization could retain distinct
+        # layouts. Recreate that valid legacy state without propagating the assignment.
+        for index, sizes in enumerate(([300, 100], [100, 300])):
+            area = manager.get_imagetool(index).slicer_area
+            splitter_sizes = area.splitter_sizes
+            splitter_sizes[0] = list(sizes)
+            area.splitter_sizes = splitter_sizes
+
+        fname = tmp_path / "restored-linked-layouts.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        wrappers = [manager._tool_graph.root_wrappers[index] for index in range(2)]
+        expected_sizes = []
+        for wrapper in wrappers:
+            attrs = wrapper.pending_workspace_payload_attrs
+            assert attrs is not None
+            expected_sizes.append(json.loads(attrs["itool_state"])["splitter_sizes"])
+
+        areas = [manager.get_imagetool(index).slicer_area for index in range(2)]
+
+        assert areas[0].is_linked
+        assert areas[1].is_linked
+        assert areas[0].splitter_sizes == expected_sizes[0]
+        assert areas[1].splitter_sizes == expected_sizes[1]
 
 
 def test_pending_link_state_operation_variants_update_saved_state(

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -131,11 +131,17 @@ def test_history_value_formatting_handles_edge_values() -> None:
     assert _history._format_value(long_text) == f"{long_text[:93]}..."
 
 
-def test_changed_paths_ignores_splitter_sizes() -> None:
+def test_changed_paths_includes_splitter_sizes() -> None:
     before = {"splitter_sizes": [1, 2], "value": 1}
     after = {"splitter_sizes": [3, 4], "value": 2}
 
-    assert _history.changed_paths(before, after) == frozenset({("value",)})
+    assert _history.changed_paths(before, after) == frozenset(
+        {
+            ("splitter_sizes", 0),
+            ("splitter_sizes", 1),
+            ("value",),
+        }
+    )
 
 
 @pytest.mark.parametrize(
@@ -402,6 +408,17 @@ def test_describe_state_change_reports_axis_inversions():
 
     assert label == "Axis inversion changed"
     assert details == ("Axis inversion changed",)
+
+
+def test_describe_state_change_reports_plot_layout() -> None:
+    prev = _base_state()
+    curr = copy.deepcopy(prev)
+    curr["splitter_sizes"] = [[200, 100]]
+
+    label, details = _history.describe_state_change(prev, curr)
+
+    assert label == "Plot layout changed"
+    assert details == ("Plot layout proportions changed",)
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -6005,6 +6005,48 @@ def test_splitter_click_does_not_replace_constrained_layout(qtbot) -> None:
     win.close()
 
 
+def test_splitter_mouse_ungrab_finishes_move(qtbot) -> None:
+    win = ImageTool(
+        xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=("x", "y"))
+    )
+    qtbot.addWidget(win)
+    win.resize(900, 900)
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    initial_layout = copy.deepcopy(area.splitter_sizes)
+    area.flush_history()
+    splitter = area._splitters[0]
+    handle = splitter.handle(1)
+    center = handle.rect().center()
+    start_position = splitter.sizes()[0]
+
+    QtTest.QTest.mousePress(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    splitter.moveSplitter(start_position + 40, 1)
+    QtWidgets.QApplication.sendEvent(
+        handle, QtCore.QEvent(QtCore.QEvent.Type.UngrabMouse)
+    )
+    qtbot.wait_until(lambda: not area._splitter_move_active)
+
+    assert not area._history_group_active
+    assert len(area._prev_states) == 1
+    assert all(
+        path and path[0] == "splitter_sizes"
+        for path in area._prev_states[-1].changed_paths
+    )
+    moved_layout = copy.deepcopy(area.splitter_sizes)
+    assert moved_layout != initial_layout
+
+    area.undo()
+    assert area.splitter_sizes == initial_layout
+    area.redo()
+    assert area.splitter_sizes == moved_layout
+
+    QtTest.QTest.mouseRelease(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    win.close()
+
+
 def test_splitter_no_net_drag_does_not_replace_constrained_layout(qtbot) -> None:
     win = ImageTool(
         xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=("x", "y"))

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5774,6 +5774,41 @@ def _apply_constrained_splitter_geometry(qtbot, area, splitter_index: int = 0) -
     )
 
 
+def test_window_resize_preserves_splitter_layout_without_reapplying_sizes(
+    qtbot, monkeypatch
+) -> None:
+    win = ImageTool(
+        xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=("x", "y"))
+    )
+    qtbot.addWidget(win)
+    win.resize(600, 700)
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    requested_layout = copy.deepcopy(area.splitter_sizes)
+    requested_layout[0] = [300, 100]
+    area.splitter_sizes = requested_layout
+    initial_proportions = _realized_splitter_proportions(area)
+    previous_total = sum(area._splitters[0].sizes())
+    apply_calls: list[list[list[int]]] = []
+    monkeypatch.setattr(
+        area,
+        "_apply_splitter_sizes",
+        lambda sizes: apply_calls.append(copy.deepcopy(sizes)),
+    )
+
+    win.resize(900, 900)
+    qtbot.wait_until(lambda: sum(area._splitters[0].sizes()) != previous_total)
+
+    assert apply_calls == []
+    for actual, expected in zip(
+        _realized_splitter_proportions(area), initial_proportions, strict=True
+    ):
+        np.testing.assert_allclose(actual, expected, atol=0.03)
+    win.close()
+
+
 @pytest.mark.parametrize("opaque_resize", [True, False])
 def test_linked_manual_splitter_move_undo_redo(qtbot, opaque_resize: bool) -> None:
     win0, win1 = _linked_pair(qtbot)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5971,6 +5971,7 @@ def test_linked_splitter_fallback_history_preserves_other_rows(qtbot) -> None:
     assert target.splitter_sizes[0] == initial_layout[0]
     assert target.splitter_sizes[1] == target_layout[1]
 
+    target._next_states.clear()
     source.redo()
     assert target.splitter_sizes[0] == moved_layout[0]
     assert target.splitter_sizes[1] == target_layout[1]
@@ -6116,6 +6117,63 @@ def test_discarded_history_group_cancels_splitter_commit(qtbot) -> None:
     win.close()
 
 
+def test_splitter_finish_ignores_stale_release_and_cleans_uninitialized_move(
+    qtbot,
+) -> None:
+    win = ImageTool(
+        xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=("x", "y"))
+    )
+    qtbot.addWidget(win)
+    win.resize(900, 900)
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    area._finish_splitter_move()
+    area._begin_splitter_move(0)
+    stale_generation = area._splitter_move_generation
+    area._begin_splitter_move(0)
+
+    area._finish_splitter_move(stale_generation)
+    assert area._splitter_move_active
+
+    area._finish_splitter_move()
+    assert not area._splitter_move_active
+
+    area._splitter_layout = None
+    area._pending_splitter_sizes = None
+    splitter = area._splitters[0]
+    area._begin_splitter_move(0)
+    splitter.moveSplitter(splitter.sizes()[0] + 20, 1)
+    area._discard_pending_history_entry()
+
+    area._finish_splitter_move()
+
+    assert not area._splitter_move_active
+    assert area._splitter_move_indices == ()
+    assert area._splitter_move_start_sizes is None
+    win.close()
+
+
+def test_splitter_event_filter_ignores_unrelated_and_non_left_events(qtbot) -> None:
+    win = ImageTool(
+        xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=("x", "y"))
+    )
+    qtbot.addWidget(win)
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    assert not area.eventFilter(None, None)
+    handle = area._splitters[0].handle(1)
+    center = handle.rect().center()
+
+    QtTest.QTest.mousePress(handle, QtCore.Qt.MouseButton.RightButton, pos=center)
+    assert not area._splitter_move_active
+    QtTest.QTest.mouseRelease(handle, QtCore.Qt.MouseButton.RightButton, pos=center)
+    win.close()
+
+
 def test_linked_splitters_skip_incompatible_dimensions(qtbot) -> None:
     data2d = xr.DataArray(np.zeros((5, 5)), dims=("x", "y"))
     data3d = xr.DataArray(np.zeros((5, 5, 5)), dims=("x", "y", "z"))
@@ -6127,6 +6185,10 @@ def test_linked_splitters_skip_incompatible_dimensions(qtbot) -> None:
         win.slicer_area.flush_history()
 
     original_sizes = win3d.slicer_area.splitter_sizes
+    with win3d.slicer_area.link_sync_suppressed():
+        win3d.slicer_area._set_linked_splitter_sizes(
+            win2d.slicer_area.splitter_sizes, 2
+        )
     win2d.slicer_area._set_linked_splitter_sizes(
         [[300, 100], *win2d.slicer_area.splitter_sizes[1:]], 2
     )
@@ -6134,7 +6196,52 @@ def test_linked_splitters_skip_incompatible_dimensions(qtbot) -> None:
     assert win3d.slicer_area.splitter_sizes == original_sizes
     assert not win3d.slicer_area.undoable
 
+    win2d.slicer_area.undo()
+    assert win3d.slicer_area.splitter_sizes == original_sizes
+
     win2d.slicer_area.unlink()
+    win2d.close()
+    win3d.close()
+
+
+def test_splitter_layout_helpers_skip_incompatible_targets(qtbot) -> None:
+    win2d = ImageTool(xr.DataArray(np.zeros((5, 5)), dims=("x", "y")))
+    win3d = ImageTool(xr.DataArray(np.zeros((5, 5, 5)), dims=("x", "y", "z")))
+    for win in (win2d, win3d):
+        qtbot.addWidget(win)
+        with qtbot.waitExposed(win):
+            win.show()
+        win.slicer_area.flush_history()
+
+    area2d = win2d.slicer_area
+    area3d = win3d.slicer_area
+    area2d._pending_splitter_sizes = None
+    area2d._splitter_layout = None
+    realized_layout = [splitter.sizes() for splitter in area2d._splitters]
+    assert area2d.splitter_sizes == realized_layout
+    assert area2d._capture_splitter_layout((0,)) == realized_layout
+
+    requested_layout = copy.deepcopy(realized_layout)
+    requested_layout[0] = list(reversed(requested_layout[0]))
+    incompatible_layout = copy.deepcopy(area3d.splitter_sizes)
+    imagetool_viewer_linking.apply_splitter_layout(
+        (area2d, area3d),
+        requested_layout,
+        area2d.data.ndim,
+    )
+
+    assert area2d.splitter_sizes == requested_layout
+    assert area3d.splitter_sizes == incompatible_layout
+    assert not area2d.undoable
+    assert not area3d.undoable
+
+    proxy = imagetool_viewer_linking.SlicerLinkProxy(
+        area2d,
+        align_splitters=False,
+    )
+    with pytest.raises(ValueError, match="Source is not linked"):
+        proxy.align_splitter_sizes(area3d)
+    proxy.unlink_all()
     win2d.close()
     win3d.close()
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -17,7 +17,7 @@ import xarray as xr
 import xarray.testing
 import xarray_lmfit
 from numpy.testing import assert_almost_equal
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtTest, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool._highdim as imagetool_highdim
@@ -25,6 +25,7 @@ import erlab.interactive.imagetool._itool as itool_mod
 import erlab.interactive.imagetool._mainwindow as imagetool_mainwindow
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._server as imagetool_manager_server
+import erlab.interactive.imagetool.viewer_linking as imagetool_viewer_linking
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state
 from erlab.interactive._figurecomposer import (
     FigureDataSelectionState,
@@ -2768,6 +2769,41 @@ def test_lazy_secondary_restore_repairs_malformed_2d_profile_splitter(qtbot) -> 
     profile_x, profile_y = vertical_profile.slicer_data_items[0].getData()
     assert len(profile_x) > 0
     assert len(profile_y) > 0
+    restored.close()
+
+
+def test_deferred_materialized_resize_waits_for_pending_splitter_restore(
+    qtbot,
+) -> None:
+    data = xr.DataArray(np.arange(30.0).reshape(5, 6), dims=("y", "x"))
+    source = ImageTool(data, _in_manager=True)
+    qtbot.addWidget(source)
+    saved_state = copy.deepcopy(source.slicer_area.state)
+    source.close()
+    saved_state["splitter_sizes"].pop()
+
+    restored = ImageTool(
+        data,
+        _in_manager=True,
+        _defer_secondary_plots=True,
+        state=saved_state,
+    )
+    qtbot.addWidget(restored)
+    restored_area = restored.slicer_area
+
+    # Materialize while hidden, leaving the malformed saved layout pending until show.
+    restored_area.get_axes(2)
+    assert restored_area._pending_splitter_sizes == saved_state["splitter_sizes"]
+
+    restored.resize(900, 600)
+    restored.show()
+    qtbot.waitExposed(restored)
+    qtbot.wait_until(
+        lambda: restored_area._pending_splitter_sizes is None,
+        timeout=5000,
+    )
+
+    assert len(restored_area.splitter_sizes) == len(restored_area._splitters)
     restored.close()
 
 
@@ -5695,6 +5731,404 @@ def _linked_pair_with_different_x_grids(qtbot):
     for win in wins:
         qtbot.addWidget(win)
     return typing.cast("list[ImageTool]", wins)
+
+
+def _splitter_proportions(area) -> list[list[float]]:
+    proportions: list[list[float]] = []
+    for sizes in area.splitter_sizes:
+        total = sum(sizes)
+        proportions.append(
+            [size / total for size in sizes] if total else [0.0] * len(sizes)
+        )
+    return proportions
+
+
+def _realized_splitter_proportions(area) -> list[list[float]]:
+    proportions: list[list[float]] = []
+    for splitter in area._splitters:
+        sizes = splitter.sizes()
+        total = sum(sizes)
+        proportions.append(
+            [size / total for size in sizes] if total else [0.0] * len(sizes)
+        )
+    return proportions
+
+
+def _apply_constrained_splitter_geometry(qtbot, area, splitter_index: int = 0) -> None:
+    """Force Qt geometry away from the canonical layout without changing it."""
+    canonical_proportions = _splitter_proportions(area)[splitter_index]
+    constrained_layout = copy.deepcopy(area.splitter_sizes)
+    constrained_layout[splitter_index] = (
+        [1, 1000] if canonical_proportions[0] >= 0.5 else [1000, 1]
+    )
+    area._apply_splitter_sizes(constrained_layout)
+    qtbot.wait_until(
+        lambda: (
+            not np.allclose(
+                _realized_splitter_proportions(area)[splitter_index],
+                _splitter_proportions(area)[splitter_index],
+                rtol=0.0,
+                atol=0.05,
+            )
+        )
+    )
+
+
+@pytest.mark.parametrize("opaque_resize", [True, False])
+def test_linked_manual_splitter_move_undo_redo(qtbot, opaque_resize: bool) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    win0.resize(480, 520)
+    win1.resize(760, 650)
+    for win in (win0, win1):
+        with qtbot.waitExposed(win):
+            win.show()
+        win.slicer_area.flush_history()
+
+    initial_proportions = [
+        _realized_splitter_proportions(win.slicer_area) for win in (win0, win1)
+    ]
+    splitter = win0.slicer_area._splitters[0]
+    splitter.setOpaqueResize(opaque_resize)
+    handle = splitter.handle(1)
+    center = handle.rect().center()
+    QtTest.QTest.mousePress(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    for offset in (10, 20, 30, 40):
+        QtTest.QTest.mouseMove(handle, center + QtCore.QPoint(0, offset), delay=1)
+    QtTest.QTest.mouseRelease(
+        handle,
+        QtCore.Qt.MouseButton.LeftButton,
+        pos=center + QtCore.QPoint(0, 40),
+    )
+    qtbot.wait_until(lambda: not win0.slicer_area._splitter_move_active)
+
+    for win in (win0, win1):
+        assert len(win.slicer_area._prev_states) == 1
+        assert all(
+            path and path[0] == "splitter_sizes"
+            for path in win.slicer_area._prev_states[-1].changed_paths
+        )
+        assert {path[1] for path in win.slicer_area._prev_states[-1].changed_paths} == {
+            0
+        }
+    assert (
+        win0.slicer_area._prev_states[-1].transaction_id
+        == win1.slicer_area._prev_states[-1].transaction_id
+    )
+    moved_proportions = [
+        _realized_splitter_proportions(win.slicer_area) for win in (win0, win1)
+    ]
+    for source, target in zip(moved_proportions[0], moved_proportions[1], strict=True):
+        np.testing.assert_allclose(source, target, atol=0.03)
+
+    previous_total = sum(win1.slicer_area._splitters[0].sizes())
+    win1.resize(760, 850)
+    qtbot.wait_until(
+        lambda: sum(win1.slicer_area._splitters[0].sizes()) != previous_total
+    )
+    for actual, expected in zip(
+        _realized_splitter_proportions(win1.slicer_area),
+        moved_proportions[1],
+        strict=True,
+    ):
+        np.testing.assert_allclose(actual, expected, atol=0.03)
+
+    win0.slicer_area.undo()
+    for actual, expected in zip(
+        (win0.slicer_area, win1.slicer_area),
+        initial_proportions,
+        strict=True,
+    ):
+        for source, target in zip(
+            _realized_splitter_proportions(actual), expected, strict=True
+        ):
+            np.testing.assert_allclose(source, target, atol=0.03)
+
+    win0.slicer_area.redo()
+    for actual, expected in zip(
+        (win0.slicer_area, win1.slicer_area),
+        moved_proportions,
+        strict=True,
+    ):
+        for source, target in zip(
+            _realized_splitter_proportions(actual), expected, strict=True
+        ):
+            np.testing.assert_allclose(source, target, atol=0.03)
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_splitter_history_survives_constrained_peer_geometry(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    win0.resize(600, 700)
+    win1.resize(900, 900)
+    for win in (win0, win1):
+        with qtbot.waitExposed(win):
+            win.show()
+        win.slicer_area.flush_history()
+
+    initial_layouts = [
+        copy.deepcopy(win.slicer_area.splitter_sizes) for win in (win0, win1)
+    ]
+    splitter = win0.slicer_area._splitters[0]
+    handle = splitter.handle(1)
+    center = handle.rect().center()
+    QtTest.QTest.mousePress(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    QtTest.QTest.mouseMove(handle, center + QtCore.QPoint(0, 40), delay=1)
+    QtTest.QTest.mouseRelease(
+        handle,
+        QtCore.Qt.MouseButton.LeftButton,
+        pos=center + QtCore.QPoint(0, 40),
+    )
+    qtbot.wait_until(lambda: not win0.slicer_area._splitter_move_active)
+    moved_layouts = [
+        copy.deepcopy(win.slicer_area.splitter_sizes) for win in (win0, win1)
+    ]
+
+    _apply_constrained_splitter_geometry(qtbot, win1.slicer_area)
+
+    win0.slicer_area.undo()
+
+    assert win0.slicer_area.splitter_sizes == initial_layouts[0]
+    assert win1.slicer_area.splitter_sizes == initial_layouts[1]
+    assert win1.slicer_area.redoable
+
+    qtbot.wait_until(
+        lambda: np.allclose(
+            _realized_splitter_proportions(win1.slicer_area)[0],
+            _splitter_proportions(win1.slicer_area)[0],
+            rtol=0.0,
+            atol=0.03,
+        )
+    )
+
+    win0.slicer_area.redo()
+
+    assert win0.slicer_area.splitter_sizes == moved_layouts[0]
+    assert win1.slicer_area.splitter_sizes == moved_layouts[1]
+
+    win0.slicer_area.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_linked_splitter_fallback_history_preserves_other_rows(qtbot) -> None:
+    win0, win1 = _linked_pair(qtbot)
+    source = win0.slicer_area
+    target = win1.slicer_area
+    for area in (source, target):
+        area.flush_history()
+
+    initial_layout = copy.deepcopy(source.splitter_sizes)
+    moved_layout = copy.deepcopy(initial_layout)
+    moved_layout[0] = list(reversed(moved_layout[0]))
+    source._set_linked_splitter_sizes(moved_layout, source.data.ndim)
+
+    # Simulate a linked workspace peer materialized after the original gesture:
+    # its state is synchronized, but it has no matching history transaction.
+    target.flush_history()
+    target_layout = copy.deepcopy(target.splitter_sizes)
+    target_layout[1] = list(reversed(target_layout[1]))
+    target.splitter_sizes = target_layout
+
+    source.undo()
+    assert target.splitter_sizes[0] == initial_layout[0]
+    assert target.splitter_sizes[1] == target_layout[1]
+
+    source.redo()
+    assert target.splitter_sizes[0] == moved_layout[0]
+    assert target.splitter_sizes[1] == target_layout[1]
+
+    source.unlink()
+    win0.close()
+    win1.close()
+
+
+def test_splitter_click_does_not_replace_constrained_layout(qtbot) -> None:
+    win = ImageTool(
+        xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=("x", "y"))
+    )
+    qtbot.addWidget(win)
+    win.resize(900, 900)
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    requested_layout = copy.deepcopy(area.splitter_sizes)
+    _apply_constrained_splitter_geometry(qtbot, area)
+    area.flush_history()
+
+    handle = area._splitters[0].handle(1)
+    center = handle.rect().center()
+    QtTest.QTest.mousePress(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    QtTest.QTest.mouseRelease(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    qtbot.wait_until(lambda: not area._splitter_move_active)
+
+    assert area.splitter_sizes == requested_layout
+    assert not area.undoable
+    win.close()
+
+
+def test_splitter_no_net_drag_does_not_replace_constrained_layout(qtbot) -> None:
+    win = ImageTool(
+        xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=("x", "y"))
+    )
+    qtbot.addWidget(win)
+    win.resize(900, 900)
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    requested_layout = copy.deepcopy(area.splitter_sizes)
+    _apply_constrained_splitter_geometry(qtbot, area)
+    area.flush_history()
+
+    splitter = area._splitters[0]
+    handle = splitter.handle(1)
+    center = handle.rect().center()
+    start_position = splitter.sizes()[0]
+    QtTest.QTest.mousePress(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    splitter.moveSplitter(start_position + 20, 1)
+    splitter.moveSplitter(start_position, 1)
+    QtTest.QTest.mouseRelease(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    qtbot.wait_until(lambda: not area._splitter_move_active)
+
+    assert area.splitter_sizes == requested_layout
+    assert not area.undoable
+    win.close()
+
+
+def test_discarded_history_group_cancels_splitter_commit(qtbot) -> None:
+    win = ImageTool(
+        xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=("x", "y"))
+    )
+    qtbot.addWidget(win)
+    win.resize(900, 900)
+    with qtbot.waitExposed(win):
+        win.show()
+
+    area = win.slicer_area
+    requested_layout = copy.deepcopy(area.splitter_sizes)
+    area.flush_history()
+    splitter = area._splitters[0]
+    handle = splitter.handle(1)
+    center = handle.rect().center()
+    start_position = splitter.sizes()[0]
+
+    QtTest.QTest.mousePress(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    splitter.moveSplitter(start_position + 40, 1)
+    QtTest.QTest.mouseRelease(handle, QtCore.Qt.MouseButton.LeftButton, pos=center)
+    win.close()
+    qtbot.wait_until(lambda: not area._splitter_move_active)
+
+    assert area.splitter_sizes == requested_layout
+    assert not area.undoable
+
+    win.resize(760, 760)
+    with qtbot.waitExposed(win):
+        win.show()
+    qtbot.wait_until(
+        lambda: np.allclose(
+            _realized_splitter_proportions(area)[0],
+            _splitter_proportions(area)[0],
+            rtol=0.0,
+            atol=0.03,
+        )
+    )
+    win.close()
+
+
+def test_linked_splitters_skip_incompatible_dimensions(qtbot) -> None:
+    data2d = xr.DataArray(np.zeros((5, 5)), dims=("x", "y"))
+    data3d = xr.DataArray(np.zeros((5, 5, 5)), dims=("x", "y", "z"))
+    wins = itool([data2d, data3d], execute=False, link=True)
+    assert isinstance(wins, list)
+    win2d, win3d = wins
+    for win in wins:
+        qtbot.addWidget(win)
+        win.slicer_area.flush_history()
+
+    original_sizes = win3d.slicer_area.splitter_sizes
+    win2d.slicer_area._set_linked_splitter_sizes(
+        [[300, 100], *win2d.slicer_area.splitter_sizes[1:]], 2
+    )
+
+    assert win3d.slicer_area.splitter_sizes == original_sizes
+    assert not win3d.slicer_area.undoable
+
+    win2d.slicer_area.unlink()
+    win2d.close()
+    win3d.close()
+
+
+def test_incrementally_linked_splitters_align_to_existing_layout(qtbot) -> None:
+    data = xr.DataArray(np.zeros((5, 5)), dims=("x", "y"))
+    source = ImageTool(data)
+    target = ImageTool(data)
+    for win in (source, target):
+        qtbot.addWidget(win)
+
+    source_layout = source.slicer_area.splitter_sizes
+    source_layout[0] = [300, 100]
+    source.slicer_area.splitter_sizes = source_layout
+    target_layout = target.slicer_area.splitter_sizes
+    target_layout[0] = [100, 300]
+    target.slicer_area.splitter_sizes = target_layout
+    for win in (source, target):
+        win.slicer_area.flush_history()
+
+    proxy = imagetool_viewer_linking.SlicerLinkProxy(source.slicer_area)
+    target.slicer_area.link(proxy)
+
+    assert target.slicer_area.splitter_sizes == source.slicer_area.splitter_sizes
+    assert not source.slicer_area.undoable
+    assert not target.slicer_area.undoable
+
+    proxy.unlink_all()
+    source.close()
+    target.close()
+
+
+def test_link_alignment_is_neutral_to_pending_history(qtbot) -> None:
+    data = xr.DataArray(np.zeros((5, 5)), dims=("x", "y"))
+    source = ImageTool(data)
+    target = ImageTool(data)
+    for win in (source, target):
+        qtbot.addWidget(win)
+
+    source_layout = source.slicer_area.splitter_sizes
+    source_layout[0] = [300, 100]
+    source.slicer_area.splitter_sizes = source_layout
+    target_layout = target.slicer_area.splitter_sizes
+    target_layout[0] = [100, 300]
+    target.slicer_area.splitter_sizes = target_layout
+    for win in (source, target):
+        win.slicer_area.flush_history()
+
+    target_area = target.slicer_area
+    initial_index = target_area.current_indices[0]
+    target_area.begin_history_group(None)
+    target_area.set_index(0, initial_index + 1)
+
+    proxy = imagetool_viewer_linking.SlicerLinkProxy(
+        source.slicer_area,
+        target_area,
+    )
+    target_area.end_history_group()
+
+    assert target_area.splitter_sizes == source.slicer_area.splitter_sizes
+    entry = target_area._prev_states[-1]
+    assert entry.changed_paths
+    assert all(path[0] != "splitter_sizes" for path in entry.changed_paths)
+
+    target_area.undo()
+    assert target_area.current_indices[0] == initial_index
+    assert target_area.splitter_sizes == source.slicer_area.splitter_sizes
+
+    proxy.unlink_all()
+    source.close()
+    target.close()
 
 
 def test_linked_swap_axes_skips_targets_without_swapped_dimensions(qtbot) -> None:


### PR DESCRIPTION
## Summary

- align newly linked ImageTools to the active compatible tool's splitter layout
- propagate manual splitter changes proportionally across linked windows with different sizes
- include user-initiated splitter changes in linked undo/redo history
- preserve linked layouts across pending ImageTool workspace payloads while skipping incompatible dimensionalities

## Implementation

Splitter layouts are stored as canonical relative weights instead of relying on constrained pixel geometry. Mouse gestures commit once at the release boundary, so no-net drags create no history and cancelled history transactions cannot leak partial layout changes. Automatic link alignment uses a history-neutral state mutation that rebases any already-open user history entry rather than absorbing the alignment into it.

Manager linking uses the same layout application path for materialized and pending tools. Restore paths opt out of realignment so existing saved layouts remain intact until a new link is created explicitly.

## User impact

Linked ImageTools now keep compatible plot layouts synchronized by default. Manual splitter moves can be undone and redone as one linked operation, and resizing differently sized windows preserves the intended proportions.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/test_history.py tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/manager/test_modelview.py tests/interactive/imagetool/manager/workspace/test_pending_persistence.py` (620 passed)
- focused splitter/linking tests under `QT_API=pyside6` (8 passed)
- `uv run ruff format --check` on changed Python files
- `uv run ruff check` on changed Python files
- `uv run mypy src/erlab/interactive/imagetool/viewer.py src/erlab/interactive/imagetool/viewer_linking.py src/erlab/interactive/imagetool/manager/_actions.py`
- `git diff --check origin/main...HEAD`
