### PR TITLE
feat(imagetool): support scalar-coordinate offsets

### DIFF
--- a/src/erlab/interactive/imagetool/_dialog_widgets.py
+++ b/src/erlab/interactive/imagetool/_dialog_widgets.py
@@ -12,6 +12,9 @@ import erlab
 
 __all__ = ["CoordinateEditorWidget", "CoordinateGridWidget"]
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Mapping
+
 
 class CoordinateGridWidget(QtWidgets.QWidget):
     """Edit coordinate values using start/end-or-delta controls and a table.
@@ -277,10 +280,18 @@ class CoordinateEditorWidget(QtWidgets.QWidget):
     values
         Initial reference coordinate values for both the editable value grid and affine
         preview table.
+    scalar_coords
+        Numeric scalar coordinates that can contribute a data-dependent affine offset.
     """
 
-    def __init__(self, values: npt.ArrayLike) -> None:
+    def __init__(
+        self,
+        values: npt.ArrayLike,
+        *,
+        scalar_coords: Mapping[str, float] | None = None,
+    ) -> None:
         super().__init__()
+        self._scalar_coords = dict(scalar_coords or {})
         self.init_ui(values)
         self.set_old_coord(values)
 
@@ -322,6 +333,38 @@ class CoordinateEditorWidget(QtWidgets.QWidget):
         self.offset_spin.valueChanged.connect(self.update_affine_preview)
         affine_layout.addRow("Offset", self.offset_spin)
 
+        self.scalar_offset_widget = QtWidgets.QWidget()
+        scalar_offset_layout = QtWidgets.QHBoxLayout(self.scalar_offset_widget)
+        scalar_offset_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.offset_coord_sign_combo = QtWidgets.QComboBox()
+        self.offset_coord_sign_combo.setObjectName("coordinateOffsetSignCombo")
+        self.offset_coord_sign_combo.addItem("Add", userData=1)
+        self.offset_coord_sign_combo.addItem("Subtract", userData=-1)
+        self.offset_coord_sign_combo.currentIndexChanged.connect(
+            self.update_affine_preview
+        )
+        scalar_offset_layout.addWidget(self.offset_coord_sign_combo)
+
+        self.offset_coord_combo = QtWidgets.QComboBox()
+        self.offset_coord_combo.setObjectName("coordinateOffsetCoordCombo")
+        self.offset_coord_combo.addItem("None", userData=None)
+        for name, value in self._scalar_coords.items():
+            self.offset_coord_combo.addItem(name, userData=name)
+            self.offset_coord_combo.setItemData(
+                self.offset_coord_combo.count() - 1,
+                f"Current value: {value}",
+                QtCore.Qt.ItemDataRole.ToolTipRole,
+            )
+        self.offset_coord_combo.currentIndexChanged.connect(self._offset_coord_changed)
+        scalar_offset_layout.addWidget(self.offset_coord_combo)
+        affine_layout.addRow("Coordinate Offset", self.scalar_offset_widget)
+        if not self._scalar_coords:
+            label = affine_layout.labelForField(self.scalar_offset_widget)
+            if label is not None:
+                label.hide()
+            self.scalar_offset_widget.hide()
+
         self.affine_table = QtWidgets.QTableWidget()
         self.affine_table.setColumnCount(2)
         self.affine_table.setHorizontalHeaderLabels(["Current", "Transformed"])
@@ -357,9 +400,35 @@ class CoordinateEditorWidget(QtWidgets.QWidget):
         return float(self.offset_spin.value())
 
     @property
+    def affine_offset_coord(self) -> str | None:
+        """Get the scalar coordinate used as an additional offset."""
+        coord_name = self.offset_coord_combo.currentData(
+            QtCore.Qt.ItemDataRole.UserRole
+        )
+        return None if coord_name is None else str(coord_name)
+
+    @property
+    def affine_offset_coord_sign(self) -> typing.Literal[-1, 1]:
+        """Get whether the scalar-coordinate offset is added or subtracted."""
+        return typing.cast(
+            "typing.Literal[-1, 1]",
+            self.offset_coord_sign_combo.currentData(QtCore.Qt.ItemDataRole.UserRole),
+        )
+
+    @property
+    def _resolved_affine_offset(self) -> float:
+        offset = self.affine_offset
+        if self.affine_offset_coord is not None:
+            offset += (
+                self.affine_offset_coord_sign
+                * self._scalar_coords[self.affine_offset_coord]
+            )
+        return offset
+
+    @property
     def affine_coord(self) -> npt.NDArray:
         """Get the affine-transformed coordinates as a numpy array."""
-        return self.affine_scale * self._old_coord + self.affine_offset
+        return self.affine_scale * self._old_coord + self._resolved_affine_offset
 
     def _affine_supported(self) -> bool:
         values = np.asarray(self._old_coord)
@@ -378,10 +447,24 @@ class CoordinateEditorWidget(QtWidgets.QWidget):
         with (
             QtCore.QSignalBlocker(self.scale_spin),
             QtCore.QSignalBlocker(self.offset_spin),
+            QtCore.QSignalBlocker(self.offset_coord_combo),
+            QtCore.QSignalBlocker(self.offset_coord_sign_combo),
         ):
             self.scale_spin.setValue(1.0)
             self.offset_spin.setValue(0.0)
+            self.offset_coord_combo.setCurrentIndex(0)
+            self.offset_coord_sign_combo.setCurrentIndex(0)
+        self._sync_offset_coord_controls()
         self.update_affine_preview()
+
+    @QtCore.Slot()
+    @QtCore.Slot(int)
+    def _offset_coord_changed(self, _index: int | None = None) -> None:
+        self._sync_offset_coord_controls()
+        self.update_affine_preview()
+
+    def _sync_offset_coord_controls(self) -> None:
+        self.offset_coord_sign_combo.setEnabled(self.affine_offset_coord is not None)
 
     @QtCore.Slot(int)
     def _edit_mode_changed(self, _index: int) -> None:

--- a/src/erlab/interactive/imagetool/_dialog_widgets.py
+++ b/src/erlab/interactive/imagetool/_dialog_widgets.py
@@ -464,7 +464,11 @@ class CoordinateEditorWidget(QtWidgets.QWidget):
         self.update_affine_preview()
 
     def _sync_offset_coord_controls(self) -> None:
-        self.offset_coord_sign_combo.setEnabled(self.affine_offset_coord is not None)
+        has_offset_coord = self.affine_offset_coord is not None
+        self.offset_coord_sign_combo.setEnabled(has_offset_coord)
+        if not has_offset_coord:
+            with QtCore.QSignalBlocker(self.offset_coord_sign_combo):
+                self.offset_coord_sign_combo.setCurrentIndex(0)
 
     @QtCore.Slot(int)
     def _edit_mode_changed(self, _index: int) -> None:

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_coordinates.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_coordinates.py
@@ -107,6 +107,14 @@ class AffineCoordOperation(ToolProvenanceOperation):
     coord_name: str
     scale: float
     offset: float
+    offset_coord: str | None = pydantic.Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
+    offset_coord_sign: typing.Literal[-1, 1] = pydantic.Field(
+        default=1,
+        exclude_if=lambda value: value == 1,
+    )
 
     @pydantic.field_validator("scale", "offset")
     @classmethod
@@ -115,13 +123,46 @@ class AffineCoordOperation(ToolProvenanceOperation):
             raise ValueError("affine coordinate scale and offset must be finite")
         return value
 
+    @pydantic.model_validator(mode="after")
+    def _validate_offset_coord(self) -> typing.Self:
+        if self.offset_coord == "":
+            raise ValueError("affine offset coordinate name must not be empty")
+        if self.offset_coord is None and self.offset_coord_sign != 1:
+            raise ValueError(
+                "affine offset coordinate sign requires an offset coordinate"
+            )
+        return self
+
+    def _resolved_offset(self, data: xr.DataArray) -> float:
+        offset = float(self.offset)
+        if self.offset_coord is None:
+            return offset
+        if self.offset_coord not in data.coords:
+            raise ValueError(
+                f"Offset coordinate {self.offset_coord!r} is not present in the data."
+            )
+        coord = data.coords[self.offset_coord]
+        values = np.asarray(coord.values)
+        if values.ndim != 0:
+            raise ValueError(f"Offset coordinate {self.offset_coord!r} must be scalar.")
+        if not np.issubdtype(values.dtype, np.number) or np.issubdtype(
+            values.dtype, np.complexfloating
+        ):
+            raise ValueError(
+                f"Offset coordinate {self.offset_coord!r} must contain a real number."
+            )
+        value = float(values)
+        if not np.isfinite(value):
+            raise ValueError(f"Offset coordinate {self.offset_coord!r} must be finite.")
+        return offset + self.offset_coord_sign * value
+
     def apply(self, data: xr.DataArray) -> xr.DataArray:
         coord = data.coords[self.coord_name]
         return erlab.utils.array.sort_coord_order(
             data.assign_coords(
                 {
                     self.coord_name: coord.copy(
-                        data=self.scale * coord.values + self.offset
+                        data=self.scale * coord.values + self._resolved_offset(data)
                     )
                 }
             ),
@@ -135,6 +176,9 @@ class AffineCoordOperation(ToolProvenanceOperation):
             "scale": self.scale,
             "offset": self.offset,
         }
+        if self.offset_coord is not None:
+            label_kwargs["offset_coord"] = self.offset_coord
+            label_kwargs["offset_coord_sign"] = self.offset_coord_sign
         return f"Scale/Offset Coordinate({_format_derivation_value(label_kwargs)})"
 
     def expression_code(
@@ -154,6 +198,13 @@ class AffineCoordOperation(ToolProvenanceOperation):
         elif offset < 0.0:
             offset_code = erlab.interactive.utils._parse_single_arg(abs(offset))
             data_code = f"{data_code} - {offset_code}"
+        if self.offset_coord is not None:
+            offset_coord_code = repr(self.offset_coord)
+            scalar_offset_code = f"{input_name}[{offset_coord_code}].values.item()"
+            if self.offset_coord_sign == 1:
+                data_code = f"{data_code} + {scalar_offset_code}"
+            else:
+                data_code = f"{data_code} - {scalar_offset_code}"
         return (
             f"{input_name}.assign_coords({{{coord_name_code}: "
             f"{input_name}[{coord_name_code}].copy(data={data_code})}})"

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_coordinates.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_coordinates.py
@@ -145,9 +145,7 @@ class AffineCoordOperation(ToolProvenanceOperation):
         values = np.asarray(coord.values)
         if values.ndim != 0:
             raise ValueError(f"Offset coordinate {self.offset_coord!r} must be scalar.")
-        if not np.issubdtype(values.dtype, np.number) or np.issubdtype(
-            values.dtype, np.complexfloating
-        ):
+        if values.dtype.kind not in "iuf":
             raise ValueError(
                 f"Offset coordinate {self.offset_coord!r} must contain a real number."
             )

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -5179,6 +5179,17 @@ class AssignCoordsDialog(DataTransformDialog):
         self._mode_tabs = QtWidgets.QTabWidget(self)
         self.layout_.addRow(self._mode_tabs)
 
+        scalar_coords: dict[str, float] = {}
+        for name, coord in self.slicer_area.data.coords.items():
+            values = np.asarray(coord.values)
+            if (
+                values.ndim == 0
+                and np.issubdtype(values.dtype, np.number)
+                and not np.issubdtype(values.dtype, np.complexfloating)
+                and np.isfinite(values).item()
+            ):
+                scalar_coords[str(name)] = float(values)
+
         existing_widget = QtWidgets.QWidget(self)
         existing_layout = QtWidgets.QVBoxLayout(existing_widget)
 
@@ -5194,7 +5205,10 @@ class AssignCoordsDialog(DataTransformDialog):
 
         self._coord_combo.currentTextChanged.connect(self._coord_selection_changed)
 
-        self.coord_widget = CoordinateEditorWidget(np.array([0, 1]))
+        self.coord_widget = CoordinateEditorWidget(
+            np.array([0, 1]),
+            scalar_coords=scalar_coords,
+        )
         self._coord_selection_changed()
         existing_layout.addWidget(self.coord_widget)
         self._mode_tabs.addTab(existing_widget, "Edit Existing")
@@ -5385,6 +5399,8 @@ class AssignCoordsDialog(DataTransformDialog):
                 coord_name=self.current_coord_name,
                 scale=self.coord_widget.affine_scale,
                 offset=self.coord_widget.affine_offset,
+                offset_coord=self.coord_widget.affine_offset_coord,
+                offset_coord_sign=self.coord_widget.affine_offset_coord_sign,
             )
         return AssignCoordsOperation(
             coord_name=self.current_coord_name,
@@ -5407,6 +5423,18 @@ class AssignCoordsDialog(DataTransformDialog):
             self.coord_widget.edit_mode_tabs.setCurrentIndex(1)
             self.coord_widget.scale_spin.setValue(float(operation.scale))
             self.coord_widget.offset_spin.setValue(float(operation.offset))
+            if operation.offset_coord is not None:
+                if not _set_combo_data(
+                    self.coord_widget.offset_coord_combo,
+                    operation.offset_coord,
+                ):
+                    raise ValueError(
+                        f"Scalar coordinate {operation.offset_coord!r} is not available"
+                    )
+                _set_combo_data(
+                    self.coord_widget.offset_coord_sign_combo,
+                    operation.offset_coord_sign,
+                )
             self.coord_widget.update_affine_preview()
             return
         if isinstance(

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -5184,8 +5184,7 @@ class AssignCoordsDialog(DataTransformDialog):
             values = np.asarray(coord.values)
             if (
                 values.ndim == 0
-                and np.issubdtype(values.dtype, np.number)
-                and not np.issubdtype(values.dtype, np.complexfloating)
+                and values.dtype.kind in "iuf"
                 and np.isfinite(values).item()
             ):
                 scalar_coords[str(name)] = float(values)

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
@@ -1700,6 +1700,8 @@ class _ProvenanceEditController:
             return None
         if operation.scale == 0.0:
             return None
+        if operation.offset_coord == operation.coord_name:
+            return None
 
         if dialog_match.stop != len(spec.operations):
             return None
@@ -1713,7 +1715,9 @@ class _ProvenanceEditController:
                 np.complexfloating,
             ):
                 return None
-            old_coord_values = (coord_values - operation.offset) / operation.scale
+            old_coord_values = (
+                coord_values - operation._resolved_offset(data)
+            ) / operation.scale
             if not np.all(np.isfinite(old_coord_values)):
                 return None
             return data.assign_coords(

--- a/tests/interactive/imagetool/manager/provenance/test_clipboard.py
+++ b/tests/interactive/imagetool/manager/provenance/test_clipboard.py
@@ -1123,6 +1123,68 @@ def test_manager_paste_structured_provenance_steps_into_selected_imagetools(
         assert manager._tool_graph.root_wrappers[index_b].displayed_provenance_spec
 
 
+def test_manager_pasted_scalar_coordinate_offset_uses_each_destination_value(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    operation = AffineCoordOperation(
+        coord_name="eV",
+        scale=1.0,
+        offset=0.0,
+        offset_coord="hv",
+        offset_coord_sign=-1,
+    )
+    kinetic_energy = np.linspace(20.0, 23.0, 4)
+    data_a = xr.DataArray(
+        np.arange(4, dtype=float),
+        dims="eV",
+        coords={"eV": kinetic_energy, "hv": 21.2},
+    )
+    data_b = data_a.assign_coords(hv=40.0)
+
+    with manager_context() as manager:
+        tool_a = itool(data_a.copy(deep=True), manager=False, execute=False)
+        tool_b = itool(data_b.copy(deep=True), manager=False, execute=False)
+        assert isinstance(tool_a, erlab.interactive.imagetool.ImageTool)
+        assert isinstance(tool_b, erlab.interactive.imagetool.ImageTool)
+        index_a = manager.add_imagetool(
+            tool_a,
+            show=False,
+            provenance_spec=full_data(),
+        )
+        index_b = manager.add_imagetool(
+            tool_b,
+            show=False,
+            provenance_spec=full_data(),
+        )
+        _set_provenance_steps_clipboard((operation,))
+
+        select_tools(manager, [index_a, index_b])
+        manager._paste_provenance_steps_from_clipboard()
+
+        np.testing.assert_allclose(
+            tool_a.slicer_area._data.eV.values,
+            kinetic_energy - data_a.hv.item(),
+        )
+        np.testing.assert_allclose(
+            tool_b.slicer_area._data.eV.values,
+            kinetic_energy - data_b.hv.item(),
+        )
+        assert (
+            manager._tool_graph.root_wrappers[
+                index_a
+            ].displayed_provenance_spec.operations[-1]
+            == operation
+        )
+        assert (
+            manager._tool_graph.root_wrappers[
+                index_b
+            ].displayed_provenance_spec.operations[-1]
+            == operation
+        )
+
+
 @pytest.mark.parametrize("target_kind", ["root", "source_child"])
 def test_manager_paste_steps_preserves_nonuniform_public_dimension(
     target_kind: str,

--- a/tests/interactive/imagetool/manager/provenance/test_operation_editing.py
+++ b/tests/interactive/imagetool/manager/provenance/test_operation_editing.py
@@ -516,12 +516,18 @@ def test_manager_affine_coord_edit_opens_without_replay(
     base = xr.DataArray(
         np.arange(6, dtype=float).reshape((2, 3)),
         dims=("x", "y"),
-        coords={"x": [0.0, 1.0], "y": [10.0, 20.0, 30.0]},
+        coords={
+            "x": [0.0, 1.0],
+            "y": [10.0, 20.0, 30.0],
+            "hv": 21.2,
+        },
     )
     operation = AffineCoordOperation(
         coord_name="y",
         scale=2.0,
         offset=0.5,
+        offset_coord="hv",
+        offset_coord_sign=-1,
     )
     current = operation.apply(base)
     spec = _manager_replay_file_spec(tmp_path / "source.h5", operation)
@@ -540,6 +546,8 @@ def test_manager_affine_coord_edit_opens_without_replay(
         captured["coord_name"] = dialog.current_coord_name
         captured["scale"] = float(dialog.coord_widget.scale_spin.value())
         captured["offset"] = float(dialog.coord_widget.offset_spin.value())
+        captured["offset_coord"] = dialog.coord_widget.affine_offset_coord
+        captured["offset_coord_sign"] = dialog.coord_widget.affine_offset_coord_sign
         captured["reference_coord"] = dialog.coord_widget._old_coord.copy()
         captured["dialog_coord"] = dialog.slicer_area.data["y"].values.copy()
         return int(QtWidgets.QDialog.DialogCode.Rejected)
@@ -572,6 +580,8 @@ def test_manager_affine_coord_edit_opens_without_replay(
     assert captured["coord_name"] == "y"
     assert captured["scale"] == 2.0
     assert captured["offset"] == 0.5
+    assert captured["offset_coord"] == "hv"
+    assert captured["offset_coord_sign"] == -1
     np.testing.assert_allclose(captured["reference_coord"], base.y.values)
     np.testing.assert_allclose(captured["dialog_coord"], base.y.values)
 
@@ -697,6 +707,22 @@ def test_manager_affine_coord_edit_accept_still_replays_for_validation(
                 coords={"x": [0.0, 1.0], "y": [10.0, 20.0, 30.0]},
             ),
             id="missing-coordinate",
+        ),
+        pytest.param(
+            (
+                AffineCoordOperation(
+                    coord_name="y",
+                    scale=2.0,
+                    offset=0.5,
+                    offset_coord="y",
+                ),
+            ),
+            xr.DataArray(
+                np.arange(6, dtype=float).reshape((2, 3)),
+                dims=("x", "y"),
+                coords={"x": [0.0, 1.0], "y": [10.0, 20.0, 30.0]},
+            ),
+            id="self-referential-offset-coordinate",
         ),
     ],
 )

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -55,6 +55,7 @@ from erlab.interactive.imagetool._provenance._model import (
     selection,
 )
 from erlab.interactive.imagetool._provenance._operations import (
+    AffineCoordOperation,
     AssignAttrsOperation,
     AssignScalarCoordOperation,
     ImageDerivativeOperation,
@@ -4011,6 +4012,55 @@ def test_batch_sortby_transform_replace(
             xarray.testing.assert_identical(
                 manager.get_imagetool(index).slicer_area._data.rename(None),
                 expected_data.rename(None),
+            )
+
+
+def test_batch_affine_coord_offset_uses_each_scalar_coordinate(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    kinetic_energy = np.linspace(20.0, 23.0, 4)
+    data0 = _batch_data("scan0", dims=("x", "eV")).assign_coords(
+        eV=kinetic_energy,
+        hv=21.2,
+    )
+    data1 = _batch_data("scan1", dims=("x", "eV"), offset=100.0).assign_coords(
+        eV=kinetic_energy,
+        hv=40.0,
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, data0, data1)
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.AssignCoordsDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        dialog._coord_combo.setCurrentText("eV")
+        dialog.coord_widget.edit_mode_tabs.setCurrentIndex(1)
+        dialog.coord_widget.offset_coord_combo.setCurrentIndex(
+            dialog.coord_widget.offset_coord_combo.findData("hv")
+        )
+        dialog.coord_widget.offset_coord_sign_combo.setCurrentIndex(
+            dialog.coord_widget.offset_coord_sign_combo.findData(-1)
+        )
+
+        assert manager.apply_batch_transform_dialog(dialog, "replace")
+        operation = AffineCoordOperation(
+            coord_name="eV",
+            scale=1.0,
+            offset=0.0,
+            offset_coord="hv",
+            offset_coord_sign=-1,
+        )
+        for index, data in enumerate((data0, data1)):
+            xarray.testing.assert_identical(
+                manager.get_imagetool(index).slicer_area._data.rename(None),
+                operation.apply(data).rename(None),
             )
 
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -10402,6 +10402,27 @@ def test_transform_dialog_restore_operation_roundtrip(
     win.close()
 
 
+def test_assign_coords_restore_scalar_offset_requires_coordinate(qtbot) -> None:
+    win = itool(_restore_dialog_data(), execute=False)
+    qtbot.addWidget(win)
+    dialog = AssignCoordsDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    with pytest.raises(ValueError, match="'hv' is not available"):
+        dialog.restore_transform_operation(
+            AffineCoordOperation(
+                coord_name="x",
+                scale=1.0,
+                offset=0.0,
+                offset_coord="hv",
+                offset_coord_sign=-1,
+            )
+        )
+
+    dialog.close()
+    win.close()
+
+
 def test_squeeze_dialog_restore_operation_roundtrip(qtbot) -> None:
     data = xr.DataArray(
         np.arange(15, dtype=float).reshape((1, 3, 1, 5)),
@@ -12129,6 +12150,75 @@ def test_itool_assign_coords_affine(qtbot, accept_dialog) -> None:
     assert "['y'].values - 3.7" in display_code
     assert "1.0 *" not in display_code
     assert "+ -3.7" not in display_code
+
+
+def test_itool_assign_coords_affine_scalar_coordinate_offset(
+    qtbot, accept_dialog
+) -> None:
+    data = xr.DataArray(
+        np.arange(12).reshape((3, 4)).astype(float),
+        dims=["x", "eV"],
+        coords={
+            "x": np.arange(3),
+            "eV": np.linspace(20.0, 23.0, 4),
+            "hv": 21.2,
+            "label": "scan",
+            "varying": ("x", np.arange(3)),
+            "invalid": np.nan,
+        },
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    def _set_dialog_params(dialog: AssignCoordsDialog) -> None:
+        dialog._coord_combo.setCurrentText("eV")
+        dialog.coord_widget.edit_mode_tabs.setCurrentIndex(1)
+        dialog.coord_widget.offset_coord_combo.setCurrentIndex(
+            _combo_index_for_data(dialog.coord_widget.offset_coord_combo, "hv")
+        )
+        dialog.coord_widget.offset_coord_sign_combo.setCurrentIndex(
+            _combo_index_for_data(dialog.coord_widget.offset_coord_sign_combo, -1)
+        )
+        dialog.launch_mode_combo.setCurrentText("Replace Current")
+
+    accept_dialog(win.mnb._assign_coords, pre_call=_set_dialog_params, timeout=10.0)
+    np.testing.assert_allclose(
+        win.slicer_area._data.eV.values,
+        data.eV.values - data.hv.item(),
+    )
+    assert win.provenance_spec is not None
+    operations = [
+        operation
+        for operation in win.provenance_spec.operations
+        if isinstance(operation, AffineCoordOperation)
+    ]
+    assert operations == [
+        AffineCoordOperation(
+            coord_name="eV",
+            scale=1.0,
+            offset=0.0,
+            offset_coord="hv",
+            offset_coord_sign=-1,
+        )
+    ]
+
+    display_code = win.provenance_spec.display_code(parent_data=data)
+    assert display_code is not None
+    destination = data.assign_coords(hv=40.0)
+    namespace = _exec_generated_code(
+        display_code,
+        {"data": destination.copy(deep=True)},
+    )
+    xr.testing.assert_identical(
+        namespace["derived"],
+        destination.assign_coords(
+            {
+                "eV": destination.eV.copy(
+                    data=destination.eV.values - destination.hv.item()
+                )
+            }
+        ),
+    )
 
 
 def _combo_index_for_data(combo: QtWidgets.QComboBox, data: object) -> int:

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -10423,6 +10423,23 @@ def test_assign_coords_restore_scalar_offset_requires_coordinate(qtbot) -> None:
     win.close()
 
 
+def test_assign_coords_ignores_scalar_timedelta_offset(qtbot) -> None:
+    data = _restore_dialog_data().assign_coords(
+        hv=21.2,
+        elapsed=np.timedelta64(1, "s"),
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    dialog = AssignCoordsDialog(win.slicer_area)
+    qtbot.addWidget(dialog)
+
+    assert dialog.coord_widget.offset_coord_combo.findData("hv") >= 0
+    assert dialog.coord_widget.offset_coord_combo.findData("elapsed") == -1
+
+    dialog.close()
+    win.close()
+
+
 def test_squeeze_dialog_restore_operation_roundtrip(qtbot) -> None:
     data = xr.DataArray(
         np.arange(15, dtype=float).reshape((1, 3, 1, 5)),

--- a/tests/interactive/imagetool/test_imagetool_coordinate_widget.py
+++ b/tests/interactive/imagetool/test_imagetool_coordinate_widget.py
@@ -222,6 +222,16 @@ def test_coordinate_widget_affine_scalar_coordinate_offset(qtbot):
     np.testing.assert_allclose(widget.affine_coord, arr + 0.5 - 21.2)
     np.testing.assert_allclose(_affine_preview_values(widget), arr + 0.5 - 21.2)
 
+    widget.offset_coord_combo.setCurrentIndex(widget.offset_coord_combo.findData(None))
+    assert widget.affine_offset_coord is None
+    assert widget.affine_offset_coord_sign == 1
+    assert not widget.offset_coord_sign_combo.isEnabled()
+    np.testing.assert_allclose(widget.affine_coord, arr + 0.5)
+
+    widget.offset_coord_combo.setCurrentIndex(widget.offset_coord_combo.findData("hv"))
+    widget.offset_coord_sign_combo.setCurrentIndex(
+        widget.offset_coord_sign_combo.findData(-1)
+    )
     widget.reset()
     assert widget.affine_offset_coord is None
     assert widget.affine_offset_coord_sign == 1

--- a/tests/interactive/imagetool/test_imagetool_coordinate_widget.py
+++ b/tests/interactive/imagetool/test_imagetool_coordinate_widget.py
@@ -157,6 +157,7 @@ def test_coordinate_widget_affine_identity(qtbot):
     assert widget.affine_offset == 0.0
     assert np.allclose(widget.affine_coord, arr)
     assert np.allclose(_affine_preview_values(widget), arr)
+    assert widget.scalar_offset_widget.isHidden()
 
 
 def test_coordinate_widget_affine_scale_offset(qtbot):
@@ -202,6 +203,30 @@ def test_coordinate_widget_affine_offset_only(qtbot):
     widget.edit_mode_tabs.setCurrentIndex(1)
     widget.offset_spin.setValue(3.0)
     assert np.allclose(widget.affine_coord, [4.0, 5.0, 7.0])
+
+
+def test_coordinate_widget_affine_scalar_coordinate_offset(qtbot):
+    arr = np.array([20.0, 21.0, 22.0])
+    widget = CoordinateEditorWidget(arr, scalar_coords={"hv": 21.2})
+    qtbot.addWidget(widget)
+    widget.edit_mode_tabs.setCurrentIndex(1)
+    assert not widget.scalar_offset_widget.isHidden()
+    widget.offset_spin.setValue(0.5)
+    widget.offset_coord_combo.setCurrentIndex(widget.offset_coord_combo.findData("hv"))
+    widget.offset_coord_sign_combo.setCurrentIndex(
+        widget.offset_coord_sign_combo.findData(-1)
+    )
+
+    assert widget.affine_offset_coord == "hv"
+    assert widget.affine_offset_coord_sign == -1
+    np.testing.assert_allclose(widget.affine_coord, arr + 0.5 - 21.2)
+    np.testing.assert_allclose(_affine_preview_values(widget), arr + 0.5 - 21.2)
+
+    widget.reset()
+    assert widget.affine_offset_coord is None
+    assert widget.affine_offset_coord_sign == 1
+    assert not widget.offset_coord_sign_combo.isEnabled()
+    np.testing.assert_allclose(widget.affine_coord, arr)
 
 
 def test_coordinate_widget_affine_reset(qtbot):

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -2278,6 +2278,117 @@ def test_tool_provenance_affine_coord_display_code_formats_no_ops(
     )
 
 
+def test_tool_provenance_affine_coord_uses_scalar_coordinate_offset() -> None:
+    data = _base_data().assign_coords(hv=21.2)
+    operation = AffineCoordOperation(
+        coord_name="y",
+        scale=1.0,
+        offset=0.5,
+        offset_coord="hv",
+        offset_coord_sign=-1,
+    )
+
+    expected = data.assign_coords(
+        {"y": data.y.copy(data=data.y.values + 0.5 - data.hv.item())}
+    )
+    xr.testing.assert_identical(operation.apply(data), expected)
+
+    parsed = parse_tool_provenance_operation(operation.model_dump(mode="json"))
+    assert parsed == operation
+    legacy_payload = AffineCoordOperation(
+        coord_name="y",
+        scale=1.0,
+        offset=0.0,
+    ).model_dump(mode="json")
+    assert not {"offset_coord", "offset_coord_sign"} & legacy_payload.keys()
+
+    code = full_data(operation).to_replay_spec().display_code(parent_data=data)
+    assert code is not None
+    destination = data.assign_coords(hv=40.0)
+    namespace = _exec_generated_code(code, {"data": destination.copy(deep=True)})
+    xr.testing.assert_identical(
+        namespace["derived"],
+        destination.assign_coords(
+            {
+                "y": destination.y.copy(
+                    data=destination.y.values + 0.5 - destination.hv.item()
+                )
+            }
+        ),
+    )
+
+
+def test_tool_provenance_affine_coord_lazy_scalar_offset_code() -> None:
+    import dask.array as da
+
+    data = _base_data().assign_coords(
+        hv=xr.DataArray(da.from_array(np.array(40.0), chunks=()))
+    )
+    operation = AffineCoordOperation(
+        coord_name="y",
+        scale=1.0,
+        offset=0.5,
+        offset_coord="hv",
+        offset_coord_sign=-1,
+    )
+
+    code = full_data(operation).to_replay_spec().display_code(parent_data=data)
+    assert code is not None
+    namespace = _exec_generated_code(code, {"data": data})
+    xr.testing.assert_identical(
+        namespace["derived"],
+        data.assign_coords(
+            {"y": data.y.copy(data=data.y.values + 0.5 - data.hv.values.item())}
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("data", "error"),
+    [
+        (_base_data(), "is not present"),
+        (
+            _base_data().assign_coords(hv=("x", [20.0, 21.0, 22.0])),
+            "must be scalar",
+        ),
+        (_base_data().assign_coords(hv="21.2"), "must contain a real number"),
+        (_base_data().assign_coords(hv=21.2 + 0.0j), "must contain a real number"),
+        (_base_data().assign_coords(hv=np.nan), "must be finite"),
+    ],
+)
+def test_tool_provenance_affine_coord_rejects_invalid_scalar_coordinate_offset(
+    data: xr.DataArray,
+    error: str,
+) -> None:
+    operation = AffineCoordOperation(
+        coord_name="y",
+        scale=1.0,
+        offset=0.0,
+        offset_coord="hv",
+    )
+    with pytest.raises(ValueError, match=error):
+        operation.apply(data)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"offset_coord": ""},
+        {"offset_coord_sign": -1},
+    ],
+)
+def test_tool_provenance_affine_coord_rejects_invalid_offset_reference(
+    kwargs: dict[str, typing.Any],
+) -> None:
+    with pytest.raises(ValidationError):
+        AffineCoordOperation(
+            coord_name="y",
+            scale=1.0,
+            offset=0.0,
+            **kwargs,
+        )
+
+
 @pytest.mark.parametrize(
     ("scale", "offset"),
     [

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -2353,6 +2353,10 @@ def test_tool_provenance_affine_coord_lazy_scalar_offset_code() -> None:
         ),
         (_base_data().assign_coords(hv="21.2"), "must contain a real number"),
         (_base_data().assign_coords(hv=21.2 + 0.0j), "must contain a real number"),
+        (
+            _base_data().assign_coords(hv=np.timedelta64(1, "s")),
+            "must contain a real number",
+        ),
         (_base_data().assign_coords(hv=np.nan), "must be finite"),
     ],
 )


### PR DESCRIPTION
## Summary

- add a coordinate-offset control to ImageTool's Coordinate Editor so affine coordinate transforms can add or subtract a finite numeric scalar coordinate
- keep the scalar coordinate reference symbolic in provenance, generated code, operation editing, and batch operations so each destination dataset uses its own value
- validate missing or incompatible scalar coordinates and keep copied code executable for lazily backed scalar coordinates

For example, a kinetic-energy `eV` coordinate can subtract the current dataset's scalar `hv` coordinate. Pasting or batching that provenance against another dataset resolves that dataset's own photon energy.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run python -m scripts.ci_test_groups --check-partition`
- PyQt6 provenance suite: 261 passed
- broader PyQt6 ImageTool/provenance regression selection: 298 passed
- focused PySide6 scalar-offset, operation-editing, clipboard, and batch coverage: 42 passed
- direct batch scalar-offset regression passed under both PyQt6 and PySide6
