### PR TITLE
feat(interactive): edit kspace input coordinates

### DIFF
--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -731,6 +731,16 @@ which ImageTool data and selection opened it:
   should not remain group-editable. When full groups are pasted, refresh their group
   identities before appending them to the destination provenance so adjacent copies
   remain separate editable groups.
+- Each provenance operation type must have one editor registration. Do not list the
+  same operation type in `operation_types` for both a standalone dialog and a grouped
+  dialog. A grouped dialog can include primitive operations owned by another editor
+  without declaring those types in `operation_types`; the group remains editable from
+  its other registered operation rows. List these additional emitted operations in
+  `batch_operation_types` when the grouped dialog supports batch use. If a batch group
+  intentionally replaces existing coordinates, list those assignment types in
+  `batch_coordinate_replacement_types`. Run
+  `test_manager_provenance_operation_editor_contract_is_valid` after you change an
+  editor registration.
 - To make a transform or filter dialog reusable for manager step edits, keep the widget
   state restoration separate from the normal apply path. Transform dialogs should
   implement `restore_transform_operation(...)` or `restore_transform_operations(...)`

--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -1093,14 +1093,19 @@ class MomentumAccessor(ERLabDataArrayAccessor):
         except (IncompleteDataError, ValueError):
             return False
 
+        required_dimension_coords = {"alpha"} | {
+            name for name in ("beta", "eV", "hv") if name in self._obj.dims
+        }
+        if not required_dimension_coords.issubset(self._obj.coords):
+            return False
+
         if self._obj.ndim == 2:
             # alpha-beta 2D scan or alpha-energy cut with a fixed beta coordinate
             if set(self._obj.dims) == {"alpha", "beta"}:
                 return True
-            return (
-                set(self._obj.dims) == {"alpha", "eV"}
-                and "beta" in self._obj.coords
-                and self._obj["beta"].size == 1
+            beta = self._obj.coords.get("beta")
+            return set(self._obj.dims) == {"alpha", "eV"} and (
+                beta is None or beta.size == 1
             )
 
         if self._obj.ndim == 3:
@@ -1586,8 +1591,8 @@ class MomentumAccessor(ERLabDataArrayAccessor):
 
         - 2D data with `alpha` and `beta` dimensions (constant energy surfaces)
 
-        - 2D data with `alpha` and `eV` dimensions, and a fixed `beta` coordinate
-          (angle-energy cuts)
+        - 2D data with `alpha` and `eV` dimensions, and a fixed or assigned `beta`
+          coordinate (angle-energy cuts)
 
         - 3D data with dimensions including `alpha` and `eV` (including maps and
           hv-dependent cuts)

--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -1088,10 +1088,11 @@ class MomentumAccessor(ERLabDataArrayAccessor):
     @property
     def _interactive_compatible(self) -> bool:
         """Check if the data is compatible with the interactive tool."""
-        try:
-            _ = self.configuration
-        except (IncompleteDataError, ValueError):
-            return False
+        if "configuration" in self._obj.attrs:
+            try:
+                _ = self.configuration
+            except ValueError:
+                return False
 
         required_dimension_coords = {"alpha"} | {
             name for name in ("beta", "eV", "hv") if name in self._obj.dims

--- a/src/erlab/interactive/imagetool/_dialog_widgets.py
+++ b/src/erlab/interactive/imagetool/_dialog_widgets.py
@@ -6,14 +6,403 @@ import typing
 
 import numpy as np
 import numpy.typing as npt
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+from erlab.interactive.imagetool import _kspace_conversion
 
-__all__ = ["CoordinateEditorWidget", "CoordinateGridWidget"]
+__all__ = [
+    "CoordinateEditorWidget",
+    "CoordinateGridWidget",
+    "KspaceInputCoordinatesControl",
+    "KspaceInputCoordinatesDialog",
+    "KspaceInputCoordinatesWidget",
+    "prompt_kspace_input_coordinates",
+]
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
+
+    import xarray as xr
+
+
+class KspaceInputCoordinatesWidget(QtWidgets.QWidget):
+    """Edit scalar coordinates used for momentum conversion."""
+
+    valuesChanged = QtCore.Signal()
+
+    _LABELS: typing.ClassVar[dict[str, str]] = {
+        "beta": "𝛽",
+        "xi": "𝜉",
+        "chi": "𝜒",
+        "hv": "hν",
+        "eV": "E",
+    }
+
+    def __init__(
+        self,
+        data: xr.DataArray,
+        *,
+        object_name_prefix: str,
+        values: Mapping[str, float | None] | None = None,
+        edited_names: Iterable[str] = (),
+    ) -> None:
+        super().__init__()
+        self._object_name_prefix = object_name_prefix
+        self._edits: dict[str, QtWidgets.QLineEdit] = {}
+        self._edited_names: set[str] = set()
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.description_label = QtWidgets.QLabel(self)
+        self.description_label.setObjectName(f"{object_name_prefix}Description")
+        self.description_label.setWordWrap(True)
+        self.description_label.setText(
+            "Edit scalar coordinates used by momentum conversion."
+        )
+        layout.addWidget(self.description_label)
+
+        self.form = QtWidgets.QFormLayout()
+        layout.addLayout(self.form)
+        self._populate(data, values=values, edited_names=edited_names)
+
+    @property
+    def values(self) -> dict[str, float | None]:
+        """Return the current coordinate values."""
+        return {
+            name: self._parse_value(edit.text()) for name, edit in self._edits.items()
+        }
+
+    @property
+    def is_complete(self) -> bool:
+        """Return whether every coordinate has a finite value."""
+        return all(value is not None for value in self.values.values())
+
+    @property
+    def edited_names(self) -> frozenset[str]:
+        """Return coordinate names changed explicitly by the user."""
+        return frozenset(self._edited_names)
+
+    def focus_first_control(self) -> None:
+        """Give keyboard focus to the first available coordinate control."""
+        edit = next(
+            (edit for name, edit in self._edits.items() if self.values[name] is None),
+            next(iter(self._edits.values())),
+        )
+        edit.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
+        edit.selectAll()
+
+    def _populate(
+        self,
+        data: xr.DataArray,
+        *,
+        values: Mapping[str, float | None] | None = None,
+        edited_names: Iterable[str] = (),
+    ) -> None:
+        """Build controls for ``data`` and restore applicable values."""
+        coordinate_values = _kspace_conversion.kspace_input_coordinate_values(data)
+        if values is not None:
+            coordinate_values.update(
+                {
+                    name: value
+                    for name, value in values.items()
+                    if name in coordinate_values
+                }
+            )
+
+        self._edited_names = set(edited_names) & set(coordinate_values)
+
+        for name, value in coordinate_values.items():
+            edit = QtWidgets.QLineEdit(self)
+            edit.setObjectName(f"{self._object_name_prefix}{name.title()}Coordinate")
+            validator = QtGui.QDoubleValidator(edit)
+            validator.setNotation(QtGui.QDoubleValidator.Notation.ScientificNotation)
+            edit.setValidator(validator)
+            edit.setPlaceholderText("Required")
+            edit.setClearButtonEnabled(True)
+            if value is not None:
+                edit.setText(np.format_float_positional(float(value), trim="-"))
+            edit.textChanged.connect(
+                lambda _text, *, coord_name=name: self._coordinate_changed(coord_name)
+            )
+            self._edits[name] = edit
+            self._sync_validity(name)
+
+            row = QtWidgets.QWidget(self)
+            row_layout = QtWidgets.QHBoxLayout(row)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+            row_layout.addWidget(edit)
+            row_layout.addWidget(
+                QtWidgets.QLabel("eV" if name in {"hv", "eV"} else "°", row)
+            )
+            self.form.addRow(self._LABELS[name], row)
+
+    def _coordinate_changed(self, name: str) -> None:
+        self._edited_names.add(name)
+        self._sync_validity(name)
+        self.valuesChanged.emit()
+
+    def _sync_validity(self, name: str) -> None:
+        edit = self._edits[name]
+        invalid = self._parse_value(edit.text()) is None
+        edit.setProperty("invalid", invalid)
+        edit.setToolTip("A finite value is required." if invalid else "")
+
+    @staticmethod
+    def _parse_value(text: str) -> float | None:
+        try:
+            value = float(text.strip())
+        except ValueError:
+            return None
+        return value if np.isfinite(value) else None
+
+
+class KspaceInputCoordinatesDialog(QtWidgets.QDialog):
+    """Small editor dialog for momentum-conversion input coordinates."""
+
+    _ANGLE_CONVENTION_URL = (
+        "https://erlabpy.readthedocs.io/en/stable/user-guide/kconv.html#nomenclature"
+    )
+
+    def __init__(
+        self,
+        data: xr.DataArray,
+        *,
+        values: Mapping[str, float | None],
+        edited_names: Iterable[str],
+        object_name_prefix: str,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName(f"{object_name_prefix}Dialog")
+        self.setWindowTitle("Edit Input Coordinates")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        self.editor = KspaceInputCoordinatesWidget(
+            data,
+            object_name_prefix=object_name_prefix,
+            values=values,
+            edited_names=edited_names,
+        )
+        layout.addWidget(self.editor)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+            | QtWidgets.QDialogButtonBox.StandardButton.Help,
+            parent=self,
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        self.button_box.helpRequested.connect(self._open_angle_convention_help)
+        help_button = self.button_box.button(
+            QtWidgets.QDialogButtonBox.StandardButton.Help
+        )
+        if help_button is not None:
+            help_button.setObjectName(f"{object_name_prefix}HelpButton")
+        layout.addWidget(self.button_box)
+        self.editor.valuesChanged.connect(self._sync_validity)
+        self._sync_validity()
+
+    @property
+    def values(self) -> dict[str, float | None]:
+        """Return the values in the editor."""
+        return self.editor.values
+
+    @property
+    def resolved_values(self) -> dict[str, float]:
+        """Return complete finite coordinate values."""
+        if not self.editor.is_complete:
+            raise ValueError("All momentum-conversion input coordinates are required.")
+        return typing.cast("dict[str, float]", self.editor.values)
+
+    @property
+    def edited_names(self) -> frozenset[str]:
+        """Return coordinate names changed explicitly in the editor."""
+        return self.editor.edited_names
+
+    @QtCore.Slot()
+    def _sync_validity(self) -> None:
+        button = self.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        if button is not None:
+            button.setEnabled(self.editor.is_complete)
+
+    @QtCore.Slot()
+    def accept(self) -> None:
+        if not self.editor.is_complete:
+            return
+        super().accept()
+
+    @QtCore.Slot()
+    def _open_angle_convention_help(self) -> None:
+        QtGui.QDesktopServices.openUrl(QtCore.QUrl(self._ANGLE_CONVENTION_URL))
+
+
+class KspaceInputCoordinatesControl(QtWidgets.QWidget):
+    """Open the input-coordinate editor from a compact button."""
+
+    valuesChanged = QtCore.Signal()
+
+    def __init__(
+        self,
+        data: xr.DataArray,
+        *,
+        object_name_prefix: str,
+        button_text: str = "Edit…",
+    ) -> None:
+        super().__init__()
+        self._object_name_prefix = object_name_prefix
+        self._data = data
+        self._values: dict[str, float | None] = {}
+        self._edited_names: set[str] = set()
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.edit_button = QtWidgets.QPushButton(button_text, self)
+        self.edit_button.setObjectName(f"{object_name_prefix}EditButton")
+        self.edit_button.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+        self.edit_button.clicked.connect(self.edit_coordinates)
+        layout.addWidget(self.edit_button)
+
+        self.set_data(data)
+
+    @property
+    def values(self) -> dict[str, float | None]:
+        """Return current coordinate values."""
+        return dict(self._values)
+
+    @property
+    def resolved_values(self) -> dict[str, float]:
+        """Return complete finite coordinate values."""
+        if not self.is_complete:
+            raise ValueError("All momentum-conversion input coordinates are required.")
+        return typing.cast("dict[str, float]", self.values)
+
+    @property
+    def is_complete(self) -> bool:
+        """Return whether every coordinate has a finite value."""
+        return all(value is not None for value in self._values.values())
+
+    @property
+    def edited_names(self) -> frozenset[str]:
+        """Return coordinate names changed explicitly by the user."""
+        return frozenset(self._edited_names)
+
+    @property
+    def missing_names(self) -> frozenset[str]:
+        """Return coordinate names that do not have a finite value."""
+        return frozenset(name for name, value in self._values.items() if value is None)
+
+    def focus_first_control(self) -> None:
+        """Give keyboard focus to the edit button."""
+        self.edit_button.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
+
+    def set_data(
+        self,
+        data: xr.DataArray,
+        *,
+        values: Mapping[str, float | None] | None = None,
+        edited_names: Iterable[str] = (),
+    ) -> None:
+        """Update the source data and restore applicable coordinate values."""
+        coordinate_values = _kspace_conversion.kspace_input_coordinate_values(data)
+        if values is not None:
+            coordinate_values.update(
+                {
+                    name: value
+                    for name, value in values.items()
+                    if name in coordinate_values
+                }
+            )
+        self._data = data
+        self._values = coordinate_values
+        self._edited_names = set(edited_names) & set(coordinate_values)
+        self._update_tooltip()
+
+    @QtCore.Slot()
+    def edit_coordinates(self) -> bool:
+        """Open the coordinate editor and return whether the user accepted it."""
+        dialog = KspaceInputCoordinatesDialog(
+            self._data,
+            values=self._values,
+            edited_names=self._edited_names,
+            object_name_prefix=self._object_name_prefix,
+            parent=self,
+        )
+        dialog.editor.focus_first_control()
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            dialog.setParent(None)
+            dialog.deleteLater()
+            return False
+
+        values = dialog.resolved_values
+        edited_names = set(dialog.edited_names)
+        dialog.setParent(None)
+        dialog.deleteLater()
+        if values == self._values and edited_names == self._edited_names:
+            return True
+        self._values = typing.cast("dict[str, float | None]", values)
+        self._edited_names = edited_names
+        self._update_tooltip()
+        self.valuesChanged.emit()
+        return True
+
+    def _update_tooltip(self) -> None:
+        parts: list[str] = []
+        for name, value in self._values.items():
+            if value is None:
+                continue
+            suffix = " eV" if name in {"hv", "eV"} else "°"
+            parts.append(
+                f"{KspaceInputCoordinatesWidget._LABELS[name]} "
+                f"{np.format_float_positional(value, precision=4, trim='-')}"
+                f"{suffix}"
+            )
+        summary = " · ".join(parts)
+        tooltip = f"Current values: {summary}" if summary else ""
+        if self.missing_names:
+            missing = ", ".join(
+                str(KspaceInputCoordinatesWidget._LABELS[name])
+                for name in self._values
+                if name in self.missing_names
+            )
+            tooltip = f"{tooltip}\n" if tooltip else ""
+            tooltip += f"Required: {missing}"
+        self.edit_button.setProperty("invalid", not self.is_complete)
+        self.edit_button.setToolTip(tooltip)
+
+
+def prompt_kspace_input_coordinates(
+    data: xr.DataArray,
+    *,
+    object_name_prefix: str,
+    parent: QtWidgets.QWidget | None = None,
+) -> tuple[dict[str, float], frozenset[str]] | None:
+    """Prompt for unresolved scalar conversion inputs and return complete values."""
+    values = _kspace_conversion.kspace_input_coordinate_values(data)
+    if all(value is not None for value in values.values()):
+        return typing.cast("dict[str, float]", values), frozenset()
+
+    dialog = KspaceInputCoordinatesDialog(
+        data,
+        values=values,
+        edited_names=(),
+        object_name_prefix=object_name_prefix,
+        parent=parent,
+    )
+    dialog.editor.focus_first_control()
+    if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+        dialog.setParent(None)
+        dialog.deleteLater()
+        return None
+    resolved = dialog.resolved_values
+    edited_names = dialog.edited_names
+    dialog.setParent(None)
+    dialog.deleteLater()
+    return resolved, edited_names
 
 
 class CoordinateGridWidget(QtWidgets.QWidget):

--- a/src/erlab/interactive/imagetool/_dialog_widgets.py
+++ b/src/erlab/interactive/imagetool/_dialog_widgets.py
@@ -137,6 +137,25 @@ class KspaceInputCoordinatesWidget(QtWidgets.QWidget):
             )
             self.form.addRow(self._LABELS[name], row)
 
+    def set_data(
+        self,
+        data: xr.DataArray,
+        *,
+        values: Mapping[str, float | None] | None = None,
+        edited_names: Iterable[str] = (),
+    ) -> None:
+        """Rebuild the editor and restore values that apply to the new data."""
+        while self.form.count():
+            item = self.form.takeAt(0)
+            if item is None:
+                continue
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        self._edits.clear()
+        self._populate(data, values=values, edited_names=edited_names)
+        self.valuesChanged.emit()
+
     def _coordinate_changed(self, name: str) -> None:
         self._edited_names.add(name)
         self._sync_validity(name)
@@ -176,8 +195,26 @@ class KspaceInputCoordinatesDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.setObjectName(f"{object_name_prefix}Dialog")
         self.setWindowTitle("Edit Input Coordinates")
+        self._data = data
+        self._configuration = _kspace_conversion.kspace_configuration(data)
 
         layout = QtWidgets.QVBoxLayout(self)
+        self.configuration_combo: QtWidgets.QComboBox | None = None
+        if self._configuration is None:
+            self.configuration_combo = QtWidgets.QComboBox(self)
+            self.configuration_combo.setObjectName(
+                f"{object_name_prefix}ConfigurationCombo"
+            )
+            self.configuration_combo.addItem("Select configuration…", None)
+            for configuration in erlab.constants.AxesConfiguration:
+                self.configuration_combo.addItem(
+                    _kspace_conversion.configuration_text(configuration),
+                    int(configuration),
+                )
+            self.configuration_combo.currentIndexChanged.connect(
+                self._configuration_changed
+            )
+            layout.addWidget(self.configuration_combo)
         self.editor = KspaceInputCoordinatesWidget(
             data,
             object_name_prefix=object_name_prefix,
@@ -217,21 +254,66 @@ class KspaceInputCoordinatesDialog(QtWidgets.QDialog):
         return typing.cast("dict[str, float]", self.editor.values)
 
     @property
+    def configuration(self) -> erlab.constants.AxesConfiguration | None:
+        """Return the selected or existing configuration."""
+        if self.configuration_combo is None:
+            return self._configuration
+        value = self.configuration_combo.currentData(QtCore.Qt.ItemDataRole.UserRole)
+        if value is None:
+            return None
+        return erlab.constants.AxesConfiguration(int(value))
+
+    @property
+    def resolved_configuration(self) -> erlab.constants.AxesConfiguration:
+        """Return the selected or existing configuration."""
+        configuration = self.configuration
+        if configuration is None:
+            raise ValueError("A configuration is required for momentum conversion.")
+        return configuration
+
+    @property
     def edited_names(self) -> frozenset[str]:
         """Return coordinate names changed explicitly in the editor."""
         return self.editor.edited_names
+
+    def focus_first_control(self) -> None:
+        """Focus the first unresolved control."""
+        if self.configuration is None and self.configuration_combo is not None:
+            self.configuration_combo.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
+            return
+        self.editor.focus_first_control()
 
     @QtCore.Slot()
     def _sync_validity(self) -> None:
         button = self.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
         if button is not None:
-            button.setEnabled(self.editor.is_complete)
+            button.setEnabled(
+                self.configuration is not None and self.editor.is_complete
+            )
 
     @QtCore.Slot()
     def accept(self) -> None:
-        if not self.editor.is_complete:
+        if self.configuration is None or not self.editor.is_complete:
             return
         super().accept()
+
+    @QtCore.Slot(int)
+    def _configuration_changed(self, _index: int = -1) -> None:
+        values = self.editor.values
+        edited_names = self.editor.edited_names
+        configuration = self.configuration
+        data = self._data
+        if configuration is not None:
+            data = _kspace_conversion.assign_kspace_configuration(
+                data,
+                configuration,
+            )
+        self.editor.set_data(
+            data,
+            values=values,
+            edited_names=edited_names,
+        )
+        self._sync_validity()
 
     @QtCore.Slot()
     def _open_angle_convention_help(self) -> None:
@@ -380,11 +462,24 @@ def prompt_kspace_input_coordinates(
     *,
     object_name_prefix: str,
     parent: QtWidgets.QWidget | None = None,
-) -> tuple[dict[str, float], frozenset[str]] | None:
+) -> (
+    tuple[
+        erlab.constants.AxesConfiguration,
+        dict[str, float],
+        frozenset[str],
+    ]
+    | None
+):
     """Prompt for unresolved scalar conversion inputs and return complete values."""
-    values = _kspace_conversion.kspace_input_coordinate_values(data)
-    if all(value is not None for value in values.values()):
-        return typing.cast("dict[str, float]", values), frozenset()
+    configuration = _kspace_conversion.kspace_configuration(data)
+    values = _kspace_conversion.kspace_input_coordinate_values(
+        data,
+        configuration=configuration,
+    )
+    if configuration is not None and all(
+        value is not None for value in values.values()
+    ):
+        return configuration, typing.cast("dict[str, float]", values), frozenset()
 
     dialog = KspaceInputCoordinatesDialog(
         data,
@@ -393,16 +488,17 @@ def prompt_kspace_input_coordinates(
         object_name_prefix=object_name_prefix,
         parent=parent,
     )
-    dialog.editor.focus_first_control()
+    dialog.focus_first_control()
     if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
         dialog.setParent(None)
         dialog.deleteLater()
         return None
     resolved = dialog.resolved_values
+    resolved_configuration = dialog.resolved_configuration
     edited_names = dialog.edited_names
     dialog.setParent(None)
     dialog.deleteLater()
-    return resolved, edited_names
+    return resolved_configuration, resolved, edited_names
 
 
 class CoordinateGridWidget(QtWidgets.QWidget):

--- a/src/erlab/interactive/imagetool/_kspace_conversion.py
+++ b/src/erlab/interactive/imagetool/_kspace_conversion.py
@@ -21,6 +21,7 @@ from erlab.interactive.imagetool._provenance._model import (
     stamp_operation_group,
 )
 from erlab.interactive.imagetool._provenance._operations import (
+    AssignScalarCoordOperation,
     KspaceConfigurationOperation,
     KspaceConvertOperation,
     KspaceInnerPotentialOperation,
@@ -43,14 +44,17 @@ _MISSING_INNER_POTENTIAL_WARNING_RE = (
     r"^Inner potential not found in data attributes, assuming 10 eV$"
 )
 KSPACE_CONVERSION_GROUP_KIND = "kspace_conversion"
+_FOCUS_INPUT_COORDINATES = "input_coordinates"
 _FOCUS_CONFIGURATION = "configuration"
 _FOCUS_WORK_FUNCTION = "work_function"
 _FOCUS_INNER_POTENTIAL = "inner_potential"
 _FOCUS_NORMAL = "normal_emission"
 _FOCUS_CONVERT = "bounds_resolution"
+_KSPACE_INPUT_COORDINATE_NAMES = ("hv", "eV", "beta", "xi", "chi")
 
 _KSPACE_SETUP_TYPES = (
     KspaceConfigurationOperation,
+    AssignScalarCoordOperation,
     KspaceWorkFunctionOperation,
     KspaceInnerPotentialOperation,
     KspaceSetNormalOperation,
@@ -60,6 +64,23 @@ _KSPACE_CONVERSION_TYPES = (
     KspaceConvertOperation,
 )
 _GIB = 1024**3
+
+
+def _is_kspace_conversion_operation(
+    operation: ToolProvenanceOperation,
+) -> bool:
+    if isinstance(operation, AssignScalarCoordOperation):
+        return operation.coord_name in _KSPACE_INPUT_COORDINATE_NAMES
+    return isinstance(
+        operation,
+        (
+            KspaceConfigurationOperation,
+            KspaceWorkFunctionOperation,
+            KspaceInnerPotentialOperation,
+            KspaceSetNormalOperation,
+            KspaceConvertOperation,
+        ),
+    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -186,6 +207,77 @@ def kspace_inner_potential(data: xr.DataArray) -> float:
 
 def rounded_spin_value(spin: QtWidgets.QDoubleSpinBox) -> float:
     return float(np.round(spin.value(), spin.decimals()))
+
+
+def kspace_input_coordinate_names(
+    data: xr.DataArray,
+) -> tuple[str, ...]:
+    """Return scalar coordinates that can be set for conversion."""
+    names = [
+        name
+        for name in ("hv", "eV")
+        if name not in data.dims and (name not in data.coords or data[name].ndim == 0)
+    ]
+    if "beta" not in data.dims and (
+        "beta" not in data.coords or data["beta"].ndim == 0
+    ):
+        names.append("beta")
+    names.append("xi")
+    if data.kspace.configuration in (
+        AxesConfiguration.Type1DA,
+        AxesConfiguration.Type2DA,
+    ):
+        names.append("chi")
+    return tuple(names)
+
+
+def kspace_input_coordinate_values(
+    data: xr.DataArray,
+) -> dict[str, float | None]:
+    """Return editable scalar coordinates with missing values left unresolved."""
+    values: dict[str, float | None] = {}
+    for name in kspace_input_coordinate_names(data):
+        if name not in data.coords:
+            values[name] = None
+            continue
+        coord = data[name]
+        if coord.ndim != 0:
+            raise ValueError(
+                f"Coordinate {name!r} must be scalar for momentum conversion."
+            )
+        value = float(coord.values)
+        if not np.isfinite(value):
+            values[name] = None
+            continue
+        values[name] = value
+    return values
+
+
+def assign_kspace_input_coordinates(
+    data: xr.DataArray,
+    values: Mapping[str, float] | None = None,
+) -> xr.DataArray:
+    """Assign editable scalar coordinates to a shallow data copy."""
+    coordinate_values = kspace_input_coordinate_values(data)
+    if values is not None:
+        unknown = set(values) - set(coordinate_values)
+        if unknown:
+            raise ValueError(
+                "Coordinates are not editable for this momentum conversion: "
+                + ", ".join(sorted(unknown))
+            )
+        coordinate_values.update({name: float(value) for name, value in values.items()})
+    unresolved = [
+        name
+        for name, value in coordinate_values.items()
+        if value is None or not np.isfinite(value)
+    ]
+    if unresolved:
+        raise ValueError(
+            "Momentum-conversion input coordinates must be assigned: "
+            + ", ".join(unresolved)
+        )
+    return data.assign_coords(typing.cast("dict[str, float]", coordinate_values))
 
 
 def system_memory_budget() -> KspaceMemoryBudget:
@@ -511,6 +603,7 @@ def kspace_conversion_operations(
     force_scalars: bool,
     alpha_scale: float | None = None,
     beta_scale: float | None = None,
+    input_coordinates: Mapping[str, float] | None = None,
 ) -> tuple[ToolProvenanceOperation, ...]:
     operations: list[ToolProvenanceOperation] = []
     focuses: list[str] = []
@@ -525,6 +618,34 @@ def kspace_conversion_operations(
         configured_data = source_data.kspace.as_configuration(target_configuration)
     else:
         configured_data = source_data
+
+    if input_coordinates is not None:
+        editable_coordinates = set(kspace_input_coordinate_names(configured_data))
+        unknown_coordinates = set(input_coordinates) - editable_coordinates
+        if unknown_coordinates:
+            raise ValueError(
+                "Coordinates are not editable for this momentum conversion: "
+                + ", ".join(sorted(unknown_coordinates))
+            )
+        for name in _KSPACE_INPUT_COORDINATE_NAMES:
+            if name not in input_coordinates:
+                continue
+            value = float(input_coordinates[name])
+            if not np.isfinite(value):
+                raise ValueError(
+                    f"Coordinate {name!r} must be finite for momentum conversion."
+                )
+            current = configured_data.coords.get(name)
+            if (
+                current is not None
+                and current.ndim == 0
+                and np.isclose(float(current.values), value)
+            ):
+                continue
+            operation = AssignScalarCoordOperation(coord_name=name, value=value)
+            operations.append(operation)
+            focuses.append(_FOCUS_INPUT_COORDINATES)
+            configured_data = operation.apply(configured_data)
 
     if configured_data.kspace._has_hv and inner_potential is not None:
         with ignore_missing_kspace_parameter_warnings():
@@ -570,6 +691,8 @@ def kspace_conversion_operations(
 def _focus_for_operation(
     operation: ToolProvenanceOperation,
 ) -> str | None:
+    if isinstance(operation, AssignScalarCoordOperation):
+        return _FOCUS_INPUT_COORDINATES
     if isinstance(
         operation,
         KspaceConfigurationOperation,
@@ -622,12 +745,26 @@ def _complete_kspace_conversion_group(
         != 1
     ):
         return False
-    for operation_type in _KSPACE_SETUP_TYPES:
+    for operation_type in (
+        KspaceConfigurationOperation,
+        KspaceWorkFunctionOperation,
+        KspaceInnerPotentialOperation,
+        KspaceSetNormalOperation,
+    ):
         if (
             sum(isinstance(operation, operation_type) for operation in setup_operations)
             > 1
         ):
             return False
+    input_coordinates = [
+        operation.coord_name
+        for operation in setup_operations
+        if isinstance(operation, AssignScalarCoordOperation)
+    ]
+    if any(
+        name not in _KSPACE_INPUT_COORDINATE_NAMES for name in input_coordinates
+    ) or len(input_coordinates) != len(set(input_coordinates)):
+        return False
     return all(
         isinstance(operation, _KSPACE_CONVERSION_TYPES) for operation in operations
     )
@@ -658,9 +795,8 @@ def stamp_kspace_conversion_groups(
     index = 0
     while index < len(output):
         operation = output[index]
-        if operation.group is not None or not isinstance(
-            operation,
-            _KSPACE_CONVERSION_TYPES,
+        if operation.group is not None or not _is_kspace_conversion_operation(
+            operation
         ):
             index += 1
             continue
@@ -668,10 +804,7 @@ def stamp_kspace_conversion_groups(
         while (
             index < len(output)
             and output[index].group is None
-            and isinstance(
-                output[index],
-                _KSPACE_CONVERSION_TYPES,
-            )
+            and _is_kspace_conversion_operation(output[index])
         ):
             if isinstance(
                 output[index],
@@ -700,12 +833,12 @@ def incomplete_kspace_conversion_edit_reason(
     operation: ToolProvenanceOperation,
 ) -> str | None:
     """Return the edit tooltip/message for standalone primitive kspace rows."""
-    if not isinstance(operation, _KSPACE_CONVERSION_TYPES):
+    if not _is_kspace_conversion_operation(operation):
         return None
     return (
         "This kspace step is structured and replayable, but it is not part of a "
         "complete editable momentum-conversion group. To edit it in the conversion "
         "dialog, include the full operation set: `Set normal emission` and "
         "`Convert to momentum`. Configuration, work-function, and inner-potential "
-        "steps are optional setup rows."
+        "steps and scalar input-coordinate assignments are optional setup rows."
     )

--- a/src/erlab/interactive/imagetool/_kspace_conversion.py
+++ b/src/erlab/interactive/imagetool/_kspace_conversion.py
@@ -21,6 +21,7 @@ from erlab.interactive.imagetool._provenance._model import (
     stamp_operation_group,
 )
 from erlab.interactive.imagetool._provenance._operations import (
+    AssignAttrsOperation,
     AssignScalarCoordOperation,
     KspaceConfigurationOperation,
     KspaceConvertOperation,
@@ -53,6 +54,7 @@ _FOCUS_CONVERT = "bounds_resolution"
 _KSPACE_INPUT_COORDINATE_NAMES = ("hv", "eV", "beta", "xi", "chi")
 
 _KSPACE_SETUP_TYPES = (
+    AssignAttrsOperation,
     KspaceConfigurationOperation,
     AssignScalarCoordOperation,
     KspaceWorkFunctionOperation,
@@ -66,9 +68,25 @@ _KSPACE_CONVERSION_TYPES = (
 _GIB = 1024**3
 
 
+def _is_kspace_configuration_assignment(
+    operation: ToolProvenanceOperation,
+) -> bool:
+    if not isinstance(operation, AssignAttrsOperation) or set(operation.attrs) != {
+        "configuration"
+    }:
+        return False
+    try:
+        AxesConfiguration(int(operation.attrs["configuration"]))
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def _is_kspace_conversion_operation(
     operation: ToolProvenanceOperation,
 ) -> bool:
+    if isinstance(operation, AssignAttrsOperation):
+        return _is_kspace_configuration_assignment(operation)
     if isinstance(operation, AssignScalarCoordOperation):
         return operation.coord_name in _KSPACE_INPUT_COORDINATE_NAMES
     return isinstance(
@@ -144,6 +162,22 @@ def configuration_text(configuration: AxesConfiguration | int) -> str:
     return f"Configuration {int(configuration)} ({configuration.name})"
 
 
+def kspace_configuration(data: xr.DataArray) -> AxesConfiguration | None:
+    """Return the configured axes, or ``None`` when the attribute is absent."""
+    try:
+        return data.kspace.configuration
+    except IncompleteDataError:
+        return None
+
+
+def assign_kspace_configuration(
+    data: xr.DataArray,
+    configuration: AxesConfiguration | int,
+) -> xr.DataArray:
+    """Assign a missing momentum-conversion configuration to a shallow copy."""
+    return data.assign_attrs(configuration=int(AxesConfiguration(int(configuration))))
+
+
 def initial_normal_emission_from_slicer_area(
     slicer_area: ImageSlicerArea,
 ) -> tuple[tuple[float, float] | None, float | None]:
@@ -211,8 +245,14 @@ def rounded_spin_value(spin: QtWidgets.QDoubleSpinBox) -> float:
 
 def kspace_input_coordinate_names(
     data: xr.DataArray,
+    *,
+    configuration: AxesConfiguration | int | None = None,
 ) -> tuple[str, ...]:
     """Return scalar coordinates that can be set for conversion."""
+    if configuration is None:
+        configuration = kspace_configuration(data)
+    elif not isinstance(configuration, AxesConfiguration):
+        configuration = AxesConfiguration(int(configuration))
     names = [
         name
         for name in ("hv", "eV")
@@ -223,7 +263,7 @@ def kspace_input_coordinate_names(
     ):
         names.append("beta")
     names.append("xi")
-    if data.kspace.configuration in (
+    if configuration in (
         AxesConfiguration.Type1DA,
         AxesConfiguration.Type2DA,
     ):
@@ -233,10 +273,12 @@ def kspace_input_coordinate_names(
 
 def kspace_input_coordinate_values(
     data: xr.DataArray,
+    *,
+    configuration: AxesConfiguration | int | None = None,
 ) -> dict[str, float | None]:
     """Return editable scalar coordinates with missing values left unresolved."""
     values: dict[str, float | None] = {}
-    for name in kspace_input_coordinate_names(data):
+    for name in kspace_input_coordinate_names(data, configuration=configuration):
         if name not in data.coords:
             values[name] = None
             continue
@@ -608,16 +650,31 @@ def kspace_conversion_operations(
     operations: list[ToolProvenanceOperation] = []
     focuses: list[str] = []
     target_configuration = AxesConfiguration(int(target_configuration))
+    data_configuration = kspace_configuration(source_data)
     if source_configuration is None:
-        source_configuration = source_data.kspace.configuration
+        if data_configuration is None:
+            raise ValueError(
+                "A source configuration is required for momentum conversion."
+            )
+        source_configuration = data_configuration
+    source_configuration = AxesConfiguration(int(source_configuration))
+    if data_configuration is None:
+        operations.append(
+            AssignAttrsOperation(attrs={"configuration": int(source_configuration)})
+        )
+        focuses.append(_FOCUS_CONFIGURATION)
+        configured_data = assign_kspace_configuration(
+            source_data,
+            source_configuration,
+        )
+    else:
+        configured_data = source_data
     if int(target_configuration) != int(source_configuration):
         operations.append(
             KspaceConfigurationOperation(configuration=int(target_configuration))
         )
         focuses.append(_FOCUS_CONFIGURATION)
-        configured_data = source_data.kspace.as_configuration(target_configuration)
-    else:
-        configured_data = source_data
+        configured_data = configured_data.kspace.as_configuration(target_configuration)
 
     if input_coordinates is not None:
         editable_coordinates = set(kspace_input_coordinate_names(configured_data))
@@ -691,6 +748,10 @@ def kspace_conversion_operations(
 def _focus_for_operation(
     operation: ToolProvenanceOperation,
 ) -> str | None:
+    if isinstance(operation, AssignAttrsOperation):
+        if _is_kspace_configuration_assignment(operation):
+            return _FOCUS_CONFIGURATION
+        return None
     if isinstance(operation, AssignScalarCoordOperation):
         return _FOCUS_INPUT_COORDINATES
     if isinstance(
@@ -746,6 +807,7 @@ def _complete_kspace_conversion_group(
     ):
         return False
     for operation_type in (
+        AssignAttrsOperation,
         KspaceConfigurationOperation,
         KspaceWorkFunctionOperation,
         KspaceInnerPotentialOperation,
@@ -764,6 +826,16 @@ def _complete_kspace_conversion_group(
     if any(
         name not in _KSPACE_INPUT_COORDINATE_NAMES for name in input_coordinates
     ) or len(input_coordinates) != len(set(input_coordinates)):
+        return False
+    configuration_assignments = [
+        operation
+        for operation in setup_operations
+        if isinstance(operation, AssignAttrsOperation)
+    ]
+    if configuration_assignments and (
+        setup_operations[0] is not configuration_assignments[0]
+        or not _is_kspace_configuration_assignment(configuration_assignments[0])
+    ):
         return False
     return all(
         isinstance(operation, _KSPACE_CONVERSION_TYPES) for operation in operations

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -21,6 +21,7 @@ from erlab.interactive.imagetool import _kspace_conversion
 from erlab.interactive.imagetool._dialog_widgets import (
     CoordinateEditorWidget,
     CoordinateGridWidget,
+    KspaceInputCoordinatesControl,
 )
 from erlab.interactive.imagetool._provenance._code import _provenance_value_code
 from erlab.interactive.imagetool._provenance._model import (
@@ -102,7 +103,7 @@ __all__ = [
 ]
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable, Sequence
+    from collections.abc import Hashable, Iterable, Sequence
 
     import xarray as xr
 
@@ -365,7 +366,24 @@ class _DataManipulationDialog(QtWidgets.QDialog):
             ...,
         ]
     ] = ()
-    """Operation classes this dialog can emit directly."""
+    """Operation classes this dialog owns for provenance editor registration."""
+
+    batch_operation_types: typing.ClassVar[
+        tuple[
+            type[ToolProvenanceOperation],
+            ...,
+        ]
+        | None
+    ] = None
+    """Operation classes accepted from this dialog during batch processing."""
+
+    batch_coordinate_replacement_types: typing.ClassVar[
+        tuple[
+            type[ToolProvenanceOperation],
+            ...,
+        ]
+    ] = ()
+    """Coordinate assignments that can replace existing batch target coordinates."""
 
     _sigCodeCopied = QtCore.Signal(str)
 
@@ -1288,6 +1306,8 @@ class KspaceConversionDialog(DataTransformDialog):
         KspaceSetNormalOperation,
         KspaceConvertOperation,
     )
+    batch_operation_types = (*operation_types, AssignScalarCoordOperation)
+    batch_coordinate_replacement_types = (AssignScalarCoordOperation,)
 
     _OFFSET_LABELS: typing.ClassVar[dict[str, str]] = {"V0": "V₀", "wf": "𝜙"}
     _OFFSET_UNITS: typing.ClassVar[dict[str, str]] = {"V0": " eV", "wf": " eV"}
@@ -1313,6 +1333,8 @@ class KspaceConversionDialog(DataTransformDialog):
             self.slicer_area.data
         )
         self._compatible = bool(self._source_data.kspace._interactive_compatible)
+        self._coordinate_preflight_cancelled = False
+        self._input_coordinates_signal_connected = False
         self._control_data = self._source_data
         self._normal_delta: float | None = None
 
@@ -1332,7 +1354,14 @@ class KspaceConversionDialog(DataTransformDialog):
         self.configuration_combo.currentIndexChanged.connect(
             self._handle_configuration_changed
         )
-        self.layout_.addRow("Configuration", self.configuration_combo)
+        self.layout_.addRow(self.configuration_combo)
+
+        self._input_coordinates_widget = KspaceInputCoordinatesControl(
+            self._source_data,
+            object_name_prefix="kspaceConversionInput",
+            button_text="Edit coordinates…",
+        )
+        self.layout_.addRow(self._input_coordinates_widget)
 
         self.parameters_group = QtWidgets.QGroupBox("Parameters")
         self.parameters_group.setLayout(QtWidgets.QFormLayout())
@@ -1358,7 +1387,27 @@ class KspaceConversionDialog(DataTransformDialog):
         self.resolution_group = self.resolution_supergroup
         self.layout_.addRow(self.resolution_supergroup)
 
-        self._set_configuration_combo(self._source_configuration)
+        if (
+            self.is_provenance_edit_mode
+            and not self._input_coordinates_widget.is_complete
+        ):
+            return
+        if (
+            not self._input_coordinates_widget.is_complete
+            and not self._input_coordinates_widget.edit_coordinates()
+        ):
+            self._coordinate_preflight_cancelled = True
+            return
+        self._input_coordinates_widget.valuesChanged.connect(
+            self._input_coordinates_changed
+        )
+        self._input_coordinates_signal_connected = True
+
+        self._set_control_configuration(
+            self._source_configuration,
+            input_values=self._input_coordinates_widget.resolved_values,
+            edited_names=self._input_coordinates_widget.edited_names,
+        )
         self._rebuild_kspace_controls()
         if not self._seed_from_newest_ktool():
             self._seed_from_current_view()
@@ -1387,9 +1436,39 @@ class KspaceConversionDialog(DataTransformDialog):
             return self._control_data.kspace.configuration
         return erlab.constants.AxesConfiguration(int(value))
 
-    def _set_control_configuration(self, configuration: int) -> None:
-        self._control_data = self._source_data.kspace.as_configuration(configuration)
+    def _set_control_configuration(
+        self,
+        configuration: int,
+        *,
+        input_values: Mapping[str, float | None] | None = None,
+        edited_names: Iterable[str] = (),
+    ) -> bool:
+        previous_data = getattr(self, "_control_base_data", self._source_data)
+        previous_values = self._input_coordinates_widget.values
+        previous_edited_names = self._input_coordinates_widget.edited_names
+        control_base_data = self._source_data.kspace.as_configuration(configuration)
+        self._input_coordinates_widget.set_data(
+            control_base_data,
+            values=input_values,
+            edited_names=edited_names,
+        )
+        if not self._input_coordinates_widget.is_complete:
+            with QtCore.QSignalBlocker(self._input_coordinates_widget):
+                accepted = self._input_coordinates_widget.edit_coordinates()
+            if not accepted:
+                self._input_coordinates_widget.set_data(
+                    previous_data,
+                    values=previous_values,
+                    edited_names=previous_edited_names,
+                )
+                return False
+        self._control_base_data = control_base_data
+        self._control_data = _kspace_conversion.assign_kspace_input_coordinates(
+            self._control_base_data,
+            self._input_coordinates_widget.resolved_values,
+        )
         self._set_configuration_combo(configuration)
+        return True
 
     @QtCore.Slot(int)
     def _handle_configuration_changed(self, _index: int = -1) -> None:
@@ -1399,13 +1478,46 @@ class KspaceConversionDialog(DataTransformDialog):
             self.normal_emission if hasattr(self, "_normal_emission_spins") else None
         )
         delta = self._normal_delta
-        self._control_data = self._source_data.kspace.as_configuration(
+        mapped_control_data = self._control_data.kspace.as_configuration(
             self.current_configuration
         )
+        mapped_input_values = _kspace_conversion.kspace_input_coordinate_values(
+            mapped_control_data
+        )
+        target_base_values = _kspace_conversion.kspace_input_coordinate_values(
+            self._source_data.kspace.as_configuration(self.current_configuration)
+        )
+        edited_names = {
+            name
+            for name, value in mapped_input_values.items()
+            if name in self._input_coordinates_widget.edited_names
+            or (
+                value is not None
+                and (
+                    (base_value := target_base_values[name]) is None
+                    or not np.isclose(value, base_value)
+                )
+            )
+        }
+        if not self._set_control_configuration(
+            int(self.current_configuration),
+            input_values=mapped_input_values,
+            edited_names=edited_names,
+        ):
+            self._set_configuration_combo(int(self._control_data.kspace.configuration))
+            return
         self._rebuild_kspace_controls(
             initial_normal_emission=normal,
             initial_delta=delta,
         )
+
+    @QtCore.Slot()
+    def _input_coordinates_changed(self) -> None:
+        self._control_data = _kspace_conversion.assign_kspace_input_coordinates(
+            self._control_base_data,
+            self._input_coordinates_widget.resolved_values,
+        )
+        self._update_memory_estimate()
 
     def _rebuild_kspace_controls(
         self,
@@ -1561,7 +1673,11 @@ class KspaceConversionDialog(DataTransformDialog):
         if ktool is None:
             return False
         configuration = int(ktool.current_configuration)
-        self._set_control_configuration(configuration)
+        self._set_control_configuration(
+            configuration,
+            input_values=ktool.input_coordinates,
+            edited_names=ktool._input_coordinates_widget.edited_names,
+        )
         self._control_data.kspace.angle_scales = ktool.data.kspace.angle_scales
         self._rebuild_kspace_controls(
             initial_normal_emission=ktool._current_normal_emission_angles(),
@@ -1671,10 +1787,36 @@ class KspaceConversionDialog(DataTransformDialog):
             source_data = source_data.kspace.as_configuration(
                 self.current_configuration
             )
+        source_data = _kspace_conversion.assign_kspace_input_coordinates(
+            source_data,
+            self._input_coordinates_for_data(source_data),
+        )
         return self._parameterized_data(
             source_data.copy(deep=False),
             source_data=source_data,
         )
+
+    def _input_coordinates_for_data(
+        self,
+        data: xr.DataArray,
+    ) -> dict[str, float]:
+        source_data = erlab.utils.array._restore_nonuniform_dims(data)
+        if int(source_data.kspace.configuration) != int(self.current_configuration):
+            source_data = source_data.kspace.as_configuration(
+                self.current_configuration
+            )
+        values = _kspace_conversion.kspace_input_coordinate_values(source_data)
+        edited_values = self._input_coordinates_widget.resolved_values
+        for name in self._input_coordinates_widget.edited_names:
+            if name in values:
+                values[name] = edited_values[name]
+        unresolved = [name for name, value in values.items() if value is None]
+        if unresolved:
+            raise ValueError(
+                "Momentum-conversion input coordinates must be assigned: "
+                + ", ".join(unresolved)
+            )
+        return typing.cast("dict[str, float]", values)
 
     def conversion_estimate_for_data(
         self,
@@ -1792,6 +1934,7 @@ class KspaceConversionDialog(DataTransformDialog):
             bounds=self.bounds,
             resolution=self.resolution,
             force_scalars=True,
+            input_coordinates=self._input_coordinates_for_data(source_data),
         )
 
     def source_operations(
@@ -1812,6 +1955,8 @@ class KspaceConversionDialog(DataTransformDialog):
 
     def focus_operation_group_control(self, focus: str | None) -> None:
         match focus:
+            case "input_coordinates":
+                self._input_coordinates_widget.focus_first_control()
             case "configuration":
                 self.configuration_combo.setFocus(
                     QtCore.Qt.FocusReason.OtherFocusReason
@@ -1847,14 +1992,30 @@ class KspaceConversionDialog(DataTransformDialog):
         bounds: dict[str, tuple[float, float]] | None = None
         resolution: dict[str, float] | None = None
         restored_angle_scales = False
+        configuration = int(self.current_configuration)
+        input_coordinates: dict[str, float] = {}
         for operation in operations:
             if isinstance(
                 operation,
                 KspaceConfigurationOperation,
             ):
-                self._set_control_configuration(operation.configuration)
-                self._rebuild_kspace_controls()
-                break
+                configuration = operation.configuration
+            elif isinstance(operation, AssignScalarCoordOperation):
+                input_coordinates[str(operation.coord_name)] = float(
+                    operation.decoded_value
+                )
+        if configuration != int(self.current_configuration) or input_coordinates:
+            self._set_control_configuration(
+                configuration,
+                input_values=input_coordinates,
+                edited_names=input_coordinates,
+            )
+            self._rebuild_kspace_controls()
+        if not self._input_coordinates_signal_connected:
+            self._input_coordinates_widget.valuesChanged.connect(
+                self._input_coordinates_changed
+            )
+            self._input_coordinates_signal_connected = True
         for operation in operations:
             if isinstance(
                 operation,
@@ -1912,6 +2073,8 @@ class KspaceConversionDialog(DataTransformDialog):
         self.restore_transform_operations((operation,))
 
     def _validate(self) -> QtWidgets.QDialog.DialogCode:
+        if self._coordinate_preflight_cancelled:
+            return QtWidgets.QDialog.DialogCode.Rejected
         if self._compatible:
             return QtWidgets.QDialog.DialogCode.Accepted
         QtWidgets.QMessageBox.warning(

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -22,6 +22,7 @@ from erlab.interactive.imagetool._dialog_widgets import (
     CoordinateEditorWidget,
     CoordinateGridWidget,
     KspaceInputCoordinatesControl,
+    prompt_kspace_input_coordinates,
 )
 from erlab.interactive.imagetool._provenance._code import _provenance_value_code
 from erlab.interactive.imagetool._provenance._model import (
@@ -1306,7 +1307,11 @@ class KspaceConversionDialog(DataTransformDialog):
         KspaceSetNormalOperation,
         KspaceConvertOperation,
     )
-    batch_operation_types = (*operation_types, AssignScalarCoordOperation)
+    batch_operation_types = (
+        *operation_types,
+        AssignAttrsOperation,
+        AssignScalarCoordOperation,
+    )
     batch_coordinate_replacement_types = (AssignScalarCoordOperation,)
 
     _OFFSET_LABELS: typing.ClassVar[dict[str, str]] = {"V0": "V₀", "wf": "𝜙"}
@@ -1337,6 +1342,9 @@ class KspaceConversionDialog(DataTransformDialog):
         self._input_coordinates_signal_connected = False
         self._control_data = self._source_data
         self._normal_delta: float | None = None
+        self._source_configuration_missing = (
+            _kspace_conversion.kspace_configuration(self._source_data) is None
+        )
 
         if not self._compatible:
             self.layout_.addRow(
@@ -1344,7 +1352,20 @@ class KspaceConversionDialog(DataTransformDialog):
             )
             return
 
-        self._source_configuration = int(self._source_data.kspace.configuration)
+        source_configuration = _kspace_conversion.kspace_configuration(
+            self._source_data
+        )
+        if source_configuration is None:
+            source_configuration = erlab.constants.AxesConfiguration.Type1
+        self._source_configuration = int(source_configuration)
+        self._source_configured_data = (
+            _kspace_conversion.assign_kspace_configuration(
+                self._source_data,
+                source_configuration,
+            )
+            if self._source_configuration_missing
+            else self._source_data
+        )
         self.configuration_combo = QtWidgets.QComboBox()
         for configuration in erlab.constants.AxesConfiguration:
             self.configuration_combo.addItem(
@@ -1357,7 +1378,7 @@ class KspaceConversionDialog(DataTransformDialog):
         self.layout_.addRow(self.configuration_combo)
 
         self._input_coordinates_widget = KspaceInputCoordinatesControl(
-            self._source_data,
+            self._source_configured_data,
             object_name_prefix="kspaceConversionInput",
             button_text="Edit coordinates…",
         )
@@ -1387,17 +1408,33 @@ class KspaceConversionDialog(DataTransformDialog):
         self.resolution_group = self.resolution_supergroup
         self.layout_.addRow(self.resolution_supergroup)
 
-        if (
-            self.is_provenance_edit_mode
-            and not self._input_coordinates_widget.is_complete
+        if self.is_provenance_edit_mode and (
+            self._source_configuration_missing
+            or not self._input_coordinates_widget.is_complete
         ):
             return
-        if (
-            not self._input_coordinates_widget.is_complete
-            and not self._input_coordinates_widget.edit_coordinates()
-        ):
+        preflight = prompt_kspace_input_coordinates(
+            self._source_data,
+            object_name_prefix="kspaceConversionInput",
+            parent=self,
+        )
+        if preflight is None:
             self._coordinate_preflight_cancelled = True
             return
+        source_configuration, input_values, edited_names = preflight
+        self._source_configuration = int(source_configuration)
+        if self._source_configuration_missing:
+            self._source_configured_data = (
+                _kspace_conversion.assign_kspace_configuration(
+                    self._source_data,
+                    source_configuration,
+                )
+            )
+        self._input_coordinates_widget.set_data(
+            self._source_configured_data,
+            values=input_values,
+            edited_names=edited_names,
+        )
         self._input_coordinates_widget.valuesChanged.connect(
             self._input_coordinates_changed
         )
@@ -1405,8 +1442,8 @@ class KspaceConversionDialog(DataTransformDialog):
 
         self._set_control_configuration(
             self._source_configuration,
-            input_values=self._input_coordinates_widget.resolved_values,
-            edited_names=self._input_coordinates_widget.edited_names,
+            input_values=input_values,
+            edited_names=edited_names,
         )
         self._rebuild_kspace_controls()
         if not self._seed_from_newest_ktool():
@@ -1436,6 +1473,14 @@ class KspaceConversionDialog(DataTransformDialog):
             return self._control_data.kspace.configuration
         return erlab.constants.AxesConfiguration(int(value))
 
+    def _source_data_for_configuration(
+        self,
+        configuration: erlab.constants.AxesConfiguration | int,
+    ) -> xr.DataArray:
+        if int(configuration) == self._source_configuration:
+            return self._source_configured_data
+        return self._source_configured_data.kspace.as_configuration(configuration)
+
     def _set_control_configuration(
         self,
         configuration: int,
@@ -1443,10 +1488,14 @@ class KspaceConversionDialog(DataTransformDialog):
         input_values: Mapping[str, float | None] | None = None,
         edited_names: Iterable[str] = (),
     ) -> bool:
-        previous_data = getattr(self, "_control_base_data", self._source_data)
+        previous_data = getattr(
+            self,
+            "_control_base_data",
+            self._source_configured_data,
+        )
         previous_values = self._input_coordinates_widget.values
         previous_edited_names = self._input_coordinates_widget.edited_names
-        control_base_data = self._source_data.kspace.as_configuration(configuration)
+        control_base_data = self._source_data_for_configuration(configuration)
         self._input_coordinates_widget.set_data(
             control_base_data,
             values=input_values,
@@ -1485,7 +1534,7 @@ class KspaceConversionDialog(DataTransformDialog):
             mapped_control_data
         )
         target_base_values = _kspace_conversion.kspace_input_coordinate_values(
-            self._source_data.kspace.as_configuration(self.current_configuration)
+            self._source_data_for_configuration(self.current_configuration)
         )
         edited_names = {
             name
@@ -1783,6 +1832,11 @@ class KspaceConversionDialog(DataTransformDialog):
 
     def _conversion_input_for_data(self, data: xr.DataArray) -> xr.DataArray:
         source_data = erlab.utils.array._restore_nonuniform_dims(data)
+        if _kspace_conversion.kspace_configuration(source_data) is None:
+            source_data = _kspace_conversion.assign_kspace_configuration(
+                source_data,
+                self._source_configuration,
+            )
         if int(source_data.kspace.configuration) != int(self.current_configuration):
             source_data = source_data.kspace.as_configuration(
                 self.current_configuration
@@ -1801,6 +1855,11 @@ class KspaceConversionDialog(DataTransformDialog):
         data: xr.DataArray,
     ) -> dict[str, float]:
         source_data = erlab.utils.array._restore_nonuniform_dims(data)
+        if _kspace_conversion.kspace_configuration(source_data) is None:
+            source_data = _kspace_conversion.assign_kspace_configuration(
+                source_data,
+                self._source_configuration,
+            )
         if int(source_data.kspace.configuration) != int(self.current_configuration):
             source_data = source_data.kspace.as_configuration(
                 self.current_configuration
@@ -1921,10 +1980,15 @@ class KspaceConversionDialog(DataTransformDialog):
         data: xr.DataArray,
     ) -> tuple[ToolProvenanceOperation, ...]:
         source_data = erlab.utils.array._restore_nonuniform_dims(data)
+        source_configuration = _kspace_conversion.kspace_configuration(source_data)
+        if source_configuration is None:
+            source_configuration = erlab.constants.AxesConfiguration(
+                self._source_configuration
+            )
         return _kspace_conversion.kspace_conversion_operations(
             source_data,
             target_configuration=self.current_configuration,
-            source_configuration=source_data.kspace.configuration,
+            source_configuration=source_configuration,
             work_function=self._work_function,
             inner_potential=self._inner_potential,
             normal_emission=self.normal_emission,
@@ -1992,10 +2056,16 @@ class KspaceConversionDialog(DataTransformDialog):
         bounds: dict[str, tuple[float, float]] | None = None
         resolution: dict[str, float] | None = None
         restored_angle_scales = False
+        source_configuration = self._source_configuration
         configuration = int(self.current_configuration)
         input_coordinates: dict[str, float] = {}
         for operation in operations:
-            if isinstance(
+            if isinstance(operation, AssignAttrsOperation):
+                assigned_configuration = operation.attrs.get("configuration")
+                if assigned_configuration is not None:
+                    source_configuration = int(assigned_configuration)
+                    configuration = source_configuration
+            elif isinstance(
                 operation,
                 KspaceConfigurationOperation,
             ):
@@ -2004,7 +2074,19 @@ class KspaceConversionDialog(DataTransformDialog):
                 input_coordinates[str(operation.coord_name)] = float(
                     operation.decoded_value
                 )
-        if configuration != int(self.current_configuration) or input_coordinates:
+        if source_configuration != self._source_configuration:
+            self._source_configuration = source_configuration
+            self._source_configured_data = (
+                _kspace_conversion.assign_kspace_configuration(
+                    self._source_data,
+                    source_configuration,
+                )
+            )
+        if (
+            configuration != int(self.current_configuration)
+            or input_coordinates
+            or self._source_configuration_missing
+        ):
             self._set_control_configuration(
                 configuration,
                 input_values=input_coordinates,

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -502,7 +502,10 @@ class _ActionsController:
             ...,
         ] = (),
     ) -> None:
-        declared_types = tuple(dialog.operation_types)
+        declared_types = dialog.batch_operation_types
+        if declared_types is None:
+            declared_types = dialog.operation_types
+        declared_types = tuple(declared_types)
         accepted_types = declared_types + extra_types
         for operation in operations:
             if accepted_types and not isinstance(operation, accepted_types):
@@ -517,9 +520,11 @@ class _ActionsController:
 
     def _validate_batch_target_operations(
         self,
+        dialog: typing.Any,
         operations: Iterable[ToolProvenanceOperation],
         data: xr.DataArray,
     ) -> None:
+        replacement_types = tuple(dialog.batch_coordinate_replacement_types)
         for operation in operations:
             if not isinstance(
                 operation,
@@ -528,6 +533,8 @@ class _ActionsController:
                     AssignCoord1DOperation,
                 ),
             ):
+                continue
+            if replacement_types and isinstance(operation, replacement_types):
                 continue
             if operation.coord_name in data.dims or operation.coord_name in data.coords:
                 raise ValueError(
@@ -625,6 +632,7 @@ class _ActionsController:
                         source_data
                     )
                 self._validate_batch_target_operations(
+                    dialog,
                     source_spec.operations,
                     source_data,
                 )

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -73,8 +73,11 @@ _BATCH_OPERATION_CATEGORIES: tuple[tuple[str, tuple[_BatchDialogType, ...]], ...
 
 
 def _dialog_batch_available(dialog_cls: _BatchDialogType) -> bool:
-    return bool(dialog_cls.operation_types) and all(
-        operation_type.batch_available for operation_type in dialog_cls.operation_types
+    operation_types = dialog_cls.batch_operation_types
+    if operation_types is None:
+        operation_types = dialog_cls.operation_types
+    return bool(operation_types) and all(
+        operation_type.batch_available for operation_type in operation_types
     )
 
 

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -3814,6 +3814,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
             options_model=self._options_model,
             execute=False,
         )
+        if tool is None:
+            return
         if isinstance(tool, erlab.interactive.utils.ToolWindow):
             tool.set_source_binding(full_data())
         self.add_tool_window(tool)

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -410,6 +410,7 @@ class KspaceTool(KspaceToolGUI):
     _source_input_data: xr.DataArray
     _input_coordinates_widget: KspaceInputCoordinatesControl
     _source_configuration: int
+    _source_configuration_missing: bool
     _offset_spins: dict[str, QtWidgets.QDoubleSpinBox]
     _normal_emission_offset_values: dict[str, float]
     _normal_emission_offset_labels: dict[str, QtWidgets.QLabel]
@@ -438,6 +439,7 @@ class KspaceTool(KspaceToolGUI):
         input_coordinates: dict[str, float] = pydantic.Field(default_factory=dict)
         input_coordinate_edited_names: tuple[str, ...] = ()
         source_configuration: int | None = None
+        source_configuration_missing: bool = False
         source_input_coordinates: dict[str, float | None] = pydantic.Field(
             default_factory=dict
         )
@@ -626,9 +628,11 @@ class KspaceTool(KspaceToolGUI):
                 sorted(self._input_coordinates_widget.edited_names)
             ),
             source_configuration=self._source_configuration,
+            source_configuration_missing=self._source_configuration_missing,
             source_input_coordinates=(
                 _kspace_conversion.kspace_input_coordinate_values(
-                    self._source_input_data
+                    self._source_input_data,
+                    configuration=self._source_configuration,
                 )
             ),
             source_work_function=_kspace_conversion.kspace_work_function(
@@ -815,7 +819,11 @@ class KspaceTool(KspaceToolGUI):
         if status.source_inner_potential is not None:
             source_data.attrs["inner_potential"] = status.source_inner_potential
 
+        if status.source_configuration_missing:
+            source_data.attrs.pop("configuration", None)
+
         self._source_configuration = status.source_configuration
+        self._source_configuration_missing = status.source_configuration_missing
         self._source_input_data = source_data
 
     _OFFSET_LABELS: typing.ClassVar[dict[str, str]] = {
@@ -855,6 +863,7 @@ class KspaceTool(KspaceToolGUI):
         options_model: AppOptions | None = None,
         _input_coordinates: Mapping[str, float] | None = None,
         _input_coordinate_edited_names: Iterable[str] = (),
+        _configuration: AxesConfiguration | int | None = None,
     ) -> None:
         super().__init__(
             avec=avec,
@@ -880,10 +889,27 @@ class KspaceTool(KspaceToolGUI):
             data_name, "data", func=KspaceTool.__init__, fallback="data"
         )
 
-        self._source_configuration = int(data.kspace.configuration)
+        source_configuration = _kspace_conversion.kspace_configuration(data)
+        self._source_configuration_missing = source_configuration is None
+        if source_configuration is None:
+            if _configuration is None:
+                raise ValueError(
+                    "Missing momentum-conversion configuration. "
+                    "Open the tool with erlab.interactive.ktool()."
+                )
+            source_configuration = AxesConfiguration(int(_configuration))
+            configured_data = _kspace_conversion.assign_kspace_configuration(
+                data,
+                source_configuration,
+            )
+        else:
+            configured_data = data
+        self._source_configuration = int(source_configuration)
         self._source_input_data = data.copy(deep=False)
         if _input_coordinates is None:
-            input_coordinates = _kspace_conversion.kspace_input_coordinate_values(data)
+            input_coordinates = _kspace_conversion.kspace_input_coordinate_values(
+                configured_data
+            )
             if any(value is None for value in input_coordinates.values()):
                 raise ValueError(
                     "Missing scalar momentum-conversion input coordinates. "
@@ -894,16 +920,16 @@ class KspaceTool(KspaceToolGUI):
                 input_coordinates,
             )
         self.data = _kspace_conversion.assign_kspace_input_coordinates(
-            data,
+            configured_data,
             _input_coordinates,
         ).copy(deep=True)
         self._input_coordinates_widget = KspaceInputCoordinatesControl(
-            self._source_input_data,
+            configured_data,
             object_name_prefix="ktoolInput",
             button_text="Edit coordinates…",
         )
         self._input_coordinates_widget.set_data(
-            self._source_input_data,
+            configured_data,
             values=_input_coordinates,
             edited_names=_input_coordinate_edited_names,
         )
@@ -988,13 +1014,15 @@ class KspaceTool(KspaceToolGUI):
         return self._input_coordinates_widget.resolved_values
 
     def _source_data_for_current_configuration(self) -> xr.DataArray:
-        if int(self._source_input_data.kspace.configuration) == int(
-            self.data.kspace.configuration
-        ):
-            return self._source_input_data
-        return self._source_input_data.kspace.as_configuration(
-            self.data.kspace.configuration
-        )
+        source_data = self._source_input_data
+        if _kspace_conversion.kspace_configuration(source_data) is None:
+            source_data = _kspace_conversion.assign_kspace_configuration(
+                source_data,
+                self._source_configuration,
+            )
+        if int(source_data.kspace.configuration) == int(self.data.kspace.configuration):
+            return source_data
+        return source_data.kspace.as_configuration(self.data.kspace.configuration)
 
     def _rebuild_input_coordinates(
         self,
@@ -1228,12 +1256,31 @@ class KspaceTool(KspaceToolGUI):
     def update_data(self, new_data: xr.DataArray) -> None:
         status = self.tool_status
         parsed_new_data = erlab.interactive.utils.parse_data(new_data)
-        source_configuration = int(parsed_new_data.kspace.configuration)
         if not parsed_new_data.kspace._interactive_compatible:
             raise ValueError(
                 "Updated data is not compatible with the interactive tool."
             )
-        control_data = parsed_new_data
+        source_configuration = _kspace_conversion.kspace_configuration(parsed_new_data)
+        source_configuration_missing = source_configuration is None
+        source_edited_names: frozenset[str] = frozenset()
+        if source_configuration is None:
+            source_result = prompt_kspace_input_coordinates(
+                parsed_new_data,
+                object_name_prefix="ktoolInput",
+                parent=self,
+            )
+            if source_result is None:
+                return
+            source_configuration, source_values, source_edited_names = source_result
+            control_data = _kspace_conversion.assign_kspace_input_coordinates(
+                _kspace_conversion.assign_kspace_configuration(
+                    parsed_new_data,
+                    source_configuration,
+                ),
+                source_values,
+            )
+        else:
+            control_data = parsed_new_data
         if source_configuration != int(self.current_configuration):
             try:
                 control_data = control_data.kspace.as_configuration(
@@ -1241,7 +1288,7 @@ class KspaceTool(KspaceToolGUI):
                 )
             except Exception as exc:
                 raise ValueError(
-                    "Updated data has incompatible analyzer configuration."
+                    "Updated data has an incompatible configuration."
                 ) from exc
         resolved_input_coordinates = prompt_kspace_input_coordinates(
             control_data,
@@ -1250,14 +1297,21 @@ class KspaceTool(KspaceToolGUI):
         )
         if resolved_input_coordinates is None:
             return
-        input_coordinates, edited_names = resolved_input_coordinates
+        _, input_coordinates, edited_names = resolved_input_coordinates
+        edited_names = frozenset((*source_edited_names, *edited_names)) & set(
+            input_coordinates
+        )
         status = status.model_copy(
             update={
                 "input_coordinates": input_coordinates,
                 "input_coordinate_edited_names": tuple(sorted(edited_names)),
-                "source_configuration": source_configuration,
+                "source_configuration": int(source_configuration),
+                "source_configuration_missing": source_configuration_missing,
                 "source_input_coordinates": (
-                    _kspace_conversion.kspace_input_coordinate_values(parsed_new_data)
+                    _kspace_conversion.kspace_input_coordinate_values(
+                        parsed_new_data,
+                        configuration=source_configuration,
+                    )
                 ),
                 "source_work_function": _kspace_conversion.kspace_work_function(
                     parsed_new_data
@@ -1276,7 +1330,8 @@ class KspaceTool(KspaceToolGUI):
 
         self._source_input_data = parsed_new_data.copy(deep=False)
         self.data = new_data.copy(deep=True)
-        self._source_configuration = source_configuration
+        self._source_configuration = int(source_configuration)
+        self._source_configuration_missing = source_configuration_missing
         self._bz_cache_key = None
         self._bz_cache_value = None
         self._invalidate_preview_memory_estimate()
@@ -1324,7 +1379,7 @@ class KspaceTool(KspaceToolGUI):
                 data = data.kspace.as_configuration(self.current_configuration)
             except Exception as exc:
                 raise ValueError(
-                    "Updated data has incompatible analyzer configuration."
+                    "Updated data has an incompatible configuration."
                 ) from exc
         if tuple(data.kspace._valid_offset_keys) != current_offset_keys:
             raise ValueError("Updated data has incompatible offset coordinates.")
@@ -2225,11 +2280,11 @@ def ktool(
     Notes
     -----
     .. versionchanged:: 3.27.0
-        The tool opens the input-coordinate editor when a required scalar energy or
-        angle coordinate is not in the data. Enter a finite value for each blank
-        coordinate to open the tool. The editor also changes existing scalar
-        coordinates such as ``hv`` and ``eV``. The ``alpha`` coordinate and swept
-        coordinates remain required in the source data.
+        The tool opens the input-coordinate editor when the configuration or a required
+        scalar energy or angle coordinate is not in the data. Select a configuration
+        and enter a finite value for each blank coordinate to open the tool. The editor
+        also changes existing scalar coordinates such as ``hv`` and ``eV``. The
+        ``alpha`` coordinate and swept coordinates remain required in the source data.
     """
     if data_name is None:
         try:
@@ -2244,7 +2299,7 @@ def ktool(
         )
         if resolved_input_coordinates is None:
             return None
-        input_coordinates, edited_names = resolved_input_coordinates
+        configuration, input_coordinates, edited_names = resolved_input_coordinates
         win = KspaceTool(
             data,
             avec=avec,
@@ -2258,6 +2313,7 @@ def ktool(
             options_model=options_model,
             _input_coordinates=input_coordinates,
             _input_coordinate_edited_names=edited_names,
+            _configuration=configuration,
         )
         win.show()
         win.raise_()

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -32,9 +32,13 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 from erlab.constants import AxesConfiguration
 from erlab.interactive.imagetool import _kspace_conversion
+from erlab.interactive.imagetool._dialog_widgets import (
+    KspaceInputCoordinatesControl,
+    prompt_kspace_input_coordinates,
+)
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
 
     import matplotlib
     import varname
@@ -403,6 +407,8 @@ class KspaceTool(KspaceToolGUI):
     _OUTPUT_MEMORY_ESTIMATE_DELAY_MS = 250
     _MANAGER_NOTIFY_DELAY_MS = 250
     data: xr.DataArray
+    _source_input_data: xr.DataArray
+    _input_coordinates_widget: KspaceInputCoordinatesControl
     _source_configuration: int
     _offset_spins: dict[str, QtWidgets.QDoubleSpinBox]
     _normal_emission_offset_values: dict[str, float]
@@ -429,6 +435,14 @@ class KspaceTool(KspaceToolGUI):
         center: float
         width: int
         offsets: dict[str, float]
+        input_coordinates: dict[str, float] = pydantic.Field(default_factory=dict)
+        input_coordinate_edited_names: tuple[str, ...] = ()
+        source_configuration: int | None = None
+        source_input_coordinates: dict[str, float | None] = pydantic.Field(
+            default_factory=dict
+        )
+        source_work_function: float | None = None
+        source_inner_potential: float | None = None
         angle_scales: dict[str, float] = pydantic.Field(default_factory=dict)
         bounds_enabled: bool
         bounds: dict[str, float]
@@ -551,7 +565,38 @@ class KspaceTool(KspaceToolGUI):
         configuration = self.current_configuration
         if int(configuration) == int(self.data.kspace.configuration):
             return
+        previous_data = self.data
+        previous_values = self._input_coordinates_widget.values
+        previous_edited_names = self._input_coordinates_widget.edited_names
         self.data = self.data.kspace.as_configuration(configuration)
+        input_coordinates = _kspace_conversion.kspace_input_coordinate_values(self.data)
+        source_coordinates = _kspace_conversion.kspace_input_coordinate_values(
+            self._source_data_for_current_configuration()
+        )
+        edited_names = {
+            name
+            for name, value in input_coordinates.items()
+            if name in previous_edited_names
+            or (
+                value is not None
+                and (
+                    (source_value := source_coordinates[name]) is None
+                    or not np.isclose(value, source_value)
+                )
+            )
+        }
+        if not self._rebuild_input_coordinates(
+            values=input_coordinates,
+            edited_names=edited_names,
+        ):
+            self.data = previous_data
+            self._set_configuration_combo(previous_data.kspace.configuration)
+            self._input_coordinates_widget.set_data(
+                self._source_data_for_current_configuration(),
+                values=previous_values,
+                edited_names=previous_edited_names,
+            )
+            return
         self._bz_cache_key = None
         self._bz_cache_value = None
         self._invalidate_preview_memory_estimate()
@@ -576,6 +621,22 @@ class KspaceTool(KspaceToolGUI):
                     if k not in self.data.kspace._valid_offset_keys
                 },
             },
+            input_coordinates=self.input_coordinates,
+            input_coordinate_edited_names=tuple(
+                sorted(self._input_coordinates_widget.edited_names)
+            ),
+            source_configuration=self._source_configuration,
+            source_input_coordinates=(
+                _kspace_conversion.kspace_input_coordinate_values(
+                    self._source_input_data
+                )
+            ),
+            source_work_function=_kspace_conversion.kspace_work_function(
+                self._source_input_data
+            ),
+            source_inner_potential=_kspace_conversion.kspace_inner_potential(
+                self._source_input_data
+            ),
             angle_scales={
                 k: round(spin.value(), spin.decimals())
                 for k, spin in self._angle_scale_spins.items()
@@ -604,6 +665,7 @@ class KspaceTool(KspaceToolGUI):
     @tool_status.setter
     def tool_status(self, status: StateModel) -> None:
         self._argnames["data"] = status.data_name
+        self._restore_source_input_state(status)
         configuration = int(
             self.data.kspace.configuration
             if status.configuration is None
@@ -612,9 +674,17 @@ class KspaceTool(KspaceToolGUI):
         if int(self.data.kspace.configuration) != configuration:
             self.data = self.data.kspace.as_configuration(configuration)
             self._set_configuration_combo(configuration)
+            self._rebuild_input_coordinates(
+                values=status.input_coordinates,
+                edited_names=status.input_coordinate_edited_names,
+            )
             self._rebuild_kspace_controls()
         else:
             self._set_configuration_combo(configuration)
+            self._rebuild_input_coordinates(
+                values=status.input_coordinates,
+                edited_names=status.input_coordinate_edited_names,
+            )
 
         self.center_spin.blockSignals(True)
         self.center_spin.setValue(status.center)
@@ -722,6 +792,32 @@ class KspaceTool(KspaceToolGUI):
     def tool_data(self) -> xr.DataArray:
         return self.data
 
+    def _restore_source_input_state(self, status: StateModel) -> None:
+        if status.source_configuration is None:
+            return
+
+        source_data = self.data.copy(deep=False)
+        if int(source_data.kspace.configuration) != status.source_configuration:
+            source_data = source_data.kspace.as_configuration(
+                status.source_configuration
+            )
+        for name, value in status.source_input_coordinates.items():
+            if value is None:
+                if name in source_data.coords and name not in source_data.dims:
+                    source_data = source_data.drop_vars(name)
+            else:
+                source_data = source_data.assign_coords({name: value})
+
+        source_data = source_data.copy(deep=False)
+        source_data.attrs = dict(source_data.attrs)
+        if status.source_work_function is not None:
+            source_data.attrs["sample_workfunction"] = status.source_work_function
+        if status.source_inner_potential is not None:
+            source_data.attrs["inner_potential"] = status.source_inner_potential
+
+        self._source_configuration = status.source_configuration
+        self._source_input_data = source_data
+
     _OFFSET_LABELS: typing.ClassVar[dict[str, str]] = {
         "delta": "𝛿",
         "chi": "𝜒₀",
@@ -757,6 +853,8 @@ class KspaceTool(KspaceToolGUI):
         initial_normal_emission: tuple[float, float] | None = None,
         initial_delta: float | None = None,
         options_model: AppOptions | None = None,
+        _input_coordinates: Mapping[str, float] | None = None,
+        _input_coordinate_edited_names: Iterable[str] = (),
     ) -> None:
         super().__init__(
             avec=avec,
@@ -783,7 +881,36 @@ class KspaceTool(KspaceToolGUI):
         )
 
         self._source_configuration = int(data.kspace.configuration)
-        self.data = data.copy(deep=True)
+        self._source_input_data = data.copy(deep=False)
+        if _input_coordinates is None:
+            input_coordinates = _kspace_conversion.kspace_input_coordinate_values(data)
+            if any(value is None for value in input_coordinates.values()):
+                raise ValueError(
+                    "Missing scalar momentum-conversion input coordinates. "
+                    "Open the tool with erlab.interactive.ktool()."
+                )
+            _input_coordinates = typing.cast(
+                "dict[str, float]",
+                input_coordinates,
+            )
+        self.data = _kspace_conversion.assign_kspace_input_coordinates(
+            data,
+            _input_coordinates,
+        ).copy(deep=True)
+        self._input_coordinates_widget = KspaceInputCoordinatesControl(
+            self._source_input_data,
+            object_name_prefix="ktoolInput",
+            button_text="Edit coordinates…",
+        )
+        self._input_coordinates_widget.set_data(
+            self._source_input_data,
+            values=_input_coordinates,
+            edited_names=_input_coordinate_edited_names,
+        )
+        self.input_coordinates_layout.addWidget(self._input_coordinates_widget)
+        self._input_coordinates_widget.valuesChanged.connect(
+            self._input_coordinates_changed
+        )
         self._populate_configuration_combo()
         self._update_proxy = pg.SignalProxy(
             self._sigTriggerUpdate,
@@ -854,6 +981,53 @@ class KspaceTool(KspaceToolGUI):
         self.center_spin.valueChanged.connect(self.queue_update)
         self.width_spin.valueChanged.connect(self.queue_update)
         self._energy_controls_connected = True
+
+    @property
+    def input_coordinates(self) -> dict[str, float]:
+        """Return scalar angle coordinates used by this conversion."""
+        return self._input_coordinates_widget.resolved_values
+
+    def _source_data_for_current_configuration(self) -> xr.DataArray:
+        if int(self._source_input_data.kspace.configuration) == int(
+            self.data.kspace.configuration
+        ):
+            return self._source_input_data
+        return self._source_input_data.kspace.as_configuration(
+            self.data.kspace.configuration
+        )
+
+    def _rebuild_input_coordinates(
+        self,
+        *,
+        values: Mapping[str, float | None] | None = None,
+        edited_names: Iterable[str] = (),
+    ) -> bool:
+        self._input_coordinates_widget.set_data(
+            self._source_data_for_current_configuration(),
+            values=values,
+            edited_names=edited_names,
+        )
+        if not self._input_coordinates_widget.is_complete:
+            with QtCore.QSignalBlocker(self._input_coordinates_widget):
+                if not self._input_coordinates_widget.edit_coordinates():
+                    return False
+        self.data = _kspace_conversion.assign_kspace_input_coordinates(
+            self.data,
+            self.input_coordinates,
+        )
+        return True
+
+    @QtCore.Slot()
+    def _input_coordinates_changed(self) -> None:
+        self.data = _kspace_conversion.assign_kspace_input_coordinates(
+            self.data,
+            self.input_coordinates,
+        )
+        self._invalidate_preview_memory_estimate()
+        if hasattr(self, "_normal_emission_spins"):
+            self._update_offsets_from_normal_emission()
+        self.queue_update()
+        self._write_state()
 
     @staticmethod
     def _clear_layout(layout: QtWidgets.QLayout) -> None:
@@ -1055,14 +1229,62 @@ class KspaceTool(KspaceToolGUI):
         status = self.tool_status
         parsed_new_data = erlab.interactive.utils.parse_data(new_data)
         source_configuration = int(parsed_new_data.kspace.configuration)
-        new_data = self.validate_update_data(parsed_new_data)
+        if not parsed_new_data.kspace._interactive_compatible:
+            raise ValueError(
+                "Updated data is not compatible with the interactive tool."
+            )
+        control_data = parsed_new_data
+        if source_configuration != int(self.current_configuration):
+            try:
+                control_data = control_data.kspace.as_configuration(
+                    self.current_configuration
+                )
+            except Exception as exc:
+                raise ValueError(
+                    "Updated data has incompatible analyzer configuration."
+                ) from exc
+        resolved_input_coordinates = prompt_kspace_input_coordinates(
+            control_data,
+            object_name_prefix="ktoolInput",
+            parent=self,
+        )
+        if resolved_input_coordinates is None:
+            return
+        input_coordinates, edited_names = resolved_input_coordinates
+        status = status.model_copy(
+            update={
+                "input_coordinates": input_coordinates,
+                "input_coordinate_edited_names": tuple(sorted(edited_names)),
+                "source_configuration": source_configuration,
+                "source_input_coordinates": (
+                    _kspace_conversion.kspace_input_coordinate_values(parsed_new_data)
+                ),
+                "source_work_function": _kspace_conversion.kspace_work_function(
+                    parsed_new_data
+                ),
+                "source_inner_potential": _kspace_conversion.kspace_inner_potential(
+                    parsed_new_data
+                ),
+            },
+        )
+        new_data = self.validate_update_data(
+            _kspace_conversion.assign_kspace_input_coordinates(
+                control_data,
+                input_coordinates,
+            )
+        )
 
+        self._source_input_data = parsed_new_data.copy(deep=False)
         self.data = new_data.copy(deep=True)
         self._source_configuration = source_configuration
         self._bz_cache_key = None
         self._bz_cache_value = None
         self._invalidate_preview_memory_estimate()
         self._set_configuration_combo(self.data.kspace.configuration)
+        self._rebuild_input_coordinates(
+            values=input_coordinates,
+            edited_names=edited_names,
+        )
         with self._history_suppressed():
             self._rebuild_kspace_controls()
 
@@ -1511,7 +1733,7 @@ class KspaceTool(KspaceToolGUI):
     ) -> tuple[ToolProvenanceOperation, ...]:
         alpha_normal, beta_normal = self._current_normal_emission_angles()
         return _kspace_conversion.kspace_conversion_operations(
-            self.data,
+            self._source_input_data,
             target_configuration=self.data.kspace.configuration,
             source_configuration=self._source_configuration,
             work_function=self._work_function,
@@ -1523,6 +1745,7 @@ class KspaceTool(KspaceToolGUI):
             bounds=self.bounds,
             resolution=self.resolution,
             force_scalars=False,
+            input_coordinates=self.input_coordinates,
         )
 
     def _copy_assign_target(
@@ -1962,7 +2185,7 @@ def ktool(
     initial_delta: float | None = None,
     options_model: AppOptions | None = None,
     execute: bool | None = None,
-) -> KspaceTool:
+) -> KspaceTool | None:
     """Interactive momentum conversion tool.
 
     This tool can also be accessed with :meth:`DataArray.kspace.interactive`, or from
@@ -1973,8 +2196,8 @@ def ktool(
     data
         Data to convert. Currently supports constant energy slices (2D data with alpha
         and beta dimensions), 2D angle-energy cuts with alpha and eV dimensions and a
-        fixed beta coordinate, and all 3D data that has eV and alpha dimensions,
-        including maps and photon energy dependent data.
+        fixed or assigned beta coordinate, and all 3D data that has eV and alpha
+        dimensions, including maps and photon energy dependent data.
     avec : array-like, optional
         Real-space lattice vectors as a 2x2 or 3x3 numpy array. If provided, the
         Brillouin zone boundary overlay will be calculated based on these vectors. If
@@ -1998,6 +2221,15 @@ def ktool(
         seed the normal emission controls and derived angle offsets.
     initial_delta
         Optional delta value to apply alongside ``initial_normal_emission``.
+
+    Notes
+    -----
+    .. versionchanged:: 3.27.0
+        The tool opens the input-coordinate editor when a required scalar energy or
+        angle coordinate is not in the data. Enter a finite value for each blank
+        coordinate to open the tool. The editor also changes existing scalar
+        coordinates such as ``hv`` and ``eV``. The ``alpha`` coordinate and swept
+        coordinates remain required in the source data.
     """
     if data_name is None:
         try:
@@ -2006,6 +2238,13 @@ def ktool(
             data_name = "data"
 
     with erlab.interactive.utils.setup_qapp(execute):
+        resolved_input_coordinates = prompt_kspace_input_coordinates(
+            data,
+            object_name_prefix="ktoolInput",
+        )
+        if resolved_input_coordinates is None:
+            return None
+        input_coordinates, edited_names = resolved_input_coordinates
         win = KspaceTool(
             data,
             avec=avec,
@@ -2017,6 +2256,8 @@ def ktool(
             initial_normal_emission=initial_normal_emission,
             initial_delta=initial_delta,
             options_model=options_model,
+            _input_coordinates=input_coordinates,
+            _input_coordinate_edited_names=edited_names,
         )
         win.show()
         win.raise_()

--- a/src/erlab/interactive/ktool.ui
+++ b/src/erlab/interactive/ktool.ui
@@ -48,6 +48,9 @@
          </widget>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="input_coordinates_layout"/>
+        </item>
+        <item>
          <widget class="Line" name="line">
           <property name="orientation">
            <enum>Qt::Orientation::Horizontal</enum>

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -733,6 +733,8 @@ def _select_batch_operation(
 
 class _BatchTransformStub:
     operation_types = (AssignAttrsOperation,)
+    batch_operation_types = None
+    batch_coordinate_replacement_types: tuple[type[ToolProvenanceOperation], ...] = ()
 
     def __init__(
         self,
@@ -791,6 +793,7 @@ class _BatchTransformStub:
 
 class _BatchFilterStub:
     operation_types = (NormalizeOperation,)
+    batch_operation_types = None
 
     def __init__(
         self,
@@ -3042,17 +3045,21 @@ def test_metadata_editor_preflights_every_target(
 
 def test_batch_operation_metadata_matches_launcher() -> None:
     dialog_classes = _batch_operation_dialog_classes()
+    batch_operation_types = [
+        dialog_cls.operation_types
+        if dialog_cls.batch_operation_types is None
+        else dialog_cls.batch_operation_types
+        for dialog_cls in dialog_classes
+    ]
     assert dialog_classes
     assert imagetool_dialogs.EdgeCorrectionDialog not in dialog_classes
     assert imagetool_dialogs.ROIPathDialog not in dialog_classes
     assert imagetool_dialogs.ROIMaskDialog not in dialog_classes
-    assert [
-        dialog_cls for dialog_cls in dialog_classes if not dialog_cls.operation_types
-    ] == []
+    assert all(batch_operation_types)
     assert [
         operation_type
-        for dialog_cls in dialog_classes
-        for operation_type in dialog_cls.operation_types
+        for operation_types in batch_operation_types
+        for operation_type in operation_types
         if not operation_type.batch_available
     ] == []
     assert RestoreNonuniformDimsOperation.batch_available
@@ -4061,6 +4068,49 @@ def test_batch_affine_coord_offset_uses_each_scalar_coordinate(
             xarray.testing.assert_identical(
                 manager.get_imagetool(index).slicer_area._data.rename(None),
                 operation.apply(data).rename(None),
+            )
+
+
+def test_batch_kspace_conversion_replaces_scalar_input_coordinates(
+    qtbot,
+    anglemap,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data0 = anglemap.isel(alpha=slice(0, 4), beta=slice(0, 5), eV=slice(0, 3)).rename(
+        "scan0"
+    )
+    data1 = data0.copy(deep=True).assign_coords(hv=float(data0.hv) + 10.0)
+    data1.data = np.asarray(data1.data) + 1.0
+    data1 = data1.rename("scan1")
+
+    with manager_context() as manager:
+        manager.show()
+        _add_batch_tools(qtbot, manager, data0, data1)
+        select_tools(manager, [0, 1])
+
+        dialog = imagetool_dialogs.KspaceConversionDialog(
+            manager.get_imagetool(0).slicer_area,
+            batch_manager=manager,
+        )
+        values = dialog._input_coordinates_widget.resolved_values
+        values["hv"] = 52.0
+        dialog._input_coordinates_widget.set_data(
+            data0,
+            values=values,
+            edited_names={"hv"},
+        )
+        dialog._input_coordinates_changed()
+        expected = [
+            dialog.source_spec_for_data(data).apply(data) for data in (data0, data1)
+        ]
+
+        assert manager.apply_batch_transform_dialog(dialog, "replace")
+        for index, expected_data in enumerate(expected):
+            xarray.testing.assert_identical(
+                manager.get_imagetool(index).slicer_area._data.rename(None),
+                expected_data.rename(None),
             )
 
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -8252,6 +8252,22 @@ def test_itool_open_in_ktool_sets_full_data_source_binding(qtbot, monkeypatch) -
     win.close()
 
 
+def test_itool_open_in_ktool_cancel_does_not_add_tool(qtbot, monkeypatch) -> None:
+    win = itool(_TEST_DATA["3D"].copy(), execute=False)
+    qtbot.addWidget(win)
+
+    monkeypatch.setattr(erlab.interactive, "ktool", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        win.slicer_area,
+        "add_tool_window",
+        lambda *args, **kwargs: pytest.fail("cancelled ktool was added"),
+    )
+
+    win.slicer_area.open_in_ktool()
+
+    win.close()
+
+
 def test_itool_open_in_ktool_uses_guideline_seed_on_alpha_beta_plane(
     qtbot, monkeypatch
 ) -> None:

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -11,7 +11,7 @@ import erlab
 from erlab.accessors.kspace import IncompleteDataError, MomentumAccessor
 from erlab.constants import AxesConfiguration
 from erlab.interactive._options.schema import AppOptions
-from erlab.interactive.imagetool import _kspace_conversion
+from erlab.interactive.imagetool import _dialog_widgets, _kspace_conversion
 from erlab.interactive.imagetool import dialogs as imagetool_dialogs
 from erlab.interactive.imagetool._provenance._model import (
     full_data,
@@ -22,6 +22,7 @@ from erlab.interactive.imagetool._provenance._model import (
     strip_operation_groups,
 )
 from erlab.interactive.imagetool._provenance._operations import (
+    AssignScalarCoordOperation,
     AverageOperation,
     IselOperation,
     KspaceConfigurationOperation,
@@ -31,6 +32,9 @@ from erlab.interactive.imagetool._provenance._operations import (
     KspaceWorkFunctionOperation,
 )
 from erlab.interactive.imagetool.dialogs import KspaceConversionDialog
+from erlab.interactive.imagetool.manager._provenance_edit import (
+    _controller as provenance_edit_controller,
+)
 from erlab.interactive.kspace import KspaceTool, ktool
 from erlab.io.exampledata import generate_hvdep_cuts
 
@@ -112,6 +116,17 @@ def _add_hidden_tool(qtbot, widget):
     qtbot.addWidget(widget)
     widget.hide()
     return widget
+
+
+def _set_input_coordinates(dialog, values: dict[str, float]) -> None:
+    prefix = dialog.objectName().removesuffix("Dialog")
+    for name, value in values.items():
+        edit = dialog.findChild(
+            imagetool_dialogs.QtWidgets.QLineEdit,
+            f"{prefix}{name.title()}Coordinate",
+        )
+        assert edit is not None
+        edit.setText(str(value))
 
 
 def _restore_ktool_offsets(win: KspaceTool, offsets: dict[str, float]) -> None:
@@ -206,23 +221,417 @@ def test_ktool_compatible(anglemap) -> None:
     )
     cut_without_configuration = cut.copy(deep=True)
     del cut_without_configuration.attrs["configuration"]
+    cut_without_alpha_coord = cut.drop_vars("alpha")
     data_4d = anglemap.expand_dims("x", 2)
     data_3d_without_alpha = data_4d.qsel(alpha=-8.3)
+    cut_without_hv = cut.drop_vars("hv")
+    const_energy_without_ev = const_energy.drop_vars("eV")
+    map_without_ev_dimension_coord = anglemap.drop_vars("eV")
 
     assert cut.kspace._interactive_compatible
     assert const_energy.kspace._interactive_compatible
+    assert cut_without_beta.kspace._interactive_compatible
+    assert cut_without_hv.kspace._interactive_compatible
+    assert const_energy_without_ev.kspace._interactive_compatible
 
     for data in (
-        cut_without_beta,
         cut_with_beta_coord,
         cut_without_configuration,
+        cut_without_alpha_coord,
         data_4d,
         data_3d_without_alpha,
+        map_without_ev_dimension_coord,
     ):
         with pytest.raises(
             ValueError, match=r"Data is not compatible with the interactive tool."
         ):
             data.kspace.interactive()
+
+
+def test_ktool_assigns_missing_scalar_angle_coordinates(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = (
+        anglemap.isel(alpha=slice(0, 4), eV=slice(0, 5))
+        .qsel(beta=-8.3)
+        .drop_vars(("beta", "xi", "hv"))
+        .copy(deep=True)
+    )
+
+    holder: dict[str, KspaceTool | None] = {}
+
+    def _open_ktool() -> None:
+        holder["win"] = ktool(data, data_name="cut", execute=False)
+
+    def _complete_preflight(dialog) -> None:
+        assert dialog.values == {"hv": None, "beta": None, "xi": None}
+        ok_button = dialog.button_box.button(
+            imagetool_dialogs.QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
+        assert ok_button is not None
+        assert not ok_button.isEnabled()
+        _set_input_coordinates(dialog, {"hv": 51.0, "beta": 0.0, "xi": 0.0})
+        assert ok_button.isEnabled()
+
+    accept_dialog(_open_ktool, pre_call=_complete_preflight)
+    win = holder["win"]
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+
+    assert not win._input_coordinates_widget.missing_names
+    assert (
+        win.configuration_combo.geometry().bottom()
+        < win._input_coordinates_widget.geometry().top()
+    )
+    assert win.input_coordinates == pytest.approx({"hv": 51.0, "beta": 0.0, "xi": 0.0})
+    assert "hv" not in data.coords
+    assert "beta" not in data.coords
+    assert "xi" not in data.coords
+
+    def _edit_coordinates(dialog) -> None:
+        _set_input_coordinates(
+            dialog,
+            {"beta": -3.25, "xi": 4.5, "hv": 52.0},
+        )
+
+    accept_dialog(
+        win._input_coordinates_widget.edit_coordinates,
+        pre_call=_edit_coordinates,
+    )
+
+    expected = win._converted_output()
+    code = win.copy_code()
+    namespace = {"cut": data.copy(deep=True)}
+    exec(code, {"__builtins__": {}}, namespace)  # noqa: S102
+
+    xr.testing.assert_allclose(namespace["cut_kconv"], expected)
+    assert float(win.data.beta) == pytest.approx(-3.25)
+    assert float(win.data.xi) == pytest.approx(4.5)
+    assert float(win.data.hv) == pytest.approx(52.0)
+    assert "beta" not in data.coords
+    assert "xi" not in data.coords
+    assert "hv" not in data.coords
+
+    accepted_values = win.input_coordinates
+    accept_dialog(
+        win._input_coordinates_widget.edit_coordinates,
+        pre_call=lambda dialog: _set_input_coordinates(dialog, {"hv": 53.0}),
+        accept_call=lambda dialog: dialog.reject(),
+    )
+    assert win.input_coordinates == accepted_values
+
+    cancelled: dict[str, KspaceTool | None] = {}
+    accept_dialog(
+        lambda: cancelled.update(win=ktool(data, execute=False)),
+        pre_call=lambda dialog: _set_input_coordinates(
+            dialog,
+            {"hv": 51.0, "beta": 0.0, "xi": 0.0},
+        ),
+        accept_call=lambda dialog: dialog.reject(),
+    )
+    assert cancelled["win"] is None
+    accept_dialog(win._input_coordinates_widget.edit_coordinates)
+    assert win.input_coordinates == accepted_values
+
+    with pytest.raises(
+        ValueError, match=r"Open the tool with erlab\.interactive\.ktool"
+    ):
+        KspaceTool(data)
+
+
+def test_ktool_missing_coordinate_persistence_preserves_copy_operations(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = (
+        anglemap.isel(alpha=slice(0, 4), eV=slice(0, 5))
+        .qsel(beta=-8.3)
+        .drop_vars("hv")
+        .copy(deep=True)
+    )
+    holder: dict[str, KspaceTool | None] = {}
+    accept_dialog(
+        lambda: holder.update(win=ktool(data, data_name="scan", execute=False)),
+        pre_call=lambda dialog: _set_input_coordinates(dialog, {"hv": 52.0}),
+    )
+    win = holder["win"]
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    assert isinstance(restored, KspaceTool)
+    _add_hidden_tool(qtbot, restored)
+
+    assert "hv" not in restored._source_input_data.coords
+    assert restored._input_coordinates_widget.edited_names == {"hv"}
+    assert any(
+        isinstance(operation, AssignScalarCoordOperation)
+        and operation.coord_name == "hv"
+        and float(operation.decoded_value) == pytest.approx(52.0)
+        for operation in restored._copy_operations()
+    )
+
+    namespace = {"scan": data.copy(deep=True)}
+    exec(restored.copy_code(), {"__builtins__": {}}, namespace)  # noqa: S102
+    xr.testing.assert_allclose(namespace["scan_kconv"], restored._converted_output())
+
+
+def test_kspace_conversion_dialog_assigns_missing_scalar_angle_coordinates(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = (
+        anglemap.isel(alpha=slice(0, 4), eV=slice(0, 5))
+        .qsel(beta=-8.3)
+        .drop_vars(("beta", "xi"))
+        .copy(deep=True)
+    )
+    win = erlab.interactive.itool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+    holder: dict[str, KspaceConversionDialog] = {}
+
+    def _open_dialog() -> None:
+        holder["dialog"] = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
+
+    def _complete_preflight(coordinate_dialog) -> None:
+        assert coordinate_dialog.values["beta"] is None
+        assert coordinate_dialog.values["xi"] is None
+        _set_input_coordinates(
+            coordinate_dialog,
+            {"beta": 0.0, "xi": 0.0},
+        )
+
+    accept_dialog(_open_dialog, pre_call=_complete_preflight)
+    dialog = holder["dialog"]
+
+    assert dialog._compatible
+    assert not dialog._input_coordinates_widget.missing_names
+
+    source_hv = float(data.hv)
+    dialog.focus_operation_group_control("input_coordinates")
+
+    def _edit_coordinates(coordinate_dialog) -> None:
+        _set_input_coordinates(
+            coordinate_dialog,
+            {"beta": -2.0, "xi": 5.0, "hv": source_hv + 2.0},
+        )
+
+    accept_dialog(
+        dialog._input_coordinates_widget.edit_coordinates,
+        pre_call=_edit_coordinates,
+    )
+
+    operations = dialog.source_operations()
+    coordinate_operations = [
+        operation
+        for operation in operations
+        if isinstance(operation, AssignScalarCoordOperation)
+    ]
+    assert {
+        str(operation.coord_name): float(operation.decoded_value)
+        for operation in coordinate_operations
+    } == pytest.approx({"hv": source_hv + 2.0, "beta": -2.0, "xi": 5.0})
+    for index in range(len(operations)):
+        assert KspaceConversionDialog.operation_group_for_edit(
+            operations,
+            index,
+        ) == (0, len(operations))
+
+    restored_holder: dict[str, KspaceConversionDialog] = {}
+    accept_dialog(
+        lambda: restored_holder.update(
+            dialog=_add_kspace_conversion_dialog(qtbot, win.slicer_area)
+        ),
+        pre_call=_complete_preflight,
+    )
+    restored = restored_holder["dialog"]
+    restored.restore_transform_operations(operations)
+    assert restored._input_coordinates_widget.values == pytest.approx(
+        {"hv": source_hv + 2.0, "beta": -2.0, "xi": 5.0}
+    )
+
+    expected = dialog.process_data(data.copy(deep=True))
+    code = dialog.make_code()
+    namespace = {"data": data.copy(deep=True)}
+    exec(code, {"__builtins__": {}}, namespace)  # noqa: S102
+
+    xr.testing.assert_allclose(namespace["data_kconv"], expected)
+    assert "beta" not in data.coords
+    assert "xi" not in data.coords
+    assert float(data.hv) == pytest.approx(source_hv)
+
+    other_configuration = (
+        AxesConfiguration.Type2
+        if data.kspace.configuration == AxesConfiguration.Type1
+        else AxesConfiguration.Type1
+    )
+    dialog._set_configuration_combo(int(other_configuration))
+    assert dialog._input_coordinates_for_data(data) == pytest.approx(
+        {"hv": source_hv + 2.0, "beta": -2.0, "xi": 5.0}
+    )
+
+
+def test_kspace_conversion_dialog_missing_hv_preflight_accept_and_cancel(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.qsel(beta=-8.3).drop_vars("hv").copy(deep=True)
+    win = erlab.interactive.itool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+    holder: dict[str, KspaceConversionDialog] = {}
+
+    def _open_dialog() -> None:
+        holder["dialog"] = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
+
+    def _complete_preflight(coordinate_dialog) -> None:
+        assert coordinate_dialog.values["hv"] is None
+        assert (
+            coordinate_dialog.findChild(
+                imagetool_dialogs.QtWidgets.QLabel,
+                "kspaceConversionInputHvStatus",
+            )
+            is None
+        )
+        _set_input_coordinates(coordinate_dialog, {"hv": 52.0})
+
+    accept_dialog(_open_dialog, pre_call=_complete_preflight)
+    dialog = holder["dialog"]
+    assert float(dialog._control_data.hv) == pytest.approx(52.0)
+    assert {
+        str(operation.coord_name): float(operation.decoded_value)
+        for operation in dialog.source_operations()
+        if isinstance(operation, AssignScalarCoordOperation)
+    }["hv"] == pytest.approx(52.0)
+
+    cancelled: dict[str, KspaceConversionDialog] = {}
+    accept_dialog(
+        lambda: cancelled.update(
+            dialog=_add_kspace_conversion_dialog(qtbot, win.slicer_area)
+        ),
+        accept_call=lambda coordinate_dialog: coordinate_dialog.reject(),
+    )
+    cancelled_dialog = cancelled["dialog"]
+    assert cancelled_dialog._coordinate_preflight_cancelled
+    with pytest.raises(ValueError, match="input coordinates are required"):
+        _ = cancelled_dialog._input_coordinates_widget.resolved_values
+    assert (
+        cancelled_dialog._validate()
+        == imagetool_dialogs.QtWidgets.QDialog.DialogCode.Rejected
+    )
+
+
+def test_kspace_conversion_provenance_edit_restores_before_coordinate_prompt(
+    qtbot,
+    anglemap,
+    monkeypatch,
+) -> None:
+    data = anglemap.qsel(beta=-8.3).drop_vars("hv").copy(deep=True)
+    win = erlab.interactive.itool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+
+    monkeypatch.setattr(
+        _dialog_widgets.KspaceInputCoordinatesControl,
+        "edit_coordinates",
+        lambda _self: pytest.fail(
+            "provenance coordinates must restore before prompting"
+        ),
+    )
+    dialog = KspaceConversionDialog(
+        win.slicer_area,
+        provenance_edit_mode=True,
+    )
+    qtbot.addWidget(dialog)
+    operations = stamp_operation_group(
+        (
+            AssignScalarCoordOperation(coord_name="hv", value=52.0),
+            KspaceSetNormalOperation(alpha=0.0, beta=0.0, delta=0.0),
+            KspaceConvertOperation(bounds=None, resolution=None),
+        ),
+        kind=_kspace_conversion.KSPACE_CONVERSION_GROUP_KIND,
+    )
+
+    provenance_edit_controller._ProvenanceEditController._restore_native_edit_dialog(
+        dialog,
+        operations,
+        "input_coordinates",
+    )
+    assert dialog._input_coordinates_widget.resolved_values["hv"] == pytest.approx(52.0)
+    assert dialog.parameters_group.layout().count() > 0
+
+    dialog.reject()
+    assert dialog.result() == int(
+        imagetool_dialogs.QtWidgets.QDialog.DialogCode.Rejected
+    )
+
+
+def test_ktool_assigns_missing_deflector_angle_coordinates(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = _make_da_ktool_data(anglemap).drop_vars(("xi", "chi"))
+
+    holder: dict[str, KspaceTool | None] = {}
+    accept_dialog(
+        lambda: holder.update(win=ktool(data, execute=False)),
+        pre_call=lambda dialog: _set_input_coordinates(
+            dialog,
+            {"xi": 0.0, "chi": 0.0},
+        ),
+    )
+    win = holder["win"]
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+
+    assert not win._input_coordinates_widget.missing_names
+    assert win.input_coordinates == pytest.approx(
+        {"hv": float(data.hv), "xi": 0.0, "chi": 0.0}
+    )
+    coordinate_operations = [
+        operation
+        for operation in win._copy_operations()
+        if isinstance(operation, AssignScalarCoordOperation)
+    ]
+    assert {str(operation.coord_name) for operation in coordinate_operations} == {
+        "xi",
+        "chi",
+    }
+
+
+def test_ktool_assigns_missing_scalar_energy_coordinate(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = (
+        anglemap.isel(alpha=slice(0, 4), beta=slice(0, 5))
+        .qsel(eV=-0.1)
+        .drop_vars("eV")
+        .copy(deep=True)
+    )
+    holder: dict[str, KspaceTool | None] = {}
+
+    accept_dialog(
+        lambda: holder.update(win=ktool(data, data_name="surface", execute=False)),
+        pre_call=lambda dialog: _set_input_coordinates(dialog, {"eV": -0.1}),
+    )
+    win = holder["win"]
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+
+    assert win.input_coordinates["eV"] == pytest.approx(-0.1)
+    assert "eV" not in data.coords
+    assert any(
+        isinstance(operation, AssignScalarCoordOperation)
+        and operation.coord_name == "eV"
+        for operation in win._copy_operations()
+    )
+    assert win._converted_output().size > 0
 
 
 def test_kspace_conversion_dialog_requires_configuration(
@@ -321,6 +730,164 @@ def test_kspace_conversion_operations_default_source_configuration(anglemap) -> 
     assert operations[0].group.focus == "normal_emission"
     assert operations[1].group is not None
     assert operations[1].group.focus == "bounds_resolution"
+
+
+def test_kspace_input_coordinate_validation(anglemap) -> None:
+    data = _make_ktool_data(anglemap, AxesConfiguration.Type1, {"xi": 0.0})
+    data.kspace.work_function = 4.5
+    constant_energy = data.qsel(eV=float(data.eV[0]))
+    energy_values = _kspace_conversion.kspace_input_coordinate_values(constant_energy)
+
+    assert energy_values["hv"] == pytest.approx(float(data.hv))
+    assert energy_values["eV"] == pytest.approx(float(constant_energy.eV))
+    assert float(
+        _kspace_conversion.assign_kspace_input_coordinates(
+            constant_energy,
+            {"eV": -0.25},
+        ).eV
+    ) == pytest.approx(-0.25)
+
+    with pytest.raises(ValueError, match="must be scalar"):
+        _kspace_conversion.kspace_input_coordinate_values(
+            data.assign_coords(xi=("alpha", np.zeros(data.sizes["alpha"])))
+        )
+    assert (
+        _kspace_conversion.kspace_input_coordinate_values(
+            data.assign_coords(xi=np.nan)
+        )["xi"]
+        is None
+    )
+    data_without_hv = data.drop_vars("hv")
+    assert (
+        _kspace_conversion.kspace_input_coordinate_values(data_without_hv)["hv"] is None
+    )
+    with pytest.raises(ValueError, match="must be assigned: hv"):
+        _kspace_conversion.assign_kspace_input_coordinates(data_without_hv)
+    with pytest.raises(ValueError, match="not editable"):
+        _kspace_conversion.assign_kspace_input_coordinates(data, {"chi": 0.0})
+    with pytest.raises(ValueError, match="must be assigned: xi"):
+        _kspace_conversion.assign_kspace_input_coordinates(data, {"xi": np.nan})
+
+    operation_kwargs = {
+        "target_configuration": AxesConfiguration.Type1,
+        "source_configuration": None,
+        "work_function": 4.5,
+        "inner_potential": None,
+        "normal_emission": (1.0, 2.0),
+        "delta": None,
+        "bounds": None,
+        "resolution": None,
+        "force_scalars": False,
+    }
+    with pytest.raises(ValueError, match="not editable"):
+        _kspace_conversion.kspace_conversion_operations(
+            data,
+            input_coordinates={"chi": 0.0},
+            **operation_kwargs,
+        )
+    with pytest.raises(ValueError, match="must be finite"):
+        _kspace_conversion.kspace_conversion_operations(
+            data,
+            input_coordinates={"xi": np.nan},
+            **operation_kwargs,
+        )
+
+
+def test_kspace_input_coordinate_help(qtbot, anglemap, monkeypatch) -> None:
+    urls: list[str] = []
+    monkeypatch.setattr(
+        _dialog_widgets.QtGui.QDesktopServices,
+        "openUrl",
+        lambda url: urls.append(url.toString()),
+    )
+    data = anglemap.qsel(beta=-8.3).drop_vars("hv")
+    dialog = _dialog_widgets.KspaceInputCoordinatesDialog(
+        data,
+        values=_kspace_conversion.kspace_input_coordinate_values(data),
+        edited_names=(),
+        object_name_prefix="kspaceHelpTest",
+    )
+    qtbot.addWidget(dialog)
+
+    with pytest.raises(ValueError, match="input coordinates are required"):
+        _ = dialog.resolved_values
+    dialog.accept()
+    assert dialog.result() == imagetool_dialogs.QtWidgets.QDialog.DialogCode.Rejected
+
+    help_button = dialog.findChild(
+        imagetool_dialogs.QtWidgets.QPushButton,
+        "kspaceHelpTestHelpButton",
+    )
+    assert help_button is not None
+    help_button.click()
+
+    assert urls == [
+        "https://erlabpy.readthedocs.io/en/stable/user-guide/kconv.html#nomenclature"
+    ]
+    assert dialog.result() == imagetool_dialogs.QtWidgets.QDialog.DialogCode.Rejected
+
+
+def test_ktool_configuration_change_prompts_for_new_coordinate(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 4), eV=slice(0, 5)).qsel(beta=-8.3)
+    win = ktool(data, execute=False)
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+    original_values = win.input_coordinates
+    target_index = win.configuration_combo.findData(int(AxesConfiguration.Type1DA))
+    assert target_index >= 0
+
+    accept_dialog(
+        lambda: win.configuration_combo.setCurrentIndex(target_index),
+        pre_call=lambda dialog: _set_input_coordinates(dialog, {"beta": 1.0}),
+        accept_call=lambda dialog: dialog.reject(),
+    )
+    assert win.current_configuration == AxesConfiguration.Type1
+    assert win.input_coordinates == original_values
+
+    accept_dialog(
+        lambda: win.configuration_combo.setCurrentIndex(target_index),
+        pre_call=lambda dialog: _set_input_coordinates(dialog, {"beta": 1.0}),
+    )
+    assert win.current_configuration == AxesConfiguration.Type1DA
+    assert win.input_coordinates["beta"] == pytest.approx(1.0)
+
+
+def test_kspace_dialog_configuration_change_cancel_restores_coordinates(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 4), eV=slice(0, 5)).qsel(beta=-8.3)
+    win = erlab.interactive.itool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
+    original_values = dialog._input_coordinates_widget.values
+    target_index = dialog.configuration_combo.findData(int(AxesConfiguration.Type1DA))
+    assert target_index >= 0
+
+    accept_dialog(
+        lambda: dialog.configuration_combo.setCurrentIndex(target_index),
+        pre_call=lambda coordinate_dialog: _set_input_coordinates(
+            coordinate_dialog, {"beta": 1.0}
+        ),
+        accept_call=lambda coordinate_dialog: coordinate_dialog.reject(),
+    )
+
+    assert dialog.current_configuration == AxesConfiguration.Type1
+    assert dialog._input_coordinates_widget.values == original_values
+
+    accept_dialog(
+        lambda: dialog.configuration_combo.setCurrentIndex(target_index),
+        pre_call=lambda coordinate_dialog: _set_input_coordinates(
+            coordinate_dialog, {"beta": 1.0}
+        ),
+    )
+    assert dialog.current_configuration == AxesConfiguration.Type1DA
+    assert dialog._input_coordinates_widget.values["beta"] == pytest.approx(1.0)
 
 
 def test_kspace_conversion_operations_include_nondefault_angle_scales(
@@ -518,7 +1085,9 @@ def test_kspace_conversion_estimate_uses_explicit_grid_directly(
 
 def test_kspace_conversion_console_group_stamping_focuses_rows() -> None:
     operations = (
+        AssignScalarCoordOperation(coord_name="sample_temp", value=20.0),
         KspaceConfigurationOperation(configuration=AxesConfiguration.Type2),
+        AssignScalarCoordOperation(coord_name="xi", value=0.0),
         KspaceInnerPotentialOperation(inner_potential=12.0),
         KspaceWorkFunctionOperation(work_function=4.2),
         KspaceSetNormalOperation(alpha=1.0, beta=2.0, delta=3.0),
@@ -531,12 +1100,18 @@ def test_kspace_conversion_console_group_stamping_focuses_rows() -> None:
         None if operation.group is None else operation.group.focus
         for operation in stamped
     ] == [
+        None,
         "configuration",
+        "input_coordinates",
         "inner_potential",
         "work_function",
         "normal_emission",
         "bounds_resolution",
     ]
+    assert (
+        _kspace_conversion.incomplete_kspace_conversion_edit_reason(operations[0])
+        is None
+    )
     assert (
         _kspace_conversion._focus_for_operation(AverageOperation(dims=("x",))) is None
     )
@@ -550,6 +1125,18 @@ def test_kspace_conversion_console_group_stamping_focuses_rows() -> None:
             )
         )[0].group
         is None
+    )
+    duplicate_coordinate = stamp_operation_group(
+        (
+            AssignScalarCoordOperation(coord_name="xi", value=0.0),
+            AssignScalarCoordOperation(coord_name="xi", value=1.0),
+            KspaceSetNormalOperation(alpha=1.0, beta=2.0),
+            KspaceConvertOperation(bounds=None, resolution=None),
+        ),
+        kind=_kspace_conversion.KSPACE_CONVERSION_GROUP_KIND,
+    )
+    assert (
+        KspaceConversionDialog.operation_group_for_edit(duplicate_coordinate, 0) is None
     )
 
 
@@ -1380,6 +1967,8 @@ def test_kspace_conversion_dialog_estimate_defensive_paths(
     estimate = dialog.conversion_estimate_for_data(data)
 
     assert estimate.is_safe
+    with pytest.raises(ValueError, match="must be assigned: hv"):
+        dialog._input_coordinates_for_data(data.drop_vars("hv"))
     dialog.preflight_data(data)
     assert not dialog._handle_process_error(RuntimeError("not a memory guard"))
 
@@ -2716,6 +3305,76 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
     xr.testing.assert_identical(win.tool_data, expected_tool_data)
     assert win.images[0].data_array is not None
     assert win.images[1].data_array is not None
+
+
+def test_ktool_update_data_cancel_keeps_current_data(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5))
+    win = ktool(data, execute=False)
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+    original_data = win.data.copy(deep=True)
+
+    accept_dialog(
+        lambda: win.update_data(data.drop_vars("hv")),
+        pre_call=lambda dialog: _set_input_coordinates(dialog, {"hv": 52.0}),
+        accept_call=lambda dialog: dialog.reject(),
+    )
+
+    xr.testing.assert_identical(win.data, original_data)
+
+
+def test_ktool_update_data_rejects_unmappable_configuration(
+    qtbot,
+    anglemap,
+    monkeypatch,
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5))
+    win = ktool(data, execute=False)
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+    fake_kspace = SimpleNamespace(
+        _interactive_compatible=True,
+        configuration=int(AxesConfiguration.Type2),
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "parse_data",
+        lambda _: SimpleNamespace(kspace=fake_kspace),
+    )
+
+    with pytest.raises(ValueError, match="incompatible analyzer configuration"):
+        win.update_data(object())
+
+
+def test_ktool_update_data_assigns_missing_coordinate(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5))
+    win = ktool(data, data_name="scan", execute=False)
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+    updated = data.drop_vars("hv")
+
+    accept_dialog(
+        lambda: win.update_data(updated),
+        pre_call=lambda dialog: _set_input_coordinates(dialog, {"hv": 52.0}),
+    )
+
+    assert win.input_coordinates["hv"] == pytest.approx(52.0)
+    assert float(win.data.hv) == pytest.approx(52.0)
+    assert "hv" not in win._source_input_data.coords
+    assert any(
+        isinstance(operation, AssignScalarCoordOperation)
+        and operation.coord_name == "hv"
+        and float(operation.decoded_value) == pytest.approx(52.0)
+        for operation in win._copy_operations()
+    )
 
 
 def test_ktool_undo_redo_colormap_state(qtbot, anglemap) -> None:

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -22,6 +22,7 @@ from erlab.interactive.imagetool._provenance._model import (
     strip_operation_groups,
 )
 from erlab.interactive.imagetool._provenance._operations import (
+    AssignAttrsOperation,
     AssignScalarCoordOperation,
     AverageOperation,
     IselOperation,
@@ -129,6 +130,17 @@ def _set_input_coordinates(dialog, values: dict[str, float]) -> None:
         edit.setText(str(value))
 
 
+def _select_input_configuration(
+    dialog,
+    configuration: AxesConfiguration,
+) -> None:
+    combo = dialog.configuration_combo
+    assert combo is not None
+    index = combo.findData(int(configuration))
+    assert index >= 0
+    combo.setCurrentIndex(index)
+
+
 def _restore_ktool_offsets(win: KspaceTool, offsets: dict[str, float]) -> None:
     status = win.tool_status
     win.tool_status = status.model_copy(
@@ -221,6 +233,7 @@ def test_ktool_compatible(anglemap) -> None:
     )
     cut_without_configuration = cut.copy(deep=True)
     del cut_without_configuration.attrs["configuration"]
+    cut_with_invalid_configuration = cut.assign_attrs(configuration=999)
     cut_without_alpha_coord = cut.drop_vars("alpha")
     data_4d = anglemap.expand_dims("x", 2)
     data_3d_without_alpha = data_4d.qsel(alpha=-8.3)
@@ -233,10 +246,11 @@ def test_ktool_compatible(anglemap) -> None:
     assert cut_without_beta.kspace._interactive_compatible
     assert cut_without_hv.kspace._interactive_compatible
     assert const_energy_without_ev.kspace._interactive_compatible
+    assert cut_without_configuration.kspace._interactive_compatible
 
     for data in (
         cut_with_beta_coord,
-        cut_without_configuration,
+        cut_with_invalid_configuration,
         cut_without_alpha_coord,
         data_4d,
         data_3d_without_alpha,
@@ -334,6 +348,59 @@ def test_ktool_assigns_missing_scalar_angle_coordinates(
     assert cancelled["win"] is None
     accept_dialog(win._input_coordinates_widget.edit_coordinates)
     assert win.input_coordinates == accepted_values
+
+    with pytest.raises(
+        ValueError, match=r"Open the tool with erlab\.interactive\.ktool"
+    ):
+        KspaceTool(data)
+
+
+def test_ktool_assigns_missing_configuration(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.qsel(beta=-8.3).copy(deep=True)
+    del data.attrs["configuration"]
+    holder: dict[str, KspaceTool | None] = {}
+
+    def _select_configuration(dialog) -> None:
+        assert dialog.configuration is None
+        assert dialog.editor.is_complete
+        ok_button = dialog.button_box.button(
+            imagetool_dialogs.QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
+        assert ok_button is not None
+        assert not ok_button.isEnabled()
+        _select_input_configuration(dialog, AxesConfiguration.Type1)
+        assert ok_button.isEnabled()
+
+    accept_dialog(
+        lambda: holder.update(
+            win=ktool(data, data_name="cut", execute=False),
+        ),
+        pre_call=_select_configuration,
+    )
+    win = holder["win"]
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+
+    assert "configuration" not in data.attrs
+    assert "configuration" not in win._source_input_data.attrs
+    assert win.data.kspace.configuration == AxesConfiguration.Type1
+    operations = win._copy_operations()
+    assert isinstance(operations[0], AssignAttrsOperation)
+    assert operations[0].attrs == {"configuration": int(AxesConfiguration.Type1)}
+
+    namespace = {"cut": data.copy(deep=True)}
+    exec(win.copy_code(), {"__builtins__": {}}, namespace)  # noqa: S102
+    xr.testing.assert_allclose(namespace["cut_kconv"], win._converted_output())
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    assert isinstance(restored, KspaceTool)
+    _add_hidden_tool(qtbot, restored)
+    assert "configuration" not in restored._source_input_data.attrs
+    assert isinstance(restored._copy_operations()[0], AssignAttrsOperation)
 
     with pytest.raises(
         ValueError, match=r"Open the tool with erlab\.interactive\.ktool"
@@ -473,6 +540,53 @@ def test_kspace_conversion_dialog_assigns_missing_scalar_angle_coordinates(
     assert dialog._input_coordinates_for_data(data) == pytest.approx(
         {"hv": source_hv + 2.0, "beta": -2.0, "xi": 5.0}
     )
+
+
+def test_kspace_conversion_dialog_assigns_missing_configuration(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.qsel(beta=-8.3).copy(deep=True)
+    del data.attrs["configuration"]
+    win = erlab.interactive.itool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+    holder: dict[str, KspaceConversionDialog] = {}
+
+    accept_dialog(
+        lambda: holder.update(
+            dialog=_add_kspace_conversion_dialog(qtbot, win.slicer_area)
+        ),
+        pre_call=lambda coordinate_dialog: _select_input_configuration(
+            coordinate_dialog,
+            AxesConfiguration.Type1,
+        ),
+    )
+    dialog = holder["dialog"]
+
+    operations = dialog.source_operations()
+    assert isinstance(operations[0], AssignAttrsOperation)
+    assert operations[0].attrs == {"configuration": int(AxesConfiguration.Type1)}
+    for index in range(len(operations)):
+        assert KspaceConversionDialog.operation_group_for_edit(
+            operations,
+            index,
+        ) == (0, len(operations))
+
+    expected = dialog.process_data(data.copy(deep=True))
+    namespace = {"data": data.copy(deep=True)}
+    exec(dialog.make_code(), {"__builtins__": {}}, namespace)  # noqa: S102
+    xr.testing.assert_allclose(namespace["data_kconv"], expected)
+    assert "configuration" not in data.attrs
+
+    restored = KspaceConversionDialog(
+        win.slicer_area,
+        provenance_edit_mode=True,
+    )
+    qtbot.addWidget(restored)
+    restored.restore_transform_operations(operations)
+    assert restored.current_configuration == AxesConfiguration.Type1
+    assert restored._input_coordinates_widget.is_complete
 
 
 def test_kspace_conversion_dialog_missing_hv_preflight_accept_and_cancel(
@@ -634,28 +748,27 @@ def test_ktool_assigns_missing_scalar_energy_coordinate(
     assert win._converted_output().size > 0
 
 
-def test_kspace_conversion_dialog_requires_configuration(
+def test_kspace_conversion_dialog_missing_configuration_cancel(
     qtbot,
-    monkeypatch,
     anglemap,
+    accept_dialog,
 ) -> None:
     data = anglemap.qsel(eV=-0.1).copy(deep=True)
     del data.attrs["configuration"]
 
     win = erlab.interactive.itool(data, execute=False)
     _add_hidden_tool(qtbot, win)
-    dialog = _add_kspace_conversion_dialog(qtbot, win.slicer_area)
-
-    assert dialog._compatible is False
-    assert not hasattr(dialog, "configuration_combo")
-    dialog._handle_configuration_changed()
-    dialog._update_memory_estimate()
-    dialog._set_memory_estimate(_conversion_estimate_stub())
-    monkeypatch.setattr(
-        imagetool_dialogs.QtWidgets.QMessageBox,
-        "warning",
-        lambda *args, **kwargs: None,
+    holder: dict[str, KspaceConversionDialog] = {}
+    accept_dialog(
+        lambda: holder.update(
+            dialog=_add_kspace_conversion_dialog(qtbot, win.slicer_area)
+        ),
+        accept_call=lambda coordinate_dialog: coordinate_dialog.reject(),
     )
+    dialog = holder["dialog"]
+
+    assert dialog._compatible
+    assert dialog._coordinate_preflight_cancelled
     assert dialog._validate() == imagetool_dialogs.QtWidgets.QDialog.DialogCode.Rejected
 
 
@@ -825,6 +938,34 @@ def test_kspace_input_coordinate_help(qtbot, anglemap, monkeypatch) -> None:
         "https://erlabpy.readthedocs.io/en/stable/user-guide/kconv.html#nomenclature"
     ]
     assert dialog.result() == imagetool_dialogs.QtWidgets.QDialog.DialogCode.Rejected
+
+
+def test_kspace_input_coordinate_configuration_selection(qtbot, anglemap) -> None:
+    data = anglemap.qsel(beta=-8.3).drop_vars("chi", errors="ignore").copy(deep=True)
+    del data.attrs["configuration"]
+    dialog = _dialog_widgets.KspaceInputCoordinatesDialog(
+        data,
+        values=_kspace_conversion.kspace_input_coordinate_values(data),
+        edited_names=(),
+        object_name_prefix="kspaceConfigurationTest",
+    )
+    qtbot.addWidget(dialog)
+    ok_button = dialog.button_box.button(
+        imagetool_dialogs.QtWidgets.QDialogButtonBox.StandardButton.Ok
+    )
+    assert ok_button is not None
+
+    assert dialog.configuration is None
+    assert "chi" not in dialog.values
+    assert not ok_button.isEnabled()
+
+    _select_input_configuration(dialog, AxesConfiguration.Type1DA)
+
+    assert dialog.configuration == AxesConfiguration.Type1DA
+    assert dialog.values["chi"] is None
+    assert not ok_button.isEnabled()
+    _set_input_coordinates(dialog, {"chi": 0.0})
+    assert ok_button.isEnabled()
 
 
 def test_ktool_configuration_change_prompts_for_new_coordinate(
@@ -1137,6 +1278,17 @@ def test_kspace_conversion_console_group_stamping_focuses_rows() -> None:
     )
     assert (
         KspaceConversionDialog.operation_group_for_edit(duplicate_coordinate, 0) is None
+    )
+    unrelated_attribute = stamp_operation_group(
+        (
+            AssignAttrsOperation(attrs={"sample_temp": 20.0}),
+            KspaceSetNormalOperation(alpha=1.0, beta=2.0),
+            KspaceConvertOperation(bounds=None, resolution=None),
+        ),
+        kind=_kspace_conversion.KSPACE_CONVERSION_GROUP_KIND,
+    )
+    assert (
+        KspaceConversionDialog.operation_group_for_edit(unrelated_attribute, 0) is None
     )
 
 
@@ -3346,7 +3498,7 @@ def test_ktool_update_data_rejects_unmappable_configuration(
         lambda _: SimpleNamespace(kspace=fake_kspace),
     )
 
-    with pytest.raises(ValueError, match="incompatible analyzer configuration"):
+    with pytest.raises(ValueError, match="incompatible configuration"):
         win.update_data(object())
 
 
@@ -3470,7 +3622,7 @@ def test_ktool_update_data_rejects_noninteractive_replacement_for_cut(
             "incompatible offset coordinates",
         ),
         ("momentum_axes", ("kx",), "incompatible momentum axes"),
-        ("configuration", 999, "incompatible analyzer configuration"),
+        ("configuration", 999, "incompatible configuration"),
         ("_has_hv", True, "incompatible photon-energy dimensions"),
     ],
 )


### PR DESCRIPTION
## Summary

- Add a compact editor for scalar momentum-conversion inputs.
- Prompt users to select a configuration when the data does not contain one.
- Open the editor automatically when photon energy or required scalar angles are missing.
- Update the coordinate fields when the selected configuration changes.
- Let users change existing scalar coordinates such as `hv` and `eV`.
- Use the same `Edit coordinates…` action in KspaceTool and the ImageTool conversion dialog.
- Preserve configuration and coordinate assignments in generated code, provenance groups, batch operations, and saved KspaceTool sessions.
- Add a help action for the documented angle convention.

## Motivation

Momentum conversion uses relative scalar angle values for many common datasets. Requiring users to open the general coordinate editor before each conversion was inconvenient. Data without photon energy or configuration metadata could not open KspaceTool even when the user could supply the missing input.

## Root cause and implementation

The interactive compatibility check treated missing configuration and scalar inputs as structural data errors. The shared preflight now separates required swept coordinates from assignable inputs.

A missing configuration is recorded as the first assignment in the momentum-conversion provenance group. Coordinate assignments and conversion follow it. Copied code, replay, batch operations, and saved KspaceTool state therefore retain the complete input repair without modifying the source data.

Each provenance operation type still has one editor owner. The grouped conversion dialog declares additional batch operation types without registering duplicate standalone editors.

## User impact

Users can open KspaceTool or Convert to kspace with missing configuration or scalar input coordinates. The dialog shows `Select configuration…` only when the configuration is absent. Blank values remain invalid until the user supplies all required inputs.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/test_kspace.py tests/interactive/imagetool/manager/provenance/test_editor_foundations.py::test_manager_provenance_operation_editor_contract_is_valid` — 119 passed.
- `QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run --group pyside6 pytest` for the new configuration and editor-contract cases — 4 passed.
- `uv run mypy src` — 259 source files passed.
- Ruff check, Ruff format check, commit hooks, and `git diff --check` passed.
