### PR TITLE
fix(interactive.ptable): normalize full-width energy input

### DIFF
--- a/src/erlab/interactive/ptable/_shared.py
+++ b/src/erlab/interactive/ptable/_shared.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import html
 import re
+import unicodedata
 from dataclasses import dataclass
 
 import numpy as np
@@ -385,10 +386,16 @@ def _format_energy(value: float) -> str:
     return np.format_float_positional(float(value), precision=4, trim="-")
 
 
-def _parse_positive_float(text: str) -> float | None:
+def _parse_float(text: str) -> float | None:
     try:
-        value = float(text)
+        return float(unicodedata.normalize("NFKC", text))
     except ValueError:
+        return None
+
+
+def _parse_positive_float(text: str) -> float | None:
+    value = _parse_float(text)
+    if value is None:
         return None
     return value if value > 0.0 else None
 

--- a/src/erlab/interactive/ptable/_window.py
+++ b/src/erlab/interactive/ptable/_window.py
@@ -19,6 +19,7 @@ from erlab.interactive.ptable._shared import (
     _has_keyboard_modifier,
     _is_toggle_selection_modifier,
     _navigation_atomic_numbers,
+    _parse_float,
     _parse_positive_float,
     _parse_symbol_selection_query,
     _rectangular_selection_range,
@@ -680,9 +681,8 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         text = self.workfunction_edit.text().strip()
         if text == "":
             return 0.0
-        try:
-            value = float(text)
-        except ValueError:
+        value = _parse_float(text)
+        if value is None:
             return 0.0
         return max(value, 0.0)
 
@@ -1114,10 +1114,8 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         if workfunction_text == "":
             work_invalid = False
         else:
-            try:
-                work_invalid = float(workfunction_text) < 0.0
-            except ValueError:
-                work_invalid = True
+            workfunction = _parse_float(workfunction_text)
+            work_invalid = workfunction is None or workfunction < 0.0
         self._set_line_edit_invalid_state(self.workfunction_edit, work_invalid)
         harmonics_enabled = (
             photon_text != "" and _parse_positive_float(photon_text) is not None

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -2151,6 +2151,40 @@ def test_ptable_harmonic_rows_expand_from_spinbox(
     win.close()
 
 
+def test_ptable_full_width_energy_inputs(
+    qtbot,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        erlab.analysis.xps,
+        "get_edge",
+        lambda _symbol: {"1s": 12.0},
+    )
+    monkeypatch.setattr(erlab.analysis.xps, "get_cross_section", _fake_cross_sections)
+
+    win = PeriodicTableWindow()
+    _show_window(qtbot, win)
+    win._handle_card_selected(1, QtCore.Qt.KeyboardModifier.NoModifier)
+
+    photon_text = "\uff18\uff10\uff0e\uff10"
+    workfunction_text = "\uff14\uff0e\uff15"
+    win.hv_edit.setText(photon_text)
+    win.workfunction_edit.setText(workfunction_text)
+
+    assert win.hv_edit.text() == photon_text
+    assert win.workfunction_edit.text() == workfunction_text
+    assert win.hv == pytest.approx(80.0)
+    assert win.workfunction == pytest.approx(4.5)
+    assert win.hv_edit.property("invalid") is False
+    assert win.workfunction_edit.property("invalid") is False
+    assert win.harmonic_frame.isEnabled() is True
+    assert win.max_harmonic_spin.isEnabled() is True
+    assert win.inspector.levels_table.item(1, 0).text() == "63.5"
+    assert win.inspector.cross_section_plot.photon_line_energy == pytest.approx(80.0)
+
+    win.close()
+
+
 def test_ptable_copy_actions_and_invalid_inputs(
     qtbot,
     monkeypatch,


### PR DESCRIPTION
## Summary

- Normalize Unicode compatibility characters before parsing Periodic Table energy inputs.
- Use one parsing path for photon energy, work function, and validity state.
- Preserve the exact text shown in the line edits and saved in workspace state.
- Add a regression test for full-width photon-energy and work-function values.

## Root cause

The Periodic Table line edits preserve arbitrary Unicode text. Their numeric conversion called `float()` directly. Python accepts full-width digits, but it does not accept the full-width decimal point. Photon energy became invalid, and work function fell back to `0.0` when this text reached the parser.

## User impact

Full-width numeric input now produces the correct photon energy, work function, harmonic state, and kinetic-energy values. ASCII input is unchanged.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_ptable.py` — 63 passed
- `uv run ruff check src/erlab/interactive/ptable/_shared.py src/erlab/interactive/ptable/_window.py tests/interactive/test_ptable.py`
- `uv run ruff format --check src/erlab/interactive/ptable/_shared.py src/erlab/interactive/ptable/_window.py tests/interactive/test_ptable.py`
- `git diff --check`
