### PR TITLE
Fix Figure Composer axes batch editing

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -209,6 +209,7 @@ _INITIAL_SIZE_HINT_EXTRA_HEIGHT = 80
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
+_AXES_EXPRESSION_PLACEHOLDER = "Advanced: axs[0, :] or axs[:, 0]"
 logger = logging.getLogger(__name__)
 
 _OPERATION_STATUS_LABELS = {
@@ -1342,7 +1343,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             "Use All Axes", self.target_axes_page
         )
         self.use_all_axes_button.setToolTip(
-            "Retarget the selected step to every axis in the current figure grid."
+            "Retarget the selected steps to every axis in the current figure grid."
         )
         self.use_all_axes_button.clicked.connect(
             self._target_current_operation_all_axes
@@ -1351,7 +1352,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             "Drop Removed Axes", self.target_axes_page
         )
         self.keep_valid_axes_button.setToolTip(
-            "Keep only selected axes that still exist in the current figure grid."
+            "For the selected steps, keep only axes that still exist in the current "
+            "figure grid."
         )
         self.keep_valid_axes_button.clicked.connect(
             self._target_current_operation_valid_axes
@@ -1361,7 +1363,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         target_axes_action_layout.addStretch(1)
         target_axes_layout.addLayout(target_axes_action_layout)
         self.axes_expression_edit = QtWidgets.QLineEdit(self.target_axes_page)
-        self.axes_expression_edit.setPlaceholderText("Advanced: axs[0, :] or axs[:, 0]")
+        self.axes_expression_edit.setPlaceholderText(_AXES_EXPRESSION_PLACEHOLDER)
         self.axes_expression_edit.setToolTip(
             "Optional advanced axes expression used verbatim in copied Python code."
         )
@@ -2483,6 +2485,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _sync_axes_selector(self) -> None:
         current = self._current_operation()
+        selected_axes_operations = self._selected_axes_operations()
+        expression_mixed = (
+            len({operation.axes.expression for operation in selected_axes_operations})
+            > 1
+        )
         selected_axes = set()
         selected_axes_ids: tuple[str, ...] = ()
         expression = ""
@@ -2519,12 +2526,23 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 self._refresh_gridspec_axes_selector()
             else:
                 self.axes_selector.set_selected_axes(tuple(sorted(selected_axes)))
-            if self.axes_expression_edit.text() != expression:
+            displayed_expression = "" if expression_mixed else expression
+            if self.axes_expression_edit.text() != displayed_expression:
                 blocker = QtCore.QSignalBlocker(self.axes_expression_edit)
-                self.axes_expression_edit.setText(expression)
+                self.axes_expression_edit.setText(displayed_expression)
                 del blocker
+            self.operation_editor.apply_mixed_line_edit(
+                self.axes_expression_edit, expression_mixed
+            )
+            if not expression_mixed:
+                self.axes_expression_edit.setPlaceholderText(
+                    _AXES_EXPRESSION_PLACEHOLDER
+                )
             self.keep_valid_axes_button.setEnabled(
-                bool(invalid_axes_ids) if grid_mode else bool(invalid_axes)
+                any(
+                    self._operation_has_removed_axes(operation)
+                    for operation in selected_axes_operations
+                )
             )
             if current is None:
                 self.target_axes_status_label.setText("Select a step to choose axes.")
@@ -2872,6 +2890,30 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         return tuple(
             operation.operation_id for _index, operation in self._editable_operations()
         )
+
+    def _selected_axes_operations(self) -> tuple[FigureOperationState, ...]:
+        operations: list[FigureOperationState] = []
+        for index in self._selected_operation_indices():
+            operation = self._document.recipe.operations[index]
+            if _registry.spec_for(operation.kind).uses_axes(operation):
+                operations.append(operation)
+        return tuple(operations)
+
+    def _selected_axes_operation_ids(self) -> tuple[str, ...]:
+        return tuple(
+            operation.operation_id for operation in self._selected_axes_operations()
+        )
+
+    def _operation_has_removed_axes(self, operation: FigureOperationState) -> bool:
+        if operation.axes.expression:
+            return False
+        if self._document.recipe.setup.layout_mode == "gridspec":
+            return bool(
+                _gridspec_invalid_axes_ids(
+                    self._document.recipe.setup, operation.axes.axes_ids
+                )
+            )
+        return bool(operation.axes.invalid_axes(self._document.recipe.setup))
 
     @QtCore.Slot(object)
     def _apply_operation_edit_request(self, request_object: object) -> None:
@@ -3226,22 +3268,22 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _axes_selection_changed(self, axes_obj: object) -> None:
         if self._updating_controls:
             return
-        current = self._current_operation()
-        if current is None:
-            return
-        if not _registry.spec_for(current[1].kind).uses_axes(current[1]):
+        operation_ids = self._selected_axes_operation_ids()
+        if not operation_ids:
             return
         axes = typing.cast("tuple[tuple[int, int], ...]", axes_obj)
         if not axes:
             axes = ((0, 0),)
-        index, operation = current
-        selection = operation.axes.model_copy(update={"axes": axes, "expression": ""})
-        if selection == operation.axes:
-            erlab.interactive.utils.single_shot(self, 0, self._sync_axes_selector)
-            return
-        self._replace_operation(
-            index,
-            operation.model_copy(update={"axes": selection}),
+
+        self._update_operations_by_ids(
+            operation_ids,
+            lambda _index, operation: operation.model_copy(
+                update={
+                    "axes": operation.axes.model_copy(
+                        update={"axes": axes, "expression": ""}
+                    )
+                }
+            ),
             defer_render=True,
             sync_axes=False,
         )
@@ -3251,22 +3293,19 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _gridspec_axes_selection_changed(self) -> None:
         if self._updating_controls:
             return
-        current = self._current_operation()
-        if current is None:
-            return
-        if not _registry.spec_for(current[1].kind).uses_axes(current[1]):
+        operation_ids = self._selected_axes_operation_ids()
+        if not operation_ids:
             return
         axes_ids = self.gridspec_axes_selector.selected_axes_ids()
-        index, operation = current
-        selection = operation.axes.model_copy(
-            update={"axes_ids": axes_ids, "expression": ""}
-        )
-        if selection == operation.axes:
-            erlab.interactive.utils.single_shot(self, 0, self._sync_axes_selector)
-            return
-        self._replace_operation(
-            index,
-            operation.model_copy(update={"axes": selection}),
+        self._update_operations_by_ids(
+            operation_ids,
+            lambda _index, operation: operation.model_copy(
+                update={
+                    "axes": operation.axes.model_copy(
+                        update={"axes_ids": axes_ids, "expression": ""}
+                    )
+                }
+            ),
             defer_render=True,
             sync_axes=False,
         )
@@ -3276,21 +3315,19 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _axes_expression_changed(self) -> None:
         if self._updating_controls:
             return
-        current = self._current_operation()
-        if current is None:
+        if self.operation_editor.line_edit_batch_unchanged(self.axes_expression_edit):
             return
-        if not _registry.spec_for(current[1].kind).uses_axes(current[1]):
+        operation_ids = self._selected_axes_operation_ids()
+        if not operation_ids:
             return
-        index, operation = current
-        selection = operation.axes.model_copy(
-            update={"expression": self.axes_expression_edit.text().strip()}
-        )
-        if selection == operation.axes:
-            erlab.interactive.utils.single_shot(self, 0, self._sync_axes_selector)
-            return
-        self._replace_operation(
-            index,
-            operation.model_copy(update={"axes": selection}),
+        expression = self.axes_expression_edit.text().strip()
+        self._update_operations_by_ids(
+            operation_ids,
+            lambda _index, operation: operation.model_copy(
+                update={
+                    "axes": operation.axes.model_copy(update={"expression": expression})
+                }
+            ),
             defer_render=True,
             sync_axes=False,
         )
@@ -3302,7 +3339,25 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         _current_id: object,
         _selected_ids: object,
     ) -> None:
+        selected_ids = self._selected_operation_ids()
+        if selected_ids and self._current_operation_index() not in (
+            self._selected_operation_indices()
+        ):
+            erlab.interactive.utils.single_shot(
+                self, 0, self._ensure_current_operation_selected
+            )
         self._update_step_action_buttons()
+        self._sync_axes_selector()
+        self._refresh_operation_editor()
+
+    def _ensure_current_operation_selected(self) -> None:
+        selected_ids = self._selected_operation_ids()
+        if not selected_ids:
+            return
+        selected_indices = self._selected_operation_indices()
+        if self._current_operation_index() in selected_indices:
+            return
+        self._set_current_operation_row_silent(selected_indices[0])
         self._sync_axes_selector()
         self._refresh_operation_editor()
 
@@ -3457,54 +3512,60 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     @QtCore.Slot()
     def _target_current_operation_all_axes(self) -> None:
-        current = self._current_operation()
-        if current is None:
-            return
-        index, operation = current
-        if not _registry.spec_for(operation.kind).uses_axes(operation):
+        operation_ids = self._selected_axes_operation_ids()
+        if not operation_ids:
             return
         if self._document.recipe.setup.layout_mode == "gridspec":
-            selection = operation.axes.model_copy(
-                update={
-                    "axes_ids": _gridspec_all_axes_ids(self._document.recipe.setup),
-                    "expression": "",
-                }
-            )
-            self._replace_operation(
-                index, operation.model_copy(update={"axes": selection})
-            )
-            return
-        selection = operation.axes.model_copy(
-            update={"axes": _all_axes(self._document.recipe.setup), "expression": ""}
+            axes_updates: dict[str, object] = {
+                "axes_ids": _gridspec_all_axes_ids(self._document.recipe.setup),
+                "expression": "",
+            }
+        else:
+            axes_updates = {
+                "axes": _all_axes(self._document.recipe.setup),
+                "expression": "",
+            }
+        self._update_operations_by_ids(
+            operation_ids,
+            lambda _index, operation: operation.model_copy(
+                update={"axes": operation.axes.model_copy(update=axes_updates)}
+            ),
         )
-        self._replace_operation(index, operation.model_copy(update={"axes": selection}))
 
     @QtCore.Slot()
     def _target_current_operation_valid_axes(self) -> None:
-        current = self._current_operation()
-        if current is None:
+        operation_ids = tuple(
+            operation.operation_id
+            for operation in self._selected_axes_operations()
+            if self._operation_has_removed_axes(operation)
+        )
+        if not operation_ids:
             return
-        index, operation = current
-        if not _registry.spec_for(operation.kind).uses_axes(operation):
-            return
-        if self._document.recipe.setup.layout_mode == "gridspec":
-            axes_ids = _gridspec_valid_axes_ids(
-                self._document.recipe.setup, operation.axes.axes_ids
+        grid_mode = self._document.recipe.setup.layout_mode == "gridspec"
+        fallback_axes_ids = _gridspec_all_axes_ids(self._document.recipe.setup)[:1]
+
+        def update_operation(
+            _index: int, operation: FigureOperationState
+        ) -> FigureOperationState:
+            if grid_mode:
+                axes_ids = _gridspec_valid_axes_ids(
+                    self._document.recipe.setup, operation.axes.axes_ids
+                )
+                axes_updates: dict[str, object] = {
+                    "axes_ids": axes_ids or fallback_axes_ids,
+                    "expression": "",
+                }
+            else:
+                axes = operation.axes.valid_axes(self._document.recipe.setup)
+                axes_updates = {
+                    "axes": axes or ((0, 0),),
+                    "expression": "",
+                }
+            return operation.model_copy(
+                update={"axes": operation.axes.model_copy(update=axes_updates)}
             )
-            if not axes_ids:
-                axes_ids = _gridspec_all_axes_ids(self._document.recipe.setup)[:1]
-            selection = operation.axes.model_copy(
-                update={"axes_ids": axes_ids, "expression": ""}
-            )
-            self._replace_operation(
-                index, operation.model_copy(update={"axes": selection})
-            )
-            return
-        axes = operation.axes.valid_axes(self._document.recipe.setup)
-        if not axes:
-            axes = ((0, 0),)
-        selection = operation.axes.model_copy(update={"axes": axes, "expression": ""})
-        self._replace_operation(index, operation.model_copy(update={"axes": selection}))
+
+        self._update_operations_by_ids(operation_ids, update_operation)
 
     def _source_display_name(self, name: str) -> str:
         sources = self._document.source_by_name()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -2134,6 +2134,188 @@ def test_figure_composer_axes_selection_guards_recipe_updates(
     assert tool.tool_status.operations[1].axes.expression == ""
 
 
+def test_figure_composer_axes_selection_updates_selected_steps(qtbot) -> None:
+    data = _figure_composer_profile_source("data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(ncols=2),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.line(
+                    label="left",
+                    source="data",
+                    axes=FigureAxesSelectionState(
+                        axes=((0, 0),), expression="axs[0, 0]"
+                    ),
+                ),
+                FigureOperationState.line(
+                    label="right",
+                    source="data",
+                    axes=FigureAxesSelectionState(axes=((0, 1), (1, 0))),
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool.show()
+    operation_list = tool.operation_panel.operation_list
+    viewport = typing.cast("QtWidgets.QWidget", operation_list.viewport())
+
+    def click_operation_row(
+        row: int,
+        modifiers: QtCore.Qt.KeyboardModifier = (QtCore.Qt.KeyboardModifier.NoModifier),
+    ) -> None:
+        item = operation_list.topLevelItem(row)
+        assert item is not None
+        rect = operation_list.visualItemRect(item)
+        assert not rect.isNull()
+        qtbot.mouseClick(
+            viewport,
+            QtCore.Qt.MouseButton.LeftButton,
+            modifiers,
+            pos=rect.center(),
+        )
+
+    click_operation_row(0)
+    click_operation_row(1, QtCore.Qt.KeyboardModifier.ControlModifier)
+    click_operation_row(1, QtCore.Qt.KeyboardModifier.ControlModifier)
+    qtbot.waitUntil(lambda: tool._current_operation_index() == 0)
+
+    assert _selected_operation_rows(tool) == (0,)
+    assert tool.axes_expression_edit.text() == "axs[0, 0]"
+
+    tool.axes_expression_edit.editingFinished.emit()
+
+    assert tuple(
+        operation.axes.expression for operation in tool.tool_status.operations
+    ) == ("axs[0, 0]", "")
+
+    _select_operation_rows(tool, (0, 1))
+    assert tool.axes_expression_edit.text() == ""
+    assert tool.axes_expression_edit.property("batch_mixed")
+
+    tool.axes_expression_edit.editingFinished.emit()
+
+    assert tuple(
+        operation.axes.expression for operation in tool.tool_status.operations
+    ) == ("axs[0, 0]", "")
+    assert tool.keep_valid_axes_button.isEnabled()
+    tool.keep_valid_axes_button.click()
+
+    assert tuple(operation.axes.axes for operation in tool.tool_status.operations) == (
+        ((0, 0),),
+        ((0, 1),),
+    )
+    assert tuple(
+        operation.axes.expression for operation in tool.tool_status.operations
+    ) == ("axs[0, 0]", "")
+    assert not tool.keep_valid_axes_button.isEnabled()
+
+    tool.axes_selector.set_selected_axes(((0, 1),), emit=True)
+
+    assert tuple(operation.axes.axes for operation in tool.tool_status.operations) == (
+        ((0, 1),),
+        ((0, 1),),
+    )
+    assert _selected_operation_rows(tool) == (0, 1)
+
+    tool.axes_expression_edit.setText("axs[:, 0]")
+    tool.axes_expression_edit.setModified(True)
+    tool.axes_expression_edit.editingFinished.emit()
+
+    assert tuple(
+        operation.axes.expression for operation in tool.tool_status.operations
+    ) == ("axs[:, 0]", "axs[:, 0]")
+
+    tool.use_all_axes_button.click()
+
+    assert tuple(operation.axes.axes for operation in tool.tool_status.operations) == (
+        ((0, 0), (0, 1)),
+        ((0, 0), (0, 1)),
+    )
+    assert tuple(
+        operation.axes.expression for operation in tool.tool_status.operations
+    ) == ("", "")
+
+
+def test_figure_composer_gridspec_axes_selection_updates_selected_steps(
+    qtbot,
+) -> None:
+    data = _figure_composer_profile_source("data")
+    root = FigureGridSpecGridState(
+        nrows=1,
+        ncols=2,
+        axes=(
+            FigureGridSpecAxesState(
+                axes_id="left",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=0,
+                    col_stop=1,
+                ),
+            ),
+            FigureGridSpecAxesState(
+                axes_id="right",
+                span=FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=1,
+                    col_stop=2,
+                ),
+            ),
+        ),
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=FigureSubplotsState(
+                layout_mode="gridspec",
+                gridspec=FigureGridSpecLayoutState(root=root),
+            ),
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.line(
+                    label="first",
+                    source="data",
+                    axes=FigureAxesSelectionState(axes_ids=("left",)),
+                ),
+                FigureOperationState.line(
+                    label="second",
+                    source="data",
+                    axes=FigureAxesSelectionState(axes_ids=("right", "missing-second")),
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    _select_operation_rows(tool, (0, 1))
+    assert tool.keep_valid_axes_button.isEnabled()
+    tool.keep_valid_axes_button.click()
+
+    assert tuple(
+        operation.axes.axes_ids for operation in tool.tool_status.operations
+    ) == (("left",), ("right",))
+
+    tool.gridspec_axes_selector.set_selected_axes_ids(("right",), emit=True)
+
+    assert tuple(
+        operation.axes.axes_ids for operation in tool.tool_status.operations
+    ) == (("right",), ("right",))
+    assert _selected_operation_rows(tool) == (0, 1)
+
+    tool.use_all_axes_button.click()
+
+    assert tuple(
+        operation.axes.axes_ids for operation in tool.tool_status.operations
+    ) == (("left", "right"), ("left", "right"))
+
+
 def test_figure_composer_gridspec_axes_selection_guards_recipe_updates(
     qtbot,
     monkeypatch,


### PR DESCRIPTION
## Summary

- Apply axes selection changes to all selected axes-using steps.
- Preserve mixed advanced axes expressions until the user edits them.
- Keep the visible axes editor aligned with the selected steps.
- Enable **Drop Removed Axes** only when a selected step has removed explicit axes.

## Root cause

The axes handlers replaced only the current operation. Extended selection could also leave the current row outside the selected rows. The editor could then show one step while a batch action changed different steps.

## User impact

Users can change axes for multiple Figure Composer steps in one action. Distinct advanced expressions remain unchanged until the user enters a new expression.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py` — 149 passed
- `uv run ruff check src/erlab/interactive/_figurecomposer/_tool.py tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py`
- `uv run ruff format --check src/erlab/interactive/_figurecomposer/_tool.py tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py`
- `uv run mypy src/erlab/interactive/_figurecomposer/_tool.py`
- `git diff --check origin/main...HEAD`
