### PR TITLE
fix(manager): publish immutable workspace generations

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -1441,7 +1441,12 @@ class _ActionsController:
             )
 
     def _show_operation_error(self, log_message: str, text: str) -> None:
-        logger.exception(log_message, extra={"suppress_ui_alert": True})
+        logger.error(
+            "%s\n%s",
+            log_message,
+            traceback.format_exc(),
+            extra={"suppress_ui_alert": True},
+        )
         erlab.interactive.utils.MessageDialog.critical(
             self._manager,
             "Error",
@@ -1455,15 +1460,9 @@ class _ActionsController:
         self, error: workspace_saving._WorkspaceSaveError
     ) -> None:
         source_path = error.missing_source_path
-        if source_path is None:
-            title = "Error"
-            text = "An error occurred while saving the workspace file."
-            logger.error(
-                "Error while saving workspace\n%s",
-                error.traceback_text,
-                extra={"suppress_ui_alert": True},
-            )
-        else:
+        access_denied_path = error.access_denied_path
+        publication_conflict_path = error.publication_conflict_path
+        if source_path is not None:
             title = "Workspace Backing File Missing"
             text = (
                 "ImageTool Manager could not save this workspace because it still "
@@ -1476,12 +1475,48 @@ class _ActionsController:
                 "memory cannot be recovered. Items already loaded may remain available "
                 "in the current session."
             )
-            logger.error(
-                "Error while saving workspace; backing file is missing: %s\n%s",
-                source_path,
-                error.traceback_text,
-                extra={"suppress_ui_alert": True},
+            log_message = (
+                f"Error while saving workspace; backing file is missing: {source_path}"
             )
+        elif access_denied_path is not None:
+            title = "Workspace File Access Denied"
+            text = (
+                "ImageTool Manager could not access a file needed to save this "
+                "workspace:\n\n"
+                f"{access_denied_path}\n\n"
+                "The existing workspace was not changed. Close programs that are "
+                "previewing the file. Pause folder sync if necessary. Check that you "
+                "can write to the folder, then try again. You can also use Save As to "
+                "select another folder."
+            )
+            log_message = (
+                "Error while saving workspace; file access was denied: "
+                f"{access_denied_path}"
+            )
+        elif publication_conflict_path is not None:
+            title = "Workspace Changed During Save"
+            text = (
+                "Another process changed this workspace while ImageTool Manager was "
+                "preparing the save:\n\n"
+                f"{publication_conflict_path}\n\n"
+                "ImageTool Manager did not overwrite the newer file. Reopen the "
+                "workspace, or use Save As to keep the current session in a separate "
+                "file."
+            )
+            log_message = (
+                "Error while saving workspace; publication conflict: "
+                f"{publication_conflict_path}"
+            )
+        else:
+            title = "Error"
+            text = "An error occurred while saving the workspace file."
+            log_message = "Error while saving workspace"
+        logger.error(
+            "%s\n%s",
+            log_message,
+            error.traceback_text,
+            extra={"suppress_ui_alert": True},
+        )
         erlab.interactive.utils.MessageDialog.critical(
             self._manager,
             title,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import threading
 import typing
+import weakref
 
 import h5netcdf
 import hdf5plugin
@@ -37,6 +38,8 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 )
 
 _WORKSPACE_FILE_LOCKS: dict[str, threading.RLock] = {}
+_WORKSPACE_FILE_MANAGERS: dict[str, weakref.WeakSet[WorkspaceFileManager]] = {}
+_WORKSPACE_FILE_MANAGERS_LOCK = threading.Lock()
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
@@ -249,6 +252,27 @@ class WorkspaceFileManager(CachingFileManager):
             manager_id=("erlab-workspace", *identity, "r+"),
         )
         self.workspace_path = target
+        with _WORKSPACE_FILE_MANAGERS_LOCK:
+            managers = _WORKSPACE_FILE_MANAGERS.setdefault(target, weakref.WeakSet())
+            managers.add(self)
+
+
+def _close_workspace_file_managers(path: str | os.PathLike[str]) -> None:
+    """Close all cached manager-owned readers for one workspace path.
+
+    The caller must hold the lock returned by :func:`_workspace_file_lock` for
+    the same path. This prevents a lazy reader from reopening the file while
+    the cached handles are being closed.
+    """
+    target = _normalized_file_path(path)
+    if target is None:
+        target = os.fsdecode(path)
+    with _WORKSPACE_FILE_MANAGERS_LOCK:
+        managers = tuple(_WORKSPACE_FILE_MANAGERS.get(target, ()))
+        if not managers:
+            _WORKSPACE_FILE_MANAGERS.pop(target, None)
+    for manager in managers:
+        manager.close(needs_lock=False)
 
 
 def _iter_h5netcdf_group_paths(group: object, path: str = "/") -> Iterator[str]:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -62,6 +62,7 @@ _WORKSPACE_FILE_CLEANUP_WORKER: threading.Thread | None = None
 _WORKSPACE_FILE_CLEANUP_WORKER_LOCK = threading.Lock()
 _WORKSPACE_READER_DIRECTORY_SUFFIX = ".readers"
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
+_WORKSPACE_MATERIALIZED_CHUNKSIZES = "_erlab_workspace_materialized_chunksizes"
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
 _SAVED_TOOL_DATA_BLOB_DIM_PREFIX = _serialization.SAVED_TOOL_DATA_BLOB_DIM_PREFIX
@@ -78,10 +79,19 @@ class _WorkspaceReaderFile:
     cleanup: Callable[[], None]
 
 
-_WorkspaceExportKey: typing.TypeAlias = tuple[str, int, int, int, str]
-_WORKSPACE_SESSION_EXPORTS: dict[_WorkspaceExportKey, _WorkspaceReaderFile] = {}
-_WORKSPACE_SESSION_EXPORTS_LOCK = threading.Lock()
-_WORKSPACE_SESSION_EXPORTS_OWNER_PID = os.getpid()
+@dataclass(frozen=True)
+class _WorkspaceReaderHandoff:
+    """One serialized-reader lease for a logical workspace generation."""
+
+    reader_file: _WorkspaceReaderFile
+    generation_key: tuple[str, str]
+
+
+_WORKSPACE_READER_HANDOFFS: dict[str, _WorkspaceReaderHandoff] = {}
+_WORKSPACE_READER_HANDOFFS_LOCK = threading.Lock()
+_WORKSPACE_READER_HANDOFFS_OWNER_PID = os.getpid()
+_WORKSPACE_MAX_PENDING_READER_GENERATIONS = 8
+_WORKSPACE_MAX_PENDING_READER_HANDOFFS = 64
 
 
 def _normalized_workspace_group(group: str) -> str:
@@ -156,7 +166,7 @@ def _create_workspace_reader_file(
     source_path: str | os.PathLike[str],
     workspace_path: str | os.PathLike[str],
     *,
-    kind: typing.Literal["reader", "export"] = "reader",
+    kind: typing.Literal["reader", "export", "handoff"] = "reader",
     copy_only: bool = False,
 ) -> _WorkspaceReaderFile:
     """Create a private hard link or copy for one reader generation."""
@@ -222,7 +232,7 @@ def _create_workspace_group_reader_file(
 
 
 def _workspace_reader_file_owner_pid(path: pathlib.Path) -> int | None:
-    for kind in ("reader", "export"):
+    for kind in ("reader", "export", "handoff"):
         prefix = f"{kind}-"
         if not path.name.startswith(prefix) or not path.name.endswith(".itws"):
             continue
@@ -268,33 +278,91 @@ def _cleanup_stale_workspace_reader_files(
         directory.rmdir()
 
 
-def _cleanup_workspace_session_exports() -> None:
-    """Remove cross-process exports owned by this Python process."""
-    if os.getpid() != _WORKSPACE_SESSION_EXPORTS_OWNER_PID:
+def _create_workspace_reader_handoff(
+    export_file: _WorkspaceReaderFile,
+    workspace_path: str | os.PathLike[str],
+    revision: str,
+) -> _WorkspaceReaderFile:
+    """Create one independently owned handoff for a serialized reader."""
+    with _WORKSPACE_READER_HANDOFFS_LOCK:
+        for path in tuple(_WORKSPACE_READER_HANDOFFS):
+            if not pathlib.Path(path).exists():
+                _WORKSPACE_READER_HANDOFFS.pop(path, None)
+        generation_key = (os.fsdecode(workspace_path), revision)
+        pending_generations = {
+            handoff.generation_key for handoff in _WORKSPACE_READER_HANDOFFS.values()
+        }
+        if len(
+            _WORKSPACE_READER_HANDOFFS
+        ) >= _WORKSPACE_MAX_PENDING_READER_HANDOFFS or (
+            generation_key not in pending_generations
+            and len(pending_generations) >= _WORKSPACE_MAX_PENDING_READER_GENERATIONS
+        ):
+            raise RuntimeError(
+                "Too many workspace readers are waiting for another process. Wait "
+                "for background work to finish, then try again. If no work is "
+                "running, restart the ImageTool Manager."
+            )
+        handoff = _create_workspace_reader_file(
+            export_file.path,
+            workspace_path,
+            kind="handoff",
+        )
+        _WORKSPACE_READER_HANDOFFS[handoff.path] = _WorkspaceReaderHandoff(
+            handoff,
+            generation_key,
+        )
+    return handoff
+
+
+def _consume_workspace_reader_handoff(
+    path: str | os.PathLike[str],
+    workspace_path: str | os.PathLike[str],
+) -> None:
+    """Remove a handoff after its receiver owns a private reader file."""
+    handoff_path = pathlib.Path(path)
+    try:
+        expected_parent = _workspace_reader_directory(workspace_path).resolve()
+        is_internal = handoff_path.resolve().parent == expected_parent
+    except OSError:
+        is_internal = False
+    if not is_internal or not handoff_path.name.startswith("handoff-"):
         return
-    with _WORKSPACE_SESSION_EXPORTS_LOCK:
-        reader_files = tuple(_WORKSPACE_SESSION_EXPORTS.values())
-        _WORKSPACE_SESSION_EXPORTS.clear()
-    for reader_file in reader_files:
+    with _WORKSPACE_READER_HANDOFFS_LOCK:
+        handoff = _WORKSPACE_READER_HANDOFFS.pop(str(handoff_path), None)
+    if handoff is not None:
+        handoff.reader_file.cleanup()
+    else:
+        _cleanup_workspace_reader_path(handoff_path)
+
+
+def _cleanup_workspace_reader_handoffs() -> None:
+    """Remove unconsumed reader handoffs owned by this Python process."""
+    if os.getpid() != _WORKSPACE_READER_HANDOFFS_OWNER_PID:
+        return
+    with _WORKSPACE_READER_HANDOFFS_LOCK:
+        handoffs = tuple(_WORKSPACE_READER_HANDOFFS.values())
+        _WORKSPACE_READER_HANDOFFS.clear()
+    for handoff in handoffs:
         with contextlib.suppress(Exception):
-            reader_file.cleanup()
+            handoff.reader_file.cleanup()
 
 
-def _reset_workspace_session_exports_after_fork() -> None:
-    """Forget parent-owned exports without deleting them in a forked child."""
-    global _WORKSPACE_SESSION_EXPORTS_LOCK
-    global _WORKSPACE_SESSION_EXPORTS_OWNER_PID
+def _reset_workspace_reader_handoffs_after_fork() -> None:
+    """Forget parent-owned handoffs without deleting them in a forked child."""
+    global _WORKSPACE_READER_HANDOFFS_LOCK
+    global _WORKSPACE_READER_HANDOFFS_OWNER_PID
 
-    _WORKSPACE_SESSION_EXPORTS.clear()
-    _WORKSPACE_SESSION_EXPORTS_LOCK = threading.Lock()
-    _WORKSPACE_SESSION_EXPORTS_OWNER_PID = os.getpid()
+    _WORKSPACE_READER_HANDOFFS.clear()
+    _WORKSPACE_READER_HANDOFFS_LOCK = threading.Lock()
+    _WORKSPACE_READER_HANDOFFS_OWNER_PID = os.getpid()
 
 
 if hasattr(os, "register_at_fork"):
-    os.register_at_fork(after_in_child=_reset_workspace_session_exports_after_fork)
+    os.register_at_fork(after_in_child=_reset_workspace_reader_handoffs_after_fork)
 
 
-atexit.register(_cleanup_workspace_session_exports)
+atexit.register(_cleanup_workspace_reader_handoffs)
 
 
 class _WorkspaceFileGenerationResources:
@@ -313,6 +381,7 @@ class _WorkspaceFileGenerationResources:
             self._new_file_manager(path)
         )
         self.cleanup: Callable[[], None] | None = None
+        self.exports: dict[tuple[str, str], _WorkspaceReaderFile] = {}
 
     def _new_file_manager(self, path: str) -> CachingFileManager[typing.Any]:
         return CachingFileManager(
@@ -385,21 +454,78 @@ class _WorkspaceFileGenerationResources:
 
     def activate(self, path: str, file_identity: tuple[str, int, int, int]) -> None:
         self.close(needs_lock=False)
+        self.clear_exports()
         self.path = path
         self.file_identity = file_identity
         self.file_manager = self._new_file_manager(path)
+
+    def export(
+        self,
+        workspace_path: str,
+        revision: str,
+        group: str,
+    ) -> _WorkspaceReaderFile:
+        """Create or reuse the immutable export for one logical generation."""
+        workspace_group = _normalized_workspace_group(group)
+        key = (revision, workspace_group)
+        export_file = self.exports.get(key)
+        if export_file is not None:
+            _export_identity, export_exists = _workspace_file_state(export_file.path)
+            if export_exists:
+                return export_file
+            self.exports.pop(key, None)
+
+        self.close(needs_lock=False)
+        source_identity = _workspace_file_identity(self.path)
+        if source_identity[1:] != self.file_identity[1:]:
+            raise RuntimeError(
+                "Workspace reader generation changed before it could be exported: "
+                f"{self.path}"
+            )
+        export_file = _create_workspace_group_reader_file(
+            self.path,
+            workspace_path,
+            workspace_group,
+            kind="export",
+        )
+        try:
+            source_identity_after = _workspace_file_identity(self.path)
+        except BaseException:
+            export_file.cleanup()
+            raise
+        if source_identity_after[1:] != source_identity[1:]:
+            export_file.cleanup()
+            raise RuntimeError(
+                "Workspace reader generation changed while it was being exported: "
+                f"{self.path}"
+            )
+        self.exports[key] = export_file
+        return export_file
+
+    def clear_exports(self) -> None:
+        """Release exports after their handoffs have independent file links."""
+        exports = tuple(self.exports.values())
+        self.exports.clear()
+        for export_file in exports:
+            with contextlib.suppress(Exception):
+                export_file.cleanup()
 
     def release(self) -> None:
         file_manager = self.file_manager
         self.file_manager = None
         cleanup = self.cleanup
         self.cleanup = None
+        exports = tuple(self.exports.values())
+        self.exports.clear()
         with contextlib.suppress(Exception):
             if file_manager is not None:
                 file_manager.close(needs_lock=False)
         if cleanup is not None:
             with contextlib.suppress(Exception):
                 cleanup()
+        for export_file in exports:
+            with contextlib.suppress(Exception):
+                export_file.cleanup()
 
 
 class _WorkspaceFileGeneration:
@@ -433,6 +559,7 @@ class _WorkspaceFileGeneration:
         self._state_lock = threading.Lock()
         self._retired = reader_file is not None
         self._created_without_file = created_without_file
+        self._revision = uuid.uuid4().hex
         self._invalid_reason: str | None = None
         self._cleanup_scheduled = False
         self._disposed = False
@@ -451,6 +578,12 @@ class _WorkspaceFileGeneration:
     def created_without_file(self) -> bool:
         with self._state_lock:
             return self._created_without_file
+
+    @property
+    def revision(self) -> str:
+        """Return the logical identity of the current generation contents."""
+        with self._state_lock:
+            return self._revision
 
     def add_manager(self, manager: WorkspaceFileManager | None = None) -> None:
         with self._state_lock:
@@ -517,12 +650,15 @@ class _WorkspaceFileGeneration:
         self.file_identity = identity
         with self._state_lock:
             self._created_without_file = False
+            self._revision = uuid.uuid4().hex
 
     def refresh_in_place(self, file_identity: tuple[str, int, int, int]) -> None:
         """Reopen this generation after a managed in-place transaction."""
         self._raise_if_unavailable()
         self._resources.activate(self.workspace_path, file_identity)
         self.file_identity = file_identity
+        with self._state_lock:
+            self._revision = uuid.uuid4().hex
 
     def invalidate(self, reason: str) -> None:
         self._resources.close(needs_lock=False)
@@ -533,11 +669,20 @@ class _WorkspaceFileGeneration:
     def export_reader_state(
         self, group: str
     ) -> tuple[str, str, tuple[int, int, int], str]:
-        """Create or reuse a session-owned file for cross-process readers."""
+        """Create an owned handoff for one cross-process reader."""
         self._raise_if_unavailable()
-        reader_file = _workspace_session_export(self, group)
-        identity = _workspace_file_identity(reader_file.path)[1:]
-        return self.workspace_path, reader_file.path, identity, group
+        export_file = self._resources.export(
+            self.workspace_path,
+            self.revision,
+            group,
+        )
+        handoff = _create_workspace_reader_handoff(
+            export_file,
+            self.workspace_path,
+            self.revision,
+        )
+        identity = _workspace_file_identity(handoff.path)[1:]
+        return self.workspace_path, handoff.path, identity, group
 
     def _raise_if_unavailable(self) -> None:
         with self._state_lock:
@@ -563,56 +708,6 @@ class _WorkspaceFileGeneration:
             self._disposed = True
             self._cleanup_scheduled = False
         self._finalizer()
-
-
-def _workspace_session_export(
-    generation: _WorkspaceFileGeneration,
-    group: str,
-) -> _WorkspaceReaderFile:
-    """Return one immutable group export owned by this Python process."""
-    resources = generation._resources
-    workspace_group = _normalized_workspace_group(group)
-    resources.close(needs_lock=False)
-    source_identity = _workspace_file_identity(resources.path)
-    if source_identity[1:] != resources.file_identity[1:]:
-        raise RuntimeError(
-            "Workspace reader generation changed before it could be exported: "
-            f"{resources.path}"
-        )
-    key: _WorkspaceExportKey = (
-        generation.workspace_path,
-        source_identity[1],
-        source_identity[2],
-        source_identity[3],
-        workspace_group,
-    )
-    with _WORKSPACE_SESSION_EXPORTS_LOCK:
-        reader_file = _WORKSPACE_SESSION_EXPORTS.get(key)
-        if reader_file is not None:
-            _reader_identity, reader_exists = _workspace_file_state(reader_file.path)
-            if reader_exists:
-                return reader_file
-            _WORKSPACE_SESSION_EXPORTS.pop(key, None)
-
-        reader_file = _create_workspace_group_reader_file(
-            resources.path,
-            generation.workspace_path,
-            workspace_group,
-            kind="export",
-        )
-        try:
-            source_identity_after = _workspace_file_identity(resources.path)
-        except BaseException:
-            reader_file.cleanup()
-            raise
-        if source_identity_after[1:] != source_identity[1:]:
-            reader_file.cleanup()
-            raise RuntimeError(
-                "Workspace reader generation changed while it was being exported: "
-                f"{resources.path}"
-            )
-        _WORKSPACE_SESSION_EXPORTS[key] = reader_file
-        return reader_file
 
 
 def _replace_h5_attrs(target_attrs, attrs: Mapping[typing.Any, typing.Any]) -> None:
@@ -761,9 +856,19 @@ def _should_compress_workspace_variable(
 def _workspace_chunksizes_for_dataarray(
     data_array: xr.DataArray,
 ) -> tuple[int, ...] | None:
-    """Return a valid fixed HDF5 chunk shape for dask-backed workspace data."""
+    """Return a valid fixed HDF5 chunk shape for workspace data."""
     chunks = data_array.chunks
-    if chunks is None or data_array.ndim == 0:
+    if chunks is None:
+        materialized_chunks = data_array.encoding.get(
+            _WORKSPACE_MATERIALIZED_CHUNKSIZES
+        )
+        if (
+            not isinstance(materialized_chunks, tuple)
+            or len(materialized_chunks) != data_array.ndim
+        ):
+            return None
+        chunks = tuple((chunk,) for chunk in materialized_chunks)
+    if data_array.ndim == 0:
         return None
 
     chunksizes: list[int] = []
@@ -807,8 +912,9 @@ def workspace_dataset_encoding(
 
 def _workspace_file_generation(
     path: str,
+    manager: WorkspaceFileManager | None = None,
 ) -> _WorkspaceFileGeneration:
-    """Return the current shared generation for a normalized workspace path."""
+    """Return a current generation and optionally register its reader lease."""
     _ensure_workspace_file_cleanup_worker()
     with _workspace_file_lock(path):
         identity, file_exists = _workspace_file_state(path)
@@ -829,6 +935,8 @@ def _workspace_file_generation(
             )
             with _WORKSPACE_FILE_GENERATIONS_LOCK:
                 _WORKSPACE_FILE_GENERATIONS[path] = generation
+        if manager is not None:
+            generation.add_manager(manager)
         return generation
 
 
@@ -841,6 +949,7 @@ def _workspace_file_generation_from_reader(
     _ensure_workspace_file_cleanup_worker()
     with _workspace_file_lock(workspace_path):
         if _workspace_file_identity(reader_path)[1:] != expected_identity:
+            _consume_workspace_reader_handoff(reader_path, workspace_path)
             raise RuntimeError(
                 "Serialized workspace reader generation is no longer available: "
                 f"{reader_path}"
@@ -853,6 +962,7 @@ def _workspace_file_generation_from_reader(
             raise
         if reader_identity_after != expected_identity:
             reader_file.cleanup()
+            _consume_workspace_reader_handoff(reader_path, workspace_path)
             raise RuntimeError(
                 "Serialized workspace reader generation changed while it was "
                 f"being opened: {reader_path}"
@@ -866,6 +976,7 @@ def _workspace_file_generation_from_reader(
         except BaseException:
             reader_file.cleanup()
             raise
+        _consume_workspace_reader_handoff(reader_path, workspace_path)
         return generation
 
 
@@ -1061,8 +1172,7 @@ class WorkspaceFileManager(FileManager[typing.Any]):
             target = os.fsdecode(path)
         self.workspace_path = target
         self.workspace_group = _normalized_workspace_group(group)
-        self._generation = _workspace_file_generation(target)
-        self._generation.add_manager(self)
+        self._generation = _workspace_file_generation(target, self)
         self._finalizer = weakref.finalize(
             self, _release_workspace_file_generation, self._generation
         )
@@ -1087,6 +1197,15 @@ class WorkspaceFileManager(FileManager[typing.Any]):
         """Serialize an immutable reference to this workspace generation."""
         return _workspace_file_manager_pickle_state(self)
 
+    def __dask_tokenize__(self) -> tuple[str, str, str, str]:
+        """Return a stable token without creating a cross-process handoff."""
+        return (
+            type(self).__name__,
+            self.workspace_path,
+            self.workspace_group,
+            self._generation.revision,
+        )
+
     def __setstate__(self, state: tuple[str, str, tuple[int, int, int], str]) -> None:
         workspace_path, reader_path, expected_identity, group = state
         ensure_workspace_hdf5_filters_registered()
@@ -1095,12 +1214,18 @@ class WorkspaceFileManager(FileManager[typing.Any]):
             target = os.fsdecode(workspace_path)
         self.workspace_path = target
         self.workspace_group = _normalized_workspace_group(group)
-        self._generation = _workspace_file_generation_from_reader(
-            target,
-            reader_path,
-            expected_identity,
-        )
-        self._generation.add_manager(self)
+        with _workspace_file_lock(target):
+            generation = _workspace_file_generation_from_reader(
+                target,
+                reader_path,
+                expected_identity,
+            )
+            try:
+                generation.add_manager(self)
+            except BaseException:
+                generation.dispose()
+                raise
+            self._generation = generation
         self._finalizer = weakref.finalize(
             self, _release_workspace_file_generation, self._generation
         )
@@ -1139,6 +1264,20 @@ class WorkspaceFileManager(FileManager[typing.Any]):
         self._finalizer()
 
 
+class _WorkspaceH5NetCDFStore(H5NetCDFStore):
+    """HDF5 store with side-effect-free Dask generation identity."""
+
+    def __dask_tokenize__(self) -> tuple[object, ...]:
+        """Identify lazy arrays without serializing their file manager."""
+        manager = typing.cast("WorkspaceFileManager", self._manager)
+        return (
+            type(self).__name__,
+            manager.__dask_tokenize__(),
+            self._group,
+            self._mode,
+        )
+
+
 def _iter_h5netcdf_group_paths(group: object, path: str = "/") -> Iterator[str]:
     yield path
     groups = getattr(group, "groups", {})
@@ -1153,7 +1292,7 @@ def _open_workspace_dataset_from_manager(
     *,
     chunks: typing.Any,
 ) -> xr.Dataset:
-    store = H5NetCDFStore(
+    store = _WorkspaceH5NetCDFStore(
         file_manager,
         group=group,
         mode="r",
@@ -2212,6 +2351,7 @@ def _write_workspace_dataset_group_to_file(
         "preferred_chunks",
         "shuffle",
         "source",
+        _WORKSPACE_MATERIALIZED_CHUNKSIZES,
     }
     for variable in ds.variables.values():
         for key in stale_encoding_keys:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -12,6 +12,7 @@ import shutil
 import stat
 import sys
 import threading
+import time
 import typing
 import uuid
 import weakref
@@ -49,6 +50,10 @@ _WORKSPACE_FILE_LOCKS: weakref.WeakValueDictionary[str, threading.RLock] = (
     weakref.WeakValueDictionary()
 )
 _WORKSPACE_FILE_LOCKS_LOCK = threading.Lock()
+_WORKSPACE_SAVE_LOCKS: weakref.WeakValueDictionary[str, threading.RLock] = (
+    weakref.WeakValueDictionary()
+)
+_WORKSPACE_SAVE_LOCKS_LOCK = threading.Lock()
 # Current generations stay alive until their final reader lease is cleaned up.
 # This lets a save find and close a handle even when final lease release races it.
 _WORKSPACE_FILE_GENERATIONS: dict[str, _WorkspaceFileGeneration] = {}
@@ -79,12 +84,13 @@ class _WorkspaceReaderFile:
     cleanup: Callable[[], None]
 
 
-@dataclass(frozen=True)
+@dataclass
 class _WorkspaceReaderHandoff:
-    """One serialized-reader lease for a logical workspace generation."""
+    """One reusable serialized-reader export for a workspace generation."""
 
     reader_file: _WorkspaceReaderFile
-    generation_key: tuple[str, str]
+    generation_key: tuple[str, str, str]
+    retire_at: float | None = None
 
 
 _WORKSPACE_READER_HANDOFFS: dict[str, _WorkspaceReaderHandoff] = {}
@@ -92,6 +98,7 @@ _WORKSPACE_READER_HANDOFFS_LOCK = threading.Lock()
 _WORKSPACE_READER_HANDOFFS_OWNER_PID = os.getpid()
 _WORKSPACE_MAX_PENDING_READER_GENERATIONS = 8
 _WORKSPACE_MAX_PENDING_READER_HANDOFFS = 64
+_WORKSPACE_READER_HANDOFF_RETENTION_SECONDS = 60.0
 
 
 def _normalized_workspace_group(group: str) -> str:
@@ -282,20 +289,25 @@ def _create_workspace_reader_handoff(
     export_file: _WorkspaceReaderFile,
     workspace_path: str | os.PathLike[str],
     revision: str,
+    group: str,
 ) -> _WorkspaceReaderFile:
-    """Create one independently owned handoff for a serialized reader."""
+    """Return one reusable handoff for a serialized reader generation."""
+    _cleanup_expired_workspace_reader_handoffs()
+    normalized_group = _normalized_workspace_group(group)
+    generation_key = (os.fsdecode(workspace_path), revision, normalized_group)
     with _WORKSPACE_READER_HANDOFFS_LOCK:
-        for path in tuple(_WORKSPACE_READER_HANDOFFS):
-            if not pathlib.Path(path).exists():
-                _WORKSPACE_READER_HANDOFFS.pop(path, None)
-        generation_key = (os.fsdecode(workspace_path), revision)
+        for handoff in _WORKSPACE_READER_HANDOFFS.values():
+            if handoff.generation_key == generation_key:
+                handoff.retire_at = None
+                return handoff.reader_file
         pending_generations = {
-            handoff.generation_key for handoff in _WORKSPACE_READER_HANDOFFS.values()
+            handoff.generation_key[:2]
+            for handoff in _WORKSPACE_READER_HANDOFFS.values()
         }
         if len(
             _WORKSPACE_READER_HANDOFFS
         ) >= _WORKSPACE_MAX_PENDING_READER_HANDOFFS or (
-            generation_key not in pending_generations
+            generation_key[:2] not in pending_generations
             and len(pending_generations) >= _WORKSPACE_MAX_PENDING_READER_GENERATIONS
         ):
             raise RuntimeError(
@@ -315,29 +327,44 @@ def _create_workspace_reader_handoff(
     return handoff
 
 
-def _consume_workspace_reader_handoff(
-    path: str | os.PathLike[str],
-    workspace_path: str | os.PathLike[str],
-) -> None:
-    """Remove a handoff after its receiver owns a private reader file."""
-    handoff_path = pathlib.Path(path)
-    try:
-        expected_parent = _workspace_reader_directory(workspace_path).resolve()
-        is_internal = handoff_path.resolve().parent == expected_parent
-    except OSError:
-        is_internal = False
-    if not is_internal or not handoff_path.name.startswith("handoff-"):
-        return
+def _take_expired_workspace_reader_handoffs() -> tuple[_WorkspaceReaderHandoff, ...]:
+    """Remove and return expired or missing reader handoffs."""
+    now = time.monotonic()
+    expired: list[_WorkspaceReaderHandoff] = []
     with _WORKSPACE_READER_HANDOFFS_LOCK:
-        handoff = _WORKSPACE_READER_HANDOFFS.pop(str(handoff_path), None)
-    if handoff is not None:
-        handoff.reader_file.cleanup()
-    else:
-        _cleanup_workspace_reader_path(handoff_path)
+        for path, handoff in tuple(_WORKSPACE_READER_HANDOFFS.items()):
+            retire_at = handoff.retire_at
+            if not pathlib.Path(path).exists() or (
+                retire_at is not None and retire_at <= now
+            ):
+                _WORKSPACE_READER_HANDOFFS.pop(path, None)
+                expired.append(handoff)
+    return tuple(expired)
+
+
+def _cleanup_expired_workspace_reader_handoffs() -> None:
+    """Clean reusable reader exports after their retention period."""
+    for handoff in _take_expired_workspace_reader_handoffs():
+        with contextlib.suppress(Exception):
+            handoff.reader_file.cleanup()
+
+
+def _retire_workspace_reader_handoffs(
+    workspace_path: str | os.PathLike[str], revision: str
+) -> None:
+    """Schedule reusable exports for cleanup after their generation retires."""
+    generation_key = (os.fsdecode(workspace_path), revision)
+    retire_at = time.monotonic() + _WORKSPACE_READER_HANDOFF_RETENTION_SECONDS
+    with _WORKSPACE_READER_HANDOFFS_LOCK:
+        for handoff in _WORKSPACE_READER_HANDOFFS.values():
+            if handoff.generation_key[:2] != generation_key:
+                continue
+            if handoff.retire_at is None or retire_at < handoff.retire_at:
+                handoff.retire_at = retire_at
 
 
 def _cleanup_workspace_reader_handoffs() -> None:
-    """Remove unconsumed reader handoffs owned by this Python process."""
+    """Remove reusable reader exports owned by this Python process."""
     if os.getpid() != _WORKSPACE_READER_HANDOFFS_OWNER_PID:
         return
     with _WORKSPACE_READER_HANDOFFS_LOCK:
@@ -350,9 +377,13 @@ def _cleanup_workspace_reader_handoffs() -> None:
 
 def _reset_workspace_reader_handoffs_after_fork() -> None:
     """Forget parent-owned handoffs without deleting them in a forked child."""
+    global _WORKSPACE_SAVE_LOCKS
+    global _WORKSPACE_SAVE_LOCKS_LOCK
     global _WORKSPACE_READER_HANDOFFS_LOCK
     global _WORKSPACE_READER_HANDOFFS_OWNER_PID
 
+    _WORKSPACE_SAVE_LOCKS = weakref.WeakValueDictionary()
+    _WORKSPACE_SAVE_LOCKS_LOCK = threading.Lock()
     _WORKSPACE_READER_HANDOFFS.clear()
     _WORKSPACE_READER_HANDOFFS_LOCK = threading.Lock()
     _WORKSPACE_READER_HANDOFFS_OWNER_PID = os.getpid()
@@ -645,26 +676,32 @@ class _WorkspaceFileGeneration:
                 raise RuntimeError(
                     "Cannot bind an existing workspace reader generation to a new file"
                 )
+        previous_revision = self.revision
         identity = _workspace_file_identity(self.workspace_path)
         self._resources.activate(self.workspace_path, identity)
         self.file_identity = identity
         with self._state_lock:
             self._created_without_file = False
             self._revision = uuid.uuid4().hex
+        _retire_workspace_reader_handoffs(self.workspace_path, previous_revision)
 
     def refresh_in_place(self, file_identity: tuple[str, int, int, int]) -> None:
         """Reopen this generation after a managed in-place transaction."""
         self._raise_if_unavailable()
+        previous_revision = self.revision
         self._resources.activate(self.workspace_path, file_identity)
         self.file_identity = file_identity
         with self._state_lock:
             self._revision = uuid.uuid4().hex
+        _retire_workspace_reader_handoffs(self.workspace_path, previous_revision)
 
     def invalidate(self, reason: str) -> None:
         self._resources.close(needs_lock=False)
+        revision = self.revision
         with self._state_lock:
             self._retired = True
             self._invalid_reason = reason
+        _retire_workspace_reader_handoffs(self.workspace_path, revision)
 
     def export_reader_state(
         self, group: str
@@ -680,6 +717,7 @@ class _WorkspaceFileGeneration:
             export_file,
             self.workspace_path,
             self.revision,
+            group,
         )
         identity = _workspace_file_identity(handoff.path)[1:]
         return self.workspace_path, handoff.path, identity, group
@@ -707,6 +745,8 @@ class _WorkspaceFileGeneration:
                 return
             self._disposed = True
             self._cleanup_scheduled = False
+            revision = self._revision
+        _retire_workspace_reader_handoffs(self.workspace_path, revision)
         self._finalizer()
 
 
@@ -742,6 +782,19 @@ def _workspace_file_lock(path: str | os.PathLike[str]) -> threading.RLock:
         if lock is None:
             lock = threading.RLock()
             _WORKSPACE_FILE_LOCKS[target] = lock
+        return lock
+
+
+def _workspace_save_lock(path: str | os.PathLike[str]) -> threading.RLock:
+    """Return the lock that serializes save preparation for one workspace."""
+    target = _normalized_file_path(path)
+    if target is None:
+        target = os.fsdecode(path)
+    with _WORKSPACE_SAVE_LOCKS_LOCK:
+        lock = _WORKSPACE_SAVE_LOCKS.get(target)
+        if lock is None:
+            lock = threading.RLock()
+            _WORKSPACE_SAVE_LOCKS[target] = lock
         return lock
 
 
@@ -949,7 +1002,6 @@ def _workspace_file_generation_from_reader(
     _ensure_workspace_file_cleanup_worker()
     with _workspace_file_lock(workspace_path):
         if _workspace_file_identity(reader_path)[1:] != expected_identity:
-            _consume_workspace_reader_handoff(reader_path, workspace_path)
             raise RuntimeError(
                 "Serialized workspace reader generation is no longer available: "
                 f"{reader_path}"
@@ -962,7 +1014,6 @@ def _workspace_file_generation_from_reader(
             raise
         if reader_identity_after != expected_identity:
             reader_file.cleanup()
-            _consume_workspace_reader_handoff(reader_path, workspace_path)
             raise RuntimeError(
                 "Serialized workspace reader generation changed while it was "
                 f"being opened: {reader_path}"
@@ -976,7 +1027,6 @@ def _workspace_file_generation_from_reader(
         except BaseException:
             reader_file.cleanup()
             raise
-        _consume_workspace_reader_handoff(reader_path, workspace_path)
         return generation
 
 

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -13,8 +13,7 @@ import h5netcdf
 import hdf5plugin
 import numpy as np
 import xarray as xr
-from xarray.backends import CachingFileManager, H5NetCDFStore
-from xarray.backends.file_manager import FILE_CACHE
+from xarray.backends import FileManager, H5NetCDFStore
 
 import erlab
 from erlab.interactive.imagetool import _serialization
@@ -39,9 +38,11 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 )
 
 _WORKSPACE_FILE_LOCKS: dict[str, threading.RLock] = {}
-_WORKSPACE_FILE_MANAGERS: dict[str, weakref.WeakSet[WorkspaceFileManager]] = {}
-_WORKSPACE_FILE_CACHE_KEYS: dict[str, weakref.WeakSet[Hashable]] = {}
-_WORKSPACE_FILE_MANAGERS_LOCK = threading.Lock()
+# Keep current generations alive even when their last manager is released while
+# another thread owns the path lock. A later replacement must still find and
+# close the generation's file handle.
+_WORKSPACE_FILE_GENERATIONS: dict[str, _WorkspaceFileGeneration] = {}
+_WORKSPACE_FILE_GENERATIONS_LOCK = threading.Lock()
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
@@ -51,16 +52,123 @@ _WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS = frozenset(
 )
 
 
-class _WorkspaceFileGeneration:
-    """A preserved workspace file generation shared by lazy readers."""
+class _WorkspaceFileGenerationResources:
+    """File resources owned by one workspace generation."""
 
     def __init__(
         self,
-        path: str | os.PathLike[str],
-        cleanup: Callable[[], None],
+        path: str,
+        lock: threading.RLock,
     ) -> None:
-        self.path = os.fsdecode(path)
-        self._finalizer = weakref.finalize(self, cleanup)
+        self.path = path
+        self.lock = lock
+        self.file: typing.Any | None = None
+        self.cleanup: Callable[[], None] | None = None
+
+    @contextlib.contextmanager
+    def optional_lock(self, needs_lock: bool) -> Iterator[None]:
+        if needs_lock:
+            with self.lock:
+                yield
+        else:
+            yield
+
+    def acquire(self, *, needs_lock: bool) -> tuple[typing.Any, bool]:
+        with self.optional_lock(needs_lock):
+            if self.file is None:
+                self.file = h5netcdf.File(
+                    self.path,
+                    mode="r+",
+                    invalid_netcdf=None,
+                    phony_dims="sort",
+                    decode_vlen_strings=True,
+                )
+                return self.file, True
+            return self.file, False
+
+    def close(self, *, needs_lock: bool) -> None:
+        with self.optional_lock(needs_lock):
+            file = self.file
+            self.file = None
+            if file is not None:
+                file.close()
+
+    def retire(self, path: str, cleanup: Callable[[], None]) -> None:
+        self.path = path
+        self.cleanup = cleanup
+
+    def release(self) -> None:
+        with contextlib.suppress(Exception):
+            self.close(needs_lock=False)
+        cleanup = self.cleanup
+        self.cleanup = None
+        if cleanup is not None:
+            with contextlib.suppress(Exception):
+                cleanup()
+
+
+class _WorkspaceFileGeneration:
+    """Own one workspace file generation and its shared reader handle."""
+
+    def __init__(
+        self,
+        workspace_path: str,
+        file_identity: tuple[str, int, int, int],
+    ) -> None:
+        self.workspace_path = workspace_path
+        self.file_identity = file_identity
+        self._resources = _WorkspaceFileGenerationResources(
+            workspace_path, _workspace_file_lock(workspace_path)
+        )
+        self._manager_count = 0
+        self._state_lock = threading.Lock()
+        self._retired = False
+        self._finalizer = weakref.finalize(self, self._resources.release)
+
+    @property
+    def path(self) -> str:
+        return self._resources.path
+
+    @property
+    def retired(self) -> bool:
+        return self._retired
+
+    def add_manager(self) -> None:
+        with self._state_lock:
+            self._manager_count += 1
+
+    def remove_manager(self) -> bool:
+        with self._state_lock:
+            self._manager_count -= 1
+            return self._manager_count == 0
+
+    def has_managers(self) -> bool:
+        with self._state_lock:
+            return self._manager_count != 0
+
+    def acquire(self, *, needs_lock: bool) -> typing.Any:
+        file, _ = self._resources.acquire(needs_lock=needs_lock)
+        return file
+
+    @contextlib.contextmanager
+    def acquire_context(self, *, needs_lock: bool) -> Iterator[typing.Any]:
+        file, opened = self._resources.acquire(needs_lock=needs_lock)
+        try:
+            yield file
+        except Exception:
+            if opened:
+                self.close(needs_lock=needs_lock)
+            raise
+
+    def close(self, *, needs_lock: bool) -> None:
+        self._resources.close(needs_lock=needs_lock)
+
+    def retire(self, path: str, cleanup: Callable[[], None]) -> None:
+        self._resources.retire(path, cleanup)
+        self._retired = True
+
+    def refresh_file_identity(self) -> None:
+        self.file_identity = _workspace_file_identity(self.workspace_path)
 
 
 def _replace_h5_attrs(target_attrs, attrs: Mapping[typing.Any, typing.Any]) -> None:
@@ -240,154 +348,116 @@ def workspace_dataset_encoding(
     return encoding
 
 
-class WorkspaceFileManager(CachingFileManager):
-    """xarray file manager for manager-owned workspace readers."""
+def _workspace_file_generation(path: str) -> _WorkspaceFileGeneration:
+    """Return the current shared generation for a normalized workspace path."""
+    with _workspace_file_lock(path):
+        identity = _workspace_file_identity(path)
+        with _WORKSPACE_FILE_GENERATIONS_LOCK:
+            generation = _WORKSPACE_FILE_GENERATIONS.get(path)
+            # An incremental save changes the modification time in place. Only
+            # a new filesystem object starts a new generation here.
+            if generation is None or generation.file_identity[:3] != identity[:3]:
+                generation = _WorkspaceFileGeneration(path, identity)
+                _WORKSPACE_FILE_GENERATIONS[path] = generation
+            generation.add_manager()
+            return generation
+
+
+def _current_workspace_file_generation(
+    path: str | os.PathLike[str],
+) -> _WorkspaceFileGeneration | None:
+    """Return the current generation for a path while its file lock is held."""
+    target = _normalized_file_path(path)
+    if target is None:
+        target = os.fsdecode(path)
+    with _WORKSPACE_FILE_GENERATIONS_LOCK:
+        return _WORKSPACE_FILE_GENERATIONS.get(target)
+
+
+def _retire_workspace_file_generation(
+    path: str | os.PathLike[str],
+    generation: _WorkspaceFileGeneration,
+    preserved_path: str,
+    cleanup: Callable[[], None],
+) -> None:
+    """Move a published generation to its preserved backing file."""
+    generation.retire(preserved_path, cleanup)
+    _discard_workspace_file_generation(path, generation)
+
+
+def _discard_workspace_file_generation(
+    path: str | os.PathLike[str],
+    generation: _WorkspaceFileGeneration,
+) -> None:
+    """Remove a generation from the current path registry."""
+    target = _normalized_file_path(path)
+    if target is None:
+        target = os.fsdecode(path)
+    with _WORKSPACE_FILE_GENERATIONS_LOCK:
+        if _WORKSPACE_FILE_GENERATIONS.get(target) is generation:
+            del _WORKSPACE_FILE_GENERATIONS[target]
+
+
+def _release_workspace_file_generation(
+    generation: _WorkspaceFileGeneration,
+) -> None:
+    """Release one manager and discard an unused current generation when safe."""
+    if not generation.remove_manager():
+        return
+    if generation.retired:
+        generation.close(needs_lock=False)
+        return
+
+    lock = _workspace_file_lock(generation.workspace_path)
+    if not lock.acquire(blocking=False):
+        # The strong registry keeps this generation discoverable until the
+        # operation that owns the lock finishes or a later replacement starts.
+        return
+    try:
+        if generation.has_managers():
+            return
+        generation.close(needs_lock=False)
+        with _WORKSPACE_FILE_GENERATIONS_LOCK:
+            if _WORKSPACE_FILE_GENERATIONS.get(generation.workspace_path) is generation:
+                del _WORKSPACE_FILE_GENERATIONS[generation.workspace_path]
+    finally:
+        lock.release()
+
+
+class WorkspaceFileManager(FileManager[typing.Any]):
+    """xarray file manager backed by an explicit workspace generation."""
 
     def __init__(self, path: str | os.PathLike[str]) -> None:
-
         ensure_workspace_hdf5_filters_registered()
         target = _normalized_file_path(path)
         if target is None:
             target = os.fsdecode(path)
-        identity = _workspace_file_identity(target)
-        super().__init__(
-            h5netcdf.File,
-            target,
-            mode="r+",
-            kwargs={
-                "invalid_netcdf": None,
-                "phony_dims": "sort",
-                "decode_vlen_strings": True,
-            },
-            lock=_workspace_file_lock(target),
-            # xarray documents manager_id as a test/dependency-injection hook,
-            # but the manager needs repeated workspace readers for the same
-            # file identity to share one cached h5netcdf handle.
-            manager_id=("erlab-workspace", *identity, "r+"),
-        )
         self.workspace_path = target
-        self._workspace_manager_id = self._manager_id
-        self._preserved_generation: _WorkspaceFileGeneration | None = None
-        with _WORKSPACE_FILE_MANAGERS_LOCK:
-            managers = _WORKSPACE_FILE_MANAGERS.setdefault(target, weakref.WeakSet())
-            managers.add(self)
-            cache_keys = _WORKSPACE_FILE_CACHE_KEYS.setdefault(
-                target, weakref.WeakSet()
-            )
-            cache_keys.add(self._key)
+        self._generation = _workspace_file_generation(target)
 
-    def _acquire_with_cache_info(
+    def __getstate__(self) -> str:
+        """Serialize the backing path, but not locks or open file handles."""
+        return self._generation.path
+
+    def __setstate__(self, path: str) -> None:
+        WorkspaceFileManager.__init__(self, path)
+
+    def acquire(self, needs_lock: bool = True) -> typing.Any:
+        return self._generation.acquire(needs_lock=needs_lock)
+
+    def acquire_context(
         self, needs_lock: bool = True
-    ) -> tuple[typing.Any, bool]:
-        if needs_lock:
-            with self._optional_lock(needs_lock=True):
-                return self._acquire_with_cache_info(needs_lock=False)
-        if self._preserved_generation is None:
-            # An equal key object can replace an evicted cache key. Register on
-            # each acquire so replacement still finds the reopened handle.
-            with _WORKSPACE_FILE_MANAGERS_LOCK:
-                cache_keys = _WORKSPACE_FILE_CACHE_KEYS.setdefault(
-                    self.workspace_path, weakref.WeakSet()
-                )
-                cache_keys.add(self._key)
-        return super()._acquire_with_cache_info(needs_lock=False)
+    ) -> contextlib.AbstractContextManager[typing.Any]:
+        return self._generation.acquire_context(needs_lock=needs_lock)
 
-    def _retarget(
-        self,
-        path: str,
-        manager_id: Hashable,
-    ) -> None:
-        """Move this manager to a distinct xarray cache generation."""
-        # CachingFileManager uses the key for both its cache and destructor
-        # reference count. Move both together so generations close independently.
-        self._ref_counter.decrement(self._key)
-        self._args = (path,)
-        self._manager_id = manager_id
-        self._key = self._make_key()
-        self._ref_counter.increment(self._key)
+    def close(self, needs_lock: bool = True) -> None:
+        self._generation.close(needs_lock=needs_lock)
 
-    def _use_preserved_generation(self, generation: _WorkspaceFileGeneration) -> None:
-        self.close(needs_lock=False)
-        self._retarget(
-            generation.path,
-            # The cache key must retain the generation while its file handle is
-            # cached. Cleanup can then run only after xarray closes that handle.
-            ("erlab-workspace-generation", generation, generation.path, "r+"),
-        )
-        self._preserved_generation = generation
-
-    def _restore_workspace_path(self) -> None:
-        if self._preserved_generation is None:
-            return
-        self.close(needs_lock=False)
-        self._retarget(self.workspace_path, self._workspace_manager_id)
-        self._preserved_generation = None
-
-
-def _detach_workspace_file_readers(
-    path: str | os.PathLike[str],
-) -> tuple[tuple[WorkspaceFileManager, ...], tuple[Hashable, ...]]:
-    """Remove and return managers and cache keys for one workspace path."""
-    target = _normalized_file_path(path)
-    if target is None:
-        target = os.fsdecode(path)
-    with _WORKSPACE_FILE_MANAGERS_LOCK:
-        managers = tuple(_WORKSPACE_FILE_MANAGERS.pop(target, ()))
-        cache_keys = tuple(_WORKSPACE_FILE_CACHE_KEYS.pop(target, ()))
-    return managers, cache_keys
-
-
-def _restore_workspace_file_readers(
-    path: str | os.PathLike[str],
-    managers: Iterable[WorkspaceFileManager],
-    cache_keys: Iterable[Hashable],
-) -> None:
-    """Restore detached readers after a workspace replacement fails."""
-    target = _normalized_file_path(path)
-    if target is None:
-        target = os.fsdecode(path)
-    managers = tuple(managers)
-    cache_keys = tuple(cache_keys)
-    for manager in managers:
-        manager._restore_workspace_path()
-    with _WORKSPACE_FILE_MANAGERS_LOCK:
-        registered = _WORKSPACE_FILE_MANAGERS.setdefault(target, weakref.WeakSet())
-        registered.update(managers)
-        registered_cache_keys = _WORKSPACE_FILE_CACHE_KEYS.setdefault(
-            target, weakref.WeakSet()
-        )
-        # Add the current manager keys first. A restored manager has a new key
-        # object that can compare equal to its detached key object.
-        registered_cache_keys.update(manager._key for manager in managers)
-        registered_cache_keys.update(cache_keys)
-
-
-def _close_workspace_file_cache_entries(cache_keys: Iterable[Hashable]) -> None:
-    """Close detached xarray cache entries, including entries without managers."""
-    with contextlib.ExitStack() as stack:
-        for cache_key in cache_keys:
-            cached_file = FILE_CACHE.pop(cache_key, None)
-            if cached_file is not None:
-                stack.callback(cached_file.close)
-
-
-def _close_workspace_file_managers(
-    path: str | os.PathLike[str],
-) -> tuple[WorkspaceFileManager, ...]:
-    """Detach and close all manager-owned readers for one workspace path.
-
-    The caller must hold the lock returned by :func:`_workspace_file_lock` for
-    the same path. This prevents a lazy reader from reopening a cached handle
-    while it is being closed.
-    """
-    target = _normalized_file_path(path)
-    if target is None:
-        target = os.fsdecode(path)
-    managers, cache_keys = _detach_workspace_file_readers(target)
-    _close_workspace_file_cache_entries(cache_keys)
-    for manager in managers:
-        manager.close(needs_lock=False)
-    return managers
+    def __del__(self) -> None:
+        generation = getattr(self, "_generation", None)
+        if generation is not None:
+            with contextlib.suppress(Exception):
+                _release_workspace_file_generation(generation)
 
 
 def _iter_h5netcdf_group_paths(group: object, path: str = "/") -> Iterator[str]:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import ctypes
 import os
@@ -60,7 +61,6 @@ _WORKSPACE_FILE_CLEANUP_QUEUE: queue.SimpleQueue[_WorkspaceFileGeneration] = (
 _WORKSPACE_FILE_CLEANUP_WORKER: threading.Thread | None = None
 _WORKSPACE_FILE_CLEANUP_WORKER_LOCK = threading.Lock()
 _WORKSPACE_READER_DIRECTORY_SUFFIX = ".readers"
-_WORKSPACE_EXPORT_REQUIRES_COPY = os.name == "nt"
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
@@ -76,6 +76,18 @@ class _WorkspaceReaderFile:
 
     path: str
     cleanup: Callable[[], None]
+
+
+_WorkspaceExportKey: typing.TypeAlias = tuple[str, int, int, int, str]
+_WORKSPACE_SESSION_EXPORTS: dict[_WorkspaceExportKey, _WorkspaceReaderFile] = {}
+_WORKSPACE_SESSION_EXPORTS_LOCK = threading.Lock()
+_WORKSPACE_SESSION_EXPORTS_OWNER_PID = os.getpid()
+
+
+def _normalized_workspace_group(group: str) -> str:
+    """Return one absolute HDF5 group path."""
+    stripped = group.strip("/")
+    return "/" if not stripped else f"/{stripped}"
 
 
 def _hide_workspace_internal_path(path: str | os.PathLike[str]) -> None:
@@ -168,6 +180,47 @@ def _create_workspace_reader_file(
     )
 
 
+def _create_workspace_group_reader_file(
+    source_path: str | os.PathLike[str],
+    workspace_path: str | os.PathLike[str],
+    group: str,
+    *,
+    kind: typing.Literal["reader", "export"] = "reader",
+) -> _WorkspaceReaderFile:
+    """Copy one workspace group to a private reader file."""
+    source = pathlib.Path(source_path).resolve()
+    workspace_group = _normalized_workspace_group(group)
+    directory = _ensure_workspace_reader_directory(workspace_path)
+    destination = directory / f"{kind}-{os.getpid()}-{uuid.uuid4().hex}.itws"
+    copied = True
+    try:
+        if workspace_group == "/":
+            shutil.copyfile(source, destination)
+        else:
+            ensure_workspace_hdf5_filters_registered()
+            with (
+                h5py.File(source, "r") as source_file,
+                h5py.File(destination, "w") as target_file,
+            ):
+                copied = _copy_workspace_h5_group_to_open_file(
+                    source_file,
+                    target_file,
+                    workspace_group,
+                    workspace_group,
+                    None,
+                )
+    except BaseException:
+        _cleanup_workspace_reader_path(destination)
+        raise
+    if not copied:
+        _cleanup_workspace_reader_path(destination)
+        raise KeyError(f"Workspace reader group is missing: {workspace_group}")
+    return _WorkspaceReaderFile(
+        path=str(destination),
+        cleanup=lambda: _cleanup_workspace_reader_path(destination),
+    )
+
+
 def _workspace_reader_file_owner_pid(path: pathlib.Path) -> int | None:
     for kind in ("reader", "export"):
         prefix = f"{kind}-"
@@ -215,6 +268,35 @@ def _cleanup_stale_workspace_reader_files(
         directory.rmdir()
 
 
+def _cleanup_workspace_session_exports() -> None:
+    """Remove cross-process exports owned by this Python process."""
+    if os.getpid() != _WORKSPACE_SESSION_EXPORTS_OWNER_PID:
+        return
+    with _WORKSPACE_SESSION_EXPORTS_LOCK:
+        reader_files = tuple(_WORKSPACE_SESSION_EXPORTS.values())
+        _WORKSPACE_SESSION_EXPORTS.clear()
+    for reader_file in reader_files:
+        with contextlib.suppress(Exception):
+            reader_file.cleanup()
+
+
+def _reset_workspace_session_exports_after_fork() -> None:
+    """Forget parent-owned exports without deleting them in a forked child."""
+    global _WORKSPACE_SESSION_EXPORTS_LOCK
+    global _WORKSPACE_SESSION_EXPORTS_OWNER_PID
+
+    _WORKSPACE_SESSION_EXPORTS.clear()
+    _WORKSPACE_SESSION_EXPORTS_LOCK = threading.Lock()
+    _WORKSPACE_SESSION_EXPORTS_OWNER_PID = os.getpid()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_workspace_session_exports_after_fork)
+
+
+atexit.register(_cleanup_workspace_session_exports)
+
+
 class _WorkspaceFileGenerationResources:
     """Evictable handle and preserved file owned by one generation."""
 
@@ -231,8 +313,6 @@ class _WorkspaceFileGenerationResources:
             self._new_file_manager(path)
         )
         self.cleanup: Callable[[], None] | None = None
-        self.export_file: _WorkspaceReaderFile | None = None
-        self.export_identity: tuple[int, int, int] | None = None
 
     def _new_file_manager(self, path: str) -> CachingFileManager[typing.Any]:
         return CachingFileManager(
@@ -309,68 +389,17 @@ class _WorkspaceFileGenerationResources:
         self.file_identity = file_identity
         self.file_manager = self._new_file_manager(path)
 
-    def export(self, workspace_path: str) -> _WorkspaceReaderFile:
-        export_file = self.export_file
-        export_identity = self.export_identity
-        if (
-            export_file is not None
-            and export_identity is not None
-            and _workspace_file_identity(export_file.path)[1:] == export_identity
-        ):
-            return export_file
-
-        if export_file is not None:
-            export_file.cleanup()
-            self.export_file = None
-            self.export_identity = None
-
-        self.close(needs_lock=False)
-        source_identity = _workspace_file_identity(self.path)
-        if source_identity[1:] != self.file_identity[1:]:
-            raise RuntimeError(
-                "Workspace reader generation changed before it could be exported: "
-                f"{self.path}"
-            )
-        reader_file = _create_workspace_reader_file(
-            self.path,
-            workspace_path,
-            kind="export",
-            # A Windows handle to any hard link can prevent replacement of the
-            # canonical link. Give cross-process readers a separate file object.
-            copy_only=_WORKSPACE_EXPORT_REQUIRES_COPY,
-        )
-        try:
-            source_identity_after = _workspace_file_identity(self.path)
-        except BaseException:
-            reader_file.cleanup()
-            raise
-        if source_identity_after[1:] != source_identity[1:]:
-            reader_file.cleanup()
-            raise RuntimeError(
-                "Workspace reader generation changed while it was being exported: "
-                f"{self.path}"
-            )
-        self.export_file = reader_file
-        self.export_identity = _workspace_file_identity(reader_file.path)[1:]
-        return reader_file
-
     def release(self) -> None:
         file_manager = self.file_manager
         self.file_manager = None
         cleanup = self.cleanup
         self.cleanup = None
-        export_file = self.export_file
-        self.export_file = None
-        self.export_identity = None
         with contextlib.suppress(Exception):
             if file_manager is not None:
                 file_manager.close(needs_lock=False)
         if cleanup is not None:
             with contextlib.suppress(Exception):
                 cleanup()
-        if export_file is not None:
-            with contextlib.suppress(Exception):
-                export_file.cleanup()
 
 
 class _WorkspaceFileGeneration:
@@ -400,6 +429,7 @@ class _WorkspaceFileGeneration:
         if reader_file is not None:
             self._resources.cleanup = reader_file.cleanup
         self._manager_count = 0
+        self._managers: weakref.WeakSet[WorkspaceFileManager] = weakref.WeakSet()
         self._state_lock = threading.Lock()
         self._retired = reader_file is not None
         self._created_without_file = created_without_file
@@ -422,7 +452,7 @@ class _WorkspaceFileGeneration:
         with self._state_lock:
             return self._created_without_file
 
-    def add_manager(self) -> None:
+    def add_manager(self, manager: WorkspaceFileManager | None = None) -> None:
         with self._state_lock:
             if self._disposed or self._invalid_reason is not None:
                 raise RuntimeError(
@@ -430,10 +460,14 @@ class _WorkspaceFileGeneration:
                     or "Workspace file generation is no longer available"
                 )
             self._manager_count += 1
+            if manager is not None:
+                self._managers.add(manager)
 
-    def release_manager(self) -> bool:
+    def release_manager(self, manager: WorkspaceFileManager | None = None) -> bool:
         """Release one reader and claim cleanup after the final reader."""
         with self._state_lock:
+            if manager is not None:
+                self._managers.discard(manager)
             self._manager_count -= 1
             if self._manager_count != 0 or self._disposed or self._cleanup_scheduled:
                 return False
@@ -443,6 +477,11 @@ class _WorkspaceFileGeneration:
     def has_managers(self) -> bool:
         with self._state_lock:
             return self._manager_count != 0
+
+    def managers(self) -> tuple[WorkspaceFileManager, ...]:
+        """Return the live managers that use this generation."""
+        with self._state_lock:
+            return tuple(self._managers)
 
     def acquire(self, *, needs_lock: bool) -> typing.Any:
         self._raise_if_unavailable()
@@ -479,18 +518,26 @@ class _WorkspaceFileGeneration:
         with self._state_lock:
             self._created_without_file = False
 
+    def refresh_in_place(self, file_identity: tuple[str, int, int, int]) -> None:
+        """Reopen this generation after a managed in-place transaction."""
+        self._raise_if_unavailable()
+        self._resources.activate(self.workspace_path, file_identity)
+        self.file_identity = file_identity
+
     def invalidate(self, reason: str) -> None:
         self._resources.close(needs_lock=False)
         with self._state_lock:
             self._retired = True
             self._invalid_reason = reason
 
-    def export_reader_state(self) -> tuple[str, str, tuple[int, int, int]]:
-        """Create or reuse an owned immutable file for cross-process readers."""
+    def export_reader_state(
+        self, group: str
+    ) -> tuple[str, str, tuple[int, int, int], str]:
+        """Create or reuse a session-owned file for cross-process readers."""
         self._raise_if_unavailable()
-        reader_file = self._resources.export(self.workspace_path)
+        reader_file = _workspace_session_export(self, group)
         identity = _workspace_file_identity(reader_file.path)[1:]
-        return self.workspace_path, reader_file.path, identity
+        return self.workspace_path, reader_file.path, identity, group
 
     def _raise_if_unavailable(self) -> None:
         with self._state_lock:
@@ -516,6 +563,56 @@ class _WorkspaceFileGeneration:
             self._disposed = True
             self._cleanup_scheduled = False
         self._finalizer()
+
+
+def _workspace_session_export(
+    generation: _WorkspaceFileGeneration,
+    group: str,
+) -> _WorkspaceReaderFile:
+    """Return one immutable group export owned by this Python process."""
+    resources = generation._resources
+    workspace_group = _normalized_workspace_group(group)
+    resources.close(needs_lock=False)
+    source_identity = _workspace_file_identity(resources.path)
+    if source_identity[1:] != resources.file_identity[1:]:
+        raise RuntimeError(
+            "Workspace reader generation changed before it could be exported: "
+            f"{resources.path}"
+        )
+    key: _WorkspaceExportKey = (
+        generation.workspace_path,
+        source_identity[1],
+        source_identity[2],
+        source_identity[3],
+        workspace_group,
+    )
+    with _WORKSPACE_SESSION_EXPORTS_LOCK:
+        reader_file = _WORKSPACE_SESSION_EXPORTS.get(key)
+        if reader_file is not None:
+            _reader_identity, reader_exists = _workspace_file_state(reader_file.path)
+            if reader_exists:
+                return reader_file
+            _WORKSPACE_SESSION_EXPORTS.pop(key, None)
+
+        reader_file = _create_workspace_group_reader_file(
+            resources.path,
+            generation.workspace_path,
+            workspace_group,
+            kind="export",
+        )
+        try:
+            source_identity_after = _workspace_file_identity(resources.path)
+        except BaseException:
+            reader_file.cleanup()
+            raise
+        if source_identity_after[1:] != source_identity[1:]:
+            reader_file.cleanup()
+            raise RuntimeError(
+                "Workspace reader generation changed while it was being exported: "
+                f"{resources.path}"
+            )
+        _WORKSPACE_SESSION_EXPORTS[key] = reader_file
+        return reader_file
 
 
 def _replace_h5_attrs(target_attrs, attrs: Mapping[typing.Any, typing.Any]) -> None:
@@ -732,7 +829,6 @@ def _workspace_file_generation(
             )
             with _WORKSPACE_FILE_GENERATIONS_LOCK:
                 _WORKSPACE_FILE_GENERATIONS[path] = generation
-        generation.add_manager()
         return generation
 
 
@@ -767,7 +863,6 @@ def _workspace_file_generation_from_reader(
                 _workspace_file_identity(workspace_path),
                 reader_file=reader_file,
             )
-            generation.add_manager()
         except BaseException:
             reader_file.cleanup()
             raise
@@ -812,9 +907,10 @@ def _discard_workspace_file_generation(
 
 def _release_workspace_file_generation(
     generation: _WorkspaceFileGeneration,
+    manager: WorkspaceFileManager | None = None,
 ) -> None:
     """Release one reader lease without doing cleanup in the finalizer."""
-    if generation.release_manager():
+    if generation.release_manager(manager):
         _WORKSPACE_FILE_CLEANUP_QUEUE.put(generation)
 
 
@@ -864,61 +960,183 @@ def _cleanup_workspace_file_generation_locked(
     generation.dispose()
 
 
+def _workspace_groups_intersect(first: str, second: str) -> bool:
+    first = first.strip("/")
+    second = second.strip("/")
+    if not first or not second:
+        return True
+    return (
+        first == second
+        or first.startswith(f"{second}/")
+        or second.startswith(f"{first}/")
+    )
+
+
+def _detach_workspace_file_generation_readers(
+    path: str | os.PathLike[str],
+    rewrite_groups: Iterable[str],
+) -> None:
+    """Move readers of groups that will change to private snapshots."""
+    generation = _current_workspace_file_generation(path)
+    if generation is None:
+        return
+    normalized_rewrites = tuple(
+        _normalized_workspace_group(group) for group in rewrite_groups
+    )
+    managers = tuple(
+        manager
+        for manager in generation.managers()
+        if manager._generation is generation
+        and manager._finalizer.alive
+        and any(
+            _workspace_groups_intersect(manager.workspace_group, rewrite_group)
+            for rewrite_group in normalized_rewrites
+        )
+    )
+    if not managers:
+        return
+
+    generation.close(needs_lock=False)
+    source_identity = _workspace_file_identity(generation.path)
+    if source_identity[1:] != generation._resources.file_identity[1:]:
+        raise RuntimeError(
+            "Workspace reader generation changed before active readers could be "
+            f"preserved: {generation.path}"
+        )
+
+    detached_by_group: dict[str, _WorkspaceFileGeneration] = {}
+    try:
+        for group in {manager.workspace_group for manager in managers}:
+            reader_file = _create_workspace_group_reader_file(
+                generation.path,
+                generation.workspace_path,
+                group,
+            )
+            detached_by_group[group] = _WorkspaceFileGeneration(
+                generation.workspace_path,
+                generation.file_identity,
+                reader_file=reader_file,
+            )
+    except BaseException:
+        for detached in detached_by_group.values():
+            if not detached.has_managers():
+                detached.dispose()
+        raise
+    source_identity_after = _workspace_file_identity(generation.path)
+    if source_identity_after[1:] != source_identity[1:]:
+        for detached in detached_by_group.values():
+            detached.dispose()
+        raise RuntimeError(
+            "Workspace reader generation changed while active readers were being "
+            f"preserved: {generation.path}"
+        )
+    try:
+        for manager in managers:
+            manager._switch_generation(detached_by_group[manager.workspace_group])
+    except BaseException:
+        for detached in detached_by_group.values():
+            if not detached.has_managers():
+                detached.dispose()
+        raise
+
+
 def _workspace_file_manager_pickle_state(
-    generation: _WorkspaceFileGeneration,
-) -> tuple[str, str, tuple[int, int, int]]:
+    manager: WorkspaceFileManager,
+) -> tuple[str, str, tuple[int, int, int], str]:
     """Return an immutable serialization reference for one generation."""
-    with _workspace_file_lock(generation.workspace_path):
-        return generation.export_reader_state()
+    with _workspace_file_lock(manager.workspace_path):
+        return manager._generation.export_reader_state(manager.workspace_group)
 
 
 class WorkspaceFileManager(FileManager[typing.Any]):
     """xarray file manager backed by an explicit workspace generation."""
 
-    def __init__(self, path: str | os.PathLike[str]) -> None:
-        self._initialize(path)
+    def __init__(self, path: str | os.PathLike[str], group: str = "/") -> None:
+        self._initialize(path, group)
 
-    def _initialize(self, path: str | os.PathLike[str]) -> None:
+    def _initialize(self, path: str | os.PathLike[str], group: str) -> None:
         ensure_workspace_hdf5_filters_registered()
         target = _normalized_file_path(path)
         if target is None:
             target = os.fsdecode(path)
         self.workspace_path = target
+        self.workspace_group = _normalized_workspace_group(group)
         self._generation = _workspace_file_generation(target)
+        self._generation.add_manager(self)
         self._finalizer = weakref.finalize(
             self, _release_workspace_file_generation, self._generation
         )
 
-    def __getstate__(self) -> tuple[str, str, tuple[int, int, int]]:
-        """Serialize an immutable reference to this workspace generation."""
-        return _workspace_file_manager_pickle_state(self._generation)
+    def _switch_generation(self, generation: _WorkspaceFileGeneration) -> None:
+        """Move this manager to an already prepared reader generation."""
+        with _workspace_file_lock(self.workspace_path):
+            if generation is self._generation:
+                return
+            generation.add_manager(self)
+            previous = self._generation
+            if self._finalizer.detach() is None:
+                _release_workspace_file_generation(generation, self)
+                raise RuntimeError("Workspace file manager is already released")
+            self._generation = generation
+            self._finalizer = weakref.finalize(
+                self, _release_workspace_file_generation, generation
+            )
+            _release_workspace_file_generation(previous, self)
 
-    def __setstate__(self, state: tuple[str, str, tuple[int, int, int]]) -> None:
-        workspace_path, reader_path, expected_identity = state
+    def __getstate__(self) -> tuple[str, str, tuple[int, int, int], str]:
+        """Serialize an immutable reference to this workspace generation."""
+        return _workspace_file_manager_pickle_state(self)
+
+    def __setstate__(self, state: tuple[str, str, tuple[int, int, int], str]) -> None:
+        workspace_path, reader_path, expected_identity, group = state
         ensure_workspace_hdf5_filters_registered()
         target = _normalized_file_path(workspace_path)
         if target is None:
             target = os.fsdecode(workspace_path)
         self.workspace_path = target
+        self.workspace_group = _normalized_workspace_group(group)
         self._generation = _workspace_file_generation_from_reader(
             target,
             reader_path,
             expected_identity,
         )
+        self._generation.add_manager(self)
         self._finalizer = weakref.finalize(
             self, _release_workspace_file_generation, self._generation
         )
 
     def acquire(self, needs_lock: bool = True) -> typing.Any:
+        if needs_lock:
+            with _workspace_file_lock(self.workspace_path):
+                return self._generation.acquire(needs_lock=False)
         return self._generation.acquire(needs_lock=needs_lock)
 
     def acquire_context(
         self, needs_lock: bool = True
     ) -> contextlib.AbstractContextManager[typing.Any]:
+        if needs_lock:
+            return self._acquire_context_locked()
         return self._generation.acquire_context(needs_lock=needs_lock)
 
+    @contextlib.contextmanager
+    def _acquire_context_locked(self) -> Iterator[typing.Any]:
+        with (
+            _workspace_file_lock(self.workspace_path),
+            self._generation.acquire_context(needs_lock=False) as file,
+        ):
+            yield file
+
     def close(self, needs_lock: bool = True) -> None:
+        if needs_lock:
+            with _workspace_file_lock(self.workspace_path):
+                self._generation.close(needs_lock=False)
+            return
         self._generation.close(needs_lock=needs_lock)
+
+    def _release(self) -> None:
+        """Close this manager and release its generation lease."""
+        self.close()
+        self._finalizer()
 
 
 def _iter_h5netcdf_group_paths(group: object, path: str = "/") -> Iterator[str]:
@@ -963,7 +1181,7 @@ def open_workspace_dataset(
     if target is None:
         target = os.fsdecode(path)
     return _open_workspace_dataset_from_manager(
-        WorkspaceFileManager(target), group, chunks=chunks
+        WorkspaceFileManager(target, group), group, chunks=chunks
     )
 
 
@@ -974,21 +1192,24 @@ def open_workspace_datatree(
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
-    file_manager = WorkspaceFileManager(target)
-    with file_manager.acquire_context() as h5_file:
-        group_paths = tuple(_iter_h5netcdf_group_paths(h5_file))
-
+    enumerator = WorkspaceFileManager(target)
     groups: dict[str, xr.Dataset] = {}
     try:
+        with enumerator.acquire_context() as h5_file:
+            group_paths = tuple(_iter_h5netcdf_group_paths(h5_file))
         for group_path in group_paths:
             groups[group_path] = _open_workspace_dataset_from_manager(
-                file_manager, group_path, chunks=chunks
+                WorkspaceFileManager(target, group_path),
+                group_path,
+                chunks=chunks,
             )
         tree = xr.DataTree.from_dict(groups)
     except Exception:
         for ds in groups.values():
             ds.close()
         raise
+    finally:
+        enumerator._release()
 
     for group_path, ds in groups.items():
         tree[group_path].set_close(ds.close)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -13,7 +13,7 @@ import h5netcdf
 import hdf5plugin
 import numpy as np
 import xarray as xr
-from xarray.backends import FileManager, H5NetCDFStore
+from xarray.backends import CachingFileManager, FileManager, H5NetCDFStore
 
 import erlab
 from erlab.interactive.imagetool import _serialization
@@ -37,10 +37,12 @@ from erlab.interactive.imagetool.manager._workspace._format import (
     _workspace_serializable_attrs,
 )
 
-_WORKSPACE_FILE_LOCKS: dict[str, threading.RLock] = {}
-# Keep current generations alive even when their last manager is released while
-# another thread owns the path lock. A later replacement must still find and
-# close the generation's file handle.
+_WORKSPACE_FILE_LOCKS: weakref.WeakValueDictionary[str, threading.RLock] = (
+    weakref.WeakValueDictionary()
+)
+_WORKSPACE_FILE_LOCKS_LOCK = threading.Lock()
+# Current generations stay alive until their final reader lease is cleaned up.
+# This lets a save find and close a handle even when final lease release races it.
 _WORKSPACE_FILE_GENERATIONS: dict[str, _WorkspaceFileGeneration] = {}
 _WORKSPACE_FILE_GENERATIONS_LOCK = threading.Lock()
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
@@ -53,7 +55,7 @@ _WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS = frozenset(
 
 
 class _WorkspaceFileGenerationResources:
-    """File resources owned by one workspace generation."""
+    """Evictable handle and preserved file owned by one generation."""
 
     def __init__(
         self,
@@ -62,46 +64,57 @@ class _WorkspaceFileGenerationResources:
     ) -> None:
         self.path = path
         self.lock = lock
-        self.file: typing.Any | None = None
+        self.file_manager: CachingFileManager[typing.Any] | None = (
+            self._new_file_manager(path)
+        )
         self.cleanup: Callable[[], None] | None = None
 
-    @contextlib.contextmanager
-    def optional_lock(self, needs_lock: bool) -> Iterator[None]:
-        if needs_lock:
-            with self.lock:
-                yield
-        else:
-            yield
+    def _new_file_manager(self, path: str) -> CachingFileManager[typing.Any]:
+        return CachingFileManager(
+            h5netcdf.File,
+            path,
+            mode="r+",
+            kwargs={
+                "invalid_netcdf": None,
+                "phony_dims": "sort",
+                "decode_vlen_strings": True,
+            },
+            lock=self.lock,
+        )
 
-    def acquire(self, *, needs_lock: bool) -> tuple[typing.Any, bool]:
-        with self.optional_lock(needs_lock):
-            if self.file is None:
-                self.file = h5netcdf.File(
-                    self.path,
-                    mode="r+",
-                    invalid_netcdf=None,
-                    phony_dims="sort",
-                    decode_vlen_strings=True,
-                )
-                return self.file, True
-            return self.file, False
+    def acquire(self, *, needs_lock: bool) -> typing.Any:
+        file_manager = self.file_manager
+        if file_manager is None:
+            raise RuntimeError("Workspace file generation is no longer available")
+        return file_manager.acquire(needs_lock=needs_lock)
+
+    def acquire_context(
+        self, *, needs_lock: bool
+    ) -> contextlib.AbstractContextManager[typing.Any]:
+        file_manager = self.file_manager
+        if file_manager is None:
+            raise RuntimeError("Workspace file generation is no longer available")
+        return file_manager.acquire_context(needs_lock=needs_lock)
 
     def close(self, *, needs_lock: bool) -> None:
-        with self.optional_lock(needs_lock):
-            file = self.file
-            self.file = None
-            if file is not None:
-                file.close()
+        file_manager = self.file_manager
+        if file_manager is not None:
+            file_manager.close(needs_lock=needs_lock)
 
     def retire(self, path: str, cleanup: Callable[[], None]) -> None:
+        self.close(needs_lock=False)
         self.path = path
+        self.file_manager = self._new_file_manager(path)
         self.cleanup = cleanup
 
     def release(self) -> None:
-        with contextlib.suppress(Exception):
-            self.close(needs_lock=False)
+        file_manager = self.file_manager
+        self.file_manager = None
         cleanup = self.cleanup
         self.cleanup = None
+        with contextlib.suppress(Exception):
+            if file_manager is not None:
+                file_manager.close(needs_lock=False)
         if cleanup is not None:
             with contextlib.suppress(Exception):
                 cleanup()
@@ -123,6 +136,8 @@ class _WorkspaceFileGeneration:
         self._manager_count = 0
         self._state_lock = threading.Lock()
         self._retired = False
+        self._cleanup_scheduled = False
+        self._disposed = False
         self._finalizer = weakref.finalize(self, self._resources.release)
 
     @property
@@ -131,10 +146,13 @@ class _WorkspaceFileGeneration:
 
     @property
     def retired(self) -> bool:
-        return self._retired
+        with self._state_lock:
+            return self._retired
 
     def add_manager(self) -> None:
         with self._state_lock:
+            if self._disposed:
+                raise RuntimeError("Workspace file generation is no longer available")
             self._manager_count += 1
 
     def remove_manager(self) -> bool:
@@ -147,28 +165,48 @@ class _WorkspaceFileGeneration:
             return self._manager_count != 0
 
     def acquire(self, *, needs_lock: bool) -> typing.Any:
-        file, _ = self._resources.acquire(needs_lock=needs_lock)
-        return file
+        return self._resources.acquire(needs_lock=needs_lock)
 
-    @contextlib.contextmanager
-    def acquire_context(self, *, needs_lock: bool) -> Iterator[typing.Any]:
-        file, opened = self._resources.acquire(needs_lock=needs_lock)
-        try:
-            yield file
-        except Exception:
-            if opened:
-                self.close(needs_lock=needs_lock)
-            raise
+    def acquire_context(
+        self, *, needs_lock: bool
+    ) -> contextlib.AbstractContextManager[typing.Any]:
+        return self._resources.acquire_context(needs_lock=needs_lock)
 
     def close(self, *, needs_lock: bool) -> None:
         self._resources.close(needs_lock=needs_lock)
 
     def retire(self, path: str, cleanup: Callable[[], None]) -> None:
         self._resources.retire(path, cleanup)
-        self._retired = True
+        with self._state_lock:
+            self._retired = True
 
     def refresh_file_identity(self) -> None:
         self.file_identity = _workspace_file_identity(self.workspace_path)
+
+    def schedule_cleanup(self) -> bool:
+        """Mark cleanup as pending if no worker already owns it."""
+        with self._state_lock:
+            if self._manager_count != 0 or self._disposed or self._cleanup_scheduled:
+                return False
+            self._cleanup_scheduled = True
+            return True
+
+    def keep_if_in_use(self) -> bool:
+        """Cancel pending cleanup when this generation has a new reader."""
+        with self._state_lock:
+            if self._manager_count == 0:
+                return False
+            self._cleanup_scheduled = False
+            return True
+
+    def dispose(self) -> None:
+        """Release this generation once it has no reader leases."""
+        with self._state_lock:
+            if self._disposed:
+                return
+            self._disposed = True
+            self._cleanup_scheduled = False
+        self._finalizer()
 
 
 def _replace_h5_attrs(target_attrs, attrs: Mapping[typing.Any, typing.Any]) -> None:
@@ -198,14 +236,17 @@ def _workspace_file_lock(path: str | os.PathLike[str]) -> threading.RLock:
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
-    lock = _WORKSPACE_FILE_LOCKS.get(target)
-    if lock is None:
-        lock = threading.RLock()
-        _WORKSPACE_FILE_LOCKS[target] = lock
-    return lock
+    with _WORKSPACE_FILE_LOCKS_LOCK:
+        lock = _WORKSPACE_FILE_LOCKS.get(target)
+        if lock is None:
+            lock = threading.RLock()
+            _WORKSPACE_FILE_LOCKS[target] = lock
+        return lock
 
 
-def _workspace_file_identity(path: str | os.PathLike[str]) -> tuple[str, int, int, int]:
+def _workspace_file_identity(
+    path: str | os.PathLike[str],
+) -> tuple[str, int, int, int]:
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
@@ -348,10 +389,18 @@ def workspace_dataset_encoding(
     return encoding
 
 
-def _workspace_file_generation(path: str) -> _WorkspaceFileGeneration:
+def _workspace_file_generation(
+    path: str,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+) -> _WorkspaceFileGeneration:
     """Return the current shared generation for a normalized workspace path."""
     with _workspace_file_lock(path):
         identity = _workspace_file_identity(path)
+        if expected_identity is not None and identity[1:3] != expected_identity:
+            raise RuntimeError(
+                f"Workspace changed after its reader was serialized: {path}"
+            )
         with _WORKSPACE_FILE_GENERATIONS_LOCK:
             generation = _WORKSPACE_FILE_GENERATIONS.get(path)
             # An incremental save changes the modification time in place. Only
@@ -381,8 +430,8 @@ def _retire_workspace_file_generation(
     cleanup: Callable[[], None],
 ) -> None:
     """Move a published generation to its preserved backing file."""
-    generation.retire(preserved_path, cleanup)
     _discard_workspace_file_generation(path, generation)
+    generation.retire(preserved_path, cleanup)
 
 
 def _discard_workspace_file_generation(
@@ -401,46 +450,93 @@ def _discard_workspace_file_generation(
 def _release_workspace_file_generation(
     generation: _WorkspaceFileGeneration,
 ) -> None:
-    """Release one manager and discard an unused current generation when safe."""
+    """Release one reader lease and arrange reliable generation cleanup."""
     if not generation.remove_manager():
-        return
-    if generation.retired:
-        generation.close(needs_lock=False)
         return
 
     lock = _workspace_file_lock(generation.workspace_path)
-    if not lock.acquire(blocking=False):
-        # The strong registry keeps this generation discoverable until the
-        # operation that owns the lock finishes or a later replacement starts.
+    if lock.acquire(blocking=False):
+        try:
+            _cleanup_workspace_file_generation_locked(generation)
+        finally:
+            lock.release()
         return
-    try:
-        if generation.has_managers():
-            return
-        generation.close(needs_lock=False)
+
+    if generation.schedule_cleanup():
+        threading.Thread(
+            target=_cleanup_workspace_file_generation,
+            args=(generation,),
+            name="erlab-workspace-reader-cleanup",
+            daemon=True,
+        ).start()
+
+
+def _cleanup_workspace_file_generation(
+    generation: _WorkspaceFileGeneration,
+) -> None:
+    """Wait for the path lock and finish a pending generation cleanup."""
+    with _workspace_file_lock(generation.workspace_path):
+        _cleanup_workspace_file_generation_locked(generation)
+
+
+def _cleanup_workspace_file_generation_locked(
+    generation: _WorkspaceFileGeneration,
+) -> None:
+    """Dispose an unused generation while its workspace path is locked."""
+    if generation.keep_if_in_use():
+        return
+    _discard_workspace_file_generation(generation.workspace_path, generation)
+    generation.dispose()
+
+
+def _workspace_file_manager_pickle_state(
+    generation: _WorkspaceFileGeneration,
+) -> tuple[str, tuple[int, int]]:
+    """Return a stable serialization reference for a current generation."""
+    with _workspace_file_lock(generation.workspace_path):
         with _WORKSPACE_FILE_GENERATIONS_LOCK:
-            if _WORKSPACE_FILE_GENERATIONS.get(generation.workspace_path) is generation:
-                del _WORKSPACE_FILE_GENERATIONS[generation.workspace_path]
-    finally:
-        lock.release()
+            is_current = (
+                _WORKSPACE_FILE_GENERATIONS.get(generation.workspace_path) is generation
+            )
+        if generation.retired or not is_current:
+            raise TypeError(
+                "Cannot serialize lazy data from a replaced workspace generation. "
+                "Load the data into memory before sending it to another process."
+            )
+        return generation.workspace_path, generation.file_identity[1:3]
 
 
 class WorkspaceFileManager(FileManager[typing.Any]):
     """xarray file manager backed by an explicit workspace generation."""
 
     def __init__(self, path: str | os.PathLike[str]) -> None:
+        self._initialize(path)
+
+    def _initialize(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        expected_identity: tuple[int, int] | None = None,
+    ) -> None:
         ensure_workspace_hdf5_filters_registered()
         target = _normalized_file_path(path)
         if target is None:
             target = os.fsdecode(path)
         self.workspace_path = target
-        self._generation = _workspace_file_generation(target)
+        self._generation = _workspace_file_generation(
+            target, expected_identity=expected_identity
+        )
+        self._finalizer = weakref.finalize(
+            self, _release_workspace_file_generation, self._generation
+        )
 
-    def __getstate__(self) -> str:
-        """Serialize the backing path, but not locks or open file handles."""
-        return self._generation.path
+    def __getstate__(self) -> tuple[str, tuple[int, int]]:
+        """Serialize a validated reference to the current workspace generation."""
+        return _workspace_file_manager_pickle_state(self._generation)
 
-    def __setstate__(self, path: str) -> None:
-        WorkspaceFileManager.__init__(self, path)
+    def __setstate__(self, state: tuple[str, tuple[int, int]]) -> None:
+        path, expected_identity = state
+        self._initialize(path, expected_identity=expected_identity)
 
     def acquire(self, needs_lock: bool = True) -> typing.Any:
         return self._generation.acquire(needs_lock=needs_lock)
@@ -452,12 +548,6 @@ class WorkspaceFileManager(FileManager[typing.Any]):
 
     def close(self, needs_lock: bool = True) -> None:
         self._generation.close(needs_lock=needs_lock)
-
-    def __del__(self) -> None:
-        generation = getattr(self, "_generation", None)
-        if generation is not None:
-            with contextlib.suppress(Exception):
-                _release_workspace_file_generation(generation)
 
 
 def _iter_h5netcdf_group_paths(group: object, path: str = "/") -> Iterator[str]:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -19,7 +19,7 @@ import erlab
 from erlab.interactive.imagetool import _serialization
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Hashable, Iterable, Iterator, Mapping
+    from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
 
     import h5py
 
@@ -49,15 +49,16 @@ _WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS = frozenset(
 )
 
 
-class _WorkspaceFileReplacedError(RuntimeError):
-    """A lazy reader still targets a replaced workspace generation."""
+class _WorkspaceFileGeneration:
+    """A preserved workspace file generation shared by lazy readers."""
 
-    def __init__(self, path: str | os.PathLike[str]) -> None:
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        cleanup: Callable[[], None],
+    ) -> None:
         self.path = os.fsdecode(path)
-        super().__init__(
-            "Workspace data changed while this operation was reading it. "
-            f"Retry the operation to use the current saved data: {self.path}"
-        )
+        self._finalizer = weakref.finalize(self, cleanup)
 
 
 def _replace_h5_attrs(target_attrs, attrs: Mapping[typing.Any, typing.Any]) -> None:
@@ -263,42 +264,82 @@ class WorkspaceFileManager(CachingFileManager):
             manager_id=("erlab-workspace", *identity, "r+"),
         )
         self.workspace_path = target
-        self._file_replaced = False
+        self._workspace_manager_id = self._manager_id
+        self._preserved_generation: _WorkspaceFileGeneration | None = None
         with _WORKSPACE_FILE_MANAGERS_LOCK:
             managers = _WORKSPACE_FILE_MANAGERS.setdefault(target, weakref.WeakSet())
             managers.add(self)
 
-    def _acquire_with_cache_info(
-        self, needs_lock: bool = True
-    ) -> tuple[typing.Any, bool]:
-        if needs_lock:
-            with _workspace_file_lock(self.workspace_path):
-                return self._acquire_with_cache_info(needs_lock=False)
-        if self._file_replaced:
-            raise _WorkspaceFileReplacedError(self.workspace_path)
-        return super()._acquire_with_cache_info(needs_lock=False)
+    def _retarget(
+        self,
+        path: str,
+        manager_id: Hashable,
+    ) -> None:
+        """Move this manager to a distinct xarray cache generation."""
+        # CachingFileManager uses the key for both its cache and destructor
+        # reference count. Move both together so generations close independently.
+        self._ref_counter.decrement(self._key)
+        self._args = (path,)
+        self._manager_id = manager_id
+        self._key = self._make_key()
+        self._ref_counter.increment(self._key)
 
-    def _mark_file_replaced(self) -> None:
-        self._file_replaced = True
+    def _use_preserved_generation(self, generation: _WorkspaceFileGeneration) -> None:
+        self.close(needs_lock=False)
+        self._retarget(
+            generation.path,
+            ("erlab-workspace-generation", generation.path, "r+"),
+        )
+        self._preserved_generation = generation
+
+    def _restore_workspace_path(self) -> None:
+        if self._preserved_generation is None:
+            return
+        self.close(needs_lock=False)
+        self._retarget(self.workspace_path, self._workspace_manager_id)
+        self._preserved_generation = None
+
+
+def _detach_workspace_file_managers(
+    path: str | os.PathLike[str],
+) -> tuple[WorkspaceFileManager, ...]:
+    """Remove and return active readers for one workspace path."""
+    target = _normalized_file_path(path)
+    if target is None:
+        target = os.fsdecode(path)
+    with _WORKSPACE_FILE_MANAGERS_LOCK:
+        return tuple(_WORKSPACE_FILE_MANAGERS.pop(target, ()))
+
+
+def _restore_workspace_file_managers(
+    path: str | os.PathLike[str],
+    managers: Iterable[WorkspaceFileManager],
+) -> None:
+    """Restore detached readers after a workspace replacement fails."""
+    target = _normalized_file_path(path)
+    if target is None:
+        target = os.fsdecode(path)
+    managers = tuple(managers)
+    for manager in managers:
+        manager._restore_workspace_path()
+    with _WORKSPACE_FILE_MANAGERS_LOCK:
+        registered = _WORKSPACE_FILE_MANAGERS.setdefault(target, weakref.WeakSet())
+        registered.update(managers)
 
 
 def _close_workspace_file_managers(
     path: str | os.PathLike[str],
 ) -> tuple[WorkspaceFileManager, ...]:
-    """Close all cached manager-owned readers for one workspace path.
+    """Detach and close all manager-owned readers for one workspace path.
 
     The caller must hold the lock returned by :func:`_workspace_file_lock` for
-    the same path. This prevents a lazy reader from reopening the file while
-    the cached handles are being closed. The caller can retire the returned
-    managers after the replacement commits.
+    the same path. This prevents a lazy reader from reopening a cached handle
+    while it is being closed.
     """
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
-    with _WORKSPACE_FILE_MANAGERS_LOCK:
-        managers = tuple(_WORKSPACE_FILE_MANAGERS.get(target, ()))
-        if not managers:
-            _WORKSPACE_FILE_MANAGERS.pop(target, None)
+    managers = _detach_workspace_file_managers(target)
     for manager in managers:
         manager.close(needs_lock=False)
     return managers

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -14,6 +14,7 @@ import hdf5plugin
 import numpy as np
 import xarray as xr
 from xarray.backends import CachingFileManager, H5NetCDFStore
+from xarray.backends.file_manager import FILE_CACHE
 
 import erlab
 from erlab.interactive.imagetool import _serialization
@@ -39,6 +40,7 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 
 _WORKSPACE_FILE_LOCKS: dict[str, threading.RLock] = {}
 _WORKSPACE_FILE_MANAGERS: dict[str, weakref.WeakSet[WorkspaceFileManager]] = {}
+_WORKSPACE_FILE_CACHE_KEYS: dict[str, weakref.WeakSet[Hashable]] = {}
 _WORKSPACE_FILE_MANAGERS_LOCK = threading.Lock()
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
@@ -269,6 +271,26 @@ class WorkspaceFileManager(CachingFileManager):
         with _WORKSPACE_FILE_MANAGERS_LOCK:
             managers = _WORKSPACE_FILE_MANAGERS.setdefault(target, weakref.WeakSet())
             managers.add(self)
+            cache_keys = _WORKSPACE_FILE_CACHE_KEYS.setdefault(
+                target, weakref.WeakSet()
+            )
+            cache_keys.add(self._key)
+
+    def _acquire_with_cache_info(
+        self, needs_lock: bool = True
+    ) -> tuple[typing.Any, bool]:
+        if needs_lock:
+            with self._optional_lock(needs_lock=True):
+                return self._acquire_with_cache_info(needs_lock=False)
+        if self._preserved_generation is None:
+            # An equal key object can replace an evicted cache key. Register on
+            # each acquire so replacement still finds the reopened handle.
+            with _WORKSPACE_FILE_MANAGERS_LOCK:
+                cache_keys = _WORKSPACE_FILE_CACHE_KEYS.setdefault(
+                    self.workspace_path, weakref.WeakSet()
+                )
+                cache_keys.add(self._key)
+        return super()._acquire_with_cache_info(needs_lock=False)
 
     def _retarget(
         self,
@@ -302,31 +324,51 @@ class WorkspaceFileManager(CachingFileManager):
         self._preserved_generation = None
 
 
-def _detach_workspace_file_managers(
+def _detach_workspace_file_readers(
     path: str | os.PathLike[str],
-) -> tuple[WorkspaceFileManager, ...]:
-    """Remove and return active readers for one workspace path."""
+) -> tuple[tuple[WorkspaceFileManager, ...], tuple[Hashable, ...]]:
+    """Remove and return managers and cache keys for one workspace path."""
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
     with _WORKSPACE_FILE_MANAGERS_LOCK:
-        return tuple(_WORKSPACE_FILE_MANAGERS.pop(target, ()))
+        managers = tuple(_WORKSPACE_FILE_MANAGERS.pop(target, ()))
+        cache_keys = tuple(_WORKSPACE_FILE_CACHE_KEYS.pop(target, ()))
+    return managers, cache_keys
 
 
-def _restore_workspace_file_managers(
+def _restore_workspace_file_readers(
     path: str | os.PathLike[str],
     managers: Iterable[WorkspaceFileManager],
+    cache_keys: Iterable[Hashable],
 ) -> None:
     """Restore detached readers after a workspace replacement fails."""
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
     managers = tuple(managers)
+    cache_keys = tuple(cache_keys)
     for manager in managers:
         manager._restore_workspace_path()
     with _WORKSPACE_FILE_MANAGERS_LOCK:
         registered = _WORKSPACE_FILE_MANAGERS.setdefault(target, weakref.WeakSet())
         registered.update(managers)
+        registered_cache_keys = _WORKSPACE_FILE_CACHE_KEYS.setdefault(
+            target, weakref.WeakSet()
+        )
+        # Add the current manager keys first. A restored manager has a new key
+        # object that can compare equal to its detached key object.
+        registered_cache_keys.update(manager._key for manager in managers)
+        registered_cache_keys.update(cache_keys)
+
+
+def _close_workspace_file_cache_entries(cache_keys: Iterable[Hashable]) -> None:
+    """Close detached xarray cache entries, including entries without managers."""
+    with contextlib.ExitStack() as stack:
+        for cache_key in cache_keys:
+            cached_file = FILE_CACHE.pop(cache_key, None)
+            if cached_file is not None:
+                stack.callback(cached_file.close)
 
 
 def _close_workspace_file_managers(
@@ -341,7 +383,8 @@ def _close_workspace_file_managers(
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
-    managers = _detach_workspace_file_managers(target)
+    managers, cache_keys = _detach_workspace_file_readers(target)
+    _close_workspace_file_cache_entries(cache_keys)
     for manager in managers:
         manager.close(needs_lock=False)
     return managers

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import contextlib
+import ctypes
 import os
 import pathlib
 import queue
+import shutil
+import stat
+import sys
 import threading
 import typing
+import uuid
 import weakref
+from dataclasses import dataclass
 
 import h5netcdf
 import hdf5plugin
@@ -53,6 +59,8 @@ _WORKSPACE_FILE_CLEANUP_QUEUE: queue.SimpleQueue[_WorkspaceFileGeneration] = (
 )
 _WORKSPACE_FILE_CLEANUP_WORKER: threading.Thread | None = None
 _WORKSPACE_FILE_CLEANUP_WORKER_LOCK = threading.Lock()
+_WORKSPACE_READER_DIRECTORY_SUFFIX = ".readers"
+_WORKSPACE_EXPORT_REQUIRES_COPY = os.name == "nt"
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
@@ -62,6 +70,151 @@ _WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS = frozenset(
 )
 
 
+@dataclass(frozen=True)
+class _WorkspaceReaderFile:
+    """One private file that pins a workspace reader generation."""
+
+    path: str
+    cleanup: Callable[[], None]
+
+
+def _hide_workspace_internal_path(path: str | os.PathLike[str]) -> None:
+    """Hide an internal workspace file or directory when the platform supports it."""
+    path_str = os.fsdecode(path)
+    if sys.platform == "darwin":
+        with contextlib.suppress(AttributeError, OSError):
+            path_stat = os.lstat(path_str)
+            if stat.S_ISLNK(path_stat.st_mode):
+                return
+            os.chflags(path_str, path_stat.st_flags | stat.UF_HIDDEN)
+        return
+    if os.name != "nt":
+        return
+
+    with contextlib.suppress(Exception):
+        windll = getattr(ctypes, "windll", None)
+        if windll is None:
+            return
+        attributes = windll.kernel32.GetFileAttributesW(path_str)
+        if attributes in (-1, 0xFFFFFFFF):
+            return
+        windll.kernel32.SetFileAttributesW(
+            path_str,
+            attributes | 0x2,  # FILE_ATTRIBUTE_HIDDEN
+        )
+
+
+def _workspace_reader_directory(
+    workspace_path: str | os.PathLike[str],
+) -> pathlib.Path:
+    """Return the private reader-generation directory for a workspace."""
+    normalized = _normalized_file_path(workspace_path)
+    path = pathlib.Path(
+        os.fsdecode(workspace_path) if normalized is None else normalized
+    )
+    return path.with_name(f".{path.name}{_WORKSPACE_READER_DIRECTORY_SUFFIX}")
+
+
+def _ensure_workspace_reader_directory(
+    workspace_path: str | os.PathLike[str],
+) -> pathlib.Path:
+    directory = _workspace_reader_directory(workspace_path)
+    try:
+        directory.mkdir(mode=0o700)
+    except FileExistsError:
+        directory_stat = directory.lstat()
+        if stat.S_ISLNK(directory_stat.st_mode) or not stat.S_ISDIR(
+            directory_stat.st_mode
+        ):
+            raise OSError(
+                f"Workspace reader path is not a private directory: {directory}"
+            ) from None
+    _hide_workspace_internal_path(directory)
+    return directory
+
+
+def _cleanup_workspace_reader_path(path: pathlib.Path) -> None:
+    with contextlib.suppress(FileNotFoundError):
+        path.unlink()
+    with contextlib.suppress(OSError):
+        path.parent.rmdir()
+
+
+def _create_workspace_reader_file(
+    source_path: str | os.PathLike[str],
+    workspace_path: str | os.PathLike[str],
+    *,
+    kind: typing.Literal["reader", "export"] = "reader",
+    copy_only: bool = False,
+) -> _WorkspaceReaderFile:
+    """Create a private hard link or copy for one reader generation."""
+    source = pathlib.Path(source_path).resolve()
+    directory = _ensure_workspace_reader_directory(workspace_path)
+    destination = directory / f"{kind}-{os.getpid()}-{uuid.uuid4().hex}.itws"
+    try:
+        if copy_only:
+            shutil.copyfile(source, destination)
+        else:
+            try:
+                os.link(source, destination)
+            except OSError:
+                shutil.copyfile(source, destination)
+    except BaseException:
+        _cleanup_workspace_reader_path(destination)
+        raise
+    return _WorkspaceReaderFile(
+        path=str(destination),
+        cleanup=lambda: _cleanup_workspace_reader_path(destination),
+    )
+
+
+def _workspace_reader_file_owner_pid(path: pathlib.Path) -> int | None:
+    for kind in ("reader", "export"):
+        prefix = f"{kind}-"
+        if not path.name.startswith(prefix) or not path.name.endswith(".itws"):
+            continue
+        pid_text, separator, token = path.name[len(prefix) :].partition("-")
+        if not separator:
+            return None
+        try:
+            pid = int(pid_text)
+            uuid.UUID(hex=token.removesuffix(".itws"))
+        except (ValueError, TypeError):
+            return None
+        return pid if pid > 0 else None
+    return None
+
+
+def _cleanup_stale_workspace_reader_files(
+    workspace_path: str | os.PathLike[str],
+) -> None:
+    """Remove private reader files whose owner process no longer exists."""
+    directory = _workspace_reader_directory(workspace_path)
+    try:
+        directory_stat = directory.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(directory_stat.st_mode) or not stat.S_ISDIR(directory_stat.st_mode):
+        return
+
+    import psutil
+
+    current_pid = os.getpid()
+    for path in directory.iterdir():
+        owner_pid = _workspace_reader_file_owner_pid(path)
+        if (
+            owner_pid is None
+            or owner_pid == current_pid
+            or psutil.pid_exists(owner_pid)
+        ):
+            continue
+        with contextlib.suppress(FileNotFoundError, OSError):
+            if stat.S_ISREG(path.lstat().st_mode):
+                path.unlink()
+    with contextlib.suppress(OSError):
+        directory.rmdir()
+
+
 class _WorkspaceFileGenerationResources:
     """Evictable handle and preserved file owned by one generation."""
 
@@ -69,19 +222,23 @@ class _WorkspaceFileGenerationResources:
         self,
         path: str,
         lock: threading.RLock,
+        file_identity: tuple[str, int, int, int],
     ) -> None:
         self.path = path
         self.lock = lock
+        self.file_identity = file_identity
         self.file_manager: CachingFileManager[typing.Any] | None = (
             self._new_file_manager(path)
         )
         self.cleanup: Callable[[], None] | None = None
+        self.export_file: _WorkspaceReaderFile | None = None
+        self.export_identity: tuple[int, int, int] | None = None
 
     def _new_file_manager(self, path: str) -> CachingFileManager[typing.Any]:
         return CachingFileManager(
             h5netcdf.File,
             path,
-            mode="r+",
+            mode="r",
             kwargs={
                 "invalid_netcdf": None,
                 "phony_dims": "sort",
@@ -90,42 +247,130 @@ class _WorkspaceFileGenerationResources:
             lock=self.lock,
         )
 
-    def acquire(self, *, needs_lock: bool) -> typing.Any:
-        file_manager = self.file_manager
-        if file_manager is None:
-            raise RuntimeError("Workspace file generation is no longer available")
-        return file_manager.acquire(needs_lock=needs_lock)
+    def _assert_file_identity(self) -> None:
+        identity = _workspace_file_identity(self.path)
+        if identity[1:] != self.file_identity[1:]:
+            raise RuntimeError(
+                "Workspace reader generation changed or is no longer available: "
+                f"{self.path}"
+            )
 
-    def acquire_context(
-        self, *, needs_lock: bool
-    ) -> contextlib.AbstractContextManager[typing.Any]:
+    def _acquire_locked(self) -> typing.Any:
         file_manager = self.file_manager
         if file_manager is None:
             raise RuntimeError("Workspace file generation is no longer available")
-        return file_manager.acquire_context(needs_lock=needs_lock)
+        self._assert_file_identity()
+        file = file_manager.acquire(needs_lock=False)
+        try:
+            self._assert_file_identity()
+        except BaseException:
+            file_manager.close(needs_lock=False)
+            raise
+        return file
+
+    def acquire(self, *, needs_lock: bool) -> typing.Any:
+        if needs_lock:
+            with self.lock:
+                return self._acquire_locked()
+        return self._acquire_locked()
+
+    @contextlib.contextmanager
+    def acquire_context(self, *, needs_lock: bool) -> Iterator[typing.Any]:
+        file_manager = self.file_manager
+        if file_manager is None:
+            raise RuntimeError("Workspace file generation is no longer available")
+        maybe_lock = self.lock if needs_lock else contextlib.nullcontext()
+        with maybe_lock:
+            self._assert_file_identity()
+            with file_manager.acquire_context(needs_lock=False) as file:
+                self._assert_file_identity()
+                yield file
 
     def close(self, *, needs_lock: bool) -> None:
         file_manager = self.file_manager
         if file_manager is not None:
             file_manager.close(needs_lock=needs_lock)
 
-    def retire(self, path: str, cleanup: Callable[[], None]) -> None:
+    def retire(
+        self,
+        path: str,
+        file_identity: tuple[str, int, int, int],
+        cleanup: Callable[[], None],
+    ) -> None:
         self.close(needs_lock=False)
         self.path = path
+        self.file_identity = file_identity
         self.file_manager = self._new_file_manager(path)
         self.cleanup = cleanup
+
+    def activate(self, path: str, file_identity: tuple[str, int, int, int]) -> None:
+        self.close(needs_lock=False)
+        self.path = path
+        self.file_identity = file_identity
+        self.file_manager = self._new_file_manager(path)
+
+    def export(self, workspace_path: str) -> _WorkspaceReaderFile:
+        export_file = self.export_file
+        export_identity = self.export_identity
+        if (
+            export_file is not None
+            and export_identity is not None
+            and _workspace_file_identity(export_file.path)[1:] == export_identity
+        ):
+            return export_file
+
+        if export_file is not None:
+            export_file.cleanup()
+            self.export_file = None
+            self.export_identity = None
+
+        self.close(needs_lock=False)
+        source_identity = _workspace_file_identity(self.path)
+        if source_identity[1:] != self.file_identity[1:]:
+            raise RuntimeError(
+                "Workspace reader generation changed before it could be exported: "
+                f"{self.path}"
+            )
+        reader_file = _create_workspace_reader_file(
+            self.path,
+            workspace_path,
+            kind="export",
+            # A Windows handle to any hard link can prevent replacement of the
+            # canonical link. Give cross-process readers a separate file object.
+            copy_only=_WORKSPACE_EXPORT_REQUIRES_COPY,
+        )
+        try:
+            source_identity_after = _workspace_file_identity(self.path)
+        except BaseException:
+            reader_file.cleanup()
+            raise
+        if source_identity_after[1:] != source_identity[1:]:
+            reader_file.cleanup()
+            raise RuntimeError(
+                "Workspace reader generation changed while it was being exported: "
+                f"{self.path}"
+            )
+        self.export_file = reader_file
+        self.export_identity = _workspace_file_identity(reader_file.path)[1:]
+        return reader_file
 
     def release(self) -> None:
         file_manager = self.file_manager
         self.file_manager = None
         cleanup = self.cleanup
         self.cleanup = None
+        export_file = self.export_file
+        self.export_file = None
+        self.export_identity = None
         with contextlib.suppress(Exception):
             if file_manager is not None:
                 file_manager.close(needs_lock=False)
         if cleanup is not None:
             with contextlib.suppress(Exception):
                 cleanup()
+        if export_file is not None:
+            with contextlib.suppress(Exception):
+                export_file.cleanup()
 
 
 class _WorkspaceFileGeneration:
@@ -135,15 +380,30 @@ class _WorkspaceFileGeneration:
         self,
         workspace_path: str,
         file_identity: tuple[str, int, int, int],
+        *,
+        created_without_file: bool = False,
+        reader_file: _WorkspaceReaderFile | None = None,
     ) -> None:
         self.workspace_path = workspace_path
         self.file_identity = file_identity
-        self._resources = _WorkspaceFileGenerationResources(
-            workspace_path, _workspace_file_lock(workspace_path)
+        resource_path = workspace_path if reader_file is None else reader_file.path
+        resource_identity = (
+            file_identity
+            if reader_file is None
+            else _workspace_file_identity(reader_file.path)
         )
+        self._resources = _WorkspaceFileGenerationResources(
+            resource_path,
+            _workspace_file_lock(workspace_path),
+            resource_identity,
+        )
+        if reader_file is not None:
+            self._resources.cleanup = reader_file.cleanup
         self._manager_count = 0
         self._state_lock = threading.Lock()
-        self._retired = False
+        self._retired = reader_file is not None
+        self._created_without_file = created_without_file
+        self._invalid_reason: str | None = None
         self._cleanup_scheduled = False
         self._disposed = False
         self._finalizer = weakref.finalize(self, self._resources.release)
@@ -157,10 +417,18 @@ class _WorkspaceFileGeneration:
         with self._state_lock:
             return self._retired
 
+    @property
+    def created_without_file(self) -> bool:
+        with self._state_lock:
+            return self._created_without_file
+
     def add_manager(self) -> None:
         with self._state_lock:
-            if self._disposed:
-                raise RuntimeError("Workspace file generation is no longer available")
+            if self._disposed or self._invalid_reason is not None:
+                raise RuntimeError(
+                    self._invalid_reason
+                    or "Workspace file generation is no longer available"
+                )
             self._manager_count += 1
 
     def release_manager(self) -> bool:
@@ -177,23 +445,60 @@ class _WorkspaceFileGeneration:
             return self._manager_count != 0
 
     def acquire(self, *, needs_lock: bool) -> typing.Any:
+        self._raise_if_unavailable()
         return self._resources.acquire(needs_lock=needs_lock)
 
     def acquire_context(
         self, *, needs_lock: bool
     ) -> contextlib.AbstractContextManager[typing.Any]:
+        self._raise_if_unavailable()
         return self._resources.acquire_context(needs_lock=needs_lock)
 
     def close(self, *, needs_lock: bool) -> None:
         self._resources.close(needs_lock=needs_lock)
 
-    def retire(self, path: str, cleanup: Callable[[], None]) -> None:
-        self._resources.retire(path, cleanup)
+    def retire(
+        self,
+        path: str,
+        file_identity: tuple[str, int, int, int],
+        cleanup: Callable[[], None],
+    ) -> None:
+        self._resources.retire(path, file_identity, cleanup)
         with self._state_lock:
             self._retired = True
 
-    def refresh_file_identity(self) -> None:
-        self.file_identity = _workspace_file_identity(self.workspace_path)
+    def activate_new_file(self) -> None:
+        with self._state_lock:
+            if not self._created_without_file:
+                raise RuntimeError(
+                    "Cannot bind an existing workspace reader generation to a new file"
+                )
+        identity = _workspace_file_identity(self.workspace_path)
+        self._resources.activate(self.workspace_path, identity)
+        self.file_identity = identity
+        with self._state_lock:
+            self._created_without_file = False
+
+    def invalidate(self, reason: str) -> None:
+        self._resources.close(needs_lock=False)
+        with self._state_lock:
+            self._retired = True
+            self._invalid_reason = reason
+
+    def export_reader_state(self) -> tuple[str, str, tuple[int, int, int]]:
+        """Create or reuse an owned immutable file for cross-process readers."""
+        self._raise_if_unavailable()
+        reader_file = self._resources.export(self.workspace_path)
+        identity = _workspace_file_identity(reader_file.path)[1:]
+        return self.workspace_path, reader_file.path, identity
+
+    def _raise_if_unavailable(self) -> None:
+        with self._state_lock:
+            if self._disposed or self._invalid_reason is not None:
+                raise RuntimeError(
+                    self._invalid_reason
+                    or "Workspace file generation is no longer available"
+                )
 
     def keep_if_in_use(self) -> bool:
         """Cancel pending cleanup when this generation has a new reader."""
@@ -248,17 +553,27 @@ def _workspace_file_lock(path: str | os.PathLike[str]) -> threading.RLock:
         return lock
 
 
-def _workspace_file_identity(
+def _workspace_file_state(
     path: str | os.PathLike[str],
-) -> tuple[str, int, int, int]:
+) -> tuple[tuple[str, int, int, int], bool]:
+    """Read a workspace identity and existence state with one stat call."""
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
     try:
         stat_result = os.stat(target)
-    except OSError:
-        return target, 0, 0, 0
-    return target, stat_result.st_dev, stat_result.st_ino, stat_result.st_mtime_ns
+    except FileNotFoundError:
+        return (target, 0, 0, 0), False
+    return (
+        (target, stat_result.st_dev, stat_result.st_ino, stat_result.st_mtime_ns),
+        True,
+    )
+
+
+def _workspace_file_identity(
+    path: str | os.PathLike[str],
+) -> tuple[str, int, int, int]:
+    return _workspace_file_state(path)[0]
 
 
 def _xarray_source_path(value: object) -> str | None:
@@ -395,27 +710,67 @@ def workspace_dataset_encoding(
 
 def _workspace_file_generation(
     path: str,
-    *,
-    expected_identity: tuple[int, int] | None = None,
 ) -> _WorkspaceFileGeneration:
     """Return the current shared generation for a normalized workspace path."""
     _ensure_workspace_file_cleanup_worker()
     with _workspace_file_lock(path):
-        identity = _workspace_file_identity(path)
-        if expected_identity is not None and identity[1:3] != expected_identity:
-            raise RuntimeError(
-                f"Workspace changed after its reader was serialized: {path}"
-            )
+        identity, file_exists = _workspace_file_state(path)
         with _WORKSPACE_FILE_GENERATIONS_LOCK:
             generation = _WORKSPACE_FILE_GENERATIONS.get(path)
-        # An incremental save changes the modification time in place. Only a
-        # new filesystem object starts a new generation here. The path lock
-        # makes construction and publication atomic for this workspace.
-        if generation is None or generation.file_identity[:3] != identity[:3]:
-            generation = _WorkspaceFileGeneration(path, identity)
+        # Published workspace files are immutable. A replacement or an external
+        # in-place modification therefore always starts a new generation.
+        if generation is None or generation.file_identity[1:] != identity[1:]:
+            if generation is not None:
+                generation.invalidate(
+                    "Workspace file was replaced outside its managed save operation: "
+                    f"{path}"
+                )
+            generation = _WorkspaceFileGeneration(
+                path,
+                identity,
+                created_without_file=not file_exists,
+            )
             with _WORKSPACE_FILE_GENERATIONS_LOCK:
                 _WORKSPACE_FILE_GENERATIONS[path] = generation
         generation.add_manager()
+        return generation
+
+
+def _workspace_file_generation_from_reader(
+    workspace_path: str,
+    reader_path: str,
+    expected_identity: tuple[int, int, int],
+) -> _WorkspaceFileGeneration:
+    """Create a detached generation from an immutable serialized reader file."""
+    _ensure_workspace_file_cleanup_worker()
+    with _workspace_file_lock(workspace_path):
+        if _workspace_file_identity(reader_path)[1:] != expected_identity:
+            raise RuntimeError(
+                "Serialized workspace reader generation is no longer available: "
+                f"{reader_path}"
+            )
+        reader_file = _create_workspace_reader_file(reader_path, workspace_path)
+        try:
+            reader_identity_after = _workspace_file_identity(reader_path)[1:]
+        except BaseException:
+            reader_file.cleanup()
+            raise
+        if reader_identity_after != expected_identity:
+            reader_file.cleanup()
+            raise RuntimeError(
+                "Serialized workspace reader generation changed while it was "
+                f"being opened: {reader_path}"
+            )
+        try:
+            generation = _WorkspaceFileGeneration(
+                workspace_path,
+                _workspace_file_identity(workspace_path),
+                reader_file=reader_file,
+            )
+            generation.add_manager()
+        except BaseException:
+            reader_file.cleanup()
+            raise
         return generation
 
 
@@ -434,11 +789,12 @@ def _retire_workspace_file_generation(
     path: str | os.PathLike[str],
     generation: _WorkspaceFileGeneration,
     preserved_path: str,
+    preserved_identity: tuple[str, int, int, int],
     cleanup: Callable[[], None],
 ) -> None:
     """Move a published generation to its preserved backing file."""
     _discard_workspace_file_generation(path, generation)
-    generation.retire(preserved_path, cleanup)
+    generation.retire(preserved_path, preserved_identity, cleanup)
 
 
 def _discard_workspace_file_generation(
@@ -510,19 +866,10 @@ def _cleanup_workspace_file_generation_locked(
 
 def _workspace_file_manager_pickle_state(
     generation: _WorkspaceFileGeneration,
-) -> tuple[str, tuple[int, int]]:
-    """Return a stable serialization reference for a current generation."""
+) -> tuple[str, str, tuple[int, int, int]]:
+    """Return an immutable serialization reference for one generation."""
     with _workspace_file_lock(generation.workspace_path):
-        with _WORKSPACE_FILE_GENERATIONS_LOCK:
-            is_current = (
-                _WORKSPACE_FILE_GENERATIONS.get(generation.workspace_path) is generation
-            )
-        if generation.retired or not is_current:
-            raise TypeError(
-                "Cannot serialize lazy data from a replaced workspace generation. "
-                "Load the data into memory before sending it to another process."
-            )
-        return generation.workspace_path, generation.file_identity[1:3]
+        return generation.export_reader_state()
 
 
 class WorkspaceFileManager(FileManager[typing.Any]):
@@ -531,31 +878,36 @@ class WorkspaceFileManager(FileManager[typing.Any]):
     def __init__(self, path: str | os.PathLike[str]) -> None:
         self._initialize(path)
 
-    def _initialize(
-        self,
-        path: str | os.PathLike[str],
-        *,
-        expected_identity: tuple[int, int] | None = None,
-    ) -> None:
+    def _initialize(self, path: str | os.PathLike[str]) -> None:
         ensure_workspace_hdf5_filters_registered()
         target = _normalized_file_path(path)
         if target is None:
             target = os.fsdecode(path)
         self.workspace_path = target
-        self._generation = _workspace_file_generation(
-            target, expected_identity=expected_identity
-        )
+        self._generation = _workspace_file_generation(target)
         self._finalizer = weakref.finalize(
             self, _release_workspace_file_generation, self._generation
         )
 
-    def __getstate__(self) -> tuple[str, tuple[int, int]]:
-        """Serialize a validated reference to the current workspace generation."""
+    def __getstate__(self) -> tuple[str, str, tuple[int, int, int]]:
+        """Serialize an immutable reference to this workspace generation."""
         return _workspace_file_manager_pickle_state(self._generation)
 
-    def __setstate__(self, state: tuple[str, tuple[int, int]]) -> None:
-        path, expected_identity = state
-        self._initialize(path, expected_identity=expected_identity)
+    def __setstate__(self, state: tuple[str, str, tuple[int, int, int]]) -> None:
+        workspace_path, reader_path, expected_identity = state
+        ensure_workspace_hdf5_filters_registered()
+        target = _normalized_file_path(workspace_path)
+        if target is None:
+            target = os.fsdecode(workspace_path)
+        self.workspace_path = target
+        self._generation = _workspace_file_generation_from_reader(
+            target,
+            reader_path,
+            expected_identity,
+        )
+        self._finalizer = weakref.finalize(
+            self, _release_workspace_file_generation, self._generation
+        )
 
     def acquire(self, needs_lock: bool = True) -> typing.Any:
         return self._generation.acquire(needs_lock=needs_lock)
@@ -586,13 +938,18 @@ def _open_workspace_dataset_from_manager(
     store = H5NetCDFStore(
         file_manager,
         group=group,
-        mode="r+",
+        mode="r",
         lock=_workspace_file_lock(file_manager.workspace_path),
         autoclose=False,
     )
     if chunks is None:
-        return xr.open_dataset(store)
-    return xr.open_dataset(store, chunks=chunks)
+        dataset = xr.open_dataset(store)
+    else:
+        dataset = xr.open_dataset(store, chunks=chunks)
+    for variable in dataset.variables.values():
+        if "source" in variable.encoding:
+            variable.encoding["source"] = file_manager.workspace_path
+    return dataset
 
 
 def open_workspace_dataset(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -49,6 +49,17 @@ _WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS = frozenset(
 )
 
 
+class _WorkspaceFileReplacedError(RuntimeError):
+    """A lazy reader still targets a replaced workspace generation."""
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self.path = os.fsdecode(path)
+        super().__init__(
+            "Workspace data changed while this operation was reading it. "
+            f"Retry the operation to use the current saved data: {self.path}"
+        )
+
+
 def _replace_h5_attrs(target_attrs, attrs: Mapping[typing.Any, typing.Any]) -> None:
     for key in list(target_attrs):
         del target_attrs[key]
@@ -252,17 +263,34 @@ class WorkspaceFileManager(CachingFileManager):
             manager_id=("erlab-workspace", *identity, "r+"),
         )
         self.workspace_path = target
+        self._file_replaced = False
         with _WORKSPACE_FILE_MANAGERS_LOCK:
             managers = _WORKSPACE_FILE_MANAGERS.setdefault(target, weakref.WeakSet())
             managers.add(self)
 
+    def _acquire_with_cache_info(
+        self, needs_lock: bool = True
+    ) -> tuple[typing.Any, bool]:
+        if needs_lock:
+            with _workspace_file_lock(self.workspace_path):
+                return self._acquire_with_cache_info(needs_lock=False)
+        if self._file_replaced:
+            raise _WorkspaceFileReplacedError(self.workspace_path)
+        return super()._acquire_with_cache_info(needs_lock=False)
 
-def _close_workspace_file_managers(path: str | os.PathLike[str]) -> None:
+    def _mark_file_replaced(self) -> None:
+        self._file_replaced = True
+
+
+def _close_workspace_file_managers(
+    path: str | os.PathLike[str],
+) -> tuple[WorkspaceFileManager, ...]:
     """Close all cached manager-owned readers for one workspace path.
 
     The caller must hold the lock returned by :func:`_workspace_file_lock` for
     the same path. This prevents a lazy reader from reopening the file while
-    the cached handles are being closed.
+    the cached handles are being closed. The caller can retire the returned
+    managers after the replacement commits.
     """
     target = _normalized_file_path(path)
     if target is None:
@@ -273,6 +301,7 @@ def _close_workspace_file_managers(path: str | os.PathLike[str]) -> None:
             _WORKSPACE_FILE_MANAGERS.pop(target, None)
     for manager in managers:
         manager.close(needs_lock=False)
+    return managers
 
 
 def _iter_h5netcdf_group_paths(group: object, path: str = "/") -> Iterator[str]:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import os
 import pathlib
+import queue
 import threading
 import typing
 import weakref
@@ -45,6 +46,13 @@ _WORKSPACE_FILE_LOCKS_LOCK = threading.Lock()
 # This lets a save find and close a handle even when final lease release races it.
 _WORKSPACE_FILE_GENERATIONS: dict[str, _WorkspaceFileGeneration] = {}
 _WORKSPACE_FILE_GENERATIONS_LOCK = threading.Lock()
+# CPython's SimpleQueue.put is reentrant, so a weakref callback can enqueue without
+# entering workspace locks or cleanup code.
+_WORKSPACE_FILE_CLEANUP_QUEUE: queue.SimpleQueue[_WorkspaceFileGeneration] = (
+    queue.SimpleQueue()
+)
+_WORKSPACE_FILE_CLEANUP_WORKER: threading.Thread | None = None
+_WORKSPACE_FILE_CLEANUP_WORKER_LOCK = threading.Lock()
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
@@ -155,10 +163,14 @@ class _WorkspaceFileGeneration:
                 raise RuntimeError("Workspace file generation is no longer available")
             self._manager_count += 1
 
-    def remove_manager(self) -> bool:
+    def release_manager(self) -> bool:
+        """Release one reader and claim cleanup after the final reader."""
         with self._state_lock:
             self._manager_count -= 1
-            return self._manager_count == 0
+            if self._manager_count != 0 or self._disposed or self._cleanup_scheduled:
+                return False
+            self._cleanup_scheduled = True
+            return True
 
     def has_managers(self) -> bool:
         with self._state_lock:
@@ -182,14 +194,6 @@ class _WorkspaceFileGeneration:
 
     def refresh_file_identity(self) -> None:
         self.file_identity = _workspace_file_identity(self.workspace_path)
-
-    def schedule_cleanup(self) -> bool:
-        """Mark cleanup as pending if no worker already owns it."""
-        with self._state_lock:
-            if self._manager_count != 0 or self._disposed or self._cleanup_scheduled:
-                return False
-            self._cleanup_scheduled = True
-            return True
 
     def keep_if_in_use(self) -> bool:
         """Cancel pending cleanup when this generation has a new reader."""
@@ -395,6 +399,7 @@ def _workspace_file_generation(
     expected_identity: tuple[int, int] | None = None,
 ) -> _WorkspaceFileGeneration:
     """Return the current shared generation for a normalized workspace path."""
+    _ensure_workspace_file_cleanup_worker()
     with _workspace_file_lock(path):
         identity = _workspace_file_identity(path)
         if expected_identity is not None and identity[1:3] != expected_identity:
@@ -403,13 +408,15 @@ def _workspace_file_generation(
             )
         with _WORKSPACE_FILE_GENERATIONS_LOCK:
             generation = _WORKSPACE_FILE_GENERATIONS.get(path)
-            # An incremental save changes the modification time in place. Only
-            # a new filesystem object starts a new generation here.
-            if generation is None or generation.file_identity[:3] != identity[:3]:
-                generation = _WorkspaceFileGeneration(path, identity)
+        # An incremental save changes the modification time in place. Only a
+        # new filesystem object starts a new generation here. The path lock
+        # makes construction and publication atomic for this workspace.
+        if generation is None or generation.file_identity[:3] != identity[:3]:
+            generation = _WorkspaceFileGeneration(path, identity)
+            with _WORKSPACE_FILE_GENERATIONS_LOCK:
                 _WORKSPACE_FILE_GENERATIONS[path] = generation
-            generation.add_manager()
-            return generation
+        generation.add_manager()
+        return generation
 
 
 def _current_workspace_file_generation(
@@ -450,25 +457,37 @@ def _discard_workspace_file_generation(
 def _release_workspace_file_generation(
     generation: _WorkspaceFileGeneration,
 ) -> None:
-    """Release one reader lease and arrange reliable generation cleanup."""
-    if not generation.remove_manager():
-        return
+    """Release one reader lease without doing cleanup in the finalizer."""
+    if generation.release_manager():
+        _WORKSPACE_FILE_CLEANUP_QUEUE.put(generation)
 
-    lock = _workspace_file_lock(generation.workspace_path)
-    if lock.acquire(blocking=False):
-        try:
-            _cleanup_workspace_file_generation_locked(generation)
-        finally:
-            lock.release()
-        return
 
-    if generation.schedule_cleanup():
-        threading.Thread(
-            target=_cleanup_workspace_file_generation,
-            args=(generation,),
+def _ensure_workspace_file_cleanup_worker() -> None:
+    """Start the shared workspace generation cleanup worker once."""
+    global _WORKSPACE_FILE_CLEANUP_WORKER
+
+    with _WORKSPACE_FILE_CLEANUP_WORKER_LOCK:
+        worker = _WORKSPACE_FILE_CLEANUP_WORKER
+        if worker is not None and worker.is_alive():
+            return
+        worker = threading.Thread(
+            target=_workspace_file_cleanup_worker,
             name="erlab-workspace-reader-cleanup",
             daemon=True,
-        ).start()
+        )
+        _WORKSPACE_FILE_CLEANUP_WORKER = worker
+        worker.start()
+
+
+def _workspace_file_cleanup_worker() -> None:
+    """Clean unused generations outside object finalizer call stacks."""
+    while True:
+        generation = _WORKSPACE_FILE_CLEANUP_QUEUE.get()
+        try:
+            _cleanup_workspace_file_generation(generation)
+        finally:
+            # Do not retain the last disposed generation while the queue is idle.
+            del generation
 
 
 def _cleanup_workspace_file_generation(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -288,7 +288,9 @@ class WorkspaceFileManager(CachingFileManager):
         self.close(needs_lock=False)
         self._retarget(
             generation.path,
-            ("erlab-workspace-generation", generation.path, "r+"),
+            # The cache key must retain the generation while its file handle is
+            # cached. Cleanup can then run only after xarray closes that handle.
+            ("erlab-workspace-generation", generation, generation.path, "r+"),
         )
         self._preserved_generation = generation
 

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -808,7 +808,7 @@ class _WorkspaceController:
                 node.slicer_area.state = state
                 node._set_name(name, manual=False)
 
-    def _refresh_workspace_payload_bindings_after_full_save(
+    def _refresh_workspace_payload_bindings_after_save(
         self,
         workspace_path: str | os.PathLike[str],
         *,
@@ -1402,6 +1402,7 @@ class _WorkspaceController:
     def _offload_targets_to_current_workspace(
         self, offload_targets: Iterable[int | str]
     ) -> bool:
+        offload_targets = tuple(offload_targets)
         workspace_path = self._manager._workspace_state.path
         if workspace_path is None:
             return False
@@ -1421,6 +1422,12 @@ class _WorkspaceController:
                     self.saving._workspace_root_attrs_payload(
                         delta_save_count=self._manager._workspace_state.delta_save_count
                     ),
+                )
+                # The metadata update publishes a new immutable generation.
+                self.loading._rebind_workspace_backed_imagetools(
+                    workspace_path,
+                    targets=offload_targets,
+                    chunks={},
                 )
             self._manager._status_bar.showMessage("Data offloaded to workspace", 5000)
         except Exception:
@@ -1605,20 +1612,20 @@ class _WorkspaceController:
             for event in post_save_events
             if event.uid is not None and (event.data or event.added)
         )
+        try:
+            self._refresh_workspace_payload_bindings_after_save(
+                workspace_path,
+                backing_snapshot=backing_snapshot,
+                old_workspace_path=old_workspace_path,
+                skip_live_data_rebind_uids=post_save_data_uids,
+            )
+        except _WorkspacePostSaveBindingError:
+            self._mark_workspace_post_save_binding_refresh_failed()
+            self._show_workspace_post_save_binding_error(workspace_path)
+            if restore_focus:
+                self._restore_focus_after_workspace_save(origin)
+            return False
         if snapshot.full_tree is not None:
-            try:
-                self._refresh_workspace_payload_bindings_after_full_save(
-                    workspace_path,
-                    backing_snapshot=backing_snapshot,
-                    old_workspace_path=old_workspace_path,
-                    skip_live_data_rebind_uids=post_save_data_uids,
-                )
-            except _WorkspacePostSaveBindingError:
-                self._mark_workspace_post_save_binding_refresh_failed()
-                self._show_workspace_post_save_binding_error(workspace_path)
-                if restore_focus:
-                    self._restore_focus_after_workspace_save(origin)
-                return False
             self._manager._workspace_state.schema_version = (
                 workspace_format._current_workspace_schema_version()
             )
@@ -1904,7 +1911,7 @@ class _WorkspaceController:
 
             if snapshot.full_tree is not None:
                 try:
-                    self._refresh_workspace_payload_bindings_after_full_save(
+                    self._refresh_workspace_payload_bindings_after_save(
                         access.path,
                         backing_snapshot=backing_snapshot,
                         old_workspace_path=old_workspace_path,
@@ -2025,7 +2032,7 @@ class _WorkspaceController:
                 workspace_path = self._manager._workspace_state.path
                 if workspace_path is not None:
                     try:
-                        self._refresh_workspace_payload_bindings_after_full_save(
+                        self._refresh_workspace_payload_bindings_after_save(
                             workspace_path
                         )
                     except _WorkspacePostSaveBindingError:
@@ -2093,7 +2100,7 @@ class _WorkspaceController:
                     require_matching_compression=True,
                     mark_clean=False,
                 )
-                self._refresh_workspace_payload_bindings_after_full_save(
+                self._refresh_workspace_payload_bindings_after_save(
                     workspace_path,
                     backing_snapshot=backing_snapshot,
                     old_workspace_path=old_workspace_path,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -87,6 +87,8 @@ class _WorkspaceSaveSnapshot:
 class _WorkspaceSaveError:
     traceback_text: str
     missing_source_path: str | None = None
+    access_denied_path: str | None = None
+    publication_conflict_path: str | None = None
 
 
 class _WorkspaceSaveWorkerSignals(QtCore.QObject):
@@ -160,6 +162,21 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
             error = _WorkspaceSaveError(
                 traceback_text=traceback.format_exc(),
                 missing_source_path=exc.source_path,
+            )
+        except workspace_storage._WorkspacePublicationConflictError as exc:
+            error = _WorkspaceSaveError(
+                traceback_text=traceback.format_exc(),
+                publication_conflict_path=exc.path,
+            )
+        except PermissionError as exc:
+            denied_path = (
+                getattr(exc, "filename2", None)
+                or exc.filename
+                or os.fsdecode(self._fname)
+            )
+            error = _WorkspaceSaveError(
+                traceback_text=traceback.format_exc(),
+                access_denied_path=os.fsdecode(denied_path),
             )
         except Exception:
             error = _WorkspaceSaveError(traceback_text=traceback.format_exc())

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -12,6 +12,7 @@ import shutil
 import stat
 import sys
 import tempfile
+import time
 import typing
 import uuid
 from dataclasses import dataclass
@@ -48,6 +49,7 @@ _WorkspaceCopyGroup: typing.TypeAlias = tuple[str, str, dict[str, typing.Any] | 
 _WorkspaceCopyGroupWithSource: typing.TypeAlias = tuple[
     str, str, str, dict[str, typing.Any] | None
 ]
+_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS = (0.02, 0.05, 0.1)
 
 
 class _WorkspaceBackingFileNotFoundError(FileNotFoundError):
@@ -222,6 +224,38 @@ def _workspace_path_is_high_risk(path: str | os.PathLike[str]) -> bool:
     return _workspace_path_is_likely_network_path(
         path
     ) or _workspace_path_is_likely_cloud_path(path)
+
+
+def _workspace_replace_retry_delays(exc: PermissionError) -> tuple[float, ...]:
+    if os.name != "nt":
+        return ()
+    if getattr(exc, "winerror", None) not in (None, 5, 32):
+        return ()
+    if exc.errno not in (None, errno.EACCES, errno.EPERM):
+        return ()
+    return _WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS
+
+
+def _replace_workspace_file(
+    source: str | os.PathLike[str], destination: str | os.PathLike[str]
+) -> None:
+    """Atomically replace a workspace after closing manager-owned readers."""
+    with workspace_arrays._workspace_file_lock(destination):
+        workspace_arrays._close_workspace_file_managers(destination)
+        retry_delays: tuple[float, ...] | None = None
+        while True:
+            try:
+                os.replace(source, destination)
+            except PermissionError as exc:
+                if retry_delays is None:
+                    retry_delays = _workspace_replace_retry_delays(exc)
+                if not retry_delays:
+                    raise
+                delay, *remaining_delays = retry_delays
+                retry_delays = tuple(remaining_delays)
+                time.sleep(delay)
+            else:
+                break
 
 
 def _workspace_use_incremental_enabled() -> bool:
@@ -777,17 +811,17 @@ def _write_full_workspace_tree_file(
         _fsync_file(tmp_fname)
         if use_scratch:
             try:
-                os.replace(tmp_fname, fname)
+                _replace_workspace_file(tmp_fname, fname)
             except OSError as err:
                 if err.errno != errno.EXDEV:
                     raise
                 destination_tmp = f"{fname}.tmp-{uuid.uuid4().hex}"
                 shutil.copyfile(tmp_fname, destination_tmp)
                 _fsync_file(destination_tmp)
-                os.replace(destination_tmp, fname)
+                _replace_workspace_file(destination_tmp, fname)
             _fsync_parent_directory(fname)
         else:
-            os.replace(tmp_fname, fname)
+            _replace_workspace_file(tmp_fname, fname)
             _fsync_parent_directory(fname)
     finally:
         with contextlib.suppress(FileNotFoundError):

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -92,13 +92,65 @@ class _PreservedWorkspaceFile:
 def _open_workspace_h5_file_for_update(
     fname: str | os.PathLike[str],
 ) -> Iterator[typing.Any]:
-    """Open a private workspace successor for mutation.
-
-    Published workspace files must not use this helper. High-level writers first
-    copy the published generation to a private successor and publish it atomically.
-    """
+    """Open a workspace file for mutation while its process lock is held."""
     with workspace_arrays._workspace_file_lock(fname), h5py.File(fname, "a") as h5_file:
         yield h5_file
+
+
+@contextlib.contextmanager
+def _workspace_in_place_update(
+    fname: str | os.PathLike[str],
+    *,
+    rewrite_groups: Iterable[str] = (),
+) -> Iterator[None]:
+    """Coordinate one recoverable in-place workspace update."""
+    with workspace_arrays._workspace_file_lock(fname):
+        generation = workspace_arrays._current_workspace_file_generation(fname)
+        initial_state = workspace_arrays._workspace_file_state(fname)
+        if generation is not None:
+            generation.close(needs_lock=False)
+            workspace_arrays._detach_workspace_file_generation_readers(
+                fname, rewrite_groups
+            )
+
+        body_error: BaseException | None = None
+        try:
+            yield
+        except BaseException as exc:
+            body_error = exc
+            raise
+        finally:
+            current_generation = workspace_arrays._current_workspace_file_generation(
+                fname
+            )
+            current_identity, current_exists = workspace_arrays._workspace_file_state(
+                fname
+            )
+            initial_identity, initial_exists = initial_state
+            same_file = (
+                initial_exists
+                and current_exists
+                and current_identity[1:3] == initial_identity[1:3]
+            )
+            if generation is not None and current_generation is generation:
+                if same_file:
+                    generation.refresh_in_place(current_identity)
+                else:
+                    generation.invalidate(
+                        "Workspace file changed during an in-place save: "
+                        f"{os.fsdecode(fname)}"
+                    )
+                    workspace_arrays._discard_workspace_file_generation(
+                        fname, generation
+                    )
+                    if body_error is None:
+                        raise _WorkspacePublicationConflictError(
+                            fname, "Workspace changed during its in-place save"
+                        )
+            elif not same_file and body_error is None:
+                raise _WorkspacePublicationConflictError(
+                    fname, "Workspace changed during its in-place save"
+                )
 
 
 def _iter_exception_chain(exc: BaseException) -> Iterator[BaseException]:
@@ -344,78 +396,6 @@ def _replace_workspace_file(
                 generation.dispose()
 
 
-@contextlib.contextmanager
-def _workspace_successor_file(
-    fname: str | os.PathLike[str],
-) -> Iterator[tuple[str, tuple[tuple[str, int, int, int], bool]]]:
-    """Copy one published workspace generation to a private successor."""
-    fname = os.fsdecode(fname)
-    tmp_dir: tempfile.TemporaryDirectory[str] | None = None
-    if _workspace_path_is_high_risk(fname):
-        tmp_dir = tempfile.TemporaryDirectory(prefix="erlab-itws-successor-")
-        successor = str(pathlib.Path(tmp_dir.name) / pathlib.Path(fname).name)
-    else:
-        successor = str(
-            pathlib.Path(fname).with_name(
-                f".{pathlib.Path(fname).name}.next-{uuid.uuid4().hex}.itws"
-            )
-        )
-
-    try:
-        with workspace_arrays._workspace_file_lock(fname):
-            generation = workspace_arrays._current_workspace_file_generation(fname)
-            if generation is not None:
-                generation.close(needs_lock=False)
-            expected_state = workspace_arrays._workspace_file_state(fname)
-            source_identity, source_exists = expected_state
-            if not source_exists:
-                raise FileNotFoundError(
-                    errno.ENOENT, "Workspace file is missing", fname
-                )
-            shutil.copyfile(fname, successor)
-            source_identity_after = workspace_arrays._workspace_file_identity(fname)
-            if source_identity_after[1:] != source_identity[1:]:
-                raise _WorkspacePublicationConflictError(
-                    fname, "Workspace changed while its successor was copied"
-                )
-        yield successor, expected_state
-    finally:
-        with contextlib.suppress(FileNotFoundError):
-            os.remove(successor)
-        if tmp_dir is not None:
-            tmp_dir.cleanup()
-
-
-def _publish_workspace_successor(
-    successor: str | os.PathLike[str],
-    fname: str | os.PathLike[str],
-    expected_state: tuple[tuple[str, int, int, int], bool],
-) -> None:
-    """Validate, sync, and atomically publish one private successor."""
-    fname = os.fsdecode(fname)
-    successor = os.fsdecode(successor)
-    destination_tmp: str | None = None
-    _validate_workspace_h5_file(successor)
-    _fsync_file(successor)
-    try:
-        try:
-            _replace_workspace_file(successor, fname, expected_state=expected_state)
-        except OSError as err:
-            if err.errno != errno.EXDEV:
-                raise
-            destination_tmp = f"{fname}.tmp-{uuid.uuid4().hex}"
-            shutil.copyfile(successor, destination_tmp)
-            _fsync_file(destination_tmp)
-            _replace_workspace_file(
-                destination_tmp, fname, expected_state=expected_state
-            )
-        _fsync_parent_directory(fname)
-    finally:
-        if destination_tmp is not None:
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(destination_tmp)
-
-
 def _workspace_use_incremental_enabled() -> bool:
     return bool(erlab.interactive.options.model.io.workspace.use_incremental)
 
@@ -588,9 +568,8 @@ def _cleanup_orphan_workspace_internal_groups(h5_file) -> None:
 def _workspace_transaction_recovery_needed(
     fname: str | os.PathLike[str],
 ) -> bool:
-    if not pathlib.Path(fname).exists():
-        return False
-    if not _workspace_path_is_itws(fname):
+    """Return True when a workspace contains unfinished transaction state."""
+    if not pathlib.Path(fname).exists() or not _workspace_path_is_itws(fname):
         return False
     with workspace_arrays._workspace_file_lock(fname):
         generation = workspace_arrays._current_workspace_file_generation(fname)
@@ -614,7 +593,7 @@ def _workspace_transaction_recovery_needed(
 def _recover_workspace_transactions_in_place(
     fname: str | os.PathLike[str],
 ) -> None:
-    """Recover transaction state in an unpublished workspace successor."""
+    """Recover transaction state while the workspace update lock is held."""
     with _open_workspace_h5_file_for_update(fname) as h5_file:
         if not _workspace_file_is_workspace(h5_file):
             return
@@ -628,9 +607,9 @@ def _recover_workspace_transactions_in_place(
 def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
     if not _workspace_transaction_recovery_needed(fname):
         return
-    with _workspace_successor_file(fname) as (successor, expected_state):
-        _recover_workspace_transactions_in_place(successor)
-        _publish_workspace_successor(successor, fname, expected_state)
+    with _workspace_in_place_update(fname):
+        _recover_workspace_transactions_in_place(fname)
+        _fsync_file(fname)
 
 
 def _write_root_attrs_to_open_workspace_file(
@@ -652,12 +631,7 @@ def _write_workspace_root_attrs_to_file(
     *,
     replace: bool = False,
 ) -> None:
-    _recover_workspace_transactions(fname)
-    with _workspace_successor_file(fname) as (successor, expected_state):
-        with _open_workspace_h5_file_for_update(successor) as h5_file:
-            _write_root_attrs_to_open_workspace_file(h5_file, attrs, replace=replace)
-            h5_file.flush()
-        _publish_workspace_successor(successor, fname, expected_state)
+    _write_workspace_root_attrs_transaction_file(fname, attrs, replace=replace)
 
 
 def _workspace_obsolete_estimate(
@@ -721,6 +695,33 @@ def _path_is_at_or_under(path: str, root_path: str) -> bool:
     path = path.strip("/")
     root_path = root_path.strip("/")
     return path == root_path or path.startswith(f"{root_path}/")
+
+
+def _workspace_missing_attr_fallback_groups(
+    fname: str | os.PathLike[str],
+    rewrite_paths: Iterable[str],
+    attr_updates: Iterable[
+        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
+    ],
+) -> tuple[str, ...]:
+    """Return fallback groups needed for missing attribute targets."""
+    initial_paths = tuple(path.strip("/") for path in rewrite_paths)
+    required_paths = set(initial_paths)
+    with h5py.File(fname, "r") as h5_file:
+        for payload_path, _attrs, fallback in attr_updates:
+            attr_path = payload_path.strip("/")
+            if any(
+                _path_is_at_or_under(attr_path, rewrite_path)
+                for rewrite_path in required_paths
+            ):
+                continue
+            fallback_path = fallback[0].strip("/")
+            if attr_path not in h5_file and not any(
+                _path_is_at_or_under(fallback_path, rewrite_path)
+                for rewrite_path in required_paths
+            ):
+                required_paths.add(fallback_path)
+    return tuple(sorted(required_paths.difference(initial_paths)))
 
 
 def _move_h5_path(h5_file, source_path: str, destination_path: str) -> None:
@@ -837,6 +838,8 @@ def _commit_workspace_transaction(
         tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
     ],
     root_attrs: Mapping[str, typing.Any],
+    *,
+    replace_root_attrs: bool = False,
 ) -> None:
     with _open_workspace_h5_file_for_update(fname) as h5_file:
         _set_workspace_transaction_status(h5_file, txn_path, "committing")
@@ -857,8 +860,50 @@ def _commit_workspace_transaction(
             if target_attrs is not None:
                 workspace_arrays._replace_h5_attrs(target_attrs, attrs)
 
-        _write_root_attrs_to_open_workspace_file(h5_file, root_attrs)
+        _write_root_attrs_to_open_workspace_file(
+            h5_file, root_attrs, replace=replace_root_attrs
+        )
         _set_workspace_transaction_status(h5_file, txn_path, "committed")
+
+
+def _write_workspace_root_attrs_transaction_file(
+    fname: str | os.PathLike[str],
+    attrs: Mapping[str, typing.Any],
+    *,
+    replace: bool,
+) -> None:
+    """Write root attributes through the recoverable transaction protocol."""
+    _recover_workspace_transactions(fname)
+    txn_id = uuid.uuid4().hex
+    txn_path = f"{_WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
+    pending_root = f"{_WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
+    backup_root = f"{_WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
+    with _workspace_in_place_update(fname):
+        try:
+            group_operations, attr_updates = _prepare_workspace_transaction(
+                fname,
+                txn_path,
+                pending_root,
+                backup_root,
+                {},
+                (),
+                attrs,
+            )
+            _commit_workspace_transaction(
+                fname,
+                txn_path,
+                group_operations,
+                attr_updates,
+                attrs,
+                replace_root_attrs=replace,
+            )
+        except BaseException:
+            with contextlib.suppress(Exception):
+                _recover_workspace_transactions_in_place(fname)
+                _fsync_file(fname)
+            raise
+        _recover_workspace_transactions_in_place(fname)
+        _fsync_file(fname)
 
 
 def _write_workspace_transaction_file(
@@ -871,62 +916,54 @@ def _write_workspace_transaction_file(
     *,
     compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
-    """Publish one copy-on-write workspace update.
-
-    Recovery of legacy transaction groups happens before the copy. All new changes
-    are then made only in the unpublished successor, so a failed update needs no
-    rollback and cannot expose partial groups in the canonical file.
-    """
+    """Write one recoverable incremental workspace transaction."""
     _recover_workspace_transactions(fname)
-    with _workspace_successor_file(fname) as (successor, expected_state):
-        rewrite_map = {
-            group_path.strip("/"): (group_path, constructor)
-            for group_path, constructor in rewrite_groups
-        }
-        attr_updates_to_write: list[
-            tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
-        ] = []
-        with _open_workspace_h5_file_for_update(successor) as h5_file:
-            for payload_path, attrs, fallback in attr_updates:
-                attr_path = payload_path.strip("/")
-                if any(
-                    _path_is_at_or_under(attr_path, rewrite_path)
-                    for rewrite_path in rewrite_map
-                ):
-                    continue
-                if attr_path in h5_file:
-                    attr_updates_to_write.append((payload_path, attrs, fallback))
-                    continue
-                fallback_path = fallback[0].strip("/")
-                if not any(
-                    _path_is_at_or_under(fallback_path, rewrite_path)
-                    for rewrite_path in rewrite_map
-                ):
-                    rewrite_map[fallback_path] = fallback
-
-            for group_path in sorted(rewrite_map):
-                workspace_arrays._delete_h5_path(h5_file, group_path)
-            h5_file.flush()
-
-        for group_path, (rewrite_group_path, constructor) in sorted(
-            rewrite_map.items()
-        ):
-            _write_workspace_constructor_groups_to_path(
-                successor,
-                constructor,
-                rewrite_group_path,
-                group_path,
+    rewrite_map = {
+        group_path.strip("/"): (group_path, constructor)
+        for group_path, constructor in rewrite_groups
+    }
+    attr_updates_tuple = tuple(attr_updates)
+    txn_id = uuid.uuid4().hex
+    txn_path = f"{_WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
+    pending_root = f"{_WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
+    backup_root = f"{_WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
+    with _workspace_in_place_update(fname, rewrite_groups=rewrite_map):
+        try:
+            missing_fallback_groups = _workspace_missing_attr_fallback_groups(
+                fname, rewrite_map, attr_updates_tuple
+            )
+            workspace_arrays._detach_workspace_file_generation_readers(
+                fname, missing_fallback_groups
+            )
+            group_operations, attr_updates_to_write = _prepare_workspace_transaction(
+                fname,
+                txn_path,
+                pending_root,
+                backup_root,
+                rewrite_map,
+                attr_updates_tuple,
+                root_attrs,
+            )
+            _write_workspace_transaction_pending_groups(
+                fname,
+                rewrite_map,
+                pending_root,
                 compression_mode=compression_mode,
             )
-
-        with _open_workspace_h5_file_for_update(successor) as h5_file:
-            for payload_path, attrs, _fallback in attr_updates_to_write:
-                target_attrs = _workspace_txn_attr_target(h5_file, payload_path)
-                if target_attrs is not None:
-                    workspace_arrays._replace_h5_attrs(target_attrs, attrs)
-            _write_root_attrs_to_open_workspace_file(h5_file, root_attrs)
-            h5_file.flush()
-        _publish_workspace_successor(successor, fname, expected_state)
+            _commit_workspace_transaction(
+                fname,
+                txn_path,
+                group_operations,
+                attr_updates_to_write,
+                root_attrs,
+            )
+        except BaseException:
+            with contextlib.suppress(Exception):
+                _recover_workspace_transactions_in_place(fname)
+                _fsync_file(fname)
+            raise
+        _recover_workspace_transactions_in_place(fname)
+        _fsync_file(fname)
 
 
 def _write_full_workspace_tree_file(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -241,7 +241,7 @@ def _replace_workspace_file(
 ) -> None:
     """Atomically replace a workspace after closing manager-owned readers."""
     with workspace_arrays._workspace_file_lock(destination):
-        workspace_arrays._close_workspace_file_managers(destination)
+        managers = workspace_arrays._close_workspace_file_managers(destination)
         retry_delays: tuple[float, ...] | None = None
         while True:
             try:
@@ -256,6 +256,9 @@ def _replace_workspace_file(
                 time.sleep(delay)
             else:
                 break
+        # A stale lazy graph must not reopen the new file with old metadata.
+        for manager in managers:
+            manager._mark_file_replaced()
 
 
 def _workspace_use_incremental_enabled() -> bool:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -270,11 +270,14 @@ def _replace_workspace_file(
 ) -> None:
     """Atomically replace a workspace and preserve active reader generations."""
     with workspace_arrays._workspace_file_lock(destination):
-        managers = workspace_arrays._detach_workspace_file_managers(destination)
+        managers, cache_keys = workspace_arrays._detach_workspace_file_readers(
+            destination
+        )
         generation: workspace_arrays._WorkspaceFileGeneration | None = None
         try:
             if managers and pathlib.Path(destination).is_file():
                 generation = _preserve_workspace_file_generation(destination)
+            workspace_arrays._close_workspace_file_cache_entries(cache_keys)
             for manager in managers:
                 if generation is None:
                     manager.close(needs_lock=False)
@@ -296,10 +299,14 @@ def _replace_workspace_file(
                 else:
                     break
         except BaseException:
-            workspace_arrays._restore_workspace_file_managers(destination, managers)
+            workspace_arrays._restore_workspace_file_readers(
+                destination, managers, cache_keys
+            )
             raise
         if generation is None:
-            workspace_arrays._restore_workspace_file_managers(destination, managers)
+            workspace_arrays._restore_workspace_file_readers(
+                destination, managers, cache_keys
+            )
         else:
             # A hard link shares file attributes with the original workspace.
             # Hide it only after the destination refers to the new file.

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -257,7 +257,6 @@ def _preserve_workspace_file_generation(
             raise
         cleanup = temporary_directory.cleanup
     else:
-        _hide_workspace_lock_file(str(generation_path))
 
         def cleanup() -> None:
             with contextlib.suppress(OSError):
@@ -301,6 +300,10 @@ def _replace_workspace_file(
             raise
         if generation is None:
             workspace_arrays._restore_workspace_file_managers(destination, managers)
+        else:
+            # A hard link shares file attributes with the original workspace.
+            # Hide it only after the destination refers to the new file.
+            _hide_workspace_lock_file(generation.path)
 
 
 def _workspace_use_incremental_enabled() -> bool:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -73,6 +73,15 @@ class _WorkspaceDocumentLockInfo:
     pid: int | None
 
 
+@dataclass(frozen=True)
+class _PreservedWorkspaceFile:
+    """A private file that keeps one retired workspace generation available."""
+
+    path: str
+    cleanup: Callable[[], None]
+    hide_after_publish: bool = False
+
+
 @contextlib.contextmanager
 def _open_workspace_h5_file_for_update(
     fname: str | os.PathLike[str],
@@ -121,12 +130,12 @@ def _workspace_lock_path(fname: str | os.PathLike[str]) -> str:
     return str(workspace_path.with_name(f".{workspace_path.name}.lock"))
 
 
-def _hide_workspace_lock_file(lock_path: str) -> None:
+def _hide_workspace_internal_file(path: str) -> None:
     if sys.platform == "darwin":
         with contextlib.suppress(AttributeError, OSError):
-            if not stat.S_ISREG(os.lstat(lock_path).st_mode):
+            if not stat.S_ISREG(os.lstat(path).st_mode):
                 return
-            os.chflags(lock_path, stat.UF_HIDDEN)
+            os.chflags(path, stat.UF_HIDDEN)
         return
     if os.name != "nt":
         return
@@ -136,7 +145,7 @@ def _hide_workspace_lock_file(lock_path: str) -> None:
         if windll is None:
             return
         windll.kernel32.SetFileAttributesW(
-            str(lock_path),
+            str(path),
             0x2,  # FILE_ATTRIBUTE_HIDDEN
         )
 
@@ -179,7 +188,7 @@ def _acquire_workspace_document_lock(
             errno.EAGAIN,
             f"Workspace file is already open or locked: {fname}",
         )
-    _hide_workspace_lock_file(lock_path)
+    _hide_workspace_internal_file(lock_path)
     return lock
 
 
@@ -238,22 +247,33 @@ def _workspace_replace_retry_delays(exc: PermissionError) -> tuple[float, ...]:
 
 def _preserve_workspace_file_generation(
     path: str | os.PathLike[str],
-) -> tuple[str, Callable[[], None]]:
+) -> _PreservedWorkspaceFile:
     """Preserve one workspace generation for existing lazy readers."""
-    source = pathlib.Path(path)
-    # Keep old generations outside the workspace directory. This prevents
-    # visible artifacts and lets TemporaryDirectory own all cleanup paths.
-    temporary_directory = tempfile.TemporaryDirectory(prefix="erlab-workspace-read-")
-    generation_path = pathlib.Path(temporary_directory.name) / "workspace.itws"
+    source = pathlib.Path(path).resolve()
+    generation_path = source.with_name(f".{source.name}.read-{uuid.uuid4().hex}")
     try:
         os.link(source, generation_path)
     except OSError:
-        try:
-            shutil.copyfile(source, generation_path)
-        except BaseException:
-            temporary_directory.cleanup()
-            raise
-    return str(generation_path), temporary_directory.cleanup
+        pass
+    else:
+        return _PreservedWorkspaceFile(
+            path=str(generation_path),
+            cleanup=lambda: generation_path.unlink(missing_ok=True),
+            hide_after_publish=True,
+        )
+
+    # Some filesystems do not support hard links. Copy to private temporary
+    # storage only after the same-filesystem hard-link attempt fails.
+    temporary_directory = tempfile.TemporaryDirectory(prefix="erlab-workspace-read-")
+    generation_path = pathlib.Path(temporary_directory.name) / "workspace.itws"
+    try:
+        shutil.copyfile(source, generation_path)
+    except BaseException:
+        temporary_directory.cleanup()
+        raise
+    return _PreservedWorkspaceFile(
+        path=str(generation_path), cleanup=temporary_directory.cleanup
+    )
 
 
 def _replace_workspace_file(
@@ -263,12 +283,12 @@ def _replace_workspace_file(
     with workspace_arrays._workspace_file_lock(destination):
         generation = workspace_arrays._current_workspace_file_generation(destination)
         generation_has_managers = generation is not None and generation.has_managers()
-        preserved: tuple[str, Callable[[], None]] | None = None
-        if generation_has_managers and pathlib.Path(destination).is_file():
-            preserved = _preserve_workspace_file_generation(destination)
+        preserved: _PreservedWorkspaceFile | None = None
         try:
             if generation is not None:
                 generation.close(needs_lock=False)
+            if generation_has_managers and pathlib.Path(destination).is_file():
+                preserved = _preserve_workspace_file_generation(destination)
 
             retry_delays: tuple[float, ...] | None = None
             while True:
@@ -287,16 +307,18 @@ def _replace_workspace_file(
         except BaseException:
             if preserved is not None:
                 with contextlib.suppress(Exception):
-                    preserved[1]()
+                    preserved.cleanup()
             raise
 
         if generation is not None:
             if preserved is not None:
+                if preserved.hide_after_publish:
+                    _hide_workspace_internal_file(preserved.path)
                 workspace_arrays._retire_workspace_file_generation(
                     destination,
                     generation,
-                    preserved[0],
-                    preserved[1],
+                    preserved.path,
+                    preserved.cleanup,
                 )
             elif generation_has_managers:
                 generation.refresh_file_identity()
@@ -304,6 +326,7 @@ def _replace_workspace_file(
                 workspace_arrays._discard_workspace_file_generation(
                     destination, generation
                 )
+                generation.dispose()
 
 
 def _workspace_use_incremental_enabled() -> bool:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -327,6 +327,15 @@ def _preserve_workspace_file_generation(
     )
 
 
+def _validate_workspace_publication_state(
+    path: str | os.PathLike[str],
+    expected_state: tuple[tuple[str, int, int, int], bool],
+    message: str,
+) -> None:
+    if workspace_arrays._workspace_file_state(path) != expected_state:
+        raise _WorkspacePublicationConflictError(path, message)
+
+
 def _replace_workspace_file(
     source: str | os.PathLike[str],
     destination: str | os.PathLike[str],
@@ -360,6 +369,11 @@ def _replace_workspace_file(
 
             retry_delays: tuple[float, ...] | None = None
             while True:
+                _validate_workspace_publication_state(
+                    destination,
+                    current_state,
+                    "Workspace changed while replacement was waiting for access",
+                )
                 try:
                     os.replace(source, destination)
                 except PermissionError as exc:
@@ -374,8 +388,21 @@ def _replace_workspace_file(
                     break
         except BaseException:
             if preserved is not None:
-                with contextlib.suppress(Exception):
-                    preserved.cleanup()
+                if (
+                    generation is not None
+                    and workspace_arrays._workspace_file_state(destination)
+                    != current_state
+                ):
+                    workspace_arrays._retire_workspace_file_generation(
+                        destination,
+                        generation,
+                        preserved.path,
+                        preserved.file_identity,
+                        preserved.cleanup,
+                    )
+                else:
+                    with contextlib.suppress(Exception):
+                        preserved.cleanup()
             raise
 
         if generation is not None:
@@ -691,6 +718,41 @@ def _write_workspace_constructor_groups_to_path(
         )
 
 
+def _materialize_workspace_constructor_sources(
+    fname: str | os.PathLike[str],
+    rewrite_map: Mapping[str, tuple[str, dict[str, xr.Dataset]]],
+) -> None:
+    """Load constructor data that reads from the file about to be mutated."""
+    normalized_path = workspace_arrays._normalized_file_path(fname)
+    materialized: dict[int, xr.Dataset] = {}
+    for _group_path, constructor in rewrite_map.values():
+        for constructor_group_path, ds in tuple(constructor.items()):
+            loaded_ds = materialized.get(id(ds))
+            if loaded_ds is not None:
+                constructor[constructor_group_path] = loaded_ds
+                continue
+            if normalized_path is not None and any(
+                normalized_path in workspace_arrays.dataarray_source_paths(data_array)
+                for data_array in (*ds.data_vars.values(), *ds.coords.values())
+            ):
+                variable_chunks: dict[typing.Hashable, tuple[int, ...]] = {}
+                for name, data_array in ds.data_vars.items():
+                    chunksizes = workspace_arrays._workspace_chunksizes_for_dataarray(
+                        data_array
+                    )
+                    if chunksizes is not None:
+                        variable_chunks[name] = chunksizes
+                loaded_ds = ds.compute()
+                for name, chunksizes in variable_chunks.items():
+                    loaded_ds[name].encoding[
+                        workspace_arrays._WORKSPACE_MATERIALIZED_CHUNKSIZES
+                    ] = chunksizes
+                for variable in loaded_ds.variables.values():
+                    variable.encoding.pop("source", None)
+                materialized[id(ds)] = loaded_ds
+                constructor[constructor_group_path] = loaded_ds
+
+
 def _path_is_at_or_under(path: str, root_path: str) -> bool:
     path = path.strip("/")
     root_path = root_path.strip("/")
@@ -932,9 +994,18 @@ def _write_workspace_transaction_file(
             missing_fallback_groups = _workspace_missing_attr_fallback_groups(
                 fname, rewrite_map, attr_updates_tuple
             )
+            missing_fallback_group_set = set(missing_fallback_groups)
+            for _payload_path, _attrs, fallback in attr_updates_tuple:
+                fallback_path = fallback[0].strip("/")
+                if fallback_path in missing_fallback_group_set:
+                    rewrite_map[fallback_path] = fallback
             workspace_arrays._detach_workspace_file_generation_readers(
                 fname, missing_fallback_groups
             )
+            _materialize_workspace_constructor_sources(fname, rewrite_map)
+            generation = workspace_arrays._current_workspace_file_generation(fname)
+            if generation is not None:
+                generation.close(needs_lock=False)
             group_operations, attr_updates_to_write = _prepare_workspace_transaction(
                 fname,
                 txn_path,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -33,7 +33,7 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping
+    from collections.abc import Callable, Iterable, Iterator, Mapping
 
     import h5py
     import xarray as xr
@@ -238,31 +238,22 @@ def _workspace_replace_retry_delays(exc: PermissionError) -> tuple[float, ...]:
 
 def _preserve_workspace_file_generation(
     path: str | os.PathLike[str],
-) -> workspace_arrays._WorkspaceFileGeneration:
+) -> tuple[str, Callable[[], None]]:
     """Preserve one workspace generation for existing lazy readers."""
     source = pathlib.Path(path)
-    generation_path = source.with_name(f".{uuid.uuid4().hex}.erlab-workspace-read")
-
+    # Keep old generations outside the workspace directory. This prevents
+    # visible artifacts and lets TemporaryDirectory own all cleanup paths.
+    temporary_directory = tempfile.TemporaryDirectory(prefix="erlab-workspace-read-")
+    generation_path = pathlib.Path(temporary_directory.name) / "workspace.itws"
     try:
         os.link(source, generation_path)
     except OSError:
-        temporary_directory = tempfile.TemporaryDirectory(
-            prefix="erlab-workspace-read-"
-        )
-        generation_path = pathlib.Path(temporary_directory.name) / "workspace.itws"
         try:
             shutil.copyfile(source, generation_path)
         except BaseException:
             temporary_directory.cleanup()
             raise
-        cleanup = temporary_directory.cleanup
-    else:
-
-        def cleanup() -> None:
-            with contextlib.suppress(OSError):
-                os.remove(generation_path)
-
-    return workspace_arrays._WorkspaceFileGeneration(generation_path, cleanup)
+    return str(generation_path), temporary_directory.cleanup
 
 
 def _replace_workspace_file(
@@ -270,19 +261,14 @@ def _replace_workspace_file(
 ) -> None:
     """Atomically replace a workspace and preserve active reader generations."""
     with workspace_arrays._workspace_file_lock(destination):
-        managers, cache_keys = workspace_arrays._detach_workspace_file_readers(
-            destination
-        )
-        generation: workspace_arrays._WorkspaceFileGeneration | None = None
+        generation = workspace_arrays._current_workspace_file_generation(destination)
+        generation_has_managers = generation is not None and generation.has_managers()
+        preserved: tuple[str, Callable[[], None]] | None = None
+        if generation_has_managers and pathlib.Path(destination).is_file():
+            preserved = _preserve_workspace_file_generation(destination)
         try:
-            if managers and pathlib.Path(destination).is_file():
-                generation = _preserve_workspace_file_generation(destination)
-            workspace_arrays._close_workspace_file_cache_entries(cache_keys)
-            for manager in managers:
-                if generation is None:
-                    manager.close(needs_lock=False)
-                else:
-                    manager._use_preserved_generation(generation)
+            if generation is not None:
+                generation.close(needs_lock=False)
 
             retry_delays: tuple[float, ...] | None = None
             while True:
@@ -299,18 +285,25 @@ def _replace_workspace_file(
                 else:
                     break
         except BaseException:
-            workspace_arrays._restore_workspace_file_readers(
-                destination, managers, cache_keys
-            )
+            if preserved is not None:
+                with contextlib.suppress(Exception):
+                    preserved[1]()
             raise
-        if generation is None:
-            workspace_arrays._restore_workspace_file_readers(
-                destination, managers, cache_keys
-            )
-        else:
-            # A hard link shares file attributes with the original workspace.
-            # Hide it only after the destination refers to the new file.
-            _hide_workspace_lock_file(generation.path)
+
+        if generation is not None:
+            if preserved is not None:
+                workspace_arrays._retire_workspace_file_generation(
+                    destination,
+                    generation,
+                    preserved[0],
+                    preserved[1],
+                )
+            elif generation_has_managers:
+                generation.refresh_file_identity()
+            else:
+                workspace_arrays._discard_workspace_file_generation(
+                    destination, generation
+                )
 
 
 def _workspace_use_incremental_enabled() -> bool:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import contextlib
-import ctypes
 import errno
 import json
 import os
 import pathlib
 import shutil
-import stat
 import sys
 import tempfile
 import time
@@ -49,7 +47,7 @@ _WorkspaceCopyGroup: typing.TypeAlias = tuple[str, str, dict[str, typing.Any] | 
 _WorkspaceCopyGroupWithSource: typing.TypeAlias = tuple[
     str, str, str, dict[str, typing.Any] | None
 ]
-_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS = (0.02, 0.05, 0.1)
+_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 
 
 class _WorkspaceBackingFileNotFoundError(FileNotFoundError):
@@ -62,6 +60,14 @@ class _WorkspaceBackingFileNotFoundError(FileNotFoundError):
             "Workspace backing file is missing",
             self.source_path,
         )
+
+
+class _WorkspacePublicationConflictError(RuntimeError):
+    """A workspace changed before its prepared successor could be published."""
+
+    def __init__(self, path: str | os.PathLike[str], message: str) -> None:
+        self.path = os.fsdecode(path)
+        super().__init__(f"{message}: {self.path}")
 
 
 @dataclass(frozen=True)
@@ -78,14 +84,19 @@ class _PreservedWorkspaceFile:
     """A private file that keeps one retired workspace generation available."""
 
     path: str
+    file_identity: tuple[str, int, int, int]
     cleanup: Callable[[], None]
-    hide_after_publish: bool = False
 
 
 @contextlib.contextmanager
 def _open_workspace_h5_file_for_update(
     fname: str | os.PathLike[str],
 ) -> Iterator[typing.Any]:
+    """Open a private workspace successor for mutation.
+
+    Published workspace files must not use this helper. High-level writers first
+    copy the published generation to a private successor and publish it atomically.
+    """
     with workspace_arrays._workspace_file_lock(fname), h5py.File(fname, "a") as h5_file:
         yield h5_file
 
@@ -131,23 +142,7 @@ def _workspace_lock_path(fname: str | os.PathLike[str]) -> str:
 
 
 def _hide_workspace_internal_file(path: str) -> None:
-    if sys.platform == "darwin":
-        with contextlib.suppress(AttributeError, OSError):
-            if not stat.S_ISREG(os.lstat(path).st_mode):
-                return
-            os.chflags(path, stat.UF_HIDDEN)
-        return
-    if os.name != "nt":
-        return
-
-    with contextlib.suppress(Exception):
-        windll = getattr(ctypes, "windll", None)
-        if windll is None:
-            return
-        windll.kernel32.SetFileAttributesW(
-            str(path),
-            0x2,  # FILE_ATTRIBUTE_HIDDEN
-        )
+    workspace_arrays._hide_workspace_internal_path(path)
 
 
 def _workspace_document_lock_info(
@@ -188,6 +183,8 @@ def _acquire_workspace_document_lock(
             errno.EAGAIN,
             f"Workspace file is already open or locked: {fname}",
         )
+    with contextlib.suppress(Exception):
+        workspace_arrays._cleanup_stale_workspace_reader_files(fname)
     _hide_workspace_internal_file(lock_path)
     return lock
 
@@ -247,48 +244,67 @@ def _workspace_replace_retry_delays(exc: PermissionError) -> tuple[float, ...]:
 
 def _preserve_workspace_file_generation(
     path: str | os.PathLike[str],
+    expected_identity: tuple[str, int, int, int],
 ) -> _PreservedWorkspaceFile:
     """Preserve one workspace generation for existing lazy readers."""
-    source = pathlib.Path(path).resolve()
-    generation_path = source.with_name(f".{source.name}.read-{uuid.uuid4().hex}")
-    try:
-        os.link(source, generation_path)
-    except OSError:
-        pass
-    else:
-        return _PreservedWorkspaceFile(
-            path=str(generation_path),
-            cleanup=lambda: generation_path.unlink(missing_ok=True),
-            hide_after_publish=True,
+    source_identity, source_exists = workspace_arrays._workspace_file_state(path)
+    if not source_exists:
+        raise FileNotFoundError(errno.ENOENT, "Workspace file is missing", path)
+    if source_identity[1:] != expected_identity[1:]:
+        raise _WorkspacePublicationConflictError(
+            path, "Workspace changed before it could be preserved"
         )
 
-    # Some filesystems do not support hard links. Copy to private temporary
-    # storage only after the same-filesystem hard-link attempt fails.
-    temporary_directory = tempfile.TemporaryDirectory(prefix="erlab-workspace-read-")
-    generation_path = pathlib.Path(temporary_directory.name) / "workspace.itws"
+    reader_file = workspace_arrays._create_workspace_reader_file(path, path)
+    cleanup = reader_file.cleanup
     try:
-        shutil.copyfile(source, generation_path)
+        source_identity_after = workspace_arrays._workspace_file_identity(path)
+        preserved_identity = workspace_arrays._workspace_file_identity(reader_file.path)
     except BaseException:
-        temporary_directory.cleanup()
+        cleanup()
         raise
+    if source_identity_after[1:] != source_identity[1:]:
+        cleanup()
+        raise _WorkspacePublicationConflictError(
+            path, "Workspace changed while it was being preserved"
+        )
     return _PreservedWorkspaceFile(
-        path=str(generation_path), cleanup=temporary_directory.cleanup
+        path=reader_file.path,
+        file_identity=preserved_identity,
+        cleanup=cleanup,
     )
 
 
 def _replace_workspace_file(
-    source: str | os.PathLike[str], destination: str | os.PathLike[str]
+    source: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    *,
+    expected_state: tuple[tuple[str, int, int, int], bool] | None = None,
 ) -> None:
     """Atomically replace a workspace and preserve active reader generations."""
     with workspace_arrays._workspace_file_lock(destination):
+        current_state = workspace_arrays._workspace_file_state(destination)
+        if expected_state is not None and current_state != expected_state:
+            raise _WorkspacePublicationConflictError(
+                destination, "Workspace changed while its successor was prepared"
+            )
         generation = workspace_arrays._current_workspace_file_generation(destination)
         generation_has_managers = generation is not None and generation.has_managers()
+        generation_started_without_file = (
+            generation is not None and generation.created_without_file
+        )
         preserved: _PreservedWorkspaceFile | None = None
         try:
             if generation is not None:
                 generation.close(needs_lock=False)
-            if generation_has_managers and pathlib.Path(destination).is_file():
-                preserved = _preserve_workspace_file_generation(destination)
+            if (
+                generation is not None
+                and generation_has_managers
+                and not generation_started_without_file
+            ):
+                preserved = _preserve_workspace_file_generation(
+                    destination, generation.file_identity
+                )
 
             retry_delays: tuple[float, ...] | None = None
             while True:
@@ -312,21 +328,92 @@ def _replace_workspace_file(
 
         if generation is not None:
             if preserved is not None:
-                if preserved.hide_after_publish:
-                    _hide_workspace_internal_file(preserved.path)
                 workspace_arrays._retire_workspace_file_generation(
                     destination,
                     generation,
                     preserved.path,
+                    preserved.file_identity,
                     preserved.cleanup,
                 )
             elif generation_has_managers:
-                generation.refresh_file_identity()
+                generation.activate_new_file()
             else:
                 workspace_arrays._discard_workspace_file_generation(
                     destination, generation
                 )
                 generation.dispose()
+
+
+@contextlib.contextmanager
+def _workspace_successor_file(
+    fname: str | os.PathLike[str],
+) -> Iterator[tuple[str, tuple[tuple[str, int, int, int], bool]]]:
+    """Copy one published workspace generation to a private successor."""
+    fname = os.fsdecode(fname)
+    tmp_dir: tempfile.TemporaryDirectory[str] | None = None
+    if _workspace_path_is_high_risk(fname):
+        tmp_dir = tempfile.TemporaryDirectory(prefix="erlab-itws-successor-")
+        successor = str(pathlib.Path(tmp_dir.name) / pathlib.Path(fname).name)
+    else:
+        successor = str(
+            pathlib.Path(fname).with_name(
+                f".{pathlib.Path(fname).name}.next-{uuid.uuid4().hex}.itws"
+            )
+        )
+
+    try:
+        with workspace_arrays._workspace_file_lock(fname):
+            generation = workspace_arrays._current_workspace_file_generation(fname)
+            if generation is not None:
+                generation.close(needs_lock=False)
+            expected_state = workspace_arrays._workspace_file_state(fname)
+            source_identity, source_exists = expected_state
+            if not source_exists:
+                raise FileNotFoundError(
+                    errno.ENOENT, "Workspace file is missing", fname
+                )
+            shutil.copyfile(fname, successor)
+            source_identity_after = workspace_arrays._workspace_file_identity(fname)
+            if source_identity_after[1:] != source_identity[1:]:
+                raise _WorkspacePublicationConflictError(
+                    fname, "Workspace changed while its successor was copied"
+                )
+        yield successor, expected_state
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(successor)
+        if tmp_dir is not None:
+            tmp_dir.cleanup()
+
+
+def _publish_workspace_successor(
+    successor: str | os.PathLike[str],
+    fname: str | os.PathLike[str],
+    expected_state: tuple[tuple[str, int, int, int], bool],
+) -> None:
+    """Validate, sync, and atomically publish one private successor."""
+    fname = os.fsdecode(fname)
+    successor = os.fsdecode(successor)
+    destination_tmp: str | None = None
+    _validate_workspace_h5_file(successor)
+    _fsync_file(successor)
+    try:
+        try:
+            _replace_workspace_file(successor, fname, expected_state=expected_state)
+        except OSError as err:
+            if err.errno != errno.EXDEV:
+                raise
+            destination_tmp = f"{fname}.tmp-{uuid.uuid4().hex}"
+            shutil.copyfile(successor, destination_tmp)
+            _fsync_file(destination_tmp)
+            _replace_workspace_file(
+                destination_tmp, fname, expected_state=expected_state
+            )
+        _fsync_parent_directory(fname)
+    finally:
+        if destination_tmp is not None:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(destination_tmp)
 
 
 def _workspace_use_incremental_enabled() -> bool:
@@ -498,12 +585,37 @@ def _cleanup_orphan_workspace_internal_groups(h5_file) -> None:
             del h5_file[name]
 
 
-def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
+def _workspace_transaction_recovery_needed(
+    fname: str | os.PathLike[str],
+) -> bool:
     if not pathlib.Path(fname).exists():
-        return
+        return False
     if not _workspace_path_is_itws(fname):
-        return
-    with workspace_arrays._workspace_file_lock(fname), h5py.File(fname, "a") as h5_file:
+        return False
+    with workspace_arrays._workspace_file_lock(fname):
+        generation = workspace_arrays._current_workspace_file_generation(fname)
+        if generation is not None:
+            generation.close(needs_lock=False)
+        with h5py.File(fname, "r") as h5_file:
+            if not _workspace_file_is_workspace(h5_file):
+                return False
+            return any(
+                name.startswith(
+                    (
+                        _WORKSPACE_TRANSACTION_GROUP_PREFIX,
+                        _WORKSPACE_PENDING_GROUP_PREFIX,
+                        _WORKSPACE_BACKUP_GROUP_PREFIX,
+                    )
+                )
+                for name in h5_file
+            )
+
+
+def _recover_workspace_transactions_in_place(
+    fname: str | os.PathLike[str],
+) -> None:
+    """Recover transaction state in an unpublished workspace successor."""
+    with _open_workspace_h5_file_for_update(fname) as h5_file:
         if not _workspace_file_is_workspace(h5_file):
             return
         for name in list(h5_file):
@@ -511,6 +623,14 @@ def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
                 _recover_open_workspace_transaction(h5_file, name)
         _cleanup_orphan_workspace_internal_groups(h5_file)
         h5_file.flush()
+
+
+def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
+    if not _workspace_transaction_recovery_needed(fname):
+        return
+    with _workspace_successor_file(fname) as (successor, expected_state):
+        _recover_workspace_transactions_in_place(successor)
+        _publish_workspace_successor(successor, fname, expected_state)
 
 
 def _write_root_attrs_to_open_workspace_file(
@@ -532,8 +652,12 @@ def _write_workspace_root_attrs_to_file(
     *,
     replace: bool = False,
 ) -> None:
-    with _open_workspace_h5_file_for_update(fname) as h5_file:
-        _write_root_attrs_to_open_workspace_file(h5_file, attrs, replace=replace)
+    _recover_workspace_transactions(fname)
+    with _workspace_successor_file(fname) as (successor, expected_state):
+        with _open_workspace_h5_file_for_update(successor) as h5_file:
+            _write_root_attrs_to_open_workspace_file(h5_file, attrs, replace=replace)
+            h5_file.flush()
+        _publish_workspace_successor(successor, fname, expected_state)
 
 
 def _workspace_obsolete_estimate(
@@ -560,16 +684,16 @@ def _workspace_file_repack_payload(
     )
 
 
-def _write_workspace_constructor_groups_to_pending(
+def _write_workspace_constructor_groups_to_path(
     fname: str | os.PathLike[str],
     constructor: Mapping[str, xr.Dataset],
     group_path: str,
-    pending_path: str,
+    destination_path: str,
     *,
     compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
     target_group_path = group_path.strip("/")
-    pending_path = pending_path.strip("/")
+    destination_path = destination_path.strip("/")
     for constructor_group_path, ds in sorted(
         constructor.items(), key=lambda item: item[0].count("/")
     ):
@@ -579,12 +703,14 @@ def _write_workspace_constructor_groups_to_pending(
         ):
             continue
         relative_path = source_group_path.removeprefix(target_group_path).strip("/")
-        pending_group_path = (
-            pending_path if not relative_path else f"{pending_path}/{relative_path}"
+        output_group_path = (
+            destination_path
+            if not relative_path
+            else f"{destination_path}/{relative_path}"
         )
         workspace_arrays._write_workspace_dataset_group_to_file(
             fname,
-            pending_group_path,
+            output_group_path,
             ds,
             lock_path=fname,
             compression_mode=compression_mode,
@@ -689,7 +815,7 @@ def _write_workspace_transaction_pending_groups(
             rewrite_map.items()
         ):
             pending_group_path = f"{pending_root}/{group_path}"
-            _write_workspace_constructor_groups_to_pending(
+            _write_workspace_constructor_groups_to_path(
                 fname,
                 constructor,
                 rewrite_group_path,
@@ -745,43 +871,62 @@ def _write_workspace_transaction_file(
     *,
     compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
+    """Publish one copy-on-write workspace update.
+
+    Recovery of legacy transaction groups happens before the copy. All new changes
+    are then made only in the unpublished successor, so a failed update needs no
+    rollback and cannot expose partial groups in the canonical file.
+    """
     _recover_workspace_transactions(fname)
-    rewrite_map = {
-        group_path.strip("/"): (group_path, constructor)
-        for group_path, constructor in rewrite_groups
-    }
-    attr_updates_tuple = tuple(attr_updates)
-    txn_id = uuid.uuid4().hex
-    txn_path = f"{_WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
-    pending_root = f"{_WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
-    backup_root = f"{_WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
-    group_operations, attr_updates_to_write = _prepare_workspace_transaction(
-        fname,
-        txn_path,
-        pending_root,
-        backup_root,
-        rewrite_map,
-        attr_updates_tuple,
-        root_attrs,
-    )
-    try:
-        _write_workspace_transaction_pending_groups(
-            fname,
-            rewrite_map,
-            pending_root,
-            compression_mode=compression_mode,
-        )
-        _commit_workspace_transaction(
-            fname,
-            txn_path,
-            group_operations,
-            attr_updates_to_write,
-            root_attrs,
-        )
-    except Exception:
-        _recover_workspace_transactions(fname)
-        raise
-    _recover_workspace_transactions(fname)
+    with _workspace_successor_file(fname) as (successor, expected_state):
+        rewrite_map = {
+            group_path.strip("/"): (group_path, constructor)
+            for group_path, constructor in rewrite_groups
+        }
+        attr_updates_to_write: list[
+            tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
+        ] = []
+        with _open_workspace_h5_file_for_update(successor) as h5_file:
+            for payload_path, attrs, fallback in attr_updates:
+                attr_path = payload_path.strip("/")
+                if any(
+                    _path_is_at_or_under(attr_path, rewrite_path)
+                    for rewrite_path in rewrite_map
+                ):
+                    continue
+                if attr_path in h5_file:
+                    attr_updates_to_write.append((payload_path, attrs, fallback))
+                    continue
+                fallback_path = fallback[0].strip("/")
+                if not any(
+                    _path_is_at_or_under(fallback_path, rewrite_path)
+                    for rewrite_path in rewrite_map
+                ):
+                    rewrite_map[fallback_path] = fallback
+
+            for group_path in sorted(rewrite_map):
+                workspace_arrays._delete_h5_path(h5_file, group_path)
+            h5_file.flush()
+
+        for group_path, (rewrite_group_path, constructor) in sorted(
+            rewrite_map.items()
+        ):
+            _write_workspace_constructor_groups_to_path(
+                successor,
+                constructor,
+                rewrite_group_path,
+                group_path,
+                compression_mode=compression_mode,
+            )
+
+        with _open_workspace_h5_file_for_update(successor) as h5_file:
+            for payload_path, attrs, _fallback in attr_updates_to_write:
+                target_attrs = _workspace_txn_attr_target(h5_file, payload_path)
+                if target_attrs is not None:
+                    workspace_arrays._replace_h5_attrs(target_attrs, attrs)
+            _write_root_attrs_to_open_workspace_file(h5_file, root_attrs)
+            h5_file.flush()
+        _publish_workspace_successor(successor, fname, expected_state)
 
 
 def _write_full_workspace_tree_file(
@@ -795,6 +940,11 @@ def _write_full_workspace_tree_file(
     compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
     fname = os.fsdecode(fname)
+    with workspace_arrays._workspace_file_lock(fname):
+        generation = workspace_arrays._current_workspace_file_generation(fname)
+        if generation is not None:
+            generation.close(needs_lock=False)
+        expected_state = workspace_arrays._workspace_file_state(fname)
     use_scratch = _workspace_path_is_high_risk(fname)
     tmp_dir: tempfile.TemporaryDirectory[str] | None = None
     destination_tmp: str | None = None
@@ -882,17 +1032,19 @@ def _write_full_workspace_tree_file(
         _fsync_file(tmp_fname)
         if use_scratch:
             try:
-                _replace_workspace_file(tmp_fname, fname)
+                _replace_workspace_file(tmp_fname, fname, expected_state=expected_state)
             except OSError as err:
                 if err.errno != errno.EXDEV:
                     raise
                 destination_tmp = f"{fname}.tmp-{uuid.uuid4().hex}"
                 shutil.copyfile(tmp_fname, destination_tmp)
                 _fsync_file(destination_tmp)
-                _replace_workspace_file(destination_tmp, fname)
+                _replace_workspace_file(
+                    destination_tmp, fname, expected_state=expected_state
+                )
             _fsync_parent_directory(fname)
         else:
-            _replace_workspace_file(tmp_fname, fname)
+            _replace_workspace_file(tmp_fname, fname, expected_state=expected_state)
             _fsync_parent_directory(fname)
     finally:
         with contextlib.suppress(FileNotFoundError):

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -102,11 +102,16 @@ def _workspace_in_place_update(
     fname: str | os.PathLike[str],
     *,
     rewrite_groups: Iterable[str] = (),
+    expected_state: tuple[tuple[str, int, int, int], bool] | None = None,
 ) -> Iterator[None]:
     """Coordinate one recoverable in-place workspace update."""
     with workspace_arrays._workspace_file_lock(fname):
         generation = workspace_arrays._current_workspace_file_generation(fname)
         initial_state = workspace_arrays._workspace_file_state(fname)
+        if expected_state is not None and initial_state != expected_state:
+            raise _WorkspacePublicationConflictError(
+                fname, "Workspace changed while its incremental save was prepared"
+            )
         if generation is not None:
             generation.close(needs_lock=False)
             workspace_arrays._detach_workspace_file_generation_readers(
@@ -632,6 +637,14 @@ def _recover_workspace_transactions_in_place(
 
 
 def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
+    with workspace_arrays._workspace_save_lock(fname):
+        _recover_workspace_transactions_coordinated(fname)
+
+
+def _recover_workspace_transactions_coordinated(
+    fname: str | os.PathLike[str],
+) -> None:
+    """Recover transactions while this process owns the workspace save lock."""
     if not _workspace_transaction_recovery_needed(fname):
         return
     with _workspace_in_place_update(fname):
@@ -677,12 +690,13 @@ def _workspace_file_repack_payload(
 ) -> tuple[
     dict[str, typing.Any], tuple[tuple[str, str, dict[str, typing.Any] | None], ...]
 ]:
-    _recover_workspace_transactions(fname)
-    root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
-    return (
-        _compacted_workspace_root_attrs(root_attrs),
-        workspace_arrays._workspace_live_root_group_copy_groups(fname),
-    )
+    with workspace_arrays._workspace_save_lock(fname):
+        _recover_workspace_transactions_coordinated(fname)
+        root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
+        return (
+            _compacted_workspace_root_attrs(root_attrs),
+            workspace_arrays._workspace_live_root_group_copy_groups(fname),
+        )
 
 
 def _write_workspace_constructor_groups_to_path(
@@ -935,7 +949,20 @@ def _write_workspace_root_attrs_transaction_file(
     replace: bool,
 ) -> None:
     """Write root attributes through the recoverable transaction protocol."""
-    _recover_workspace_transactions(fname)
+    with workspace_arrays._workspace_save_lock(fname):
+        _write_workspace_root_attrs_transaction_file_coordinated(
+            fname, attrs, replace=replace
+        )
+
+
+def _write_workspace_root_attrs_transaction_file_coordinated(
+    fname: str | os.PathLike[str],
+    attrs: Mapping[str, typing.Any],
+    *,
+    replace: bool,
+) -> None:
+    """Write root attributes while this process owns the workspace save lock."""
+    _recover_workspace_transactions_coordinated(fname)
     txn_id = uuid.uuid4().hex
     txn_path = f"{_WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
     pending_root = f"{_WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
@@ -979,33 +1006,58 @@ def _write_workspace_transaction_file(
     compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
     """Write one recoverable incremental workspace transaction."""
-    _recover_workspace_transactions(fname)
+    with workspace_arrays._workspace_save_lock(fname):
+        _write_workspace_transaction_file_coordinated(
+            fname,
+            rewrite_groups,
+            attr_updates,
+            root_attrs,
+            compression_mode=compression_mode,
+        )
+
+
+def _write_workspace_transaction_file_coordinated(
+    fname: str | os.PathLike[str],
+    rewrite_groups: Iterable[tuple[str, dict[str, xr.Dataset]]],
+    attr_updates: Iterable[
+        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
+    ],
+    root_attrs: Mapping[str, typing.Any],
+    *,
+    compression_mode: WorkspaceCompressionMode | None,
+) -> None:
+    """Prepare and write a delta while this process owns the save lock."""
+    _recover_workspace_transactions_coordinated(fname)
     rewrite_map = {
         group_path.strip("/"): (group_path, constructor)
         for group_path, constructor in rewrite_groups
     }
     attr_updates_tuple = tuple(attr_updates)
+    with workspace_arrays._workspace_file_lock(fname):
+        expected_state = workspace_arrays._workspace_file_state(fname)
+        missing_fallback_groups = _workspace_missing_attr_fallback_groups(
+            fname, rewrite_map, attr_updates_tuple
+        )
+        missing_fallback_group_set = set(missing_fallback_groups)
+        for _payload_path, _attrs, fallback in attr_updates_tuple:
+            fallback_path = fallback[0].strip("/")
+            if fallback_path in missing_fallback_group_set:
+                rewrite_map[fallback_path] = fallback
+
+    # Dask can schedule reads on worker threads. Materialize before the file lock so
+    # those reads can acquire their generation without waiting on the save thread.
+    _materialize_workspace_constructor_sources(fname, rewrite_map)
+
     txn_id = uuid.uuid4().hex
     txn_path = f"{_WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
     pending_root = f"{_WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
     backup_root = f"{_WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
-    with _workspace_in_place_update(fname, rewrite_groups=rewrite_map):
+    with _workspace_in_place_update(
+        fname,
+        rewrite_groups=rewrite_map,
+        expected_state=expected_state,
+    ):
         try:
-            missing_fallback_groups = _workspace_missing_attr_fallback_groups(
-                fname, rewrite_map, attr_updates_tuple
-            )
-            missing_fallback_group_set = set(missing_fallback_groups)
-            for _payload_path, _attrs, fallback in attr_updates_tuple:
-                fallback_path = fallback[0].strip("/")
-                if fallback_path in missing_fallback_group_set:
-                    rewrite_map[fallback_path] = fallback
-            workspace_arrays._detach_workspace_file_generation_readers(
-                fname, missing_fallback_groups
-            )
-            _materialize_workspace_constructor_sources(fname, rewrite_map)
-            generation = workspace_arrays._current_workspace_file_generation(fname)
-            if generation is not None:
-                generation.close(needs_lock=False)
             group_operations, attr_updates_to_write = _prepare_workspace_transaction(
                 fname,
                 txn_path,
@@ -1047,6 +1099,30 @@ def _write_full_workspace_tree_file(
     copy_group_sources: Iterable[_WorkspaceCopyGroupWithSource] = (),
     compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
+    """Write and publish one complete workspace successor."""
+    with workspace_arrays._workspace_save_lock(fname):
+        _write_full_workspace_tree_file_coordinated(
+            fname,
+            tree,
+            root_attrs,
+            copy_source=copy_source,
+            copy_groups=copy_groups,
+            copy_group_sources=copy_group_sources,
+            compression_mode=compression_mode,
+        )
+
+
+def _write_full_workspace_tree_file_coordinated(
+    fname: str | os.PathLike[str],
+    tree: xr.DataTree | None,
+    root_attrs: Mapping[str, typing.Any],
+    *,
+    copy_source: str | os.PathLike[str] | None,
+    copy_groups: Iterable[_WorkspaceCopyGroup],
+    copy_group_sources: Iterable[_WorkspaceCopyGroupWithSource],
+    compression_mode: WorkspaceCompressionMode | None,
+) -> None:
+    """Build a successor while this process owns the workspace save lock."""
     fname = os.fsdecode(fname)
     with workspace_arrays._workspace_file_lock(fname):
         generation = workspace_arrays._current_workspace_file_generation(fname)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -236,29 +236,71 @@ def _workspace_replace_retry_delays(exc: PermissionError) -> tuple[float, ...]:
     return _WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS
 
 
+def _preserve_workspace_file_generation(
+    path: str | os.PathLike[str],
+) -> workspace_arrays._WorkspaceFileGeneration:
+    """Preserve one workspace generation for existing lazy readers."""
+    source = pathlib.Path(path)
+    generation_path = source.with_name(f".{uuid.uuid4().hex}.erlab-workspace-read")
+
+    try:
+        os.link(source, generation_path)
+    except OSError:
+        temporary_directory = tempfile.TemporaryDirectory(
+            prefix="erlab-workspace-read-"
+        )
+        generation_path = pathlib.Path(temporary_directory.name) / "workspace.itws"
+        try:
+            shutil.copyfile(source, generation_path)
+        except BaseException:
+            temporary_directory.cleanup()
+            raise
+        cleanup = temporary_directory.cleanup
+    else:
+        _hide_workspace_lock_file(str(generation_path))
+
+        def cleanup() -> None:
+            with contextlib.suppress(OSError):
+                os.remove(generation_path)
+
+    return workspace_arrays._WorkspaceFileGeneration(generation_path, cleanup)
+
+
 def _replace_workspace_file(
     source: str | os.PathLike[str], destination: str | os.PathLike[str]
 ) -> None:
-    """Atomically replace a workspace after closing manager-owned readers."""
+    """Atomically replace a workspace and preserve active reader generations."""
     with workspace_arrays._workspace_file_lock(destination):
-        managers = workspace_arrays._close_workspace_file_managers(destination)
-        retry_delays: tuple[float, ...] | None = None
-        while True:
-            try:
-                os.replace(source, destination)
-            except PermissionError as exc:
-                if retry_delays is None:
-                    retry_delays = _workspace_replace_retry_delays(exc)
-                if not retry_delays:
-                    raise
-                delay, *remaining_delays = retry_delays
-                retry_delays = tuple(remaining_delays)
-                time.sleep(delay)
-            else:
-                break
-        # A stale lazy graph must not reopen the new file with old metadata.
-        for manager in managers:
-            manager._mark_file_replaced()
+        managers = workspace_arrays._detach_workspace_file_managers(destination)
+        generation: workspace_arrays._WorkspaceFileGeneration | None = None
+        try:
+            if managers and pathlib.Path(destination).is_file():
+                generation = _preserve_workspace_file_generation(destination)
+            for manager in managers:
+                if generation is None:
+                    manager.close(needs_lock=False)
+                else:
+                    manager._use_preserved_generation(generation)
+
+            retry_delays: tuple[float, ...] | None = None
+            while True:
+                try:
+                    os.replace(source, destination)
+                except PermissionError as exc:
+                    if retry_delays is None:
+                        retry_delays = _workspace_replace_retry_delays(exc)
+                    if not retry_delays:
+                        raise
+                    delay, *remaining_delays = retry_delays
+                    retry_delays = tuple(remaining_delays)
+                    time.sleep(delay)
+                else:
+                    break
+        except BaseException:
+            workspace_arrays._restore_workspace_file_managers(destination, managers)
+            raise
+        if generation is None:
+            workspace_arrays._restore_workspace_file_managers(destination, managers)
 
 
 def _workspace_use_incremental_enabled() -> bool:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -47,6 +47,48 @@ def test_workspace_h5py_helpers_reject_non_workspace_files(tmp_path) -> None:
     assert workspace_arrays._workspace_h5_object_storage_size(object()) == 0
 
 
+def test_workspace_file_manager_registry_closes_all_path_identities(
+    monkeypatch, tmp_path
+) -> None:
+    first = tmp_path / "first.h5"
+    second = tmp_path / "second.h5"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(first, engine="h5netcdf")
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(second, engine="h5netcdf")
+    first_target = workspace_arrays._normalized_file_path(first)
+    original_identity = workspace_arrays._workspace_file_identity
+    first_identity_generation = iter((1, 2))
+
+    def _identity(path):
+        target = workspace_arrays._normalized_file_path(path)
+        if target == first_target:
+            return target, 0, 0, next(first_identity_generation)
+        return original_identity(path)
+
+    monkeypatch.setattr(workspace_arrays, "_workspace_file_identity", _identity)
+    first_manager = workspace_arrays.WorkspaceFileManager(first)
+    second_first_manager = workspace_arrays.WorkspaceFileManager(first)
+    other_manager = workspace_arrays.WorkspaceFileManager(second)
+    first_file = first_manager.acquire()
+    second_first_file = second_first_manager.acquire()
+    other_file = other_manager.acquire()
+    try:
+        assert first_file is not second_first_file
+        monkeypatch.setattr(
+            workspace_arrays, "_normalized_file_path", lambda _path: None
+        )
+        with workspace_arrays._workspace_file_lock(first):
+            workspace_arrays._close_workspace_file_managers(first)
+
+        assert first_file._closed
+        assert second_first_file._closed
+        assert not other_file._closed
+    finally:
+        with workspace_arrays._workspace_file_lock(first):
+            workspace_arrays._close_workspace_file_managers(first)
+        with workspace_arrays._workspace_file_lock(second):
+            workspace_arrays._close_workspace_file_managers(second)
+
+
 def test_workspace_h5py_filter_matching_edge_cases(tmp_path) -> None:
 
     fname = tmp_path / "filters.h5"

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -36,6 +36,12 @@ from tests.interactive.imagetool.manager.workspace._support import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _cleanup_workspace_session_exports() -> typing.Iterator[None]:
+    yield
+    workspace_arrays._cleanup_workspace_session_exports()
+
+
 def test_workspace_h5py_helpers_reject_non_workspace_files(tmp_path) -> None:
 
     fname = tmp_path / "not-workspace.itws"
@@ -95,11 +101,11 @@ def test_workspace_file_generation_registration_uses_short_registry_lock(
         )
         return generation_type(*args, **kwargs)
 
-    def _add_manager(generation) -> None:
+    def _add_manager(generation, manager=None) -> None:
         lease_lock_states.append(
             workspace_arrays._WORKSPACE_FILE_GENERATIONS_LOCK.locked()
         )
-        original_add_manager(generation)
+        original_add_manager(generation, manager)
 
     monkeypatch.setattr(workspace_arrays, "_WorkspaceFileGeneration", _new_generation)
     monkeypatch.setattr(generation_type, "add_manager", _add_manager)
@@ -166,6 +172,26 @@ def test_workspace_reader_helpers_reject_unsafe_directory_and_names(tmp_path) ->
         )
 
 
+def test_workspace_session_exports_do_not_delete_parent_files_after_fork(
+    tmp_path,
+) -> None:
+    export_path = tmp_path / "parent-export.itws"
+    export_path.write_bytes(b"parent")
+    reader_file = workspace_arrays._WorkspaceReaderFile(
+        str(export_path), export_path.unlink
+    )
+    key = (str(tmp_path / "workspace.itws"), 1, 2, 3, "/")
+    workspace_arrays._WORKSPACE_SESSION_EXPORTS[key] = reader_file
+    old_lock = workspace_arrays._WORKSPACE_SESSION_EXPORTS_LOCK
+
+    workspace_arrays._reset_workspace_session_exports_after_fork()
+
+    assert workspace_arrays._WORKSPACE_SESSION_EXPORTS == {}
+    assert workspace_arrays._WORKSPACE_SESSION_EXPORTS_LOCK is not old_lock
+    assert export_path.exists()
+    reader_file.cleanup()
+
+
 def test_workspace_file_manager_finalizer_defers_cleanup(tmp_path) -> None:
     fname = tmp_path / "deferred-cleanup.itws"
     xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
@@ -214,54 +240,78 @@ def test_workspace_file_manager_opens_published_generation_read_only(tmp_path) -
         manager.close()
 
 
-def test_workspace_file_manager_copies_windows_process_export(
-    monkeypatch, tmp_path
-) -> None:
-    fname = tmp_path / "windows-export.itws"
+def test_workspace_file_manager_copies_process_export(monkeypatch, tmp_path) -> None:
+    fname = tmp_path / "process-export.itws"
     xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
     manager = workspace_arrays.WorkspaceFileManager(fname)
-    copy_only_values: list[bool] = []
-    original_create = workspace_arrays._create_workspace_reader_file
+    exported_groups: list[str] = []
+    original_create = workspace_arrays._create_workspace_group_reader_file
 
-    def _create_reader_file(*args, copy_only=False, **kwargs):
-        copy_only_values.append(copy_only)
-        return original_create(*args, copy_only=copy_only, **kwargs)
+    def _create_reader_file(source, workspace, group, **kwargs):
+        exported_groups.append(group)
+        return original_create(source, workspace, group, **kwargs)
 
-    monkeypatch.setattr(workspace_arrays, "_WORKSPACE_EXPORT_REQUIRES_COPY", True)
     monkeypatch.setattr(
-        workspace_arrays, "_create_workspace_reader_file", _create_reader_file
+        workspace_arrays, "_create_workspace_group_reader_file", _create_reader_file
     )
     try:
-        _workspace_path, export_path, _identity = manager.__getstate__()
-        assert copy_only_values == [True]
+        _workspace_path, export_path, _identity, group = manager.__getstate__()
+        assert exported_groups == ["/"]
+        assert group == "/"
         assert not pathlib.Path(export_path).samefile(fname)
     finally:
         manager.close()
 
 
-def test_workspace_file_manager_export_is_owned_by_sender_generation(tmp_path) -> None:
-    fname = tmp_path / "owned-export.itws"
+def test_workspace_file_manager_exports_only_requested_group(tmp_path) -> None:
+    fname = tmp_path / "group-export.itws"
+    tree = xr.DataTree.from_dict(
+        {
+            "0/imagetool": xr.Dataset({"data": ("x", np.arange(3))}),
+            "1/imagetool": xr.Dataset({"data": ("x", np.arange(3) + 10)}),
+        }
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            fname, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+    manager = workspace_arrays.WorkspaceFileManager(fname, "0/imagetool")
+
+    try:
+        _workspace_path, export_path, _identity, group = manager.__getstate__()
+        assert group == "/0/imagetool"
+        with h5py.File(export_path, "r") as export_file:
+            assert set(export_file) == {"0"}
+            assert set(export_file["0"]) == {"imagetool"}
+            np.testing.assert_array_equal(export_file["0/imagetool/data"], np.arange(3))
+    finally:
+        manager.close()
+
+
+def test_workspace_file_manager_export_is_owned_by_sender_session(tmp_path) -> None:
+    fname = tmp_path / "session-export.itws"
     xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
     manager = workspace_arrays.WorkspaceFileManager(fname)
     generation = manager._generation
-    state = manager.__getstate__()
-    export_path = pathlib.Path(state[1])
-    restored = workspace_arrays.WorkspaceFileManager.__new__(
-        workspace_arrays.WorkspaceFileManager
-    )
-    restored.__setstate__(state)
+    serialized = pickle.dumps(manager)
+    export_path = pathlib.Path(manager.__getstate__()[1])
 
     manager._finalizer()
     with workspace_arrays._workspace_file_lock(fname):
         workspace_arrays._cleanup_workspace_file_generation_locked(generation)
 
+    restored = pickle.loads(serialized)
     try:
-        assert not export_path.exists()
+        assert export_path.exists()
         np.testing.assert_array_equal(
             restored.acquire().variables["data"][:], np.arange(6)
         )
     finally:
         restored.close()
+        workspace_arrays._cleanup_workspace_session_exports()
+    assert not export_path.exists()
 
 
 def test_workspace_file_manager_rejects_missing_serialized_export(tmp_path) -> None:
@@ -281,12 +331,13 @@ def test_workspace_file_manager_rejects_missing_serialized_export(tmp_path) -> N
         manager.close()
 
 
-def test_workspace_file_manager_root_attr_update_publishes_new_generation(
+def test_workspace_file_manager_root_attr_update_refreshes_current_generation(
     tmp_path,
 ) -> None:
     fname = tmp_path / "updated-export.itws"
     _write_transaction_test_workspace(fname)
     manager = workspace_arrays.WorkspaceFileManager(fname)
+    generation = manager._generation
     serialized_before = pickle.dumps(manager)
 
     workspace_storage._write_workspace_root_attrs_to_file(
@@ -300,8 +351,10 @@ def test_workspace_file_manager_root_attr_update_publishes_new_generation(
 
     before = pickle.loads(serialized_before)
     try:
-        assert manager._generation.retired
-        assert "generation_marker" not in manager.acquire().attrs
+        assert manager._generation is generation
+        assert current._generation is generation
+        assert not generation.retired
+        assert manager.acquire().attrs["generation_marker"] == "updated"
         assert "generation_marker" not in before.acquire().attrs
         assert current.acquire().attrs["generation_marker"] == "updated"
     finally:
@@ -320,15 +373,17 @@ def test_workspace_file_manager_export_rejects_source_change(
         replacement, engine="h5netcdf"
     )
     manager = workspace_arrays.WorkspaceFileManager(destination)
-    original_create = workspace_arrays._create_workspace_reader_file
+    original_create = workspace_arrays._create_workspace_group_reader_file
 
-    def _create_then_replace(source, workspace_path, **kwargs):
-        result = original_create(source, workspace_path, **kwargs)
+    def _create_then_replace(source, workspace_path, group, **kwargs):
+        result = original_create(source, workspace_path, group, **kwargs)
         os.replace(replacement, destination)
         return result
 
     monkeypatch.setattr(
-        workspace_arrays, "_create_workspace_reader_file", _create_then_replace
+        workspace_arrays,
+        "_create_workspace_group_reader_file",
+        _create_then_replace,
     )
     try:
         with pytest.raises(RuntimeError, match="changed while it was being exported"):
@@ -473,7 +528,7 @@ def test_workspace_file_manager_serialization_pins_replaced_generation(
     xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(destination, engine="h5netcdf")
     xr.Dataset({"data": ("x", np.arange(3) + 1)}).to_netcdf(source, engine="h5netcdf")
     manager = workspace_arrays.WorkspaceFileManager(destination)
-    _workspace_path, export_path, _identity = manager.__getstate__()
+    _workspace_path, export_path, _identity, _group = manager.__getstate__()
     assert pathlib.Path(export_path) != destination.resolve()
     serialized = pickle.dumps(manager)
 
@@ -1017,7 +1072,7 @@ def test_open_workspace_dataset_uses_fsdecode_fallback(monkeypatch) -> None:
     calls: list[tuple[object, str, str | None]] = []
 
     class _FakeFileManager:
-        def __init__(self, path: str) -> None:
+        def __init__(self, path: str, _group: str = "/") -> None:
             self.workspace_path = path
 
     def _fake_open(file_manager, group: str, *, chunks: str | None):
@@ -1054,11 +1109,14 @@ def test_open_workspace_datatree_closes_partial_groups_on_error(monkeypatch) -> 
     class _FakeFileManager:
         workspace_path = "fallback.itws"
 
-        def __init__(self, _path: str) -> None:
+        def __init__(self, _path: str, _group: str = "/") -> None:
             pass
 
         def acquire_context(self):
             return contextlib.nullcontext(object())
+
+        def _release(self) -> None:
+            pass
 
     def _fake_open(_file_manager, group_path: str, *, chunks: str | None):
         if group_path == "/broken":

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -5,7 +5,10 @@ import logging
 import os
 import pathlib
 import pickle
+import subprocess
+import sys
 import threading
+import time
 import types
 import typing
 import warnings
@@ -28,6 +31,8 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _hdf5_blosc2_level_codec,
     _hdf5_filter_ids,
     _rich_workspace_attr_value,
+    _transaction_test_root_attrs,
+    _write_transaction_test_workspace,
 )
 
 
@@ -107,6 +112,60 @@ def test_workspace_file_generation_registration_uses_short_registry_lock(
         manager.close()
 
 
+def test_workspace_file_generation_binds_one_observed_file_state(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "single-state.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    original_file_state = workspace_arrays._workspace_file_state
+    observed_state = original_file_state(fname)
+    state_calls = 0
+
+    def _file_state(path):
+        nonlocal state_calls
+        state_calls += 1
+        assert pathlib.Path(path).resolve() == fname.resolve()
+        return observed_state
+
+    monkeypatch.setattr(workspace_arrays, "_workspace_file_state", _file_state)
+
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    try:
+        assert state_calls == 1
+        assert manager._generation.file_identity == observed_state[0]
+        assert manager._generation._resources.file_identity == observed_state[0]
+    finally:
+        manager.close()
+
+
+def test_workspace_reader_helpers_reject_unsafe_directory_and_names(tmp_path) -> None:
+    workspace_path = tmp_path / "workspace.itws"
+    reader_directory = workspace_arrays._workspace_reader_directory(workspace_path)
+    reader_directory.write_text("not a directory")
+
+    workspace_arrays._cleanup_stale_workspace_reader_files(workspace_path)
+    with pytest.raises(OSError, match="not a private directory"):
+        workspace_arrays._ensure_workspace_reader_directory(workspace_path)
+
+    valid_token = "1" * 32
+    assert (
+        workspace_arrays._workspace_reader_file_owner_pid(
+            pathlib.Path(f"reader-123-{valid_token}.itws")
+        )
+        == 123
+    )
+    for name in (
+        "reader.itws",
+        "reader-bad-token.itws",
+        f"export-0-{valid_token}.itws",
+        "notes.txt",
+    ):
+        assert (
+            workspace_arrays._workspace_reader_file_owner_pid(pathlib.Path(name))
+            is None
+        )
+
+
 def test_workspace_file_manager_finalizer_defers_cleanup(tmp_path) -> None:
     fname = tmp_path / "deferred-cleanup.itws"
     xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
@@ -141,6 +200,251 @@ def test_workspace_file_manager_is_pickleable(tmp_path) -> None:
         restored.close()
 
 
+def test_workspace_file_manager_opens_published_generation_read_only(tmp_path) -> None:
+    fname = tmp_path / "read-only.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+
+    try:
+        h5_file = manager.acquire()
+        assert h5_file.mode == "r"
+        with pytest.raises(OSError, match="no write intent"):
+            h5_file.attrs["unexpected_write"] = 1
+    finally:
+        manager.close()
+
+
+def test_workspace_file_manager_copies_windows_process_export(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "windows-export.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    copy_only_values: list[bool] = []
+    original_create = workspace_arrays._create_workspace_reader_file
+
+    def _create_reader_file(*args, copy_only=False, **kwargs):
+        copy_only_values.append(copy_only)
+        return original_create(*args, copy_only=copy_only, **kwargs)
+
+    monkeypatch.setattr(workspace_arrays, "_WORKSPACE_EXPORT_REQUIRES_COPY", True)
+    monkeypatch.setattr(
+        workspace_arrays, "_create_workspace_reader_file", _create_reader_file
+    )
+    try:
+        _workspace_path, export_path, _identity = manager.__getstate__()
+        assert copy_only_values == [True]
+        assert not pathlib.Path(export_path).samefile(fname)
+    finally:
+        manager.close()
+
+
+def test_workspace_file_manager_export_is_owned_by_sender_generation(tmp_path) -> None:
+    fname = tmp_path / "owned-export.itws"
+    xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    generation = manager._generation
+    state = manager.__getstate__()
+    export_path = pathlib.Path(state[1])
+    restored = workspace_arrays.WorkspaceFileManager.__new__(
+        workspace_arrays.WorkspaceFileManager
+    )
+    restored.__setstate__(state)
+
+    manager._finalizer()
+    with workspace_arrays._workspace_file_lock(fname):
+        workspace_arrays._cleanup_workspace_file_generation_locked(generation)
+
+    try:
+        assert not export_path.exists()
+        np.testing.assert_array_equal(
+            restored.acquire().variables["data"][:], np.arange(6)
+        )
+    finally:
+        restored.close()
+
+
+def test_workspace_file_manager_rejects_missing_serialized_export(tmp_path) -> None:
+    fname = tmp_path / "missing-export.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    state = manager.__getstate__()
+    pathlib.Path(state[1]).unlink()
+    restored = workspace_arrays.WorkspaceFileManager.__new__(
+        workspace_arrays.WorkspaceFileManager
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="no longer available"):
+            restored.__setstate__(state)
+    finally:
+        manager.close()
+
+
+def test_workspace_file_manager_root_attr_update_publishes_new_generation(
+    tmp_path,
+) -> None:
+    fname = tmp_path / "updated-export.itws"
+    _write_transaction_test_workspace(fname)
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    serialized_before = pickle.dumps(manager)
+
+    workspace_storage._write_workspace_root_attrs_to_file(
+        fname,
+        {
+            **_transaction_test_root_attrs(),
+            "generation_marker": "updated",
+        },
+    )
+    current = workspace_arrays.WorkspaceFileManager(fname)
+
+    before = pickle.loads(serialized_before)
+    try:
+        assert manager._generation.retired
+        assert "generation_marker" not in manager.acquire().attrs
+        assert "generation_marker" not in before.acquire().attrs
+        assert current.acquire().attrs["generation_marker"] == "updated"
+    finally:
+        manager.close()
+        before.close()
+        current.close()
+
+
+def test_workspace_file_manager_export_rejects_source_change(
+    monkeypatch, tmp_path
+) -> None:
+    destination = tmp_path / "current.itws"
+    replacement = tmp_path / "replacement.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(destination, engine="h5netcdf")
+    xr.Dataset({"data": ("x", np.arange(3) + 1)}).to_netcdf(
+        replacement, engine="h5netcdf"
+    )
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    original_create = workspace_arrays._create_workspace_reader_file
+
+    def _create_then_replace(source, workspace_path, **kwargs):
+        result = original_create(source, workspace_path, **kwargs)
+        os.replace(replacement, destination)
+        return result
+
+    monkeypatch.setattr(
+        workspace_arrays, "_create_workspace_reader_file", _create_then_replace
+    )
+    try:
+        with pytest.raises(RuntimeError, match="changed while it was being exported"):
+            pickle.dumps(manager)
+        assert not list(
+            workspace_arrays._workspace_reader_directory(destination).glob(
+                "export-*.itws"
+            )
+        )
+    finally:
+        manager.close()
+
+
+def test_serialized_workspace_reader_rejects_changed_export(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "serialized.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    state = manager.__getstate__()
+    original_create = workspace_arrays._create_workspace_reader_file
+
+    def _create_then_touch(source, workspace_path, **kwargs):
+        result = original_create(source, workspace_path, **kwargs)
+        source_stat = pathlib.Path(source).stat()
+        os.utime(
+            source,
+            ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns + 1_000_000_000),
+        )
+        return result
+
+    monkeypatch.setattr(
+        workspace_arrays, "_create_workspace_reader_file", _create_then_touch
+    )
+    restored = workspace_arrays.WorkspaceFileManager.__new__(
+        workspace_arrays.WorkspaceFileManager
+    )
+    try:
+        with pytest.raises(RuntimeError, match="changed while it was being opened"):
+            restored.__setstate__(state)
+        assert not list(
+            workspace_arrays._workspace_reader_directory(fname).glob("reader-*.itws")
+        )
+    finally:
+        manager.close()
+
+
+def test_pickled_workspace_reader_does_not_hold_canonical_file(tmp_path) -> None:
+    destination = tmp_path / "current.itws"
+    source = tmp_path / "replacement.itws"
+    xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(destination, engine="h5netcdf")
+    xr.Dataset({"data": ("x", np.arange(6) + 10)}).to_netcdf(source, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    serialized = pickle.dumps(manager)
+    serialized_path = tmp_path / "manager.pickle"
+    ready_path = tmp_path / "reader.ready"
+    release_path = tmp_path / "reader.release"
+    serialized_path.write_bytes(serialized)
+    child_code = """
+import json
+import pathlib
+import pickle
+import sys
+import time
+
+manager = pickle.loads(pathlib.Path(sys.argv[1]).read_bytes())
+try:
+    h5_file = manager.acquire()
+    pathlib.Path(sys.argv[2]).touch()
+    deadline = time.monotonic() + 10
+    while not pathlib.Path(sys.argv[3]).exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("Workspace reader process did not receive release")
+        time.sleep(0.01)
+    print(json.dumps(h5_file.variables["data"][:].tolist()))
+finally:
+    manager.close()
+"""
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            child_code,
+            str(serialized_path),
+            str(ready_path),
+            str(release_path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 10
+    try:
+        while not ready_path.exists() and process.poll() is None:
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.01)
+        assert ready_path.exists()
+        workspace_storage._replace_workspace_file(source, destination)
+    finally:
+        release_path.touch()
+        try:
+            stdout, stderr = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.communicate(timeout=5)
+            raise
+        finally:
+            manager.close()
+
+    assert process.returncode == 0, stderr
+    assert json.loads(stdout) == np.arange(6).tolist()
+    with xr.open_dataset(destination, engine="h5netcdf") as current:
+        np.testing.assert_array_equal(current["data"], np.arange(6) + 10)
+
+
 def test_workspace_file_manager_cache_evicts_old_handles(tmp_path) -> None:
     paths = [tmp_path / f"cache-{index}.itws" for index in range(3)]
     for path in paths:
@@ -161,7 +465,7 @@ def test_workspace_file_manager_cache_evicts_old_handles(tmp_path) -> None:
             manager.close()
 
 
-def test_workspace_file_manager_serialization_rejects_replaced_generation(
+def test_workspace_file_manager_serialization_pins_replaced_generation(
     tmp_path,
 ) -> None:
     destination = tmp_path / "current.itws"
@@ -169,21 +473,85 @@ def test_workspace_file_manager_serialization_rejects_replaced_generation(
     xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(destination, engine="h5netcdf")
     xr.Dataset({"data": ("x", np.arange(3) + 1)}).to_netcdf(source, engine="h5netcdf")
     manager = workspace_arrays.WorkspaceFileManager(destination)
+    _workspace_path, export_path, _identity = manager.__getstate__()
+    assert pathlib.Path(export_path) != destination.resolve()
     serialized = pickle.dumps(manager)
 
     workspace_storage._replace_workspace_file(source, destination)
 
+    restored = pickle.loads(serialized)
+    serialized_after_replace = pickle.dumps(manager)
+    restored_after_replace = pickle.loads(serialized_after_replace)
+    current = workspace_arrays.WorkspaceFileManager(destination)
     try:
-        with pytest.raises(TypeError, match="replaced workspace generation"):
+        for old_manager in (manager, restored, restored_after_replace):
+            np.testing.assert_array_equal(
+                old_manager.acquire().variables["data"][:], np.arange(3)
+            )
+        np.testing.assert_array_equal(
+            current.acquire().variables["data"][:], np.arange(3) + 1
+        )
+    finally:
+        for file_manager in (manager, restored, restored_after_replace, current):
+            file_manager.close()
+        del manager, restored, restored_after_replace, current
+        gc.collect()
+
+
+def test_workspace_file_manager_rejects_external_generation_replacement(
+    tmp_path,
+) -> None:
+    destination = tmp_path / "current.itws"
+    source = tmp_path / "replacement.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(destination, engine="h5netcdf")
+    xr.Dataset({"data": ("x", np.arange(3) + 1)}).to_netcdf(source, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    manager.acquire()
+    manager.close()
+
+    os.replace(source, destination)
+
+    try:
+        with pytest.raises(RuntimeError, match="reader generation changed"):
+            manager.acquire()
+        with pytest.raises(RuntimeError, match="changed before it could be exported"):
             pickle.dumps(manager)
-        with pytest.raises(
-            RuntimeError, match="changed after its reader was serialized"
-        ):
-            pickle.loads(serialized)
+        current = workspace_arrays.WorkspaceFileManager(destination)
+        try:
+            np.testing.assert_array_equal(
+                current.acquire().variables["data"][:], np.arange(3) + 1
+            )
+        finally:
+            current.close()
     finally:
         manager.close()
-        del manager
-        gc.collect()
+
+
+def test_workspace_file_manager_rejects_external_in_place_mutation(tmp_path) -> None:
+    fname = tmp_path / "mutated.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    original_stat = fname.stat()
+    manager.acquire()
+    manager.close()
+
+    with h5py.File(fname, "r+") as h5_file:
+        h5_file.attrs["external_update"] = True
+    os.utime(
+        fname,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns + 1_000_000_000),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="reader generation changed"):
+            manager.acquire()
+        current = workspace_arrays.WorkspaceFileManager(fname)
+        try:
+            assert current.acquire().attrs["external_update"]
+        finally:
+            current.close()
+    finally:
+        manager.close()
 
 
 def test_disposed_workspace_generation_rejects_reuse(tmp_path) -> None:
@@ -609,16 +977,23 @@ def test_workspace_xarray_path_helpers_cover_fallbacks(monkeypatch, tmp_path) ->
     lock = workspace_arrays._workspace_file_lock("fallback.itws")
     assert lock is workspace_arrays._workspace_file_lock("fallback.itws")
 
-    def _raise_stat_oserror(_path: str):
-        raise OSError
+    def _raise_stat_file_not_found(_path: str):
+        raise FileNotFoundError
 
-    monkeypatch.setattr(workspace_arrays.os, "stat", _raise_stat_oserror)
+    monkeypatch.setattr(workspace_arrays.os, "stat", _raise_stat_file_not_found)
     assert workspace_arrays._workspace_file_identity("missing.itws") == (
         "missing.itws",
         0,
         0,
         0,
     )
+
+    def _raise_stat_permission_error(_path: str):
+        raise PermissionError
+
+    monkeypatch.setattr(workspace_arrays.os, "stat", _raise_stat_permission_error)
+    with pytest.raises(PermissionError):
+        workspace_arrays._workspace_file_identity("denied.itws")
 
 
 def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -486,13 +486,16 @@ def test_workspace_xarray_path_helpers_cover_fallbacks(monkeypatch, tmp_path) ->
 def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
+    class _FakeCacheKey:
+        pass
+
     def _fake_init(self, opener, *args, **kwargs):
         captured["opener"] = opener
         captured["args"] = args
         captured["kwargs"] = kwargs
         self._args = args
         self._manager_id = kwargs["manager_id"]
-        self._key = "fake-key"
+        self._key = _FakeCacheKey()
         self._ref_counter = types.SimpleNamespace(decrement=lambda _key: None)
         self._cache = {}
 

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -1,4 +1,5 @@
 import contextlib
+import gc
 import json
 import logging
 import os
@@ -86,6 +87,72 @@ def test_workspace_file_manager_is_pickleable(tmp_path) -> None:
         np.testing.assert_array_equal(data, np.arange(6))
     finally:
         restored.close()
+
+
+def test_workspace_file_manager_cache_evicts_old_handles(tmp_path) -> None:
+    paths = [tmp_path / f"cache-{index}.itws" for index in range(3)]
+    for path in paths:
+        xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(path, engine="h5netcdf")
+
+    managers = [workspace_arrays.WorkspaceFileManager(path) for path in paths]
+    try:
+        with xr.set_options(file_cache_maxsize=1):
+            first_file = managers[0].acquire()
+            second_file = managers[1].acquire()
+            assert first_file._closed
+
+            third_file = managers[2].acquire()
+            assert second_file._closed
+            assert not third_file._closed
+    finally:
+        for manager in managers:
+            manager.close()
+
+
+def test_workspace_file_manager_serialization_rejects_replaced_generation(
+    tmp_path,
+) -> None:
+    destination = tmp_path / "current.itws"
+    source = tmp_path / "replacement.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(destination, engine="h5netcdf")
+    xr.Dataset({"data": ("x", np.arange(3) + 1)}).to_netcdf(source, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    serialized = pickle.dumps(manager)
+
+    workspace_storage._replace_workspace_file(source, destination)
+
+    try:
+        with pytest.raises(TypeError, match="replaced workspace generation"):
+            pickle.dumps(manager)
+        with pytest.raises(
+            RuntimeError, match="changed after its reader was serialized"
+        ):
+            pickle.loads(serialized)
+    finally:
+        manager.close()
+        del manager
+        gc.collect()
+
+
+def test_disposed_workspace_generation_rejects_reuse(tmp_path) -> None:
+    fname = tmp_path / "disposed.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    generation = manager._generation
+    manager._finalizer.detach()
+    assert generation.remove_manager()
+
+    with workspace_arrays._workspace_file_lock(fname):
+        workspace_arrays._cleanup_workspace_file_generation_locked(generation)
+
+    with pytest.raises(RuntimeError, match="no longer available"):
+        generation.acquire(needs_lock=True)
+    with pytest.raises(RuntimeError, match="no longer available"):
+        generation.acquire_context(needs_lock=True)
+    with pytest.raises(RuntimeError, match="no longer available"):
+        generation.add_manager()
+    assert not generation.schedule_cleanup()
+    generation.dispose()
 
 
 @pytest.mark.parametrize("already_open", [False, True])
@@ -509,7 +576,9 @@ def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:
     )
     monkeypatch.setattr(workspace_arrays, "_normalized_file_path", lambda _path: None)
     monkeypatch.setattr(
-        workspace_arrays, "_workspace_file_identity", lambda path: (path, 0, 0, 0)
+        workspace_arrays,
+        "_workspace_file_identity",
+        lambda path: (path, 0, 0, 0),
     )
 
     file_manager = workspace_arrays.WorkspaceFileManager("fallback.itws")

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pathlib
 import pickle
+import threading
 import types
 import typing
 import warnings
@@ -71,6 +72,57 @@ def test_workspace_file_managers_share_one_generation_per_path(tmp_path) -> None
     finally:
         first_manager.close()
         other_manager.close()
+
+
+def test_workspace_file_generation_registration_uses_short_registry_lock(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "registry-lock.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    generation_type = workspace_arrays._WorkspaceFileGeneration
+    original_add_manager = generation_type.add_manager
+    construction_lock_states: list[bool] = []
+    lease_lock_states: list[bool] = []
+
+    def _new_generation(*args, **kwargs):
+        construction_lock_states.append(
+            workspace_arrays._WORKSPACE_FILE_GENERATIONS_LOCK.locked()
+        )
+        return generation_type(*args, **kwargs)
+
+    def _add_manager(generation) -> None:
+        lease_lock_states.append(
+            workspace_arrays._WORKSPACE_FILE_GENERATIONS_LOCK.locked()
+        )
+        original_add_manager(generation)
+
+    monkeypatch.setattr(workspace_arrays, "_WorkspaceFileGeneration", _new_generation)
+    monkeypatch.setattr(generation_type, "add_manager", _add_manager)
+
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    try:
+        assert construction_lock_states == [False]
+        assert lease_lock_states == [False]
+    finally:
+        manager.close()
+
+
+def test_workspace_file_manager_finalizer_defers_cleanup(tmp_path) -> None:
+    fname = tmp_path / "deferred-cleanup.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    generation = manager._generation
+
+    with workspace_arrays._workspace_file_lock(fname):
+        manager._finalizer()
+        assert generation._finalizer.alive
+        assert workspace_arrays._current_workspace_file_generation(fname) is generation
+
+    for _ in range(100):
+        if not generation._finalizer.alive:
+            break
+        threading.Event().wait(0.01)
+    assert not generation._finalizer.alive
 
 
 def test_workspace_file_manager_is_pickleable(tmp_path) -> None:
@@ -140,7 +192,7 @@ def test_disposed_workspace_generation_rejects_reuse(tmp_path) -> None:
     manager = workspace_arrays.WorkspaceFileManager(fname)
     generation = manager._generation
     manager._finalizer.detach()
-    assert generation.remove_manager()
+    assert generation.release_manager()
 
     with workspace_arrays._workspace_file_lock(fname):
         workspace_arrays._cleanup_workspace_file_generation_locked(generation)
@@ -151,7 +203,6 @@ def test_disposed_workspace_generation_rejects_reuse(tmp_path) -> None:
         generation.acquire_context(needs_lock=True)
     with pytest.raises(RuntimeError, match="no longer available"):
         generation.add_manager()
-    assert not generation.schedule_cleanup()
     generation.dispose()
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -490,6 +490,8 @@ def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:
         captured["opener"] = opener
         captured["args"] = args
         captured["kwargs"] = kwargs
+        self._args = args
+        self._manager_id = kwargs["manager_id"]
         self._key = "fake-key"
         self._ref_counter = types.SimpleNamespace(decrement=lambda _key: None)
         self._cache = {}

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -231,15 +231,20 @@ def test_workspace_reader_handoffs_do_not_delete_parent_files_after_fork(
     workspace_arrays._WORKSPACE_READER_HANDOFFS[str(handoff_path)] = (
         workspace_arrays._WorkspaceReaderHandoff(
             reader_file,
-            (str(tmp_path / "workspace.itws"), "parent-revision"),
+            (str(tmp_path / "workspace.itws"), "parent-revision", "/"),
         )
     )
     old_lock = workspace_arrays._WORKSPACE_READER_HANDOFFS_LOCK
+    old_save_lock = workspace_arrays._workspace_save_lock(tmp_path / "workspace.itws")
 
     workspace_arrays._reset_workspace_reader_handoffs_after_fork()
 
     assert workspace_arrays._WORKSPACE_READER_HANDOFFS == {}
     assert workspace_arrays._WORKSPACE_READER_HANDOFFS_LOCK is not old_lock
+    assert (
+        workspace_arrays._workspace_save_lock(tmp_path / "workspace.itws")
+        is not old_save_lock
+    )
     assert handoff_path.exists()
     reader_file.cleanup()
 
@@ -392,8 +397,8 @@ def test_workspace_file_manager_handoff_outlives_sender_generation(
     handoff_paths: list[pathlib.Path] = []
     original_handoff = workspace_arrays._create_workspace_reader_handoff
 
-    def _record_handoff(export_file, workspace_path, revision):
-        handoff = original_handoff(export_file, workspace_path, revision)
+    def _record_handoff(export_file, workspace_path, revision, group):
+        handoff = original_handoff(export_file, workspace_path, revision, group)
         handoff_paths.append(pathlib.Path(handoff.path))
         return handoff
 
@@ -416,7 +421,7 @@ def test_workspace_file_manager_handoff_outlives_sender_generation(
     assert handoff_path.exists()
     restored = pickle.loads(serialized)
     try:
-        assert not handoff_path.exists()
+        assert handoff_path.exists()
         np.testing.assert_array_equal(
             restored.acquire().variables["data"][:], np.arange(6)
         )
@@ -424,17 +429,41 @@ def test_workspace_file_manager_handoff_outlives_sender_generation(
         restored.close()
 
 
-def test_workspace_file_manager_uses_independent_serialization_handoffs(
+def test_workspace_file_manager_cleans_retired_serialization_handoff(
     monkeypatch, tmp_path
 ) -> None:
-    fname = tmp_path / "independent-handoffs.itws"
+    fname = tmp_path / "retired-handoff.itws"
+    xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    generation = manager._generation
+    pickle.dumps(manager)
+    handoff_path = next(
+        workspace_arrays._workspace_reader_directory(fname).glob("handoff-*.itws")
+    )
+    monkeypatch.setattr(
+        workspace_arrays, "_WORKSPACE_READER_HANDOFF_RETENTION_SECONDS", 0.0
+    )
+
+    manager._finalizer()
+    with workspace_arrays._workspace_file_lock(fname):
+        workspace_arrays._cleanup_workspace_file_generation_locked(generation)
+    workspace_arrays._cleanup_expired_workspace_reader_handoffs()
+
+    assert not handoff_path.exists()
+    assert not workspace_arrays._WORKSPACE_READER_HANDOFFS
+
+
+def test_workspace_file_manager_reuses_serialization_handoff(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "reusable-handoff.itws"
     xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
     manager = workspace_arrays.WorkspaceFileManager(fname)
     handoff_paths: list[pathlib.Path] = []
     original_handoff = workspace_arrays._create_workspace_reader_handoff
 
-    def _record_handoff(export_file, workspace_path, revision):
-        handoff = original_handoff(export_file, workspace_path, revision)
+    def _record_handoff(export_file, workspace_path, revision, group):
+        handoff = original_handoff(export_file, workspace_path, revision, group)
         handoff_paths.append(pathlib.Path(handoff.path))
         return handoff
 
@@ -445,20 +474,43 @@ def test_workspace_file_manager_uses_independent_serialization_handoffs(
     second_payload = pickle.dumps(manager)
 
     assert len(handoff_paths) == 2
-    assert handoff_paths[0] != handoff_paths[1]
+    assert handoff_paths[0] == handoff_paths[1]
     assert all(path.exists() for path in handoff_paths)
     first = pickle.loads(first_payload)
+    repeated = pickle.loads(first_payload)
     second = pickle.loads(second_payload)
     try:
-        assert all(not path.exists() for path in handoff_paths)
-        for restored in (first, second):
+        assert all(path.exists() for path in handoff_paths)
+        for restored in (first, repeated, second):
             np.testing.assert_array_equal(
                 restored.acquire().variables["data"][:], np.arange(6)
             )
     finally:
         manager.close()
         first.close()
+        repeated.close()
         second.close()
+
+
+def test_workspace_file_manager_failed_pickle_reuses_handoff(tmp_path) -> None:
+    fname = tmp_path / "failed-pickle.itws"
+    xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+
+    try:
+        for _ in range(3):
+            with pytest.raises(pickle.PicklingError):
+                pickle.dumps({"manager": manager, "unpickleable": lambda: None})
+
+        handoff_paths = tuple(
+            workspace_arrays._workspace_reader_directory(fname).glob("handoff-*.itws")
+        )
+        assert len(handoff_paths) == 1
+        assert tuple(workspace_arrays._WORKSPACE_READER_HANDOFFS) == (
+            str(handoff_paths[0]),
+        )
+    finally:
+        manager.close()
 
 
 def test_workspace_file_manager_bounds_unconsumed_reader_generations(
@@ -496,31 +548,48 @@ def test_workspace_file_manager_bounds_unconsumed_reader_handoffs(
     monkeypatch, tmp_path
 ) -> None:
     fname = tmp_path / "pending-readers.itws"
-    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
-    manager = workspace_arrays.WorkspaceFileManager(fname)
+    tree = xr.DataTree.from_dict(
+        {
+            "0": xr.Dataset({"data": ("x", np.arange(3))}),
+            "1": xr.Dataset({"data": ("x", np.arange(3) + 10)}),
+        }
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            fname, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+    first_manager = workspace_arrays.WorkspaceFileManager(fname, "0")
+    second_manager = workspace_arrays.WorkspaceFileManager(fname, "1")
     monkeypatch.setattr(workspace_arrays, "_WORKSPACE_MAX_PENDING_READER_HANDOFFS", 1)
     missing_handoff = tmp_path / "missing-handoff.itws"
     workspace_arrays._WORKSPACE_READER_HANDOFFS[str(missing_handoff)] = (
         workspace_arrays._WorkspaceReaderHandoff(
             workspace_arrays._WorkspaceReaderFile(str(missing_handoff), lambda: None),
-            (str(fname), "stale-revision"),
+            (str(fname), "stale-revision", "/"),
         )
     )
-    first_payload = pickle.dumps(manager)
+    first_payload = pickle.dumps(first_manager)
     assert str(missing_handoff) not in workspace_arrays._WORKSPACE_READER_HANDOFFS
+    repeated_payload = pickle.dumps(first_manager)
 
     try:
         with pytest.raises(RuntimeError, match="Wait for background work"):
-            pickle.dumps(manager)
-        restored = pickle.loads(first_payload)
+            pickle.dumps(second_manager)
+        first = pickle.loads(first_payload)
+        repeated = pickle.loads(repeated_payload)
         try:
-            np.testing.assert_array_equal(
-                restored.acquire().variables["data"][:], np.arange(3)
-            )
+            for restored in (first, repeated):
+                np.testing.assert_array_equal(
+                    restored.acquire().groups["0"].variables["data"][:], np.arange(3)
+                )
         finally:
-            restored.close()
+            first.close()
+            repeated.close()
     finally:
-        manager.close()
+        first_manager.close()
+        second_manager.close()
 
 
 def test_workspace_file_manager_rejects_missing_serialized_export(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import pathlib
+import pickle
 import types
 import typing
 import warnings
@@ -47,24 +48,11 @@ def test_workspace_h5py_helpers_reject_non_workspace_files(tmp_path) -> None:
     assert workspace_arrays._workspace_h5_object_storage_size(object()) == 0
 
 
-def test_workspace_file_manager_registry_closes_all_path_identities(
-    monkeypatch, tmp_path
-) -> None:
+def test_workspace_file_managers_share_one_generation_per_path(tmp_path) -> None:
     first = tmp_path / "first.h5"
     second = tmp_path / "second.h5"
     xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(first, engine="h5netcdf")
     xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(second, engine="h5netcdf")
-    first_target = workspace_arrays._normalized_file_path(first)
-    original_identity = workspace_arrays._workspace_file_identity
-    first_identity_generation = iter((1, 2))
-
-    def _identity(path):
-        target = workspace_arrays._normalized_file_path(path)
-        if target == first_target:
-            return target, 0, 0, next(first_identity_generation)
-        return original_identity(path)
-
-    monkeypatch.setattr(workspace_arrays, "_workspace_file_identity", _identity)
     first_manager = workspace_arrays.WorkspaceFileManager(first)
     second_first_manager = workspace_arrays.WorkspaceFileManager(first)
     other_manager = workspace_arrays.WorkspaceFileManager(second)
@@ -72,21 +60,53 @@ def test_workspace_file_manager_registry_closes_all_path_identities(
     second_first_file = second_first_manager.acquire()
     other_file = other_manager.acquire()
     try:
-        assert first_file is not second_first_file
-        monkeypatch.setattr(
-            workspace_arrays, "_normalized_file_path", lambda _path: None
-        )
-        with workspace_arrays._workspace_file_lock(first):
-            workspace_arrays._close_workspace_file_managers(first)
-
+        assert first_manager._generation is second_first_manager._generation
+        assert first_manager._generation is not other_manager._generation
+        assert first_file is second_first_file
+        first_manager.close()
         assert first_file._closed
-        assert second_first_file._closed
         assert not other_file._closed
+        assert second_first_manager.acquire() is not first_file
     finally:
-        with workspace_arrays._workspace_file_lock(first):
-            workspace_arrays._close_workspace_file_managers(first)
-        with workspace_arrays._workspace_file_lock(second):
-            workspace_arrays._close_workspace_file_managers(second)
+        first_manager.close()
+        other_manager.close()
+
+
+def test_workspace_file_manager_is_pickleable(tmp_path) -> None:
+    fname = tmp_path / "pickleable.itws"
+    xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    manager.acquire()
+    serialized = pickle.dumps(manager)
+    manager.close()
+
+    restored = pickle.loads(serialized)
+    try:
+        data = restored.acquire().variables["data"][:]
+        np.testing.assert_array_equal(data, np.arange(6))
+    finally:
+        restored.close()
+
+
+@pytest.mark.parametrize("already_open", [False, True])
+def test_workspace_file_manager_acquire_context_error_closes_only_new_handle(
+    tmp_path, *, already_open: bool
+) -> None:
+    fname = tmp_path / "acquire-context.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    if already_open:
+        manager.acquire()
+
+    try:
+        with (
+            pytest.raises(RuntimeError, match="read failed"),
+            manager.acquire_context() as acquired,
+        ):
+            raise RuntimeError("read failed")
+        assert acquired._closed is not already_open
+    finally:
+        manager.close()
 
 
 def test_workspace_h5py_filter_matching_edge_cases(tmp_path) -> None:
@@ -484,21 +504,6 @@ def test_workspace_xarray_path_helpers_cover_fallbacks(monkeypatch, tmp_path) ->
 
 
 def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
-    class _FakeCacheKey:
-        pass
-
-    def _fake_init(self, opener, *args, **kwargs):
-        captured["opener"] = opener
-        captured["args"] = args
-        captured["kwargs"] = kwargs
-        self._args = args
-        self._manager_id = kwargs["manager_id"]
-        self._key = _FakeCacheKey()
-        self._ref_counter = types.SimpleNamespace(decrement=lambda _key: None)
-        self._cache = {}
-
     monkeypatch.setattr(
         workspace_arrays, "ensure_workspace_hdf5_filters_registered", lambda: None
     )
@@ -506,13 +511,11 @@ def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:
     monkeypatch.setattr(
         workspace_arrays, "_workspace_file_identity", lambda path: (path, 0, 0, 0)
     )
-    monkeypatch.setattr(workspace_arrays.CachingFileManager, "__init__", _fake_init)
 
     file_manager = workspace_arrays.WorkspaceFileManager("fallback.itws")
 
     assert file_manager.workspace_path == "fallback.itws"
-    assert captured["args"][0] == "fallback.itws"
-    assert captured["kwargs"]["mode"] == "r+"
+    assert file_manager._generation.path == "fallback.itws"
 
 
 def test_open_workspace_dataset_uses_fsdecode_fallback(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -13,6 +13,7 @@ import types
 import typing
 import warnings
 
+import dask.base
 import h5py
 import hdf5plugin
 import numpy as np
@@ -31,15 +32,16 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _hdf5_blosc2_level_codec,
     _hdf5_filter_ids,
     _rich_workspace_attr_value,
+    _transaction_test_dataset,
     _transaction_test_root_attrs,
     _write_transaction_test_workspace,
 )
 
 
 @pytest.fixture(autouse=True)
-def _cleanup_workspace_session_exports() -> typing.Iterator[None]:
+def _cleanup_workspace_reader_handoffs() -> typing.Iterator[None]:
     yield
-    workspace_arrays._cleanup_workspace_session_exports()
+    workspace_arrays._cleanup_workspace_reader_handoffs()
 
 
 def test_workspace_h5py_helpers_reject_non_workspace_files(tmp_path) -> None:
@@ -144,6 +146,46 @@ def test_workspace_file_generation_binds_one_observed_file_state(
         manager.close()
 
 
+def test_workspace_file_generation_registers_lease_under_path_lock(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "atomic-lease.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    generation_type = workspace_arrays._WorkspaceFileGeneration
+    original_add_manager = generation_type.add_manager
+    cleanup_started = threading.Event()
+    cleanup_finished = threading.Event()
+    cleanup_thread: threading.Thread | None = None
+
+    def _add_manager(generation, manager=None) -> None:
+        nonlocal cleanup_thread
+
+        def _cleanup() -> None:
+            cleanup_started.set()
+            workspace_arrays._cleanup_workspace_file_generation(generation)
+            cleanup_finished.set()
+
+        cleanup_thread = threading.Thread(target=_cleanup)
+        cleanup_thread.start()
+        assert cleanup_started.wait(2)
+        assert not cleanup_finished.wait(0.05)
+        original_add_manager(generation, manager)
+
+    monkeypatch.setattr(generation_type, "add_manager", _add_manager)
+
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    if cleanup_thread is None:
+        raise AssertionError("Generation cleanup thread did not start")
+    cleanup_thread.join(2)
+    try:
+        assert not cleanup_thread.is_alive()
+        assert cleanup_finished.is_set()
+        assert manager._generation.has_managers()
+        manager.acquire()
+    finally:
+        manager.close()
+
+
 def test_workspace_reader_helpers_reject_unsafe_directory_and_names(tmp_path) -> None:
     workspace_path = tmp_path / "workspace.itws"
     reader_directory = workspace_arrays._workspace_reader_directory(workspace_path)
@@ -160,6 +202,12 @@ def test_workspace_reader_helpers_reject_unsafe_directory_and_names(tmp_path) ->
         )
         == 123
     )
+    assert (
+        workspace_arrays._workspace_reader_file_owner_pid(
+            pathlib.Path(f"handoff-456-{valid_token}.itws")
+        )
+        == 456
+    )
     for name in (
         "reader.itws",
         "reader-bad-token.itws",
@@ -172,23 +220,27 @@ def test_workspace_reader_helpers_reject_unsafe_directory_and_names(tmp_path) ->
         )
 
 
-def test_workspace_session_exports_do_not_delete_parent_files_after_fork(
+def test_workspace_reader_handoffs_do_not_delete_parent_files_after_fork(
     tmp_path,
 ) -> None:
-    export_path = tmp_path / "parent-export.itws"
-    export_path.write_bytes(b"parent")
+    handoff_path = tmp_path / "parent-handoff.itws"
+    handoff_path.write_bytes(b"parent")
     reader_file = workspace_arrays._WorkspaceReaderFile(
-        str(export_path), export_path.unlink
+        str(handoff_path), handoff_path.unlink
     )
-    key = (str(tmp_path / "workspace.itws"), 1, 2, 3, "/")
-    workspace_arrays._WORKSPACE_SESSION_EXPORTS[key] = reader_file
-    old_lock = workspace_arrays._WORKSPACE_SESSION_EXPORTS_LOCK
+    workspace_arrays._WORKSPACE_READER_HANDOFFS[str(handoff_path)] = (
+        workspace_arrays._WorkspaceReaderHandoff(
+            reader_file,
+            (str(tmp_path / "workspace.itws"), "parent-revision"),
+        )
+    )
+    old_lock = workspace_arrays._WORKSPACE_READER_HANDOFFS_LOCK
 
-    workspace_arrays._reset_workspace_session_exports_after_fork()
+    workspace_arrays._reset_workspace_reader_handoffs_after_fork()
 
-    assert workspace_arrays._WORKSPACE_SESSION_EXPORTS == {}
-    assert workspace_arrays._WORKSPACE_SESSION_EXPORTS_LOCK is not old_lock
-    assert export_path.exists()
+    assert workspace_arrays._WORKSPACE_READER_HANDOFFS == {}
+    assert workspace_arrays._WORKSPACE_READER_HANDOFFS_LOCK is not old_lock
+    assert handoff_path.exists()
     reader_file.cleanup()
 
 
@@ -224,6 +276,46 @@ def test_workspace_file_manager_is_pickleable(tmp_path) -> None:
         np.testing.assert_array_equal(data, np.arange(6))
     finally:
         restored.close()
+
+
+def test_workspace_file_manager_dask_token_does_not_create_handoff(tmp_path) -> None:
+    fname = tmp_path / "dask-token.itws"
+    _write_transaction_test_workspace(fname)
+    manager = workspace_arrays.WorkspaceFileManager(fname, "0/imagetool")
+    reader_directory = workspace_arrays._workspace_reader_directory(fname)
+
+    try:
+        token_before = dask.base.tokenize(manager)
+        assert dask.base.tokenize(manager) == token_before
+        dataset_before = workspace_arrays._open_workspace_dataset_from_manager(
+            manager,
+            "0/imagetool",
+            chunks="auto",
+        )
+        dask_name_before = dataset_before["data"].data.name
+        dataset_before.close()
+        assert not list(reader_directory.glob("handoff-*.itws"))
+
+        workspace_storage._write_workspace_root_attrs_to_file(
+            fname,
+            {
+                **_transaction_test_root_attrs(),
+                "generation_marker": "updated",
+            },
+        )
+        assert dask.base.tokenize(manager) != token_before
+        dataset_after = workspace_arrays._open_workspace_dataset_from_manager(
+            manager,
+            "0/imagetool",
+            chunks="auto",
+        )
+        try:
+            assert dataset_after["data"].data.name != dask_name_before
+        finally:
+            dataset_after.close()
+        assert not list(reader_directory.glob("handoff-*.itws"))
+    finally:
+        manager.close()
 
 
 def test_workspace_file_manager_opens_published_generation_read_only(tmp_path) -> None:
@@ -290,28 +382,145 @@ def test_workspace_file_manager_exports_only_requested_group(tmp_path) -> None:
         manager.close()
 
 
-def test_workspace_file_manager_export_is_owned_by_sender_session(tmp_path) -> None:
-    fname = tmp_path / "session-export.itws"
+def test_workspace_file_manager_handoff_outlives_sender_generation(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "reader-handoff.itws"
     xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
     manager = workspace_arrays.WorkspaceFileManager(fname)
     generation = manager._generation
+    handoff_paths: list[pathlib.Path] = []
+    original_handoff = workspace_arrays._create_workspace_reader_handoff
+
+    def _record_handoff(export_file, workspace_path, revision):
+        handoff = original_handoff(export_file, workspace_path, revision)
+        handoff_paths.append(pathlib.Path(handoff.path))
+        return handoff
+
+    monkeypatch.setattr(
+        workspace_arrays, "_create_workspace_reader_handoff", _record_handoff
+    )
     serialized = pickle.dumps(manager)
-    export_path = pathlib.Path(manager.__getstate__()[1])
+    assert len(handoff_paths) == 1
+    handoff_path = handoff_paths[0]
+    export_paths = tuple(
+        workspace_arrays._workspace_reader_directory(fname).glob("export-*.itws")
+    )
+    assert len(export_paths) == 1
 
     manager._finalizer()
     with workspace_arrays._workspace_file_lock(fname):
         workspace_arrays._cleanup_workspace_file_generation_locked(generation)
 
+    assert not export_paths[0].exists()
+    assert handoff_path.exists()
     restored = pickle.loads(serialized)
     try:
-        assert export_path.exists()
+        assert not handoff_path.exists()
         np.testing.assert_array_equal(
             restored.acquire().variables["data"][:], np.arange(6)
         )
     finally:
         restored.close()
-        workspace_arrays._cleanup_workspace_session_exports()
-    assert not export_path.exists()
+
+
+def test_workspace_file_manager_uses_independent_serialization_handoffs(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "independent-handoffs.itws"
+    xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    handoff_paths: list[pathlib.Path] = []
+    original_handoff = workspace_arrays._create_workspace_reader_handoff
+
+    def _record_handoff(export_file, workspace_path, revision):
+        handoff = original_handoff(export_file, workspace_path, revision)
+        handoff_paths.append(pathlib.Path(handoff.path))
+        return handoff
+
+    monkeypatch.setattr(
+        workspace_arrays, "_create_workspace_reader_handoff", _record_handoff
+    )
+    first_payload = pickle.dumps(manager)
+    second_payload = pickle.dumps(manager)
+
+    assert len(handoff_paths) == 2
+    assert handoff_paths[0] != handoff_paths[1]
+    assert all(path.exists() for path in handoff_paths)
+    first = pickle.loads(first_payload)
+    second = pickle.loads(second_payload)
+    try:
+        assert all(not path.exists() for path in handoff_paths)
+        for restored in (first, second):
+            np.testing.assert_array_equal(
+                restored.acquire().variables["data"][:], np.arange(6)
+            )
+    finally:
+        manager.close()
+        first.close()
+        second.close()
+
+
+def test_workspace_file_manager_bounds_unconsumed_reader_generations(
+    monkeypatch, tmp_path
+) -> None:
+    first_path = tmp_path / "first-pending.itws"
+    second_path = tmp_path / "second-pending.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(first_path, engine="h5netcdf")
+    xr.Dataset({"data": ("x", np.arange(3) + 10)}).to_netcdf(
+        second_path, engine="h5netcdf"
+    )
+    first = workspace_arrays.WorkspaceFileManager(first_path)
+    second = workspace_arrays.WorkspaceFileManager(second_path)
+    monkeypatch.setattr(
+        workspace_arrays, "_WORKSPACE_MAX_PENDING_READER_GENERATIONS", 1
+    )
+    first_payload = pickle.dumps(first)
+
+    try:
+        with pytest.raises(RuntimeError, match="Wait for background work"):
+            pickle.dumps(second)
+        restored = pickle.loads(first_payload)
+        try:
+            np.testing.assert_array_equal(
+                restored.acquire().variables["data"][:], np.arange(3)
+            )
+        finally:
+            restored.close()
+    finally:
+        first.close()
+        second.close()
+
+
+def test_workspace_file_manager_bounds_unconsumed_reader_handoffs(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "pending-readers.itws"
+    xr.Dataset({"data": ("x", np.arange(3))}).to_netcdf(fname, engine="h5netcdf")
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    monkeypatch.setattr(workspace_arrays, "_WORKSPACE_MAX_PENDING_READER_HANDOFFS", 1)
+    missing_handoff = tmp_path / "missing-handoff.itws"
+    workspace_arrays._WORKSPACE_READER_HANDOFFS[str(missing_handoff)] = (
+        workspace_arrays._WorkspaceReaderHandoff(
+            workspace_arrays._WorkspaceReaderFile(str(missing_handoff), lambda: None),
+            (str(fname), "stale-revision"),
+        )
+    )
+    first_payload = pickle.dumps(manager)
+    assert str(missing_handoff) not in workspace_arrays._WORKSPACE_READER_HANDOFFS
+
+    try:
+        with pytest.raises(RuntimeError, match="Wait for background work"):
+            pickle.dumps(manager)
+        restored = pickle.loads(first_payload)
+        try:
+            np.testing.assert_array_equal(
+                restored.acquire().variables["data"][:], np.arange(3)
+            )
+        finally:
+            restored.close()
+    finally:
+        manager.close()
 
 
 def test_workspace_file_manager_rejects_missing_serialized_export(tmp_path) -> None:
@@ -361,6 +570,47 @@ def test_workspace_file_manager_root_attr_update_refreshes_current_generation(
         manager.close()
         before.close()
         current.close()
+
+
+def test_workspace_file_manager_export_uses_logical_generation_revision(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "coarse-timestamp.itws"
+    _write_transaction_test_workspace(fname, value=1.0)
+    original_file_state = workspace_arrays._workspace_file_state
+    canonical_path = fname.resolve()
+    fixed_mtime = fname.stat().st_mtime_ns
+
+    def _coarse_file_state(path):
+        identity, exists = original_file_state(path)
+        if pathlib.Path(identity[0]).resolve() == canonical_path:
+            identity = (*identity[:3], fixed_mtime)
+        return identity, exists
+
+    monkeypatch.setattr(workspace_arrays, "_workspace_file_state", _coarse_file_state)
+    before = workspace_arrays.WorkspaceFileManager(fname, "0/imagetool")
+    generation = before._generation
+    revision_before = generation.revision
+    state_before = before.__getstate__()
+
+    workspace_storage._write_workspace_transaction_file(
+        fname,
+        (("0", {"0/imagetool": _transaction_test_dataset(9.0, title="new")}),),
+        (),
+        _transaction_test_root_attrs(delta_save_count=1),
+    )
+    after = workspace_arrays.WorkspaceFileManager(fname, "0/imagetool")
+    state_after = after.__getstate__()
+    try:
+        assert generation.revision != revision_before
+        assert state_after[1] != state_before[1]
+        with h5py.File(state_before[1], "r") as old_export:
+            assert np.asarray(old_export["0/imagetool/data"]).item() == 1.0
+        with h5py.File(state_after[1], "r") as new_export:
+            assert np.asarray(new_export["0/imagetool/data"]).item() == 9.0
+    finally:
+        before.close()
+        after.close()
 
 
 def test_workspace_file_manager_export_rejects_source_change(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -5590,6 +5590,49 @@ def test_manager_workspace_same_file_lazy_data_delta_save_does_not_deadlock(
             assert saved.chunks == (128, 64)
 
 
+def test_manager_background_full_save_rebinds_cached_lazy_workspace_data(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(512 * 512, dtype=np.float64).reshape((512, 512)),
+            dims=["x", "y"],
+            coords={"x": np.arange(512), "y": np.arange(512)},
+        )
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "background-full-lazy.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
+            fname, targets=[0], chunks={}
+        )
+        tool = manager.get_imagetool(0)
+        assert tool.slicer_area.data_chunked
+        np.testing.assert_array_equal(tool.slicer_area._data.compute(), data)
+
+        uid = manager._tool_graph.root_wrappers[0].uid
+        manager._workspace_controller._mark_node_state_dirty(uid)
+        manager._workspace_state.needs_full_save = True
+        assert _request_workspace_save_and_wait(qtbot, manager)
+
+        rebound = manager.get_imagetool(0).slicer_area._data
+        assert rebound.chunks is not None
+        np.testing.assert_array_equal(rebound.compute(), data)
+
+
 def test_manager_workspace_lazy_data_delta_pending_failure_preserves_old_group(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -1459,7 +1459,9 @@ def _compact_workspace_before_shutdown_and_wait(
     return requested
 
 
-def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
+def test_workspace_save_worker_reports_specific_storage_errors(
+    monkeypatch, tmp_path
+) -> None:
     missing_source = tmp_path / "deleted-source.itws"
     target = tmp_path / "target.itws"
     snapshot = workspace_saving._WorkspaceSaveSnapshot(
@@ -1492,6 +1494,38 @@ def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
     assert error.missing_source_path == str(missing_source)
     assert error.traceback_text
 
+    def _run_worker_with_error(exc: Exception) -> workspace_saving._WorkspaceSaveError:
+        snapshot = workspace_saving._WorkspaceSaveSnapshot(
+            generation=0,
+            root_attrs=_transaction_test_root_attrs(),
+            delta_save_count=0,
+        )
+        worker = workspace_saving._WorkspaceSaveWorker(target, snapshot)
+        errors: list[workspace_saving._WorkspaceSaveError | None] = []
+        receiver = workspace_saving._WorkspaceSaveResultReceiver(
+            callback=lambda _elapsed, save_error: errors.append(save_error),
+            parent=worker.signals,
+        )
+        worker.signals.finished.connect(receiver.finish)
+        monkeypatch.setattr(
+            workspace_storage,
+            "_write_workspace_transaction_file",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(exc),
+        )
+        worker.run()
+        assert isinstance(errors[0], workspace_saving._WorkspaceSaveError)
+        return errors[0]
+
+    access_error = _run_worker_with_error(PermissionError("access denied"))
+    assert access_error.access_denied_path == str(target)
+
+    conflict_error = _run_worker_with_error(
+        workspace_storage._WorkspacePublicationConflictError(
+            target, "Workspace changed while its successor was prepared"
+        )
+    )
+    assert conflict_error.publication_conflict_path == str(target)
+
 
 def test_manager_async_save_request_error_paths(
     qtbot,
@@ -1522,6 +1556,20 @@ def test_manager_async_save_request_error_paths(
         )
         manager._show_workspace_save_worker_error(missing_error)
         assert len(critical_calls) == 2
+
+        manager._show_workspace_save_worker_error(
+            workspace_saving._WorkspaceSaveError(
+                traceback_text="Access traceback",
+                access_denied_path=str(tmp_path / "denied.itws"),
+            )
+        )
+        manager._show_workspace_save_worker_error(
+            workspace_saving._WorkspaceSaveError(
+                traceback_text="Conflict traceback",
+                publication_conflict_path=str(tmp_path / "changed.itws"),
+            )
+        )
+        assert len(critical_calls) == 4
 
         manager._workspace_state.path = tmp_path / "workspace.itws"
         manager._workspace_state.save_in_progress = True
@@ -5509,7 +5557,7 @@ def test_manager_workspace_load_keeps_visible_saved_data_in_memory(
         np.testing.assert_array_equal(loaded._data.values, data.values)
 
 
-def test_manager_workspace_lazy_data_delta_save_uses_pending_group_before_replacing(
+def test_manager_workspace_lazy_data_delta_save_publishes_successor(
     qtbot,
     tmp_path,
     manager_context: Callable[
@@ -5538,7 +5586,7 @@ def test_manager_workspace_lazy_data_delta_save_uses_pending_group_before_replac
             replacement, auto_compute=False
         )
         assert _request_workspace_save_and_wait(qtbot, manager)
-        assert list(tmp_path.glob("lazy-data.itws.delta-*")) == []
+        assert list(tmp_path.glob(".lazy-data.itws.next-*.itws")) == []
 
         import h5py
 
@@ -5670,14 +5718,14 @@ def test_manager_background_full_save_preserves_post_snapshot_dask_edit(
         original_replace = workspace_storage._replace_workspace_file
         pause_replacement = True
 
-        def _pause_first_replacement(source, destination) -> None:
+        def _pause_first_replacement(source, destination, **kwargs) -> None:
             nonlocal pause_replacement
             if pause_replacement and pathlib.Path(destination) == fname:
                 pause_replacement = False
                 replacement_started.set()
                 if not allow_replacement.wait(5):
                     raise TimeoutError("Background replacement did not resume")
-            original_replace(source, destination)
+            original_replace(source, destination, **kwargs)
 
         monkeypatch.setattr(
             workspace_storage, "_replace_workspace_file", _pause_first_replacement
@@ -5714,7 +5762,7 @@ def test_manager_background_full_save_preserves_post_snapshot_dask_edit(
             )
 
 
-def test_manager_workspace_lazy_data_delta_pending_failure_preserves_old_group(
+def test_manager_workspace_lazy_data_successor_failure_preserves_old_group(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -5741,20 +5789,21 @@ def test_manager_workspace_lazy_data_delta_pending_failure_preserves_old_group(
         replacement.data = np.asarray(replacement.data) + 10
         root.slicer_area.replace_source_data(replacement, auto_compute=False)
 
-        def _write_partial_pending_then_raise(
+        def _write_partial_successor_then_raise(
             fname: str | os.PathLike[str],
             _constructor: Mapping[str, xr.Dataset],
             _group_path: str,
-            pending_path: str,
+            destination_path: str,
+            **_kwargs,
         ) -> None:
             with workspace_storage._open_workspace_h5_file_for_update(fname) as h5_file:
-                h5_file.create_group(pending_path)
-            raise RuntimeError("pending write failed")
+                h5_file.create_group(destination_path)
+            raise RuntimeError("successor write failed")
 
         monkeypatch.setattr(
             workspace_storage,
-            "_write_workspace_constructor_groups_to_pending",
-            _write_partial_pending_then_raise,
+            "_write_workspace_constructor_groups_to_path",
+            _write_partial_successor_then_raise,
         )
         monkeypatch.setattr(
             manager, "_show_workspace_save_worker_error", lambda *args: None

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pathlib
 import sys
+import threading
 import time
 import types
 import typing
@@ -5631,6 +5632,86 @@ def test_manager_background_full_save_rebinds_cached_lazy_workspace_data(
         rebound = manager.get_imagetool(0).slicer_area._data
         assert rebound.chunks is not None
         np.testing.assert_array_equal(rebound.compute(), data)
+
+
+def test_manager_background_full_save_preserves_post_snapshot_dask_edit(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(64 * 64, dtype=np.float64).reshape((64, 64)),
+            dims=["x", "y"],
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "background-full-dask-edit.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
+            fname, targets=[0], chunks={}
+        )
+        tool = manager.get_imagetool(0)
+        assert tool.slicer_area.data_chunked
+
+        replacement_started = threading.Event()
+        allow_replacement = threading.Event()
+        original_replace = workspace_storage._replace_workspace_file
+        pause_replacement = True
+
+        def _pause_first_replacement(source, destination) -> None:
+            nonlocal pause_replacement
+            if pause_replacement and pathlib.Path(destination) == fname:
+                pause_replacement = False
+                replacement_started.set()
+                if not allow_replacement.wait(5):
+                    raise TimeoutError("Background replacement did not resume")
+            original_replace(source, destination)
+
+        monkeypatch.setattr(
+            workspace_storage, "_replace_workspace_file", _pause_first_replacement
+        )
+
+        uid = manager._tool_graph.root_wrappers[0].uid
+        manager._workspace_controller._mark_node_state_dirty(uid)
+        manager._workspace_state.needs_full_save = True
+        assert manager._workspace_controller.save()
+        try:
+            qtbot.wait_until(replacement_started.is_set, timeout=10000)
+            edited = tool.slicer_area._data + 10.0
+            tool.slicer_area.replace_source_data(
+                edited,
+                auto_compute=False,
+                emit_edited=True,
+            )
+        finally:
+            allow_replacement.set()
+
+        qtbot.wait_until(
+            lambda: not manager._workspace_state.save_in_progress, timeout=10000
+        )
+        assert manager.is_workspace_modified
+        assert uid in manager._workspace_state.dirty_data
+        np.testing.assert_array_equal(
+            tool.slicer_area._data.compute(), data.values + 10
+        )
+
+        assert _request_workspace_save_and_wait(qtbot, manager)
+        with h5py.File(fname, "r") as h5_file:
+            np.testing.assert_array_equal(
+                h5_file["0/imagetool"][_ITOOL_DATA_NAME][()], data.values + 10
+            )
 
 
 def test_manager_workspace_lazy_data_delta_pending_failure_preserves_old_group(

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -1,6 +1,7 @@
 import errno
 import json
 import pathlib
+import threading
 import types
 import typing
 
@@ -236,6 +237,204 @@ def test_write_full_workspace_tree_file_replaces_stale_root_attrs(tmp_path) -> N
         assert "stale_workspace_attr" not in h5_file.attrs
         manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
         assert manifest == {"schema_version": 4, "root_order": [0], "nodes": []}
+
+
+def test_write_full_workspace_tree_file_closes_cached_workspace_reader(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "cached-reader.itws"
+    _write_transaction_test_workspace(fname)
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    cached_file = manager.acquire()
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    original_replace = workspace_storage.os.replace
+    replacement_checked = False
+
+    def _replace_after_reader_close(source, destination):
+        nonlocal replacement_checked
+        if pathlib.Path(destination) == fname:
+            replacement_checked = True
+            assert cached_file._closed
+        original_replace(source, destination)
+
+    monkeypatch.setattr(workspace_storage.os, "replace", _replace_after_reader_close)
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            fname, tree, _transaction_test_root_attrs()
+        )
+        assert replacement_checked
+        reopened_file = manager.acquire()
+        value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
+        assert np.asarray(value).item() == 2.0
+    finally:
+        tree.close()
+        with workspace_arrays._workspace_file_lock(fname):
+            workspace_arrays._close_workspace_file_managers(fname)
+
+
+def test_write_full_workspace_tree_file_keeps_lazy_dataarray_usable(tmp_path) -> None:
+    fname = tmp_path / "lazy-reader.itws"
+    _write_transaction_test_workspace(fname)
+    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    lazy_data = opened["data"].copy(deep=False)
+    opened.close()
+    assert lazy_data.compute().item() == 1.0
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            fname, tree, _transaction_test_root_attrs()
+        )
+        assert lazy_data.compute().item() == 2.0
+    finally:
+        tree.close()
+        with workspace_arrays._workspace_file_lock(fname):
+            workspace_arrays._close_workspace_file_managers(fname)
+
+
+def test_replace_workspace_file_blocks_new_readers_during_commit(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    source.write_bytes(b"new")
+    destination.write_bytes(b"old")
+    replace_started = threading.Event()
+    allow_replace = threading.Event()
+    reader_acquired = threading.Event()
+    errors: list[BaseException] = []
+    original_replace = workspace_storage.os.replace
+
+    def _paused_replace(src, dst):
+        replace_started.set()
+        if not allow_replace.wait(2):
+            raise TimeoutError("Replacement test did not resume")
+        original_replace(src, dst)
+
+    def _replace() -> None:
+        try:
+            workspace_storage._replace_workspace_file(source, destination)
+        except BaseException as exc:  # pragma: no cover - reported in main thread
+            errors.append(exc)
+
+    def _read() -> None:
+        try:
+            with workspace_arrays._workspace_file_lock(destination):
+                reader_acquired.set()
+        except BaseException as exc:  # pragma: no cover - reported in main thread
+            errors.append(exc)
+
+    monkeypatch.setattr(workspace_storage.os, "replace", _paused_replace)
+    replace_thread = threading.Thread(target=_replace)
+    reader_thread = threading.Thread(target=_read)
+    replace_thread.start()
+    assert replace_started.wait(2)
+    reader_thread.start()
+    try:
+        assert not reader_acquired.wait(0.05)
+    finally:
+        allow_replace.set()
+        replace_thread.join(2)
+        reader_thread.join(2)
+
+    assert not replace_thread.is_alive()
+    assert not reader_thread.is_alive()
+    assert reader_acquired.is_set()
+    assert errors == []
+    assert destination.read_bytes() == b"new"
+
+
+def test_replace_workspace_file_retries_windows_sharing_violation(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    source.write_bytes(b"new")
+    destination.write_bytes(b"old")
+    attempts = 0
+    delays: list[float] = []
+    original_replace = workspace_storage.os.replace
+
+    def _replace_after_transient_failures(src, dst):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise PermissionError(errno.EACCES, "sharing violation")
+        original_replace(src, dst)
+
+    monkeypatch.setattr(
+        workspace_storage, "_workspace_replace_retry_delays", lambda _exc: (0.0, 0.0)
+    )
+    monkeypatch.setattr(
+        workspace_storage.os, "replace", _replace_after_transient_failures
+    )
+    monkeypatch.setattr(workspace_storage.time, "sleep", delays.append)
+
+    workspace_storage._replace_workspace_file(source, destination)
+
+    assert attempts == 3
+    assert delays == [0.0, 0.0]
+    assert destination.read_bytes() == b"new"
+
+
+def test_workspace_replace_retry_delays_only_allow_windows_sharing_errors(
+    monkeypatch,
+) -> None:
+    error = PermissionError(errno.EACCES, "sharing violation")
+    error.winerror = 5
+
+    assert workspace_storage._workspace_replace_retry_delays(error) == ()
+
+    monkeypatch.setattr(workspace_storage.os, "name", "nt")
+    assert workspace_storage._workspace_replace_retry_delays(error) == (
+        workspace_storage._WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS
+    )
+
+    error.winerror = 123
+    assert workspace_storage._workspace_replace_retry_delays(error) == ()
+    error.winerror = 32
+    error.errno = errno.ENOENT
+    assert workspace_storage._workspace_replace_retry_delays(error) == ()
+
+
+def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            source, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    cached_file = manager.acquire()
+
+    def _fail_replace(_source, _destination):
+        raise PermissionError(errno.EACCES, "replacement denied")
+
+    monkeypatch.setattr(workspace_storage.os, "replace", _fail_replace)
+    monkeypatch.setattr(
+        workspace_storage, "_workspace_replace_retry_delays", lambda _exc: ()
+    )
+    try:
+        with pytest.raises(PermissionError, match="replacement denied"):
+            workspace_storage._replace_workspace_file(source, destination)
+        assert cached_file._closed
+        reopened_file = manager.acquire()
+        value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
+        assert np.asarray(value).item() == 1.0
+    finally:
+        with workspace_arrays._workspace_file_lock(destination):
+            workspace_arrays._close_workspace_file_managers(destination)
 
 
 def test_write_full_workspace_tree_file_local_path_uses_destination_temp(

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -931,6 +931,55 @@ def test_replace_workspace_file_retries_windows_sharing_violation(
     assert destination.read_bytes() == b"new"
 
 
+def test_replace_workspace_file_rejects_change_during_retry(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    external = tmp_path / "external.itws"
+    xr.Dataset({"data": 2}).to_netcdf(source, engine="h5netcdf")
+    xr.Dataset({"data": 1}).to_netcdf(destination, engine="h5netcdf")
+    xr.Dataset({"data": 3}).to_netcdf(external, engine="h5netcdf")
+    reader = workspace_arrays.WorkspaceFileManager(destination)
+    assert np.asarray(reader.acquire().variables["data"]).item() == 1
+    expected_state = workspace_arrays._workspace_file_state(destination)
+    original_replace = workspace_storage.os.replace
+    attempts = 0
+
+    def _fail_first_replace(src, dst):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError(errno.EACCES, "sharing violation")
+        original_replace(src, dst)
+
+    def _replace_during_retry(_delay: float) -> None:
+        original_replace(external, destination)
+
+    monkeypatch.setattr(
+        workspace_storage, "_workspace_replace_retry_delays", lambda _exc: (0.0,)
+    )
+    monkeypatch.setattr(workspace_storage.os, "replace", _fail_first_replace)
+    monkeypatch.setattr(workspace_storage.time, "sleep", _replace_during_retry)
+
+    try:
+        with pytest.raises(RuntimeError, match="changed while replacement was waiting"):
+            workspace_storage._replace_workspace_file(
+                source,
+                destination,
+                expected_state=expected_state,
+            )
+
+        assert attempts == 1
+        with h5py.File(destination, "r") as h5_file:
+            assert np.asarray(h5_file["data"]).item() == 3
+        with h5py.File(source, "r") as h5_file:
+            assert np.asarray(h5_file["data"]).item() == 2
+        assert np.asarray(reader.acquire().variables["data"]).item() == 1
+    finally:
+        reader.close()
+
+
 def test_workspace_replace_retry_delays_only_allow_windows_sharing_errors(
     monkeypatch,
 ) -> None:
@@ -1111,9 +1160,11 @@ def test_cleanup_stale_workspace_reader_files_keeps_live_owners(
     directory = workspace_arrays._ensure_workspace_reader_directory(workspace_path)
     current = directory / f"reader-{workspace_arrays.os.getpid()}-{'1' * 32}.itws"
     stale = directory / f"export-424242-{'2' * 32}.itws"
+    stale_handoff = directory / f"handoff-424242-{'3' * 32}.itws"
     unrelated = directory / "notes.txt"
     current.write_bytes(b"current")
     stale.write_bytes(b"stale")
+    stale_handoff.write_bytes(b"stale handoff")
     unrelated.write_bytes(b"keep")
     monkeypatch.setattr(psutil, "pid_exists", lambda pid: pid != 424242)
 
@@ -1121,6 +1172,7 @@ def test_cleanup_stale_workspace_reader_files_keeps_live_owners(
 
     assert current.exists()
     assert not stale.exists()
+    assert not stale_handoff.exists()
     assert unrelated.exists()
 
 
@@ -1733,6 +1785,54 @@ def test_workspace_transaction_does_not_copy_or_replace_full_file(
     )
 
     assert _read_transaction_test_value(fname) == 4.0
+
+
+def test_workspace_transaction_materializes_lazy_source_before_mutation(
+    tmp_path,
+) -> None:
+    fname = tmp_path / "lazy-constructor-source.itws"
+    _write_transaction_test_workspace(fname, value=1.0)
+    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    snapshot = opened[["data"]].copy(deep=False)
+
+    try:
+        workspace_storage._write_workspace_transaction_file(
+            fname,
+            (("1", {"1/figure": snapshot}),),
+            (),
+            _transaction_test_root_attrs(delta_save_count=1),
+        )
+        assert snapshot["data"].compute().item() == 1.0
+        with h5py.File(fname, "r") as h5_file:
+            assert np.asarray(h5_file["1/figure/data"]).item() == 1.0
+    finally:
+        opened.close()
+
+
+def test_workspace_constructor_materialization_reuses_data_and_chunks(tmp_path) -> None:
+    fname = tmp_path / "shared-lazy-source.itws"
+    xr.Dataset({"data": ("x", np.arange(6))}).to_netcdf(fname, engine="h5netcdf")
+    opened = workspace_arrays.open_workspace_dataset(fname, "/", chunks={"x": 2})
+    snapshot = opened[["data"]].copy(deep=False)
+    first_constructor = {"first": snapshot}
+    second_constructor = {"second": snapshot}
+    rewrite_map = {
+        "first": ("first", first_constructor),
+        "second": ("second", second_constructor),
+    }
+
+    try:
+        workspace_storage._materialize_workspace_constructor_sources(fname, rewrite_map)
+        first = first_constructor["first"]
+        second = second_constructor["second"]
+        assert first is second
+        assert first["data"].chunks is None
+        assert "source" not in first["data"].encoding
+        assert workspace_arrays.workspace_dataset_encoding(first)["data"][
+            "chunksizes"
+        ] == (2,)
+    finally:
+        opened.close()
 
 
 def test_workspace_attr_transaction_does_not_copy_unchanged_payload(

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -259,20 +259,31 @@ def test_write_full_workspace_tree_file_preserves_cached_workspace_reader(
     )
     original_replace = workspace_storage.os.replace
     replacement_checked = False
+    replacement_completed = False
+    hidden_paths: list[str] = []
 
     def _replace_after_reader_close(source, destination):
-        nonlocal replacement_checked
+        nonlocal replacement_checked, replacement_completed
         if pathlib.Path(destination) == fname:
             replacement_checked = True
             assert cached_file._closed
         original_replace(source, destination)
+        replacement_completed = True
+
+    def _hide_after_replacement(path: str) -> None:
+        assert replacement_completed
+        hidden_paths.append(path)
 
     monkeypatch.setattr(workspace_storage.os, "replace", _replace_after_reader_close)
+    monkeypatch.setattr(
+        workspace_storage, "_hide_workspace_lock_file", _hide_after_replacement
+    )
     try:
         workspace_storage._write_full_workspace_tree_file(
             fname, tree, _transaction_test_root_attrs()
         )
         assert replacement_checked
+        assert hidden_paths == [manager._preserved_generation.path]
         preserved_file = manager.acquire()
         preserved_value = (
             preserved_file.groups["0"].groups["imagetool"].variables["data"][()]
@@ -643,7 +654,11 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
     def _fail_replace(_source, _destination):
         raise PermissionError(errno.EACCES, "replacement denied")
 
+    hidden_paths: list[str] = []
     monkeypatch.setattr(workspace_storage.os, "replace", _fail_replace)
+    monkeypatch.setattr(
+        workspace_storage, "_hide_workspace_lock_file", hidden_paths.append
+    )
     monkeypatch.setattr(
         workspace_storage, "_workspace_replace_retry_delays", lambda _exc: ()
     )
@@ -655,6 +670,7 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
         value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
         assert np.asarray(value).item() == 1.0
         assert manager._preserved_generation is None
+        assert hidden_paths == []
         assert list(tmp_path.glob(".*.erlab-workspace-read")) == []
     finally:
         with workspace_arrays._workspace_file_lock(destination):

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -6,6 +6,7 @@ import threading
 import types
 import typing
 import weakref
+from collections.abc import Callable
 
 import h5py
 import hdf5plugin
@@ -41,6 +42,15 @@ def _read_transaction_test_value(fname: pathlib.Path) -> float:
         return float(ds["data"].item())
     finally:
         opened.close()
+
+
+def _wait_for_workspace_cleanup(condition: Callable[[], bool]) -> bool:
+    for _ in range(100):
+        gc.collect()
+        if condition():
+            return True
+        threading.Event().wait(0.01)
+    return condition()
 
 
 def test_workspace_file_repack_payload_strips_delta_and_skips_internal_groups(
@@ -299,6 +309,47 @@ def test_write_full_workspace_tree_file_preserves_cached_workspace_reader(
             reopened_manager.close()
 
 
+def test_replace_workspace_file_defers_finalizer_cleanup_until_after_publish(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            source, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+
+    managers = [workspace_arrays.WorkspaceFileManager(destination)]
+    generation = managers[0]._generation
+    managers[0].acquire()
+    original_link = workspace_storage.os.link
+
+    def _release_last_reader_during_preservation(link_source, link_destination):
+        managers.clear()
+        gc.collect()
+        assert not generation.has_managers()
+        assert generation._finalizer.alive
+        original_link(link_source, link_destination)
+
+    monkeypatch.setattr(
+        workspace_storage.os, "link", _release_last_reader_during_preservation
+    )
+
+    workspace_storage._replace_workspace_file(source, destination)
+
+    generation_path = pathlib.Path(generation.path)
+    assert generation.retired
+    assert _wait_for_workspace_cleanup(lambda: not generation_path.exists())
+    assert not generation._finalizer.alive
+    assert _read_transaction_test_value(destination) == 2.0
+
+
 def test_preserve_workspace_generation_hard_links_on_workspace_filesystem(
     tmp_path,
 ) -> None:
@@ -450,8 +501,7 @@ def test_replace_workspace_file_copy_fallback_cleans_preserved_generation(
 
     manager.close()
     del preserved_file, generation, manager
-    gc.collect()
-    assert not generation_path.exists()
+    assert _wait_for_workspace_cleanup(lambda: not generation_path.exists())
     assert not generation_directory.exists()
 
 
@@ -482,9 +532,7 @@ def test_retired_workspace_generation_lives_until_last_manager_released(
     assert generation_path.exists()
 
     del manager, generation
-    gc.collect()
-
-    assert generation_ref() is None
+    assert _wait_for_workspace_cleanup(lambda: generation_ref() is None)
     assert cached_file._closed
     assert not generation_path.exists()
 
@@ -527,13 +575,7 @@ def test_workspace_generation_cleanup_finishes_after_path_lock_released(
         lock_thread.join(2)
     assert not lock_thread.is_alive()
 
-    for _ in range(100):
-        gc.collect()
-        if generation_ref() is None:
-            break
-        threading.Event().wait(0.01)
-
-    assert generation_ref() is None
+    assert _wait_for_workspace_cleanup(lambda: generation_ref() is None)
     assert cached_file._closed
     assert _read_transaction_test_value(destination) == 1.0
 
@@ -544,8 +586,7 @@ def test_workspace_generation_cleanup_keeps_a_new_reader(tmp_path) -> None:
     manager = workspace_arrays.WorkspaceFileManager(destination)
     generation = manager._generation
     manager._finalizer.detach()
-    assert generation.remove_manager()
-    assert generation.schedule_cleanup()
+    assert generation.release_manager()
 
     reopened_manager = workspace_arrays.WorkspaceFileManager(destination)
     try:
@@ -584,7 +625,7 @@ def test_replace_workspace_file_discards_unused_current_generation(tmp_path) -> 
     generation = manager._generation
     cached_file = manager.acquire()
     manager._finalizer.detach()
-    assert generation.remove_manager()
+    assert generation.release_manager()
 
     workspace_storage._replace_workspace_file(source, destination)
 

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -481,6 +481,74 @@ def test_replace_workspace_file_generation_lives_until_cached_handle_closes(
     assert not generation_path.exists()
 
 
+def test_replace_workspace_file_closes_cached_handle_without_live_manager(
+    monkeypatch, tmp_path
+) -> None:
+    from xarray.backends.file_manager import FILE_CACHE
+
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            source, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    cached_file = manager.acquire()
+    cache_key = manager._key
+    manager_ref = weakref.ref(manager)
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+    lock = workspace_arrays._workspace_file_lock(destination)
+
+    def _hold_workspace_lock() -> None:
+        with lock:
+            lock_held.set()
+            release_lock.wait(2)
+
+    lock_thread = threading.Thread(target=_hold_workspace_lock)
+    lock_thread.start()
+    assert lock_held.wait(2)
+    try:
+        del manager
+        gc.collect()
+        assert manager_ref() is None
+        assert cache_key in FILE_CACHE
+        assert not cached_file._closed
+    finally:
+        release_lock.set()
+        lock_thread.join(2)
+    assert not lock_thread.is_alive()
+
+    original_replace = workspace_storage.os.replace
+    replacement_checked = False
+
+    def _replace_after_orphaned_reader_close(src, dst) -> None:
+        nonlocal replacement_checked
+        if pathlib.Path(dst) == destination:
+            replacement_checked = True
+            assert cached_file._closed
+        original_replace(src, dst)
+
+    monkeypatch.setattr(
+        workspace_storage.os, "replace", _replace_after_orphaned_reader_close
+    )
+    try:
+        workspace_storage._replace_workspace_file(source, destination)
+        assert replacement_checked
+        assert cache_key not in FILE_CACHE
+        assert _read_transaction_test_value(destination) == 2.0
+    finally:
+        with workspace_arrays._workspace_file_lock(destination):
+            workspace_arrays._close_workspace_file_managers(destination)
+
+
 def test_replace_workspace_file_blocks_new_readers_during_commit(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -265,7 +265,10 @@ def test_write_full_workspace_tree_file_closes_cached_workspace_reader(
             fname, tree, _transaction_test_root_attrs()
         )
         assert replacement_checked
-        reopened_file = manager.acquire()
+        with pytest.raises(workspace_arrays._WorkspaceFileReplacedError, match="Retry"):
+            manager.acquire()
+        reopened_manager = workspace_arrays.WorkspaceFileManager(fname)
+        reopened_file = reopened_manager.acquire()
         value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
         assert np.asarray(value).item() == 2.0
     finally:
@@ -274,7 +277,7 @@ def test_write_full_workspace_tree_file_closes_cached_workspace_reader(
             workspace_arrays._close_workspace_file_managers(fname)
 
 
-def test_write_full_workspace_tree_file_keeps_lazy_dataarray_usable(tmp_path) -> None:
+def test_write_full_workspace_tree_file_retires_stale_lazy_dataarray(tmp_path) -> None:
     fname = tmp_path / "lazy-reader.itws"
     _write_transaction_test_workspace(fname)
     opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
@@ -288,7 +291,15 @@ def test_write_full_workspace_tree_file_keeps_lazy_dataarray_usable(tmp_path) ->
         workspace_storage._write_full_workspace_tree_file(
             fname, tree, _transaction_test_root_attrs()
         )
-        assert lazy_data.compute().item() == 2.0
+        with pytest.raises(workspace_arrays._WorkspaceFileReplacedError, match="Retry"):
+            lazy_data.compute()
+        reopened = workspace_arrays.open_workspace_dataset(
+            fname, "0/imagetool", chunks={}
+        )
+        try:
+            assert reopened["data"].compute().item() == 2.0
+        finally:
+            reopened.close()
     finally:
         tree.close()
         with workspace_arrays._workspace_file_lock(fname):
@@ -345,6 +356,80 @@ def test_replace_workspace_file_blocks_new_readers_during_commit(
     assert reader_acquired.is_set()
     assert errors == []
     assert destination.read_bytes() == b"new"
+
+
+def test_replace_workspace_file_retires_in_flight_multichunk_reader(
+    monkeypatch, tmp_path
+) -> None:
+    from xarray.backends.h5netcdf_ import H5NetCDFArrayWrapper
+
+    fname = tmp_path / "multichunk-reader.itws"
+
+    def _write_values(values: np.ndarray) -> None:
+        tree = xr.DataTree.from_dict(
+            {"0/imagetool": xr.Dataset({"data": ("x", values)})}
+        )
+        try:
+            workspace_storage._write_full_workspace_tree_file(
+                fname, tree, _transaction_test_root_attrs()
+            )
+        finally:
+            tree.close()
+
+    _write_values(np.ones(8, dtype=np.float64))
+    opened = workspace_arrays.open_workspace_dataset(
+        fname, "0/imagetool", chunks={"x": 1}
+    )
+    lazy_data = opened["data"]
+    first_read = threading.Event()
+    continue_read = threading.Event()
+    original_getitem = H5NetCDFArrayWrapper._getitem
+    read_count = 0
+
+    def _pause_after_first_read(self, key):
+        nonlocal read_count
+        result = original_getitem(self, key)
+        if self.variable_name == "data":
+            read_count += 1
+            if read_count == 1:
+                first_read.set()
+                if not continue_read.wait(2):
+                    raise TimeoutError("Workspace replacement did not finish")
+        return result
+
+    monkeypatch.setattr(H5NetCDFArrayWrapper, "_getitem", _pause_after_first_read)
+    results: list[xr.DataArray] = []
+    errors: list[BaseException] = []
+
+    def _compute() -> None:
+        try:
+            results.append(lazy_data.compute(scheduler="single-threaded"))
+        except BaseException as exc:  # pragma: no cover - reported in main thread
+            errors.append(exc)
+
+    compute_thread = threading.Thread(target=_compute)
+    compute_thread.start()
+    try:
+        assert first_read.wait(2)
+        _write_values(np.full(8, 2.0, dtype=np.float64))
+    finally:
+        continue_read.set()
+        compute_thread.join(2)
+        opened.close()
+
+    assert not compute_thread.is_alive()
+    assert results == []
+    assert len(errors) == 1
+    assert isinstance(errors[0], workspace_arrays._WorkspaceFileReplacedError)
+    assert "Retry the operation" in str(errors[0])
+
+    reopened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    try:
+        np.testing.assert_array_equal(
+            reopened["data"].compute(), np.full(8, 2.0, dtype=np.float64)
+        )
+    finally:
+        reopened.close()
 
 
 def test_replace_workspace_file_retries_windows_sharing_violation(

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -252,8 +252,16 @@ def test_write_full_workspace_tree_file_preserves_cached_workspace_reader(
     tree = xr.DataTree.from_dict(
         {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
     )
+    original_link = workspace_storage.os.link
     original_replace = workspace_storage.os.replace
+    preservation_checked = False
     replacement_checked = False
+
+    def _link_after_reader_close(source, destination):
+        nonlocal preservation_checked
+        preservation_checked = True
+        assert cached_file._closed
+        original_link(source, destination)
 
     def _replace_after_reader_close(source, destination):
         nonlocal replacement_checked
@@ -262,15 +270,18 @@ def test_write_full_workspace_tree_file_preserves_cached_workspace_reader(
             assert cached_file._closed
         original_replace(source, destination)
 
+    monkeypatch.setattr(workspace_storage.os, "link", _link_after_reader_close)
     monkeypatch.setattr(workspace_storage.os, "replace", _replace_after_reader_close)
     try:
         workspace_storage._write_full_workspace_tree_file(
             fname, tree, _transaction_test_root_attrs()
         )
+        assert preservation_checked
         assert replacement_checked
         assert generation.retired
         assert pathlib.Path(generation.path).is_file()
         assert pathlib.Path(generation.path) != fname
+        assert pathlib.Path(generation.path).parent == fname.parent
         preserved_file = manager.acquire()
         preserved_value = (
             preserved_file.groups["0"].groups["imagetool"].variables["data"][()]
@@ -286,6 +297,24 @@ def test_write_full_workspace_tree_file_preserves_cached_workspace_reader(
         manager.close()
         if "reopened_manager" in locals():
             reopened_manager.close()
+
+
+def test_preserve_workspace_generation_hard_links_on_workspace_filesystem(
+    tmp_path,
+) -> None:
+    source = tmp_path / "workspace.itws"
+    source.write_bytes(b"workspace generation")
+
+    preserved = workspace_storage._preserve_workspace_file_generation(source)
+    preserved_path = pathlib.Path(preserved.path)
+    try:
+        assert preserved_path.parent == source.parent
+        assert preserved.hide_after_publish
+        assert preserved_path.samefile(source)
+    finally:
+        preserved.cleanup()
+
+    assert not preserved_path.exists()
 
 
 def test_write_full_workspace_tree_file_preserves_stale_lazy_dataarray(
@@ -449,7 +478,6 @@ def test_retired_workspace_generation_lives_until_last_manager_released(
     generation = manager._generation
     assert generation.retired
     generation_path = pathlib.Path(generation.path)
-    generation_directory = generation_path.parent
     generation_ref = weakref.ref(generation)
     assert generation_path.exists()
 
@@ -459,24 +487,13 @@ def test_retired_workspace_generation_lives_until_last_manager_released(
     assert generation_ref() is None
     assert cached_file._closed
     assert not generation_path.exists()
-    assert not generation_directory.exists()
 
 
-def test_replace_workspace_file_closes_lock_busy_orphaned_generation(
-    monkeypatch, tmp_path
+def test_workspace_generation_cleanup_finishes_after_path_lock_released(
+    tmp_path,
 ) -> None:
-    source = tmp_path / "new.itws"
     destination = tmp_path / "current.itws"
     _write_transaction_test_workspace(destination)
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
-    )
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            source, tree, _transaction_test_root_attrs()
-        )
-    finally:
-        tree.close()
 
     first_manager = workspace_arrays.WorkspaceFileManager(destination)
     second_manager = workspace_arrays.WorkspaceFileManager(destination)
@@ -510,29 +527,71 @@ def test_replace_workspace_file_closes_lock_busy_orphaned_generation(
         lock_thread.join(2)
     assert not lock_thread.is_alive()
 
-    original_replace = workspace_storage.os.replace
-    replacement_checked = False
+    for _ in range(100):
+        gc.collect()
+        if generation_ref() is None:
+            break
+        threading.Event().wait(0.01)
 
-    def _replace_after_orphaned_reader_close(src, dst) -> None:
-        nonlocal replacement_checked
-        if pathlib.Path(dst) == destination:
-            replacement_checked = True
-            assert cached_file._closed
-        original_replace(src, dst)
-
-    monkeypatch.setattr(
-        workspace_storage,
-        "_preserve_workspace_file_generation",
-        lambda _path: pytest.fail("Orphaned generation was copied"),
-    )
-    monkeypatch.setattr(
-        workspace_storage.os, "replace", _replace_after_orphaned_reader_close
-    )
-    workspace_storage._replace_workspace_file(source, destination)
-    gc.collect()
-
-    assert replacement_checked
     assert generation_ref() is None
+    assert cached_file._closed
+    assert _read_transaction_test_value(destination) == 1.0
+
+
+def test_workspace_generation_cleanup_keeps_a_new_reader(tmp_path) -> None:
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    generation = manager._generation
+    manager._finalizer.detach()
+    assert generation.remove_manager()
+    assert generation.schedule_cleanup()
+
+    reopened_manager = workspace_arrays.WorkspaceFileManager(destination)
+    try:
+        with workspace_arrays._workspace_file_lock(destination):
+            workspace_arrays._cleanup_workspace_file_generation_locked(generation)
+
+        assert reopened_manager._generation is generation
+        value = (
+            reopened_manager.acquire()
+            .groups["0"]
+            .groups["imagetool"]
+            .variables["data"][()]
+        )
+        assert np.asarray(value).item() == 1.0
+    finally:
+        reopened_manager.close()
+        del reopened_manager, manager, generation
+        gc.collect()
+
+
+def test_replace_workspace_file_discards_unused_current_generation(tmp_path) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            source, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    generation = manager._generation
+    cached_file = manager.acquire()
+    manager._finalizer.detach()
+    assert generation.remove_manager()
+
+    workspace_storage._replace_workspace_file(source, destination)
+
+    assert cached_file._closed
+    assert not generation._finalizer.alive
+    with workspace_arrays._workspace_file_lock(destination):
+        assert workspace_arrays._current_workspace_file_generation(destination) is None
     assert _read_transaction_test_value(destination) == 2.0
 
 
@@ -743,8 +802,10 @@ def test_replace_workspace_file_preservation_failure_keeps_cached_reader(
     try:
         with pytest.raises(OSError, match="copy failed"):
             workspace_storage._replace_workspace_file(source, destination)
-        assert manager.acquire() is cached_file
-        value = cached_file.groups["0"].groups["imagetool"].variables["data"][()]
+        assert cached_file._closed
+        reopened_file = manager.acquire()
+        assert reopened_file is not cached_file
+        value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
         assert np.asarray(value).item() == 1.0
         assert source.exists()
     finally:
@@ -777,15 +838,23 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
 
     def _record_preserved_path(path: str | pathlib.Path):
         preserved = original_preserve(path)
-        preserved_paths.append(pathlib.Path(preserved[0]))
+        preserved_paths.append(pathlib.Path(preserved.path))
 
         def _cleanup() -> None:
-            preserved[1]()
+            preserved.cleanup()
             raise RuntimeError("temporary cleanup failed")
 
-        return preserved[0], _cleanup
+        return workspace_storage._PreservedWorkspaceFile(
+            path=preserved.path,
+            cleanup=_cleanup,
+            hide_after_publish=preserved.hide_after_publish,
+        )
 
     monkeypatch.setattr(workspace_storage.os, "replace", _fail_replace)
+    hidden_paths: list[str] = []
+    monkeypatch.setattr(
+        workspace_storage, "_hide_workspace_internal_file", hidden_paths.append
+    )
     monkeypatch.setattr(
         workspace_storage,
         "_preserve_workspace_file_generation",
@@ -805,6 +874,7 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
         assert pathlib.Path(manager._generation.path) == destination.resolve()
         assert preserved_paths
         assert all(not path.exists() for path in preserved_paths)
+        assert hidden_paths == []
         assert source.exists()
     finally:
         manager.close()
@@ -1438,7 +1508,7 @@ def test_workspace_lock_conflict_is_reported(tmp_path) -> None:
         lock.unlock()
 
 
-def test_hide_workspace_lock_file_sets_macos_hidden_flag(monkeypatch) -> None:
+def test_hide_workspace_internal_file_sets_macos_hidden_flag(monkeypatch) -> None:
     calls: list[tuple[str, int]] = []
     lock_path = "/workspace/.workspace.itws.lock"
     regular_stat = types.SimpleNamespace(st_mode=0o100600)
@@ -1452,12 +1522,12 @@ def test_hide_workspace_lock_file_sets_macos_hidden_flag(monkeypatch) -> None:
         raising=False,
     )
 
-    workspace_storage._hide_workspace_lock_file(lock_path)
+    workspace_storage._hide_workspace_internal_file(lock_path)
 
     assert calls == [(lock_path, 0x8000)]
 
 
-def test_hide_workspace_lock_file_skips_macos_symlink(monkeypatch) -> None:
+def test_hide_workspace_internal_file_skips_macos_symlink(monkeypatch) -> None:
     calls: list[tuple[str, int]] = []
     symlink_stat = types.SimpleNamespace(st_mode=0o120777)
 
@@ -1470,7 +1540,7 @@ def test_hide_workspace_lock_file_skips_macos_symlink(monkeypatch) -> None:
         raising=False,
     )
 
-    workspace_storage._hide_workspace_lock_file("/workspace/.workspace.itws.lock")
+    workspace_storage._hide_workspace_internal_file("/workspace/.workspace.itws.lock")
 
     assert calls == []
 
@@ -1642,7 +1712,7 @@ def test_workspace_lock_error_detection_message_variants() -> None:
     )
 
 
-def test_hide_workspace_lock_file_windows_paths(monkeypatch) -> None:
+def test_hide_workspace_internal_file_windows_paths(monkeypatch) -> None:
     import ctypes
 
     calls: list[tuple[str, int]] = []
@@ -1655,13 +1725,13 @@ def test_hide_workspace_lock_file_windows_paths(monkeypatch) -> None:
     monkeypatch.setattr(workspace_storage.sys, "platform", "win32")
     monkeypatch.setattr(workspace_storage.os, "name", "nt")
     monkeypatch.setattr(ctypes, "windll", None, raising=False)
-    workspace_storage._hide_workspace_lock_file("missing-windll.itws.lock")
+    workspace_storage._hide_workspace_internal_file("missing-windll.itws.lock")
     assert calls == []
 
     monkeypatch.setattr(
         ctypes, "windll", types.SimpleNamespace(kernel32=_Kernel32()), raising=False
     )
-    workspace_storage._hide_workspace_lock_file("hidden.itws.lock")
+    workspace_storage._hide_workspace_internal_file("hidden.itws.lock")
     assert calls == [("hidden.itws.lock", 0x2)]
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -80,8 +80,9 @@ def test_workspace_metadata_failure_leaves_published_generation_unchanged(
             )
 
         export_after = pathlib.Path(manager.__getstate__()[1])
-        assert export_after == export_before
         with h5py.File(export_before, "r") as h5_file:
+            assert "partial_update" not in h5_file.attrs
+        with h5py.File(export_after, "r") as h5_file:
             assert "partial_update" not in h5_file.attrs
         with h5py.File(fname, "r") as h5_file:
             assert "partial_update" not in h5_file.attrs
@@ -1712,6 +1713,62 @@ def test_workspace_transaction_attr_update_encodes_non_native_values(tmp_path) -
     _assert_no_workspace_internal_groups(fname)
 
 
+def test_workspace_transaction_does_not_copy_or_replace_full_file(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "incremental.itws"
+    _write_transaction_test_workspace(fname)
+
+    def _fail_full_file_operation(*_args, **_kwargs):
+        raise AssertionError("incremental save used a full-file operation")
+
+    monkeypatch.setattr(workspace_storage.shutil, "copyfile", _fail_full_file_operation)
+    monkeypatch.setattr(workspace_storage.os, "replace", _fail_full_file_operation)
+
+    workspace_storage._write_workspace_transaction_file(
+        fname,
+        (("0", {"0/imagetool": _transaction_test_dataset(4.0, title="new")}),),
+        (),
+        _transaction_test_root_attrs(delta_save_count=1),
+    )
+
+    assert _read_transaction_test_value(fname) == 4.0
+
+
+def test_workspace_attr_transaction_does_not_copy_unchanged_payload(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "attr-only.itws"
+    _write_transaction_test_workspace(fname)
+    manager = workspace_arrays.WorkspaceFileManager(fname, "0/imagetool")
+    fallback = (
+        "0",
+        {"0/imagetool": _transaction_test_dataset(2.0, title="fallback")},
+    )
+
+    def _fail_payload_copy(*_args, **_kwargs):
+        raise AssertionError("attribute-only save copied an unchanged payload")
+
+    monkeypatch.setattr(
+        workspace_arrays,
+        "_create_workspace_group_reader_file",
+        _fail_payload_copy,
+    )
+    try:
+        workspace_storage._write_workspace_transaction_file(
+            fname,
+            (),
+            (("0/imagetool", {"itool_title": "new"}, fallback),),
+            _transaction_test_root_attrs(delta_save_count=1),
+        )
+        assert (
+            manager.acquire().groups["0"].groups["imagetool"].attrs["itool_title"]
+            == "new"
+        )
+    finally:
+        manager.close()
+
+
 def test_workspace_transaction_publishes_immutable_reader_generation(tmp_path) -> None:
     fname = tmp_path / "immutable-delta.itws"
     _write_transaction_test_workspace(fname, value=1.0)
@@ -1731,6 +1788,74 @@ def test_workspace_transaction_publishes_immutable_reader_generation(tmp_path) -
     finally:
         before.close()
         after.close()
+
+
+def test_workspace_transaction_switches_waiting_reader_before_commit(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "waiting-reader.itws"
+    _write_transaction_test_workspace(fname, value=1.0)
+    manager = workspace_arrays.WorkspaceFileManager(fname, "0/imagetool")
+    snapshot_started = threading.Event()
+    allow_snapshot = threading.Event()
+    reader_finished = threading.Event()
+    errors: list[BaseException] = []
+    values: list[float] = []
+    original_snapshot = workspace_arrays._create_workspace_group_reader_file
+
+    def _pause_snapshot(*args, **kwargs):
+        snapshot_started.set()
+        if not allow_snapshot.wait(2):
+            raise TimeoutError("Reader snapshot test did not resume")
+        return original_snapshot(*args, **kwargs)
+
+    def _write() -> None:
+        try:
+            workspace_storage._write_workspace_transaction_file(
+                fname,
+                (
+                    (
+                        "0",
+                        {"0/imagetool": _transaction_test_dataset(2.0, title="new")},
+                    ),
+                ),
+                (),
+                _transaction_test_root_attrs(delta_save_count=1),
+            )
+        except BaseException as exc:  # pragma: no cover - reported below
+            errors.append(exc)
+
+    def _read() -> None:
+        try:
+            h5_file = manager.acquire()
+            value = h5_file.groups["0"].groups["imagetool"].variables["data"][()]
+            values.append(float(np.asarray(value).item()))
+        except BaseException as exc:  # pragma: no cover - reported below
+            errors.append(exc)
+        finally:
+            reader_finished.set()
+
+    monkeypatch.setattr(
+        workspace_arrays, "_create_workspace_group_reader_file", _pause_snapshot
+    )
+    writer = threading.Thread(target=_write)
+    reader = threading.Thread(target=_read)
+    writer.start()
+    assert snapshot_started.wait(2)
+    reader.start()
+    try:
+        assert not reader_finished.wait(0.05)
+    finally:
+        allow_snapshot.set()
+        writer.join(2)
+        reader.join(2)
+        manager.close()
+
+    assert not writer.is_alive()
+    assert not reader.is_alive()
+    assert errors == []
+    assert values == [1.0]
+    assert _read_transaction_test_value(fname) == 2.0
 
 
 def test_workspace_recovery_cleans_orphan_internal_groups(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 import h5py
 import hdf5plugin
 import numpy as np
+import psutil
 import pytest
 import xarray
 import xarray as xr
@@ -51,6 +52,76 @@ def _wait_for_workspace_cleanup(condition: Callable[[], bool]) -> bool:
             return True
         threading.Event().wait(0.01)
     return condition()
+
+
+def test_workspace_metadata_failure_leaves_published_generation_unchanged(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "partial-update.itws"
+    _write_transaction_test_workspace(fname)
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    export_before = pathlib.Path(manager.__getstate__()[1])
+    original_write = workspace_storage._write_root_attrs_to_open_workspace_file
+
+    def _write_then_fail(h5_file, attrs, *, replace=False) -> None:
+        original_write(h5_file, attrs, replace=replace)
+        raise RuntimeError("update failed")
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_write_root_attrs_to_open_workspace_file",
+        _write_then_fail,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="update failed"):
+            workspace_storage._write_workspace_root_attrs_to_file(
+                fname, {"partial_update": True}
+            )
+
+        export_after = pathlib.Path(manager.__getstate__()[1])
+        assert export_after == export_before
+        with h5py.File(export_before, "r") as h5_file:
+            assert "partial_update" not in h5_file.attrs
+        with h5py.File(fname, "r") as h5_file:
+            assert "partial_update" not in h5_file.attrs
+    finally:
+        manager.close()
+
+
+def test_full_workspace_save_does_not_overwrite_newer_generation(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "workspace.itws"
+    external = tmp_path / "external.itws"
+    _write_transaction_test_workspace(fname, value=1.0)
+    _write_transaction_test_workspace(external, value=7.0)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="save snapshot")}
+    )
+    original_validate = workspace_storage._validate_workspace_h5_file
+    replaced = False
+
+    def _validate_then_replace(path) -> None:
+        nonlocal replaced
+        original_validate(path)
+        if not replaced:
+            replaced = True
+            external.replace(fname)
+
+    monkeypatch.setattr(
+        workspace_storage, "_validate_workspace_h5_file", _validate_then_replace
+    )
+    try:
+        with pytest.raises(RuntimeError, match="changed while its successor"):
+            workspace_storage._write_full_workspace_tree_file(
+                fname, tree, _transaction_test_root_attrs()
+            )
+    finally:
+        tree.close()
+
+    assert _read_transaction_test_value(fname) == 7.0
+    assert not list(tmp_path.glob("workspace.itws.tmp-*"))
 
 
 def test_workspace_file_repack_payload_strips_delta_and_skips_internal_groups(
@@ -291,7 +362,9 @@ def test_write_full_workspace_tree_file_preserves_cached_workspace_reader(
         assert generation.retired
         assert pathlib.Path(generation.path).is_file()
         assert pathlib.Path(generation.path) != fname
-        assert pathlib.Path(generation.path).parent == fname.parent
+        assert pathlib.Path(
+            generation.path
+        ).parent == workspace_arrays._workspace_reader_directory(fname)
         preserved_file = manager.acquire()
         preserved_value = (
             preserved_file.groups["0"].groups["imagetool"].variables["data"][()]
@@ -356,16 +429,79 @@ def test_preserve_workspace_generation_hard_links_on_workspace_filesystem(
     source = tmp_path / "workspace.itws"
     source.write_bytes(b"workspace generation")
 
-    preserved = workspace_storage._preserve_workspace_file_generation(source)
+    preserved = workspace_storage._preserve_workspace_file_generation(
+        source, workspace_arrays._workspace_file_identity(source)
+    )
     preserved_path = pathlib.Path(preserved.path)
     try:
-        assert preserved_path.parent == source.parent
-        assert preserved.hide_after_publish
+        assert preserved_path.parent == workspace_arrays._workspace_reader_directory(
+            source
+        )
         assert preserved_path.samefile(source)
     finally:
         preserved.cleanup()
 
     assert not preserved_path.exists()
+
+
+def test_preserve_workspace_generation_rejects_source_replacement(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "workspace.itws"
+    replacement = tmp_path / "replacement.itws"
+    source.write_bytes(b"old generation")
+    replacement.write_bytes(b"new generation")
+    expected_identity = workspace_arrays._workspace_file_identity(source)
+    wrong_identity = (
+        expected_identity[0],
+        expected_identity[1],
+        expected_identity[2] + 1,
+        expected_identity[3],
+    )
+    with pytest.raises(RuntimeError, match="changed before it could be preserved"):
+        workspace_storage._preserve_workspace_file_generation(source, wrong_identity)
+
+    original_link = workspace_arrays.os.link
+    original_replace = workspace_arrays.os.replace
+
+    def _replace_before_link(link_source, link_destination) -> None:
+        original_replace(replacement, source)
+        original_link(link_source, link_destination)
+
+    monkeypatch.setattr(workspace_arrays.os, "link", _replace_before_link)
+
+    with pytest.raises(RuntimeError, match="changed while it was being preserved"):
+        workspace_storage._preserve_workspace_file_generation(source, expected_identity)
+
+    assert source.read_bytes() == b"new generation"
+    assert not list(
+        workspace_arrays._workspace_reader_directory(source).glob("reader-*.itws")
+    )
+
+
+def test_preserve_workspace_generation_cleans_reader_after_identity_error(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "workspace.itws"
+    source.write_bytes(b"workspace generation")
+    expected_identity = workspace_arrays._workspace_file_identity(source)
+    original_identity = workspace_arrays._workspace_file_identity
+
+    def _fail_source_identity(path):
+        if pathlib.Path(path).resolve() == source.resolve():
+            raise PermissionError("identity denied")
+        return original_identity(path)
+
+    monkeypatch.setattr(
+        workspace_arrays, "_workspace_file_identity", _fail_source_identity
+    )
+
+    with pytest.raises(PermissionError, match="identity denied"):
+        workspace_storage._preserve_workspace_file_generation(source, expected_identity)
+
+    assert not list(
+        workspace_arrays._workspace_reader_directory(source).glob("reader-*.itws")
+    )
 
 
 def test_write_full_workspace_tree_file_preserves_stale_lazy_dataarray(
@@ -877,8 +1013,11 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
     preserved_paths: list[pathlib.Path] = []
     original_preserve = workspace_storage._preserve_workspace_file_generation
 
-    def _record_preserved_path(path: str | pathlib.Path):
-        preserved = original_preserve(path)
+    def _record_preserved_path(
+        path: str | pathlib.Path,
+        expected_identity: tuple[str, int, int, int],
+    ):
+        preserved = original_preserve(path, expected_identity)
         preserved_paths.append(pathlib.Path(preserved.path))
 
         def _cleanup() -> None:
@@ -887,8 +1026,8 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
 
         return workspace_storage._PreservedWorkspaceFile(
             path=preserved.path,
+            file_identity=preserved.file_identity,
             cleanup=_cleanup,
-            hide_after_publish=preserved.hide_after_publish,
         )
 
     monkeypatch.setattr(workspace_storage.os, "replace", _fail_replace)
@@ -919,6 +1058,69 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
         assert source.exists()
     finally:
         manager.close()
+
+
+def test_replace_workspace_file_does_not_adopt_disappeared_destination(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            source, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    manager.acquire()
+    original_preserve = workspace_storage._preserve_workspace_file_generation
+
+    def _remove_before_preservation(
+        path: str | pathlib.Path,
+        expected_identity: tuple[str, int, int, int],
+    ):
+        pathlib.Path(path).unlink()
+        return original_preserve(path, expected_identity)
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_preserve_workspace_file_generation",
+        _remove_before_preservation,
+    )
+    try:
+        with pytest.raises(FileNotFoundError):
+            workspace_storage._replace_workspace_file(source, destination)
+        assert source.exists()
+        assert not destination.exists()
+        with pytest.raises(RuntimeError, match="reader generation changed"):
+            manager.acquire()
+    finally:
+        manager.close()
+
+
+def test_cleanup_stale_workspace_reader_files_keeps_live_owners(
+    monkeypatch, tmp_path
+) -> None:
+    workspace_path = tmp_path / "workspace.itws"
+    workspace_path.write_bytes(b"workspace")
+    directory = workspace_arrays._ensure_workspace_reader_directory(workspace_path)
+    current = directory / f"reader-{workspace_arrays.os.getpid()}-{'1' * 32}.itws"
+    stale = directory / f"export-424242-{'2' * 32}.itws"
+    unrelated = directory / "notes.txt"
+    current.write_bytes(b"current")
+    stale.write_bytes(b"stale")
+    unrelated.write_bytes(b"keep")
+    monkeypatch.setattr(psutil, "pid_exists", lambda pid: pid != 424242)
+
+    workspace_arrays._cleanup_stale_workspace_reader_files(workspace_path)
+
+    assert current.exists()
+    assert not stale.exists()
+    assert unrelated.exists()
 
 
 def test_write_full_workspace_tree_file_local_path_uses_destination_temp(
@@ -1510,6 +1712,27 @@ def test_workspace_transaction_attr_update_encodes_non_native_values(tmp_path) -
     _assert_no_workspace_internal_groups(fname)
 
 
+def test_workspace_transaction_publishes_immutable_reader_generation(tmp_path) -> None:
+    fname = tmp_path / "immutable-delta.itws"
+    _write_transaction_test_workspace(fname, value=1.0)
+    before = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    old_data = before["data"].copy(deep=False)
+
+    workspace_storage._write_workspace_transaction_file(
+        fname,
+        (("0", {"0/imagetool": _transaction_test_dataset(9.0, title="new")}),),
+        (),
+        _transaction_test_root_attrs(delta_save_count=1),
+    )
+    after = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    try:
+        assert old_data.compute().item() == 1.0
+        assert after["data"].compute().item() == 9.0
+    finally:
+        before.close()
+        after.close()
+
+
 def test_workspace_recovery_cleans_orphan_internal_groups(tmp_path) -> None:
 
     fname = tmp_path / "orphan-internal.itws"
@@ -1552,7 +1775,7 @@ def test_workspace_lock_conflict_is_reported(tmp_path) -> None:
 def test_hide_workspace_internal_file_sets_macos_hidden_flag(monkeypatch) -> None:
     calls: list[tuple[str, int]] = []
     lock_path = "/workspace/.workspace.itws.lock"
-    regular_stat = types.SimpleNamespace(st_mode=0o100600)
+    regular_stat = types.SimpleNamespace(st_mode=0o100600, st_flags=0)
 
     monkeypatch.setattr(workspace_storage.sys, "platform", "darwin")
     monkeypatch.setattr(workspace_storage.os, "lstat", lambda _path: regular_stat)
@@ -1760,6 +1983,10 @@ def test_hide_workspace_internal_file_windows_paths(monkeypatch) -> None:
 
     class _Kernel32:
         @staticmethod
+        def GetFileAttributesW(_path: str) -> int:
+            return 0x20
+
+        @staticmethod
         def SetFileAttributesW(path: str, attrs: int) -> None:
             calls.append((path, attrs))
 
@@ -1773,7 +2000,7 @@ def test_hide_workspace_internal_file_windows_paths(monkeypatch) -> None:
         ctypes, "windll", types.SimpleNamespace(kernel32=_Kernel32()), raising=False
     )
     workspace_storage._hide_workspace_internal_file("hidden.itws.lock")
-    assert calls == [("hidden.itws.lock", 0x2)]
+    assert calls == [("hidden.itws.lock", 0x22)]
 
 
 def test_workspace_document_lock_info_without_lock(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -1788,12 +1788,37 @@ def test_workspace_transaction_does_not_copy_or_replace_full_file(
 
 
 def test_workspace_transaction_materializes_lazy_source_before_mutation(
-    tmp_path,
+    monkeypatch, tmp_path
 ) -> None:
     fname = tmp_path / "lazy-constructor-source.itws"
     _write_transaction_test_workspace(fname, value=1.0)
-    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    opened = workspace_arrays.open_workspace_dataset(
+        fname, "0/imagetool", chunks={"x": 1}
+    )
     snapshot = opened[["data"]].copy(deep=False)
+    original_materialize = workspace_storage._materialize_workspace_constructor_sources
+
+    def _materialize_without_reader_lock(*args, **kwargs) -> None:
+        lock_results: list[bool] = []
+
+        def _probe_reader_lock() -> None:
+            lock = workspace_arrays._workspace_file_lock(fname)
+            acquired = lock.acquire(timeout=1)
+            lock_results.append(acquired)
+            if acquired:
+                lock.release()
+
+        probe = threading.Thread(target=_probe_reader_lock)
+        probe.start()
+        probe.join(2)
+        assert lock_results == [True]
+        original_materialize(*args, **kwargs)
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_materialize_workspace_constructor_sources",
+        _materialize_without_reader_lock,
+    )
 
     try:
         workspace_storage._write_workspace_transaction_file(
@@ -1807,6 +1832,117 @@ def test_workspace_transaction_materializes_lazy_source_before_mutation(
             assert np.asarray(h5_file["1/figure/data"]).item() == 1.0
     finally:
         opened.close()
+
+
+def test_workspace_transaction_serializes_save_preparation(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "concurrent-saves.itws"
+    _write_transaction_test_workspace(fname, value=1.0)
+    original_materialize = workspace_storage._materialize_workspace_constructor_sources
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    call_lock = threading.Lock()
+    errors: list[BaseException] = []
+    call_count = 0
+
+    def _coordinate_materialization(*args, **kwargs) -> None:
+        nonlocal call_count
+        with call_lock:
+            call_index = call_count
+            call_count += 1
+        if call_index == 0:
+            first_entered.set()
+            if not release_first.wait(5):
+                raise TimeoutError("First save was not released")
+        else:
+            second_entered.set()
+        original_materialize(*args, **kwargs)
+
+    def _save(value: float) -> None:
+        try:
+            workspace_storage._write_workspace_transaction_file(
+                fname,
+                (
+                    (
+                        "0",
+                        {
+                            "0/imagetool": _transaction_test_dataset(
+                                value, title=f"save {value}"
+                            )
+                        },
+                    ),
+                ),
+                (),
+                _transaction_test_root_attrs(delta_save_count=int(value)),
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_materialize_workspace_constructor_sources",
+        _coordinate_materialization,
+    )
+    first = threading.Thread(target=_save, args=(2.0,))
+    second = threading.Thread(target=_save, args=(3.0,))
+
+    first.start()
+    assert first_entered.wait(5)
+    second.start()
+    try:
+        assert not second_entered.wait(0.1)
+    finally:
+        release_first.set()
+    first.join(5)
+    second.join(5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert second_entered.is_set()
+    assert errors == []
+    assert _read_transaction_test_value(fname) == 3.0
+    _assert_no_workspace_internal_groups(fname)
+
+
+def test_workspace_transaction_rejects_change_during_materialization(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "incremental-conflict.itws"
+    external = tmp_path / "external.itws"
+    _write_transaction_test_workspace(fname, value=1.0)
+    _write_transaction_test_workspace(external, value=7.0)
+    original_materialize = workspace_storage._materialize_workspace_constructor_sources
+
+    def _materialize_then_replace(*args, **kwargs) -> None:
+        original_materialize(*args, **kwargs)
+        external.replace(fname)
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_materialize_workspace_constructor_sources",
+        _materialize_then_replace,
+    )
+
+    with pytest.raises(
+        workspace_storage._WorkspacePublicationConflictError,
+        match="incremental save was prepared",
+    ):
+        workspace_storage._write_workspace_transaction_file(
+            fname,
+            (
+                (
+                    "0",
+                    {"0/imagetool": _transaction_test_dataset(2.0, title="stale save")},
+                ),
+            ),
+            (),
+            _transaction_test_root_attrs(delta_save_count=1),
+        )
+
+    assert _read_transaction_test_value(fname) == 7.0
+    _assert_no_workspace_internal_groups(fname)
 
 
 def test_workspace_constructor_materialization_reuses_data_and_chunks(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -5,6 +5,7 @@ import pathlib
 import threading
 import types
 import typing
+import weakref
 
 import h5py
 import hdf5plugin
@@ -415,6 +416,69 @@ def test_replace_workspace_file_copy_fallback_cleans_preserved_generation(
     gc.collect()
     assert not generation_path.exists()
     assert not generation_directory.exists()
+
+
+def test_replace_workspace_file_generation_lives_until_cached_handle_closes(
+    tmp_path,
+) -> None:
+    from xarray.backends.file_manager import FILE_CACHE
+
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            source, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    manager.acquire()
+    workspace_storage._replace_workspace_file(source, destination)
+    manager.acquire()
+    generation = manager._preserved_generation
+    assert generation is not None
+    generation_path = pathlib.Path(generation.path)
+    generation_ref = weakref.ref(generation)
+    cache_key_id = id(manager._key)
+    del generation
+
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+    lock = workspace_arrays._workspace_file_lock(destination)
+
+    def _hold_workspace_lock() -> None:
+        with lock:
+            lock_held.set()
+            release_lock.wait(2)
+
+    lock_thread = threading.Thread(target=_hold_workspace_lock)
+    lock_thread.start()
+    assert lock_held.wait(2)
+    try:
+        del manager
+        gc.collect()
+        generation_alive_while_cached = generation_ref() is not None
+        generation_exists_while_cached = generation_path.exists()
+        cache_key = next(key for key in FILE_CACHE if id(key) == cache_key_id)
+    finally:
+        release_lock.set()
+        lock_thread.join(2)
+
+    assert not lock_thread.is_alive()
+    cached_file = FILE_CACHE.pop(cache_key)
+    cached_file.close()
+    del cache_key, cached_file
+    gc.collect()
+
+    assert generation_alive_while_cached
+    assert generation_exists_while_cached
+    assert generation_ref() is None
+    assert not generation_path.exists()
 
 
 def test_replace_workspace_file_blocks_new_readers_during_commit(

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -1,4 +1,5 @@
 import errno
+import gc
 import json
 import pathlib
 import threading
@@ -239,12 +240,19 @@ def test_write_full_workspace_tree_file_replaces_stale_root_attrs(tmp_path) -> N
         assert manifest == {"schema_version": 4, "root_order": [0], "nodes": []}
 
 
-def test_write_full_workspace_tree_file_closes_cached_workspace_reader(
+def test_write_full_workspace_tree_file_preserves_cached_workspace_reader(
     monkeypatch, tmp_path
 ) -> None:
     fname = tmp_path / "cached-reader.itws"
     _write_transaction_test_workspace(fname)
+    target = workspace_arrays._normalized_file_path(fname)
+    monkeypatch.setattr(
+        workspace_arrays,
+        "_workspace_file_identity",
+        lambda _path: (target, 0, 0, 0),
+    )
     manager = workspace_arrays.WorkspaceFileManager(fname)
+    original_cache_key = manager._key
     cached_file = manager.acquire()
     tree = xr.DataTree.from_dict(
         {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
@@ -265,9 +273,14 @@ def test_write_full_workspace_tree_file_closes_cached_workspace_reader(
             fname, tree, _transaction_test_root_attrs()
         )
         assert replacement_checked
-        with pytest.raises(workspace_arrays._WorkspaceFileReplacedError, match="Retry"):
-            manager.acquire()
+        preserved_file = manager.acquire()
+        preserved_value = (
+            preserved_file.groups["0"].groups["imagetool"].variables["data"][()]
+        )
+        assert np.asarray(preserved_value).item() == 1.0
         reopened_manager = workspace_arrays.WorkspaceFileManager(fname)
+        assert manager._key != original_cache_key
+        assert reopened_manager._key == original_cache_key
         reopened_file = reopened_manager.acquire()
         value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
         assert np.asarray(value).item() == 2.0
@@ -277,7 +290,9 @@ def test_write_full_workspace_tree_file_closes_cached_workspace_reader(
             workspace_arrays._close_workspace_file_managers(fname)
 
 
-def test_write_full_workspace_tree_file_retires_stale_lazy_dataarray(tmp_path) -> None:
+def test_write_full_workspace_tree_file_preserves_stale_lazy_dataarray(
+    tmp_path,
+) -> None:
     fname = tmp_path / "lazy-reader.itws"
     _write_transaction_test_workspace(fname)
     opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
@@ -291,8 +306,7 @@ def test_write_full_workspace_tree_file_retires_stale_lazy_dataarray(tmp_path) -
         workspace_storage._write_full_workspace_tree_file(
             fname, tree, _transaction_test_root_attrs()
         )
-        with pytest.raises(workspace_arrays._WorkspaceFileReplacedError, match="Retry"):
-            lazy_data.compute()
+        assert lazy_data.compute().item() == 1.0
         reopened = workspace_arrays.open_workspace_dataset(
             fname, "0/imagetool", chunks={}
         )
@@ -304,6 +318,92 @@ def test_write_full_workspace_tree_file_retires_stale_lazy_dataarray(tmp_path) -
         tree.close()
         with workspace_arrays._workspace_file_lock(fname):
             workspace_arrays._close_workspace_file_managers(fname)
+
+
+def test_replace_workspace_file_keeps_reader_generations_isolated(tmp_path) -> None:
+    destination = tmp_path / "current.itws"
+
+    def _write_generation(path: pathlib.Path, value: float) -> None:
+        tree = xr.DataTree.from_dict(
+            {"0/imagetool": _transaction_test_dataset(value, title=str(value))}
+        )
+        try:
+            workspace_storage._write_full_workspace_tree_file(
+                path, tree, _transaction_test_root_attrs()
+            )
+        finally:
+            tree.close()
+
+    def _read_value(manager: workspace_arrays.WorkspaceFileManager) -> float:
+        h5_file = manager.acquire()
+        value = h5_file.groups["0"].groups["imagetool"].variables["data"][()]
+        return float(np.asarray(value).item())
+
+    _write_generation(destination, 1.0)
+    first_manager = workspace_arrays.WorkspaceFileManager(destination)
+    assert _read_value(first_manager) == 1.0
+
+    second_source = tmp_path / "second.itws"
+    _write_generation(second_source, 2.0)
+    workspace_storage._replace_workspace_file(second_source, destination)
+    second_manager = workspace_arrays.WorkspaceFileManager(destination)
+    assert _read_value(first_manager) == 1.0
+    assert _read_value(second_manager) == 2.0
+
+    third_source = tmp_path / "third.itws"
+    _write_generation(third_source, 3.0)
+    workspace_storage._replace_workspace_file(third_source, destination)
+    current_manager = workspace_arrays.WorkspaceFileManager(destination)
+    try:
+        assert _read_value(first_manager) == 1.0
+        assert _read_value(second_manager) == 2.0
+        assert _read_value(current_manager) == 3.0
+    finally:
+        first_manager.close()
+        second_manager.close()
+        with workspace_arrays._workspace_file_lock(destination):
+            workspace_arrays._close_workspace_file_managers(destination)
+
+
+def test_replace_workspace_file_copy_fallback_cleans_preserved_generation(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            source, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    manager.acquire()
+
+    def _fail_link(_source, _destination):
+        raise OSError(errno.EPERM, "hard links unavailable")
+
+    monkeypatch.setattr(workspace_storage.os, "link", _fail_link)
+    workspace_storage._replace_workspace_file(source, destination)
+
+    generation = manager._preserved_generation
+    assert generation is not None
+    generation_path = pathlib.Path(generation.path)
+    generation_directory = generation_path.parent
+    assert generation_path.exists()
+    assert generation_directory != tmp_path
+    preserved_file = manager.acquire()
+    value = preserved_file.groups["0"].groups["imagetool"].variables["data"][()]
+    assert np.asarray(value).item() == 1.0
+
+    manager.close()
+    del preserved_file, generation, manager
+    gc.collect()
+    assert not generation_path.exists()
+    assert not generation_directory.exists()
 
 
 def test_replace_workspace_file_blocks_new_readers_during_commit(
@@ -358,7 +458,7 @@ def test_replace_workspace_file_blocks_new_readers_during_commit(
     assert destination.read_bytes() == b"new"
 
 
-def test_replace_workspace_file_retires_in_flight_multichunk_reader(
+def test_replace_workspace_file_preserves_in_flight_multichunk_reader(
     monkeypatch, tmp_path
 ) -> None:
     from xarray.backends.h5netcdf_ import H5NetCDFArrayWrapper
@@ -418,10 +518,9 @@ def test_replace_workspace_file_retires_in_flight_multichunk_reader(
         opened.close()
 
     assert not compute_thread.is_alive()
-    assert results == []
-    assert len(errors) == 1
-    assert isinstance(errors[0], workspace_arrays._WorkspaceFileReplacedError)
-    assert "Retry the operation" in str(errors[0])
+    assert errors == []
+    assert len(results) == 1
+    np.testing.assert_array_equal(results[0], np.ones(8, dtype=np.float64))
 
     reopened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
     try:
@@ -485,6 +584,44 @@ def test_workspace_replace_retry_delays_only_allow_windows_sharing_errors(
     assert workspace_storage._workspace_replace_retry_delays(error) == ()
 
 
+def test_replace_workspace_file_preservation_failure_keeps_cached_reader(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(destination)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            source, tree, _transaction_test_root_attrs()
+        )
+    finally:
+        tree.close()
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    cached_file = manager.acquire()
+
+    def _fail_link(_source, _destination):
+        raise OSError(errno.EPERM, "hard links unavailable")
+
+    def _fail_copy(_source, _destination):
+        raise OSError(errno.ENOSPC, "copy failed")
+
+    monkeypatch.setattr(workspace_storage.os, "link", _fail_link)
+    monkeypatch.setattr(workspace_storage.shutil, "copyfile", _fail_copy)
+    try:
+        with pytest.raises(OSError, match="copy failed"):
+            workspace_storage._replace_workspace_file(source, destination)
+        assert manager.acquire() is cached_file
+        value = cached_file.groups["0"].groups["imagetool"].variables["data"][()]
+        assert np.asarray(value).item() == 1.0
+        assert source.exists()
+    finally:
+        with workspace_arrays._workspace_file_lock(destination):
+            workspace_arrays._close_workspace_file_managers(destination)
+
+
 def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
     monkeypatch, tmp_path
 ) -> None:
@@ -517,6 +654,8 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
         reopened_file = manager.acquire()
         value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
         assert np.asarray(value).item() == 1.0
+        assert manager._preserved_generation is None
+        assert list(tmp_path.glob(".*.erlab-workspace-read")) == []
     finally:
         with workspace_arrays._workspace_file_lock(destination):
             workspace_arrays._close_workspace_file_managers(destination)

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -246,60 +246,46 @@ def test_write_full_workspace_tree_file_preserves_cached_workspace_reader(
 ) -> None:
     fname = tmp_path / "cached-reader.itws"
     _write_transaction_test_workspace(fname)
-    target = workspace_arrays._normalized_file_path(fname)
-    monkeypatch.setattr(
-        workspace_arrays,
-        "_workspace_file_identity",
-        lambda _path: (target, 0, 0, 0),
-    )
     manager = workspace_arrays.WorkspaceFileManager(fname)
-    original_cache_key = manager._key
+    generation = manager._generation
     cached_file = manager.acquire()
     tree = xr.DataTree.from_dict(
         {"0/imagetool": _transaction_test_dataset(2.0, title="replacement")}
     )
     original_replace = workspace_storage.os.replace
     replacement_checked = False
-    replacement_completed = False
-    hidden_paths: list[str] = []
 
     def _replace_after_reader_close(source, destination):
-        nonlocal replacement_checked, replacement_completed
+        nonlocal replacement_checked
         if pathlib.Path(destination) == fname:
             replacement_checked = True
             assert cached_file._closed
         original_replace(source, destination)
-        replacement_completed = True
-
-    def _hide_after_replacement(path: str) -> None:
-        assert replacement_completed
-        hidden_paths.append(path)
 
     monkeypatch.setattr(workspace_storage.os, "replace", _replace_after_reader_close)
-    monkeypatch.setattr(
-        workspace_storage, "_hide_workspace_lock_file", _hide_after_replacement
-    )
     try:
         workspace_storage._write_full_workspace_tree_file(
             fname, tree, _transaction_test_root_attrs()
         )
         assert replacement_checked
-        assert hidden_paths == [manager._preserved_generation.path]
+        assert generation.retired
+        assert pathlib.Path(generation.path).is_file()
+        assert pathlib.Path(generation.path) != fname
         preserved_file = manager.acquire()
         preserved_value = (
             preserved_file.groups["0"].groups["imagetool"].variables["data"][()]
         )
         assert np.asarray(preserved_value).item() == 1.0
         reopened_manager = workspace_arrays.WorkspaceFileManager(fname)
-        assert manager._key != original_cache_key
-        assert reopened_manager._key == original_cache_key
+        assert reopened_manager._generation is not generation
         reopened_file = reopened_manager.acquire()
         value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
         assert np.asarray(value).item() == 2.0
     finally:
         tree.close()
-        with workspace_arrays._workspace_file_lock(fname):
-            workspace_arrays._close_workspace_file_managers(fname)
+        manager.close()
+        if "reopened_manager" in locals():
+            reopened_manager.close()
 
 
 def test_write_full_workspace_tree_file_preserves_stale_lazy_dataarray(
@@ -328,8 +314,8 @@ def test_write_full_workspace_tree_file_preserves_stale_lazy_dataarray(
             reopened.close()
     finally:
         tree.close()
-        with workspace_arrays._workspace_file_lock(fname):
-            workspace_arrays._close_workspace_file_managers(fname)
+        del lazy_data
+        gc.collect()
 
 
 def test_replace_workspace_file_keeps_reader_generations_isolated(tmp_path) -> None:
@@ -373,8 +359,30 @@ def test_replace_workspace_file_keeps_reader_generations_isolated(tmp_path) -> N
     finally:
         first_manager.close()
         second_manager.close()
+        current_manager.close()
+
+
+def test_replace_workspace_file_activates_manager_for_new_destination(tmp_path) -> None:
+    source = tmp_path / "new.itws"
+    destination = tmp_path / "current.itws"
+    _write_transaction_test_workspace(source)
+    manager = workspace_arrays.WorkspaceFileManager(destination)
+    generation = manager._generation
+
+    try:
+        workspace_storage._replace_workspace_file(source, destination)
+
+        assert not generation.retired
+        assert generation.path == str(destination.resolve())
         with workspace_arrays._workspace_file_lock(destination):
-            workspace_arrays._close_workspace_file_managers(destination)
+            assert (
+                workspace_arrays._current_workspace_file_generation(destination)
+                is generation
+            )
+        value = manager.acquire().groups["0"].groups["imagetool"].variables["data"][()]
+        assert np.asarray(value).item() == 1.0
+    finally:
+        manager.close()
 
 
 def test_replace_workspace_file_copy_fallback_cleans_preserved_generation(
@@ -401,8 +409,8 @@ def test_replace_workspace_file_copy_fallback_cleans_preserved_generation(
     monkeypatch.setattr(workspace_storage.os, "link", _fail_link)
     workspace_storage._replace_workspace_file(source, destination)
 
-    generation = manager._preserved_generation
-    assert generation is not None
+    generation = manager._generation
+    assert generation.retired
     generation_path = pathlib.Path(generation.path)
     generation_directory = generation_path.parent
     assert generation_path.exists()
@@ -418,11 +426,9 @@ def test_replace_workspace_file_copy_fallback_cleans_preserved_generation(
     assert not generation_directory.exists()
 
 
-def test_replace_workspace_file_generation_lives_until_cached_handle_closes(
+def test_retired_workspace_generation_lives_until_last_manager_released(
     tmp_path,
 ) -> None:
-    from xarray.backends.file_manager import FILE_CACHE
-
     source = tmp_path / "new.itws"
     destination = tmp_path / "current.itws"
     _write_transaction_test_workspace(destination)
@@ -439,53 +445,26 @@ def test_replace_workspace_file_generation_lives_until_cached_handle_closes(
     manager = workspace_arrays.WorkspaceFileManager(destination)
     manager.acquire()
     workspace_storage._replace_workspace_file(source, destination)
-    manager.acquire()
-    generation = manager._preserved_generation
-    assert generation is not None
+    cached_file = manager.acquire()
+    generation = manager._generation
+    assert generation.retired
     generation_path = pathlib.Path(generation.path)
+    generation_directory = generation_path.parent
     generation_ref = weakref.ref(generation)
-    cache_key_id = id(manager._key)
-    del generation
+    assert generation_path.exists()
 
-    lock_held = threading.Event()
-    release_lock = threading.Event()
-    lock = workspace_arrays._workspace_file_lock(destination)
-
-    def _hold_workspace_lock() -> None:
-        with lock:
-            lock_held.set()
-            release_lock.wait(2)
-
-    lock_thread = threading.Thread(target=_hold_workspace_lock)
-    lock_thread.start()
-    assert lock_held.wait(2)
-    try:
-        del manager
-        gc.collect()
-        generation_alive_while_cached = generation_ref() is not None
-        generation_exists_while_cached = generation_path.exists()
-        cache_key = next(key for key in FILE_CACHE if id(key) == cache_key_id)
-    finally:
-        release_lock.set()
-        lock_thread.join(2)
-
-    assert not lock_thread.is_alive()
-    cached_file = FILE_CACHE.pop(cache_key)
-    cached_file.close()
-    del cache_key, cached_file
+    del manager, generation
     gc.collect()
 
-    assert generation_alive_while_cached
-    assert generation_exists_while_cached
     assert generation_ref() is None
+    assert cached_file._closed
     assert not generation_path.exists()
+    assert not generation_directory.exists()
 
 
-def test_replace_workspace_file_closes_cached_handle_without_live_manager(
+def test_replace_workspace_file_closes_lock_busy_orphaned_generation(
     monkeypatch, tmp_path
 ) -> None:
-    from xarray.backends.file_manager import FILE_CACHE
-
     source = tmp_path / "new.itws"
     destination = tmp_path / "current.itws"
     _write_transaction_test_workspace(destination)
@@ -499,10 +478,14 @@ def test_replace_workspace_file_closes_cached_handle_without_live_manager(
     finally:
         tree.close()
 
-    manager = workspace_arrays.WorkspaceFileManager(destination)
-    cached_file = manager.acquire()
-    cache_key = manager._key
-    manager_ref = weakref.ref(manager)
+    first_manager = workspace_arrays.WorkspaceFileManager(destination)
+    second_manager = workspace_arrays.WorkspaceFileManager(destination)
+    generation = first_manager._generation
+    cached_file = second_manager.acquire()
+    first_manager_ref = weakref.ref(first_manager)
+    second_manager_ref = weakref.ref(second_manager)
+    generation_ref = weakref.ref(generation)
+    assert second_manager._generation is generation
     lock_held = threading.Event()
     release_lock = threading.Event()
     lock = workspace_arrays._workspace_file_lock(destination)
@@ -516,10 +499,11 @@ def test_replace_workspace_file_closes_cached_handle_without_live_manager(
     lock_thread.start()
     assert lock_held.wait(2)
     try:
-        del manager
+        del first_manager, second_manager, generation
         gc.collect()
-        assert manager_ref() is None
-        assert cache_key in FILE_CACHE
+        assert first_manager_ref() is None
+        assert second_manager_ref() is None
+        assert generation_ref() is not None
         assert not cached_file._closed
     finally:
         release_lock.set()
@@ -537,16 +521,19 @@ def test_replace_workspace_file_closes_cached_handle_without_live_manager(
         original_replace(src, dst)
 
     monkeypatch.setattr(
+        workspace_storage,
+        "_preserve_workspace_file_generation",
+        lambda _path: pytest.fail("Orphaned generation was copied"),
+    )
+    monkeypatch.setattr(
         workspace_storage.os, "replace", _replace_after_orphaned_reader_close
     )
-    try:
-        workspace_storage._replace_workspace_file(source, destination)
-        assert replacement_checked
-        assert cache_key not in FILE_CACHE
-        assert _read_transaction_test_value(destination) == 2.0
-    finally:
-        with workspace_arrays._workspace_file_lock(destination):
-            workspace_arrays._close_workspace_file_managers(destination)
+    workspace_storage._replace_workspace_file(source, destination)
+    gc.collect()
+
+    assert replacement_checked
+    assert generation_ref() is None
+    assert _read_transaction_test_value(destination) == 2.0
 
 
 def test_replace_workspace_file_blocks_new_readers_during_commit(
@@ -761,8 +748,7 @@ def test_replace_workspace_file_preservation_failure_keeps_cached_reader(
         assert np.asarray(value).item() == 1.0
         assert source.exists()
     finally:
-        with workspace_arrays._workspace_file_lock(destination):
-            workspace_arrays._close_workspace_file_managers(destination)
+        manager.close()
 
 
 def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
@@ -786,10 +772,24 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
     def _fail_replace(_source, _destination):
         raise PermissionError(errno.EACCES, "replacement denied")
 
-    hidden_paths: list[str] = []
+    preserved_paths: list[pathlib.Path] = []
+    original_preserve = workspace_storage._preserve_workspace_file_generation
+
+    def _record_preserved_path(path: str | pathlib.Path):
+        preserved = original_preserve(path)
+        preserved_paths.append(pathlib.Path(preserved[0]))
+
+        def _cleanup() -> None:
+            preserved[1]()
+            raise RuntimeError("temporary cleanup failed")
+
+        return preserved[0], _cleanup
+
     monkeypatch.setattr(workspace_storage.os, "replace", _fail_replace)
     monkeypatch.setattr(
-        workspace_storage, "_hide_workspace_lock_file", hidden_paths.append
+        workspace_storage,
+        "_preserve_workspace_file_generation",
+        _record_preserved_path,
     )
     monkeypatch.setattr(
         workspace_storage, "_workspace_replace_retry_delays", lambda _exc: ()
@@ -801,12 +801,13 @@ def test_replace_workspace_file_failure_keeps_old_file_reader_usable(
         reopened_file = manager.acquire()
         value = reopened_file.groups["0"].groups["imagetool"].variables["data"][()]
         assert np.asarray(value).item() == 1.0
-        assert manager._preserved_generation is None
-        assert hidden_paths == []
-        assert list(tmp_path.glob(".*.erlab-workspace-read")) == []
+        assert not manager._generation.retired
+        assert pathlib.Path(manager._generation.path) == destination.resolve()
+        assert preserved_paths
+        assert all(not path.exists() for path in preserved_paths)
+        assert source.exists()
     finally:
-        with workspace_arrays._workspace_file_lock(destination):
-            workspace_arrays._close_workspace_file_managers(destination)
+        manager.close()
 
 
 def test_write_full_workspace_tree_file_local_path_uses_destination_temp(


### PR DESCRIPTION
## Summary

- Publish full saves, delta saves, recovery, and metadata changes as validated successor files.
- Keep each published workspace generation immutable and open all lazy readers in read-only mode.
- Preserve active reader generations across replacement and rebind saved live data after every publication.
- Give serialized readers an owned immutable transport file. Use a physical copy on Windows so another process cannot lock the canonical file through a hard link.
- Retry transient Windows sharing failures and show specific guidance for access failures or publication conflicts.

## Root cause

The canonical workspace file had three incompatible roles. It was the visible document, the mutable delta-save target, and the backing file for lazy arrays. A lazy HDF5 reader still opened the file in read-write mode. A background read could therefore change file state while a save was prepared. An open handle could also prevent `os.replace` on Windows. This caused WinError 5 or 32 only for workspaces and timing sequences that retained a lazy reader.

Incremental rollback logic reduced the effect of a failed in-place update, but it did not remove the shared mutable-file model. Each repair therefore exposed another lifetime or race condition.

## Design

A published generation never changes. A delta save copies the current generation to a private successor, applies changes only to that successor, validates and syncs it, and publishes it once with `os.replace`. A failed worker discards the successor. It does not need rollback and cannot expose partial groups in the canonical file.

Publication records the expected destination identity. It refuses to overwrite a file that another process changed while the successor was prepared. Full saves use the same conflict check.

Before publication, the manager closes its cached handle. If live leases remain, it preserves the old generation with a private hard link or copy. Existing lazy arrays continue to read the old bytes. New readers use the published generation. Post-save rebinding moves unchanged live workspace data to the new generation. Edits made after a background snapshot remain on their old generation and stay dirty.

Workspace readers and xarray stores now use read-only mode. Serialized readers use one export owned by the sending generation. A receiving process creates its own reader lease before it opens HDF5. Windows exports are physical copies because an open handle to any hard link can block replacement of the canonical link.

Legacy transaction recovery remains for files left by older interrupted saves. Recovery also runs on a private successor and publishes once.

## User impact

Background and manual saves no longer mutate the file used by active lazy arrays. A transient antivirus, preview, or folder-sync lock gets bounded retries. A persistent access failure leaves the prior workspace unchanged and gives the user specific actions. A concurrent external edit is not overwritten.

The generation registry still uses xarray's bounded file cache. Retired generation files and serialized export files are removed after their final owning lease ends. Stale files from a terminated process are removed when the workspace lock is next acquired.

## Validation

- `uv run pytest -q tests/interactive/imagetool/manager/workspace/test_arrays.py tests/interactive/imagetool/manager/workspace/test_storage.py` - 115 passed
- Seven focused live-manager tests for delta saves, lazy readers, background publication, post-snapshot edits, and successor failure - 7 passed
- Two focused save-error and user-guidance tests - 2 passed
- `uv run mypy src` - passed for 260 source files
- Ruff check and format check on all changed files - passed
- `git diff --check` - passed

Repository-wide Ruff also reports unrelated findings that are present after rebasing onto the current main branch. Native Windows execution was not available in this environment. The Windows sharing and transport paths have simulated regression coverage.
