### PR TITLE
fix(imagetool): stabilize frozen Numba cache identity

### DIFF
--- a/src/erlab/interactive/imagetool/_frozen_numba_cache.py
+++ b/src/erlab/interactive/imagetool/_frozen_numba_cache.py
@@ -1,0 +1,42 @@
+"""Numba cache compatibility for the standalone PyInstaller application."""
+
+import pathlib
+import sys
+
+from numba.core.caching import UserWideCacheLocator
+
+
+class PyInstallerCacheLocator(UserWideCacheLocator):
+    """Use a stable cache identity for modules loaded from a PyInstaller bundle.
+
+    PyInstaller stores relative ``co_filename`` values for modules in its PYZ
+    archive. Numba 0.66 resolves those paths against the current working directory
+    before hashing them, so otherwise equivalent Windows launches can select
+    different user-wide cache folders. One-file bundles can have the same problem
+    when an absolute source path contains a new ``sys._MEIPASS`` extraction root.
+
+    Keep Numba's user-wide cache location and source validation unchanged, but
+    anchor bundled source paths to the executable so their hashes remain stable.
+    This class is selected only by the frozen ImageTool Manager entry point and can
+    be removed once Numba preserves frozen cache identities itself.
+    """
+
+    @classmethod
+    def get_suitable_cache_subpath(cls, py_file: str) -> str:
+        path = pathlib.Path(py_file)
+        extraction_root = getattr(sys, "_MEIPASS", None)
+
+        if (
+            path.is_absolute()
+            and extraction_root
+            and path.is_relative_to(extraction_root)
+        ):
+            path = path.relative_to(extraction_root)
+
+        if not path.is_absolute():
+            # Treat the executable as a synthetic directory. Including its name
+            # prevents unrelated frozen applications installed together from
+            # sharing a cache identity for the same relative module path.
+            path = pathlib.Path(sys.executable) / path
+
+        return super().get_suitable_cache_subpath(str(path))

--- a/src/erlab/interactive/imagetool/_frozen_numba_cache.py
+++ b/src/erlab/interactive/imagetool/_frozen_numba_cache.py
@@ -2,41 +2,114 @@
 
 import pathlib
 import sys
+import typing
+from collections.abc import Callable
 
-from numba.core.caching import UserWideCacheLocator
+from numba.core import config
+from numba.core.caching import (
+    CacheImpl,
+    UserProvidedCacheLocator,
+    UserWideCacheLocator,
+    _CacheLocator,
+)
 
 
-class PyInstallerCacheLocator(UserWideCacheLocator):
-    """Use a stable cache identity for modules loaded from a PyInstaller bundle.
+def _is_bundled_source(py_file: str) -> bool:
+    """Return whether a source path belongs to the running PyInstaller bundle."""
+    if not (getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")):
+        return False
 
-    PyInstaller stores relative ``co_filename`` values for modules in its PYZ
-    archive. Numba 0.66 resolves those paths against the current working directory
-    before hashing them, so otherwise equivalent Windows launches can select
-    different user-wide cache folders. One-file bundles can have the same problem
-    when an absolute source path contains a new ``sys._MEIPASS`` extraction root.
+    path = pathlib.Path(py_file)
+    if not path.is_absolute():
+        # Keep synthetic paths such as ``<ipython-input-...>`` on Numba's
+        # standard locator path; PyInstaller PYZ entries are regular relative
+        # module paths.
+        return not py_file.startswith("<")
 
-    Keep Numba's user-wide cache location and source validation unchanged, but
-    anchor bundled source paths to the executable so their hashes remain stable.
-    This class is selected only by the frozen ImageTool Manager entry point and can
-    be removed once Numba preserves frozen cache identities itself.
-    """
+    return path.is_relative_to(pathlib.Path(sys._MEIPASS))
+
+
+class _PyInstallerCacheSubpathMixin:
+    """Generate stable subpaths for source files inside a PyInstaller bundle."""
 
     @classmethod
     def get_suitable_cache_subpath(cls, py_file: str) -> str:
         path = pathlib.Path(py_file)
-        extraction_root = getattr(sys, "_MEIPASS", None)
+        extraction_root = pathlib.Path(typing.cast("str", vars(sys)["_MEIPASS"]))
 
-        if (
-            path.is_absolute()
-            and extraction_root
-            and path.is_relative_to(extraction_root)
-        ):
+        if path.is_absolute():
             path = path.relative_to(extraction_root)
 
-        if not path.is_absolute():
-            # Treat the executable as a synthetic directory. Including its name
-            # prevents unrelated frozen applications installed together from
-            # sharing a cache identity for the same relative module path.
-            path = pathlib.Path(sys.executable) / path
+        # Treat the executable as a synthetic directory. Including its name
+        # prevents unrelated frozen applications installed together from
+        # sharing a cache identity for the same relative module path.
+        path = pathlib.Path(sys.executable) / path
 
-        return super().get_suitable_cache_subpath(str(path))
+        return _CacheLocator.get_suitable_cache_subpath(str(path))
+
+
+class _PyInstallerUserProvidedCacheLocator(
+    _PyInstallerCacheSubpathMixin, UserProvidedCacheLocator
+):
+    """Honor ``NUMBA_CACHE_DIR`` for bundled sources with a stable subpath."""
+
+    @classmethod
+    def from_function(
+        cls, py_func: Callable[..., typing.Any], py_file: str
+    ) -> _CacheLocator | None:
+        if not (_is_bundled_source(py_file) and config.CACHE_DIR):
+            return None
+
+        # UserProvidedCacheLocator normally rejects source paths that do not
+        # exist. Relative PyInstaller PYZ filenames are valid in a frozen app,
+        # so use the same frozen-source exception as UserWideCacheLocator.
+        self = cls(py_func, py_file)
+        try:
+            self.ensure_cache_path()
+        except OSError:
+            return None
+        return self
+
+
+class _PyInstallerUserWideCacheLocator(
+    _PyInstallerCacheSubpathMixin, UserWideCacheLocator
+):
+    """Use Numba's user-wide root for bundled sources with a stable subpath."""
+
+    @classmethod
+    def from_function(
+        cls, py_func: Callable[..., typing.Any], py_file: str
+    ) -> _CacheLocator | None:
+        if not _is_bundled_source(py_file):
+            return None
+        return super().from_function(py_func, py_file)
+
+
+class PyInstallerCacheLocator:
+    """Preserve Numba's locator policy while stabilizing bundled source paths.
+
+    ``NUMBA_CACHE_LOCATOR_CLASSES`` replaces Numba's locator chain instead of
+    extending it. This dispatcher handles PyInstaller sources with stable
+    variants of Numba's user-provided and user-wide locators, then delegates
+    every other source to Numba's original locator chain. It is selected only
+    by the frozen Windows ImageTool Manager entry point and can be removed once
+    Numba preserves frozen cache identities itself.
+    """
+
+    @classmethod
+    def from_function(
+        cls, py_func: Callable[..., typing.Any], py_file: str
+    ) -> _CacheLocator | None:
+        for locator_cls in (
+            _PyInstallerUserProvidedCacheLocator,
+            _PyInstallerUserWideCacheLocator,
+        ):
+            if locator := locator_cls.from_function(py_func, py_file):
+                return locator
+
+        # Do not copy Numba's current list here. Delegating to the class-owned
+        # chain preserves its ordering and any locators added by future releases.
+        for locator_cls in CacheImpl._locator_classes:
+            if locator := locator_cls.from_function(py_func, py_file):
+                return locator
+        return None

--- a/src/erlab/interactive/imagetool/manager/__main__.py
+++ b/src/erlab/interactive/imagetool/manager/__main__.py
@@ -5,6 +5,10 @@ import sys
 
 from qtpy import QtCore
 
+_NUMBA_CACHE_LOCATOR = (
+    "erlab.interactive.imagetool._frozen_numba_cache.PyInstallerCacheLocator"
+)
+
 
 def _cache_directory() -> pathlib.Path:
     location = QtCore.QStandardPaths.writableLocation(
@@ -36,6 +40,15 @@ def _configure_packaged_runtime_caches() -> None:
     if not (getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")):
         return
     os.environ["MPLCONFIGDIR"] = str(_mpl_cache_directory())
+    if sys.platform == "win32":
+        # PyInstaller's relative module filenames make Numba 0.66 cache hashes
+        # depend on the launch working directory. Select a frozen-app locator
+        # that stabilizes only that identity; Numba still chooses the cache root.
+        locator = os.environ.setdefault(
+            "NUMBA_CACHE_LOCATOR_CLASSES", _NUMBA_CACHE_LOCATOR
+        )
+        if numba_config := sys.modules.get("numba.core.config"):
+            numba_config.__dict__["CACHE_LOCATOR_CLASSES"] = locator
     pycache_dir = _pycache_directory()
     os.environ["PYTHONPYCACHEPREFIX"] = str(pycache_dir)
     sys.pycache_prefix = str(pycache_dir)

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -14,6 +14,8 @@ import typing
 import webbrowser
 from collections.abc import Callable
 
+import numba.core.caching
+import numba.core.config
 import pytest
 import xarray as xr
 import zmq
@@ -28,6 +30,7 @@ import erlab.interactive.imagetool.manager._updater_gui as manager_updater_gui
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.explorer._tabbed_explorer import _TabbedExplorer
+from erlab.interactive.imagetool._frozen_numba_cache import PyInstallerCacheLocator
 from erlab.interactive.imagetool.manager import load_in_manager
 from erlab.interactive.imagetool.manager._server import (
     AddDataPacket,
@@ -192,6 +195,7 @@ def test_manager_main_configure_packaged_runtime_caches_skips_source_launch(
 ) -> None:
     monkeypatch.delenv("MPLCONFIGDIR", raising=False)
     monkeypatch.delenv("NUMBA_CACHE_DIR", raising=False)
+    monkeypatch.delenv("NUMBA_CACHE_LOCATOR_CLASSES", raising=False)
     monkeypatch.delenv("PYTHONPYCACHEPREFIX", raising=False)
     monkeypatch.setattr(manager_main.sys, "frozen", True, raising=False)
     monkeypatch.delattr(manager_main.sys, "_MEIPASS", raising=False)
@@ -206,6 +210,7 @@ def test_manager_main_configure_packaged_runtime_caches_skips_source_launch(
 
     assert "MPLCONFIGDIR" not in os.environ
     assert "NUMBA_CACHE_DIR" not in os.environ
+    assert "NUMBA_CACHE_LOCATOR_CLASSES" not in os.environ
     assert "PYTHONPYCACHEPREFIX" not in os.environ
     assert manager_main.sys.pycache_prefix is None
 
@@ -216,13 +221,20 @@ def test_manager_main_configure_packaged_runtime_caches_sets_packaged_env(
     cache_root = tmp_path / "cache-root"
     monkeypatch.delenv("MPLCONFIGDIR", raising=False)
     monkeypatch.delenv("NUMBA_CACHE_DIR", raising=False)
+    monkeypatch.delenv("NUMBA_CACHE_LOCATOR_CLASSES", raising=False)
     monkeypatch.delenv("PYTHONPYCACHEPREFIX", raising=False)
     monkeypatch.setattr(manager_main.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(manager_main.sys, "platform", "win32")
     monkeypatch.setattr(
         manager_main.sys, "_MEIPASS", str(tmp_path / "_MEI"), raising=False
     )
     monkeypatch.setattr(manager_main.sys, "pycache_prefix", None)
     monkeypatch.setattr(manager_main.sys, "dont_write_bytecode", True)
+    fake_numba_config = types.ModuleType("numba.core.config")
+    fake_numba_config.CACHE_LOCATOR_CLASSES = ""
+    monkeypatch.setitem(
+        manager_main.sys.modules, "numba.core.config", fake_numba_config
+    )
     monkeypatch.setattr(
         manager_main.QtCore.QStandardPaths,
         "writableLocation",
@@ -236,11 +248,123 @@ def test_manager_main_configure_packaged_runtime_caches_sets_packaged_env(
     pycache_dir = cache_dir / "python-pycache"
     assert os.environ["MPLCONFIGDIR"] == str(mpl_cache_dir)
     assert "NUMBA_CACHE_DIR" not in os.environ
+    assert (
+        os.environ["NUMBA_CACHE_LOCATOR_CLASSES"] == manager_main._NUMBA_CACHE_LOCATOR
+    )
+    assert fake_numba_config.CACHE_LOCATOR_CLASSES == manager_main._NUMBA_CACHE_LOCATOR
     assert os.environ["PYTHONPYCACHEPREFIX"] == str(pycache_dir)
     assert manager_main.sys.pycache_prefix == str(pycache_dir)
     assert manager_main.sys.dont_write_bytecode is False
     assert mpl_cache_dir.is_dir()
     assert pycache_dir.is_dir()
+
+
+def test_manager_main_packaged_numba_locator_is_windows_only(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.delenv("NUMBA_CACHE_LOCATOR_CLASSES", raising=False)
+    monkeypatch.setattr(manager_main.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(manager_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        manager_main.sys, "_MEIPASS", str(tmp_path / "_MEI"), raising=False
+    )
+    monkeypatch.setattr(
+        manager_main.QtCore.QStandardPaths,
+        "writableLocation",
+        lambda location: str(tmp_path / "cache-root"),
+    )
+
+    manager_main._configure_packaged_runtime_caches()
+
+    assert "NUMBA_CACHE_LOCATOR_CLASSES" not in os.environ
+
+
+def test_packaged_numba_cache_locator_stabilizes_relative_paths(
+    tmp_path, monkeypatch
+) -> None:
+    executable = tmp_path / "ImageTool Manager.exe"
+    source_path = pathlib.Path("erlab/interactive/imagetool/fastbinning.py")
+    first_cwd = tmp_path / "first"
+    second_cwd = tmp_path / "second"
+    first_cwd.mkdir()
+    second_cwd.mkdir()
+    monkeypatch.setattr(sys, "executable", str(executable))
+
+    monkeypatch.chdir(first_cwd)
+    first_subpath = PyInstallerCacheLocator.get_suitable_cache_subpath(str(source_path))
+    monkeypatch.chdir(second_cwd)
+    second_subpath = PyInstallerCacheLocator.get_suitable_cache_subpath(
+        str(source_path)
+    )
+
+    assert first_subpath == second_subpath
+
+
+def test_packaged_numba_cache_locator_preserves_external_absolute_paths(
+    tmp_path, monkeypatch
+) -> None:
+    extraction_root = tmp_path / "_MEI"
+    external_source = tmp_path / "external" / "module.py"
+    monkeypatch.setattr(sys, "_MEIPASS", str(extraction_root), raising=False)
+
+    assert PyInstallerCacheLocator.get_suitable_cache_subpath(
+        str(external_source)
+    ) == numba.core.caching.UserWideCacheLocator.get_suitable_cache_subpath(
+        str(external_source)
+    )
+
+
+def test_packaged_numba_cache_locator_is_loadable_by_numba(
+    tmp_path, monkeypatch
+) -> None:
+    executable = tmp_path / "ImageTool Manager.exe"
+    executable.touch()
+
+    def cached_function(value):
+        return value + 1
+
+    cached_function.__code__ = cached_function.__code__.replace(
+        co_filename="erlab/interactive/imagetool/fastbinning.py"
+    )
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(
+        numba.core.caching,
+        "AppDirs",
+        lambda *args, **kwargs: types.SimpleNamespace(
+            user_cache_dir=str(tmp_path / "numba-cache")
+        ),
+    )
+    monkeypatch.setattr(
+        numba.core.config,
+        "CACHE_LOCATOR_CLASSES",
+        manager_main._NUMBA_CACHE_LOCATOR,
+    )
+
+    cache = numba.core.caching.FunctionCache(cached_function)
+
+    assert isinstance(cache._impl.locator, PyInstallerCacheLocator)
+
+
+def test_packaged_numba_cache_locator_stabilizes_extraction_roots(
+    tmp_path, monkeypatch
+) -> None:
+    executable = tmp_path / "ImageTool Manager.exe"
+    relative_source = pathlib.Path("erlab/interactive/imagetool/fastbinning.py")
+    first_root = tmp_path / "_MEI-first"
+    second_root = tmp_path / "_MEI-second"
+    monkeypatch.setattr(sys, "executable", str(executable))
+
+    monkeypatch.setattr(sys, "_MEIPASS", str(first_root), raising=False)
+    first_subpath = PyInstallerCacheLocator.get_suitable_cache_subpath(
+        str(first_root / relative_source)
+    )
+    monkeypatch.setattr(sys, "_MEIPASS", str(second_root), raising=False)
+    second_subpath = PyInstallerCacheLocator.get_suitable_cache_subpath(
+        str(second_root / relative_source)
+    )
+
+    assert first_subpath == second_subpath
 
 
 def test_manager_reload(

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -283,35 +283,153 @@ def test_packaged_numba_cache_locator_stabilizes_relative_paths(
     tmp_path, monkeypatch
 ) -> None:
     executable = tmp_path / "ImageTool Manager.exe"
+    executable.touch()
     source_path = pathlib.Path("erlab/interactive/imagetool/fastbinning.py")
     first_cwd = tmp_path / "first"
     second_cwd = tmp_path / "second"
     first_cwd.mkdir()
     second_cwd.mkdir()
     monkeypatch.setattr(sys, "executable", str(executable))
-
-    monkeypatch.chdir(first_cwd)
-    first_subpath = PyInstallerCacheLocator.get_suitable_cache_subpath(str(source_path))
-    monkeypatch.chdir(second_cwd)
-    second_subpath = PyInstallerCacheLocator.get_suitable_cache_subpath(
-        str(source_path)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path / "_MEI"), raising=False)
+    monkeypatch.setattr(numba.core.config, "CACHE_DIR", "")
+    monkeypatch.setattr(
+        numba.core.caching,
+        "AppDirs",
+        lambda *args, **kwargs: types.SimpleNamespace(
+            user_cache_dir=str(tmp_path / "numba-cache")
+        ),
     )
 
-    assert first_subpath == second_subpath
+    def cached_function(value):
+        return value + 1
+
+    monkeypatch.chdir(first_cwd)
+    first_locator = PyInstallerCacheLocator.from_function(
+        cached_function, str(source_path)
+    )
+    monkeypatch.chdir(second_cwd)
+    second_locator = PyInstallerCacheLocator.from_function(
+        cached_function, str(source_path)
+    )
+
+    assert isinstance(first_locator, numba.core.caching.UserWideCacheLocator)
+    assert isinstance(second_locator, numba.core.caching.UserWideCacheLocator)
+    assert first_locator.get_cache_path() == second_locator.get_cache_path()
 
 
-def test_packaged_numba_cache_locator_preserves_external_absolute_paths(
+def test_packaged_numba_cache_locator_preserves_external_locator_chain(
     tmp_path, monkeypatch
 ) -> None:
     extraction_root = tmp_path / "_MEI"
     external_source = tmp_path / "external" / "module.py"
+    external_source.parent.mkdir()
+    external_source.touch()
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "_MEIPASS", str(extraction_root), raising=False)
+    monkeypatch.setattr(numba.core.config, "CACHE_DIR", "")
 
-    assert PyInstallerCacheLocator.get_suitable_cache_subpath(
-        str(external_source)
-    ) == numba.core.caching.UserWideCacheLocator.get_suitable_cache_subpath(
-        str(external_source)
+    def cached_function(value):
+        return value + 1
+
+    locator = PyInstallerCacheLocator.from_function(
+        cached_function, str(external_source)
     )
+
+    assert type(locator) is numba.core.caching.InTreeCacheLocator
+    assert locator.get_cache_path() == str(external_source.parent / "__pycache__")
+
+
+def test_packaged_numba_cache_locator_delegates_outside_frozen_runtime(
+    tmp_path, monkeypatch
+) -> None:
+    external_source = tmp_path / "external" / "module.py"
+    external_source.parent.mkdir()
+    external_source.touch()
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+    monkeypatch.setattr(numba.core.config, "CACHE_DIR", "")
+
+    def cached_function(value):
+        return value + 1
+
+    locator = PyInstallerCacheLocator.from_function(
+        cached_function, str(external_source)
+    )
+
+    assert type(locator) is numba.core.caching.InTreeCacheLocator
+
+
+def test_packaged_numba_cache_locator_honors_configured_cache_directory(
+    tmp_path, monkeypatch
+) -> None:
+    executable = tmp_path / "ImageTool Manager.exe"
+    executable.touch()
+    configured_cache = tmp_path / "configured-numba-cache"
+    source_path = pathlib.Path("erlab/interactive/imagetool/fastbinning.py")
+    first_cwd = tmp_path / "first"
+    second_cwd = tmp_path / "second"
+    first_cwd.mkdir()
+    second_cwd.mkdir()
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path / "_MEI"), raising=False)
+    monkeypatch.setattr(numba.core.config, "CACHE_DIR", str(configured_cache))
+
+    def cached_function(value):
+        return value + 1
+
+    monkeypatch.chdir(first_cwd)
+    first_locator = PyInstallerCacheLocator.from_function(
+        cached_function, str(source_path)
+    )
+    monkeypatch.chdir(second_cwd)
+    second_locator = PyInstallerCacheLocator.from_function(
+        cached_function, str(source_path)
+    )
+
+    assert isinstance(first_locator, numba.core.caching.UserProvidedCacheLocator)
+    assert isinstance(second_locator, numba.core.caching.UserProvidedCacheLocator)
+    assert pathlib.Path(first_locator.get_cache_path()).parent == configured_cache
+    assert first_locator.get_cache_path() == second_locator.get_cache_path()
+
+
+def test_packaged_numba_cache_locator_falls_back_from_unwritable_configured_cache(
+    tmp_path, monkeypatch
+) -> None:
+    executable = tmp_path / "ImageTool Manager.exe"
+    executable.touch()
+    source_path = pathlib.Path("erlab/interactive/imagetool/fastbinning.py")
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path / "_MEI"), raising=False)
+    monkeypatch.setattr(
+        numba.core.config, "CACHE_DIR", str(tmp_path / "unwritable-cache")
+    )
+    monkeypatch.setattr(
+        numba.core.caching,
+        "AppDirs",
+        lambda *args, **kwargs: types.SimpleNamespace(
+            user_cache_dir=str(tmp_path / "numba-cache")
+        ),
+    )
+
+    def _raise_oserror(self) -> None:
+        raise OSError
+
+    monkeypatch.setattr(
+        "erlab.interactive.imagetool._frozen_numba_cache."
+        "_PyInstallerUserProvidedCacheLocator.ensure_cache_path",
+        _raise_oserror,
+    )
+
+    def cached_function(value):
+        return value + 1
+
+    locator = PyInstallerCacheLocator.from_function(cached_function, str(source_path))
+
+    assert isinstance(locator, numba.core.caching.UserWideCacheLocator)
+    assert pathlib.Path(locator.get_cache_path()).parent == tmp_path / "numba-cache"
 
 
 def test_packaged_numba_cache_locator_is_loadable_by_numba(
@@ -328,6 +446,8 @@ def test_packaged_numba_cache_locator_is_loadable_by_numba(
     )
     monkeypatch.setattr(sys, "executable", str(executable))
     monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path / "_MEI"), raising=False)
+    monkeypatch.setattr(numba.core.config, "CACHE_DIR", "")
     monkeypatch.setattr(
         numba.core.caching,
         "AppDirs",
@@ -343,28 +463,64 @@ def test_packaged_numba_cache_locator_is_loadable_by_numba(
 
     cache = numba.core.caching.FunctionCache(cached_function)
 
-    assert isinstance(cache._impl.locator, PyInstallerCacheLocator)
+    assert isinstance(cache._impl.locator, numba.core.caching.UserWideCacheLocator)
+    assert (
+        pathlib.Path(cache._impl.locator.get_cache_path()).parent
+        == tmp_path / "numba-cache"
+    )
 
 
 def test_packaged_numba_cache_locator_stabilizes_extraction_roots(
     tmp_path, monkeypatch
 ) -> None:
     executable = tmp_path / "ImageTool Manager.exe"
+    executable.touch()
     relative_source = pathlib.Path("erlab/interactive/imagetool/fastbinning.py")
     first_root = tmp_path / "_MEI-first"
     second_root = tmp_path / "_MEI-second"
     monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(numba.core.config, "CACHE_DIR", "")
+    monkeypatch.setattr(
+        numba.core.caching,
+        "AppDirs",
+        lambda *args, **kwargs: types.SimpleNamespace(
+            user_cache_dir=str(tmp_path / "numba-cache")
+        ),
+    )
+
+    def cached_function(value):
+        return value + 1
 
     monkeypatch.setattr(sys, "_MEIPASS", str(first_root), raising=False)
-    first_subpath = PyInstallerCacheLocator.get_suitable_cache_subpath(
-        str(first_root / relative_source)
+    first_locator = PyInstallerCacheLocator.from_function(
+        cached_function, str(first_root / relative_source)
     )
     monkeypatch.setattr(sys, "_MEIPASS", str(second_root), raising=False)
-    second_subpath = PyInstallerCacheLocator.get_suitable_cache_subpath(
-        str(second_root / relative_source)
+    second_locator = PyInstallerCacheLocator.from_function(
+        cached_function, str(second_root / relative_source)
     )
 
-    assert first_subpath == second_subpath
+    assert isinstance(first_locator, numba.core.caching.UserWideCacheLocator)
+    assert isinstance(second_locator, numba.core.caching.UserWideCacheLocator)
+    assert first_locator.get_cache_path() == second_locator.get_cache_path()
+
+
+def test_packaged_numba_cache_locator_returns_none_without_a_standard_locator(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path / "_MEI"), raising=False)
+    monkeypatch.setattr(numba.core.config, "CACHE_DIR", "")
+    monkeypatch.setattr(numba.core.caching.CacheImpl, "_locator_classes", ())
+
+    def cached_function(value):
+        return value + 1
+
+    assert (
+        PyInstallerCacheLocator.from_function(cached_function, "<synthetic-source>")
+        is None
+    )
 
 
 def test_manager_reload(


### PR DESCRIPTION
## Summary

- add a PyInstaller-specific Numba cache dispatcher that stabilizes bundled source identities while preserving Numba's configured cache root and normal locator chain
- select the dispatcher only during frozen Windows ImageTool Manager startup while respecting an existing `NUMBA_CACHE_LOCATOR_CLASSES` setting
- add regression coverage for changing launch directories and `_MEIPASS` roots, configured and unwritable cache directories, external sources, non-frozen use, and Numba's real locator-loading path

## Root cause

PyInstaller stores relative `co_filename` values for modules loaded from its PYZ archive. Numba 0.66 resolves those paths against the current working directory before hashing the parent path for its user-wide cache subdirectory. Launching the standalone manager from a different directory therefore creates a different module cache folder and recompiles the same functions. Absolute paths beneath a changing one-file `_MEIPASS` root have the same identity problem.

The workaround normalizes only bundled-source identities against the manager executable. Bundled modules continue to use `NUMBA_CACHE_DIR` when configured and otherwise use Numba's user-wide cache, including its normal fallback when a configured directory is unavailable. Non-bundled sources delegate to Numba's original locator chain. The implementation remains isolated so it can be removed when Numba handles frozen cache identities upstream.

## User impact

Repeated launches of the Windows standalone ImageTool Manager can reuse the same Numba cache entries instead of creating new UID-like module directories and recompiling cached functions.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run --group pyqt6 pytest -q tests/interactive/imagetool/manager/test_app.py` (50 passed)
- `QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run --group pyside6 pytest -q tests/interactive/imagetool/manager/test_app.py -k 'packaged_runtime_caches or packaged_numba_cache_locator'` (10 passed)
- focused workaround coverage: 100% statements and branches
- PyInstaller hidden-import collection check
- `uv run ruff check src/erlab/interactive/imagetool/_frozen_numba_cache.py src/erlab/interactive/imagetool/manager/__main__.py tests/interactive/imagetool/manager/test_app.py`
- `uv run ruff format --check src/erlab/interactive/imagetool/_frozen_numba_cache.py src/erlab/interactive/imagetool/manager/__main__.py tests/interactive/imagetool/manager/test_app.py`
- `uv run mypy src/erlab/interactive/imagetool/_frozen_numba_cache.py src/erlab/interactive/imagetool/manager/__main__.py`
