### PR TITLE
feat(ktool): clarify normal emission and angle scale controls

### DIFF
--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -80,9 +80,17 @@ parameters. The image is updated in real time as you change the parameters. For
 angle-energy cuts, the preview keeps the full energy axis and displays the converted
 `k`/`eV` cut.
 
-Use the `alpha scale` and `beta scale` controls only to compensate known extrinsic
-warping in the angle coordinates. The scales multiply the `alpha` and `beta` coordinates
-before momentum conversion. In most cases, these should be left at 1.0.
+Use the {guilabel}`Normal Emission` controls to set the `alpha` and `beta` angles
+that correspond to sample normal emission. The linked angle offsets in
+{guilabel}`Offsets` are shown as values. The azimuthal offset, work function, and
+inner potential remain controls.
+
+The `alpha scale` and `beta scale` controls are hidden by default. To show them,
+enable {guilabel}`Show angle scale controls` in the `ktool` Preferences. Use these
+controls only to compensate a known scaling error in the angle coordinates. The
+scales multiply the `alpha` and `beta` coordinates before momentum conversion. If
+a saved KTool uses non-unit scales while the controls are hidden, its
+{guilabel}`Angle scales` row shows the active values.
 
 Clicking {guilabel}`Copy to clipboard` will copy the code for conversion to the
 clipboard, including any selected configuration change and momentum-conversion

--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -80,18 +80,6 @@ parameters. The image is updated in real time as you change the parameters. For
 angle-energy cuts, the preview keeps the full energy axis and displays the converted
 `k`/`eV` cut.
 
-Use the {guilabel}`Normal Emission` controls to set the `alpha` and `beta` angles
-that correspond to sample normal emission. The linked angle offsets in
-{guilabel}`Offsets` are shown as values. The azimuthal offset, work function, and
-inner potential remain controls.
-
-The `alpha scale` and `beta scale` controls are hidden by default. To show them,
-enable {guilabel}`Show angle scale controls` in the `ktool` Preferences. Use these
-controls only to compensate a known scaling error in the angle coordinates. The
-scales multiply the `alpha` and `beta` coordinates before momentum conversion. If
-a saved KTool uses non-unit scales while the controls are hidden, its
-{guilabel}`Angle scales` row shows the active values.
-
 Clicking {guilabel}`Copy to clipboard` will copy the code for conversion to the
 clipboard, including any selected configuration change and momentum-conversion
 settings.

--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -27,6 +27,11 @@ Use the sidebar to switch between setting groups:
 - {guilabel}`Figure Composer` controls default Matplotlib stylesheets and optional
   default DPI for newly created figures.
 
+The {guilabel}`Show angle scale controls` setting is off by default. Turn it on
+only when you must apply an established correction for angle-coordinate scaling
+errors. This setting changes which controls are visible. It does not remove angle
+scale values from a saved KTool.
+
 ```{versionadded} 3.25.0
 The I/O settings include a default folder for ImageTool Manager file dialogs and
 new Data Explorer windows.

--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -27,16 +27,6 @@ Use the sidebar to switch between setting groups:
 - {guilabel}`Figure Composer` controls default Matplotlib stylesheets and optional
   default DPI for newly created figures.
 
-The {guilabel}`Show angle scale controls` setting is off by default. Turn it on
-only when you must apply an established correction for angle-coordinate scaling
-errors. This setting changes which controls are visible. It does not remove angle
-scale values from a saved KTool.
-
-```{versionadded} 3.25.0
-The I/O settings include a default folder for ImageTool Manager file dialogs and
-new Data Explorer windows.
-```
-
 Rows in the {guilabel}`User` scope include a reset action that restores the application
 default for that setting. Broadly resetting all user settings still asks for
 confirmation.

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -179,6 +179,15 @@ class KToolBZOptions(BaseModel):
 class KToolOptions(BaseModel):
     """Momentum conversion tool related options."""
 
+    show_angle_scale_controls: bool = Field(
+        default=False,
+        title="Show angle scale controls",
+        description=(
+            "Show the alpha and beta scale controls in ktool. Use these controls "
+            "only with an established correction for angle-coordinate scaling errors."
+        ),
+    )
+
     bz: KToolBZOptions = Field(
         default_factory=KToolBZOptions,
         title="Brillouin zone",

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -34,6 +34,8 @@ from erlab.constants import AxesConfiguration
 from erlab.interactive.imagetool import _kspace_conversion
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import matplotlib
     import varname
     import xarray as xr
@@ -147,6 +149,7 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
     _PREVIEW_SYMMETRY_ABS_TOL = 0.05
     _PREVIEW_SYMMETRY_REL_TOL = 0.02
     _PREVIEW_SYMMETRY_ANGLE_TOL = 5.0
+    _show_angle_scale_controls: bool
 
     def __init__(
         self,
@@ -178,6 +181,7 @@ class KspaceToolGUI(erlab.interactive.utils.ToolWindow):
             plot.showGrid(x=True, y=True, alpha=0.5)
 
         opts = options_model or erlab.interactive.options.model
+        self._show_angle_scale_controls = opts.ktool.show_angle_scale_controls
 
         if cmap is None:
             cmap = opts.colors.cmap.name
@@ -401,7 +405,10 @@ class KspaceTool(KspaceToolGUI):
     data: xr.DataArray
     _source_configuration: int
     _offset_spins: dict[str, QtWidgets.QDoubleSpinBox]
+    _normal_emission_offset_values: dict[str, float]
+    _normal_emission_offset_labels: dict[str, QtWidgets.QLabel]
     _angle_scale_spins: dict[str, QtWidgets.QDoubleSpinBox]
+    _angle_scale_summary: QtWidgets.QLabel
     _normal_emission_spins: dict[str, QtWidgets.QDoubleSpinBox]
     _bound_spins: dict[str, QtWidgets.QDoubleSpinBox]
     _resolution_spins: dict[str, QtWidgets.QDoubleSpinBox]
@@ -562,8 +569,12 @@ class KspaceTool(KspaceToolGUI):
             center=self.center_spin.value(),
             width=self.width_spin.value(),
             offsets={
-                k: round(spin.value(), spin.decimals())
-                for k, spin in self._offset_spins.items()
+                **self.offset_dict,
+                **{
+                    k: round(spin.value(), spin.decimals())
+                    for k, spin in self._offset_spins.items()
+                    if k not in self.data.kspace._valid_offset_keys
+                },
             },
             angle_scales={
                 k: round(spin.value(), spin.decimals())
@@ -613,12 +624,14 @@ class KspaceTool(KspaceToolGUI):
         self.width_spin.setValue(status.width)
         self.width_spin.blockSignals(False)
 
-        for k, v in status.offsets.items():
-            if k not in self._offset_spins:
-                continue
-            self._offset_spins[k].blockSignals(True)
-            self._offset_spins[k].setValue(v)
-            self._offset_spins[k].blockSignals(False)
+        normal_emission_offsets: dict[str, float] = {}
+        for key, value in status.offsets.items():
+            if key in self._offset_spins:
+                with QtCore.QSignalBlocker(self._offset_spins[key]):
+                    self._offset_spins[key].setValue(value)
+            elif key in self._normal_emission_offset_values:
+                normal_emission_offsets[key] = value
+        self._set_normal_emission_offsets(normal_emission_offsets)
 
         for k, v in status.angle_scales.items():
             if k not in self._angle_scale_spins:
@@ -864,24 +877,45 @@ class KspaceTool(KspaceToolGUI):
         self._clear_layout(self.resolution_group.layout())
 
         self._offset_spins = {}
+        self._normal_emission_offset_values = {}
+        self._normal_emission_offset_labels = {}
         for k in self.data.kspace._valid_offset_keys:
-            self._offset_spins[k] = QtWidgets.QDoubleSpinBox()
-            self._offset_spins[k].setRange(-360, 360)
-            self._offset_spins[k].setSingleStep(0.05 if k == "delta" else 0.01)
-            self._offset_spins[k].setDecimals(3)
-            self._offset_spins[k].setValue(self.data.kspace.offsets[k])
+            value = self.data.kspace.offsets[k]
             if (
                 k != "delta"
                 and k in self.data.coords
                 and f"{k}_offset" not in self.data.attrs
             ):
-                self._offset_spins[k].setValue(float(self.data[k].mean()))
+                value = float(self.data[k].mean())
 
-            self._offset_spins[k].valueChanged.connect(self.queue_update)
-            self._offset_spins[k].setSuffix(self._OFFSET_UNITS[k])
-            self.offsets_group.layout().addRow(
-                self._OFFSET_LABELS[k], self._offset_spins[k]
-            )
+            if k == "delta":
+                spin = QtWidgets.QDoubleSpinBox()
+                spin.setObjectName("ktoolDeltaOffset")
+                spin.setRange(-360, 360)
+                spin.setSingleStep(0.05)
+                spin.setDecimals(3)
+                spin.setValue(value)
+                spin.valueChanged.connect(self.queue_update)
+                spin.setSuffix(self._OFFSET_UNITS[k])
+                self._offset_spins[k] = spin
+                self.offsets_group.layout().addRow(self._OFFSET_LABELS[k], spin)
+            else:
+                value_label = QtWidgets.QLabel()
+                value_label.setObjectName(f"ktool{k.title()}OffsetValue")
+                value_label.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+                value_label.setTextInteractionFlags(
+                    QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+                )
+                value_label.setAlignment(
+                    QtCore.Qt.AlignmentFlag.AlignRight
+                    | QtCore.Qt.AlignmentFlag.AlignVCenter
+                )
+                value_label.setToolTip("Changes with Normal Emission.")
+                value_label.setAccessibleDescription("Changes with Normal Emission.")
+                self._normal_emission_offset_values[k] = 0.0
+                self._normal_emission_offset_labels[k] = value_label
+                self.offsets_group.layout().addRow(self._OFFSET_LABELS[k], value_label)
+                self._set_normal_emission_offsets({k: value})
 
         if self.data.kspace._has_hv:
             self._offset_spins["V0"] = QtWidgets.QDoubleSpinBox()
@@ -933,6 +967,21 @@ class KspaceTool(KspaceToolGUI):
             axis_label = self._NORMAL_EMISSION_LABELS.get(axis, axis)
             self.offsets_group.layout().addRow(f"{axis_label} scale", spin)
 
+        self._angle_scale_summary = QtWidgets.QLabel()
+        self._angle_scale_summary.setObjectName("ktoolAngleScaleSummary")
+        self._angle_scale_summary.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        self._angle_scale_summary.setTextInteractionFlags(
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        self._angle_scale_summary.setToolTip(
+            "Enable angle scale controls in Preferences to change these values."
+        )
+        self._angle_scale_summary.setAccessibleDescription(
+            self._angle_scale_summary.toolTip()
+        )
+        self.offsets_group.layout().addRow("Angle scales", self._angle_scale_summary)
+        self._sync_angle_scale_visibility()
+
         self._normal_emission_spins = {}
         for axis, label in self._NORMAL_EMISSION_LABELS.items():
             spin = QtWidgets.QDoubleSpinBox()
@@ -946,9 +995,6 @@ class KspaceTool(KspaceToolGUI):
             self._normal_emission_spins[axis] = spin
             self.normal_emission_group.layout().addRow(label, spin)
 
-        for k in self.data.kspace._valid_offset_keys:
-            self._offset_spins[k].valueChanged.connect(self._sync_normal_emission_spins)
-
         self._sync_normal_emission_spins()
         if initial_normal_emission is not None:
             self.data.kspace.set_normal(
@@ -956,9 +1002,9 @@ class KspaceTool(KspaceToolGUI):
                 initial_normal_emission[1],
                 delta=initial_delta,
             )
-            for key in self.data.kspace._valid_offset_keys:
-                with QtCore.QSignalBlocker(self._offset_spins[key]):
-                    self._offset_spins[key].setValue(self.data.kspace.offsets[key])
+            with QtCore.QSignalBlocker(self._offset_spins["delta"]):
+                self._offset_spins["delta"].setValue(self.data.kspace.offsets["delta"])
+            self._set_normal_emission_offsets(self.data.kspace.offsets)
             self._sync_normal_emission_spins()
 
         self._bound_spins = {}
@@ -1519,10 +1565,9 @@ class KspaceTool(KspaceToolGUI):
 
     @property
     def offset_dict(self) -> dict[str, float]:
-        return {
-            k: float(np.round(self._offset_spins[k].value(), 5))
-            for k in self.data.kspace._valid_offset_keys
-        }
+        offsets = dict(self._normal_emission_offset_values)
+        offsets["delta"] = float(np.round(self._offset_spins["delta"].value(), 5))
+        return {k: offsets[k] for k in self.data.kspace._valid_offset_keys}
 
     @property
     def angle_scale_dict(self) -> dict[str, float]:
@@ -1544,6 +1589,37 @@ class KspaceTool(KspaceToolGUI):
                 self.data.attrs.pop(attr_key, None)
             else:
                 self.data.kspace.angle_scales[axis] = scale
+        self._sync_angle_scale_visibility()
+
+    def _sync_angle_scale_visibility(self) -> None:
+        layout = typing.cast("QtWidgets.QFormLayout", self.offsets_group.layout())
+        for spin in self._angle_scale_spins.values():
+            layout.setRowVisible(spin, self._show_angle_scale_controls)
+
+        scales = self.angle_scale_dict
+        self._angle_scale_summary.setText(
+            ", ".join(
+                f"{self._NORMAL_EMISSION_LABELS[axis]} {scale:.3f}"
+                for axis, scale in scales.items()
+            )
+        )
+        layout.setRowVisible(
+            self._angle_scale_summary,
+            not self._show_angle_scale_controls
+            and any(scale != 1.0 for scale in scales.values()),
+        )
+
+    def _set_normal_emission_offsets(self, offsets: Mapping[str, float]) -> None:
+        for key, value in offsets.items():
+            if key not in self._normal_emission_offset_values:
+                continue
+            rounded = float(np.round(value, 3))
+            if rounded == 0.0:
+                rounded = 0.0
+            self._normal_emission_offset_values[key] = rounded
+            self._normal_emission_offset_labels[key].setText(
+                f"{rounded:.3f}{self._OFFSET_UNITS[key]}"
+            )
 
     @QtCore.Slot(float)
     def _handle_angle_scale_changed(self, _value: float) -> None:
@@ -1570,11 +1646,7 @@ class KspaceTool(KspaceToolGUI):
             self._normal_emission_spins["beta"].value(),
         )
 
-        for key in data.kspace._valid_offset_keys:
-            spin = self._offset_spins[key]
-            spin.blockSignals(True)
-            spin.setValue(data.kspace.offsets[key])
-            spin.blockSignals(False)
+        self._set_normal_emission_offsets(data.kspace.offsets)
 
         self._sync_normal_emission_spins()
         self.queue_update()

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -37,6 +37,7 @@ from erlab.interactive.imagetool.manager import ImageToolManager
 from erlab.interactive.imagetool.manager._workspace import (
     _controller as workspace_controller,
 )
+from erlab.interactive.kspace import KspaceTool
 from tests.interactive.imagetool.manager.helpers import (
     action_map_by_object_name,
     adopt_workspace_path,
@@ -112,6 +113,84 @@ def test_manager_workspace_saves_added_time_for_all_node_kinds(
         assert h5_file[f"0/childtools/{tool_uid}/tool"].attrs[
             "manager_node_added_at"
         ] == tool_added.isoformat(timespec="seconds")
+
+
+def test_manager_workspace_restores_hidden_ktool_angle_scales(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    options_model = AppOptions(ktool={"show_angle_scale_controls": False})
+    data = xr.DataArray(
+        np.arange(25.0).reshape((5, 5)),
+        dims=("alpha", "eV"),
+        coords={
+            "alpha": np.linspace(-2.0, 2.0, 5),
+            "eV": np.linspace(-1.0, -0.1, 5),
+            "beta": 0.0,
+            "xi": 0.0,
+            "hv": 21.2,
+        },
+        attrs={"configuration": int(erlab.constants.AxesConfiguration.Type1)},
+    )
+    data.kspace.work_function = 4.5
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        kspace_tool = KspaceTool(data, data_name="scan", options_model=options_model)
+        kspace_tool._angle_scale_spins["alpha"].setValue(1.25)
+        kspace_tool._angle_scale_spins["beta"].setValue(0.75)
+        expected = kspace_tool._converted_output()
+        tool_uid = manager.add_childtool(kspace_tool, 0, show=False)
+
+        workspace_path = tmp_path / "hidden-ktool-scales.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        restored = manager.get_childtool(tool_uid)
+        assert isinstance(restored, KspaceTool)
+        layout = restored.offsets_group.layout()
+        assert all(
+            not layout.isRowVisible(spin)
+            for spin in restored._angle_scale_spins.values()
+        )
+        assert layout.isRowVisible(restored._angle_scale_summary)
+        assert restored.data.kspace.alpha_scale == pytest.approx(1.25)
+        assert restored.data.kspace.beta_scale == pytest.approx(0.75)
+        xr.testing.assert_allclose(restored._converted_output(), expected)
+        code = restored.copy_code()
+        assert "alpha_scale=1.25" in code
+        assert "beta_scale=0.75" in code
+
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_path, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        restored_again = manager.get_childtool(tool_uid)
+        assert isinstance(restored_again, KspaceTool)
+        assert restored_again.data.kspace.alpha_scale == pytest.approx(1.25)
+        assert restored_again.data.kspace.beta_scale == pytest.approx(0.75)
 
 
 def test_manager_workspace_layout_only_save_updates_root_manifest_only(

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -10,6 +10,7 @@ import xarray as xr
 import erlab
 from erlab.accessors.kspace import IncompleteDataError, MomentumAccessor
 from erlab.constants import AxesConfiguration
+from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.imagetool import _kspace_conversion
 from erlab.interactive.imagetool import dialogs as imagetool_dialogs
 from erlab.interactive.imagetool._provenance._model import (
@@ -111,6 +112,13 @@ def _add_hidden_tool(qtbot, widget):
     qtbot.addWidget(widget)
     widget.hide()
     return widget
+
+
+def _restore_ktool_offsets(win: KspaceTool, offsets: dict[str, float]) -> None:
+    status = win.tool_status
+    win.tool_status = status.model_copy(
+        update={"offsets": {**status.offsets, **offsets}}
+    )
 
 
 def _memory_budget(
@@ -578,9 +586,9 @@ def test_ktool(qtbot, anglemap, wf, kind, assignment) -> None:
 
     for k, v in offset_dict.items():
         if assignment == "before":
-            assert np.isclose(win._offset_spins[k].value(), v)
-        else:
-            win._offset_spins[k].setValue(v)
+            assert np.isclose(win.offset_dict[k], v)
+    if assignment == "after":
+        _restore_ktool_offsets(win, offset_dict)
 
     if wf != "wf_auto":
         if assignment == "before":
@@ -1113,7 +1121,15 @@ def test_ktool_normal_emission_updates_offsets(
     win._normal_emission_spins["beta"].setValue(beta_normal)
 
     for key, expected in reference_offsets.items():
-        assert np.isclose(win._offset_spins[key].value(), expected)
+        assert np.isclose(win.offset_dict[key], expected)
+
+    for key in set(reference_offsets) - {"delta"}:
+        label = win._normal_emission_offset_labels[key]
+        assert isinstance(label, imagetool_dialogs.QtWidgets.QLabel)
+        assert label.objectName() == f"ktool{key.title()}OffsetValue"
+        assert label.textInteractionFlags() & (
+            imagetool_dialogs.QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+        )
 
 
 @pytest.mark.parametrize(
@@ -1135,7 +1151,7 @@ def test_ktool_normal_emission_updates_offsets(
         ),
     ],
 )
-def test_ktool_normal_emission_spins_follow_offsets(
+def test_ktool_normal_emission_spins_follow_restored_offsets(
     qtbot,
     anglemap,
     configuration: AxesConfiguration,
@@ -1151,8 +1167,7 @@ def test_ktool_normal_emission_spins_follow_offsets(
     win = ktool(data, execute=False)
     _add_hidden_tool(qtbot, win)
 
-    for key, value in reference_offsets.items():
-        win._offset_spins[key].setValue(value)
+    _restore_ktool_offsets(win, reference_offsets)
 
     assert win._normal_emission_spins["alpha"].value() == pytest.approx(
         alpha_normal, abs=1e-3
@@ -1226,9 +1241,7 @@ def test_ktool_initial_normal_emission_seed(
         beta_normal, abs=1e-3
     )
     for key in expected.kspace._valid_offset_keys:
-        assert win._offset_spins[key].value() == pytest.approx(
-            expected.kspace.offsets[key]
-        )
+        assert win.offset_dict[key] == pytest.approx(expected.kspace.offsets[key])
 
 
 def test_ktool_initial_delta_overrides_delta(qtbot, anglemap) -> None:
@@ -1252,9 +1265,7 @@ def test_ktool_initial_delta_overrides_delta(qtbot, anglemap) -> None:
 
     assert win._offset_spins["delta"].value() == pytest.approx(14.5)
     for key in expected.kspace._valid_offset_keys:
-        assert win._offset_spins[key].value() == pytest.approx(
-            expected.kspace.offsets[key]
-        )
+        assert win.offset_dict[key] == pytest.approx(expected.kspace.offsets[key])
 
 
 @pytest.mark.parametrize("kind", ["cut", "map", "hv"])
@@ -1717,8 +1728,7 @@ def test_ktool_copy_code_uses_set_normal(
     win = ktool(data, execute=False)
     _add_hidden_tool(qtbot, win)
 
-    for key, value in reference_offsets.items():
-        win._offset_spins[key].setValue(value)
+    _restore_ktool_offsets(win, reference_offsets)
 
     code = win.copy_code()
     assert ".kspace.set_normal(" in code
@@ -1780,7 +1790,11 @@ def test_ktool_configuration_combo_rebuilds_controls_and_code(
     win.configuration_combo.setCurrentIndex(index)
 
     assert win.data.kspace.configuration == target_configuration
-    assert set(win._offset_spins) == expected_offsets
+    assert set(win.tool_status.offsets) == expected_offsets
+    assert set(win._offset_spins) == expected_offsets & {"delta", "V0", "wf"}
+    assert set(win._normal_emission_offset_values) == expected_offsets - set(
+        win._offset_spins
+    )
     assert set(win._resolution_spins) == expected_axes
     assert win.tool_status.configuration == int(target_configuration)
 
@@ -1948,6 +1962,58 @@ def test_ktool_angle_scales_are_set_normal_provenance_kwargs(qtbot, anglemap) ->
         assert restored.data.kspace.beta_scale == pytest.approx(0.75)
         assert restored.tool_status.angle_scales["alpha"] == pytest.approx(1.25)
         assert restored.tool_status.angle_scales["beta"] == pytest.approx(0.75)
+
+
+@pytest.mark.parametrize("show_controls", [False, True])
+def test_ktool_angle_scale_control_visibility(
+    qtbot, anglemap, show_controls: bool
+) -> None:
+    options_model = AppOptions(ktool={"show_angle_scale_controls": show_controls})
+    win = ktool(anglemap, options_model=options_model, execute=False)
+    _add_hidden_tool(qtbot, win)
+    layout = win.offsets_group.layout()
+
+    for spin in win._angle_scale_spins.values():
+        assert layout.isRowVisible(spin) is show_controls
+    assert not layout.isRowVisible(win._angle_scale_summary)
+
+
+def test_ktool_hidden_angle_scales_restore_and_remain_active(qtbot, anglemap) -> None:
+    options_model = AppOptions(ktool={"show_angle_scale_controls": False})
+    win = ktool(
+        anglemap,
+        data_name="scan",
+        options_model=options_model,
+        execute=False,
+    )
+    _add_hidden_tool(qtbot, win)
+    win._angle_scale_spins["alpha"].setValue(1.25)
+    win._angle_scale_spins["beta"].setValue(0.75)
+    saved = win.to_dataset()
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved, options_model=options_model
+    )
+    _add_hidden_tool(qtbot, restored)
+    assert isinstance(restored, KspaceTool)
+    layout = restored.offsets_group.layout()
+
+    assert all(
+        not layout.isRowVisible(spin) for spin in restored._angle_scale_spins.values()
+    )
+    assert layout.isRowVisible(restored._angle_scale_summary)
+    assert restored.data.kspace.alpha_scale == pytest.approx(1.25)
+    assert restored.data.kspace.beta_scale == pytest.approx(0.75)
+    assert restored.tool_status.angle_scales == pytest.approx(
+        {"alpha": 1.25, "beta": 0.75}
+    )
+
+    code = restored.copy_code()
+    assert "alpha_scale=1.25" in code
+    assert "beta_scale=0.75" in code
+    namespace = {"scan": anglemap.copy(deep=True)}
+    exec(code, {"__builtins__": {}}, namespace)  # noqa: S102
+    xr.testing.assert_allclose(namespace["scan_kconv"], restored._converted_output())
 
 
 def test_ktool_copy_code_aliases_expression_input_names(qtbot) -> None:
@@ -2630,8 +2696,9 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
     win._offset_spins["wf"].setValue(4.6)
     win._angle_scale_spins["alpha"].setValue(1.1)
     win._angle_scale_spins["beta"].setValue(0.9)
-    if "beta" in win._offset_spins:
-        win._offset_spins["beta"].setValue(-1.5)
+    win._normal_emission_spins["beta"].setValue(
+        win._normal_emission_spins["beta"].value() - 1.5
+    )
     win.add_circle_btn.click()
     win._roi_list[0].set_position((0.1, 0.2), 0.25)
 

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -983,6 +983,7 @@ def test_workspace_override_helpers_filter_to_curated_subset() -> None:
     assert "io/workspace/compression" in paths
     assert "io/workspace/compress" not in paths
     assert "figure/dpi" in paths
+    assert "ktool/show_angle_scale_controls" not in paths
     assert normalize_workspace_option_overrides(
         {
             "colors/cmap/name": "bwr",


### PR DESCRIPTION
## Summary

- Show normal-emission-linked angle offsets as selectable values instead of editable spin boxes.
- Add a default-off user preference for the alpha and beta scale controls.
- Preserve hidden non-unit scales across KTool files and ImageTool Manager workspaces.
- Show active scale values when the editable controls are hidden.
- Update the user guide and regression tests.

## User impact

Normal Emission is now the only UI input for its linked angle offsets. Delta,
inner potential, and work function remain editable. Users can opt in to the angle
scale controls in Preferences. Saved scale corrections continue to affect
conversion when the controls are hidden.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_kspace.py tests/interactive/test_options.py tests/interactive/imagetool/manager/workspace/test_saving.py::test_manager_workspace_restores_hidden_ktool_angle_scales` (`163 passed`)
- `QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_kspace.py tests/interactive/imagetool/manager/workspace/test_saving.py::test_manager_workspace_restores_hidden_ktool_angle_scales -k 'normal_emission_updates_offsets or normal_emission_spins_follow_restored_offsets or angle_scale_control_visibility or hidden_angle_scales_restore or workspace_restores_hidden_ktool_angle_scales'` (`10 passed`)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run --directory docs make html`
- Inspected the default and active non-unit scale layouts with offscreen Qt rendering.
