### PR TITLE
fix(interactive): honor dtool color cutoff changes

### DIFF
--- a/src/erlab/interactive/_plot_state.py
+++ b/src/erlab/interactive/_plot_state.py
@@ -622,6 +622,14 @@ class ToolPlotStateRegistry(QtCore.QObject):
         elif desired_state is not None:
             adapter.set_desired_state(desired_state)
 
+    def clear_manual_levels(self, plot_id: str) -> None:
+        """Let image updates control the levels for a registered plot."""
+        adapter = self._adapters[plot_id]
+        adapter.manual_levels = False
+        adapter.desired_state = adapter.capture()
+        self._pending_changes.add(plot_id)
+        self._flush_timer.start(0)
+
     def _queue_change(self, plot_id: str, component: str) -> None:
         adapter = self._adapters.get(plot_id)
         if adapter is None:

--- a/src/erlab/interactive/derivative.py
+++ b/src/erlab/interactive/derivative.py
@@ -279,8 +279,8 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
         self.sy_spin.valueChanged.connect(self.update_preprocess)
         self.sn_spin.valueChanged.connect(self.update_preprocess)
 
-        self.hi_spin.valueChanged.connect(self.update_image)
-        self.lo_spin.valueChanged.connect(self.update_image)
+        self.hi_spin.valueChanged.connect(self.update_color_limits)
+        self.lo_spin.valueChanged.connect(self.update_color_limits)
 
         self.tab_widget.currentChanged.connect(self.update_result)
         self.x_radio.clicked.connect(self.update_result)
@@ -396,6 +396,12 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
 
         self.images[0].setDataArray(out)
         return out
+
+    @QtCore.Slot()
+    def update_color_limits(self) -> None:
+        if not self._pause_update:
+            self._clear_manual_plot_levels("result")
+            self.update_image()
 
     @QtCore.Slot()
     def update_image(self) -> None:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3474,6 +3474,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Register a colorbar or histogram under a stable semantic plot ID."""
         self._plot_state_registry.register(plot_id, target)
 
+    def _clear_manual_plot_levels(self, plot_id: str) -> None:
+        """Let image updates control the levels for a registered plot."""
+        self._plot_state_registry.clear_manual_levels(plot_id)
+
     @property
     def undoable(self) -> bool:
         """Return whether a previous tool state is available."""

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import tempfile
 import typing
 from types import SimpleNamespace
@@ -186,6 +187,33 @@ def test_dtool_plot_appearance_roundtrip_and_image_refresh(qtbot) -> None:
     qtbot.wait_until(
         lambda: restored.hists[1].getLevels() == pytest.approx((4.0, 20.0))
     )
+
+
+@pytest.mark.parametrize(
+    ("spin_name", "value"),
+    [("hi_spin", 10.0), ("lo_spin", 15.0)],
+)
+def test_dtool_color_cutoffs_override_manual_result_levels(
+    qtbot, spin_name: str, value: float
+) -> None:
+    y, x = np.mgrid[-2:3:5j, -3:4:7j]
+    data = xr.DataArray(x**4 + y**2, dims=("y", "x"), name="data")
+    win = DerivativeTool(data)
+    qtbot.addWidget(win)
+
+    histogram = win.hists[1]
+    histogram.region.lines[0].sigDragged.emit(histogram.region.lines[0])
+    histogram.setLevels(2.0, 8.0)
+    histogram.sigLevelChangeFinished.emit(histogram)
+
+    getattr(win, spin_name).setValue(value)
+    expected = win.get_levels(win.result.values)
+    qtbot.wait(10)
+
+    assert histogram.getLevels() == pytest.approx(expected)
+    assert win.images[1].getLevels() == pytest.approx(expected)
+    view_state = json.loads(win.to_dataset().attrs["tool_view_state"])
+    assert view_state["plots"]["result"]["levels"] is None
 
 
 def test_dtool_smoothing_copy_code_uses_readable_steps(qtbot) -> None:


### PR DESCRIPTION
## Summary

- Clear saved manual result levels when the user changes the dtool High or Low color cutoff.
- Keep manual histogram levels for normal result refreshes and saved plot appearance.
- Add regression coverage for both percentage controls and the queued plot-state replay.

## Root cause

A histogram drag stored absolute result levels in `ToolPlotStateRegistry`. A color cutoff change applied the correct percentile levels to the image. The image update then queued a plot-state replay, which restored the old absolute levels.

## User impact

The High and Low percentage controls now override a previous manual histogram adjustment. The new percentage-based limits remain active after the image refresh.

## Validation

- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run mypy src`
- `QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_derivative.py` (`76 passed`)
- `QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_utils.py tests/interactive/test_derivative.py` (`274 passed`)
- `QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest -q` (`5474 passed, 1 skipped`)
