### PR TITLE
fix(analysis): ignore NaNs in leading edge detection

### DIFF
--- a/src/erlab/analysis/interpolate.py
+++ b/src/erlab/analysis/interpolate.py
@@ -551,6 +551,7 @@ def slice_along_vector(
 def _minimize_func(
     edc_values: npt.NDArray,
     coord: npt.NDArray,
+    fraction: float,
     direction: typing.Literal["positive", "negative"],
     on_failure: typing.Literal["nan", "raise"],
 ) -> float:
@@ -568,6 +569,7 @@ def _minimize_func(
     order = np.argsort(coord)
     coord = coord[order]
     edc_values = edc_values[order]
+    edc_values = edc_values - np.max(edc_values) * fraction
 
     try:
         spl = scipy.interpolate.make_interp_spline(
@@ -659,17 +661,16 @@ def leading_edge(
     if on_failure not in {"nan", "raise"}:
         raise ValueError("on_failure must be 'nan' or 'raise'")
 
-    half_max = darr.max(dim=[dim]) * fraction
-
     return xr.apply_ufunc(
         _minimize_func,
-        darr - half_max,
+        darr,
         input_core_dims=[[dim]],
         dask="parallelized",
         output_dtypes=[float],
         vectorize=True,
         kwargs={
             "coord": darr[dim].values,
+            "fraction": fraction,
             "direction": direction,
             "on_failure": on_failure,
         },

--- a/src/erlab/analysis/interpolate.py
+++ b/src/erlab/analysis/interpolate.py
@@ -554,17 +554,25 @@ def _minimize_func(
     direction: typing.Literal["positive", "negative"],
     on_failure: typing.Literal["nan", "raise"],
 ) -> float:
+    finite = np.isfinite(coord) & np.isfinite(edc_values)
+    coord = coord[finite]
+    edc_values = edc_values[finite]
+
+    if coord.size < 2:
+        if on_failure == "nan":
+            return np.nan
+        raise ValueError(
+            "at least two finite coordinate and intensity value pairs are required"
+        )
+
     order = np.argsort(coord)
     coord = coord[order]
     edc_values = edc_values[order]
 
-    if not np.all(np.isfinite(coord)) or not np.all(np.isfinite(edc_values)):
-        if on_failure == "nan":
-            return np.nan
-        raise ValueError("coordinate and intensity values must be finite")
-
     try:
-        spl = scipy.interpolate.make_interp_spline(coord, edc_values)
+        spl = scipy.interpolate.make_interp_spline(
+            coord, edc_values, k=min(3, coord.size - 1)
+        )
     except ValueError:
         if on_failure == "nan":
             return np.nan
@@ -614,6 +622,10 @@ def leading_edge(
 
     It is calculated by interpolating each curve with a spline and finding the root of
     the function defined as the difference between the curve and the target intensity.
+
+    .. versionchanged:: 3.26.0
+        Non-finite samples are ignored when fitting each curve. The spline degree is
+        reduced when fewer than four finite samples remain.
 
     Parameters
     ----------

--- a/tests/analysis/test_interpolate.py
+++ b/tests/analysis/test_interpolate.py
@@ -342,10 +342,37 @@ def test_leading_edge_vectorized_mixes_valid_and_nan_edges() -> None:
     assert np.isnan(out.sel(idx=1).item())
 
 
+def test_leading_edge_ignores_nan_samples() -> None:
+    eV = np.linspace(-1.0, 1.0, 401)
+    edge = 0.2
+    values = 1.0 / (1.0 + np.exp((eV - edge) / 0.03))
+    values[[0, 37, 240, 400]] = np.nan
+    darr = xr.DataArray(
+        np.stack([values, np.full_like(values, np.nan)]),
+        dims=("idx", "eV"),
+        coords={"eV": eV},
+    )
+
+    out = leading_edge(darr)
+
+    assert out.sel(idx=0).item() == pytest.approx(edge, abs=1e-3)
+    assert np.isnan(out.sel(idx=1).item())
+
+
+def test_leading_edge_reduces_spline_degree_for_sparse_curve() -> None:
+    eV = np.array([0.0, 1.0, 2.0, 3.0])
+    values = np.array([1.0, np.nan, np.nan, 0.0])
+    darr = xr.DataArray(values, dims=("eV",), coords={"eV": eV})
+
+    out = leading_edge(darr)
+
+    assert float(out) == pytest.approx(1.5)
+
+
 @pytest.mark.parametrize("on_failure", ["nan", "raise"])
-def test_leading_edge_nonfinite_values_handle_failure(on_failure) -> None:
+def test_leading_edge_insufficient_finite_values_handle_failure(on_failure) -> None:
     coord = np.array([0.0, 1.0, 2.0, 3.0])
-    values = np.array([1.0, np.nan, -1.0, -2.0])
+    values = np.array([np.nan, np.nan, 1.0, np.nan])
 
     if on_failure == "nan":
         out = erlab.analysis.interpolate._minimize_func(
@@ -353,7 +380,7 @@ def test_leading_edge_nonfinite_values_handle_failure(on_failure) -> None:
         )
         assert np.isnan(out)
     else:
-        with pytest.raises(ValueError, match="finite"):
+        with pytest.raises(ValueError, match="at least two finite"):
             erlab.analysis.interpolate._minimize_func(
                 values, coord, "positive", on_failure
             )
@@ -464,6 +491,7 @@ def test_leading_edge_dask_parallelized() -> None:
 
     ee, ev = np.meshgrid(edges, eV, indexing="ij")
     values = 1.0 / (1.0 + np.exp((ev - ee) / width))
+    values[:, ::37] = np.nan
 
     darr = xr.DataArray(
         values,

--- a/tests/analysis/test_interpolate.py
+++ b/tests/analysis/test_interpolate.py
@@ -359,6 +359,30 @@ def test_leading_edge_ignores_nan_samples() -> None:
     assert np.isnan(out.sel(idx=1).item())
 
 
+def test_leading_edge_ignores_infinite_intensity_in_maximum() -> None:
+    eV = np.linspace(-1.0, 1.0, 401)
+    edge = 0.2
+    values = 1.0 / (1.0 + np.exp((eV - edge) / 0.03))
+    values[-1] = np.inf
+    darr = xr.DataArray(values, dims=("eV",), coords={"eV": eV})
+
+    out = leading_edge(darr)
+
+    assert float(out) == pytest.approx(edge, abs=1e-3)
+
+
+def test_leading_edge_ignores_intensity_at_nonfinite_coordinate() -> None:
+    eV = np.linspace(-1.0, 1.0, 401)
+    edge = 0.2
+    values = 1.0 / (1.0 + np.exp((eV - edge) / 0.03))
+    eV[0] = np.nan
+    darr = xr.DataArray(values, dims=("eV",), coords={"eV": eV})
+
+    out = leading_edge(darr)
+
+    assert float(out) == pytest.approx(edge, abs=1e-3)
+
+
 def test_leading_edge_reduces_spline_degree_for_sparse_curve() -> None:
     eV = np.array([0.0, 1.0, 2.0, 3.0])
     values = np.array([1.0, np.nan, np.nan, 0.0])
@@ -376,13 +400,13 @@ def test_leading_edge_insufficient_finite_values_handle_failure(on_failure) -> N
 
     if on_failure == "nan":
         out = erlab.analysis.interpolate._minimize_func(
-            values, coord, "positive", on_failure
+            values, coord, 0.0, "positive", on_failure
         )
         assert np.isnan(out)
     else:
         with pytest.raises(ValueError, match="at least two finite"):
             erlab.analysis.interpolate._minimize_func(
-                values, coord, "positive", on_failure
+                values, coord, 0.0, "positive", on_failure
             )
 
 
@@ -393,13 +417,13 @@ def test_leading_edge_spline_errors_handle_failure(on_failure) -> None:
 
     if on_failure == "nan":
         out = erlab.analysis.interpolate._minimize_func(
-            values, coord, "positive", on_failure
+            values, coord, 0.0, "positive", on_failure
         )
         assert np.isnan(out)
     else:
         with pytest.raises(ValueError, match="duplicates"):
             erlab.analysis.interpolate._minimize_func(
-                values, coord, "positive", on_failure
+                values, coord, 0.0, "positive", on_failure
             )
 
 
@@ -407,7 +431,9 @@ def test_leading_edge_zero_peak_returns_peak_coord() -> None:
     coord = np.array([0.0, 1.0, 2.0, 3.0])
     values = np.array([0.0, -1.0, -1.0, -1.0])
 
-    out = erlab.analysis.interpolate._minimize_func(values, coord, "positive", "raise")
+    out = erlab.analysis.interpolate._minimize_func(
+        values, coord, 0.0, "positive", "raise"
+    )
 
     assert out == 0.0
 
@@ -416,7 +442,9 @@ def test_leading_edge_zero_endpoint_returns_endpoint() -> None:
     coord = np.array([0.0, 1.0, 2.0, 3.0])
     values = np.array([1.0, 0.5, 0.2, 0.0])
 
-    out = erlab.analysis.interpolate._minimize_func(values, coord, "positive", "raise")
+    out = erlab.analysis.interpolate._minimize_func(
+        values, coord, 0.0, "positive", "raise"
+    )
 
     assert out == 3.0
 
@@ -428,13 +456,13 @@ def test_leading_edge_zero_peak_and_endpoint_handle_failure(on_failure) -> None:
 
     if on_failure == "nan":
         out = erlab.analysis.interpolate._minimize_func(
-            values, coord, "positive", on_failure
+            values, coord, 0.0, "positive", on_failure
         )
         assert np.isnan(out)
     else:
         with pytest.raises(ValueError, match="single crossing"):
             erlab.analysis.interpolate._minimize_func(
-                values, coord, "positive", on_failure
+                values, coord, 0.0, "positive", on_failure
             )
 
 
@@ -451,13 +479,13 @@ def test_leading_edge_root_solver_errors_handle_failure(
 
     if on_failure == "nan":
         out = erlab.analysis.interpolate._minimize_func(
-            values, coord, "positive", on_failure
+            values, coord, 0.0, "positive", on_failure
         )
         assert np.isnan(out)
     else:
         with pytest.raises(ValueError, match="solver failed"):
             erlab.analysis.interpolate._minimize_func(
-                values, coord, "positive", on_failure
+                values, coord, 0.0, "positive", on_failure
             )
 
 


### PR DESCRIPTION
## Summary

- ignore non-finite coordinate and intensity pairs before fitting each leading-edge curve
- reduce the spline degree when only two or three finite samples remain
- preserve `on_failure` behavior when fewer than two samples remain or no crossing can be bracketed
- document the behavior change and cover NumPy-backed and Dask-backed DataArrays, including scattered and all-NaN curves

## Root cause

`DataArray.max` skipped NaNs when computing the target intensity, but the spline
helper rejected the entire residual curve as soon as any coordinate or intensity
sample was non-finite. As a result, an otherwise estimable leading edge returned
NaN.

The fit now uses the remaining finite pairs. Dask execution remains lazy and follows
the existing requirement that the fitted core dimension occupy one chunk.

## Validation

- `uv run --group pyqt6 pytest tests/analysis/test_interpolate.py -q` — 45 passed
- `uv run --group pyqt6 ruff check src/erlab/analysis/interpolate.py tests/analysis/test_interpolate.py`
- `uv run --group pyqt6 ruff format --check src/erlab/analysis/interpolate.py tests/analysis/test_interpolate.py`
- `uv run --group pyqt6 mypy src/erlab/analysis/interpolate.py`
- `git diff --check origin/main...HEAD`
