### PR TITLE
fix(manager): parse file labels across platforms

### DIFF
--- a/src/erlab/interactive/imagetool/_load_source.py
+++ b/src/erlab/interactive/imagetool/_load_source.py
@@ -61,6 +61,11 @@ _LoadFunc: typing.TypeAlias = tuple[
 _LoadKind: typing.TypeAlias = typing.Literal["erlab_loader", "callable"]
 
 
+def _file_path_stem(path: str | os.PathLike[str]) -> str:
+    """Return the stem of a recorded Windows or POSIX file path."""
+    return pathlib.PureWindowsPath(path).stem
+
+
 def _spreadsheet_metadata_source_config(
     source: erlab.io.metadata.SpreadsheetMetadataSource,
 ) -> dict[str, typing.Any] | None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -25,7 +25,10 @@ import erlab.interactive.imagetool.manager._workspace._storage as workspace_stor
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.imagetool.viewer_linking
 from erlab.interactive import _qt_state
-from erlab.interactive.imagetool._load_source import _deserialize_loader_kwargs
+from erlab.interactive.imagetool._load_source import (
+    _deserialize_loader_kwargs,
+    _file_path_stem,
+)
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME, ImageTool
 from erlab.interactive.imagetool._provenance._model import (
     ScriptInputDataRole,
@@ -218,7 +221,7 @@ def _workspace_provenance_file_stems(
         if current is None:
             return
         if current.file_load_source is not None:
-            stem = pathlib.Path(current.file_load_source.path).stem
+            stem = _file_path_stem(current.file_load_source.path)
             if stem not in stems:
                 stems.append(stem)
         for script_input in current.script_inputs:

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -43,6 +43,7 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 from erlab.interactive.imagetool._load_source import (
     _default_load_source_name,
     _deserialize_loader_kwargs,
+    _file_path_stem,
     _load_code_from_file_details,
     _load_source_details_from_file,
     _load_source_details_from_provenance,
@@ -352,7 +353,7 @@ def _collect_provenance_file_paths(
 def _compact_file_suffix(paths: Sequence[pathlib.Path]) -> str:
     if not paths:
         return ""
-    stems = tuple(dict.fromkeys(path.stem for path in paths))
+    stems = tuple(dict.fromkeys(_file_path_stem(path) for path in paths))
     if len(stems) <= 2:
         return f" ({', '.join(stems)})"
     return f" ({', '.join(stems[:2])}, +{len(stems) - 2})"

--- a/tests/interactive/imagetool/manager/provenance/test_dependencies.py
+++ b/tests/interactive/imagetool/manager/provenance/test_dependencies.py
@@ -239,6 +239,21 @@ def test_manager_compact_file_suffix(tmp_path) -> None:
     assert manager_wrapper._compact_file_suffix(paths) == " (scan_a, scan_b, +1)"
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        pathlib.Path(r"C:\Users\name\data\scan.h5"),
+        pathlib.Path(r"\\server\share\data\scan.h5"),
+        pathlib.Path("C:/Users/name/data/scan.h5"),
+        pathlib.Path("/Users/name/data/scan.h5"),
+    ],
+)
+def test_manager_compact_file_suffix_accepts_cross_platform_paths(
+    path: pathlib.Path,
+) -> None:
+    assert manager_wrapper._compact_file_suffix([path]) == " (scan)"
+
+
 def test_manager_childtool_from_filtered_parent_uses_display_provenance(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/workspace/test_format.py
+++ b/tests/interactive/imagetool/manager/workspace/test_format.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pathlib
 
 import numpy as np
 import pydantic
@@ -77,6 +78,21 @@ def test_workspace_file_suffix_helpers_collect_nested_inputs(tmp_path) -> None:
         workspace_loading._workspace_compact_file_suffix(stems)
         == " (scan_a, scan_b, +1)"
     )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        r"C:\Users\name\data\scan.h5",
+        r"\\server\share\data\scan.h5",
+        "C:/Users/name/data/scan.h5",
+        "/Users/name/data/scan.h5",
+    ],
+)
+def test_workspace_file_suffix_helpers_accept_cross_platform_paths(path: str) -> None:
+    spec = _workspace_test_file_spec(pathlib.Path(path))
+
+    assert workspace_loading._workspace_provenance_file_stems(spec) == ("scan",)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Parse recorded file stems with `pathlib.PureWindowsPath` so manager labels accept Windows, UNC, and POSIX path syntax on all operating systems.
- Use the same parser for live manager rows and restored workspace labels.
- Keep each recorded source path unchanged for replay, diagnostics, and file relinking.

## Root cause

`pathlib.Path.stem` uses the current operating system's path rules. On macOS, it treats backslashes in a recorded Windows path as ordinary filename characters. The manager therefore displayed most of the Windows path instead of only the file stem.

## User impact

ImageTool workspaces moved from Windows to macOS now show compact source filenames in the manager tree.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run --group pyqt6 pytest -q tests/interactive/imagetool/manager/provenance/test_dependencies.py::test_manager_compact_file_suffix tests/interactive/imagetool/manager/provenance/test_dependencies.py::test_manager_compact_file_suffix_accepts_cross_platform_paths tests/interactive/imagetool/manager/workspace/test_format.py` (`23 passed`)
- `uv run --group pyqt6 ruff format --check` on all changed files
- `uv run --group pyqt6 ruff check` on all changed files
- `uv run --group pyqt6 mypy` on all changed source files
- `git diff --check`
