### PR TITLE
fix(figure-composer): show render errors on the responsible step

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -6,6 +6,7 @@ import contextlib
 import typing
 
 import matplotlib as mpl
+import matplotlib.artist
 import matplotlib.axes
 import numpy as np
 import xarray as xr
@@ -41,6 +42,47 @@ if typing.TYPE_CHECKING:
         FigureGridSpecGridState,
     )
     from erlab.interactive._figurecomposer._tool import FigureComposerTool
+
+
+_OPERATION_ID_ATTR = "_erlab_figure_composer_operation_id"
+
+
+def _tag_operation_artist(artist: matplotlib.artist.Artist, operation_id: str) -> None:
+    setattr(artist, _OPERATION_ID_ATTR, operation_id)
+
+
+@contextlib.contextmanager
+def _track_operation_artists(figure: Figure, operation_id: str) -> Iterator[None]:
+    artists_before = set(figure.findobj())
+    stale_callbacks: dict[matplotlib.artist.Artist, tuple[typing.Any, typing.Any]] = {}
+    for artist in artists_before:
+        if isinstance(artist, Figure):
+            continue
+        original_callback = artist.stale_callback
+
+        # Matplotlib setters mark an artist as stale even when it was already stale.
+        # Wrap that notification to track mutations of artists from earlier steps.
+        def operation_stale_callback(
+            changed_artist: matplotlib.artist.Artist,
+            stale: bool,
+            original: typing.Any = original_callback,
+        ) -> None:
+            _tag_operation_artist(changed_artist, operation_id)
+            if original is not None:
+                original(changed_artist, stale)
+
+        artist.stale_callback = operation_stale_callback
+        stale_callbacks[artist] = (original_callback, operation_stale_callback)
+
+    try:
+        yield
+    finally:
+        for artist, (original_callback, operation_callback) in stale_callbacks.items():
+            if artist.stale_callback is operation_callback:
+                artist.stale_callback = original_callback
+        for artist in figure.findobj():
+            if artist not in artists_before:
+                _tag_operation_artist(artist, operation_id)
 
 
 def _setup_kwargs(context: FigureRecipeContext) -> dict[str, typing.Any]:
@@ -341,7 +383,8 @@ def _render_into_figure(
             ) or tool.operation_editor.has_input_error(operation):
                 continue
             try:
-                spec.render(tool, operation, figure, axs)
+                with _track_operation_artists(figure, operation.operation_id):
+                    spec.render(tool, operation, figure, axs)
             except Exception as exc:
                 render_errors[operation.operation_id] = _render_error_text(exc)
     tool._set_operation_render_errors(render_errors)
@@ -372,7 +415,39 @@ def _render_error_text(error: Exception) -> str:
 
 
 def _set_preview_draw_error(tool: FigureComposerTool, error: Exception) -> None:
-    tool._set_preview_render_error(_render_error_text(error))
+    error_text = _render_error_text(error)
+    operation_ids: set[str] = set()
+    traceback = error.__traceback__
+    while traceback is not None:
+        frame_operation_ids: set[str] = set()
+        for value in traceback.tb_frame.f_locals.values():
+            if not isinstance(value, matplotlib.artist.Artist) or isinstance(
+                value, Figure
+            ):
+                continue
+            tagged_id = getattr(value, _OPERATION_ID_ATTR, None)
+            if isinstance(tagged_id, str):
+                frame_operation_ids.add(tagged_id)
+        if frame_operation_ids:
+            # A failing leaf artist is deeper than its Axes and other draw parents.
+            operation_ids = frame_operation_ids
+        traceback = traceback.tb_next
+
+    if len(operation_ids) != 1:
+        tool._set_preview_render_error(error_text)
+        return
+
+    operation_id = operation_ids.pop()
+    if operation_id not in {
+        operation.operation_id for operation in tool._document.recipe.operations
+    }:
+        tool._set_preview_render_error(error_text)
+        return
+
+    render_errors = dict(tool._operation_render_errors)
+    render_errors[operation_id] = error_text
+    tool._set_operation_render_errors(render_errors)
+    tool._set_preview_render_error(None)
 
 
 def _render_preview(

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -138,6 +138,7 @@ from erlab.interactive._figurecomposer._rendering import (
     _render_into_figure,
     _render_preview,
     _rendered_output_figure,
+    _set_preview_draw_error,
 )
 from erlab.interactive._figurecomposer._text import _format_axes_tuple
 from erlab.interactive._figurecomposer._ui._axes_widgets import (
@@ -1275,6 +1276,21 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         output_action_layout.addWidget(self.redraw_plot_button)
         action_layout.addLayout(output_action_layout)
         root_layout.addLayout(action_layout)
+        self.preview_render_error_label = QtWidgets.QLabel(root)
+        self.preview_render_error_label.setObjectName(
+            "figureComposerPreviewRenderError"
+        )
+        self.preview_render_error_label.setWordWrap(True)
+        self.preview_render_error_label.setTextInteractionFlags(
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        preview_error_palette = self.preview_render_error_label.palette()
+        preview_error_palette.setColor(
+            QtGui.QPalette.ColorRole.WindowText, QtGui.QColor("darkRed")
+        )
+        self.preview_render_error_label.setPalette(preview_error_palette)
+        self.preview_render_error_label.hide()
+        root_layout.addWidget(self.preview_render_error_label)
         root_layout.addWidget(self.editor_tabs, 1)
 
         self.source_panel = FigureSourcePanel(self.editor_tabs)
@@ -2704,14 +2720,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if error == self._preview_render_error:
             return
         self._preview_render_error = error
-        status_bar = typing.cast("QtWidgets.QStatusBar", self.statusBar())
-        status_bar.setObjectName("figureComposerPreviewRenderStatus")
-        if error is None:
-            status_bar.clearMessage()
-            status_bar.hide()
-        else:
-            status_bar.showMessage(f"Preview render error: {error}")
-            status_bar.show()
+        self.preview_render_error_label.setText(
+            "" if error is None else f"Figure render error: {error}"
+        )
+        self.preview_render_error_label.setVisible(error is not None)
 
     @QtCore.Slot()
     def _operation_editor_validation_changed(self) -> None:
@@ -4801,8 +4813,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if not erlab.interactive.utils.qt_is_valid(canvas):
                 return False
             if redraw:
-                with self._figure_options_context(), _figure_style_context():
-                    canvas.draw()
+                try:
+                    with self._figure_options_context(), _figure_style_context():
+                        canvas.draw()
+                except Exception as exc:
+                    _set_preview_draw_error(self, exc)
+                    return False
             width, height = canvas.get_width_height(physical=True)
             if width <= 0 or height <= 0:
                 return False
@@ -4840,8 +4856,12 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 canvas = FigureCanvasAgg(figure)
                 try:
                     _render_into_figure(self, figure, sync_visible=False)
-                    with _figure_draw_context():
-                        canvas.draw()
+                    try:
+                        with _figure_draw_context():
+                            canvas.draw()
+                    except Exception as exc:
+                        _set_preview_draw_error(self, exc)
+                        return None
                     width, height = canvas.get_width_height()
                 except Exception as exc:
                     self._set_preview_render_error(_render_error_text(exc))

--- a/src/erlab/plotting/annotations.py
+++ b/src/erlab/plotting/annotations.py
@@ -256,6 +256,18 @@ def parse_special_point(name: str) -> str:
 
 
 def parse_point_labels(name: str, roman: bool = True, bar: bool = False) -> str:
+    stripped_name = name.strip()
+    if (
+        len(stripped_name) >= 2
+        and stripped_name.startswith("$")
+        and stripped_name.endswith("$")
+    ):
+        raise ValueError(
+            f"Point label {name!r} already has MathText delimiters. "
+            "When literal=False, MathText delimiters are added automatically. "
+            f"Use {stripped_name[1:-1]!r} instead, or set literal=True."
+        )
+
     name = parse_special_point(name)
 
     if name.endswith("*"):
@@ -671,7 +683,8 @@ def mark_points(
     pad
         Offset of the text in points.
     literal
-        If `True`, take the input string literally.
+        If `True`, take the input string literally. If `False`, labels are formatted
+        as MathText and must not include surrounding ``$`` delimiters.
     roman
         If `False`, itallic fonts are used.
     bar
@@ -714,7 +727,13 @@ def mark_points(
 
         default_color = kwargs.pop("c", kwargs.pop("color", None))
 
-        for xi, yi, label in zip(points, y, labels, strict=True):
+        parsed_labels = (
+            labels
+            if literal
+            else tuple(parse_point_labels(label, roman, bar) for label in labels)
+        )
+
+        for xi, yi, label in zip(points, y, parsed_labels, strict=True):
             if default_color is None:
                 color = "k" if ax.get_ylim()[1] < yi else axes_textcolor(ax)
             else:
@@ -722,7 +741,7 @@ def mark_points(
             ax.text(
                 xi,
                 yi,
-                label if literal else parse_point_labels(label, roman, bar),
+                label,
                 transform=ax.transData
                 + mtransforms.ScaledTranslation(
                     pad[0] / 72, pad[1] / 72, fig.dpi_scale_trans
@@ -758,7 +777,8 @@ def mark_points_outside(
         If ``'x'``, marks points along the horizontal axis. If ``'y'``, marks points
         along the vertical axis.
     literal
-        If `True`, take the input string literally.
+        If `True`, take the input string literally. If `False`, labels are formatted
+        as MathText and must not include surrounding ``$`` delimiters.
     roman
         If ``False``, itallic fonts are used.
     bar
@@ -783,15 +803,17 @@ def mark_points_outside(
                 ax=ax_i,
             )
     else:
+        parsed_labels = (
+            labels
+            if literal
+            else tuple(parse_point_labels(label, roman, bar) for label in labels)
+        )
         if axis == "x":
             label_ax = ax.twiny()
             label_ax.set_xlim(ax.get_xlim())
             label_ax.set_xticks(
                 points,
-                labels=[
-                    lab if literal else parse_point_labels(lab, roman, bar)
-                    for lab in labels
-                ],
+                labels=parsed_labels,
                 **kwargs,
             )
         else:
@@ -799,10 +821,7 @@ def mark_points_outside(
             label_ax.set_ylim(ax.get_ylim())
             label_ax.set_yticks(
                 points,
-                labels=[
-                    lab if literal else parse_point_labels(lab, roman, bar)
-                    for lab in labels
-                ],
+                labels=parsed_labels,
                 **kwargs,
             )
         label_ax.set_frame_on(False)

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -7,6 +7,7 @@ from pathlib import Path
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
+import matplotlib.figure
 import matplotlib.text
 import numpy as np
 import pytest
@@ -1225,6 +1226,94 @@ def test_figure_composer_unattributed_preview_draw_error_uses_inline_banner(
     assert banner is not None
     assert not banner.isHidden()
     assert tool.findChild(QtWidgets.QStatusBar) is None
+
+
+def test_figure_composer_artist_tracking_preserves_replaced_callback() -> None:
+    figure = matplotlib.figure.Figure()
+    axes = figure.subplots()
+
+    def replacement_callback(_artist, _stale: bool) -> None:
+        pass
+
+    with figurecomposer_rendering._track_operation_artists(figure, "operation"):
+        axes.stale_callback = replacement_callback
+
+    assert axes.stale_callback is replacement_callback
+
+
+def test_figure_composer_preview_draw_error_ignores_untagged_artist(qtbot) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    operation = FigureOperationState.line(label="line", source="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tagged_artist = matplotlib.text.Text()
+    setattr(
+        tagged_artist,
+        figurecomposer_rendering._OPERATION_ID_ATTR,
+        operation.operation_id,
+    )
+    untagged_artist = matplotlib.text.Text()
+
+    def raise_draw_error(
+        failing_artist: matplotlib.text.Text,
+        unrelated_artist: matplotlib.text.Text,
+    ) -> None:
+        if failing_artist is unrelated_artist:
+            raise AssertionError("Artists must be different")
+        raise RuntimeError("draw failure")
+
+    try:
+        raise_draw_error(tagged_artist, untagged_artist)
+    except RuntimeError as exc:
+        figurecomposer_rendering._set_preview_draw_error(tool, exc)
+
+    assert tool._operation_render_errors == {
+        operation.operation_id: "RuntimeError: draw failure"
+    }
+    assert tool._preview_render_error is None
+
+
+def test_figure_composer_stale_operation_draw_error_uses_inline_banner(qtbot) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    current_operation = FigureOperationState.line(label="current", source="data")
+    removed_operation = FigureOperationState.line(label="removed", source="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(current_operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    stale_artist = matplotlib.text.Text()
+    setattr(
+        stale_artist,
+        figurecomposer_rendering._OPERATION_ID_ATTR,
+        removed_operation.operation_id,
+    )
+
+    def raise_draw_error(artist: matplotlib.text.Text) -> None:
+        if artist is not stale_artist:
+            raise AssertionError("Unexpected artist")
+        raise RuntimeError("stale draw failure")
+
+    try:
+        raise_draw_error(stale_artist)
+    except RuntimeError as exc:
+        figurecomposer_rendering._set_preview_draw_error(tool, exc)
+
+    assert tool._operation_render_errors == {}
+    assert tool._preview_render_error == "RuntimeError: stale draw failure"
 
 
 def test_figure_composer_ambiguous_preview_draw_error_is_not_assigned(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -7,6 +7,7 @@ from pathlib import Path
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
+import matplotlib.text
 import numpy as np
 import pytest
 import xarray as xr
@@ -1198,7 +1199,7 @@ def test_figure_composer_redraw_and_preview_cache_edges(qtbot, monkeypatch) -> N
     )
 
 
-def test_figure_composer_preview_draw_error_is_not_assigned_to_operation(
+def test_figure_composer_unattributed_preview_draw_error_uses_inline_banner(
     qtbot,
 ) -> None:
     data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
@@ -1220,9 +1221,53 @@ def test_figure_composer_preview_draw_error_is_not_assigned_to_operation(
 
     assert tool._operation_render_errors == {}
     assert tool._preview_render_error == "RuntimeError: boom"
-    status = tool.findChild(QtWidgets.QStatusBar, "figureComposerPreviewRenderStatus")
-    assert status is not None
-    assert not status.isHidden()
+    banner = tool.findChild(QtWidgets.QLabel, "figureComposerPreviewRenderError")
+    assert banner is not None
+    assert not banner.isHidden()
+    assert tool.findChild(QtWidgets.QStatusBar) is None
+
+
+def test_figure_composer_ambiguous_preview_draw_error_is_not_assigned(qtbot) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    first_operation = FigureOperationState.line(label="first", source="data")
+    second_operation = FigureOperationState.line(label="second", source="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data"),),
+            operations=(first_operation, second_operation),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    first_artist = matplotlib.text.Text()
+    second_artist = matplotlib.text.Text()
+    setattr(
+        first_artist,
+        figurecomposer_rendering._OPERATION_ID_ATTR,
+        first_operation.operation_id,
+    )
+    setattr(
+        second_artist,
+        figurecomposer_rendering._OPERATION_ID_ATTR,
+        second_operation.operation_id,
+    )
+
+    def raise_draw_error(
+        first: matplotlib.text.Text, second: matplotlib.text.Text
+    ) -> None:
+        if first is second:
+            raise AssertionError("Artists must be different")
+        raise RuntimeError("ambiguous draw failure")
+
+    try:
+        raise_draw_error(first_artist, second_artist)
+    except RuntimeError as exc:
+        figurecomposer_rendering._set_preview_draw_error(tool, exc)
+
+    assert tool._operation_render_errors == {}
+    assert tool._preview_render_error == "RuntimeError: ambiguous draw failure"
 
 
 def test_figure_composer_preview_draw_failures_are_figure_level(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
@@ -1207,7 +1207,7 @@ def test_figure_composer_colorbar_method_target_policy(qtbot) -> None:
     assert "eplt.nice_colorbar(ax=axs)" in tool.generated_code()
 
 
-def test_figure_composer_method_draw_time_text_error_is_non_modal(qtbot) -> None:
+def test_figure_composer_method_draw_time_text_error_marks_operation(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
         dims=("kx", "ky"),
@@ -1235,15 +1235,16 @@ def test_figure_composer_method_draw_time_text_error_is_non_modal(qtbot) -> None
 
     tool._redraw_plot(show_window=True)
 
-    assert tool._operation_render_errors == {}
-    render_error = tool._preview_render_error
+    assert tool._preview_render_error is None
+    render_error = tool._operation_render_errors[title_operation.operation_id]
     assert render_error is not None
     assert "ValueError" in render_error
     assert "ParseException" in render_error
-    assert _operation_status_codes(tool, 1) == ()
-    status = tool.findChild(QtWidgets.QStatusBar, "figureComposerPreviewRenderStatus")
-    assert status is not None
-    assert not status.isHidden()
+    assert _operation_status_codes(tool, 1) == ("render_error",)
+    banner = tool.findChild(QtWidgets.QLabel, "figureComposerPreviewRenderError")
+    assert banner is not None
+    assert banner.isHidden()
+    assert tool.findChild(QtWidgets.QStatusBar) is None
 
     tool._replace_operation(
         1,
@@ -1254,4 +1255,149 @@ def test_figure_composer_method_draw_time_text_error_is_non_modal(qtbot) -> None
     assert tool._operation_render_errors == {}
     assert tool._preview_render_error is None
     assert _operation_status_codes(tool, 1) == ()
-    assert status.isHidden()
+    assert banner.isHidden()
+
+
+def test_figure_composer_mark_points_argument_error_marks_exact_operation(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    invalid_operation = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name="mark_points",
+        args=((0.0,), (r"$\Gamma$",)),
+    )
+    valid_operation = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name="mark_points",
+        args=((0.0,), ("K",)),
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(invalid_operation, valid_operation),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool._redraw_plot(show_window=True)
+
+    assert tool._preview_render_error is None
+    assert set(tool._operation_render_errors) == {invalid_operation.operation_id}
+    assert (
+        "already has MathText delimiters"
+        in tool._operation_render_errors[invalid_operation.operation_id]
+    )
+    assert (
+        "set literal=True"
+        in tool._operation_render_errors[invalid_operation.operation_id]
+    )
+    assert _operation_status_codes(tool, 0) == ("render_error",)
+    assert _operation_status_codes(tool, 1) == ()
+
+
+def test_figure_composer_draw_error_follows_later_artist_mutation(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(3.0),
+        dims=("x",),
+        coords={"x": np.arange(3.0)},
+        name="data",
+    )
+    line_operation = FigureOperationState.line(label="line", source="data")
+    mutation_operation = FigureOperationState.custom(
+        label="invalid dashes",
+        code="axs[0, 0].lines[0].set_dashes([1, -1])",
+        trusted=True,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(line_operation, mutation_operation),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool._redraw_plot(show_window=True)
+
+    assert tool._preview_render_error is None
+    assert set(tool._operation_render_errors) == {mutation_operation.operation_id}
+    assert (
+        "dash list must be non-negative"
+        in tool._operation_render_errors[mutation_operation.operation_id]
+    )
+    assert _operation_status_codes(tool, 0) == ()
+    assert _operation_status_codes(tool, 1) == ("render_error",)
+
+
+def test_figure_composer_draw_error_marks_axes_mutation(qtbot) -> None:
+    data = xr.DataArray(np.arange(2.0), dims=("x",), name="data")
+    mutation_operation = FigureOperationState.custom(
+        label="invalid aspect",
+        code="axs[0, 0].set_aspect('equal', adjustable='datalim')",
+        trusted=True,
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(
+                nrows=1,
+                ncols=2,
+                sharex=True,
+                sharey=True,
+            ),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(mutation_operation,),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool._redraw_plot(show_window=True)
+
+    assert tool._preview_render_error is None
+    assert set(tool._operation_render_errors) == {mutation_operation.operation_id}
+    assert (
+        "are not allowed when both axes are shared"
+        in (tool._operation_render_errors[mutation_operation.operation_id])
+    )
+    assert _operation_status_codes(tool, 0) == ("render_error",)
+
+
+def test_figure_composer_offscreen_draw_error_marks_operation(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    plot_operation = FigureOperationState.plot_array(label="plot", source="data")
+    title_operation = FigureOperationState.method(
+        family=FigureMethodFamily.ERLAB,
+        name="set_titles",
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+    ).model_copy(update={"text_values": ("ALS, $$39.3 eV",)})
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(plot_operation, title_operation),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    assert tool.refresh_preview_pixmap(allow_offscreen=True) is None
+
+    assert tool._preview_render_error is None
+    assert set(tool._operation_render_errors) == {title_operation.operation_id}
+    assert _operation_status_codes(tool, 0) == ()
+    assert _operation_status_codes(tool, 1) == ("render_error",)

--- a/tests/plotting/test_annotations.py
+++ b/tests/plotting/test_annotations.py
@@ -49,6 +49,41 @@ def test_mark_points() -> None:
     plt.close()
 
 
+def test_mark_points_rejects_mathtext_delimiters_before_adding_text() -> None:
+    fig, ax = plt.subplots()
+
+    with pytest.raises(ValueError, match="already has MathText delimiters") as exc_info:
+        mark_points([0.0, 1.0], ["K", r"$\Gamma$"], ax=ax)
+
+    assert str(exc_info.value) == (
+        "Point label '$\\\\Gamma$' already has MathText delimiters. "
+        "When literal=False, MathText delimiters are added automatically. "
+        "Use '\\\\Gamma' instead, or set literal=True."
+    )
+    assert len(ax.texts) == 0
+    plt.close(fig)
+
+
+def test_mark_points_accepts_delimited_literal_label() -> None:
+    fig, ax = plt.subplots()
+
+    mark_points([0.0], [r"$\Gamma$"], literal=True, ax=ax)
+    fig.canvas.draw()
+
+    assert [text.get_text() for text in ax.texts] == [r"$\Gamma$"]
+    plt.close(fig)
+
+
+def test_mark_points_outside_rejects_delimiters_before_adding_axes() -> None:
+    fig, ax = plt.subplots()
+
+    with pytest.raises(ValueError, match="already has MathText delimiters"):
+        mark_points_outside([0.0], [r"$\Gamma$"], ax=ax)
+
+    assert fig.axes == [ax]
+    plt.close(fig)
+
+
 @pytest.mark.parametrize("outline", [True, False])
 def test_copy_mathtext(outline) -> None:
     assert copy_mathtext("$c_1$", outline=outline).startswith(


### PR DESCRIPTION
## Summary

- Show delayed Matplotlib render errors on the Figure Composer step that owns the failing artist.
- Show ambiguous or figure-level failures in a visible inline banner above the editor.
- Reject dollar-delimited `mark_points` labels before the figure is modified and explain how to correct the input.

## Root cause

Some Matplotlib errors occur only when the canvas draws. The operation loop had already finished at that point, so Figure Composer only had a generic figure-level error. The UI put that message in the status bar.

`mark_points` adds MathText delimiters when `literal=False`. A label that already had dollar delimiters produced nested MathText and failed during the later canvas draw.

## Implementation

Artists are tagged with the operation that creates or mutates them. The delayed draw-error path inspects artist references in the exception traceback. It assigns the error only when it finds one valid operation. Ambiguous and unrelated draw errors remain figure-level errors.

The tracking code restores each Matplotlib stale callback after the operation. It does not assign an error from the currently selected UI step.

## Validation

- Loaded a copy of the supplied `figure itmd.itws` workspace and confirmed that only the invalid `mark_points` step reports the actionable error.
- The full Figure Composer suite passed 717 tests on the rebased runtime code.
- The three added ownership fallback tests passed.
- The complete changed-line analysis reports zero missing changed lines and zero missing touching branches.
- `tests/interactive/imagetool/manager/figurecomposer/test_core.py` and `tests/plotting/test_annotations.py` passed 54 tests.
- Seven focused ownership and error-display tests passed with PySide6.
- Ruff, formatting, mypy, and `git diff --check` passed.
