### PR TITLE
fix(options): defer typed spinbox updates

### DIFF
--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -572,6 +572,12 @@ class OptionDialog(QtWidgets.QDialog):
 
         for path in paths:
             control = self._make_control(path)
+            # The dialog saves and refreshes immediately after each value change.
+            # Defer typed numeric changes so a refresh does not interrupt entry.
+            if isinstance(control, QtWidgets.QAbstractSpinBox):
+                control.setKeyboardTracking(False)
+            for spin in control.findChildren(QtWidgets.QAbstractSpinBox):
+                spin.setKeyboardTracking(False)
             row = _SettingsRow(scope=scope, path=path, control=control, parent=page)
             self._rows[(scope, path)] = row
             self._connect_control(row)

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -143,6 +143,13 @@ def test_dialog_native_structure(dialog: OptionDialog):
     assert container.layout().contentsMargins().right() > 0
 
 
+def test_dialog_spinboxes_disable_keyboard_tracking(dialog: OptionDialog):
+    spinboxes = dialog.findChildren(QtWidgets.QAbstractSpinBox)
+
+    assert spinboxes
+    assert all(not spin.keyboardTracking() for spin in spinboxes)
+
+
 def test_dialog_setting_descriptions_are_visible_not_duplicate_tooltips(
     dialog: OptionDialog,
 ):


### PR DESCRIPTION
## Summary

- Defer typed numeric settings changes until the user presses Enter or moves focus.
- Apply the rule to direct and nested spin boxes at the shared settings dialog seam.
- Add a regression test that checks every settings spin box.

## Root cause

The settings dialog saved each `valueChanged` signal and then refreshed all controls. Qt keyboard tracking emitted this signal after each typed character. The refresh interrupted entry before the user could type the complete value.

## User impact

Users can type complete ktool and other numeric settings values. Spin-box buttons, arrow keys, and mouse-wheel changes still apply immediately.

## Validation

- `uv run ruff format --check src/erlab/interactive/_options/ui.py tests/interactive/test_options.py`
- `uv run ruff check src/erlab/interactive/_options/ui.py tests/interactive/test_options.py`
- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_options.py` with PyQt6: 61 passed
- `QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_options.py`: 61 passed
- `git diff --check`
