### PR TITLE
fix(manager): elide long provenance input lists

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -65,6 +65,7 @@ _TOOL_PREVIEW_UPDATE_DELAY_MS = 250
 _PROVENANCE_STEPS_CLIPBOARD_MIME = "application/x-erlab-imagetool-provenance-steps+json"
 _PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.imagetool.provenance.steps"
 _PROVENANCE_STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
+_MAXIMUM_WRAPPED_METADATA_LINES = 4
 
 
 def _provenance_step_clipboard_payload(
@@ -523,14 +524,24 @@ class _DetailsPanelController:
                     )
                 )
             elif field.wrap:
+                lines = field.value.splitlines()
+                value = field.value
+                if len(lines) > _MAXIMUM_WRAPPED_METADATA_LINES:
+                    value = "\n".join(
+                        (
+                            *lines[: _MAXIMUM_WRAPPED_METADATA_LINES - 1],
+                            "…",
+                        )
+                    )
                 value_label = QtWidgets.QLabel(
-                    field.value, self._manager.metadata_details_widget
+                    value, self._manager.metadata_details_widget
                 )
                 value_label.setTextInteractionFlags(
                     QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
                 )
-                value_label.setWordWrap(field.wrap)
+                value_label.setWordWrap(True)
                 value_label.setToolTip(field.value)
+                value_label.setAccessibleName(field.value)
                 value_label.setMinimumWidth(0)
                 size_policy = QtWidgets.QSizePolicy(
                     QtWidgets.QSizePolicy.Policy.Expanding,

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -4640,6 +4640,7 @@ def test_details_panel_single_line_rows_stay_compact_and_elide(
         typing.cast("manager_mainwindow.ImageToolManager", manager)
     )
     long_time = "2024-01-02 03:04:05 Pacific Daylight Time (-0700)"
+    input_text = "\n".join(f"parent {index}" for index in range(7))
 
     controller._set_metadata_fields(
         [
@@ -4651,7 +4652,11 @@ def test_details_panel_single_line_rows_stay_compact_and_elide(
                 monospace=True,
                 details=details,
             ),
-            manager_wrapper._MetadataField("Inputs", "first\nsecond", wrap=True),
+            manager_wrapper._MetadataField(
+                "Inputs",
+                input_text,
+                wrap=True,
+            ),
         ]
     )
 
@@ -4662,7 +4667,10 @@ def test_details_panel_single_line_rows_stay_compact_and_elide(
     assert isinstance(kind_label, manager_widgets._ElidedValueLabel)
     assert isinstance(added_label, manager_widgets._ElidedValueLabel)
     assert isinstance(file_label, manager_widgets._ElidedValueLabel)
-    assert not isinstance(inputs_label, manager_widgets._ElidedValueLabel)
+    assert len(inputs_label.text().splitlines()) == 4
+    assert inputs_label.text().endswith("…")
+    assert inputs_label.toolTip() == input_text
+    assert inputs_label.accessibleName() == input_text
     assert added_label.full_text == long_time
     assert added_label.sizePolicy().horizontalPolicy() == (
         QtWidgets.QSizePolicy.Policy.Ignored


### PR DESCRIPTION
## Summary

- cap wrapped provenance input details at four visible lines
- show an ellipsis when additional parent inputs are hidden
- preserve the complete input summary in the tooltip and accessible name
- keep short input lists and reload details unchanged

## Root cause

The Details tab rendered every recorded parent input as an unrestricted wrapped
label. Results derived from many inputs could therefore make the Inputs row—and
the entire details panel—excessively tall.

## Validation

- `uv run ruff format --check src/erlab/interactive/imagetool/manager/_details_panel.py tests/interactive/imagetool/manager/test_mainwindow.py`
- `uv run ruff check src/erlab/interactive/imagetool/manager/_details_panel.py tests/interactive/imagetool/manager/test_mainwindow.py`
- `QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run --group pyqt6 pytest -q tests/interactive/imagetool/manager/test_mainwindow.py::test_details_panel_single_line_rows_stay_compact_and_elide tests/interactive/imagetool/manager/test_console.py::test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent`
- `QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run --group pyside6 pytest -q tests/interactive/imagetool/manager/test_mainwindow.py::test_details_panel_single_line_rows_stay_compact_and_elide`
