### PR TITLE
perf(ptable): reduce selection refresh overhead

### DIFF
--- a/src/erlab/interactive/ptable/_window.py
+++ b/src/erlab/interactive/ptable/_window.py
@@ -901,12 +901,18 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         watched: QtCore.QObject | None,
         event: QtCore.QEvent | None,
     ) -> bool:
+        if event is None or event.type() not in {
+            QtCore.QEvent.Type.WindowDeactivate,
+            QtCore.QEvent.Type.MouseButtonPress,
+        }:
+            return super().eventFilter(watched, event)
+
         search_popup = getattr(self, "search_popup", None)
         if search_popup is None or not erlab.interactive.utils.qt_is_valid(
             search_popup
         ):
             return super().eventFilter(watched, event)
-        if search_popup.isVisible() and event is not None:
+        if search_popup.isVisible():
             if event.type() == QtCore.QEvent.Type.WindowDeactivate:
                 self._hide_search_popup(reset_navigation=True)
             elif event.type() == QtCore.QEvent.Type.MouseButtonPress:
@@ -1190,16 +1196,24 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
             if plot_atomic_number is None
             else _element_records()[plot_atomic_number]
         )
-        self.inspector.set_elements(
-            selected_records,
-            active_record=current_record,
-            plot_record=plot_record,
-            notation=self.current_notation,
-            hv=self.hv,
-            workfunction=self.workfunction,
-            max_harmonic=self.max_harmonic,
-            preview=preview,
-        )
+        inspector_updates_enabled = self.inspector.updatesEnabled()
+        if inspector_updates_enabled:
+            self.inspector.setUpdatesEnabled(False)
+        try:
+            self.inspector.set_elements(
+                selected_records,
+                active_record=current_record,
+                plot_record=plot_record,
+                notation=self.current_notation,
+                hv=self.hv,
+                workfunction=self.workfunction,
+                max_harmonic=self.max_harmonic,
+                preview=preview,
+            )
+        finally:
+            if inspector_updates_enabled:
+                self.inspector.setUpdatesEnabled(True)
+                self.inspector.update()
         self._sync_vertical_minimum_height()
         if ensure_visible:
             self.table_view.ensure_atomic_number_visible(self._current_atomic_number)
@@ -1332,7 +1346,7 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
 
     def _clear_hover_preview(self) -> None:
         self.table_view.clear_hover_tracking()
-        self._set_hover_atomic_number(None)
+        self._hover_atomic_number = None
 
     def _handle_card_selected(self, atomic_number: int, modifiers: object) -> None:
         if _has_keyboard_modifier(modifiers, QtCore.Qt.KeyboardModifier.ShiftModifier):

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -396,14 +396,15 @@ class _CloseShortcutEventFilter(QtCore.QObject):
         watched: QtCore.QObject | None,
         event: QtCore.QEvent | None,
     ) -> bool:
-        widget = self._widget_ref()
         if (
             event is None
-            or widget is None
-            or not qt_is_valid(widget)
             or event.type() != QtCore.QEvent.Type.KeyPress
             or not isinstance(event, QtGui.QKeyEvent)
         ):
+            return False
+
+        widget = self._widget_ref()
+        if widget is None or not qt_is_valid(widget):
             return False
 
         focused = watched if isinstance(watched, QtWidgets.QWidget) else None

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -3764,6 +3764,33 @@ def test_ptable_search_popup_hides_for_external_focus_and_clicks(
     win.close()
 
 
+def test_ptable_event_filter_skips_irrelevant_events_before_validity_check(
+    qtbot,
+    monkeypatch,
+) -> None:
+    win = PeriodicTableWindow()
+    _show_window(qtbot, win)
+
+    validity_calls: list[tuple[object, ...]] = []
+
+    def _record_validity_call(*objects: object) -> bool:
+        validity_calls.append(objects)
+        return True
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "qt_is_valid",
+        _record_validity_call,
+    )
+
+    event = QtCore.QEvent(QtCore.QEvent.Type.UpdateRequest)
+
+    assert win.eventFilter(win.table_view, event) is False
+    assert validity_calls == []
+
+    win.close()
+
+
 def test_ptable_find_shortcut_uses_search_controller(
     qtbot,
     monkeypatch,
@@ -3881,6 +3908,59 @@ def test_ptable_keyboard_navigation_and_background_clear(
     assert win.selected_atomic_numbers == ()
     assert win.selected_atomic_number is None
 
+    win.close()
+
+
+def test_ptable_card_selection_refreshes_once_after_hover_preview(
+    qtbot,
+    monkeypatch,
+) -> None:
+    win = PeriodicTableWindow()
+    _show_window(qtbot, win)
+    win._hover_atomic_number = 1
+    win.table_view._hovered_atomic_number = 1
+
+    refresh_calls: list[bool] = []
+    monkeypatch.setattr(
+        win,
+        "_refresh_window_state",
+        lambda *, ensure_visible: refresh_calls.append(ensure_visible),
+    )
+
+    win._handle_card_selected(2, QtCore.Qt.KeyboardModifier.NoModifier)
+
+    assert refresh_calls == [False]
+    assert win._hover_atomic_number is None
+    assert win.table_view._hovered_atomic_number is None
+
+    win.close()
+
+
+def test_ptable_refresh_batches_inspector_updates(qtbot, monkeypatch) -> None:
+    win = PeriodicTableWindow()
+    _show_window(qtbot, win)
+
+    update_states: list[bool] = []
+    set_elements = win.inspector.set_elements
+
+    def _record_update_state(*args, **kwargs) -> None:
+        update_states.append(win.inspector.updatesEnabled())
+        set_elements(*args, **kwargs)
+
+    monkeypatch.setattr(win.inspector, "set_elements", _record_update_state)
+
+    win._refresh_window_state(ensure_visible=False)
+
+    assert update_states == [False]
+    assert win.inspector.updatesEnabled() is True
+
+    win.inspector.setUpdatesEnabled(False)
+    win._refresh_window_state(ensure_visible=False)
+
+    assert update_states == [False, False]
+    assert win.inspector.updatesEnabled() is False
+
+    win.inspector.setUpdatesEnabled(True)
     win.close()
 
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -2208,6 +2208,32 @@ def test_close_shortcut_filter_weakly_refs_bound_callback(qtbot) -> None:
     assert calls == ["close", "close"]
 
 
+def test_close_shortcut_filter_skips_non_key_events_before_validity_check(
+    qtbot,
+    monkeypatch,
+) -> None:
+    window = QtWidgets.QMainWindow()
+    qtbot.addWidget(window)
+    erlab.interactive.utils._install_close_shortcut(window, lambda: None)
+    shortcut_filter = window._erlab_close_shortcut_refs[1]
+    validity_calls: list[tuple[object, ...]] = []
+
+    def _record_validity_call(*objects: object) -> bool:
+        validity_calls.append(objects)
+        return True
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "qt_is_valid",
+        _record_validity_call,
+    )
+
+    event = QtCore.QEvent(QtCore.QEvent.Type.UpdateRequest)
+
+    assert not shortcut_filter.eventFilter(window, event)
+    assert validity_calls == []
+
+
 def test_close_shortcut_default_callback_closes_live_widget(qtbot) -> None:
     window = QtWidgets.QMainWindow()
     qtbot.addWidget(window)


### PR DESCRIPTION
## Summary

- Skip unrelated application events before Qt object validity checks.
- Clear the periodic-table hover preview without an extra inspector refresh.
- Batch inspector painting while selection content changes.
- Preserve an existing disabled-updates state.
- Add regression tests for the new refresh and event-filter invariants.

## Root cause

Each periodic-table selection or keyboard navigation action refreshes the
inspector. This rebuild creates many Qt events. Two application-wide event
filters performed Python validity checks for every event, including events that
they could not handle. Clearing a hover preview during selection also caused a
full inspector refresh before the final selection refresh.

## User impact

Periodic-table selection and keyboard navigation do less work on the GUI thread.
The selected element, hover preview, search popup, close shortcut, and inspector
content keep the same behavior.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_ptable.py tests/interactive/test_utils.py` with PyQt6: 265 passed.
- `QT_QPA_PLATFORM=offscreen QT_API=pyside6 uv run pytest -q tests/interactive/test_ptable.py tests/interactive/test_utils.py`: 265 passed.
- `uv run mypy src`: passed for 259 source files.
- Ruff check and format checks passed for all changed files.
- `git diff --check` passed.
