### PR TITLE
fix(figurecomposer): improve window sizing

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -204,6 +204,7 @@ _PERSISTED_PREVIEW_CACHE_SIZE = (512, 384)
 _PERSISTED_PREVIEW_CACHE_MAX_BYTES = 384_000
 _RESTORE_OPERATION_EDITOR_KEY = "figure_composer_operation_editor"
 _RESTORE_REDRAW_KEY = "figure_composer_restored_redraw"
+_INITIAL_SIZE_HINT_EXTRA_HEIGHT = 80
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
@@ -349,6 +350,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     _PROVENANCE_IS_MODEL_OWNED = True
 
     StateModel = FigureRecipeState
+
+    def sizeHint(self) -> QtCore.QSize:
+        hint = super().sizeHint()
+        return QtCore.QSize(
+            hint.width(), hint.height() + _INITIAL_SIZE_HINT_EXTRA_HEIGHT
+        )
 
     def __init__(
         self,

--- a/src/erlab/interactive/_figurecomposer/_ui/_toolbar_dialogs.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_toolbar_dialogs.py
@@ -126,6 +126,7 @@ _STYLE_TARGET_PLOT_SLICES = "plot_slices"
 _STYLE_TARGET_LINE = "line"
 _STYLE_TARGET_IMAGE = "image"
 _STYLE_TARGET_COMBO_MINIMUM_CONTENTS = 28
+_DIALOG_AVAILABLE_HEIGHT_FRACTION = 0.9
 
 
 class _StyleTarget(typing.NamedTuple):
@@ -159,6 +160,46 @@ class _ElidingComboBox(QtWidgets.QComboBox):
         view = self.view()
         if view is not None:  # pragma: no branch - Qt creates the popup view.
             view.setTextElideMode(QtCore.Qt.TextElideMode.ElideMiddle)
+
+
+class _VerticalScrollArea(QtWidgets.QScrollArea):
+    """Scroll vertically without allowing content to clip horizontally."""
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        hint = super().minimumSizeHint()
+        content = self.widget()
+        if content is None:
+            return hint
+        width = content.minimumSizeHint().width() + 2 * self.frameWidth()
+        if (
+            self.verticalScrollBarPolicy()
+            != QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        ):
+            scrollbar = typing.cast("QtWidgets.QScrollBar", self.verticalScrollBar())
+            width += scrollbar.sizeHint().width()
+        return QtCore.QSize(max(hint.width(), width), hint.height())
+
+
+def _scrollable_tab_page(
+    parent: QtWidgets.QWidget,
+    *,
+    object_name: str,
+) -> tuple[QtWidgets.QScrollArea, QtWidgets.QWidget]:
+    scroll_area = _VerticalScrollArea(parent)
+    scroll_area.setObjectName(object_name)
+    scroll_area.setWidgetResizable(True)
+    scroll_area.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+    scroll_area.setHorizontalScrollBarPolicy(
+        QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    )
+    scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+    page = QtWidgets.QWidget(scroll_area)
+    page.setSizePolicy(
+        QtWidgets.QSizePolicy.Policy.Expanding,
+        QtWidgets.QSizePolicy.Policy.Preferred,
+    )
+    scroll_area.setWidget(page)
+    return scroll_area, page
 
 
 def _add_axis_form_row(
@@ -361,23 +402,28 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
     tab_widget.setObjectName("figureComposerToolbarCustomizeTabs")
     root_layout.addWidget(tab_widget, 1)
 
-    axes_page = QtWidgets.QWidget(tab_widget)
+    axes_tab, axes_page = _scrollable_tab_page(
+        tab_widget,
+        object_name="figureComposerToolbarAxesScrollArea",
+    )
     form_layout = QtWidgets.QFormLayout(axes_page)
     form_layout.setFieldGrowthPolicy(
         QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
     )
-    tab_widget.addTab(axes_page, "Axes")
+    tab_widget.addTab(axes_tab, "Axes")
 
-    curves_page, curves_combo, curves_layout = _style_tab_page(
+    curves_tab, curves_page, curves_combo, curves_layout = _style_tab_page(
         tab_widget,
+        scroll_object_name="figureComposerToolbarCurvesScrollArea",
         combo_object_name="figureComposerToolbarCurveTargetCombo",
     )
-    images_page, images_combo, images_layout = _style_tab_page(
+    images_tab, images_page, images_combo, images_layout = _style_tab_page(
         tab_widget,
+        scroll_object_name="figureComposerToolbarImagesScrollArea",
         combo_object_name="figureComposerToolbarImageTargetCombo",
     )
-    curves_tab_index = tab_widget.addTab(curves_page, "Curves")
-    images_tab_index = tab_widget.addTab(images_page, "Images")
+    curves_tab_index = tab_widget.addTab(curves_tab, "Curves")
+    images_tab_index = tab_widget.addTab(images_tab, "Images")
 
     title_edit = _axis_plain_text_edit(axes_page, "figureComposerToolbarAxesTitleEdit")
     xlabel_edit = _axis_plain_text_edit(
@@ -868,6 +914,17 @@ def show_axes_customize_dialog(tool: FigureComposerTool) -> None:
     button_box.rejected.connect(dialog.close)
     root_layout.addWidget(button_box)
 
+    screen = dialog.screen()
+    if screen is not None:  # pragma: no branch - QApplication assigns a screen.
+        size_hint = dialog.sizeHint()
+        available_height = screen.availableGeometry().height()
+        dialog.resize(
+            size_hint.width(),
+            min(
+                size_hint.height(),
+                int(available_height * _DIALOG_AVAILABLE_HEIGHT_FRACTION),
+            ),
+        )
     _show_toolbar_dialog(tool, "_axes_customize_dialog", dialog)
 
 
@@ -1625,9 +1682,18 @@ class _ImageOperationStyleWidget(QtWidgets.QWidget):
 def _style_tab_page(
     parent: QtWidgets.QWidget,
     *,
+    scroll_object_name: str,
     combo_object_name: str,
-) -> tuple[QtWidgets.QWidget, QtWidgets.QComboBox, QtWidgets.QVBoxLayout]:
-    page = QtWidgets.QWidget(parent)
+) -> tuple[
+    QtWidgets.QScrollArea,
+    QtWidgets.QWidget,
+    QtWidgets.QComboBox,
+    QtWidgets.QVBoxLayout,
+]:
+    scroll_area, page = _scrollable_tab_page(
+        parent,
+        object_name=scroll_object_name,
+    )
     layout = QtWidgets.QVBoxLayout(page)
     combo = _ElidingComboBox(page)
     combo.setObjectName(combo_object_name)
@@ -1640,7 +1706,7 @@ def _style_tab_page(
     editor_layout.setContentsMargins(0, 0, 0, 0)
     layout.addLayout(editor_layout)
     layout.addStretch(1)
-    return page, combo, editor_layout
+    return scroll_area, page, combo, editor_layout
 
 
 def _connect_panel_editor_signal(

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -2423,14 +2423,15 @@ class _ManagedWindowNode(QtCore.QObject):
         if not window.isVisible() and self._recent_geometry is not None:
             window.setGeometry(self._recent_geometry)
 
-        if sys.platform == "win32":  # pragma: no cover
+        if sys.platform == "win32":
+            window_flags = window.windowFlags()
+            window_geometry = window.geometry()
             window.setWindowFlags(
-                window.windowFlags() | QtCore.Qt.WindowType.WindowStaysOnTopHint
+                window_flags | QtCore.Qt.WindowType.WindowStaysOnTopHint
             )
             window.show()
-            window.setWindowFlags(
-                window.windowFlags() & ~QtCore.Qt.WindowType.WindowStaysOnTopHint
-            )
+            window.setWindowFlags(window_flags)
+            window.setGeometry(window_geometry)
 
         window.show()
         window.activateWindow()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -16,6 +16,7 @@ import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._saving as workspace_saving
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 from erlab.interactive._figurecomposer import (
     FigureComposerTool,
     FigureOperationState,
@@ -133,6 +134,44 @@ def test_selected_figure_details_track_root_reindexing(
 
         assert any("ImageTool 1" in label for label in _derivation_labels())
         assert not any("ImageTool 2" in label for label in _derivation_labels())
+
+
+def test_manager_windows_figure_activation_preserves_resized_geometry(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    class _FlagResizeFigureComposer(FigureComposerTool):
+        def setWindowFlags(self, flags: QtCore.Qt.WindowType) -> None:
+            super().setWindowFlags(flags)
+            self.resize(self.width(), self.sizeHint().height())
+
+    monkeypatch.setattr(manager_wrapper.sys, "platform", "win32")
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="line",
+    )
+
+    with manager_context() as manager:
+        tool = _FlagResizeFigureComposer(data)
+        figure_uid = manager.add_figuretool(tool, show=True)
+        qtbot.waitUntil(tool.isVisible, timeout=5000)
+        qtbot.waitUntil(
+            lambda: tool.width() >= tool.minimumSizeHint().width(), timeout=5000
+        )
+        tool.setGeometry(80, 60, tool.width() + 80, tool.height() + 180)
+        QtWidgets.QApplication.processEvents()
+        resized_geometry = tool.geometry()
+
+        item = manager._figure_collection.item_for_uid(figure_uid)
+        assert item is not None
+        manager._figure_collection._show_item(item)
+
+        assert tool.geometry() == resized_geometry
 
 
 def test_manager_figures_ui_is_lazy_and_figures_survive_source_removal(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -7918,6 +7918,66 @@ def test_figure_composer_toolbar_axes_plain_text_handles_missing_document(
     assert _method_operations(tool, FigureMethodFamily.AXES, "set_title") == ()
 
 
+def test_figure_composer_toolbar_axes_dialog_scrolls_on_small_screens(qtbot) -> None:
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+    tool.show_figure_window(activate=False)
+
+    tool._show_axes_customize_dialog()
+    dialog = tool._axes_customize_dialog
+    assert isinstance(dialog, QtWidgets.QDialog)
+    tab_widget = dialog.findChild(
+        QtWidgets.QTabWidget, "figureComposerToolbarCustomizeTabs"
+    )
+    button_box = dialog.findChild(QtWidgets.QDialogButtonBox)
+    assert tab_widget is not None
+    assert button_box is not None
+    assert dialog.height() <= int(
+        dialog.screen().availableGeometry().height()
+        * figurecomposer_toolbar_dialogs._DIALOG_AVAILABLE_HEIGHT_FRACTION
+    )
+
+    scroll_areas = tuple(
+        typing.cast("QtWidgets.QScrollArea", tab_widget.widget(index))
+        for index in range(tab_widget.count())
+    )
+    assert all(isinstance(area, QtWidgets.QScrollArea) for area in scroll_areas)
+    for scroll_area in scroll_areas:
+        assert scroll_area.widgetResizable()
+        assert (
+            scroll_area.horizontalScrollBarPolicy()
+            == QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        assert (
+            scroll_area.verticalScrollBarPolicy()
+            == QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        assert not scroll_area.isAncestorOf(button_box)
+
+    axes_scroll_area = scroll_areas[0]
+    axes_page = axes_scroll_area.widget()
+    tick_editor = axes_page.findChild(
+        figurecomposer_tick_params.TickParamsEditorWidget,
+        "figureComposerToolbarAxesTickParamsEditor",
+    )
+    assert tick_editor is not None
+
+    dialog.resize(dialog.width(), 360)
+    QtWidgets.QApplication.processEvents()
+    vertical_scrollbar = axes_scroll_area.verticalScrollBar()
+    assert vertical_scrollbar.maximum() > 0
+    assert axes_scroll_area.horizontalScrollBar().maximum() == 0
+    assert button_box.isVisible()
+
+    dialog.resize(100, dialog.height())
+    QtWidgets.QApplication.processEvents()
+    assert axes_scroll_area.horizontalScrollBar().maximum() == 0
+
+    axes_scroll_area.ensureWidgetVisible(tick_editor.advanced_disclosure)
+    QtWidgets.QApplication.processEvents()
+    assert vertical_scrollbar.value() > 0
+
+
 def test_figure_composer_toolbar_axes_dialog_updates_recipe(qtbot) -> None:
     data = _figure_composer_image_source("data")
     tool = FigureComposerTool(


### PR DESCRIPTION
## Summary

- Increase the Figure Composer editor height through its normal Qt size hint.
- Make each Customize Axes tab scroll vertically when its controls exceed the available screen height.
- Keep the dialog action buttons visible and prevent hidden horizontal overflow.
- Preserve a resized managed Figure Composer window when Windows reapplies native window flags during activation.

## Root cause

The Customize Axes pages did not have a vertical scrolling boundary. A short screen could place lower controls outside the visible dialog.

On Windows, the manager briefly changes the always-on-top window flag to raise a managed window. Reapplying native flags can restore the widget to its size hint and discard the user's resized geometry.

## User impact

The editor opens slightly taller. The axes controls remain accessible on short screens. A manager activation no longer changes a resized editor window.

## Validation

- `uv run ruff format --check` on the changed files
- `uv run ruff check` on the changed files
- `uv run mypy` on the changed runtime modules
- Commit hooks

Local pytest was not rerun after the final size-hint adjustment. CI provides the test run.
